### PR TITLE
Fix leptos SSR render import

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -5,9 +5,8 @@ use axum::{
     Router,
 };
 // GlobalAttributes enables id= usage in view! macros.
-use leptos::prelude::{
-    render_to_string, ClassAttribute, CollectView, ElementChild, GlobalAttributes,
-};
+use leptos::prelude::{ClassAttribute, CollectView, ElementChild, GlobalAttributes};
+use leptos::ssr::render_to_string;
 use leptos::{component, view, IntoView};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by an unresolved `render_to_string` import by aligning with the current Leptos API.

### Description
- Replace `render_to_string` import from `leptos::prelude` with `use leptos::ssr::render_to_string;` and keep other prelude items in `apps/storefront/src/main.rs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983992f7658832789df3d7dc990e398)