### PR TITLE
Label Leptos login language toggle; add Next login locale buttons and i18n alias

### DIFF
--- a/apps/admin/src/app.rs
+++ b/apps/admin/src/app.rs
@@ -113,6 +113,7 @@ fn Style() -> impl IntoView {
             ".auth-card { background: #fff; border-radius: 24px; padding: 32px; box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12); display: flex; flex-direction: column; gap: 20px; }\n"
             ".auth-card h2 { margin: 0; font-size: 1.75rem; }\n"
             ".auth-card p { margin: 0; color: #64748b; }\n"
+            ".auth-locale { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 0.9rem; color: #475569; }\n"
             ".input-group { display: flex; flex-direction: column; gap: 8px; }\n"
             ".input-group label { font-size: 0.9rem; color: #475569; }\n"
             ".input-group input { padding: 12px 16px; border-radius: 12px; border: 1px solid #e2e8f0; font-size: 0.95rem; }\n"

--- a/apps/admin/src/pages/login.rs
+++ b/apps/admin/src/pages/login.rs
@@ -129,7 +129,10 @@ pub fn Login() -> impl IntoView {
                         <h2>{move || translate(locale.locale.get(), "auth.title")}</h2>
                         <p>{move || translate(locale.locale.get(), "auth.subtitle")}</p>
                     </div>
-                    <LanguageToggle />
+                    <div class="auth-locale">
+                        <span>{move || translate(locale.locale.get(), "auth.languageLabel")}</span>
+                        <LanguageToggle />
+                    </div>
                     <Show when=move || error.get().is_some()>
                         <div class="alert">{move || error.get().unwrap_or_default()}</div>
                     </Show>

--- a/apps/admin/src/providers/locale/login.rs
+++ b/apps/admin/src/providers/locale/login.rs
@@ -13,6 +13,7 @@ pub fn translate_en(key: &str) -> Option<&'static str> {
         "auth.emailLabel" => Some("Email"),
         "auth.passwordLabel" => Some("Password"),
         "auth.submit" => Some("Continue"),
+        "auth.languageLabel" => Some("Language"),
         "auth.demoLink" => Some("Open demo dashboard →"),
         "auth.footer" => Some("Need access? Contact a security administrator to activate."),
         "auth.errorRequired" => Some("Please fill in all fields"),
@@ -38,6 +39,7 @@ pub fn translate_ru(key: &str) -> Option<&'static str> {
         "auth.emailLabel" => Some("Email"),
         "auth.passwordLabel" => Some("Пароль"),
         "auth.submit" => Some("Продолжить"),
+        "auth.languageLabel" => Some("Язык"),
         "auth.demoLink" => Some("Перейти в демонстрационный дашборд →"),
         "auth.footer" => Some(
             "Нужен доступ? Напишите администратору безопасности для активации.",

--- a/apps/next-admin/src/app/[locale]/login/view.tsx
+++ b/apps/next-admin/src/app/[locale]/login/view.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { locales } from "@/i18n";
 
 type LoginFormProps = {
   locale: string;
@@ -93,6 +95,24 @@ export default function LoginForm({ locale }: LoginFormProps) {
                 {t("title")}
               </h2>
               <p className="mt-2 text-sm text-slate-500">{t("subtitle")}</p>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              {locales.map((targetLocale) => (
+                <Button
+                  asChild
+                  key={targetLocale}
+                  size="md"
+                  variant={targetLocale === locale ? "primary" : "outline"}
+                >
+                  <Link
+                    aria-current={targetLocale === locale ? "page" : undefined}
+                    href={`/${targetLocale}/login`}
+                  >
+                    {targetLocale.toUpperCase()}
+                  </Link>
+                </Button>
+              ))}
             </div>
 
             {error ? (

--- a/apps/next-admin/tsconfig.json
+++ b/apps/next-admin/tsconfig.json
@@ -17,6 +17,7 @@
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["src/components/*"],
+      "@/i18n": ["src/i18n.ts"],
       "@/styles/*": ["src/styles/*"]
     }
   },


### PR DESCRIPTION
### Motivation
- Make the login locale switcher more discoverable in the Leptos admin UI by adding a label and aligned styling. 
- Surface a simple RU/EN locale toggle on the Next.js admin login and provide a stable import path for locale data so the view can iterate available locales.

### Description
- Wrapped the Leptos `LanguageToggle` with a labeled row in `apps/admin/src/pages/login.rs` and translated the label via `auth.languageLabel`.
- Added `.auth-locale` styling in `apps/admin/src/app.rs` to align the label with the toggle controls.
- Added English and Russian translations for `auth.languageLabel` in `apps/admin/src/providers/locale/login.rs`.
- Updated the Next login view in `apps/next-admin/src/app/[locale]/login/view.tsx` to import `locales` from `@/i18n` and render per-locale buttons linking to `/{locale}/login`, highlighting the active locale.
- Added a `@/i18n` path alias to `apps/next-admin/tsconfig.json` mapping to `src/i18n.ts` for stable imports.

### Testing
- No automated tests were run for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837e2817c4832786c9ef94b0e06464)