### PR TITLE
chore: bump Rust workspace dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ repository = "https://github.com/RustokCMS/RusToK"
 
 [workspace.dependencies]
 # Loco Framework
-loco-rs = "0.12"
+loco-rs = "0.16.4"
 
 # Async Runtime
 tokio = { version = "1.40", features = ["full"] }
 
 # Web
-axum = "0.7"
+axum = "0.8.8"
 tower = "0.5"
 tower-http = { version = "0.5", features = ["cors", "fs"] }
 
@@ -43,7 +43,7 @@ sea-orm = { version = "1.0", features = [
 sea-orm-migration = { version = "1.0", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 
 # GraphQL
-async-graphql = { version = "6.0", features = ["uuid", "chrono"] }
+async-graphql = { version = "7.2.1", features = ["uuid", "chrono"] }
 base64 = "0.22"
 
 # IDs
@@ -55,28 +55,28 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Error Handling
-thiserror = "1.0"
+thiserror = "2.0.18"
 anyhow = "1.0"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 
 # Leptos
-leptos = "0.6"
-leptos_axum = "0.6"
-leptos_router = "0.6"
+leptos = "0.8.15"
+leptos_axum = "0.8.15"
+leptos_router = "0.8.15"
 
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 async-trait = "0.1"
 rust_decimal = "1.36"
-utoipa = "4.2"
+utoipa = "5.4.0"
 utoipa-swagger-ui = { version = "7.0", features = ["vendored"] }
 moka = { version = "0.12", features = ["future"] }
 argon2 = "0.5"
-jsonwebtoken = "9.3"
-rand = "0.8"
+jsonwebtoken = "10.3.0"
+rand = "0.9.2"
 password-hash = "0.5"
 sha2 = "0.10"
 once_cell = "1.19"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -19,7 +19,7 @@ alloy-scripting.workspace = true
 loco-rs.workspace = true
 tokio.workspace = true
 axum.workspace = true
-axum-extra = { version = "0.9", features = ["typed-header"] }
+axum-extra = { version = "0.12.5", features = ["typed-header"] }
 sea-orm.workspace = true
 async-graphql.workspace = true
 serde.workspace = true

--- a/crates/alloy-scripting/Cargo.toml
+++ b/crates/alloy-scripting/Cargo.toml
@@ -14,7 +14,7 @@ uuid = { workspace = true }
 tokio = { version = "1", features = ["sync", "time"] }
 async-trait = "0.1"
 cron = "0.12"
-axum = "0.7"
+axum = "0.8.8"
 tower = "0.4"
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 serde_json = "1"

--- a/crates/rustok-core/Cargo.toml
+++ b/crates/rustok-core/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 tokio = { workspace = true }
-jsonwebtoken = "9"
+jsonwebtoken = "10.3.0"
 argon2.workspace = true
 once_cell = "1.19"
 sea-orm-migration.workspace = true

--- a/crates/rustok-iggy/Cargo.toml
+++ b/crates/rustok-iggy/Cargo.toml
@@ -13,7 +13,7 @@ tracing.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
-bincode = "1.3"
+bincode = "3.0.0"
 
 rustok-core.workspace = true
 


### PR DESCRIPTION
### Motivation
- Update several workspace and crate dependency versions to match recent dependency bumps (security/feature updates and newer upstream releases). 
- Keep crate manifests consistent so workspace crates can build against the same major/minor library versions.

### Description
- Bumped workspace dependencies in `Cargo.toml` for `loco-rs`, `axum`, `async-graphql`, `thiserror`, `leptos`/`leptos_axum`/`leptos_router`, `utoipa`, `jsonwebtoken`, and `rand` to the requested versions.
- Updated crate manifests to match the workspace bumps by changing `apps/server/Cargo.toml` (`axum-extra` -> `0.12.5`), `crates/alloy-scripting/Cargo.toml` (`axum` -> `0.8.8`), `crates/rustok-core/Cargo.toml` (`jsonwebtoken` -> `10.3.0`), and `crates/rustok-iggy/Cargo.toml` (`bincode` -> `3.0.0`).
- Committed the manifest changes with message `chore: bump rust dependencies`.

### Testing
- Attempted `cargo update -p ...` to refresh `Cargo.lock`, but the update failed due to crates.io network restrictions in the environment (download/config index returned a 403 CONNECT tunnel error), so `Cargo.lock` was not updated and dependency fetch failed.
- No build or test suite was run in this environment; manifest edits were committed locally and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983494ef4b0832f9faa3f4d3aec83f5)