### PR TITLE
docs: outline parallel admin stack

### DIFF
--- a/docs/UI/ui-parity.md
+++ b/docs/UI/ui-parity.md
@@ -23,6 +23,18 @@ Applies to the following apps:
 - **Leptos**: use `leptos-shadcn-ui` for equivalent primitives.
 - **Remove DaisyUI** to reduce duplicate styling systems and ensure a single source of UI truth.
 
+## Parallel admin stack (short version)
+
+When we need parity across the Leptos + Next admin apps, we align on the same
+library *roles* even if the exact implementation differs per runtime:
+
+- **Forms**: `leptos-forms-rs` for Leptos, with optional validation via validator/garde.
+- **Server state**: `leptos-query` (chosen).
+- **UI primitives**: `leptos-shadcn-ui` (Leptos) ↔ shadcn/ui (Next.js).
+- **Styling**: `tailwind-rs` + `tailwind-rs-leptos` for Leptos, Tailwind for Next.js.
+- **SEO/metadata**: `leptos-next-metadata` for Leptos; Next.js uses its built-in metadata APIs.
+- **Realtime (optional)**: `leptos-ws-pro`.
+
 Note: the canonical shadcn/ui implementation is Tailwind-first, so Tailwind remains the styling substrate
 for the Next.js apps. The Leptos side can consume the same design tokens (CSS variables) while rendering
 the shadcn-style components with leptos-shadcn-ui.


### PR DESCRIPTION
### Motivation
- Clarify the mapping of library roles between the Leptos and Next.js admin frontends to make parity decisions explicit and reduce drift.

### Description
- Add a `Parallel admin stack (short version)` section to `docs/UI/ui-parity.md` that lists the recommended role-to-library mappings for admin parity: Forms (`leptos-forms-rs`), Server state (`leptos-query`), UI primitives (`leptos-shadcn-ui` ↔ `shadcn/ui`), Styling (`tailwind-rs` + `tailwind-rs-leptos` for Leptos and Tailwind for Next.js), SEO/metadata (`leptos-next-metadata` for Leptos and Next.js built-in metadata), and optional Realtime (`leptos-ws-pro`).

### Testing
- Docs-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698638dd8c34832f9a6ca4926c87f2b5)