### PR TITLE
Harden storefront cart GraphQL helper errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -6,6 +6,9 @@ pub mod cart;
 pub mod catalog;
 pub mod checkout;
 pub mod fulfillment;
+#[path = "helpers.rs"]
+mod legacy_helpers;
+#[path = "safe_helpers.rs"]
 pub mod helpers;
 pub mod pricing;
 pub mod provider_operations;

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -1,0 +1,424 @@
+use async_graphql::{ErrorExtensions, Result};
+use rustok_api::{
+    AuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+};
+use rustok_cart::CartStorefrontPort;
+use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
+use rustok_pricing::{PriceResolutionContext, PricingReadPort};
+use rustok_product::entities::product_variant;
+use uuid::Uuid;
+
+use super::super::types::AddStorefrontCartLineItemInput;
+pub(crate) use super::legacy_helpers::{
+    ResolvedStorefrontLineItemInput, build_create_order_change_input,
+    build_create_order_return_input, build_create_return_decision_input,
+    build_return_claim_decision_input, build_return_exchange_decision_input,
+    build_return_refund_decision_input, build_storefront_pricing_context, cart_context_metadata,
+    convert_create_product_input, current_shipping_selections, ensure_no_unused_promotion_amount,
+    ensure_storefront_cart_access, ensure_storefront_order_access,
+    graphql_decision_requires_payments_update, map_cart_promotion_preview, maybe_undefined_or_existing,
+    merge_graphql_metadata, normalize_graphql_seller_id, normalize_pricing_channel_slug,
+    parse_decimal, parse_json_payload, parse_optional_decimal, parse_optional_metadata,
+    parse_pricing_currency_code, parse_required_promotion_decimal, pick_product_translation,
+    pick_variant_translation, request_public_channel_slug, resolve_commerce_graphql_locale,
+    seller_snapshot_metadata, storefront_cart_port_context, storefront_cart_pricing_snapshot,
+    storefront_cart_pricing_update, storefront_pricing_port_context,
+    storefront_public_channel_slug_for_cart, validate_admin_cart_promotion_target,
+    validate_product_shipping_profile_input, validate_shipping_option_profile_inputs,
+};
+
+fn public_graphql_error(
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
+fn storefront_customer_port_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        format!("storefront-customer:{user_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2))
+}
+
+fn customer_port_graphql_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PortError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        owner_code = %error.code,
+        owner_kind = ?error.kind,
+        owner_retryable = error.retryable,
+        "commerce GraphQL storefront customer owner port failed"
+    );
+
+    let (message, code, retryable) = match &error.kind {
+        PortErrorKind::Validation => (
+            "Customer request is invalid",
+            "CUSTOMER_REQUEST_INVALID",
+            false,
+        ),
+        PortErrorKind::NotFound => ("Customer was not found", "CUSTOMER_NOT_FOUND", false),
+        PortErrorKind::Conflict => (
+            "Customer state conflicts with the requested operation",
+            "CUSTOMER_STATE_CONFLICT",
+            false,
+        ),
+        PortErrorKind::Forbidden => (
+            "Customer operation is not permitted",
+            "CUSTOMER_ACCESS_DENIED",
+            false,
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            "Customer information is temporarily unavailable",
+            "CUSTOMER_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        PortErrorKind::InvariantViolation => (
+            "Customer operation could not be completed safely",
+            "CUSTOMER_OPERATION_FAILED",
+            false,
+        ),
+    };
+    public_graphql_error(message, code, retryable)
+}
+
+pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        operation = "storefront_cart_port",
+        owner_code = %error.code,
+        owner_kind = ?error.kind,
+        owner_retryable = error.retryable,
+        "commerce GraphQL storefront cart owner port failed"
+    );
+
+    let (message, code, retryable) = match &error.kind {
+        PortErrorKind::Validation => ("Cart request is invalid", "CART_REQUEST_INVALID", false),
+        PortErrorKind::NotFound => ("Cart resource was not found", "CART_RESOURCE_NOT_FOUND", false),
+        PortErrorKind::Conflict => (
+            "Cart operation conflicts with the current state",
+            "CART_STATE_CONFLICT",
+            false,
+        ),
+        PortErrorKind::Forbidden => (
+            "Cart operation is not permitted",
+            "CART_ACCESS_DENIED",
+            false,
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            "Cart is temporarily unavailable",
+            "CART_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        PortErrorKind::InvariantViolation => (
+            "Cart operation could not be completed safely",
+            "CART_OPERATION_FAILED",
+            false,
+        ),
+    };
+    public_graphql_error(message, code, retryable)
+}
+
+pub(crate) async fn resolve_optional_storefront_customer_id(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    auth: Option<&AuthContext>,
+) -> Result<Option<Uuid>> {
+    let Some(auth) = auth else {
+        return Ok(None);
+    };
+
+    let port_context = storefront_customer_port_context(tenant_id, auth.user_id);
+    let error_context = port_context.clone();
+    match in_process_customer_read_port(db.clone())
+        .read_customer_projection_by_user(
+            port_context,
+            CustomerUserProjectionRequest {
+                user_id: auth.user_id,
+            },
+        )
+        .await
+    {
+        Ok(customer) => Ok(Some(customer.id)),
+        Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None),
+        Err(error) => Err(customer_port_graphql_error(
+            &error_context,
+            "resolve_optional_storefront_customer_id",
+            error,
+        )),
+    }
+}
+
+fn legacy_graphql_error(
+    error: async_graphql::Error,
+    tenant_id: Uuid,
+    resource_id: Option<Uuid>,
+    operation: &'static str,
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        resource_id = ?resource_id,
+        operation,
+        "commerce GraphQL storefront cart helper failed"
+    );
+    public_graphql_error(message, code, retryable)
+}
+
+pub(crate) async fn enrich_storefront_cart(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    tenant_default_locale: &str,
+    cart: crate::dto::CartResponse,
+) -> Result<crate::dto::CartResponse> {
+    let cart_id = cart.id;
+    super::legacy_helpers::enrich_storefront_cart(
+        db,
+        tenant_id,
+        request_context,
+        tenant_default_locale,
+        cart,
+    )
+    .await
+    .map_err(|error| {
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(cart_id),
+            "enrich_storefront_cart",
+            "Cart shipping details are temporarily unavailable",
+            "CART_ENRICHMENT_UNAVAILABLE",
+            true,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn validate_selected_shipping_option(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    cart: &crate::dto::CartResponse,
+    selected_shipping_option_id: Option<Uuid>,
+    shipping_selections: Option<&[crate::dto::CartShippingSelectionInput]>,
+    currency_code: &str,
+    public_channel_slug: Option<&str>,
+    requested_locale: Option<&str>,
+    tenant_default_locale: Option<&str>,
+) -> Result<()> {
+    super::legacy_helpers::validate_selected_shipping_option(
+        db,
+        tenant_id,
+        cart,
+        selected_shipping_option_id,
+        shipping_selections,
+        currency_code,
+        public_channel_slug,
+        requested_locale,
+        tenant_default_locale,
+    )
+    .await
+    .map_err(|error| {
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(cart.id),
+            "validate_selected_shipping_option",
+            "Selected shipping option is invalid",
+            "SHIPPING_OPTION_INVALID",
+            false,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn resolve_storefront_line_item_input(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    pricing_read_port: &dyn PricingReadPort,
+    pricing_port_context: PortContext,
+    pricing_context: &PriceResolutionContext,
+    locale: &str,
+    default_locale: &str,
+    public_channel_slug: Option<&str>,
+    input: AddStorefrontCartLineItemInput,
+) -> Result<ResolvedStorefrontLineItemInput> {
+    let variant_id = input.variant_id;
+    super::legacy_helpers::resolve_storefront_line_item_input(
+        db,
+        tenant_id,
+        pricing_read_port,
+        pricing_port_context,
+        pricing_context,
+        locale,
+        default_locale,
+        public_channel_slug,
+        input,
+    )
+    .await
+    .map_err(|error| {
+        let detail = format!("{error:?}");
+        let (message, code, retryable) = if detail.contains("Variant not found")
+            || detail.contains("Product not found")
+        {
+            ("Product is not available", "CART_PRODUCT_UNAVAILABLE", false)
+        } else if detail.contains("does not have enough available inventory") {
+            (
+                "Requested quantity is not available",
+                "CART_INVENTORY_INSUFFICIENT",
+                false,
+            )
+        } else if detail.contains("Invalid JSON metadata payload") {
+            ("Cart line item input is invalid", "CART_LINE_ITEM_INVALID", false)
+        } else {
+            (
+                "Cart line item could not be resolved",
+                "CART_LINE_ITEM_RESOLUTION_FAILED",
+                true,
+            )
+        };
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(variant_id),
+            "resolve_storefront_line_item_input",
+            message,
+            code,
+            retryable,
+        )
+    })
+}
+
+pub(crate) async fn reprice_storefront_cart_line_items(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    event_bus: &rustok_outbox::TransactionalEventBus,
+    cart_storefront_port: &dyn CartStorefrontPort,
+    cart: crate::dto::CartResponse,
+) -> Result<crate::dto::CartResponse> {
+    let cart_id = cart.id;
+    super::legacy_helpers::reprice_storefront_cart_line_items(
+        db,
+        tenant_id,
+        request_context,
+        event_bus,
+        cart_storefront_port,
+        cart,
+    )
+    .await
+    .map_err(|error| {
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(cart_id),
+            "reprice_storefront_cart_line_items",
+            "Cart pricing could not be refreshed",
+            "CART_REPRICE_FAILED",
+            true,
+        )
+    })
+}
+
+pub(crate) async fn validate_storefront_line_item_quantity(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    variant_id: Uuid,
+    requested_quantity: i32,
+    public_channel_slug: Option<&str>,
+) -> Result<()> {
+    super::legacy_helpers::validate_storefront_line_item_quantity(
+        db,
+        tenant_id,
+        variant_id,
+        requested_quantity,
+        public_channel_slug,
+    )
+    .await
+    .map_err(|error| {
+        let detail = format!("{error:?}");
+        let (message, code, retryable) = if detail.contains("Variant not found") {
+            ("Product is not available", "CART_PRODUCT_UNAVAILABLE", false)
+        } else if detail.contains("does not have enough available inventory") {
+            (
+                "Requested quantity is not available",
+                "CART_INVENTORY_INSUFFICIENT",
+                false,
+            )
+        } else {
+            (
+                "Inventory availability could not be verified",
+                "CART_INVENTORY_UNAVAILABLE",
+                true,
+            )
+        };
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(variant_id),
+            "validate_storefront_line_item_quantity",
+            message,
+            code,
+            retryable,
+        )
+    })
+}
+
+pub(crate) async fn validate_storefront_variant_inventory(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    variant: &product_variant::Model,
+    requested_quantity: i32,
+    public_channel_slug: Option<&str>,
+) -> Result<()> {
+    super::legacy_helpers::validate_storefront_variant_inventory(
+        db,
+        tenant_id,
+        variant,
+        requested_quantity,
+        public_channel_slug,
+    )
+    .await
+    .map_err(|error| {
+        let detail = format!("{error:?}");
+        let (message, code, retryable) =
+            if detail.contains("does not have enough available inventory") {
+                (
+                    "Requested quantity is not available",
+                    "CART_INVENTORY_INSUFFICIENT",
+                    false,
+                )
+            } else {
+                (
+                    "Inventory availability could not be verified",
+                    "CART_INVENTORY_UNAVAILABLE",
+                    true,
+                )
+            };
+        legacy_graphql_error(
+            error,
+            tenant_id,
+            Some(variant.id),
+            "validate_storefront_variant_inventory",
+            message,
+            code,
+            retryable,
+        )
+    })
+}

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const moduleSource = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const facadeSource = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['#[path = "helpers.rs"]\nmod legacy_helpers;', 'private legacy helper routing'],
+  ['#[path = "safe_helpers.rs"]\npub mod helpers;', 'public safe helper routing'],
+]) {
+  requireText(moduleSource, value, label);
+}
+
+for (const value of [
+  'async_graphql::Error::new(error.message)',
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+  'pub(crate) use super::legacy_helpers::*',
+]) {
+  forbidText(facadeSource, value, 'storefront cart safe helper facade');
+}
+
+for (const [value, label] of [
+  ['PortError, PortErrorKind', 'port error imports'],
+  ['fn customer_port_graphql_error(', 'customer mapper'],
+  ['pub(crate) fn cart_port_error(', 'cart mapper'],
+  ['correlation_id = %context.correlation_id', 'customer correlation logging'],
+  ['tenant_id = %context.tenant_id', 'customer tenant logging'],
+  ['owner_code = %error.code', 'owner code logging'],
+  ['owner_kind = ?error.kind', 'owner kind logging'],
+  ['owner_retryable = error.retryable', 'owner retryability logging'],
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['PortErrorKind::Conflict', 'conflict mapping'],
+  ['PortErrorKind::Forbidden', 'forbidden mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'availability mapping'],
+  ['PortErrorKind::InvariantViolation', 'invariant mapping'],
+  ['"CART_REQUEST_INVALID"', 'cart validation code'],
+  ['"CART_RESOURCE_NOT_FOUND"', 'cart not-found code'],
+  ['"CART_STATE_CONFLICT"', 'cart conflict code'],
+  ['"CART_ACCESS_DENIED"', 'cart forbidden code'],
+  ['"CART_TEMPORARILY_UNAVAILABLE"', 'cart availability code'],
+  ['"CART_OPERATION_FAILED"', 'cart invariant code'],
+  ['"CUSTOMER_TEMPORARILY_UNAVAILABLE"', 'customer availability code'],
+  ['fn legacy_graphql_error(', 'legacy envelope interceptor'],
+  ['resource_id = ?resource_id', 'resource logging'],
+  ['"Cart shipping details are temporarily unavailable"', 'cart enrichment message'],
+  ['"Selected shipping option is invalid"', 'shipping selection message'],
+  ['"Product is not available"', 'product availability message'],
+  ['"Requested quantity is not available"', 'inventory insufficiency message'],
+  ['"Cart line item could not be resolved"', 'line item fallback message'],
+  ['"Cart pricing could not be refreshed"', 'reprice fallback message'],
+  ['"Inventory availability could not be verified"', 'inventory dependency message'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+]) {
+  requireText(facadeSource, value, label);
+}
+
+for (const operation of [
+  'resolve_optional_storefront_customer_id',
+  'enrich_storefront_cart',
+  'validate_selected_shipping_option',
+  'resolve_storefront_line_item_input',
+  'reprice_storefront_cart_line_items',
+  'validate_storefront_line_item_quantity',
+  'validate_storefront_variant_inventory',
+]) {
+  requireText(facadeSource, `"${operation}"`, `${operation} operation mapping`);
+}
+
+const legacyCalls =
+  facadeSource.match(/super::legacy_helpers::[a-z_]+\(/g) ?? [];
+if (legacyCalls.length !== 6) {
+  failures.push(`expected 6 intercepted legacy helper calls, found ${legacyCalls.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL storefront cart helper error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL storefront cart helpers route through stable public envelopes while legacy implementation stays private',
+);


### PR DESCRIPTION
## Summary

- route the public commerce GraphQL mutation helper module through a safe storefront-cart facade while keeping the existing implementation private as `legacy_helpers`;
- replace the shared cart `PortError.message` passthrough with stable GraphQL codes/messages for every current `PortErrorKind`;
- preserve correlation-aware customer owner-port logging and stable customer envelopes for optional storefront customer resolution;
- intercept legacy cart enrichment, shipping selection, line-item resolution, repricing, and inventory errors before they leave the helper boundary;
- remove product/variant UUIDs, shipping-option identifiers, inventory projection causes, pricing owner messages, and database text from those public GraphQL responses;
- preserve the existing helper API through explicit re-exports so cart, checkout, catalog, fulfillment, pricing, and provider mutation imports remain unchanged;
- add a static verifier for module routing, stable mappings, structured logs, explicit exports, and all six intercepted legacy helper calls.

## Scope

Three files only. Cart persistence, pricing calculations, shipping compatibility, inventory checks, permissions, DTOs, and mutation signatures are unchanged. Order-access and admin shipping-profile helper envelopes remain for the next fulfillment/order slice.

## Public envelopes

The storefront cart helper now returns stable codes including `CART_REQUEST_INVALID`, `CART_RESOURCE_NOT_FOUND`, `CART_STATE_CONFLICT`, `CART_ACCESS_DENIED`, `CART_TEMPORARILY_UNAVAILABLE`, `CART_OPERATION_FAILED`, `CART_ENRICHMENT_UNAVAILABLE`, `SHIPPING_OPTION_INVALID`, `CART_PRODUCT_UNAVAILABLE`, `CART_INVENTORY_INSUFFICIENT`, `CART_INVENTORY_UNAVAILABLE`, `CART_LINE_ITEM_INVALID`, `CART_LINE_ITEM_RESOLUTION_FAILED`, and `CART_REPRICE_FAILED`.

## Validation

- source and compare audit completed against current `main`;
- branch is directly based on current `main` and changes three files;
- explicit helper export set reviewed against all six mutation modules importing `super::helpers::*`;
- tests, cargo commands, and verifier execution were not run, per request.