### PR TITLE
ci: add Next.js lint/build jobs for next-admin and next-frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   RUSTC_BOOTSTRAP: 1
   CARGO_INCREMENTAL: 0
   SQLX_OFFLINE: true
+  NEXT_TELEMETRY_DISABLED: 1
 
 jobs:
   fmt:
@@ -199,10 +200,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  next-apps:
+    name: Next.js (${{ matrix.app }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - apps/next-admin
+          - apps/next-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.app }}/package.json
+      - name: Install dependencies
+        working-directory: ${{ matrix.app }}
+        run: npm install
+      - name: Lint
+        working-directory: ${{ matrix.app }}
+        run: npm run lint
+      - name: Build
+        working-directory: ${{ matrix.app }}
+        run: npm run build
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check, audit, deny, typos, doc, udeps, coverage, build-server, build-admin, build-storefront, test]
+    needs: [fmt, clippy, check, audit, deny, typos, doc, udeps, coverage, build-server, build-admin, build-storefront, test, next-apps]
     if: always()
     steps:
       - name: Check all jobs
@@ -219,7 +246,8 @@ jobs:
              [[ "${{ needs.build-server.result }}" != "success" ]] || \
              [[ "${{ needs.build-admin.result }}" != "success" ]] || \
              [[ "${{ needs.build-storefront.result }}" != "success" ]] || \
-             [[ "${{ needs.test.result }}" != "success" ]]; then
+             [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.next-apps.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi


### PR DESCRIPTION
### Motivation
- Add CI coverage for the repository's Next.js apps so frontend linting and builds are validated alongside Rust checks.
- Prevent Next.js telemetry from polluting CI logs by disabling it in the workflow environment.

### Description
- Updated the workflow file `/.github/workflows/ci.yml` to set `NEXT_TELEMETRY_DISABLED=1` in the CI environment.
- Added a new `next-apps` job that uses a matrix over `apps/next-admin` and `apps/next-frontend` to run `npm install`, `npm run lint`, and `npm run build` for each app.
- Wired the new `next-apps` job into the `ci-success` aggregation so CI only reports success when the Next.js jobs succeed.

### Testing
- No automated tests were run locally; this change is validated when the CI workflow runs on push or pull request and will report success/failure via GitHub Actions.
- The repository's existing CI jobs (format, clippy, check, build, test, coverage, etc.) remain unchanged and will continue to run as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883a463d60832f8fe518631eb8b656)