### PR TITLE
Format derive attributes in rustok-core types

### DIFF
--- a/crates/rustok-core/src/types.rs
+++ b/crates/rustok-core/src/types.rs
@@ -3,15 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    EnumIter,
-    DeriveActiveEnum,
-    Default,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumIter, DeriveActiveEnum, Default,
 )]
 #[sea_orm(rs_type = "String", db_type = "String(StringLen::N(32))")]
 pub enum UserRole {
@@ -39,15 +31,7 @@ impl fmt::Display for UserRole {
 }
 
 #[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    EnumIter,
-    DeriveActiveEnum,
-    Default,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumIter, DeriveActiveEnum, Default,
 )]
 #[sea_orm(rs_type = "String", db_type = "String(StringLen::N(32))")]
 pub enum UserStatus {


### PR DESCRIPTION
### Motivation
- Align derive attribute formatting in `crates/rustok-core/src/types.rs` with `rustfmt` expectations so the repository passes formatting checks.

### Description
- Reflowed the `#[derive(...)]` attributes for the `UserRole` and `UserStatus` enums in `crates/rustok-core/src/types.rs` to the `rustfmt`-preferred layout without changing any enum behavior or attributes.

### Testing
- Ran `cargo fmt --all -- --check` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a04b3f514832f90dbfba743d251fc)