### PR TITLE
docs: describe tenant cache behavior and improvements

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,12 +64,13 @@ graph TD
 Every request passes through the `TenantContext` middleware, which identifies the tenant (site/store) based on headers or hostname. All database queries are automatically scoped by `tenant_id`.
 
 ### 1.1. Request-Level Caching (Tenant Context)
-To reduce repeated tenant lookups, the tenant resolver maintains an in-memory cache keyed by identifier (host/slug/uuid). The cache is TTL-based (5 minutes) and capacity-limited (1,000 entries). When a tenant is updated, the cache entry should be invalidated so future requests re-fetch fresh data.
+**Current behavior (code today)**  
+The tenant resolver middleware keeps a **local in-memory cache** (Moka) keyed by identifier (`host` / `slug` / `uuid`). It uses a **TTL of 5 minutes** and a **max capacity of 1,000 entries**. On cache hit, the request avoids a DB lookup; on miss, it queries the DB and stores the tenant context. After tenant updates, the cache entry should be explicitly invalidated by identifier so subsequent requests re-fetch fresh data.
 
-**Planned improvements**
+**Planned improvements (not yet implemented)**
 - Normalize cache keys (e.g., `uuid:`, `slug:`, `host:` prefixes) to avoid collisions and simplify debugging.
 - Add short-lived negative caching for 404 tenant lookups to reduce repeated DB hits.
-- Centralize cache metrics (hit/miss/evictions) and configure TTL/size based on production data.
+- Add cache metrics (hit/miss/evictions) and tune TTL/size based on production traffic.
 - Consider routing tenant cache through the shared `CacheBackend` interface to enable distributed caches (e.g., Redis) and unified observability.
 
 ### 2. CQRS-lite (Write vs Read)


### PR DESCRIPTION
### Motivation
- Document the tenant resolver's request-level caching behavior and proposed operational improvements for clarity in the architecture notes.

### Description
- Added `### 1.1. Request-Level Caching (Tenant Context)` to `docs/architecture.md` describing an in-memory cache keyed by host/slug/uuid with a TTL of `5 minutes`, capacity of `1,000` entries, and invalidation on tenant updates.
- Enumerated planned improvements including cache key normalization, short-lived negative caching for 404s, centralized cache metrics, and optional routing through the shared `CacheBackend` (e.g., `Redis`) for distributed caches and unified observability.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822a2480e8832fa561098ac629074b)