### PR TITLE
Make CI manual-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### Motivation
- Prevent automatic CI runs on every `push` and `pull_request` to reduce unnecessary executions and allow manual control over when the workflow runs.

### Description
- Replaced the `push`/`pull_request` triggers in ` .github/workflows/ci.yml` with a `workflow_dispatch` trigger so the workflow runs only via manual dispatch.

### Testing
- No automated tests were run because this is a workflow trigger change only and does not affect code behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884bdbb8d0832f893d97a70d418d90)