### PR TITLE
Use RenderHtml::to_html for storefront SSR

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -5,8 +5,9 @@ use axum::{
     Router,
 };
 // GlobalAttributes enables id= usage in view! macros.
-use leptos::prelude::{ClassAttribute, CollectView, ElementChild, GlobalAttributes};
-use leptos::ssr::render_to_string;
+use leptos::prelude::{
+    ClassAttribute, CollectView, ElementChild, GlobalAttributes, RenderHtml,
+};
 use leptos::{component, view, IntoView};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -325,10 +326,10 @@ fn StorefrontShell(locale: String) -> impl IntoView {
 
 fn render_shell(locale: &str) -> String {
     let locale_owned = locale.to_string();
-    let app_html = render_to_string(move || {
+    let app_html = {
         let locale = locale_owned.clone();
-        view! { <StorefrontShell locale=locale /> }
-    });
+        view! { <StorefrontShell locale=locale /> }.to_html()
+    };
     format!(
         r#"<!DOCTYPE html>
 <html lang="{locale}" data-theme="rustok">


### PR DESCRIPTION
### Motivation
- The storefront binary failed to compile due to an unresolved `leptos::ssr::render_to_string` import, so SSR rendering was switched to the supported `RenderHtml` API to restore builds.

### Description
- Replace the obsolete `leptos::ssr::render_to_string` usage with `view! { <StorefrontShell ... /> }.to_html()` and add `RenderHtml` to the `leptos::prelude` import so server-side rendering produces an HTML string directly.

### Testing
- Ran `cargo check -p rustok-storefront` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839abf3bf48327a52023942b74fade)