### PR TITLE
Add standard module tests and align manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +280,17 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1221,6 +1241,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1447,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1647,9 +1688,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1993,6 +2036,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -2402,7 +2462,7 @@ dependencies = [
  "once_cell",
  "pad-adapter",
  "paste",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "server_fn",
@@ -2468,7 +2528,7 @@ dependencies = [
  "oco_ref",
  "paste",
  "pin-project",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "self_cell",
  "serde",
  "serde-wasm-bindgen",
@@ -2704,6 +2764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "manyhow"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,10 +2880,13 @@ version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",
@@ -2969,6 +3038,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3497,6 +3588,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,21 +3834,28 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -3710,6 +3863,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -3818,6 +3972,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.114",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +4042,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3898,6 +4092,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3939,6 +4134,7 @@ dependencies = [
  "sea-orm-migration",
  "serde",
  "serde_json",
+ "utoipa",
  "uuid",
 ]
 
@@ -3956,6 +4152,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
+ "utoipa",
  "uuid",
 ]
 
@@ -3963,13 +4160,16 @@ dependencies = [
 name = "rustok-content"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "rustok-core",
  "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "slug",
  "thiserror 1.0.69",
+ "utoipa",
  "uuid",
 ]
 
@@ -3980,6 +4180,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "jsonwebtoken",
+ "once_cell",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -4023,11 +4224,14 @@ dependencies = [
  "jsonwebtoken",
  "loco-rs",
  "migration",
+ "moka",
+ "once_cell",
  "password-hash",
  "rand 0.8.5",
  "rust_decimal",
  "rustok-blog",
  "rustok-commerce",
+ "rustok-content",
  "rustok-core",
  "sea-orm",
  "serde",
@@ -4037,6 +4241,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -5738,6 +5944,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.114",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "reqwest",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6431,6 +6682,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "num_enum",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/RUSTOK_MANIFEST.md
+++ b/RUSTOK_MANIFEST.md
@@ -34,6 +34,16 @@
 - **Specialized Modules:** Товары, Блог и пр. — у каждого свои таблицы и бизнес-логика.
 - **Empty Tables Cost Zero:** Неиспользуемые таблицы не нагружают систему.
 
+**Module Contracts (code-aligned):**
+`rustok-core` — инфраструктурный crate, не регистрируется как `RusToKModule`. Остальные модули реализуют единый контракт (slug/name/description/version) и стандартный набор unit-тестов для метаданных и миграций.
+
+| Crate | slug | name | description |
+|-------|------|------|-------------|
+| `rustok-content` | `content` | Content | Core CMS Module (Nodes, Bodies, Categories) |
+| `rustok-blog` | `blog` | Blog | Posts, Pages, Comments |
+| `rustok-commerce` | `commerce` | Commerce | Products, Orders, Cart, Checkout |
+| `rustok-index` | `index` | Index | CQRS Read Model (Fast Search) |
+
 ### 2.3 CQRS (Write vs Read)
 - **Write Model (Modules):** строгие реляционные таблицы (3NF), транзакции, валидация.
 - **Read Model (Index/Catalog):** денормализованные JSONB-таблицы/индексы, GIN, быстрый поиск.

--- a/crates/rustok-blog/src/lib.rs
+++ b/crates/rustok-blog/src/lib.rs
@@ -35,3 +35,23 @@ impl MigrationSource for BlogModule {
         Vec::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_metadata() {
+        let module = BlogModule;
+        assert_eq!(module.slug(), "blog");
+        assert_eq!(module.name(), "Blog");
+        assert_eq!(module.description(), "Posts, Pages, Comments");
+        assert_eq!(module.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn module_migrations_empty() {
+        let module = BlogModule;
+        assert!(module.migrations().is_empty());
+    }
+}

--- a/crates/rustok-commerce/src/lib.rs
+++ b/crates/rustok-commerce/src/lib.rs
@@ -37,3 +37,23 @@ impl MigrationSource for CommerceModule {
         Vec::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_metadata() {
+        let module = CommerceModule;
+        assert_eq!(module.slug(), "commerce");
+        assert_eq!(module.name(), "Commerce");
+        assert_eq!(module.description(), "Products, Orders, Cart, Checkout");
+        assert_eq!(module.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn module_migrations_empty() {
+        let module = CommerceModule;
+        assert!(module.migrations().is_empty());
+    }
+}

--- a/crates/rustok-content/src/lib.rs
+++ b/crates/rustok-content/src/lib.rs
@@ -38,3 +38,23 @@ impl MigrationSource for ContentModule {
         Vec::new() // Migrations are currently handled by the main app
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_metadata() {
+        let module = ContentModule;
+        assert_eq!(module.slug(), "content");
+        assert_eq!(module.name(), "Content");
+        assert_eq!(module.description(), "Core CMS Module (Nodes, Bodies, Categories)");
+        assert_eq!(module.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn module_migrations_empty() {
+        let module = ContentModule;
+        assert!(module.migrations().is_empty());
+    }
+}

--- a/crates/rustok-index/Cargo.toml
+++ b/crates/rustok-index/Cargo.toml
@@ -10,6 +10,7 @@ rustok-core.workspace = true
 
 # Database
 sea-orm.workspace = true
+sea-orm-migration.workspace = true
 
 # Async
 tokio.workspace = true

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! Denormalized indexes for fast reads and full-text search.
 
+use async_trait::async_trait;
+use rustok_core::{MigrationSource, RusToKModule};
+use sea_orm_migration::MigrationTrait;
+
 pub mod content;
 pub mod error;
 pub mod product;
@@ -10,3 +14,50 @@ pub mod traits;
 
 pub use error::{IndexError, IndexResult};
 pub use traits::{Indexer, IndexerContext, LocaleIndexer};
+
+pub struct IndexModule;
+
+#[async_trait]
+impl RusToKModule for IndexModule {
+    fn slug(&self) -> &'static str {
+        "index"
+    }
+
+    fn name(&self) -> &'static str {
+        "Index"
+    }
+
+    fn description(&self) -> &'static str {
+        "CQRS Read Model (Fast Search)"
+    }
+
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+}
+
+impl MigrationSource for IndexModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_metadata() {
+        let module = IndexModule;
+        assert_eq!(module.slug(), "index");
+        assert_eq!(module.name(), "Index");
+        assert_eq!(module.description(), "CQRS Read Model (Fast Search)");
+        assert_eq!(module.version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn module_migrations_empty() {
+        let module = IndexModule;
+        assert!(module.migrations().is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure each module exposes a consistent metadata/migration contract so the manifest (project passport) reflects the code.
- Provide lightweight, identical unit tests across modules to detect accidental drift in `slug`/`name`/`description`/`version` and migration availability.
- Make the `rustok-index` crate follow the same module contract as other crates so it can be treated uniformly by the system registry and documentation.

### Description
- Added identical `#[cfg(test)]` unit tests to `crates/rustok-content`, `crates/rustok-blog`, and `crates/rustok-commerce` that assert `slug()`, `name()`, `description()`, `version()` and that `migrations()` is empty.
- Implemented an `IndexModule` in `crates/rustok-index/src/lib.rs` with the same module contract and added the same unit tests for `index`.
- Added `sea-orm-migration` to `crates/rustok-index/Cargo.toml` and updated `RUSTOK_MANIFEST.md` to document the module contracts and list crates with their `slug`/`name`/`description` for parity with the code.
- Committed the resulting dependency resolution changes to `Cargo.lock` so workspace snapshots remain consistent.

### Testing
- No automated tests were executed as part of this change; the PR only adds `cfg(test)` unit tests that can be run locally or in CI with `cargo test` and will exercise the module metadata/migration smoke checks.
- The added unit tests target `slug`, `name`, `description`, `version`, and `migrations().is_empty()` for each module and will pass when the module implementations remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e48b20a08327955c1b07725c8b62)