### PR TITLE
Harden commerce GraphQL provider operation errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
@@ -1,13 +1,170 @@
-use async_graphql::{Context, Object, Result};
+use async_graphql::{Context, ErrorExtensions, Object, Result};
 use rustok_api::{Permission, graphql::require_module_enabled};
+use rustok_fulfillment::error::FulfillmentError;
+use rustok_payment::error::PaymentError;
 use uuid::Uuid;
 
+use crate::{FulfillmentOrchestrationError, PaymentOrchestrationError};
 use crate::graphql_runtime::{
     fulfillment_orchestration_from_context, payment_orchestration_from_context,
 };
 
 use super::super::{MODULE_SLUG, require_commerce_permission, types::*};
 use super::helpers::*;
+
+fn public_provider_graphql_error(
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
+fn payment_error_envelope(error: &PaymentError) -> (&'static str, &'static str, bool) {
+    match error {
+        PaymentError::Validation(_) => (
+            "Payment request is invalid",
+            "PAYMENT_REQUEST_INVALID",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            "Payment resource was not found",
+            "PAYMENT_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            "Payment operation conflicts with the current state",
+            "PAYMENT_STATE_CONFLICT",
+            false,
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+            "Payment service is temporarily unavailable",
+            "PAYMENT_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            "Payment operation is not configured",
+            "PAYMENT_CONFIGURATION_ERROR",
+            false,
+        ),
+    }
+}
+
+fn payment_orchestration_error_envelope(
+    error: &PaymentOrchestrationError,
+) -> (&'static str, &'static str, bool) {
+    match error {
+        PaymentOrchestrationError::Provider(source)
+        | PaymentOrchestrationError::Payment(source) => payment_error_envelope(source),
+        PaymentOrchestrationError::ProviderAfterRefundReservation { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+    }
+}
+
+fn fulfillment_error_envelope(error: &FulfillmentError) -> (&'static str, &'static str, bool) {
+    match error {
+        FulfillmentError::Validation(_) => (
+            "Fulfillment request is invalid",
+            "FULFILLMENT_REQUEST_INVALID",
+            false,
+        ),
+        FulfillmentError::ShippingOptionNotFound(_)
+        | FulfillmentError::FulfillmentNotFound(_) => (
+            "Fulfillment resource was not found",
+            "FULFILLMENT_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            "Fulfillment operation conflicts with the current state",
+            "FULFILLMENT_STATE_CONFLICT",
+            false,
+        ),
+        FulfillmentError::Database(_) => (
+            "Fulfillment service is temporarily unavailable",
+            "FULFILLMENT_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+    }
+}
+
+fn fulfillment_orchestration_error_envelope(
+    error: &FulfillmentOrchestrationError,
+) -> (&'static str, &'static str, bool) {
+    match error {
+        FulfillmentOrchestrationError::OrderNotFound(_) => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        FulfillmentOrchestrationError::Database(_) => (
+            "Fulfillment service is temporarily unavailable",
+            "FULFILLMENT_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        FulfillmentOrchestrationError::Fulfillment(source) => {
+            fulfillment_error_envelope(source)
+        }
+        FulfillmentOrchestrationError::Validation(_) => (
+            "Fulfillment request is invalid",
+            "FULFILLMENT_REQUEST_INVALID",
+            false,
+        ),
+        FulfillmentOrchestrationError::ProviderAfterPersistence { .. }
+        | FulfillmentOrchestrationError::PersistenceAfterProvider { .. } => (
+            "Fulfillment operation requires reconciliation",
+            "FULFILLMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+    }
+}
+
+fn payment_provider_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    error: PaymentOrchestrationError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        resource_id = %resource_id,
+        operation,
+        "commerce GraphQL payment provider operation failed"
+    );
+    let (message, code, retryable) = payment_orchestration_error_envelope(&error);
+    public_provider_graphql_error(message, code, retryable)
+}
+
+fn fulfillment_provider_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    error: FulfillmentOrchestrationError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        resource_id = %resource_id,
+        operation,
+        "commerce GraphQL fulfillment provider operation failed"
+    );
+    let (message, code, retryable) = fulfillment_orchestration_error_envelope(&error);
+    public_provider_graphql_error(message, code, retryable)
+}
 
 #[derive(Default)]
 pub struct CommerceProviderMutation;
@@ -40,7 +197,14 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "authorize_payment_collection",
+                    error,
+                )
+            })?;
         Ok(collection.into())
     }
 
@@ -68,7 +232,14 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "capture_payment_collection",
+                    error,
+                )
+            })?;
         Ok(collection.into())
     }
 
@@ -96,7 +267,14 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_payment_collection",
+                    error,
+                )
+            })?;
         Ok(collection.into())
     }
 
