### PR TITLE
Fix borrow error in script execution handler

### DIFF
--- a/crates/alloy-scripting/src/api/handlers.rs
+++ b/crates/alloy-scripting/src/api/handlers.rs
@@ -163,15 +163,16 @@ pub async fn run_script<S: ScriptRegistry>(
         .await
         .map_err(ApiError::from)?;
 
-    let (success, error, changes, return_value) = match result.outcome {
+    let (success, error, changes, return_value) = match &result.outcome {
         crate::runner::ExecutionOutcome::Success {
             return_value,
             entity_changes,
         } => (
             true,
             None,
-            Some(convert_map(entity_changes)),
+            Some(convert_map(entity_changes.clone())),
             return_value
+                .clone()
                 .map(dynamic_to_json)
                 .unwrap_or(serde_json::Value::Null),
         ),


### PR DESCRIPTION
### Motivation
- Resolve a compile error (`E0382`) in `crates/alloy-scripting/src/api/handlers.rs` where matching `result.outcome` moved fields and prevented subsequent access to `result.duration_ms()`.

### Description
- Match on a reference (`&result.outcome`) and clone the needed fields by using `entity_changes.clone()` and `return_value.clone()` so the handler no longer partially moves `result`.

### Testing
- No automated tests or builds were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836603f498832fa154eb69df19624d)