### PR TITLE
Fix rustok-index event handling, error conversion, and full-text expr types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,6 +4115,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustok-index"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rustok-core",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rustok-server"
 version = "0.1.0"
 dependencies = [

--- a/crates/rustok-index/src/error.rs
+++ b/crates/rustok-index/src/error.rs
@@ -16,3 +16,16 @@ pub enum IndexError {
 }
 
 pub type IndexResult<T> = Result<T, IndexError>;
+
+impl From<IndexError> for rustok_core::Error {
+    fn from(error: IndexError) -> Self {
+        match error {
+            IndexError::Database(error) => Self::Database(error.to_string()),
+            IndexError::NotFound { entity_type, id } => {
+                Self::Unknown(format!("Entity not found: {entity_type} with id {id}"))
+            }
+            IndexError::Index(message) => Self::Unknown(message),
+            IndexError::Serialization(error) => Self::Unknown(error.to_string()),
+        }
+    }
+}

--- a/crates/rustok-index/src/product/indexer.rs
+++ b/crates/rustok-index/src/product/indexer.rs
@@ -74,7 +74,9 @@ impl EventHandler for ProductIndexer {
                 | DomainEvent::VariantDeleted { .. }
                 | DomainEvent::InventoryUpdated { .. }
                 | DomainEvent::PriceUpdated { .. }
-                | DomainEvent::ReindexRequested { target_type, .. } if target_type == "product"
+        ) || matches!(
+            event,
+            DomainEvent::ReindexRequested { target_type, .. } if target_type == "product"
         )
     }
 

--- a/crates/rustok-index/src/search/full_text.rs
+++ b/crates/rustok-index/src/search/full_text.rs
@@ -1,12 +1,12 @@
-use sea_orm::sea_query::Expr;
+use sea_orm::sea_query::{Expr, SimpleExpr};
 
-pub fn tsvector_from_fields(fields: &[(&str, &str)]) -> Expr {
+pub fn tsvector_from_fields(fields: &[(&str, &str)]) -> SimpleExpr {
     let mut expr = None;
 
     for (weight, field) in fields {
         let weighted = Expr::cust_with_exprs(
             "setweight(to_tsvector('simple', COALESCE(?, '')), ?)",
-            [Expr::cust(field), Expr::cust(weight)],
+            [Expr::cust(*field), Expr::cust(*weight)],
         );
 
         expr = Some(match expr {


### PR DESCRIPTION
### Motivation
- Resolve compilation errors preventing `rustok-index` from building due to mismatched error types when using `?` in handlers. 
- Fix a pattern-match binding/guard issue in the product indexer that caused `target_type` to be unbound in some branches. 
- Address `sea_query::Expr` type and `Into<String>` conversion errors in the full-text helper.

### Description
- Implemented `From<IndexError> for rustok_core::Error` to allow `IndexError` to be converted to `rustok_core::Error` for `?` propagation. 
- Changed `ProductIndexer::handles` to avoid a guarded binding in a single `matches!` pattern by splitting the reindex case into a separate `matches!` and combining with `||`, preventing uninitialized binding issues. 
- Updated `tsvector_from_fields` to return `SimpleExpr`, imported `SimpleExpr`, and dereferenced tuple `(&str, &str)` elements with `*field` / `*weight` when calling `Expr::cust` to satisfy `Into<String>` bounds. 
- `Cargo.lock` was updated by the build to include the `rustok-index` package entry.

### Testing
- Ran `cargo check -p rustok-index`, which completed successfully but produced 2 non-fatal warnings about unused struct fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b37201d10832fb4de89b18f743464)