### PR TITLE
Fix auth handlers and permission queries

### DIFF
--- a/apps/server/src/extractors/auth.rs
+++ b/apps/server/src/extractors/auth.rs
@@ -1,3 +1,4 @@
+use crate::auth::{decode_access_token, AuthConfig};
 use crate::context::TenantContextExt;
 use crate::models::{
     sessions::Entity as Sessions,


### PR DESCRIPTION
### Motivation
- Remove duplicate types and handler definitions in the auth controller and implement standard login/refresh/logout flows with session tracking.
- Use the shared JWT/Auth config helpers in the request extractor for consistent token handling.
- Fix SeaORM query issues where UUID references needed dereferencing and ensure role creation returns the expected result type.

### Description
- Consolidated DTOs and removed duplicate `UserResponse` and duplicate `me`/`login` handlers in `apps/server/src/controllers/auth.rs` and added a single `AuthResponse` DTO.
- Reworked `login` to create a `sessions` record, populate `UserInfo`, generate refresh/access tokens and return structured JSON, and added `refresh` and `logout` handlers that update/revoke session tokens.
- Cleaned up routing to remove duplicate route registrations and updated `me` to return the unified response format while using `USER_AGENT` header for session metadata.
- Wired the auth extractor to use `AuthConfig` and `decode_access_token` from `crate::auth` in `apps/server/src/extractors/auth.rs` so token validation uses the configured JWT settings.
- Fixed permission/role queries in `apps/server/src/services/auth.rs` by dereferencing UUID params in `.eq()` filters, returning the created `role` correctly, and dereferencing `tenant_id` in permission lookups.

### Testing
- Attempted `cargo test -p rustok-server --no-run` to validate build artifacts, but fetching dependencies failed due to network access errors when contacting crates.io (download failed with HTTP 403), so tests could not complete.
- Local static checks (searches and quick inspections) were run to ensure the updated handlers and imports are consistent with the rest of the codebase and no duplicate symbols remain after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a33b8c200832fa7bffe488523d643)