### PR TITLE
Harden admin demo auth and JWT validation defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ cargo loco start
 
 # Run admin panel (terminal 2)
 cd apps/admin
-trunk serve --open
+RUSTOK_DEMO_MODE=1 trunk serve --open
 
 # Run storefront (terminal 3)
 cargo run -p rustok-storefront
@@ -275,6 +275,9 @@ npm run build:css
 # Admin: http://localhost:8080
 # Storefront (SSR): http://localhost:3100?lang=en
 ```
+
+> ⚠️ Admin demo mode is disabled by default. Set `RUSTOK_DEMO_MODE=1` only for local demos.
+> For real authentication, use the backend `/api/auth` endpoints with HttpOnly cookies.
 
 ### First Steps
 

--- a/apps/admin/src/pages/login.rs
+++ b/apps/admin/src/pages/login.rs
@@ -9,9 +9,10 @@ pub fn Login() -> impl IntoView {
     let auth = use_auth();
     let navigate = use_navigate();
 
-    let (tenant, set_tenant) = create_signal("demo".to_string());
-    let (email, set_email) = create_signal("admin@rustok.io".to_string());
-    let (password, set_password) = create_signal("password123".to_string());
+    let demo_mode = option_env!("RUSTOK_DEMO_MODE").is_some();
+    let (tenant, set_tenant) = create_signal(String::new());
+    let (email, set_email) = create_signal(String::new());
+    let (password, set_password) = create_signal(String::new());
     let (error, set_error) = create_signal(Option::<String>::None);
 
     let navigate_effect = navigate.clone();
@@ -24,6 +25,14 @@ pub fn Login() -> impl IntoView {
     let on_submit = move |_| {
         if tenant.get().is_empty() || email.get().is_empty() || password.get().is_empty() {
             set_error.set(Some("Заполните все поля".to_string()));
+            return;
+        }
+
+        if !demo_mode {
+            set_error.set(Some(
+                "Демо-вход отключен. Используйте серверную аутентификацию или включите RUSTOK_DEMO_MODE."
+                    .to_string(),
+            ));
             return;
         }
 
@@ -67,9 +76,11 @@ pub fn Login() -> impl IntoView {
                     <Button on_click=on_submit class="w-full">
                         "Продолжить"
                     </Button>
-                    <a class="secondary-link" href="/dashboard">
-                        "Перейти в демонстрационный дашборд →"
-                    </a>
+                    <Show when=move || demo_mode>
+                        <a class="secondary-link" href="/dashboard">
+                            "Перейти в демонстрационный дашборд →"
+                        </a>
+                    </Show>
                 </div>
                 <p style="margin:0; color:#64748b;">
                     "Нужен доступ? Напишите администратору безопасности для активации."

--- a/apps/admin/src/providers/auth.rs
+++ b/apps/admin/src/providers/auth.rs
@@ -1,4 +1,3 @@
-use gloo_storage::{LocalStorage, Storage};
 use leptos::*;
 use serde::{Deserialize, Serialize};
 
@@ -19,25 +18,8 @@ pub struct AuthContext {
 }
 
 pub fn provide_auth_context() {
-    let stored_token: Option<String> = LocalStorage::get("auth_token").ok();
-    let stored_user: Option<User> = LocalStorage::get("auth_user").ok();
-
-    let (user, set_user) = create_signal(stored_user);
-    let (token, set_token) = create_signal(stored_token);
-
-    create_effect(move |_| {
-        if let Some(t) = token.get() {
-            let _ = LocalStorage::set("auth_token", t);
-        } else {
-            LocalStorage::delete("auth_token");
-        }
-
-        if let Some(u) = user.get() {
-            let _ = LocalStorage::set("auth_user", u);
-        } else {
-            LocalStorage::delete("auth_user");
-        }
-    });
+    let (user, set_user) = create_signal(None);
+    let (token, set_token) = create_signal(None);
 
     provide_context(AuthContext {
         user,

--- a/apps/server/config/development.yaml
+++ b/apps/server/config/development.yaml
@@ -23,6 +23,8 @@ auth:
 settings:
   auth:
     refresh_expiration: 1209600
+    issuer: rustok
+    audience: rustok-admin
   rustok:
     tenant:
       enabled: true

--- a/apps/server/config/test.yaml
+++ b/apps/server/config/test.yaml
@@ -22,6 +22,8 @@ auth:
 settings:
   auth:
     refresh_expiration: 86400
+    issuer: rustok
+    audience: rustok-admin
   rustok:
     tenant:
       enabled: true

--- a/crates/rustok-content/src/services/node_service.rs
+++ b/crates/rustok-content/src/services/node_service.rs
@@ -133,7 +133,7 @@ impl NodeService {
         &self,
         node_id: Uuid,
         security: SecurityContext,
-        update: UpdateNodeInput,
+        mut update: UpdateNodeInput,
     ) -> ContentResult<NodeResponse> {
         let node_model = self.find_node(node_id).await?;
 
@@ -147,6 +147,11 @@ impl NodeService {
                 if node_model.author_id != security.user_id {
                     return Err(ContentError::Forbidden(
                         "Permission denied: Not the author".into(),
+                    ));
+                }
+                if update.author_id.is_some() {
+                    return Err(ContentError::Forbidden(
+                        "Permission denied: cannot change author".into(),
                     ));
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent insecure persistent admin auth in the browser and avoid an always-enabled demo login that can leak tokens.
- Ensure JWT validation includes issuer and audience checks with sensible defaults to reduce token misuse.
- Prevent privilege escalation by disallowing author reassignment when a user only has "own" update scope.

### Description
- Admin auth provider: stop persisting `auth_token`/`auth_user` to `LocalStorage` and use in-memory signals instead (`apps/admin/src/providers/auth.rs`).
- Admin login UI: clear default demo credentials, gate demo login behind `RUSTOK_DEMO_MODE`, and only show the demo-link when the env var is set (`apps/admin/src/pages/login.rs`).
- Node update service: make the `update` argument mutable and return `Forbidden` if a user with `PermissionScope::Own` attempts to change `author_id` (`crates/rustok-content/src/services/node_service.rs`).
- Server auth: add `iss`/`aud` claims to `Claims`, include `issuer`/`audience` in `AuthConfig`, read defaults from settings, and enforce issuer/audience validation when decoding tokens (`apps/server/src/auth.rs`).
- Config and docs: add `issuer`/`audience` defaults to `development.yaml` and `test.yaml`, and document demo-mode usage + startup hint in `README.md`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983202124548327a70940d4724dfe33)