### PR TITLE
Format user details parameter handling

### DIFF
--- a/apps/admin/src/pages/user_details.rs
+++ b/apps/admin/src/pages/user_details.rs
@@ -45,26 +45,20 @@ pub fn UserDetails() -> impl IntoView {
     let user_resource = Resource::new(
         move || {
             (
-                params.with(|params| {
-                    params
-                        .as_ref()
-                        .ok()
-                        .and_then(|params| params.id.clone())
-                }),
+                params.with(|params| params.as_ref().ok().and_then(|params| params.id.clone())),
                 tenant_slug.get(),
             )
         },
         move |_| {
             let token = auth.token.get().unwrap_or_default();
             let tenant = tenant_slug.get().trim().to_string();
-            let user_id = params
-                .with(|params| {
-                    params
-                        .as_ref()
-                        .ok()
-                        .and_then(|params| params.id.clone())
-                        .unwrap_or_default()
-                });
+            let user_id = params.with(|params| {
+                params
+                    .as_ref()
+                    .ok()
+                    .and_then(|params| params.id.clone())
+                    .unwrap_or_default()
+            });
 
             async move {
                 request::<UserVariables, GraphqlUserResponse>(


### PR DESCRIPTION
### Motivation
- Improve readability by applying rustfmt-style wrapping to parameter extraction in the admin user details resource without changing behavior.

### Description
- Rewrapped the `params.with(...)` closures in `apps/admin/src/pages/user_details.rs` to a consistent rustfmt layout: the first call is condensed to one line and the second is reformatted to multi-line indentation, with no logic changes.

### Testing
- Ran `cargo fmt --all` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b192a6848327812e31a56248774c)