### PR TITLE
Harden GraphQL order and shipping helper errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -9,6 +9,8 @@ pub mod fulfillment;
 #[path = "helpers.rs"]
 mod legacy_helpers;
 #[path = "safe_helpers.rs"]
+mod cart_safe_helpers;
+#[path = "safe_order_helpers.rs"]
 pub mod helpers;
 pub mod pricing;
 pub mod provider_operations;

--- a/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
@@ -1,0 +1,224 @@
+use async_graphql::{Context, ErrorExtensions, FieldError, Result};
+use rustok_api::{AuthContext, graphql::GraphQLError};
+use rustok_order::{OrderError, OrderService};
+use uuid::Uuid;
+
+use crate::{CommerceError, ShippingProfileService};
+use crate::storefront_shipping::normalize_shipping_profile_slug;
+
+pub(crate) use super::cart_safe_helpers::{
+    ResolvedStorefrontLineItemInput, build_create_order_change_input,
+    build_create_order_return_input, build_create_return_decision_input,
+    build_return_claim_decision_input, build_return_exchange_decision_input,
+    build_return_refund_decision_input, build_storefront_pricing_context, cart_context_metadata,
+    cart_port_error, convert_create_product_input, current_shipping_selections,
+    enrich_storefront_cart, ensure_no_unused_promotion_amount, ensure_storefront_cart_access,
+    graphql_decision_requires_payments_update, map_cart_promotion_preview,
+    maybe_undefined_or_existing, merge_graphql_metadata, normalize_graphql_seller_id,
+    normalize_pricing_channel_slug, parse_decimal, parse_json_payload, parse_optional_decimal,
+    parse_optional_metadata, parse_pricing_currency_code, parse_required_promotion_decimal,
+    pick_product_translation, pick_variant_translation, reprice_storefront_cart_line_items,
+    request_public_channel_slug, resolve_commerce_graphql_locale,
+    resolve_optional_storefront_customer_id, resolve_storefront_line_item_input,
+    seller_snapshot_metadata, storefront_cart_port_context, storefront_cart_pricing_snapshot,
+    storefront_cart_pricing_update, storefront_pricing_port_context,
+    storefront_public_channel_slug_for_cart, validate_admin_cart_promotion_target,
+    validate_selected_shipping_option, validate_storefront_line_item_quantity,
+    validate_storefront_variant_inventory,
+};
+
+fn public_graphql_error(
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
+fn order_graphql_error(
+    tenant_id: Uuid,
+    order_id: Uuid,
+    operation: &'static str,
+    error: OrderError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        order_id = %order_id,
+        operation,
+        "commerce GraphQL storefront order helper failed"
+    );
+
+    let (message, code, retryable) = match &error {
+        OrderError::Validation(_) => (
+            "Order request is invalid",
+            "ORDER_REQUEST_INVALID",
+            false,
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        OrderError::InvalidTransition { .. } => (
+            "Order operation conflicts with the current state",
+            "ORDER_STATE_CONFLICT",
+            false,
+        ),
+        OrderError::Database(_) => (
+            "Order service is temporarily unavailable",
+            "ORDER_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        OrderError::Core(_) => (
+            "Order operation could not be completed safely",
+            "ORDER_OPERATION_FAILED",
+            false,
+        ),
+    };
+
+    public_graphql_error(message, code, retryable)
+}
+
+fn shipping_profile_graphql_error(
+    tenant_id: Uuid,
+    operation: &'static str,
+    error: CommerceError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        operation,
+        "commerce GraphQL shipping profile helper failed"
+    );
+
+    let (message, code, retryable) = match &error {
+        CommerceError::Validation(_)
+        | CommerceError::InvalidPrice(_)
+        | CommerceError::InvalidOptionCombination
+        | CommerceError::NoVariants => (
+            "Shipping profile request is invalid",
+            "SHIPPING_PROFILE_REQUEST_INVALID",
+            false,
+        ),
+        CommerceError::ShippingProfileNotFound(_) => (
+            "Shipping profile was not found",
+            "SHIPPING_PROFILE_NOT_FOUND",
+            false,
+        ),
+        CommerceError::DuplicateShippingProfileSlug(_) => (
+            "Shipping profile conflicts with the current state",
+            "SHIPPING_PROFILE_STATE_CONFLICT",
+            false,
+        ),
+        CommerceError::Database(_) => (
+            "Shipping profile service is temporarily unavailable",
+            "SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        CommerceError::ProductNotFound(_)
+        | CommerceError::VariantNotFound(_)
+        | CommerceError::DuplicateHandle { .. }
+        | CommerceError::DuplicateSku(_)
+        | CommerceError::InsufficientInventory { .. }
+        | CommerceError::CannotDeletePublished
+        | CommerceError::Rich(_)
+        | CommerceError::Core(_) => (
+            "Shipping profile operation could not be completed safely",
+            "SHIPPING_PROFILE_OPERATION_FAILED",
+            false,
+        ),
+    };
+
+    public_graphql_error(message, code, retryable)
+}
+
+pub(crate) async fn ensure_storefront_order_access(
+    db: &sea_orm::DatabaseConnection,
+    event_bus: &rustok_outbox::TransactionalEventBus,
+    tenant_id: Uuid,
+    ctx: &Context<'_>,
+    order_id: Uuid,
+) -> Result<()> {
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    let customer_id = super::cart_safe_helpers::resolve_optional_storefront_customer_id(
+        db,
+        tenant_id,
+        Some(auth),
+    )
+    .await?
+    .ok_or_else(|| <FieldError as GraphQLError>::unauthenticated())?;
+
+    let order = OrderService::new(db.clone(), event_bus.clone())
+        .get_order(tenant_id, order_id)
+        .await
+        .map_err(|error| {
+            order_graphql_error(
+                tenant_id,
+                order_id,
+                "ensure_storefront_order_access",
+                error,
+            )
+        })?;
+
+    if order.customer_id != Some(customer_id) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Order does not belong to the current customer",
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn validate_product_shipping_profile_input(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    shipping_profile_slug: Option<&str>,
+) -> Result<()> {
+    let Some(slug) = shipping_profile_slug.and_then(normalize_shipping_profile_slug) else {
+        return Ok(());
+    };
+
+    ShippingProfileService::new(db.clone())
+        .ensure_shipping_profile_slug_exists(tenant_id, &slug)
+        .await
+        .map_err(|error| {
+            shipping_profile_graphql_error(
+                tenant_id,
+                "validate_product_shipping_profile_input",
+                error,
+            )
+        })?;
+
+    Ok(())
+}
+
+pub(crate) async fn validate_shipping_option_profile_inputs(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    allowed_shipping_profile_slugs: Option<&Vec<String>>,
+) -> Result<()> {
+    let Some(slugs) = allowed_shipping_profile_slugs else {
+        return Ok(());
+    };
+
+    ShippingProfileService::new(db.clone())
+        .ensure_shipping_profile_slugs_exist(tenant_id, slugs.iter())
+        .await
+        .map_err(|error| {
+            shipping_profile_graphql_error(
+                tenant_id,
+                "validate_shipping_option_profile_inputs",
+                error,
+            )
+        })?;
+
+    Ok(())
+}

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -22,7 +22,8 @@ const forbidText = (source, value, label) => {
 
 for (const [value, label] of [
   ['#[path = "helpers.rs"]\nmod legacy_helpers;', 'private legacy helper routing'],
-  ['#[path = "safe_helpers.rs"]\npub mod helpers;', 'public safe helper routing'],
+  ['#[path = "safe_helpers.rs"]\nmod cart_safe_helpers;', 'private cart safe helper routing'],
+  ['#[path = "safe_order_helpers.rs"]\npub mod helpers;', 'public layered safe helper routing'],
 ]) {
   requireText(moduleSource, value, label);
 }
@@ -97,5 +98,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers route through stable public envelopes while legacy implementation stays private',
+  '✔ Commerce GraphQL storefront cart helpers remain behind stable public envelopes while layered helper routing stays private',
 );

--- a/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const moduleSource = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const facadeSource = read('crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['#[path = "safe_helpers.rs"]\nmod cart_safe_helpers;', 'private cart facade routing'],
+  ['#[path = "safe_order_helpers.rs"]\npub mod helpers;', 'public order facade routing'],
+]) {
+  requireText(moduleSource, value, label);
+}
+
+for (const value of [
+  'async_graphql::Error::new(error.message)',
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+  'ensure_storefront_order_access,',
+  'validate_product_shipping_profile_input,',
+  'validate_shipping_option_profile_inputs,',
+]) {
+  forbidText(facadeSource, value, 'order and shipping safe helper facade');
+}
+
+for (const [value, label] of [
+  ['fn order_graphql_error(', 'order mapper'],
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  ['OrderError::OrderReturnNotFound(_)', 'order-return not-found mapping'],
+  ['OrderError::OrderChangeNotFound(_)', 'order-change not-found mapping'],
+  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order fallback mapping'],
+  ['"ORDER_REQUEST_INVALID"', 'order validation code'],
+  ['"ORDER_RESOURCE_NOT_FOUND"', 'order not-found code'],
+  ['"ORDER_STATE_CONFLICT"', 'order conflict code'],
+  ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order availability code'],
+  ['"ORDER_OPERATION_FAILED"', 'order fallback code'],
+  ['fn shipping_profile_graphql_error(', 'shipping-profile mapper'],
+  ['CommerceError::Validation(_)', 'shipping validation mapping'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'shipping not-found mapping'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping conflict mapping'],
+  ['CommerceError::Database(_)', 'shipping database mapping'],
+  ['CommerceError::Rich(_)', 'shipping rich fallback mapping'],
+  ['CommerceError::Core(_)', 'shipping core fallback mapping'],
+  ['"SHIPPING_PROFILE_REQUEST_INVALID"', 'shipping validation code'],
+  ['"SHIPPING_PROFILE_NOT_FOUND"', 'shipping not-found code'],
+  ['"SHIPPING_PROFILE_STATE_CONFLICT"', 'shipping conflict code'],
+  ['"SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE"', 'shipping availability code'],
+  ['"SHIPPING_PROFILE_OPERATION_FAILED"', 'shipping fallback code'],
+  ['super::cart_safe_helpers::resolve_optional_storefront_customer_id(', 'safe customer lookup reuse'],
+  ['pub(crate) async fn ensure_storefront_order_access(', 'safe order-access helper'],
+  ['pub(crate) async fn validate_product_shipping_profile_input(', 'safe product shipping helper'],
+  ['pub(crate) async fn validate_shipping_option_profile_inputs(', 'safe option shipping helper'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['order_id = %order_id', 'order logging'],
+  ['operation,', 'operation logging'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+]) {
+  requireText(facadeSource, value, label);
+}
+
+const orderMapperCalls = facadeSource.match(/order_graphql_error\(/g) ?? [];
+if (orderMapperCalls.length !== 2) {
+  failures.push(`expected order mapper definition plus one call, found ${orderMapperCalls.length}`);
+}
+
+const shippingMapperCalls = facadeSource.match(/shipping_profile_graphql_error\(/g) ?? [];
+if (shippingMapperCalls.length !== 3) {
+  failures.push(`expected shipping mapper definition plus two calls, found ${shippingMapperCalls.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL order and shipping helper error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL order access and shipping-profile helpers expose stable public envelopes with internal structured logs',
+);


### PR DESCRIPTION
## Summary

- add a second safe helper facade for storefront order access and shipping-profile validation while keeping the previously hardened cart facade private;
- reuse the safe customer projection lookup instead of exposing customer owner-port messages during order access checks;
- map every current `OrderError` variant to stable GraphQL codes/messages and retain order identifiers and raw causes only in structured logs;
- map every current `CommerceError` variant at shipping-profile validation boundaries without returning slugs, database causes, rich errors, or internal validation text;
- preserve all existing mutation imports and helper signatures through explicit re-exports;
- update the existing cart-helper verifier for layered routing and add a dedicated order/shipping helper verifier.

## Scope

Four files only. Order ownership semantics, shipping-profile normalization, service calls, permissions, DTOs, and mutation signatures are unchanged. Direct fulfillment/orchestration `to_string()` paths remain for the next PR.

## Public envelopes

Order helper failures now use stable codes including `ORDER_REQUEST_INVALID`, `ORDER_RESOURCE_NOT_FOUND`, `ORDER_STATE_CONFLICT`, `ORDER_TEMPORARILY_UNAVAILABLE`, and `ORDER_OPERATION_FAILED`.

Shipping-profile helper failures now use `SHIPPING_PROFILE_REQUEST_INVALID`, `SHIPPING_PROFILE_NOT_FOUND`, `SHIPPING_PROFILE_STATE_CONFLICT`, `SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE`, and `SHIPPING_PROFILE_OPERATION_FAILED`.

## Validation

- source and compare audit completed against current `main`;
- branch was rebased onto the latest `main` after an unrelated Forum commit landed;
- exhaustive matches reviewed against the current `OrderError` and `CommerceError` enums;
- mapper call counts and layered facade routing locked by static verifier source;
- tests, cargo commands, and verifier execution were not run, per request.