### PR TITLE
Format index migrations and query imports

### DIFF
--- a/apps/server/migration/src/m20250130_000010_create_index_content.rs
+++ b/apps/server/migration/src/m20250130_000010_create_index_content.rs
@@ -11,12 +11,25 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(IndexContent::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(IndexContent::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(IndexContent::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
                     .col(ColumnDef::new(IndexContent::TenantId).uuid().not_null())
                     .col(ColumnDef::new(IndexContent::NodeId).uuid().not_null())
-                    .col(ColumnDef::new(IndexContent::Locale).string_len(5).not_null())
+                    .col(
+                        ColumnDef::new(IndexContent::Locale)
+                            .string_len(5)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(IndexContent::Kind).string_len(32).not_null())
-                    .col(ColumnDef::new(IndexContent::Status).string_len(32).not_null())
+                    .col(
+                        ColumnDef::new(IndexContent::Status)
+                            .string_len(32)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(IndexContent::Title).string_len(255))
                     .col(ColumnDef::new(IndexContent::Slug).string_len(255))
                     .col(ColumnDef::new(IndexContent::Excerpt).text())
@@ -40,10 +53,30 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(IndexContent::FeaturedImageUrl).string_len(500))
                     .col(ColumnDef::new(IndexContent::FeaturedImageAlt).string_len(255))
                     .col(ColumnDef::new(IndexContent::ParentId).uuid())
-                    .col(ColumnDef::new(IndexContent::Depth).integer().not_null().default(0))
-                    .col(ColumnDef::new(IndexContent::Position).integer().not_null().default(0))
-                    .col(ColumnDef::new(IndexContent::ReplyCount).integer().not_null().default(0))
-                    .col(ColumnDef::new(IndexContent::ViewCount).integer().not_null().default(0))
+                    .col(
+                        ColumnDef::new(IndexContent::Depth)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(IndexContent::Position)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(IndexContent::ReplyCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(IndexContent::ViewCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .col(ColumnDef::new(IndexContent::SearchVector).custom(Alias::new("tsvector")))
                     .col(ColumnDef::new(IndexContent::PublishedAt).timestamp_with_time_zone())
                     .col(

--- a/apps/server/migration/src/m20250130_000011_create_index_products.rs
+++ b/apps/server/migration/src/m20250130_000011_create_index_products.rs
@@ -11,20 +11,41 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(IndexProducts::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(IndexProducts::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(IndexProducts::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
                     .col(ColumnDef::new(IndexProducts::TenantId).uuid().not_null())
                     .col(ColumnDef::new(IndexProducts::ProductId).uuid().not_null())
-                    .col(ColumnDef::new(IndexProducts::Locale).string_len(5).not_null())
-                    .col(ColumnDef::new(IndexProducts::Status).string_len(32).not_null())
+                    .col(
+                        ColumnDef::new(IndexProducts::Locale)
+                            .string_len(5)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(IndexProducts::Status)
+                            .string_len(32)
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new(IndexProducts::IsPublished)
                             .boolean()
                             .not_null()
                             .default(false),
                     )
-                    .col(ColumnDef::new(IndexProducts::Title).string_len(255).not_null())
+                    .col(
+                        ColumnDef::new(IndexProducts::Title)
+                            .string_len(255)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(IndexProducts::Subtitle).string_len(255))
-                    .col(ColumnDef::new(IndexProducts::Handle).string_len(255).not_null())
+                    .col(
+                        ColumnDef::new(IndexProducts::Handle)
+                            .string_len(255)
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(IndexProducts::Description).text())
                     .col(ColumnDef::new(IndexProducts::CategoryId).uuid())
                     .col(ColumnDef::new(IndexProducts::CategoryName).string_len(255))

--- a/crates/rustok-index/src/content/query.rs
+++ b/crates/rustok-index/src/content/query.rs
@@ -2,8 +2,8 @@ use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::IndexResult;
 use super::model::IndexContentModel;
+use crate::error::IndexResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ContentSortBy {

--- a/crates/rustok-index/src/product/query.rs
+++ b/crates/rustok-index/src/product/query.rs
@@ -2,8 +2,8 @@ use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::IndexResult;
 use super::model::IndexProductModel;
+use crate::error::IndexResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProductSortBy {


### PR DESCRIPTION
### Motivation
- Improve readability and consistency of migration column definitions by using multi-line chaining for complex `ColumnDef` expressions.
- Standardize import ordering in query modules so `model` is imported before `error` for consistent grouping.

### Description
- Reformatted column definitions in `apps/server/migration/src/m20250130_000010_create_index_content.rs` to use multi-line `ColumnDef::new(...)` chains for `Id`, `Locale`, `Status`, and the integer counters (`Depth`, `Position`, `ReplyCount`, `ViewCount`).
- Reformatted column definitions in `apps/server/migration/src/m20250130_000011_create_index_products.rs` to use multi-line `ColumnDef::new(...)` chains for `Id`, `Locale`, `Status`, `Title`, and `Handle`.
- Reordered imports in `crates/rustok-index/src/content/query.rs` and `crates/rustok-index/src/product/query.rs` so `super::model::...` appears before `crate::error::IndexResult`.
- No behavior or schema logic was changed beyond formatting and import ordering, and four files were updated (`m20250130_000010_create_index_content.rs`, `m20250130_000011_create_index_products.rs`, `content/query.rs`, `product/query.rs`).

### Testing
- No automated tests were executed for this change.
- Local commit was created successfully (`git commit` completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b35b25e90832fa42d5d58e48a50c1)