### PR TITLE
Add alpha disclaimer to documentation

### DIFF
--- a/IU/README.md
+++ b/IU/README.md
@@ -26,3 +26,5 @@ Internal UI (IU) workspace for shared design tokens and parallel component imple
 - Keep API parity across Next and Leptos components.
 - Base styling on shared tokens and support light/dark themes.
 - Avoid direct duplication of shadcn by treating it as a reference for Next only.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/docs/README.md
+++ b/IU/docs/README.md
@@ -4,3 +4,5 @@ This directory contains API contracts, usage guidelines, and examples for IU com
 
 - `api-contracts.md`: cross-framework props and behavior definitions.
 - `admin-skeleton.md`: baseline admin layout and module structure.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/docs/admin-skeleton.md
+++ b/IU/docs/admin-skeleton.md
@@ -23,3 +23,5 @@ left sidebar and top header.
 ## Navigation
 - Sidebar items map to `modules/*/pages` routes.
 - Access control hooks can be placed at route boundaries.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/docs/api-contracts.md
+++ b/IU/docs/api-contracts.md
@@ -75,3 +75,5 @@ implementation differences.
 - `variant`: `default | secondary | success | warning | danger`
 - `size`: `sm | md`
 - `dismissible`: boolean
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/leptos/README.md
+++ b/IU/leptos/README.md
@@ -1,3 +1,5 @@
 # Leptos IU
 
 Leptos (Rust) component implementation, aligned with IU tokens and API contracts.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/leptos/components/README.md
+++ b/IU/leptos/components/README.md
@@ -1,3 +1,5 @@
 # Leptos Components
 
 Leptos component implementations live here.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/next/README.md
+++ b/IU/next/README.md
@@ -1,3 +1,5 @@
 # Next IU
 
 Next.js (React) component implementation, aligned with IU tokens and API contracts.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/next/components/README.md
+++ b/IU/next/components/README.md
@@ -1,3 +1,5 @@
 # Next Components
 
 React component implementations live here.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/IU/tokens/README.md
