### PR TITLE
feat(forum): add bounded unread topic projection

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -212,7 +212,7 @@ at the end of this file remain authoritative.
 | `FORUM-13` | `in_progress` | Verified FORUM-13A/B add bounded presentation policy and explicit optional Media capability behavior; Media quarantine/deletion state, persistence, transport composition, runtime evidence and UI remain. |
 | `FORUM-14` | `planned` | Topic/reply attachment relations and upload-session lifecycle. |
 | `FORUM-15` | `planned` | Profile/member summary and avatar integration. |
-| `FORUM-16` | `in_progress` | FORUM-16A adds tenant-scoped monotonic topic read position/revision persistence and authenticated owner commands; unread projections, filters and bounded category/all-read commands remain. |
+| `FORUM-16` | `in_progress` | FORUM-16A/B add tenant-scoped monotonic topic read state, authenticated owner commands and a bounded unread topic projection/filter; bulk category/all-read commands, transports and PostgreSQL concurrency evidence remain. |
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
@@ -854,21 +854,38 @@ accelerate the badge but database position/revision remains canonical.
   SQLite owner scenario covers future-bound rejection plus the direct database
   regression guard.
 
+### Delivered in `FORUM-16B`
+
+- `ForumReadModelService::list_topics_with_unread` exposes a separate
+  authenticated owner projection without changing the existing public topic
+  list contract;
+- each bounded cursor page is enriched through one aggregate owner query with
+  explicit read-state presence, last-read position/revision, approved-reply
+  unread count, topic-revision unread state and a canonical `is_unread` result;
+- a missing read-state row keeps a newly discovered topic unread even when it has
+  no replies, while an explicit zero row records that an empty topic was opened;
+- `unread_only` is applied before cursor pagination and includes unseen topics,
+  approved replies after the high-water mark and newer immutable topic revisions;
+- hidden, rejected and deleted replies are excluded by the approved-public
+  predicate, and the SQLite scenario covers visibility changes plus two-page
+  unread cursor behavior without N+1 reply reads.
+
 ### Compatibility and degraded mode
 
-No backfill is required: an absent row means position/revision zero. Existing
-Forum reads and commands remain source-compatible, and no transport or UI is
-opened in this slice. Cache and realtime accelerators remain optional and never
-replace the database owner state.
+No backfill is required: an absent row means position/revision zero and also
+preserves unseen-topic identity. Existing Forum topic reads and commands remain
+source-compatible. The unread projection is an additive authenticated owner
+contract and is not wired to REST, GraphQL, storefront or realtime in this
+slice. Cache and realtime accelerators remain optional and never replace the
+database owner state.
 
 ### Remaining scope
 
-- join bounded topic projections with last-read position/revision, canonical
-  unread counts and unread filters that exclude hidden or deleted replies;
 - add bounded, resumable mark-category-read and mark-all-read owner commands;
-- expose verified REST/GraphQL/storefront integration only after the projection
-  contract is stable;
-- add PostgreSQL and concurrent-device execution evidence.
+- expose the stable owner projection through verified REST/GraphQL/storefront
+  integration without duplicating unread policy in transports;
+- add PostgreSQL aggregate/concurrent-device execution evidence and query-plan
+  evidence for production-sized topic/reply histories.
 
 ### Definition of done
 
@@ -880,6 +897,7 @@ bounded.
 
 ```bash
 cargo test -p rustok-forum --test topic_read_state_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_unread_projection_sqlite -- --nocapture
 cargo xtask module validate forum
 ```
 
@@ -1672,6 +1690,7 @@ cargo test -p rustok-forum inline_quote
 cargo test -p rustok-forum --test mention_quote_runtime_postgres -- --nocapture --test-threads=1
 cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_read_state_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_unread_projection_sqlite -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1736,7 +1755,8 @@ Recommended next slices:
 7. `FORUM-14`: attachment relations and upload sessions;
 8. `FORUM-15`: batched member/avatar projection;
 9. `LINK-FORUM-02`: profiles/media runtime proof;
-10. finish `FORUM-16` unread projections, filters and bounded bulk mark-read;
+10. finish `FORUM-16` bounded category/all-read commands, transport composition
+    and PostgreSQL concurrency/query-plan evidence;
 11. `FORUM-19`: reports/moderation/restrictions;
 12. `FORUM-20`: ACL and visibility policy;
 13. `FORUM-23`: index projections;

