### PR TITLE
Format migration table definitions with rustfmt

### DIFF
--- a/apps/server/migration/src/m20250130_000004_create_tenant_locales.rs
+++ b/apps/server/migration/src/m20250130_000004_create_tenant_locales.rs
@@ -13,7 +13,12 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(TenantLocales::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(TenantLocales::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(TenantLocales::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
                     .col(ColumnDef::new(TenantLocales::TenantId).uuid().not_null())
                     .col(
                         ColumnDef::new(TenantLocales::Locale)

--- a/apps/server/migration/src/m20250130_000005_create_nodes.rs
+++ b/apps/server/migration/src/m20250130_000005_create_nodes.rs
@@ -32,12 +32,7 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .default(0),
                     )
-                    .col(
-                        ColumnDef::new(Nodes::Depth)
-                            .integer()
-                            .not_null()
-                            .default(0),
-                    )
+                    .col(ColumnDef::new(Nodes::Depth).integer().not_null().default(0))
                     .col(
                         ColumnDef::new(Nodes::ReplyCount)
                             .integer()
@@ -134,11 +129,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(ColumnDef::new(Bodies::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(Bodies::NodeId).uuid().not_null())
-                    .col(
-                        ColumnDef::new(Bodies::Locale)
-                            .string_len(5)
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(Bodies::Locale).string_len(5).not_null())
                     .col(ColumnDef::new(Bodies::Body).text())
                     .col(
                         ColumnDef::new(Bodies::Format)

--- a/apps/server/migration/src/m20250130_000006_create_categories.rs
+++ b/apps/server/migration/src/m20250130_000006_create_categories.rs
@@ -13,7 +13,12 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Categories::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(Categories::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(Categories::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
                     .col(ColumnDef::new(Categories::TenantId).uuid().not_null())
                     .col(ColumnDef::new(Categories::ParentId).uuid())
                     .col(
@@ -73,8 +78,16 @@ impl MigrationTrait for Migration {
                             .not_null()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(CategoryTranslations::CategoryId).uuid().not_null())
-                    .col(ColumnDef::new(CategoryTranslations::TenantId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(CategoryTranslations::CategoryId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(CategoryTranslations::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(CategoryTranslations::Locale)
                             .string_len(5)

--- a/apps/server/migration/src/m20250130_000008_create_meta.rs
+++ b/apps/server/migration/src/m20250130_000008_create_meta.rs
@@ -15,11 +15,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(ColumnDef::new(Meta::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(Meta::TenantId).uuid().not_null())
-                    .col(
-                        ColumnDef::new(Meta::TargetType)
-                            .string_len(32)
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(Meta::TargetType).string_len(32).not_null())
                     .col(ColumnDef::new(Meta::TargetId).uuid().not_null())
                     .col(
                         ColumnDef::new(Meta::NoIndex)
@@ -63,16 +59,10 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(MetaTranslations::Title).string_len(255))
-                    .col(
-                        ColumnDef::new(MetaTranslations::Description)
-                            .string_len(500),
-                    )
+                    .col(ColumnDef::new(MetaTranslations::Description).string_len(500))
                     .col(ColumnDef::new(MetaTranslations::Keywords).string_len(255))
                     .col(ColumnDef::new(MetaTranslations::OgTitle).string_len(255))
-                    .col(
-                        ColumnDef::new(MetaTranslations::OgDescription)
-                            .string_len(500),
-                    )
+                    .col(ColumnDef::new(MetaTranslations::OgDescription).string_len(500))
                     .col(ColumnDef::new(MetaTranslations::OgImage).string_len(500))
                     .foreign_key(
                         ForeignKey::create()

--- a/apps/server/migration/src/m20250130_000009_create_media.rs
+++ b/apps/server/migration/src/m20250130_000009_create_media.rs
@@ -18,10 +18,18 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Media::TenantId).uuid().not_null())
                     .col(ColumnDef::new(Media::UploadedBy).uuid())
                     .col(ColumnDef::new(Media::Filename).string_len(255).not_null())
-                    .col(ColumnDef::new(Media::OriginalName).string_len(255).not_null())
+                    .col(
+                        ColumnDef::new(Media::OriginalName)
+                            .string_len(255)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Media::MimeType).string_len(100).not_null())
                     .col(ColumnDef::new(Media::Size).big_integer().not_null())
-                    .col(ColumnDef::new(Media::StoragePath).string_len(500).not_null())
+                    .col(
+                        ColumnDef::new(Media::StoragePath)
+                            .string_len(500)
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(Media::StorageDriver)
                             .string_len(32)


### PR DESCRIPTION
### Motivation
- Normalize formatting of migration table definitions to satisfy `rustfmt` and improve readability.
- Keep column definition layout consistent across migration files so future diffs are smaller and easier to review.

### Description
- Reflowed column definitions in migration files to a consistent multi-line style and inlined some short columns for clarity; no schema or logic changes were made.
- Updated `apps/server/migration/src/m20250130_000004_create_tenant_locales.rs` to standardize `ColumnDef` formatting for tenant locale columns.
- Updated `apps/server/migration/src/m20250130_000005_create_nodes.rs` and `..._create_nodes.rs` sections to normalize `Depth` and `Bodies::Locale` column formatting.
- Updated `apps/server/migration/src/m20250130_000006_create_categories.rs`, `..._000008_create_meta.rs`, and `..._000009_create_media.rs` to normalize `Id`, translation columns, meta fields, and media path/name column layouts.

### Testing
- Ran `cargo fmt --all` and confirmed the formatter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b20d9f528832f9905d7c9c9d38ff7)