@@ -127,7 +305,14 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(
+                    tenant_id,
+                    payment_collection_id,
+                    "create_refund",
+                    error,
+                )
+            })?;
         Ok(refund.into())
     }
 
@@ -154,7 +339,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(tenant_id, id, "complete_refund", error)
+            })?;
         Ok(refund.into())
     }
 
@@ -182,7 +369,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                payment_provider_graphql_error(tenant_id, id, "cancel_refund", error)
+            })?;
         Ok(refund.into())
     }
 
@@ -199,11 +388,12 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:create required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
+        let order_id = input.order_id;
         let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
             .create_manual_fulfillment(
                 tenant_id,
                 crate::dto::CreateFulfillmentInput {
-                    order_id: input.order_id,
+                    order_id,
                     shipping_option_id: input.shipping_option_id,
                     customer_id: input.customer_id,
                     carrier: input.carrier,
@@ -225,7 +415,14 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(
+                    tenant_id,
+                    order_id,
+                    "create_fulfillment",
+                    error,
+                )
+            })?;
         Ok(fulfillment.into())
     }
 
@@ -263,7 +460,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(tenant_id, id, "ship_fulfillment", error)
+            })?;
         Ok(fulfillment.into())
     }
 
@@ -300,7 +499,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(tenant_id, id, "deliver_fulfillment", error)
+            })?;
         Ok(fulfillment.into())
     }
 
@@ -336,7 +537,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(tenant_id, id, "reopen_fulfillment", error)
+            })?;
         Ok(fulfillment.into())
     }
 
@@ -374,7 +577,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(tenant_id, id, "reship_fulfillment", error)
+            })?;
         Ok(fulfillment.into())
     }
 
@@ -402,7 +607,9 @@ impl CommerceProviderMutation {
                 },
             )
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                fulfillment_provider_graphql_error(tenant_id, id, "cancel_fulfillment", error)
+            })?;
         Ok(fulfillment.into())
     }
 }

