### PR TITLE
Derive `Default` for `IggyConfig`

### DIFF
--- a/crates/rustok-iggy/src/config.rs
+++ b/crates/rustok-iggy/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct IggyConfig {
     #[serde(default)]
     pub mode: IggyMode,


### PR DESCRIPTION
### Motivation
- Enable `IggyConfig::default()` used by tests and callers to fix a compilation error in the `rustok-iggy` integration test.

### Description
- Add `#[derive(Default)]` to `IggyConfig` in `crates/rustok-iggy/src/config.rs` so `IggyConfig::default()` is available.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698259e91508832fac327101d3e4ffb4)