### PR TITLE
Grant workflow permissions for rustsec/audit-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
### Motivation
- Allow `rustsec/audit-check@v1` to access repository data and report findings by granting workflows `contents: read` and `issues: write` to avoid the `Resource not accessible by integration` error.

### Description
- Added a `permissions` block with `contents: read` and `issues: write` to `.github/workflows/ci.yml` and `.github/workflows/dependencies.yml`.

### Testing
- No automated CI was run because this is a workflow-only metadata change; previous audit runs indicated the `Resource not accessible by integration` error which this change is intended to resolve.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988afb04bf0832f9ee3e15d12aade39)