### PR TITLE
Fix rustok-core events module exports and EventBus publish signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "rustok-core",
+ "sea-orm-migration",
 ]
 
 [[package]]
@@ -4092,6 +4093,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "rustok-core",
+ "sea-orm-migration",
 ]
 
 [[package]]
@@ -4102,9 +4104,11 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
  "ulid",
  "uuid",

--- a/crates/rustok-core/Cargo.toml
+++ b/crates/rustok-core/Cargo.toml
@@ -16,4 +16,3 @@ async-trait.workspace = true
 tokio.workspace = true
 jsonwebtoken = "9"
 sea-orm-migration.workspace = true
-tokio.workspace = true

--- a/crates/rustok-core/src/events/bus.rs
+++ b/crates/rustok-core/src/events/bus.rs
@@ -3,10 +3,8 @@ use std::sync::{
     Arc,
 };
 
-use chrono::Utc;
 use tokio::sync::broadcast;
-
-use crate::id::generate_id;
+use uuid::Uuid;
 
 use super::{DomainEvent, EventEnvelope};
 
@@ -64,12 +62,13 @@ impl EventBus {
         receiver
     }
 
-    pub fn publish(&self, event: DomainEvent) -> crate::Result<()> {
-        let envelope = EventEnvelope {
-            id: generate_id(),
-            occurred_at: Utc::now(),
-            event,
-        };
+    pub fn publish(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Option<Uuid>,
+        event: DomainEvent,
+    ) -> crate::Result<()> {
+        let envelope = EventEnvelope::new(tenant_id, actor_id, event);
 
         if self.sender.receiver_count() == 0 {
             tracing::debug!(event = ?envelope.event, "Event published without subscribers");

--- a/crates/rustok-core/src/events/mod.rs
+++ b/crates/rustok-core/src/events/mod.rs
@@ -1,35 +1,10 @@
-use chrono::{DateTime, Utc};
-use uuid::Uuid;
-
 mod bus;
-mod dispatcher;
+mod handler;
+mod types;
 
 pub use bus::{EventBus, EventBusStats};
-pub use dispatcher::{
-    DispatcherConfig, EventDispatcher, HandlerBuilder, HandlerResult, RunningDispatcher,
+pub use handler::{
+    DispatcherConfig, EventDispatcher, EventHandler, HandlerBuilder, HandlerResult,
+    RunningDispatcher,
 };
-
-#[derive(Debug, Clone)]
-pub struct EventEnvelope {
-    pub id: Uuid,
-    pub occurred_at: DateTime<Utc>,
-    pub event: DomainEvent,
-}
-
-#[derive(Debug, Clone)]
-pub enum DomainEvent {
-    ModuleEnabled {
-        tenant_id: Uuid,
-        module_slug: String,
-    },
-    ModuleDisabled {
-        tenant_id: Uuid,
-        module_slug: String,
-    },
-}
-
-pub trait EventHandler: Send + Sync {
-    fn handles(&self, event: &DomainEvent) -> bool;
-    fn name(&self) -> &'static str;
-    fn handle(&self, envelope: &EventEnvelope) -> crate::Result<()>;
-}
+pub use types::{DomainEvent, EventEnvelope};


### PR DESCRIPTION
### Motivation
- The `events` public surface referenced items from a `dispatcher`/inline-types layout that no longer matched the async handler/types implementation, causing unresolved import errors.
- `EventBus::publish` previously built an inline envelope without tenant/actor metadata, diverging from the shared `EventEnvelope` API.
- The crate manifest contained a duplicate `tokio` dependency entry which broke workspace manifest loading.

### Description
- Rework `crates/rustok-core/src/events/mod.rs` to re-export the proper modules by switching to `mod handler` and `mod types` and exposing `DispatcherConfig`, `EventDispatcher`, `EventHandler`, `HandlerBuilder`, `HandlerResult`, `RunningDispatcher`, `DomainEvent`, and `EventEnvelope` from their respective modules.
- Change `EventBus::publish` signature to `publish(&self, tenant_id: Uuid, actor_id: Option<Uuid>, event: DomainEvent)` and construct envelopes via `EventEnvelope::new` in `crates/rustok-core/src/events/bus.rs`.
- Remove the duplicate `tokio.workspace = true` entry from `crates/rustok-core/Cargo.toml`.
- Dependency resolution updated `Cargo.lock` as part of the changes.

### Testing
- Ran `cargo check -p rustok-core`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2e1d1078832fbc133ea684a01ade)