### PR TITLE
Fix admin resource serialization and view rendering

### DIFF
--- a/apps/admin/src/api/mod.rs
+++ b/apps/admin/src/api/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 pub const API_URL: &str = "http://localhost:3000/api/graphql";
 pub const REST_API_URL: &str = "http://localhost:3000";
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum ApiError {
     #[error("Network error")]
     Network,

--- a/apps/admin/src/components/ui.rs
+++ b/apps/admin/src/components/ui.rs
@@ -8,7 +8,7 @@ pub fn Button(
     #[prop(into)] on_click: Callback<web_sys::MouseEvent>,
     #[prop(optional)] children: Option<Children>,
     #[prop(optional, into)] class: String,
-    #[prop(default = false, into)] disabled: MaybeSignal<bool>,
+    #[prop(default = false, into)] disabled: Signal<bool>,
 ) -> impl IntoView {
     view! {
         <button

--- a/apps/admin/src/pages/dashboard.rs
+++ b/apps/admin/src/pages/dashboard.rs
@@ -98,9 +98,9 @@ pub fn Dashboard() -> impl IntoView {
                     .map(|(title, value, hint)| {
                         view! {
                             <div class="stat-card">
-                                <h3>{*title}</h3>
+                                <h3>{title.clone()}</h3>
                                 <strong>{*value}</strong>
-                                <p style="margin:8px 0 0; color:#94a3b8;">{*hint}</p>
+                                <p style="margin:8px 0 0; color:#94a3b8;">{hint.clone()}</p>
                             </div>
                         }
                     })
@@ -116,10 +116,10 @@ pub fn Dashboard() -> impl IntoView {
                             view! {
                                 <div class="activity-item">
                                     <div>
-                                        <strong>{*title}</strong>
-                                        <p style="margin:4px 0 0; color:#64748b;">{*detail}</p>
+                                        <strong>{title.clone()}</strong>
+                                        <p style="margin:4px 0 0; color:#64748b;">{detail.clone()}</p>
                                     </div>
-                                    <span class="badge">{*time}</span>
+                                    <span class="badge">{time.clone()}</span>
                                 </div>
                             }
                         })

--- a/apps/admin/src/pages/user_details.rs
+++ b/apps/admin/src/pages/user_details.rs
@@ -13,12 +13,12 @@ struct UserParams {
     id: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUserResponse {
     user: Option<GraphqlUser>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUser {
     id: String,
     email: String,

--- a/apps/admin/src/pages/users.rs
+++ b/apps/admin/src/pages/users.rs
@@ -7,7 +7,7 @@ use crate::components::ui::{Button, Input, LanguageToggle};
 use crate::providers::auth::use_auth;
 use crate::providers::locale::{translate, use_locale};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct RestUser {
     id: String,
     email: String,
@@ -15,24 +15,24 @@ struct RestUser {
     role: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUsersResponse {
     users: GraphqlUsersConnection,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUsersConnection {
     edges: Vec<GraphqlUserEdge>,
     #[serde(rename = "pageInfo")]
     page_info: GraphqlPageInfo,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUserEdge {
     node: GraphqlUser,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlUser {
     id: String,
     email: String,
@@ -43,7 +43,7 @@ struct GraphqlUser {
     created_at: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct GraphqlPageInfo {
     #[serde(rename = "totalCount")]
     total_count: i64,
@@ -184,7 +184,12 @@ pub fn Users() -> impl IntoView {
                     <h4>{move || translate(locale.locale.get(), "users.rest.title")}</h4>
                     <Suspense fallback=move || view! { <p>{move || translate(locale.locale.get(), "users.rest.loading")}</p> }>
                         {move || match rest_resource.get() {
-                            None => view! { <p>{move || translate(locale.locale.get(), "users.rest.pending")}</p> }.into_view(),
+                            None => view! {
+                                <div>
+                                    <p>{move || translate(locale.locale.get(), "users.rest.pending")}</p>
+                                </div>
+                            }
+                            .into_view(),
                             Some(Ok(user)) => view! {
                                 <div class="user-card">
                                     <strong>{user.email}</strong>
@@ -215,113 +220,120 @@ pub fn Users() -> impl IntoView {
                     <h4>{move || translate(locale.locale.get(), "users.graphql.title")}</h4>
                     <Suspense fallback=move || view! { <p>{move || translate(locale.locale.get(), "users.rest.loading")}</p> }>
                         {move || match graphql_resource.get() {
-                            None => view! { <p>{move || translate(locale.locale.get(), "users.rest.pending")}</p> }.into_view(),
+                            None => view! {
+                                <div>
+                                    <p>{move || translate(locale.locale.get(), "users.rest.pending")}</p>
+                                </div>
+                            }
+                            .into_view(),
                             Some(Ok(response)) => view! {
-                                <p class="meta-text">
-                                    {move || translate(locale.locale.get(), "users.graphql.total")} " " {response.users.page_info.total_count}
-                                </p>
-                                <div class="table-filters">
-                                    <Input
-                                        value=search_query
-                                        set_value=set_search_query
-                                        placeholder=move || translate(locale.locale.get(), "users.filters.searchPlaceholder")
-                                        label=move || translate(locale.locale.get(), "users.filters.search")
-                                    />
-                                    <Input
-                                        value=role_filter
-                                        set_value=set_role_filter
-                                        placeholder=move || translate(locale.locale.get(), "users.filters.rolePlaceholder")
-                                        label=move || translate(locale.locale.get(), "users.filters.role")
-                                    />
-                                    <Input
-                                        value=status_filter
-                                        set_value=set_status_filter
-                                        placeholder=move || translate(locale.locale.get(), "users.filters.statusPlaceholder")
-                                        label=move || translate(locale.locale.get(), "users.filters.status")
-                                    />
-                                </div>
-                                <div class="table-wrap">
-                                    <table class="data-table">
-                                        <thead>
-                                            <tr>
-                                                <th>{move || translate(locale.locale.get(), "users.graphql.email")}</th>
-                                                <th>{move || translate(locale.locale.get(), "users.graphql.name")}</th>
-                                                <th>{move || translate(locale.locale.get(), "users.graphql.role")}</th>
-                                                <th>{move || translate(locale.locale.get(), "users.graphql.status")}</th>
-                                                <th>{move || translate(locale.locale.get(), "users.graphql.createdAt")}</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {{
-                                                let query = search_query.get().to_lowercase();
-                                                let role = role_filter.get().to_lowercase();
-                                                let status = status_filter.get().to_lowercase();
+                                <div>
+                                    <p class="meta-text">
+                                        {move || translate(locale.locale.get(), "users.graphql.total")} " " {response.users.page_info.total_count}
+                                    </p>
+                                    <div class="table-filters">
+                                        <Input
+                                            value=search_query
+                                            set_value=set_search_query
+                                            placeholder=move || translate(locale.locale.get(), "users.filters.searchPlaceholder")
+                                            label=move || translate(locale.locale.get(), "users.filters.search")
+                                        />
+                                        <Input
+                                            value=role_filter
+                                            set_value=set_role_filter
+                                            placeholder=move || translate(locale.locale.get(), "users.filters.rolePlaceholder")
+                                            label=move || translate(locale.locale.get(), "users.filters.role")
+                                        />
+                                        <Input
+                                            value=status_filter
+                                            set_value=set_status_filter
+                                            placeholder=move || translate(locale.locale.get(), "users.filters.statusPlaceholder")
+                                            label=move || translate(locale.locale.get(), "users.filters.status")
+                                        />
+                                    </div>
+                                    <div class="table-wrap">
+                                        <table class="data-table">
+                                            <thead>
+                                                <tr>
+                                                    <th>{move || translate(locale.locale.get(), "users.graphql.email")}</th>
+                                                    <th>{move || translate(locale.locale.get(), "users.graphql.name")}</th>
+                                                    <th>{move || translate(locale.locale.get(), "users.graphql.role")}</th>
+                                                    <th>{move || translate(locale.locale.get(), "users.graphql.status")}</th>
+                                                    <th>{move || translate(locale.locale.get(), "users.graphql.createdAt")}</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {{
+                                                    let query = search_query.get().to_lowercase();
+                                                    let role = role_filter.get().to_lowercase();
+                                                    let status = status_filter.get().to_lowercase();
 
-                                                response
-                                                    .users
-                                                    .edges
-                                                    .iter()
-                                                    .filter(|edge| {
-                                                        let user = &edge.node;
-                                                        let name = user.name.clone().unwrap_or_default().to_lowercase();
-                                                        let email = user.email.to_lowercase();
-                                                        let role_value = user.role.to_lowercase();
-                                                        let status_value = user.status.to_lowercase();
+                                                    response
+                                                        .users
+                                                        .edges
+                                                        .iter()
+                                                        .filter(|edge| {
+                                                            let user = &edge.node;
+                                                            let name = user.name.clone().unwrap_or_default().to_lowercase();
+                                                            let email = user.email.to_lowercase();
+                                                            let role_value = user.role.to_lowercase();
+                                                            let status_value = user.status.to_lowercase();
 
-                                                        let matches_query = query.is_empty()
-                                                            || email.contains(&query)
-                                                            || name.contains(&query);
-                                                        let matches_role = role.is_empty()
-                                                            || role_value.contains(&role);
-                                                        let matches_status = status.is_empty()
-                                                            || status_value.contains(&status);
+                                                            let matches_query = query.is_empty()
+                                                                || email.contains(&query)
+                                                                || name.contains(&query);
+                                                            let matches_role = role.is_empty()
+                                                                || role_value.contains(&role);
+                                                            let matches_status = status.is_empty()
+                                                                || status_value.contains(&status);
 
-                                                        matches_query && matches_role && matches_status
-                                                    })
-                                                    .map(|edge| {
-                                                        let user = &edge.node;
-                                                        view! {
-                                                            <tr>
-                                                                <td>
-                                                                    <A href=format!("/users/{}", user.id.clone())>
-                                                                        {user.email.clone()}
-                                                                    </A>
-                                                                </td>
-                                                                <td>{user.name.clone().unwrap_or_else(|| translate(locale.locale.get(), "users.placeholderDash").to_string())}</td>
-                                                                <td>{user.role.clone()}</td>
-                                                                <td>
-                                                                    <span class="status-pill">{user.status.clone()}</span>
-                                                                </td>
-                                                                <td>{user.created_at.clone()}</td>
-                                                            </tr>
-                                                        }
-                                                    })
-                                                    .collect_view()
-                                            }}
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <div class="table-actions">
-                                    <Button
-                                        on_click=previous_page
-                                        class="ghost-button"
-                                        disabled=Signal::derive(move || page.get() <= 1)
-                                    >
-                                        {move || translate(locale.locale.get(), "users.pagination.prev")}
-                                    </Button>
-                                    <span class="meta-text">
-                                        {move || translate(locale.locale.get(), "users.pagination.page")} " " {page.get()}
-                                    </span>
-                                    <Button
-                                        on_click=next_page
-                                        class="ghost-button"
-                                        disabled=Signal::derive(move || {
-                                            let total = response.users.page_info.total_count;
-                                            page.get() * limit.get() >= total
-                                        })
-                                    >
-                                        {move || translate(locale.locale.get(), "users.pagination.next")}
-                                    </Button>
+                                                            matches_query && matches_role && matches_status
+                                                        })
+                                                        .map(|edge| {
+                                                            let user = &edge.node;
+                                                            view! {
+                                                                <tr>
+                                                                    <td>
+                                                                        <A href=format!("/users/{}", user.id.clone())>
+                                                                            {user.email.clone()}
+                                                                        </A>
+                                                                    </td>
+                                                                    <td>{user.name.clone().unwrap_or_else(|| translate(locale.locale.get(), "users.placeholderDash").to_string())}</td>
+                                                                    <td>{user.role.clone()}</td>
+                                                                    <td>
+                                                                        <span class="status-pill">{user.status.clone()}</span>
+                                                                    </td>
+                                                                    <td>{user.created_at.clone()}</td>
+                                                                </tr>
+                                                            }
+                                                        })
+                                                        .collect_view()
+                                                }}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="table-actions">
+                                        <Button
+                                            on_click=previous_page
+                                            class="ghost-button"
+                                            disabled=Signal::derive(move || page.get() <= 1)
+                                        >
+                                            {move || translate(locale.locale.get(), "users.pagination.prev")}
+                                        </Button>
+                                        <span class="meta-text">
+                                            {move || translate(locale.locale.get(), "users.pagination.page")} " " {page.get()}
+                                        </span>
+                                        <Button
+                                            on_click=next_page
+                                            class="ghost-button"
+                                            disabled=Signal::derive(move || {
+                                                let total = response.users.page_info.total_count;
+                                                page.get() * limit.get() >= total
+                                            })
+                                        >
+                                            {move || translate(locale.locale.get(), "users.pagination.next")}
+                                        </Button>
+                                    </div>
                                 </div>
                             }
                             .into_view(),


### PR DESCRIPTION
### Motivation
- Fix compile errors in the admin frontend caused by deprecated signal types, ownership/move issues in view closures, and Resource codec trait bounds for serialized types.
- Ensure runtime resource/Component rendering returns consistent view types so `match` arms have compatible return types for `Suspense` and `Resource` usage.

### Description
- Replace the deprecated `MaybeSignal<bool>` prop on the `Button` component with `Signal<bool>` and adapt usage to `disabled.get()` in `apps/admin/src/components/ui.rs`.
- Prevent moves of owned `String` values when rendering dashboard stat and activity items by cloning the title/detail/time values before inserting them into views in `apps/admin/src/pages/dashboard.rs`.
- Derive `Serialize`/`Deserialize` for `ApiError` and several response types used by resources (`RestUser`, `GraphqlUsersResponse`, `GraphqlUsersConnection`, `GraphqlUserEdge`, `GraphqlUser`, `GraphqlPageInfo`, `GraphqlUserResponse`) so they satisfy `Resource::new` codec bounds in `apps/admin/src/api/mod.rs`, `apps/admin/src/pages/users.rs`, and `apps/admin/src/pages/user_details.rs`.
- Make `Suspense`/`match` branches return consistent root nodes (wrap pending branches in a `div` or unify the top-level view) to resolve incompatible `IntoView`/`View` types in `apps/admin/src/pages/users.rs`.

### Testing
- No automated tests or builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b685a4d483279abdb4e98c44101f)