### PR TITLE
Add product_id to InventoryUpdated/PriceUpdated events and propagate for indexing

### DIFF
--- a/crates/rustok-commerce/src/services/inventory.rs
+++ b/crates/rustok-commerce/src/services/inventory.rs
@@ -62,6 +62,7 @@ impl InventoryService {
             Some(actor_id),
             DomainEvent::InventoryUpdated {
                 variant_id: input.variant_id,
+                product_id: variant.product_id,
                 location_id: Uuid::nil(),
                 old_quantity,
                 new_quantity,
@@ -110,6 +111,7 @@ impl InventoryService {
             Some(actor_id),
             DomainEvent::InventoryUpdated {
                 variant_id,
+                product_id: variant.product_id,
                 location_id: Uuid::nil(),
                 old_quantity,
                 new_quantity: quantity,

--- a/crates/rustok-commerce/src/services/pricing.rs
+++ b/crates/rustok-commerce/src/services/pricing.rs
@@ -30,7 +30,7 @@ impl PricingService {
         amount: Decimal,
         compare_at_amount: Option<Decimal>,
     ) -> CommerceResult<()> {
-        let _variant = entities::product_variant::Entity::find_by_id(variant_id)
+        let variant = entities::product_variant::Entity::find_by_id(variant_id)
             .filter(entities::product_variant::Column::TenantId.eq(tenant_id))
             .one(&self.db)
             .await?
@@ -84,6 +84,7 @@ impl PricingService {
             Some(actor_id),
             DomainEvent::PriceUpdated {
                 variant_id,
+                product_id: variant.product_id,
                 currency: currency_code.to_string(),
                 old_amount: old_cents,
                 new_amount: new_cents,

--- a/crates/rustok-core/src/events/types.rs
+++ b/crates/rustok-core/src/events/types.rs
@@ -154,6 +154,7 @@ pub enum DomainEvent {
     },
     InventoryUpdated {
         variant_id: Uuid,
+        product_id: Uuid,
         location_id: Uuid,
         old_quantity: i32,
         new_quantity: i32,
@@ -166,6 +167,7 @@ pub enum DomainEvent {
     },
     PriceUpdated {
         variant_id: Uuid,
+        product_id: Uuid,
         currency: String,
         old_amount: Option<i64>,
         new_amount: i64,

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -17,5 +17,11 @@
 - `handlers/` — обработчики событий.
 - `services/` — пересборка и обновление индексов.
 
+## События, которые триггерят пересборку
+- `ProductCreated`, `ProductUpdated`, `ProductPublished`, `ProductDeleted`.
+- `VariantCreated`, `VariantUpdated`, `VariantDeleted`.
+- `InventoryUpdated`, `PriceUpdated` (ожидается `product_id` в payload для быстрого реиндекса).
+- `ReindexRequested` (массовая пересборка или точечный реиндекс).
+
 ## Кому нужен
 Поиску, витрине, любым read-heavy запросам.

--- a/crates/rustok-index/src/product/indexer.rs
+++ b/crates/rustok-index/src/product/indexer.rs
@@ -100,12 +100,12 @@ impl EventHandler for ProductIndexer {
                 self.index_one(&ctx, *product_id).await?;
             }
 
-            DomainEvent::InventoryUpdated { .. } => {
-                // TODO: resolve product_id from variant_id
+            DomainEvent::InventoryUpdated { product_id, .. } => {
+                self.index_one(&ctx, *product_id).await?;
             }
 
-            DomainEvent::PriceUpdated { .. } => {
-                // TODO: resolve product_id from variant_id
+            DomainEvent::PriceUpdated { product_id, .. } => {
+                self.index_one(&ctx, *product_id).await?;
             }
 
             DomainEvent::ReindexRequested { target_id, .. } => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ To ensure maximum Performance on read paths (Storefront) without sacrificing dat
 
 ### 3. Event-Driven Decoupling
 Modules do not call each other directly. 
-- If `rustok-commerce` updates a product price, it emits a `ProductUpdated` event.
+- If `rustok-commerce` updates inventory or pricing, it emits `InventoryUpdated`/`PriceUpdated` events (with `product_id` for index refreshes).
 - The `rustok-index` module reacts and updates the search index.
 - A notification module (if present) might react and send an email.
 


### PR DESCRIPTION
### Motivation

- Avoid extra variant->product lookups in the indexer by including `product_id` directly in inventory/price events. 
- Make it possible for `rustok-index` to refresh product read-models immediately on inventory or price changes. 
- Keep documentation and architecture notes consistent with the event payloads used by commerce services.

### Description

- Added `product_id: Uuid` to `InventoryUpdated` and `PriceUpdated` in `crates/rustok-core/src/events/types.rs` so events carry the product reference. 
- Propagated `product_id` when publishing events from `crates/rustok-commerce/src/services/inventory.rs` and `crates/rustok-commerce/src/services/pricing.rs`, and fixed a minor unused-binding in pricing to use the retrieved `variant`. 
- Updated `crates/rustok-index/src/product/indexer.rs` to handle `InventoryUpdated` and `PriceUpdated` by calling `index_one` with the provided `product_id` (removing the previous TODO to resolve product from variant). 
- Documented the expectation in `crates/rustok-index/README.md` and updated `docs/architecture.md` to mention that `InventoryUpdated`/`PriceUpdated` include `product_id` for fast reindexing.

### Testing

- Attempted `cargo check -p rustok-core -p rustok-commerce -p rustok-index`, but the command failed due to inability to download the crates.io index in this environment (network 403), so a full build/compile could not be verified. 
- No other automated test suites were executed in this run due to the same network limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982135eb9f4832f8014ce55a8cee27c)