### PR TITLE
Fix Leptos SSR render import in storefront

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -5,8 +5,9 @@ use axum::{
     Router,
 };
 // GlobalAttributes enables id= usage in view! macros.
-use leptos::prelude::{ClassAttribute, CollectView, ElementChild, GlobalAttributes};
-use leptos::ssr::render_to_string;
+use leptos::prelude::{
+    render_to_string, ClassAttribute, CollectView, ElementChild, GlobalAttributes,
+};
 use leptos::{component, view, IntoView};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;


### PR DESCRIPTION
### Motivation
- Fix the compile error caused by the unresolved import `leptos::ssr::render_to_string` by using the `render_to_string` re-export from Leptos' prelude so SSR rendering can be referenced from the storefront app.

### Description
- Update the import in `apps/storefront/src/main.rs` to pull `render_to_string` from `leptos::prelude` and consolidate the Leptos prelude imports (replacing the separate `leptos::ssr::render_to_string` import).

### Testing
- No automated tests or builds were run after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698397ce184c8327a0bfbf88a2ba3431)