### PR TITLE
Run TypeScript `typecheck` in Next.js CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,9 @@ jobs:
       - name: Lint
         working-directory: ${{ matrix.app }}
         run: npm run lint
+      - name: Typecheck
+        working-directory: ${{ matrix.app }}
+        run: npm run typecheck
       - name: Build
         working-directory: ${{ matrix.app }}
         run: npm run build

--- a/apps/next-admin/package.json
+++ b/apps/next-admin/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/apps/next-frontend/package.json
+++ b/apps/next-frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",


### PR DESCRIPTION
### Motivation
- Ensure TypeScript errors in the Next.js apps are caught during CI by running a dedicated type check step. 
- Add `typecheck` npm scripts so the CI step can invoke a consistent command (`tsc --noEmit`).

### Description
- Added a `typecheck` script (`"typecheck": "tsc --noEmit"`) to `apps/next-admin/package.json`.
- Added a `typecheck` script (`"typecheck": "tsc --noEmit"`) to `apps/next-frontend/package.json`.
- Updated `.github/workflows/ci.yml` in the `next-apps` matrix to run `npm run typecheck` (between `lint` and `build`).

### Testing
- No local automated tests were run; this change is CI-only and will be validated when the workflow runs and executes `npm run typecheck` for each Next.js app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883e732668832fa0871d0ae83595b3)