### PR TITLE
Expand Dependabot coverage across Rust crates and frontend apps, run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,40 +3,264 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      minor-updates:
-        update-types: ["minor", "patch"]
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/apps/admin"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/apps/server"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/apps/server/migration"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/apps/storefront"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/apps/mcp"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/alloy-scripting"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-auth"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-graphql"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-hook-form"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-shadcn-pagination"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-table"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-zod"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/leptos-zustand"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-blog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-commerce"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-content"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-core"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-forum"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-iggy"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-iggy-connector"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-index"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-mcp"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-outbox"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-pages"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-rbac"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-telemetry"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/rustok-tenant"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
+  - package-ecosystem: "cargo"
+    directory: "/crates/utoipa-swagger-ui-vendored"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-updates:
+        update-types: ["major", "minor", "patch"]
   - package-ecosystem: "npm"
     directory: "/apps/next-frontend"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      minor-updates:
-        update-types: ["minor", "patch"]
+      all-updates:
+        update-types: ["major", "minor", "patch"]
   - package-ecosystem: "npm"
     directory: "/apps/next-admin"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      minor-updates:
-        update-types: ["minor", "patch"]
+      all-updates:
+        update-types: ["major", "minor", "patch"]
   - package-ecosystem: "npm"
     directory: "/apps/storefront"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      minor-updates:
-        update-types: ["minor", "patch"]
+      all-updates:
+        update-types: ["major", "minor", "patch"]
   - package-ecosystem: "npm"
     directory: "/apps/admin"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      minor-updates:
-        update-types: ["minor", "patch"]
+      all-updates:
+        update-types: ["major", "minor", "patch"]

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  security-events: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### Motivation
- Ensure all Rust crates, the MCP/server/admin modules, and frontend Leptos apps receive frequent dependency updates so libraries remain current. 
- Allow Dependabot to propose major updates in grouped PRs and run checks daily to reduce drift across the monorepo.

### Description
- Updated `.github/dependabot.yml` to change update intervals from weekly to `daily` and replaced the previous `minor-updates` groups with `all-updates` that allow `major`, `minor`, and `patch` update-types. 
- Added per-package entries for relevant Cargo directories (for example `apps/admin`, `apps/server`, `apps/storefront`, `apps/mcp`, and many `crates/*` folders) and switched the npm app entries (`/apps/next-frontend`, `/apps/next-admin`, `/apps/storefront`, `/apps/admin`) to daily `all-updates`. 
- Updated `.github/workflows/dependencies.yml` to grant the workflow `security-events: write` permission to support security-related automation.
- Changes were committed with the message `Expand Dependabot coverage`.

### Testing
- No automated tests were run because this is a CI/configuration-only change. 
- The updated `dependabot.yml` and workflow files were inspected in-repo to verify the new entries and permissions were added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b2daf114832f84e8ac6ec14adc4c)