+++ b/IU/tokens/README.md
@@ -4,3 +4,5 @@ Design tokens live here (colors, typography, spacing, radius, shadows, and theme
 
 - `base.css`: minimal token set aligned to shadcn defaults (HSL values) with light/dark themes.
 - Consumers should map these to framework-specific styling systems.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/README.md
+++ b/README.md
@@ -640,3 +640,5 @@ Built with amazing open-source projects:
 
 ⬆ Back to Top  
 Made with 🦀 by the RusToK community
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/RUSTOK_MANIFEST.md
+++ b/RUSTOK_MANIFEST.md
@@ -1183,3 +1183,5 @@ We keep a lightweight decision log in the manifest to acknowledge complexity and
 This log exists to keep the project realistic and aligned as the system grows.
 
 END OF MANIFEST v4.1
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -11,3 +11,5 @@
 - [Tech parity tracker](../../docs/UI/tech-parity.md)
 - [Template integration plan](../../docs/UI/admin-template-integration-plan.md)
 - [Admin libraries parity](../../docs/UI/admin-libraries-parity.md)
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/apps/next-admin/README.md
+++ b/apps/next-admin/README.md
@@ -40,3 +40,5 @@ npm run dev
 - [Tech parity tracker](../../docs/UI/tech-parity.md)
 - [Template integration plan](../../docs/UI/admin-template-integration-plan.md)
 - [Admin libraries parity](../../docs/UI/admin-libraries-parity.md)
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/apps/next-frontend/README.md
+++ b/apps/next-frontend/README.md
@@ -30,3 +30,5 @@ npm run dev
 - Analytics: posthog-js
 - Monitoring: @sentry/nextjs
 - Notifications: react-hot-toast
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-blog/README.md
+++ b/crates/rustok-blog/README.md
@@ -19,3 +19,5 @@
 
 ## Кому нужен
 Админке и публичной части для блога/новостей.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-commerce/README.md
+++ b/crates/rustok-commerce/README.md
@@ -20,3 +20,5 @@
 
 ## Кому нужен
 Магазин, витрина, аналитика, интеграции и фоновая обработка заказов.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-content/README.md
+++ b/crates/rustok-content/README.md
@@ -20,3 +20,5 @@
 
 ## Кому нужен
 Всем, кто работает с контентом: админка, фронтенд, поисковые индексы.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-core/README.md
+++ b/crates/rustok-core/README.md
@@ -21,3 +21,5 @@
 
 ## Кому нужен
 Этот модуль подключают **все** остальные crates, потому что без него нет единого языка событий и базовых типов.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-forum/README.md
+++ b/crates/rustok-forum/README.md
@@ -21,3 +21,5 @@
 
 ## Кому нужен
 Форуму, комьюнити-разделам, поддержке и контентным обсуждениям.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-iggy/README.md
+++ b/crates/rustok-iggy/README.md
@@ -30,3 +30,5 @@
 
 ## Кому нужен
 Крупным инсталляциям, где нужны стриминг, replay и горизонтальное масштабирование потребителей.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -25,3 +25,5 @@
 
 ## Кому нужен
 Поиску, витрине, любым read-heavy запросам.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-mcp/README.md
+++ b/crates/rustok-mcp/README.md
@@ -24,3 +24,5 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 For more details see `docs/mcp.md`.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-outbox/README.md
+++ b/crates/rustok-outbox/README.md
@@ -21,3 +21,5 @@
 
 ## Кому нужен
 Продакшену на одном узле, когда in-memory событий недостаточно, но полноценный стриминг ещё не нужен.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-pages/README.md
+++ b/crates/rustok-pages/README.md
@@ -1,3 +1,5 @@
 # rustok-pages
 
 Pages and menus domain logic for RusToK.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-rbac/README.md
+++ b/crates/rustok-rbac/README.md
@@ -1,3 +1,5 @@
 # rustok-rbac
 
 Role and permission helpers for RusToK.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/crates/rustok-tenant/README.md
+++ b/crates/rustok-tenant/README.md
@@ -1,3 +1,5 @@
 # rustok-tenant
 
 Multi-tenancy helpers and tenant metadata for RusToK.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/ALLOY_MANIFEST.md
+++ b/docs/ALLOY_MANIFEST.md
@@ -91,3 +91,5 @@ Alloy — это не «ещё одна CRM/ERP», а платформа для 
 
 ## 7. Итог
 Alloy — это сплав производительности Rust и гибкости скриптов, который позволяет бизнесу строить свои процессы и аккуратно поглощать legacy-данные, а не подстраиваться под чужие ограничения.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -284,3 +284,5 @@ mYYYYMMDD_<module>_<nnn>_<description>.rs
 - [ROADMAP.md](./ROADMAP.md) — фазы разработки
 - [modules/flex.md](./modules/flex.md) — подробная спецификация Flex
 - [MANIFEST_ADDENDUM.md](./MANIFEST_ADDENDUM.md) — дополнения к манифесту
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -306,3 +306,5 @@ mYYYYMMDD_<module>_<nnn>_<description>.rs
 
 - [MODULE_MATRIX.md](./modules/MODULE_MATRIX.md) — матрица модулей
 - [ARCHITECTURE_GUIDE.md](./ARCHITECTURE_GUIDE.md) — архитектура
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -246,3 +246,5 @@ Flex — это **новый концепт** из архитектурного 
 | `docs/ARCHITECTURE_GUIDE.md` | Пометить реализованные пункты как ✅ |
 | `docs/ROADMAP.md` | Обновить статусы Phase 1 задач |
 | `docs/MANIFEST_ADDENDUM.md` | Добавить отметки "уже реализовано" |
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/MANIFEST_ADDENDUM.md
+++ b/docs/MANIFEST_ADDENDUM.md
@@ -238,3 +238,5 @@ m20250201_commerce_002_create_variants.rs
 - [ROADMAP.md](./ROADMAP.md)
 - [ARCHITECTURE_GUIDE.md](./ARCHITECTURE_GUIDE.md)  
 - [modules/flex.md](./modules/flex.md)
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,3 +121,5 @@ Week 9+:   Phase 3 — Business logic implementation
 - [ARCHITECTURE_GUIDE.md](./ARCHITECTURE_GUIDE.md) — архитектурные принципы
 - [modules/flex.md](./modules/flex.md) — спецификация Flex модуля
 - [MANIFEST_ADDENDUM.md](./MANIFEST_ADDENDUM.md) — дополнения к манифесту
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/admin-libraries-parity.md
+++ b/docs/UI/admin-libraries-parity.md
@@ -38,3 +38,5 @@
 
 Чтобы не раздувать документ, отдельная матрица с источниками и ссылками ведётся здесь:
 [`docs/UI/admin-reuse-matrix.md`](./admin-reuse-matrix.md).
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/admin-reuse-matrix.md
+++ b/docs/UI/admin-reuse-matrix.md
@@ -26,3 +26,5 @@
 | Большие Leptos‑проекты (поиск) | https://github.com/search?q=leptos+admin+stars%3A%3E20&type=repositories | UI/архитектура админки, auth, data‑fetching | backlog | Отфильтровать активные репозитории. |
 | Большие Leptos‑проекты (поиск) | https://github.com/search?q=leptos+dashboard+stars%3A%3E20&type=repositories | Таблицы, графики, layout | backlog | Отфильтровать активные репозитории. |
 | Большие Leptos‑проекты (поиск) | https://github.com/search?q=leptos+cms+stars%3A%3E20&type=repositories | Контентные админки, формы | backlog | Отфильтровать активные репозитории. |
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/developer-storefront-plan.md
+++ b/docs/UI/developer-storefront-plan.md
@@ -788,3 +788,5 @@ Phase 3 can be considered done when:
 - Локализация покрывает новые UI строки.
 - Нет регрессий по API/валидации/роутингу.
 - Документация обновлена и содержит ссылки на шаблон и план интеграции.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/mini-kits.md
+++ b/docs/UI/mini-kits.md
@@ -60,3 +60,5 @@
 1. Сначала фиксируем контракт и минимальный API.
 2. Реализуем его в Rust и TS.
 3. Подключаем на 1–2 экранах, только затем масштабируем.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/storefront.md
+++ b/docs/UI/storefront.md
@@ -47,3 +47,5 @@ with the `lang` query parameter:
 
 Add more locales by extending the `locale_strings` mapping in
 `apps/storefront/src/main.rs`.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/tech-parity.md
+++ b/docs/UI/tech-parity.md
@@ -123,3 +123,5 @@ Use a short, consistent marker near the custom implementation:
 - Define shared route maps for admin and storefront.
 - Add a standard error code map and i18n keys list.
 - Add a parity gap log (custom implementations + planned migrations).
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/UI/ui-parity.md
+++ b/docs/UI/ui-parity.md
@@ -130,3 +130,5 @@ and can consume the same design tokens and shadcn-style component contracts.
 | Users Table | ✅ | Implemented with URL sync and PageHeader |
 | Auth Guards | ✅ | Refactored to generic `ProtectedRoute` |
 | Tailwind | ✅ | Build pipeline via `Trunk` configured |
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,3 +143,5 @@ Interaction follows a strict hierarchy:
 5. `rustok-index` receives the event and runs its **Indexer**.
 6. The **Indexer** fetches the updated post, merges it with tags and author info, and saves it to the `index_content` table.
 7. **Storefront** users see the update near-instantly by querying the fast `index_content` table.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/concepts/social-matrix.md
+++ b/docs/concepts/social-matrix.md
@@ -646,3 +646,4 @@ graph TD
 От Opus взяли: полную модульную раскладку, таблицы ролей/приватности/жизненных циклов, админку, безопасность, поиск, уведомления, форумный движок как ядро
 
 В итоге: единый документ, который можно резать на модули и сразу проектировать домены/контракты.
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/concepts/social-modules.md
+++ b/docs/concepts/social-modules.md
@@ -224,3 +224,4 @@ mod_reputation (trust gating)
 
 Слить mod_reputation + mod_moderation → mod_engagement (как у Gemini: “наблюдатель/каратель”)
 И получите 12 crate’ов, сохранив отдельный mod_media_social.
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/lockfile-troubleshooting.md
+++ b/docs/lockfile-troubleshooting.md
@@ -33,3 +33,5 @@ different checksum.
 If you are in an offline or restricted network environment, perform the lockfile
 regeneration on a machine with registry access and commit the updated
 `Cargo.lock`.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -49,3 +49,5 @@ managed and deployed independently. To wire actual modules, construct a `ModuleR
 
 - The adapter should remain thin; heavy logic belongs in domain services.
 - Updating MCP protocol behavior should be handled by updating the `rmcp` dependency.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/MODULE_MATRIX.md
+++ b/docs/modules/MODULE_MATRIX.md
@@ -160,3 +160,5 @@ graph TD
 
 - [DATABASE_SCHEMA.md](./DATABASE_SCHEMA.md) — таблицы БД
 - [ARCHITECTURE_GUIDE.md](./ARCHITECTURE_GUIDE.md) — архитектура
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/flex.md
+++ b/docs/modules/flex.md
@@ -393,3 +393,5 @@ impl EventHandler for FlexIndexer {
 
 - [ARCHITECTURE_GUIDE.md](../ARCHITECTURE_GUIDE.md) — общая архитектура
 - [ROADMAP.md](../ROADMAP.md) — фазы разработки
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/module-manifest.md
+++ b/docs/modules/module-manifest.md
@@ -178,3 +178,5 @@ UI шаги:
 
 - `build_id`, `release_id`, `status`, `started_at`, `finished_at`
 - `manifest_hash`, `modules_delta`, `requested_by`, `reason`
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/module-rebuild-plan.md
+++ b/docs/modules/module-rebuild-plan.md
@@ -176,3 +176,5 @@ tags = ["community"]
 
 Если нужно, следующий шаг — разложить эти этапы в задачи по репозиторию
 (`apps/server`, `apps/admin`, `docs`, `CI`) и оценить трудозатраты.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/module-registry.md
+++ b/docs/modules/module-registry.md
@@ -84,3 +84,5 @@ mutation ToggleModule {
   }
 }
 ```
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/modules/modules.md
+++ b/docs/modules/modules.md
@@ -186,3 +186,5 @@ API для admin rebuild, пайплайн сборки и rollback).
 
 - Модуль объявляет миграции через `MigrationSource`.
 - Registry собирает список миграций для запуска в рамках общей миграции.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/templates/module_contract.md
