### PR TITLE
Fix storefront SSR import

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -6,7 +6,6 @@ use axum::{
 };
 // GlobalAttributes enables id= usage in view! macros.
 use leptos::prelude::{ClassAttribute, CollectView, ElementChild, GlobalAttributes, RenderHtml};
-use leptos::ssr::render_to_string;
 use leptos::{component, view, IntoView};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;


### PR DESCRIPTION
### Motivation
- Remove an unused `leptos::ssr::render_to_string` import that caused a compile error (`could not find ssr in leptos`) when building the `rustok-storefront` binary.

### Description
- Deleted the unused import line in `apps/storefront/src/main.rs` (`use leptos::ssr::render_to_string;`) to eliminate the unresolved import error.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839e9c45f483278acb92a45cf78b1e)