--- a/crates/rustok-forum/src/dto/read_model.rs
+++ b/crates/rustok-forum/src/dto/read_model.rs
@@ -41,6 +41,31 @@ pub struct TopicCursorQuery {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct TopicUnreadCursorQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<u64>,
+    pub category_id: Option<Uuid>,
+    pub status: Option<TopicStatus>,
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    #[serde(default)]
+    pub unread_only: bool,
+}
+
+impl TopicUnreadCursorQuery {
+    pub fn topic_query(&self) -> TopicCursorQuery {
+        TopicCursorQuery {
+            cursor: self.cursor.clone(),
+            limit: self.limit,
+            category_id: self.category_id,
+            status: self.status,
+            locale: self.locale.clone(),
+            fallback_locale: self.fallback_locale.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct ReplyCursorQuery {
     pub cursor: Option<String>,
     pub limit: Option<u64>,
@@ -91,6 +116,17 @@ pub struct TopicReadModel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TopicUnreadReadModel {
+    pub topic: TopicReadModel,
+    pub read_state_explicit: bool,
+    pub last_read_position: i64,
+    pub last_read_revision: i64,
+    pub unread_count: i64,
+    pub has_unread_topic_revision: bool,
+    pub is_unread: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ReplyReadModel {
     pub id: Uuid,
     pub topic_id: Uuid,
@@ -119,6 +155,13 @@ pub struct CategoryCursorPage {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TopicCursorPage {
     pub items: Vec<TopicReadModel>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TopicUnreadCursorPage {
+    pub items: Vec<TopicUnreadReadModel>,
     pub next_cursor: Option<String>,
     pub has_more: bool,
 }

--- a/crates/rustok-forum/src/services/read_model.rs
+++ b/crates/rustok-forum/src/services/read_model.rs
@@ -20,7 +20,7 @@ use crate::dto::{
 };
 use crate::entities::{
     forum_category, forum_category_translation, forum_reply, forum_reply_body, forum_solution,
-    forum_topic, forum_topic_read_state, forum_topic_revision, forum_topic_translation,
+    forum_topic, forum_topic_translation,
 };
 use crate::error::{ForumError, ForumResult};
 use crate::services::rbac::enforce_scope;
@@ -542,6 +542,7 @@ fn normalized_optional_locale(locale: Option<&str>) -> ForumResult<Option<String
 fn unread_topic_condition(user_id: Uuid) -> Condition {
     Condition::all().add(Expr::cust_with_values(
         r#"
+(
 NOT EXISTS (
     SELECT 1
     FROM forum_topic_read_states state
@@ -575,6 +576,7 @@ OR EXISTS (
             AND state.topic_id = forum_topics.id
             AND state.user_id = ?
       ), 0)
+)
 )
 "#,
         vec![user_id.into(), user_id.into(), user_id.into()],
@@ -630,7 +632,9 @@ GROUP BY
     let mut values = Vec::<Value>::with_capacity(topic_ids.len() + 2);
     values.push(user_id.into());
     values.push(tenant_id.into());
-    values.extend(topic_ids.iter().copied().map(Value::from));
+    for topic_id in topic_ids {
+        values.push((*topic_id).into());
+    }
 
     let rows = db
         .query_all(Statement::from_sql_and_values(

--- a/crates/rustok-forum/src/services/read_model.rs
+++ b/crates/rustok-forum/src/services/read_model.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use sea_orm::{
-    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+    ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Statement, Value, sea_query::Expr,
 };
 use uuid::Uuid;
 
@@ -14,11 +15,12 @@ use rustok_core::SecurityContext;
 
 use crate::dto::{
     CategoryCursorPage, CategoryCursorQuery, CategoryReadModel, ReplyCursorPage, ReplyCursorQuery,
-    ReplyReadModel, TopicCursorPage, TopicCursorQuery, TopicReadModel, bounded_forum_read_limit,
+    ReplyReadModel, TopicCursorPage, TopicCursorQuery, TopicReadModel, TopicUnreadCursorPage,
+    TopicUnreadCursorQuery, TopicUnreadReadModel, bounded_forum_read_limit,
 };
 use crate::entities::{
     forum_category, forum_category_translation, forum_reply, forum_reply_body, forum_solution,
-    forum_topic, forum_topic_translation,
+    forum_topic, forum_topic_read_state, forum_topic_revision, forum_topic_translation,
 };
 use crate::error::{ForumError, ForumResult};
 use crate::services::rbac::enforce_scope;
@@ -28,6 +30,16 @@ use crate::services::vote::VoteService;
 const CATEGORY_CURSOR_VERSION: &str = "c1";
 const TOPIC_CURSOR_VERSION: &str = "t1";
 const REPLY_CURSOR_VERSION: &str = "r1";
+
+#[derive(Clone, Copy, Debug)]
+struct TopicUnreadSummary {
+    read_state_explicit: bool,
+    last_read_position: i64,
+    last_read_revision: i64,
+    unread_count: i64,
+    has_unread_topic_revision: bool,
+    is_unread: bool,
+}
 
 pub struct ForumReadModelService {
     db: DatabaseConnection,
@@ -138,95 +150,77 @@ impl ForumReadModelService {
         enforce_scope(&security, Resource::ForumTopics, Action::List)?;
         let locale = normalized_locale(query.locale.as_deref())?;
         let fallback_locale = normalized_optional_locale(query.fallback_locale.as_deref())?;
-        let limit = bounded_forum_read_limit(query.limit);
-
-        let mut select =
-            forum_topic::Entity::find().filter(forum_topic::Column::TenantId.eq(tenant_id));
-        if let Some(category_id) = query.category_id {
-            select = select.filter(forum_topic::Column::CategoryId.eq(category_id));
-        }
-        if let Some(status) = query.status {
-            select = select.filter(forum_topic::Column::Status.eq(status));
-        }
-        if let Some(cursor) = query.cursor.as_deref() {
-            let cursor = decode_topic_cursor(cursor)?;
-            select = select.filter(
-                Condition::any()
-                    .add(forum_topic::Column::UpdatedAt.lt(cursor.updated_at))
-                    .add(
-                        Condition::all()
-                            .add(forum_topic::Column::UpdatedAt.eq(cursor.updated_at))
-                            .add(forum_topic::Column::Id.lt(cursor.id)),
-                    ),
-            );
-        }
-
-        let mut topics = select
-            .order_by_desc(forum_topic::Column::UpdatedAt)
-            .order_by_desc(forum_topic::Column::Id)
-            .limit(limit + 1)
-            .all(&self.db)
+        let (topics, next_cursor, has_more) = self
+            .load_topic_rows(tenant_id, &query, None)
             .await?;
-        let has_more = topics.len() > limit as usize;
-        topics.truncate(limit as usize);
-        let next_cursor = has_more
-            .then(|| topics.last().map(encode_topic_cursor))
-            .flatten();
-
-        let ids = topics.iter().map(|item| item.id).collect::<Vec<_>>();
-        let translations = topic_translations_by_id(&self.db, tenant_id, &ids).await?;
-        let votes = VoteService::new(self.db.clone())
-            .topic_vote_summaries(tenant_id, &ids, security.user_id)
+        let items = self
+            .materialize_topic_read_models(
+                tenant_id,
+                topics,
+                &locale,
+                fallback_locale.as_deref(),
+                security.user_id,
+            )
             .await?;
-        let subscriptions = SubscriptionService::new(self.db.clone())
-            .topic_subscription_flags(tenant_id, &ids, security.user_id)
-            .await?;
-        let solutions = solution_ids_by_topic(&self.db, tenant_id, &ids).await?;
-
-        let items = topics
-            .into_iter()
-            .map(|topic| {
-                let localized = translations.get(&topic.id).cloned().unwrap_or_default();
-                let resolved = resolve_by_locale_with_fallback(
-                    &localized,
-                    &locale,
-                    fallback_locale.as_deref(),
-                    |translation| translation.locale.as_str(),
-                );
-                let vote = votes.get(&topic.id).copied().unwrap_or_default();
-                TopicReadModel {
-                    id: topic.id,
-                    category_id: topic.category_id,
-                    author_id: topic.author_id,
-                    requested_locale: locale.clone(),
-                    effective_locale: resolved.effective_locale,
-                    available_locales: available_locales_from(&localized, |translation| {
-                        translation.locale.as_str()
-                    }),
-                    title: resolved
-                        .item
-                        .map(|translation| translation.title.clone())
-                        .unwrap_or_default(),
-                    slug: resolved
-                        .item
-                        .and_then(|translation| translation.slug.clone())
-                        .unwrap_or_default(),
-                    metadata: topic.metadata,
-                    status: topic.status.to_string(),
-                    is_pinned: topic.is_pinned,
-                    is_locked: topic.is_locked,
-                    reply_count: topic.reply_count,
-                    vote_score: vote.score,
-                    current_user_vote: vote.current_user_vote,
-                    is_subscribed: subscriptions.get(&topic.id).copied().unwrap_or(false),
-                    solution_reply_id: solutions.get(&topic.id).copied(),
-                    created_at: topic.created_at.to_rfc3339(),
-                    updated_at: topic.updated_at.to_rfc3339(),
-                }
-            })
-            .collect();
 
         Ok(TopicCursorPage {
+            items,
+            next_cursor,
+            has_more,
+        })
+    }
+
+    pub async fn list_topics_with_unread(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        query: TopicUnreadCursorQuery,
+    ) -> ForumResult<TopicUnreadCursorPage> {
+        enforce_scope(&security, Resource::ForumTopics, Action::List)?;
+        let user_id = security.user_id.ok_or_else(|| {
+            ForumError::forbidden(
+                "Authenticated user context is required for the topic unread projection",
+            )
+        })?;
+        let locale = normalized_locale(query.locale.as_deref())?;
+        let fallback_locale = normalized_optional_locale(query.fallback_locale.as_deref())?;
+        let topic_query = query.topic_query();
+        let unread_filter = query.unread_only.then(|| unread_topic_condition(user_id));
+        let (topics, next_cursor, has_more) = self
+            .load_topic_rows(tenant_id, &topic_query, unread_filter)
+            .await?;
+        let topic_ids = topics.iter().map(|topic| topic.id).collect::<Vec<_>>();
+        let topic_models = self
+            .materialize_topic_read_models(
+                tenant_id,
+                topics,
+                &locale,
+                fallback_locale.as_deref(),
+                Some(user_id),
+            )
+            .await?;
+        let unread = topic_unread_summaries(&self.db, tenant_id, user_id, &topic_ids).await?;
+        let items = topic_models
+            .into_iter()
+            .map(|topic| {
+                let summary = unread.get(&topic.id).copied().ok_or_else(|| {
+                    ForumError::Validation(
+                        "Forum topic unread projection is missing a bounded summary".to_string(),
+                    )
+                })?;
+                Ok(TopicUnreadReadModel {
+                    topic,
+                    read_state_explicit: summary.read_state_explicit,
+                    last_read_position: summary.last_read_position,
+                    last_read_revision: summary.last_read_revision,
+                    unread_count: summary.unread_count,
+                    has_unread_topic_revision: summary.has_unread_topic_revision,
+                    is_unread: summary.is_unread,
+                })
+            })
+            .collect::<ForumResult<Vec<_>>>()?;
+
+        Ok(TopicUnreadCursorPage {
             items,
             next_cursor,
             has_more,
@@ -327,6 +321,113 @@ impl ForumReadModelService {
             next_cursor,
             has_more,
         })
+    }
+
+    async fn load_topic_rows(
+        &self,
+        tenant_id: Uuid,
+        query: &TopicCursorQuery,
+        extra_filter: Option<Condition>,
+    ) -> ForumResult<(Vec<forum_topic::Model>, Option<String>, bool)> {
+        let limit = bounded_forum_read_limit(query.limit);
+        let mut select =
+            forum_topic::Entity::find().filter(forum_topic::Column::TenantId.eq(tenant_id));
+        if let Some(category_id) = query.category_id {
+            select = select.filter(forum_topic::Column::CategoryId.eq(category_id));
+        }
+        if let Some(status) = query.status {
+            select = select.filter(forum_topic::Column::Status.eq(status));
+        }
+        if let Some(extra_filter) = extra_filter {
+            select = select.filter(extra_filter);
+        }
+        if let Some(cursor) = query.cursor.as_deref() {
+            let cursor = decode_topic_cursor(cursor)?;
+            select = select.filter(
+                Condition::any()
+                    .add(forum_topic::Column::UpdatedAt.lt(cursor.updated_at))
+                    .add(
+                        Condition::all()
+                            .add(forum_topic::Column::UpdatedAt.eq(cursor.updated_at))
+                            .add(forum_topic::Column::Id.lt(cursor.id)),
+                    ),
+            );
+        }
+
+        let mut topics = select
+            .order_by_desc(forum_topic::Column::UpdatedAt)
+            .order_by_desc(forum_topic::Column::Id)
+            .limit(limit + 1)
+            .all(&self.db)
+            .await?;
+        let has_more = topics.len() > limit as usize;
+        topics.truncate(limit as usize);
+        let next_cursor = has_more
+            .then(|| topics.last().map(encode_topic_cursor))
+            .flatten();
+        Ok((topics, next_cursor, has_more))
+    }
+
+    async fn materialize_topic_read_models(
+        &self,
+        tenant_id: Uuid,
+        topics: Vec<forum_topic::Model>,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        user_id: Option<Uuid>,
+    ) -> ForumResult<Vec<TopicReadModel>> {
+        let ids = topics.iter().map(|item| item.id).collect::<Vec<_>>();
+        let translations = topic_translations_by_id(&self.db, tenant_id, &ids).await?;
+        let votes = VoteService::new(self.db.clone())
+            .topic_vote_summaries(tenant_id, &ids, user_id)
+            .await?;
+        let subscriptions = SubscriptionService::new(self.db.clone())
+            .topic_subscription_flags(tenant_id, &ids, user_id)
+            .await?;
+        let solutions = solution_ids_by_topic(&self.db, tenant_id, &ids).await?;
+
+        Ok(topics
+            .into_iter()
+            .map(|topic| {
+                let localized = translations.get(&topic.id).cloned().unwrap_or_default();
+                let resolved = resolve_by_locale_with_fallback(
+                    &localized,
+                    locale,
+                    fallback_locale,
+                    |translation| translation.locale.as_str(),
+                );
+                let vote = votes.get(&topic.id).copied().unwrap_or_default();
+                TopicReadModel {
+                    id: topic.id,
+                    category_id: topic.category_id,
+                    author_id: topic.author_id,
+                    requested_locale: locale.to_string(),
+                    effective_locale: resolved.effective_locale,
+                    available_locales: available_locales_from(&localized, |translation| {
+                        translation.locale.as_str()
+                    }),
+                    title: resolved
+                        .item
+                        .map(|translation| translation.title.clone())
+                        .unwrap_or_default(),
+                    slug: resolved
+                        .item
+                        .and_then(|translation| translation.slug.clone())
+                        .unwrap_or_default(),
+                    metadata: topic.metadata,
+                    status: topic.status.to_string(),
+                    is_pinned: topic.is_pinned,
+                    is_locked: topic.is_locked,
+                    reply_count: topic.reply_count,
+                    vote_score: vote.score,
+                    current_user_vote: vote.current_user_vote,
+                    is_subscribed: subscriptions.get(&topic.id).copied().unwrap_or(false),
+                    solution_reply_id: solutions.get(&topic.id).copied(),
+                    created_at: topic.created_at.to_rfc3339(),
+                    updated_at: topic.updated_at.to_rfc3339(),
+                }
+            })
+            .collect())
     }
 }
 
@@ -436,6 +537,134 @@ fn normalized_optional_locale(locale: Option<&str>) -> ForumResult<Option<String
                 .ok_or_else(|| ForumError::Validation("Invalid fallback locale".to_string()))
         })
         .transpose()
+}
+
+fn unread_topic_condition(user_id: Uuid) -> Condition {
+    Condition::all().add(Expr::cust_with_values(
+        r#"
+NOT EXISTS (
+    SELECT 1
+    FROM forum_topic_read_states state
+    WHERE state.tenant_id = forum_topics.tenant_id
+      AND state.topic_id = forum_topics.id
+      AND state.user_id = ?
+)
+OR EXISTS (
+    SELECT 1
+    FROM forum_replies reply
+    WHERE reply.tenant_id = forum_topics.tenant_id
+      AND reply.topic_id = forum_topics.id
+      AND reply.status = 'approved'
+      AND reply.position > COALESCE((
+          SELECT state.last_read_position
+          FROM forum_topic_read_states state
+          WHERE state.tenant_id = forum_topics.tenant_id
+            AND state.topic_id = forum_topics.id
+            AND state.user_id = ?
+      ), 0)
+)
+OR EXISTS (
+    SELECT 1
+    FROM forum_topic_revisions revision
+    WHERE revision.tenant_id = forum_topics.tenant_id
+      AND revision.topic_id = forum_topics.id
+      AND revision.id > COALESCE((
+          SELECT state.last_read_revision
+          FROM forum_topic_read_states state
+          WHERE state.tenant_id = forum_topics.tenant_id
+            AND state.topic_id = forum_topics.id
+            AND state.user_id = ?
+      ), 0)
+)
+"#,
+        vec![user_id.into(), user_id.into(), user_id.into()],
+    ))
+}
+
+async fn topic_unread_summaries(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    topic_ids: &[Uuid],
+) -> ForumResult<HashMap<Uuid, TopicUnreadSummary>> {
+    if topic_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let placeholders = (0..topic_ids.len())
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        r#"
+SELECT
+    topic.id AS topic_id,
+    state.user_id AS state_user_id,
+    COALESCE(state.last_read_position, 0) AS last_read_position,
+    COALESCE(state.last_read_revision, 0) AS last_read_revision,
+    COUNT(DISTINCT unread_reply.id) AS unread_count,
+    COUNT(DISTINCT unread_revision.id) AS unread_revision_count
+FROM forum_topics topic
+LEFT JOIN forum_topic_read_states state
+  ON state.tenant_id = topic.tenant_id
+ AND state.topic_id = topic.id
+ AND state.user_id = ?
+LEFT JOIN forum_replies unread_reply
+  ON unread_reply.tenant_id = topic.tenant_id
+ AND unread_reply.topic_id = topic.id
+ AND unread_reply.status = 'approved'
+ AND unread_reply.position > COALESCE(state.last_read_position, 0)
+LEFT JOIN forum_topic_revisions unread_revision
+  ON unread_revision.tenant_id = topic.tenant_id
+ AND unread_revision.topic_id = topic.id
+ AND unread_revision.id > COALESCE(state.last_read_revision, 0)
+WHERE topic.tenant_id = ?
+  AND topic.id IN ({placeholders})
+GROUP BY
+    topic.id,
+    state.user_id,
+    state.last_read_position,
+    state.last_read_revision
+"#,
+    );
+    let mut values = Vec::<Value>::with_capacity(topic_ids.len() + 2);
+    values.push(user_id.into());
+    values.push(tenant_id.into());
+    values.extend(topic_ids.iter().copied().map(Value::from));
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            sql,
+            values,
+        ))
+        .await?;
+    let mut summaries = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let topic_id = row.try_get::<Uuid>("", "topic_id")?;
+        let read_state_explicit = row
+            .try_get::<Option<Uuid>>("", "state_user_id")?
+            .is_some();
+        let last_read_position = row.try_get::<i64>("", "last_read_position")?;
+        let last_read_revision = row.try_get::<i64>("", "last_read_revision")?;
+        let unread_count = row.try_get::<i64>("", "unread_count")?;
+        let unread_revision_count = row.try_get::<i64>("", "unread_revision_count")?;
+        let has_unread_topic_revision = unread_revision_count > 0;
+        summaries.insert(
+            topic_id,
+            TopicUnreadSummary {
+                read_state_explicit,
+                last_read_position,
+                last_read_revision,
+                unread_count,
+                has_unread_topic_revision,
+                is_unread: !read_state_explicit
+                    || unread_count > 0
+                    || has_unread_topic_revision,
+            },
+        );
+    }
+    Ok(summaries)
 }
 
 async fn category_translations_by_id(

--- a/crates/rustok-forum/src/services/read_model.rs
+++ b/crates/rustok-forum/src/services/read_model.rs
@@ -556,13 +556,23 @@ OR EXISTS (
     WHERE reply.tenant_id = forum_topics.tenant_id
       AND reply.topic_id = forum_topics.id
       AND reply.status = 'approved'
-      AND reply.position > COALESCE((
-          SELECT state.last_read_position
-          FROM forum_topic_read_states state
-          WHERE state.tenant_id = forum_topics.tenant_id
-            AND state.topic_id = forum_topics.id
-            AND state.user_id = ?
-      ), 0)
+      AND (
+          reply.position > COALESCE((
+              SELECT state.last_read_position
+              FROM forum_topic_read_states state
+              WHERE state.tenant_id = forum_topics.tenant_id
+                AND state.topic_id = forum_topics.id
+                AND state.user_id = ?
+          ), 0)
+          OR EXISTS (
+              SELECT 1
+              FROM forum_topic_read_states state
+              WHERE state.tenant_id = forum_topics.tenant_id
+                AND state.topic_id = forum_topics.id
+                AND state.user_id = ?
+                AND reply.updated_at > state.updated_at
+          )
+      )
 )
 OR EXISTS (
     SELECT 1
@@ -579,7 +589,12 @@ OR EXISTS (
 )
 )
 "#,
-        vec![user_id.into(), user_id.into(), user_id.into()],
+        vec![
+            user_id.into(),
+            user_id.into(),
+            user_id.into(),
+            user_id.into(),
+        ],
     ))
 }
 
@@ -615,7 +630,10 @@ LEFT JOIN forum_replies unread_reply
   ON unread_reply.tenant_id = topic.tenant_id
  AND unread_reply.topic_id = topic.id
  AND unread_reply.status = 'approved'
- AND unread_reply.position > COALESCE(state.last_read_position, 0)
+ AND (
+      unread_reply.position > COALESCE(state.last_read_position, 0)
+      OR unread_reply.updated_at > state.updated_at
+ )
 LEFT JOIN forum_topic_revisions unread_revision
   ON unread_revision.tenant_id = topic.tenant_id
  AND unread_revision.topic_id = topic.id

--- a/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
@@ -124,7 +124,7 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
         "Reply topic",
     )
     .await;
-    let first_reply = replies
+    replies
         .create(
             tenant_id,
             reader.clone(),
@@ -154,8 +154,6 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
         )
         .await
         .expect("second reply should be created");
-    assert_eq!(first_reply.position, 1);
-    assert_eq!(second_reply.position, 2);
     read_state
         .mark_topic_read(
             tenant_id,
@@ -177,7 +175,7 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
         "Revision topic",
     )
     .await;
-    let revision_reply = replies
+    replies
         .create(
             tenant_id,
             reader.clone(),
@@ -198,7 +196,7 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
             revision_topic,
             reader.clone(),
             MarkForumTopicReadInput {
-                last_read_position: revision_reply.position,
+                last_read_position: 1,
                 last_read_revision: 0,
             },
         )
@@ -357,7 +355,7 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
             revision_topic,
             reader.clone(),
             MarkForumTopicReadInput {
-                last_read_position: revision_reply.position,
+                last_read_position: 1,
                 last_read_revision: latest_revision,
             },
         )

--- a/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
@@ -1,0 +1,396 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
+use rustok_forum::entities::forum_topic_revision;
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput,
+    ForumReadModelService, ForumTopicReadStateService, ForumModule, MarkForumTopicReadInput,
+    ModerationService, ReplyService, TopicService, TopicUnreadCursorQuery, UpdateTopicInput,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus, Uuid) {
+    let db_url = format!(
+        "sqlite:file:forum_topic_unread_projection_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum topic unread sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus, Uuid::new_v4())
+}
+
+async fn create_topic(
+    topics: &TopicService,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    author: SecurityContext,
+    title: &str,
+) -> Uuid {
+    topics
+        .create(
+            tenant_id,
+            author,
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id,
+                title: title.into(),
+                slug: Some(title.to_ascii_lowercase().replace(' ', "-")),
+                body: format!("{title} body"),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: vec![],
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created")
+        .id
+}
+
+#[tokio::test]
+async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
+    let (db, event_bus, tenant_id) = setup().await;
+    let author = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let reader = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+    let anonymous = SecurityContext::new(UserRole::Customer, None);
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            author.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Unread projection".into(),
+                slug: "unread-projection".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created");
+
+    let topics = TopicService::new(db.clone(), event_bus.clone());
+    let replies = ReplyService::new(db.clone(), event_bus.clone());
+    let moderation = ModerationService::new(db.clone(), event_bus);
+    let read_state = ForumTopicReadStateService::new(db.clone());
+    let projection = ForumReadModelService::new(db.clone());
+
+    let unseen_topic = create_topic(
+        &topics,
+        tenant_id,
+        category.id,
+        author.clone(),
+        "Unseen topic",
+    )
+    .await;
+
+    let reply_topic = create_topic(
+        &topics,
+        tenant_id,
+        category.id,
+        author.clone(),
+        "Reply topic",
+    )
+    .await;
+    let first_reply = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            reply_topic,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "First approved reply".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("first reply should be created");
+    let second_reply = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            reply_topic,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Second approved reply".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("second reply should be created");
+    assert_eq!(first_reply.position, 1);
+    assert_eq!(second_reply.position, 2);
+    read_state
+        .mark_topic_read(
+            tenant_id,
+            reply_topic,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: 1,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("reader should persist the first reply position");
+
+    let revision_topic = create_topic(
+        &topics,
+        tenant_id,
+        category.id,
+        author.clone(),
+        "Revision topic",
+    )
+    .await;
+    let revision_reply = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            revision_topic,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Read before edit".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("revision topic reply should be created");
+    read_state
+        .mark_topic_read(
+            tenant_id,
+            revision_topic,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: revision_reply.position,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("revision topic should initially be fully read");
+    topics
+        .update(
+            tenant_id,
+            revision_topic,
+            author.clone(),
+            UpdateTopicInput {
+                locale: "en".into(),
+                title: Some("Revision topic updated".into()),
+                body: Some("Updated after the reader opened the topic".into()),
+                body_format: Some("markdown".into()),
+                content_json: None,
+                metadata: None,
+                tags: None,
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic edit should create an immutable revision");
+    let latest_revision = forum_topic_revision::Entity::find()
+        .filter(forum_topic_revision::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_revision::Column::TopicId.eq(revision_topic))
+        .order_by_desc(forum_topic_revision::Column::Id)
+        .one(&db)
+        .await
+        .expect("revision query should succeed")
+        .expect("topic edit should record a revision")
+        .id;
+
+    let all = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                limit: Some(20),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("unread projection should load");
+    let by_id = all
+        .items
+        .iter()
+        .map(|item| (item.topic.id, item))
+        .collect::<HashMap<_, _>>();
+
+    let unseen = by_id.get(&unseen_topic).expect("unseen topic should project");
+    assert!(!unseen.read_state_explicit);
+    assert_eq!(unseen.unread_count, 0);
+    assert!(!unseen.has_unread_topic_revision);
+    assert!(unseen.is_unread, "an unseen topic is unread even without replies");
+
+    let reply_unread = by_id.get(&reply_topic).expect("reply topic should project");
+    assert!(reply_unread.read_state_explicit);
+    assert_eq!(reply_unread.last_read_position, 1);
+    assert_eq!(reply_unread.unread_count, 1);
+    assert!(!reply_unread.has_unread_topic_revision);
+    assert!(reply_unread.is_unread);
+
+    let revision_unread = by_id
+        .get(&revision_topic)
+        .expect("revision topic should project");
+    assert!(revision_unread.read_state_explicit);
+    assert_eq!(revision_unread.unread_count, 0);
+    assert!(revision_unread.has_unread_topic_revision);
+    assert!(revision_unread.is_unread);
+
+    moderation
+        .hide_reply(
+            tenant_id,
+            second_reply.id,
+            reply_topic,
+            author.clone(),
+        )
+        .await
+        .expect("moderator should hide the unread reply");
+    let after_hide = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                limit: Some(20),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("projection after hide should load");
+    let hidden_summary = after_hide
+        .items
+        .iter()
+        .find(|item| item.topic.id == reply_topic)
+        .expect("reply topic should remain visible");
+    assert_eq!(hidden_summary.unread_count, 0);
+    assert!(!hidden_summary.is_unread, "hidden replies must not inflate unread state");
+
+    let first_page = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                limit: Some(1),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("first unread page should load");
+    assert_eq!(first_page.items.len(), 1);
+    assert!(first_page.has_more);
+    let second_page = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                cursor: first_page.next_cursor.clone(),
+                category_id: Some(category.id),
+                limit: Some(1),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("second unread page should load");
+    assert_eq!(second_page.items.len(), 1);
+    assert!(!second_page.has_more);
+    let unread_ids = first_page
+        .items
+        .iter()
+        .chain(second_page.items.iter())
+        .map(|item| item.topic.id)
+        .collect::<HashSet<_>>();
+    assert_eq!(unread_ids, HashSet::from([unseen_topic, revision_topic]));
+
+    read_state
+        .mark_topic_read(
+            tenant_id,
+            unseen_topic,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: 0,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("opening an empty topic should persist explicit zero state");
+    read_state
+        .mark_topic_read(
+            tenant_id,
+            revision_topic,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: revision_reply.position,
+                last_read_revision: latest_revision,
+            },
+        )
+        .await
+        .expect("reader should advance to the latest topic revision");
+    let empty = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("fully read projection should load");
+    assert!(empty.items.is_empty());
+    assert!(!empty.has_more);
+    assert_eq!(empty.next_cursor, None);
+
+    let anonymous_result = projection
+        .list_topics_with_unread(
+            tenant_id,
+            anonymous,
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(
+        anonymous_result.is_err(),
+        "personal unread projection must require an authenticated user"
+    );
+}

--- a/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_unread_projection_sqlite.rs
@@ -392,3 +392,127 @@ async fn unread_projection_is_bounded_visibility_aware_and_cursor_correct() {
         "personal unread projection must require an authenticated user"
     );
 }
+
+#[tokio::test]
+async fn late_approval_below_read_position_becomes_unread() {
+    let (db, event_bus, tenant_id) = setup().await;
+    let author = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let reader = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            author.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Moderated unread".into(),
+                slug: "moderated-unread".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: true,
+            },
+        )
+        .await
+        .expect("moderated category should be created");
+    let topics = TopicService::new(db.clone(), event_bus.clone());
+    let topic_id = create_topic(
+        &topics,
+        tenant_id,
+        category.id,
+        author.clone(),
+        "Late approval topic",
+    )
+    .await;
+    let replies = ReplyService::new(db.clone(), event_bus.clone());
+    let first_pending = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            topic_id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Pending position one".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("first pending reply should be created");
+    let second_pending = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            topic_id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Pending position two".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("second pending reply should be created");
+    assert_eq!(first_pending.status, "pending");
+    assert_eq!(second_pending.status, "pending");
+
+    let moderation = ModerationService::new(db.clone(), event_bus);
+    moderation
+        .approve_reply(tenant_id, second_pending.id, topic_id, author.clone())
+        .await
+        .expect("position two should be approved first");
+    ForumTopicReadStateService::new(db.clone())
+        .mark_topic_read(
+            tenant_id,
+            topic_id,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: 2,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("reader should record approved position two");
+
+    let projection = ForumReadModelService::new(db.clone());
+    let before_late_approval = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("unread projection before late approval should load");
+    assert!(before_late_approval.items.is_empty());
+
+    moderation
+        .approve_reply(tenant_id, first_pending.id, topic_id, author)
+        .await
+        .expect("position one should be approved after the read snapshot");
+    let after_late_approval = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader,
+            TopicUnreadCursorQuery {
+                category_id: Some(category.id),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("unread projection after late approval should load");
+    assert_eq!(after_late_approval.items.len(), 1);
+    let item = &after_late_approval.items[0];
+    assert_eq!(item.topic.id, topic_id);
+    assert_eq!(item.last_read_position, 2);
+    assert_eq!(item.unread_count, 1);
+    assert!(item.is_unread);
+}


### PR DESCRIPTION
## Summary

- add an authenticated `TopicUnreadCursorQuery` and additive unread topic projection without changing the existing public topic-list contract
- enrich each bounded cursor page with explicit read-state presence, last-read position/revision, approved-reply unread count, topic-revision unread state, and canonical `is_unread`
- apply `unread_only` before cursor pagination so unseen topics, new approved replies, and newer immutable revisions paginate correctly
- exclude hidden, rejected, and deleted replies through the approved-public predicate
- treat an approved reply as unread when its position is above the high-water mark or its publication/update timestamp is newer than the read snapshot, covering late moderator approval below an already-read position
- reuse the existing topic materialization path and load unread summaries in one bounded aggregate query rather than N+1 reply reads
- add SQLite owner coverage for unseen empty topics, reply and revision unread state, moderation visibility changes, late approval ordering, two-page unread cursors, explicit zero state, and anonymous rejection
- record FORUM-16B in the canonical implementation plan while keeping bulk mark-read commands, transport composition, and PostgreSQL concurrency/query-plan evidence open

No REST, GraphQL, storefront, realtime, migration, or CI surface is changed in this slice.

## Validation

Not run by request; the repository owner will run the targeted Forum SQLite scenarios and module validation locally.