### PR TITLE
Fix leptos render_to_string import for storefront SSR

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -6,7 +6,8 @@ use axum::{
 };
 // GlobalAttributes enables id= usage in view! macros.
 use leptos::prelude::{ClassAttribute, CollectView, ElementChild, GlobalAttributes};
-use leptos::{component, render_to_string, view, IntoView};
+use leptos::ssr::render_to_string;
+use leptos::{component, view, IntoView};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 


### PR DESCRIPTION
### Motivation
- Update the storefront SSR import because `render_to_string` is no longer exported from the `leptos` root, causing a compile error (E0432) when building the storefront.

### Description
- Replace `use leptos::{component, render_to_string, view, IntoView};` with `use leptos::ssr::render_to_string;` and `use leptos::{component, view, IntoView};` in `apps/storefront/src/main.rs`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983968d02e48327aebb6d978fde2b42)