+++ b/docs/templates/module_contract.md
@@ -229,3 +229,5 @@ _Описание сценариев взаимодействия с други�
 ## 10. Notes / Open Questions
 
 _Любые открытые вопросы или заметки о модуле_
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -26,3 +26,5 @@ These guidelines capture what we should take from the shared rules to keep tests
 ## Mocking boundaries
 - Mock **ports** (e.g., `PricingPort`, `InventoryPort`, `TaxPort`) when unit testing services.  
 - Avoid mocking internal persistence layers (e.g., SeaORM models) unless the test explicitly targets that integration boundary.  
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-auth/README.md
+++ b/packages/leptos-auth/README.md
@@ -153,3 +153,5 @@ packages/leptos-auth/ # TS helper module for Next.js frontends
 
 **Minimal baseline** for Phase 3 admin auth. Designed to grow as the template
 integration lands.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-graphql/README.md
+++ b/packages/leptos-graphql/README.md
@@ -73,3 +73,5 @@ const response = await fetchGraphql({
 
 **Minimal baseline** for shared GraphQL fetch behavior. Extend only when a real
 use-case appears in admin or storefront UIs.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-hook-form/README.md
+++ b/packages/leptos-hook-form/README.md
@@ -76,3 +76,5 @@ const state = FormState.withFieldErrors(fieldErrors);
 ## Status
 
 **Minimal baseline** for shared form state + errors. Extend only when needed.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-table/README.md
+++ b/packages/leptos-table/README.md
@@ -72,3 +72,5 @@ const state = TableState.withSort({
 ## Status
 
 **Minimal baseline** for shared table state. Extend only when needed.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-zod/README.md
+++ b/packages/leptos-zod/README.md
@@ -62,3 +62,5 @@ const error = mapZodError({
 ## Status
 
 **Minimal baseline** for validation error parity. Extend only when needed.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.

--- a/packages/leptos-zustand/README.md
+++ b/packages/leptos-zustand/README.md
@@ -67,3 +67,5 @@ const snapshot: StoreSnapshot<string> = { state: "ready" };
 ## Status
 
 **Minimal baseline** for shared store shapes. Extend only when needed.
+
+This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.


### PR DESCRIPTION
### Motivation
- Add a clear, English-language alpha-version disclaimer across repository documentation so readers understand content is draft and may contain errors.

### Description
- Ran a repository-wide Markdown update that appends the notice to `*.md` files while skipping `node_modules`, `vendor`, `.git`, and `advisory-db-empty*` directories and avoiding duplicates via an `rg -q` presence check.
- Appended the sentence `This is an alpha version and requires clarification. Be careful, there may be errors in the text. So that no one thinks that this is an immutable rule.` to top-level docs, `docs/` pages, app READMEs, crate/package READMEs, and IU documentation.
- These are documentation-only edits and do not change source code, build scripts, or runtime behavior.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698848a52b00832fb6ff448467d60d38)