### PR TITLE
Fix content indexer instrumentation and event matching

### DIFF
--- a/crates/rustok-index/src/content/indexer.rs
+++ b/crates/rustok-index/src/content/indexer.rs
@@ -21,15 +21,17 @@ impl ContentIndexer {
     #[instrument(skip(self, ctx))]
     async fn build_index_content(
         &self,
-        _ctx: &IndexerContext,
+        ctx: &IndexerContext,
         node_id: Uuid,
         locale: &str,
     ) -> IndexResult<Option<super::model::IndexContentModel>> {
+        let _ = ctx;
         debug!(node_id = %node_id, locale = locale, "Building index content");
         Ok(None)
     }
 
-    async fn get_tenant_locales(&self, _ctx: &IndexerContext) -> IndexResult<Vec<String>> {
+    async fn get_tenant_locales(&self, ctx: &IndexerContext) -> IndexResult<Vec<String>> {
+        let _ = ctx;
         Ok(vec!["en".to_string()])
     }
 }
@@ -52,7 +54,8 @@ impl Indexer for ContentIndexer {
     }
 
     #[instrument(skip(self, ctx))]
-    async fn remove_one(&self, _ctx: &IndexerContext, entity_id: Uuid) -> IndexResult<()> {
+    async fn remove_one(&self, ctx: &IndexerContext, entity_id: Uuid) -> IndexResult<()> {
+        let _ = ctx;
         debug!(node_id = %entity_id, "Removing from content index");
         Ok(())
     }
@@ -105,20 +108,20 @@ impl EventHandler for ContentIndexer {
     }
 
     fn handles(&self, event: &DomainEvent) -> bool {
-        matches!(
-            event,
+        match event {
             DomainEvent::NodeCreated { .. }
-                | DomainEvent::NodeUpdated { .. }
-                | DomainEvent::NodeTranslationUpdated { .. }
-                | DomainEvent::NodePublished { .. }
-                | DomainEvent::NodeUnpublished { .. }
-                | DomainEvent::NodeDeleted { .. }
-                | DomainEvent::BodyUpdated { .. }
-                | DomainEvent::TagAttached { target_type, .. } if target_type == "node"
-                | DomainEvent::TagDetached { target_type, .. } if target_type == "node"
-                | DomainEvent::CategoryUpdated { .. }
-                | DomainEvent::ReindexRequested { target_type, .. } if target_type == "content"
-        )
+            | DomainEvent::NodeUpdated { .. }
+            | DomainEvent::NodeTranslationUpdated { .. }
+            | DomainEvent::NodePublished { .. }
+            | DomainEvent::NodeUnpublished { .. }
+            | DomainEvent::NodeDeleted { .. }
+            | DomainEvent::BodyUpdated { .. }
+            | DomainEvent::CategoryUpdated { .. } => true,
+            DomainEvent::TagAttached { target_type, .. }
+            | DomainEvent::TagDetached { target_type, .. } => target_type == "node",
+            DomainEvent::ReindexRequested { target_type, .. } => target_type == "content",
+            _ => false,
+        }
     }
 
     async fn handle(&self, envelope: &EventEnvelope) -> HandlerResult {


### PR DESCRIPTION
### Motivation
- Fix compile errors caused by tracing instrumentation referencing a non-existent parameter and by using `matches!` with guarded patterns which the macro doesn't accept.
- Ensure the `ContentIndexer` event filtering and helper signatures compile and behave as intended.

### Description
- Rename `_ctx` parameters to `ctx` in `build_index_content`, `get_tenant_locales`, and `remove_one` and add `let _ = ctx;` to avoid unused variable warnings while matching the `#[instrument(skip(self, ctx))]` attribute.
- Replace the `matches!`-based `handles` implementation with a `match` expression that returns `true`/`false` and supports guarded arms for `TagAttached`, `TagDetached`, and `ReindexRequested`.
- Keep behavior unchanged for indexing logic and event handling in `handle` while making the code compile cleanly.

### Testing
- No automated tests were run as part of this change.
- The patch was crafted to address the compilation errors reported previously by CI (`attempting to skip non-existent parameter` and macro guard parsing errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b36584234832fa647c2ff55a26fd8)