### PR TITLE
Fix redis cache query_async generics

### DIFF
--- a/crates/rustok-core/src/cache.rs
+++ b/crates/rustok-core/src/cache.rs
@@ -131,7 +131,7 @@ impl CacheBackend for RedisCacheBackend {
             .arg(value)
             .arg("EX")
             .arg(self.ttl.as_secs())
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         Ok(())
@@ -145,7 +145,7 @@ impl CacheBackend for RedisCacheBackend {
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         redis::cmd("DEL")
             .arg(self.key(key))
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         Ok(())


### PR DESCRIPTION
### Motivation
- Fix compilation errors caused by incorrect generic usage on `redis::Cmd::query_async` after upgrading to `redis` 0.31, where the method accepts a single generic type and the unit/never-type fallback must be explicit.

### Description
- Replace `.query_async::<_, ()>(&mut conn)` with `.query_async::<()>(&mut conn)` on `SET` and `DEL` calls in `crates/rustok-core/src/cache.rs` to explicitly set the return type to `()`.

### Testing
- No automated tests or builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698864ba8318832f963144342a61ba79)