### PR TITLE
Fix README navigation anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 [![Rust](https://img.shields.io/badge/rust-1.75%2B-orange.svg)](https://www.rust-lang.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-[Features](#-features) •
-[Why Rust?](#-why-rust) •
-[Comparison](#-comparison) •
-[Quick Start](#-quick-start) •
-[Architecture](#-architecture) •
-[Roadmap](#-roadmap)
+[Features](#features) •
+[Why Rust?](#why-rust) •
+[Comparison](#comparison) •
+[Quick Start](#quick-start) •
+[Architecture](#architecture) •
+[Roadmap](#roadmap)
 
 </div>
 


### PR DESCRIPTION
### Motivation
- Fix broken table-of-contents links in the project README so in-page navigation works as expected.

### Description
- Update `README.md` TOC links to use plain section anchors (for example change `[Features](#-features)` to `[Features](#features)`) so they match the generated heading IDs.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b0dd8d58c832f977ea6a4cf5cc252)