### PR TITLE
Harden commerce GraphQL fulfillment public errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
@@ -1,12 +1,14 @@
-use async_graphql::{Context, FieldError, Object, Result};
+use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result};
 use rustok_api::Permission;
 use rustok_api::{
     AuthContext,
     graphql::{GraphQLError, require_module_enabled},
 };
-use rustok_order::OrderService;
+use rustok_order::{OrderError, OrderService};
+use rustok_payment::error::PaymentError;
 use uuid::Uuid;
 
+use crate::{PaymentOrchestrationError, PostOrderOrchestrationError};
 use crate::graphql_runtime::{
     order_change_orchestration_from_context, post_order_orchestration_from_context,
     return_completion_orchestration_from_context,
@@ -14,6 +16,143 @@ use crate::graphql_runtime::{
 
 use super::super::{MODULE_SLUG, current_tenant_scope, require_commerce_permission, types::*};
 use super::helpers::*;
+
+fn public_fulfillment_graphql_error(
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
+fn order_error_envelope(error: &OrderError) -> (&'static str, &'static str, bool) {
+    match error {
+        OrderError::Validation(_) => ("Order request is invalid", "ORDER_REQUEST_INVALID", false),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        OrderError::InvalidTransition { .. } => (
+            "Order operation conflicts with the current state",
+            "ORDER_STATE_CONFLICT",
+            false,
+        ),
+        OrderError::Database(_) => (
+            "Order service is temporarily unavailable",
+            "ORDER_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        OrderError::Core(_) => (
+            "Order operation could not be completed safely",
+            "ORDER_OPERATION_FAILED",
+            false,
+        ),
+    }
+}
+
+fn payment_error_envelope(error: &PaymentError) -> (&'static str, &'static str, bool) {
+    match error {
+        PaymentError::Validation(_) => (
+            "Payment request is invalid",
+            "PAYMENT_REQUEST_INVALID",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            "Payment resource was not found",
+            "PAYMENT_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            "Payment operation conflicts with the current state",
+            "PAYMENT_STATE_CONFLICT",
+            false,
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+            "Payment service is temporarily unavailable",
+            "PAYMENT_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            "Payment operation is not configured",
+            "PAYMENT_CONFIGURATION_ERROR",
+            false,
+        ),
+    }
+}
+
+fn payment_orchestration_error_envelope(
+    error: &PaymentOrchestrationError,
+) -> (&'static str, &'static str, bool) {
+    match error {
+        PaymentOrchestrationError::Provider(source)
+        | PaymentOrchestrationError::Payment(source) => payment_error_envelope(source),
+        PaymentOrchestrationError::ProviderAfterRefundReservation { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+    }
+}
+
+fn order_mutation_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    error: OrderError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        resource_id = %resource_id,
+        operation,
+        "commerce GraphQL fulfillment order mutation failed"
+    );
+    let (message, code, retryable) = order_error_envelope(&error);
+    public_fulfillment_graphql_error(message, code, retryable)
+}
+
+fn post_order_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    error: PostOrderOrchestrationError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        resource_id = %resource_id,
+        operation,
+        "commerce GraphQL post-order orchestration failed"
+    );
+
+    let (message, code, retryable) = match &error {
+        PostOrderOrchestrationError::Order(source) => order_error_envelope(source),
+        PostOrderOrchestrationError::Payment(source) => payment_error_envelope(source),
+        PostOrderOrchestrationError::PaymentOrchestration(source) => {
+            payment_orchestration_error_envelope(source)
+        }
+        PostOrderOrchestrationError::Validation(_) => (
+            "Post-order request is invalid",
+            "POST_ORDER_REQUEST_INVALID",
+            false,
+        ),
+    };
+    public_fulfillment_graphql_error(message, code, retryable)
+}
 
 #[derive(Default)]
 pub struct CommerceFulfillmentMutation;
@@ -39,7 +178,14 @@ impl CommerceFulfillmentMutation {
         let item = OrderService::new(db.clone(), event_bus.clone())
             .create_return(tenant_id, order_id, build_create_order_return_input(input)?)
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))?;
+            .map_err(|error| {
+                order_mutation_graphql_error(
+                    tenant_id,
+                    order_id,
+                    "create_storefront_order_return",
+                    error,
+                )
+            })?;
 
         Ok(item.into())
     }