--- a/scripts/verify/verify-commerce-graphql-provider-operation-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-provider-operation-error-safety.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const source = read('crates/rustok-commerce/src/graphql/mutations/provider_operations.rs');
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'FieldError::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+]) {
+  forbidText(value, 'provider operation public boundary');
+}
+
+for (const [value, label] of [
+  ['ErrorExtensions', 'GraphQL extension support'],
+  ['fn public_provider_graphql_error(', 'public envelope constructor'],
+  ['fn payment_error_envelope(', 'payment owner mapper'],
+  ['fn payment_orchestration_error_envelope(', 'payment orchestration mapper'],
+  ['fn fulfillment_error_envelope(', 'fulfillment owner mapper'],
+  ['fn fulfillment_orchestration_error_envelope(', 'fulfillment orchestration mapper'],
+  ['fn payment_provider_graphql_error(', 'payment provider logger'],
+  ['fn fulfillment_provider_graphql_error(', 'fulfillment provider logger'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['resource_id = %resource_id', 'resource logging'],
+  ['operation,', 'operation logging'],
+  ['extensions.set("code", code)', 'stable code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['PaymentError::Validation(_)', 'payment validation mapping'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'payment collection not-found mapping'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found mapping'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found mapping'],
+  ['PaymentError::InvalidTransition { .. }', 'payment transition mapping'],
+  ['PaymentError::ProviderUnavailable { .. }', 'payment provider outage mapping'],
+  ['PaymentError::ProviderRejected { .. }', 'payment provider rejection mapping'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'payment invalid response mapping'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'payment unknown outcome mapping'],
+  ['PaymentError::ProviderConfiguration { .. }', 'payment configuration mapping'],
+  ['PaymentError::Database(_)', 'payment database mapping'],
+  ['PaymentOrchestrationError::Provider(source)', 'payment orchestration provider mapping'],
+  ['PaymentOrchestrationError::ProviderAfterRefundReservation { .. }', 'payment reserved-refund mapping'],
+  ['PaymentOrchestrationError::Payment(source)', 'payment orchestration owner mapping'],
+  ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'fulfillment transition mapping'],
+  ['FulfillmentError::Database(_)', 'fulfillment database mapping'],
+  ['FulfillmentOrchestrationError::OrderNotFound(_)', 'fulfillment order mapping'],
+  ['FulfillmentOrchestrationError::Database(_)', 'fulfillment orchestration database mapping'],
+  ['FulfillmentOrchestrationError::Fulfillment(source)', 'fulfillment owner orchestration mapping'],
+  ['FulfillmentOrchestrationError::Validation(_)', 'fulfillment orchestration validation mapping'],
+  ['FulfillmentOrchestrationError::ProviderAfterPersistence { .. }', 'provider-after-persistence mapping'],
+  ['FulfillmentOrchestrationError::PersistenceAfterProvider { .. }', 'persistence-after-provider mapping'],
+  ['"PAYMENT_REQUEST_INVALID"', 'payment validation code'],
+  ['"PAYMENT_RESOURCE_NOT_FOUND"', 'payment resource code'],
+  ['"PAYMENT_STATE_CONFLICT"', 'payment conflict code'],
+  ['"PAYMENT_TEMPORARILY_UNAVAILABLE"', 'payment temporary code'],
+  ['"PAYMENT_RECONCILIATION_REQUIRED"', 'payment reconciliation code'],
+  ['"PAYMENT_CONFIGURATION_ERROR"', 'payment configuration code'],
+  ['"FULFILLMENT_REQUEST_INVALID"', 'fulfillment validation code'],
+  ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'fulfillment resource code'],
+  ['"FULFILLMENT_STATE_CONFLICT"', 'fulfillment conflict code'],
+  ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'fulfillment temporary code'],
+  ['"FULFILLMENT_RECONCILIATION_REQUIRED"', 'fulfillment reconciliation code'],
+  ['"ORDER_RESOURCE_NOT_FOUND"', 'fulfillment order code'],
+]) {
+  requireText(value, label);
+}
+
+for (const operation of [
+  'authorize_payment_collection',
+  'capture_payment_collection',
+  'cancel_payment_collection',
+  'create_refund',
+  'complete_refund',
+  'cancel_refund',
+  'create_fulfillment',
+  'ship_fulfillment',
+  'deliver_fulfillment',
+  'reopen_fulfillment',
+  'reship_fulfillment',
+  'cancel_fulfillment',
+]) {
+  requireText(`"${operation}"`, `${operation} operation mapping`);
+  requireText(`async fn ${operation}(`, `${operation} mutation preservation`);
+}
+
+const paymentMapperCalls = source.match(/payment_provider_graphql_error\(/g) ?? [];
+if (paymentMapperCalls.length !== 7) {
+  failures.push(`expected payment mapper definition plus six calls, found ${paymentMapperCalls.length}`);
+}
+const fulfillmentMapperCalls = source.match(/fulfillment_provider_graphql_error\(/g) ?? [];
+if (fulfillmentMapperCalls.length !== 7) {
+  failures.push(`expected fulfillment mapper definition plus six calls, found ${fulfillmentMapperCalls.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL provider operation error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL payment and fulfillment provider operations expose stable public envelopes with internal structured logs',
+);


### PR DESCRIPTION
## Summary

- replace all twelve explicit `error.to_string()` passthroughs in commerce GraphQL payment/refund and fulfillment provider mutations with stable public envelopes;
- map every current `PaymentError`, `PaymentOrchestrationError`, `FulfillmentError`, and `FulfillmentOrchestrationError` variant without publishing provider IDs, operation details, resource identifiers, transition values, database causes, validation text, or persisted side-effect identifiers;
- keep raw errors in structured logs with tenant, resource, and operation context;
- mark database/provider outages retryable while unknown payment outcomes, refund-after-reservation, provider-after-persistence, and persistence-after-provider failures return non-retryable reconciliation envelopes;
- preserve all twelve mutation signatures, permissions, DTO construction, parsing, runtime registry use, service calls, and response conversion;
- add a dedicated static verifier for forbidden constructors, exhaustive enum coverage, stable codes, operation labels, mutation preservation, and mapper call counts.

## Scope

Two files only: `graphql/mutations/provider_operations.rs` and its verifier. No provider orchestration, owner service, permission, DTO, or GraphQL schema behavior is changed beyond public error serialization.

## Public envelopes

Payment operations use `PAYMENT_REQUEST_INVALID`, `PAYMENT_RESOURCE_NOT_FOUND`, `PAYMENT_STATE_CONFLICT`, `PAYMENT_TEMPORARILY_UNAVAILABLE`, `PAYMENT_RECONCILIATION_REQUIRED`, and `PAYMENT_CONFIGURATION_ERROR`.

Fulfillment operations use `FULFILLMENT_REQUEST_INVALID`, `FULFILLMENT_RESOURCE_NOT_FOUND`, `FULFILLMENT_STATE_CONFLICT`, `FULFILLMENT_TEMPORARILY_UNAVAILABLE`, `FULFILLMENT_RECONCILIATION_REQUIRED`, and `ORDER_RESOURCE_NOT_FOUND`.

## Validation

- source and compare audit completed against current `main`;
- branch is directly based on current `main` and changes two files;
- exhaustive matches reviewed against the four current error enums;
- verified six payment mapper calls and six fulfillment mapper calls;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.