### PR TITLE
Harden module toggling and tenant resolution

### DIFF
--- a/apps/server/src/graphql/mutations.rs
+++ b/apps/server/src/graphql/mutations.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Context, FieldError, Object, Result};
+use std::collections::HashSet;
 
 use crate::context::{AuthContext, TenantContext};
 use crate::graphql::errors::GraphQLError;
@@ -32,34 +33,68 @@ impl RootMutation {
         let tenant = ctx.data::<TenantContext>()?;
         let registry = ctx.data::<ModuleRegistry>()?;
 
-        if !registry.contains(&module_slug) {
+        let Some(module_impl) = registry.get(&module_slug) else {
             return Err(FieldError::new("Unknown module"));
+        };
+
+        let enabled_modules = TenantModulesEntity::find_enabled(&app_ctx.db, tenant.id)
+            .await
+            .map_err(|err| <FieldError as GraphQLError>::internal_error(&err.to_string()))?;
+        let enabled_set: HashSet<String> = enabled_modules.into_iter().collect();
+
+        if enabled {
+            let missing: Vec<String> = module_impl
+                .dependencies()
+                .iter()
+                .filter(|dependency| !enabled_set.contains(**dependency))
+                .map(|dependency| (*dependency).to_string())
+                .collect();
+
+            if !missing.is_empty() {
+                return Err(FieldError::new(format!(
+                    "Missing module dependencies: {}",
+                    missing.join(", ")
+                )));
+            }
+        } else {
+            let dependents: Vec<String> = registry
+                .list()
+                .into_iter()
+                .filter(|module| enabled_set.contains(module.slug()))
+                .filter(|module| module.dependencies().iter().any(|dep| *dep == module_slug))
+                .map(|module| module.slug().to_string())
+                .collect();
+
+            if !dependents.is_empty() {
+                return Err(FieldError::new(format!(
+                    "Module is required by: {}",
+                    dependents.join(", ")
+                )));
+            }
         }
         let module = TenantModulesEntity::toggle(&app_ctx.db, tenant.id, &module_slug, enabled)
             .await
             .map_err(|err| <FieldError as GraphQLError>::internal_error(&err.to_string()))?;
 
-        if let Some(module_impl) = registry.get(&module_slug) {
-            let module_ctx = ModuleContext {
-                db: &app_ctx.db,
-                tenant_id: tenant.id,
-                config: &module.settings,
-            };
+        let module_ctx = ModuleContext {
+            db: &app_ctx.db,
+            tenant_id: tenant.id,
+            config: &module.settings,
+        };
 
-            let hook_result = if enabled {
-                module_impl.on_enable(module_ctx).await
-            } else {
-                module_impl.on_disable(module_ctx).await
-            };
+        let hook_result = if enabled {
+            module_impl.on_enable(module_ctx).await
+        } else {
+            module_impl.on_disable(module_ctx).await
+        };
 
-            if let Err(err) = hook_result {
-                tracing::error!(
-                    "Module hook failed for {} (enabled={}): {}",
-                    module_slug,
-                    enabled,
-                    err
-                );
-            }
+        if let Err(err) = hook_result {
+            tracing::error!(
+                "Module hook failed for {} (enabled={}): {}",
+                module_slug,
+                enabled,
+                err
+            );
         }
 
         Ok(TenantModule {

--- a/crates/rustok-core/src/registry.rs
+++ b/crates/rustok-core/src/registry.rs
@@ -27,15 +27,15 @@ impl ModuleRegistry {
     }
 
     pub fn list(&self) -> Vec<&dyn RusToKModule> {
-        self.modules
-            .values()
-            .map(|module| module.as_ref())
-            .collect()
+        let mut modules: Vec<&dyn RusToKModule> =
+            self.modules.values().map(|module| module.as_ref()).collect();
+        modules.sort_by_key(|module| module.slug());
+        modules
     }
 
     pub fn migrations(&self) -> Vec<ModuleMigration> {
-        self.modules
-            .values()
+        self.list()
+            .into_iter()
             .map(|module| ModuleMigration {
                 module_slug: module.slug(),
                 migrations: module.migrations(),
@@ -44,8 +44,8 @@ impl ModuleRegistry {
     }
 
     pub fn event_listeners(&self) -> Vec<Box<dyn EventListener>> {
-        self.modules
-            .values()
+        self.list()
+            .into_iter()
             .flat_map(|module| module.event_listeners())
             .collect()
     }


### PR DESCRIPTION
### Motivation
- Make module registry outputs deterministic so listings, migrations and event listeners are stable across runs.
- Prevent tenants from enabling modules with missing dependencies and from disabling modules that are required by other enabled modules.
- Resolve tenant host correctly when the app is behind proxies by honoring `X-Forwarded-Host` and `Forwarded` headers before falling back to `Host`.

### Description
- Sort module entries in `ModuleRegistry::list` by `slug` and make `migrations` and `event_listeners` iterate the sorted list instead of the raw map values (`crates/rustok-core/src/registry.rs`).
- Harden `toggle_module` GraphQL mutation to validate module existence, load the tenant's enabled modules, check for missing dependencies when enabling and check for dependents when disabling, and still run module hooks while logging hook failures (`apps/server/src/graphql/mutations.rs`).
- Improve tenant resolution middleware to extract the host from `X-Forwarded-Host` or parse the `Forwarded` header (looking for `host=`) before using the `Host` header, and keep the existing tenant caching behavior (`apps/server/src/middleware/tenant.rs`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b675d5d8832f89c191fc9f98ceac)