@@ -221,7 +367,9 @@ impl CommerceFulfillmentMutation {
         let result = order_change_orchestration_from_context(ctx, db.clone(), event_bus.clone())
             .apply_order_change(tenant_id, id, difference_refund, metadata)
             .await
-            .map_err(|err| FieldError::new(err.to_string()))?;
+            .map_err(|error| {
+                post_order_graphql_error(tenant_id, id, "apply_order_change", error)
+            })?;
 
         Ok(result.order_change.into())
     }
@@ -317,7 +465,14 @@ impl CommerceFulfillmentMutation {
                 build_create_return_decision_input(input)?,
             )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))?;
+            .map_err(|error| {
+                post_order_graphql_error(
+                    tenant_id,
+                    order_id,
+                    "create_order_return_decision",
+                    error,
+                )
+            })?;
 
         Ok(decision.into())
     }
@@ -395,7 +550,9 @@ impl CommerceFulfillmentMutation {
         let item = return_completion_orchestration_from_context(ctx, db.clone(), event_bus.clone())
             .complete_return(tenant_id, auth.user_id, id, command)
             .await
-            .map_err(|err| FieldError::new(err.to_string()))?;
+            .map_err(|error| {
+                post_order_graphql_error(tenant_id, id, "complete_order_return", error)
+            })?;
 
         Ok(item.into())
     }

