### PR TITLE
Fix ULID to UUID conversion in id utilities

### DIFF
--- a/crates/rustok-core/src/id.rs
+++ b/crates/rustok-core/src/id.rs
@@ -4,13 +4,13 @@ use uuid::Uuid;
 use crate::error::{Error, Result};
 
 pub fn generate_id() -> Uuid {
-    Uuid::from(Ulid::new())
+    Uuid::from_bytes(Ulid::new().to_bytes())
 }
 
 pub fn parse_id(value: &str) -> Result<Uuid> {
     value
         .parse::<Ulid>()
-        .map(Uuid::from)
+        .map(|ulid| Uuid::from_bytes(ulid.to_bytes()))
         .or_else(|_| value.parse::<Uuid>())
         .map_err(|_| Error::InvalidIdFormat(value.to_string()))
 }


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by using `Uuid::from(Ulid)` which fails because `From<Ulid>` is not implemented for `Uuid`, so convert ULID bytes to a `Uuid` instead.

### Description
- Replace `Uuid::from(Ulid::new())` with `Uuid::from_bytes(Ulid::new().to_bytes())` and update parsing to use `.map(|ulid| Uuid::from_bytes(ulid.to_bytes()))` in `crates/rustok-core/src/id.rs`.

### Testing
- No automated tests were run; this is a small compile-time fix intended to resolve the previous build error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e3f1a544832f9de3707dcc327ccb)