### PR TITLE
Format Rust sources with `cargo fmt`

### DIFF
--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -1,5 +1,5 @@
-use chrono::{Duration, Utc};
 use argon2::{PasswordHasher, PasswordVerifier};
+use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use loco_rs::{app::AppContext, Error, Result};
 use rand::RngCore;

--- a/apps/server/src/controllers/auth.rs
+++ b/apps/server/src/controllers/auth.rs
@@ -1,4 +1,9 @@
-use axum::{extract::ConnectInfo, http::header::USER_AGENT, routing::{get, post}, Json};
+use axum::{
+    extract::ConnectInfo,
+    http::header::USER_AGENT,
+    routing::{get, post},
+    Json,
+};
 use chrono::{Duration, Utc};
 use loco_rs::prelude::*;
 use sea_orm::{ActiveModelTrait, Set};
@@ -120,16 +125,10 @@ async fn register(
     let token_hash = hash_refresh_token(&refresh_token);
     let expires_at = now + Duration::seconds(config.refresh_expiration as i64);
 
-    let session = sessions::ActiveModel::new(
-        tenant.id,
-        user.id,
-        token_hash,
-        expires_at,
-        None,
-        None,
-    )
-    .insert(&ctx.db)
-    .await?;
+    let session =
+        sessions::ActiveModel::new(tenant.id, user.id, token_hash, expires_at, None, None)
+            .insert(&ctx.db)
+            .await?;
 
     let access_token = encode_access_token(&config, user.id, tenant.id, user.role, session.id)?;
 

--- a/apps/server/src/extractors/auth.rs
+++ b/apps/server/src/extractors/auth.rs
@@ -1,3 +1,8 @@
+use crate::context::TenantContextExt;
+use crate::models::{
+    sessions::Entity as Sessions,
+    users::{self, Entity as Users},
+};
 use axum::{
     async_trait,
     extract::{FromRef, FromRequestParts},
@@ -8,11 +13,6 @@ use axum_extra::{
     TypedHeader,
 };
 use loco_rs::prelude::*;
-use crate::context::TenantContextExt;
-use crate::models::{
-    sessions::Entity as Sessions,
-    users::{self, Entity as Users},
-};
 
 // Структура, которую мы будем просить в контроллерах
 pub struct CurrentUser {
@@ -45,8 +45,12 @@ where
                 .map_err(|_| (StatusCode::UNAUTHORIZED, "Missing or invalid token"))?;
 
         // 4. Берем секрет из конфига Loco
-        let auth_config = AuthConfig::from_ctx(&ctx)
-            .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "JWT secret not configured"))?;
+        let auth_config = AuthConfig::from_ctx(&ctx).map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "JWT secret not configured",
+            )
+        })?;
 
         // 5. Валидируем токен
         let claims = decode_access_token(&auth_config, bearer.token())

--- a/apps/server/src/extractors/mod.rs
+++ b/apps/server/src/extractors/mod.rs
@@ -1,2 +1,2 @@
-pub mod tenant;
 pub mod auth;
+pub mod tenant;

--- a/apps/server/src/models/sessions.rs
+++ b/apps/server/src/models/sessions.rs
@@ -3,8 +3,8 @@ use sea_orm::prelude::*;
 
 use rustok_core::generate_id;
 
-pub use super::_entities::sessions::{ActiveModel, Entity, Model};
 use super::_entities::sessions::{self};
+pub use super::_entities::sessions::{ActiveModel, Entity, Model};
 
 impl Model {
     pub fn is_active(&self) -> bool {

--- a/apps/server/src/models/users.rs
+++ b/apps/server/src/models/users.rs
@@ -2,8 +2,8 @@ use sea_orm::prelude::*;
 
 use rustok_core::{generate_id, UserRole, UserStatus};
 
-pub use super::_entities::users::{ActiveModel, Entity, Model};
 use super::_entities::users::{self};
+pub use super::_entities::users::{ActiveModel, Entity, Model};
 
 impl Model {
     pub fn is_active(&self) -> bool {

--- a/crates/rustok-core/src/lib.rs
+++ b/crates/rustok-core/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod error;
 pub mod auth;
+pub mod error;
 pub mod id;
 pub mod module;
 pub mod types;


### PR DESCRIPTION
### Motivation
- Fix formatting issues reported by `cargo fmt --all -- --check` to satisfy style checks and CI requirements.
- Changes are purely cosmetic (imports/exports ordering, line wrapping) and do not alter runtime logic or behavior.
- No special skills from the AGENTS list were required or used for this change.

### Description
- Reformatted code in `apps/server/src/auth.rs`, `apps/server/src/controllers/auth.rs`, and `apps/server/src/extractors/auth.rs` to adjust import ordering and line wrapping. 
- Adjusted session creation expression formatting in `apps/server/src/controllers/auth.rs` for line-length compliance.
- Reordered module declarations in `apps/server/src/extractors/mod.rs` and re-aligned `pub use` exports in `apps/server/src/models/sessions.rs` and `apps/server/src/models/users.rs`.
- Reordered modules in `crates/rustok-core/src/lib.rs` to match `rustfmt`/style expectations.

### Testing
- Ran `cargo fmt --all` to apply formatting changes, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2a0c771c832fa352c677d5f3a491)