--- a/scripts/verify/verify-commerce-graphql-fulfillment-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-fulfillment-error-safety.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const source = read('crates/rustok-commerce/src/graphql/mutations/fulfillment.rs');
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const value of [
+  'async_graphql::Error::new(err.to_string())',
+  'async_graphql::Error::new(error.to_string())',
+  'FieldError::new(err.to_string())',
+  'FieldError::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+]) {
+  forbidText(value, 'fulfillment mutation public boundary');
+}
+
+for (const [value, label] of [
+  ['ErrorExtensions', 'GraphQL extension support'],
+  ['fn public_fulfillment_graphql_error(', 'public envelope constructor'],
+  ['fn order_error_envelope(', 'order envelope mapper'],
+  ['fn payment_error_envelope(', 'payment envelope mapper'],
+  ['fn payment_orchestration_error_envelope(', 'payment orchestration mapper'],
+  ['fn order_mutation_graphql_error(', 'order mutation logger'],
+  ['fn post_order_graphql_error(', 'post-order logger'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['resource_id = %resource_id', 'resource logging'],
+  ['operation,', 'operation logging'],
+  ['extensions.set("code", code)', 'stable code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  ['OrderError::OrderReturnNotFound(_)', 'order-return mapping'],
+  ['OrderError::OrderChangeNotFound(_)', 'order-change mapping'],
+  ['OrderError::InvalidTransition { .. }', 'order conflict mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order fallback mapping'],
+  ['PaymentError::Validation(_)', 'payment validation mapping'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'payment collection mapping'],
+  ['PaymentError::PaymentNotFound(_)', 'payment mapping'],
+  ['PaymentError::RefundNotFound(_)', 'refund mapping'],
+  ['PaymentError::InvalidTransition { .. }', 'payment conflict mapping'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable mapping'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected mapping'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'invalid provider response mapping'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'unknown provider outcome mapping'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration mapping'],
+  ['PaymentError::Database(_)', 'payment database mapping'],
+  ['PaymentOrchestrationError::Provider(source)', 'payment provider orchestration mapping'],
+  ['PaymentOrchestrationError::ProviderAfterRefundReservation { .. }', 'reserved refund reconciliation mapping'],
+  ['PaymentOrchestrationError::Payment(source)', 'payment owner orchestration mapping'],
+  ['PostOrderOrchestrationError::Order(source)', 'post-order order mapping'],
+  ['PostOrderOrchestrationError::Payment(source)', 'post-order payment mapping'],
+  ['PostOrderOrchestrationError::PaymentOrchestration(source)', 'post-order orchestration mapping'],
+  ['PostOrderOrchestrationError::Validation(_)', 'post-order validation mapping'],
+  ['"ORDER_REQUEST_INVALID"', 'order validation code'],
+  ['"ORDER_RESOURCE_NOT_FOUND"', 'order resource code'],
+  ['"ORDER_STATE_CONFLICT"', 'order conflict code'],
+  ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order temporary code'],
+  ['"ORDER_OPERATION_FAILED"', 'order fallback code'],
+  ['"PAYMENT_REQUEST_INVALID"', 'payment validation code'],
+  ['"PAYMENT_RESOURCE_NOT_FOUND"', 'payment resource code'],
+  ['"PAYMENT_STATE_CONFLICT"', 'payment conflict code'],
+  ['"PAYMENT_TEMPORARILY_UNAVAILABLE"', 'payment temporary code'],
+  ['"PAYMENT_RECONCILIATION_REQUIRED"', 'payment reconciliation code'],
+  ['"PAYMENT_CONFIGURATION_ERROR"', 'payment configuration code'],
+  ['"POST_ORDER_REQUEST_INVALID"', 'post-order validation code'],
+]) {
+  requireText(value, label);
+}
+
+for (const operation of [
+  'create_storefront_order_return',
+  'apply_order_change',
+  'create_order_return_decision',
+  'complete_order_return',
+]) {
+  requireText(`"${operation}"`, `${operation} operation mapping`);
+}
+
+for (const mutation of [
+  'async fn create_storefront_order_return(',
+  'async fn mark_order_paid(',
+  'async fn ship_order(',
+  'async fn deliver_order(',
+  'async fn cancel_order(',
+  'async fn create_order_change(',
+  'async fn apply_order_change(',
+  'async fn cancel_order_change(',
+  'async fn create_order_return(',
+  'async fn create_order_return_decision(',
+  'async fn complete_order_return(',
+  'async fn cancel_order_return(',
+]) {
+  requireText(mutation, `${mutation} mutation preservation`);
+}
+
+const orderMapperCalls = source.match(/order_mutation_graphql_error\(/g) ?? [];
+if (orderMapperCalls.length !== 2) {
+  failures.push(`expected order mapper definition plus one call, found ${orderMapperCalls.length}`);
+}
+const postOrderMapperCalls = source.match(/post_order_graphql_error\(/g) ?? [];
+if (postOrderMapperCalls.length !== 4) {
+  failures.push(`expected post-order mapper definition plus three calls, found ${postOrderMapperCalls.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL fulfillment error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL fulfillment mutations expose stable order/payment/post-order envelopes with internal structured logs',
+);


### PR DESCRIPTION
## Summary

- replace the four explicit dynamic error passthroughs in commerce GraphQL fulfillment mutations with stable public envelopes;
- map every current `OrderError`, `PaymentError`, `PaymentOrchestrationError`, and `PostOrderOrchestrationError` variant without copying owner/provider messages, identifiers, transitions, database causes, or reconciliation details into GraphQL messages;
- keep raw errors in structured logs with tenant, resource, and operation context;
- mark provider unavailable and database failures retryable, while malformed/unknown provider outcomes and post-reservation failures require non-retryable reconciliation;
- preserve all twelve mutation signatures, permission checks, input parsing, service calls, DTO conversion, actor enforcement, and orchestration behavior;
- add a dedicated static verifier that rejects the previous `to_string()` constructors and locks enum coverage, codes, retryability extensions, operation labels, mapper call counts, and mutation presence.

## Scope

Two files only: `graphql/mutations/fulfillment.rs` and its verifier. This PR covers storefront return creation, order-change application, return-decision creation, and return completion. Other `OrderService` mutations using the existing typed GraphQL conversion path are unchanged.

## Public envelopes

The boundary now returns stable codes including `ORDER_REQUEST_INVALID`, `ORDER_RESOURCE_NOT_FOUND`, `ORDER_STATE_CONFLICT`, `ORDER_TEMPORARILY_UNAVAILABLE`, `ORDER_OPERATION_FAILED`, `PAYMENT_REQUEST_INVALID`, `PAYMENT_RESOURCE_NOT_FOUND`, `PAYMENT_STATE_CONFLICT`, `PAYMENT_TEMPORARILY_UNAVAILABLE`, `PAYMENT_RECONCILIATION_REQUIRED`, `PAYMENT_CONFIGURATION_ERROR`, and `POST_ORDER_REQUEST_INVALID`.

## Validation

- source and compare audit completed against current `main`;
- branch is directly based on current `main` and changes two files;
- exhaustive matches reviewed against the current four error enums;
- verified one order mapper call and three post-order mapper calls across the four identified boundaries;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.