### PR TITLE
Handle storefront startup errors gracefully

### DIFF
--- a/apps/storefront/src/main.rs
+++ b/apps/storefront/src/main.rs
@@ -365,7 +365,7 @@ async fn css_handler() -> impl IntoResponse {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new()
         .route(
             "/",
@@ -383,8 +383,7 @@ async fn main() {
         )
         .route("/assets/app.css", get(css_handler));
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3100")
-        .await
-        .expect("bind storefront");
-    axum::serve(listener, app).await.expect("serve storefront");
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3100").await?;
+    axum::serve(listener, app).await?;
+    Ok(())
 }


### PR DESCRIPTION
### Motivation
- Prevent the storefront process from panicking on startup bind/serve failures by propagating errors instead of calling `expect`, improving robustness and observability.

### Description
- Change the main entrypoint signature to `async fn main() -> Result<(), Box<dyn std::error::Error>>` in `apps/storefront/src/main.rs`.
- Replace `expect("bind storefront")` and `expect("serve storefront")` with the `?` operator to propagate errors from `tokio::net::TcpListener::bind` and `axum::serve`.
- Add an explicit `Ok(())` return at the end of `main`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862066c7b8832f88f021ca0ec0acbf)