### PR TITLE
Fix redis query_async generics and bump next-intl for Next 16 compatibility

### DIFF
--- a/apps/next-admin/package.json
+++ b/apps/next-admin/package.json
@@ -29,7 +29,7 @@
     "lucide-react": "^0.563.0",
     "next": "^16.1.0",
     "next-auth": "^4.24.7",
-    "next-intl": "^3.17.2",
+    "next-intl": "^4.0.0",
     "openapi-fetch": "^0.15.0",
     "posthog-js": "^1.161.0",
     "react": "^19.2.4",

--- a/apps/next-frontend/package.json
+++ b/apps/next-frontend/package.json
@@ -28,7 +28,7 @@
     "lucide-react": "^0.563.0",
     "next": "^16.1.0",
     "next-auth": "^4.24.7",
-    "next-intl": "^3.17.2",
+    "next-intl": "^4.0.0",
     "next-seo": "^6.6.0",
     "openapi-fetch": "^0.15.0",
     "posthog-js": "^1.161.0",

--- a/crates/rustok-core/src/cache.rs
+++ b/crates/rustok-core/src/cache.rs
@@ -131,7 +131,7 @@ impl CacheBackend for RedisCacheBackend {
             .arg(value)
             .arg("EX")
             .arg(self.ttl.as_secs())
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         Ok(())
@@ -145,7 +145,7 @@ impl CacheBackend for RedisCacheBackend {
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         redis::cmd("DEL")
             .arg(self.key(key))
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .map_err(|err| crate::Error::Cache(err.to_string()))?;
         Ok(())


### PR DESCRIPTION
### Motivation
- Fix a compilation issue caused by the `redis::Cmd::query_async` API change (redis 0.31) which requires an explicit single generic return type instead of a two-parameter form. 
- Resolve an `npm` peer-dependency conflict where `next-intl@^3.17.2` does not accept `next@^16.x`, causing `npm install` to fail with `ERESOLVE`.

### Description
- Update `crates/rustok-core/src/cache.rs` to call `.query_async::<()>(&mut conn)` for `SET` and `DEL` so the return type is explicitly `()` and compiles against `redis` 0.31. 
- Bump `next-intl` to `^4.0.0` in `apps/next-admin/package.json` to satisfy `next@^16.x` peer requirements. 
- Bump `next-intl` to `^4.0.0` in `apps/next-frontend/package.json` to keep frontend apps aligned with the same compatible range.

### Testing
- No automated tests or CI builds were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698864ba8318832f963144342a61ba79)