### PR TITLE
feat(forum): add resumable bulk read commands

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -212,7 +212,7 @@ at the end of this file remain authoritative.
 | `FORUM-13` | `in_progress` | Verified FORUM-13A/B add bounded presentation policy and explicit optional Media capability behavior; Media quarantine/deletion state, persistence, transport composition, runtime evidence and UI remain. |
 | `FORUM-14` | `planned` | Topic/reply attachment relations and upload-session lifecycle. |
 | `FORUM-15` | `planned` | Profile/member summary and avatar integration. |
-| `FORUM-16` | `in_progress` | FORUM-16A/B add tenant-scoped monotonic topic read state, authenticated owner commands and a bounded unread topic projection/filter; bulk category/all-read commands, transports and PostgreSQL concurrency evidence remain. |
+| `FORUM-16` | `in_progress` | FORUM-16A-C add tenant-scoped monotonic topic read state, bounded unread projections and resumable category-subtree/all-read owner commands; transports and PostgreSQL concurrency/query-plan evidence remain. |
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
@@ -870,20 +870,41 @@ accelerate the badge but database position/revision remains canonical.
   predicate, and the SQLite scenario covers visibility changes plus two-page
   unread cursor behavior without N+1 reply reads.
 
+### Delivered in `FORUM-16C`
+
+- `ForumTopicReadStateService::mark_category_read` marks a root category and its
+  current descendant subtree, while `mark_all_read` covers the tenant scope;
+- each command processes at most 100 topics in one transaction and returns an
+  exact `(snapshot_at, created_at, topic_id)` continuation cursor bound to the
+  tenant, authenticated user and command scope;
+- the first page fixes the topic-creation snapshot, so topics created later are
+  excluded from that operation and picked up by a subsequent idempotent pass;
+- category traversal reuses the existing 512-node owner bound and fails closed
+  for an oversized, missing or cyclic tenant tree;
+- one aggregate query per bounded page resolves the latest approved-reply
+  position and latest immutable topic revision before monotonic owner upserts;
+- equal non-stale high-water marks refresh the read snapshot so a late moderator
+  approval below an already-read position can be acknowledged, while stale lower
+  markers cannot regress state or refresh the snapshot;
+- SQLite owner scenarios cover subtree pagination, snapshot exclusion, cursor
+  scope isolation, tenant-wide replay, bounds, anonymous rejection and late
+  approval acknowledgement.
+
 ### Compatibility and degraded mode
 
-No backfill is required: an absent row means position/revision zero and also
-preserves unseen-topic identity. Existing Forum topic reads and commands remain
-source-compatible. The unread projection is an additive authenticated owner
-contract and is not wired to REST, GraphQL, storefront or realtime in this
-slice. Cache and realtime accelerators remain optional and never replace the
-database owner state.
+No migration or backfill is required: an absent row means position/revision zero
+and preserves unseen-topic identity. Existing Forum topic reads and commands
+remain source-compatible. The unread projection and bulk commands are additive
+authenticated owner contracts and are not wired to REST, GraphQL, storefront or
+realtime in this slice. Category membership is revalidated on every resumed page;
+a subsequent idempotent pass converges after a concurrent category move. Cache
+and realtime accelerators remain optional and never replace database owner state.
 
 ### Remaining scope
 
-- add bounded, resumable mark-category-read and mark-all-read owner commands;
-- expose the stable owner projection through verified REST/GraphQL/storefront
-  integration without duplicating unread policy in transports;
+- expose the stable owner projection and topic/category/all-read commands through
+  verified REST/GraphQL/storefront integration without duplicating unread policy
+  in transports;
 - add PostgreSQL aggregate/concurrent-device execution evidence and query-plan
   evidence for production-sized topic/reply histories.
 
@@ -898,6 +919,7 @@ bounded.
 ```bash
 cargo test -p rustok-forum --test topic_read_state_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_unread_projection_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_bulk_read_state_sqlite -- --nocapture
 cargo xtask module validate forum
 ```
 
@@ -1691,6 +1713,7 @@ cargo test -p rustok-forum --test mention_quote_runtime_postgres -- --nocapture 
 cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_read_state_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_unread_projection_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_bulk_read_state_sqlite -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1755,8 +1778,8 @@ Recommended next slices:
 7. `FORUM-14`: attachment relations and upload sessions;
 8. `FORUM-15`: batched member/avatar projection;
 9. `LINK-FORUM-02`: profiles/media runtime proof;
-10. finish `FORUM-16` bounded category/all-read commands, transport composition
-    and PostgreSQL concurrency/query-plan evidence;
+10. finish `FORUM-16` transport composition and PostgreSQL concurrency/query-plan
+    evidence;
 11. `FORUM-19`: reports/moderation/restrictions;
 12. `FORUM-20`: ACL and visibility policy;
 13. `FORUM-23`: index projections;

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -33,8 +33,9 @@ pub use mentions::*;
 pub use services::{
     CategoryService, ForumEventService, ForumQuoteCommandService, ForumReadModelService,
     ForumRelationReadService, ForumTopicReadState, ForumTopicReadStateService,
-    ForumWidgetContractService, MarkForumTopicReadInput, ModerationService, ReplyService,
-    RevisionService, SubscriptionService, TopicService, UserStatsService, VoteService,
+    ForumWidgetContractService, MarkForumTopicReadInput, MarkForumTopicsReadBatchInput,
+    MarkForumTopicsReadBatchResult, ModerationService, ReplyService, RevisionService,
+    SubscriptionService, TopicService, UserStatsService, VoteService,
 };
 pub use state_machine::{ReplyStatus, TopicStatus};
 pub use subscription::{ForumDigestMode, ForumSubscriptionLevel, ForumSubscriptionPreferences};
@@ -121,11 +122,4 @@ impl MigrationSource for ForumModule {
     fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
         migrations::migrations()
     }
-
-    fn migration_dependencies(&self) -> Vec<rustok_core::MigrationDependencyDescriptor> {
-        migrations::migration_dependencies()
-    }
 }
-
-#[cfg(test)]
-mod contract_tests;

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -122,4 +122,11 @@ impl MigrationSource for ForumModule {
     fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
         migrations::migrations()
     }
+
+    fn migration_dependencies(&self) -> Vec<rustok_core::MigrationDependencyDescriptor> {
+        migrations::migration_dependencies()
+    }
 }
+
+#[cfg(test)]
+mod contract_tests;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -58,6 +58,7 @@ pub use quote_command::ForumQuoteCommandService;
 pub use read_model::ForumReadModelService;
 pub use read_tracking::{
     ForumTopicReadState, ForumTopicReadStateService, MarkForumTopicReadInput,
+    MarkForumTopicsReadBatchInput, MarkForumTopicsReadBatchResult,
 };
 pub use relation_read::ForumRelationReadService;
 pub use reply_facade::ReplyService;

--- a/crates/rustok-forum/src/services/read_tracking.rs
+++ b/crates/rustok-forum/src/services/read_tracking.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use sea_orm::{
     ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, DatabaseTransaction, EntityTrait,
     QueryFilter, QueryOrder, QuerySelect, TransactionTrait, sea_query::OnConflict,
@@ -316,7 +316,7 @@ impl ForumTopicReadStateService {
             processed,
             next_cursor,
             has_more,
-            snapshot_at: snapshot_at.to_rfc3339(),
+            snapshot_at: snapshot_at.to_rfc3339_opts(SecondsFormat::Nanos, true),
         })
     }
 }
@@ -549,40 +549,36 @@ fn encode_bulk_read_cursor(
     topic: &forum_topic::Model,
 ) -> String {
     format!(
-        "{BULK_READ_CURSOR_VERSION}:{}:{}:{}:{}",
+        "{BULK_READ_CURSOR_VERSION}|{}|{}|{}|{}",
         scope.cursor_token(),
-        snapshot_at.timestamp_millis(),
-        topic.created_at.timestamp_millis(),
+        snapshot_at.to_rfc3339_opts(SecondsFormat::Nanos, true),
+        topic
+            .created_at
+            .to_rfc3339_opts(SecondsFormat::Nanos, true),
         topic.id
     )
 }
 
 fn decode_bulk_read_cursor(value: &str, expected_scope: BulkReadScope) -> ForumResult<BulkReadCursor> {
     let expected_token = expected_scope.cursor_token();
-    let mut parts = value.splitn(5, ':');
+    let mut parts = value.splitn(5, '|');
     if parts.next() != Some(BULK_READ_CURSOR_VERSION)
         || parts.next() != Some(expected_token.as_str())
     {
         return Err(invalid_bulk_read_cursor());
     }
-    let snapshot_millis = parts
+    let snapshot_at = parts
         .next()
-        .and_then(|value| value.parse::<i64>().ok())
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
         .ok_or_else(invalid_bulk_read_cursor)?;
-    let created_millis = parts
+    let created_at = parts
         .next()
-        .and_then(|value| value.parse::<i64>().ok())
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
         .ok_or_else(invalid_bulk_read_cursor)?;
     let topic_id = parts
         .next()
         .and_then(|value| Uuid::parse_str(value).ok())
         .ok_or_else(invalid_bulk_read_cursor)?;
-    let snapshot_at = DateTime::<Utc>::from_timestamp_millis(snapshot_millis)
-        .ok_or_else(invalid_bulk_read_cursor)?
-        .fixed_offset();
-    let created_at = DateTime::<Utc>::from_timestamp_millis(created_millis)
-        .ok_or_else(invalid_bulk_read_cursor)?
-        .fixed_offset();
     if created_at > snapshot_at {
         return Err(invalid_bulk_read_cursor());
     }

--- a/crates/rustok-forum/src/services/read_tracking.rs
+++ b/crates/rustok-forum/src/services/read_tracking.rs
@@ -242,7 +242,7 @@ impl ForumTopicReadStateService {
             .transpose()?;
         let snapshot_at = cursor
             .as_ref()
-            .map(|cursor| cursor.snapshot_at)
+            .map(|cursor| cursor.snapshot_at.clone())
             .unwrap_or_else(|| Utc::now().into());
 
         let txn = self.db.begin().await?;
@@ -255,17 +255,17 @@ impl ForumTopicReadStateService {
 
         let mut select = forum_topic::Entity::find()
             .filter(forum_topic::Column::TenantId.eq(tenant_id))
-            .filter(forum_topic::Column::CreatedAt.lte(snapshot_at));
+            .filter(forum_topic::Column::CreatedAt.lte(snapshot_at.clone()));
         if let Some(category_ids) = category_ids {
             select = select.filter(forum_topic::Column::CategoryId.is_in(category_ids));
         }
         if let Some(cursor) = cursor.as_ref() {
             select = select.filter(
                 Condition::any()
-                    .add(forum_topic::Column::CreatedAt.gt(cursor.created_at))
+                    .add(forum_topic::Column::CreatedAt.gt(cursor.created_at.clone()))
                     .add(
                         Condition::all()
-                            .add(forum_topic::Column::CreatedAt.eq(cursor.created_at))
+                            .add(forum_topic::Column::CreatedAt.eq(cursor.created_at.clone()))
                             .add(forum_topic::Column::Id.gt(cursor.topic_id)),
                     ),
             );
@@ -558,9 +558,10 @@ fn encode_bulk_read_cursor(
 }
 
 fn decode_bulk_read_cursor(value: &str, expected_scope: BulkReadScope) -> ForumResult<BulkReadCursor> {
+    let expected_token = expected_scope.cursor_token();
     let mut parts = value.splitn(5, ':');
     if parts.next() != Some(BULK_READ_CURSOR_VERSION)
-        || parts.next() != Some(expected_scope.cursor_token().as_str())
+        || parts.next() != Some(expected_token.as_str())
     {
         return Err(invalid_bulk_read_cursor());
     }

--- a/crates/rustok-forum/src/services/read_tracking.rs
+++ b/crates/rustok-forum/src/services/read_tracking.rs
@@ -1,7 +1,9 @@
-use chrono::Utc;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use chrono::{DateTime, Utc};
 use sea_orm::{
-    ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
-    TransactionTrait, sea_query::OnConflict,
+    ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    QueryFilter, QueryOrder, QuerySelect, TransactionTrait, sea_query::OnConflict,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -10,17 +12,36 @@ use uuid::Uuid;
 use rustok_api::{Action, Resource};
 use rustok_core::SecurityContext;
 
+use crate::dto::MAX_FORUM_CATEGORY_TREE_NODES;
 use crate::entities::{
-    forum_reply, forum_topic, forum_topic_read_state, forum_topic_revision,
+    forum_category, forum_reply, forum_topic, forum_topic_read_state, forum_topic_revision,
 };
 use crate::error::{ForumError, ForumResult};
 use crate::services::rbac::enforce_scope;
 use crate::state_machine::ReplyStatus;
 
+const BULK_READ_CURSOR_VERSION: &str = "br1";
+const DEFAULT_BULK_READ_LIMIT: u64 = 50;
+const MAX_BULK_READ_LIMIT: u64 = 100;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct MarkForumTopicReadInput {
     pub last_read_position: i64,
     pub last_read_revision: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct MarkForumTopicsReadBatchInput {
+    pub cursor: Option<String>,
+    pub limit: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct MarkForumTopicsReadBatchResult {
+    pub processed: u64,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+    pub snapshot_at: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -33,6 +54,35 @@ pub struct ForumTopicReadState {
     pub explicit: bool,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BulkReadScope {
+    Tenant,
+    Category(Uuid),
+}
+
+impl BulkReadScope {
+    fn cursor_token(self) -> String {
+        match self {
+            Self::Tenant => "all".to_string(),
+            Self::Category(category_id) => category_id.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BulkReadCursor {
+    snapshot_at: sea_orm::prelude::DateTimeWithTimeZone,
+    created_at: sea_orm::prelude::DateTimeWithTimeZone,
+    topic_id: Uuid,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TopicReadHighWater {
+    topic_id: Uuid,
+    last_read_position: i64,
+    last_read_revision: i64,
 }
 
 pub struct ForumTopicReadStateService {
@@ -77,9 +127,10 @@ impl ForumTopicReadStateService {
         input: MarkForumTopicReadInput,
     ) -> ForumResult<ForumTopicReadState> {
         enforce_scope(&security, Resource::ForumTopics, Action::Read)?;
-        let user_id = security.user_id.ok_or_else(|| {
-            ForumError::forbidden("Authenticated user context is required to mark a topic read")
-        })?;
+        let user_id = authenticated_user_id(
+            &security,
+            "Authenticated user context is required to mark a topic read",
+        )?;
         validate_nonnegative(&input)?;
 
         let txn = self.db.begin().await?;
@@ -121,72 +172,169 @@ impl ForumTopicReadStateService {
         }
 
         let now: sea_orm::prelude::DateTimeWithTimeZone = Utc::now().into();
-        forum_topic_read_state::Entity::insert(forum_topic_read_state::ActiveModel {
-            tenant_id: Set(tenant_id),
-            topic_id: Set(topic.id),
-            user_id: Set(user_id),
-            last_read_position: Set(input.last_read_position),
-            last_read_revision: Set(input.last_read_revision),
-            created_at: Set(now.clone()),
-            updated_at: Set(now.clone()),
-        })
-        .on_conflict(
-            OnConflict::columns([
-                forum_topic_read_state::Column::TenantId,
-                forum_topic_read_state::Column::TopicId,
-                forum_topic_read_state::Column::UserId,
-            ])
-            .do_nothing()
-            .to_owned(),
+        upsert_topic_read_high_water_in_tx(
+            &txn,
+            tenant_id,
+            user_id,
+            TopicReadHighWater {
+                topic_id: topic.id,
+                last_read_position: input.last_read_position,
+                last_read_revision: input.last_read_revision,
+            },
+            &now,
         )
-        .exec_without_returning(&txn)
         .await?;
 
-        forum_topic_read_state::Entity::update_many()
-            .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
-            .filter(forum_topic_read_state::Column::TopicId.eq(topic.id))
-            .filter(forum_topic_read_state::Column::UserId.eq(user_id))
-            .filter(
-                forum_topic_read_state::Column::LastReadPosition.lt(input.last_read_position),
-            )
-            .set(forum_topic_read_state::ActiveModel {
-                last_read_position: Set(input.last_read_position),
-                updated_at: Set(now.clone()),
-                ..Default::default()
-            })
-            .exec(&txn)
-            .await?;
-
-        forum_topic_read_state::Entity::update_many()
-            .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
-            .filter(forum_topic_read_state::Column::TopicId.eq(topic.id))
-            .filter(forum_topic_read_state::Column::UserId.eq(user_id))
-            .filter(
-                forum_topic_read_state::Column::LastReadRevision.lt(input.last_read_revision),
-            )
-            .set(forum_topic_read_state::ActiveModel {
-                last_read_revision: Set(input.last_read_revision),
-                updated_at: Set(now),
-                ..Default::default()
-            })
-            .exec(&txn)
-            .await?;
-
-        let state = forum_topic_read_state::Entity::find()
-            .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
-            .filter(forum_topic_read_state::Column::TopicId.eq(topic.id))
-            .filter(forum_topic_read_state::Column::UserId.eq(user_id))
-            .one(&txn)
-            .await?
-            .ok_or_else(|| {
-                ForumError::Validation(
-                    "Forum topic read state disappeared during monotonic update".to_string(),
-                )
-            })?;
+        let state = load_explicit_state_in_tx(&txn, tenant_id, topic.id, user_id).await?;
         txn.commit().await?;
 
         Ok(explicit_state(state))
     }
+
+    /// Marks the current category subtree read in one bounded, resumable page.
+    ///
+    /// The first page fixes a topic-creation snapshot. Topics created after that
+    /// point are intentionally excluded and are picked up by a later operation.
+    pub async fn mark_category_read(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: MarkForumTopicsReadBatchInput,
+    ) -> ForumResult<MarkForumTopicsReadBatchResult> {
+        self.mark_scope_read(
+            tenant_id,
+            BulkReadScope::Category(category_id),
+            security,
+            input,
+        )
+        .await
+    }
+
+    /// Marks all current tenant topics read in one bounded, resumable page.
+    pub async fn mark_all_read(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        input: MarkForumTopicsReadBatchInput,
+    ) -> ForumResult<MarkForumTopicsReadBatchResult> {
+        self.mark_scope_read(tenant_id, BulkReadScope::Tenant, security, input)
+            .await
+    }
+
+    async fn mark_scope_read(
+        &self,
+        tenant_id: Uuid,
+        scope: BulkReadScope,
+        security: SecurityContext,
+        input: MarkForumTopicsReadBatchInput,
+    ) -> ForumResult<MarkForumTopicsReadBatchResult> {
+        enforce_scope(&security, Resource::ForumTopics, Action::Read)?;
+        let user_id = authenticated_user_id(
+            &security,
+            "Authenticated user context is required to mark forum topics read",
+        )?;
+        let limit = validated_bulk_read_limit(input.limit)?;
+        let cursor = input
+            .cursor
+            .as_deref()
+            .map(|value| decode_bulk_read_cursor(value, scope))
+            .transpose()?;
+        let snapshot_at = cursor
+            .as_ref()
+            .map(|cursor| cursor.snapshot_at)
+            .unwrap_or_else(|| Utc::now().into());
+
+        let txn = self.db.begin().await?;
+        let category_ids = match scope {
+            BulkReadScope::Tenant => None,
+            BulkReadScope::Category(category_id) => {
+                Some(category_subtree_ids_in_tx(&txn, tenant_id, category_id).await?)
+            }
+        };
+
+        let mut select = forum_topic::Entity::find()
+            .filter(forum_topic::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic::Column::CreatedAt.lte(snapshot_at));
+        if let Some(category_ids) = category_ids {
+            select = select.filter(forum_topic::Column::CategoryId.is_in(category_ids));
+        }
+        if let Some(cursor) = cursor.as_ref() {
+            select = select.filter(
+                Condition::any()
+                    .add(forum_topic::Column::CreatedAt.gt(cursor.created_at))
+                    .add(
+                        Condition::all()
+                            .add(forum_topic::Column::CreatedAt.eq(cursor.created_at))
+                            .add(forum_topic::Column::Id.gt(cursor.topic_id)),
+                    ),
+            );
+        }
+
+        let mut topics = select
+            .order_by_asc(forum_topic::Column::CreatedAt)
+            .order_by_asc(forum_topic::Column::Id)
+            .limit(limit + 1)
+            .all(&txn)
+            .await?;
+        let has_more = topics.len() > limit as usize;
+        topics.truncate(limit as usize);
+
+        let topic_ids = topics.iter().map(|topic| topic.id).collect::<Vec<_>>();
+        let public_positions = latest_public_positions_in_tx(&txn, tenant_id, &topic_ids).await?;
+        let topic_revisions = latest_topic_revisions_in_tx(&txn, tenant_id, &topic_ids).await?;
+        let now: sea_orm::prelude::DateTimeWithTimeZone = Utc::now().into();
+        for topic in &topics {
+            upsert_topic_read_high_water_in_tx(
+                &txn,
+                tenant_id,
+                user_id,
+                TopicReadHighWater {
+                    topic_id: topic.id,
+                    last_read_position: public_positions
+                        .get(&topic.id)
+                        .copied()
+                        .unwrap_or(0),
+                    last_read_revision: topic_revisions.get(&topic.id).copied().unwrap_or(0),
+                },
+                &now,
+            )
+            .await?;
+        }
+
+        let next_cursor = has_more
+            .then(|| {
+                topics
+                    .last()
+                    .map(|topic| encode_bulk_read_cursor(scope, &snapshot_at, topic))
+            })
+            .flatten();
+        let processed = topics.len() as u64;
+        txn.commit().await?;
+
+        Ok(MarkForumTopicsReadBatchResult {
+            processed,
+            next_cursor,
+            has_more,
+            snapshot_at: snapshot_at.to_rfc3339(),
+        })
+    }
+}
+
+fn authenticated_user_id(security: &SecurityContext, message: &str) -> ForumResult<Uuid> {
+    security
+        .user_id
+        .ok_or_else(|| ForumError::forbidden(message))
+}
+
+fn validated_bulk_read_limit(limit: Option<u64>) -> ForumResult<u64> {
+    let limit = limit.unwrap_or(DEFAULT_BULK_READ_LIMIT);
+    if !(1..=MAX_BULK_READ_LIMIT).contains(&limit) {
+        return Err(ForumError::Validation(format!(
+            "Forum bulk read limit must be between 1 and {MAX_BULK_READ_LIMIT}"
+        )));
+    }
+    Ok(limit)
 }
 
 fn validate_nonnegative(input: &MarkForumTopicReadInput) -> ForumResult<()> {
@@ -201,6 +349,251 @@ fn validate_nonnegative(input: &MarkForumTopicReadInput) -> ForumResult<()> {
         ));
     }
     Ok(())
+}
+
+async fn category_subtree_ids_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    root_category_id: Uuid,
+) -> ForumResult<Vec<Uuid>> {
+    let categories = forum_category::Entity::find()
+        .filter(forum_category::Column::TenantId.eq(tenant_id))
+        .order_by_asc(forum_category::Column::Id)
+        .limit(MAX_FORUM_CATEGORY_TREE_NODES + 1)
+        .all(txn)
+        .await?;
+    if categories.len() > MAX_FORUM_CATEGORY_TREE_NODES as usize {
+        return Err(ForumError::Validation(format!(
+            "Forum category subtree exceeds the {MAX_FORUM_CATEGORY_TREE_NODES}-node owner bound"
+        )));
+    }
+    if !categories
+        .iter()
+        .any(|category| category.id == root_category_id)
+    {
+        return Err(ForumError::CategoryNotFound(root_category_id));
+    }
+
+    let mut children = HashMap::<Uuid, Vec<Uuid>>::new();
+    for category in &categories {
+        if let Some(parent_id) = category.parent_id {
+            children.entry(parent_id).or_default().push(category.id);
+        }
+    }
+
+    let mut seen = HashSet::new();
+    let mut queue = VecDeque::from([root_category_id]);
+    while let Some(category_id) = queue.pop_front() {
+        if !seen.insert(category_id) {
+            return Err(ForumError::Validation(
+                "Forum category subtree contains a cycle".to_string(),
+            ));
+        }
+        if let Some(child_ids) = children.get(&category_id) {
+            queue.extend(child_ids.iter().copied());
+        }
+    }
+
+    let mut ids = seen.into_iter().collect::<Vec<_>>();
+    ids.sort_unstable();
+    Ok(ids)
+}
+
+async fn latest_public_positions_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    topic_ids: &[Uuid],
+) -> ForumResult<HashMap<Uuid, i64>> {
+    if topic_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = forum_reply::Entity::find()
+        .select_only()
+        .column(forum_reply::Column::TopicId)
+        .column_as(forum_reply::Column::Position.max(), "last_read_position")
+        .filter(forum_reply::Column::TenantId.eq(tenant_id))
+        .filter(forum_reply::Column::TopicId.is_in(topic_ids.to_vec()))
+        .filter(forum_reply::Column::Status.eq(ReplyStatus::Approved))
+        .group_by(forum_reply::Column::TopicId)
+        .into_tuple::<(Uuid, Option<i64>)>()
+        .all(txn)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(topic_id, position)| (topic_id, position.unwrap_or(0)))
+        .collect())
+}
+
+async fn latest_topic_revisions_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    topic_ids: &[Uuid],
+) -> ForumResult<HashMap<Uuid, i64>> {
+    if topic_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = forum_topic_revision::Entity::find()
+        .select_only()
+        .column(forum_topic_revision::Column::TopicId)
+        .column_as(forum_topic_revision::Column::Id.max(), "last_read_revision")
+        .filter(forum_topic_revision::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_revision::Column::TopicId.is_in(topic_ids.to_vec()))
+        .group_by(forum_topic_revision::Column::TopicId)
+        .into_tuple::<(Uuid, Option<i64>)>()
+        .all(txn)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(topic_id, revision)| (topic_id, revision.unwrap_or(0)))
+        .collect())
+}
+
+async fn upsert_topic_read_high_water_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    high_water: TopicReadHighWater,
+    observed_at: &sea_orm::prelude::DateTimeWithTimeZone,
+) -> ForumResult<()> {
+    forum_topic_read_state::Entity::insert(forum_topic_read_state::ActiveModel {
+        tenant_id: Set(tenant_id),
+        topic_id: Set(high_water.topic_id),
+        user_id: Set(user_id),
+        last_read_position: Set(high_water.last_read_position),
+        last_read_revision: Set(high_water.last_read_revision),
+        created_at: Set(observed_at.clone()),
+        updated_at: Set(observed_at.clone()),
+    })
+    .on_conflict(
+        OnConflict::columns([
+            forum_topic_read_state::Column::TenantId,
+            forum_topic_read_state::Column::TopicId,
+            forum_topic_read_state::Column::UserId,
+        ])
+        .do_nothing()
+        .to_owned(),
+    )
+    .exec_without_returning(txn)
+    .await?;
+
+    forum_topic_read_state::Entity::update_many()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::TopicId.eq(high_water.topic_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(user_id))
+        .filter(
+            forum_topic_read_state::Column::LastReadPosition.lt(high_water.last_read_position),
+        )
+        .set(forum_topic_read_state::ActiveModel {
+            last_read_position: Set(high_water.last_read_position),
+            ..Default::default()
+        })
+        .exec(txn)
+        .await?;
+
+    forum_topic_read_state::Entity::update_many()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::TopicId.eq(high_water.topic_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(user_id))
+        .filter(
+            forum_topic_read_state::Column::LastReadRevision.lt(high_water.last_read_revision),
+        )
+        .set(forum_topic_read_state::ActiveModel {
+            last_read_revision: Set(high_water.last_read_revision),
+            ..Default::default()
+        })
+        .exec(txn)
+        .await?;
+
+    forum_topic_read_state::Entity::update_many()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::TopicId.eq(high_water.topic_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(user_id))
+        .filter(
+            forum_topic_read_state::Column::LastReadPosition.lte(high_water.last_read_position),
+        )
+        .filter(
+            forum_topic_read_state::Column::LastReadRevision.lte(high_water.last_read_revision),
+        )
+        .set(forum_topic_read_state::ActiveModel {
+            updated_at: Set(observed_at.clone()),
+            ..Default::default()
+        })
+        .exec(txn)
+        .await?;
+
+    Ok(())
+}
+
+async fn load_explicit_state_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+    user_id: Uuid,
+) -> ForumResult<forum_topic_read_state::Model> {
+    forum_topic_read_state::Entity::find()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::TopicId.eq(topic_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(user_id))
+        .one(txn)
+        .await?
+        .ok_or_else(|| {
+            ForumError::Validation(
+                "Forum topic read state disappeared during monotonic update".to_string(),
+            )
+        })
+}
+
+fn encode_bulk_read_cursor(
+    scope: BulkReadScope,
+    snapshot_at: &sea_orm::prelude::DateTimeWithTimeZone,
+    topic: &forum_topic::Model,
+) -> String {
+    format!(
+        "{BULK_READ_CURSOR_VERSION}:{}:{}:{}:{}",
+        scope.cursor_token(),
+        snapshot_at.timestamp_millis(),
+        topic.created_at.timestamp_millis(),
+        topic.id
+    )
+}
+
+fn decode_bulk_read_cursor(value: &str, expected_scope: BulkReadScope) -> ForumResult<BulkReadCursor> {
+    let mut parts = value.splitn(5, ':');
+    if parts.next() != Some(BULK_READ_CURSOR_VERSION)
+        || parts.next() != Some(expected_scope.cursor_token().as_str())
+    {
+        return Err(invalid_bulk_read_cursor());
+    }
+    let snapshot_millis = parts
+        .next()
+        .and_then(|value| value.parse::<i64>().ok())
+        .ok_or_else(invalid_bulk_read_cursor)?;
+    let created_millis = parts
+        .next()
+        .and_then(|value| value.parse::<i64>().ok())
+        .ok_or_else(invalid_bulk_read_cursor)?;
+    let topic_id = parts
+        .next()
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .ok_or_else(invalid_bulk_read_cursor)?;
+    let snapshot_at = DateTime::<Utc>::from_timestamp_millis(snapshot_millis)
+        .ok_or_else(invalid_bulk_read_cursor)?
+        .fixed_offset();
+    let created_at = DateTime::<Utc>::from_timestamp_millis(created_millis)
+        .ok_or_else(invalid_bulk_read_cursor)?
+        .fixed_offset();
+    if created_at > snapshot_at {
+        return Err(invalid_bulk_read_cursor());
+    }
+    Ok(BulkReadCursor {
+        snapshot_at,
+        created_at,
+        topic_id,
+    })
+}
+
+fn invalid_bulk_read_cursor() -> ForumError {
+    ForumError::Validation("Invalid forum bulk read cursor".to_string())
 }
 
 async fn ensure_topic_exists(

--- a/crates/rustok-forum/src/services/read_tracking.rs
+++ b/crates/rustok-forum/src/services/read_tracking.rs
@@ -238,7 +238,7 @@ impl ForumTopicReadStateService {
         let cursor = input
             .cursor
             .as_deref()
-            .map(|value| decode_bulk_read_cursor(value, scope))
+            .map(|value| decode_bulk_read_cursor(value, tenant_id, user_id, scope))
             .transpose()?;
         let snapshot_at = cursor
             .as_ref()
@@ -304,9 +304,15 @@ impl ForumTopicReadStateService {
 
         let next_cursor = has_more
             .then(|| {
-                topics
-                    .last()
-                    .map(|topic| encode_bulk_read_cursor(scope, &snapshot_at, topic))
+                topics.last().map(|topic| {
+                    encode_bulk_read_cursor(
+                        tenant_id,
+                        user_id,
+                        scope,
+                        &snapshot_at,
+                        topic,
+                    )
+                })
             })
             .flatten();
         let processed = topics.len() as u64;
@@ -544,12 +550,14 @@ async fn load_explicit_state_in_tx(
 }
 
 fn encode_bulk_read_cursor(
+    tenant_id: Uuid,
+    user_id: Uuid,
     scope: BulkReadScope,
     snapshot_at: &sea_orm::prelude::DateTimeWithTimeZone,
     topic: &forum_topic::Model,
 ) -> String {
     format!(
-        "{BULK_READ_CURSOR_VERSION}|{}|{}|{}|{}",
+        "{BULK_READ_CURSOR_VERSION}|{tenant_id}|{user_id}|{}|{}|{}|{}",
         scope.cursor_token(),
         snapshot_at.to_rfc3339_opts(SecondsFormat::Nanos, true),
         topic
@@ -559,11 +567,18 @@ fn encode_bulk_read_cursor(
     )
 }
 
-fn decode_bulk_read_cursor(value: &str, expected_scope: BulkReadScope) -> ForumResult<BulkReadCursor> {
-    let expected_token = expected_scope.cursor_token();
-    let mut parts = value.splitn(5, '|');
+fn decode_bulk_read_cursor(
+    value: &str,
+    expected_tenant_id: Uuid,
+    expected_user_id: Uuid,
+    expected_scope: BulkReadScope,
+) -> ForumResult<BulkReadCursor> {
+    let expected_scope_token = expected_scope.cursor_token();
+    let mut parts = value.splitn(7, '|');
     if parts.next() != Some(BULK_READ_CURSOR_VERSION)
-        || parts.next() != Some(expected_token.as_str())
+        || parts.next() != Some(expected_tenant_id.to_string().as_str())
+        || parts.next() != Some(expected_user_id.to_string().as_str())
+        || parts.next() != Some(expected_scope_token.as_str())
     {
         return Err(invalid_bulk_read_cursor());
     }

--- a/crates/rustok-forum/tests/topic_bulk_read_state_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_bulk_read_state_sqlite.rs
@@ -1,0 +1,546 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
+use rustok_forum::entities::forum_topic_read_state;
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput, ForumModule,
+    ForumReadModelService, ForumTopicReadStateService, MarkForumTopicReadInput,
+    MarkForumTopicsReadBatchInput, ModerationService, ReplyService, TopicService,
+    TopicUnreadCursorQuery, UpdateTopicInput,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus, Uuid) {
+    let db_url = format!(
+        "sqlite:file:forum_topic_bulk_read_state_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum topic bulk read sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus, Uuid::new_v4())
+}
+
+async fn create_category(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    security: SecurityContext,
+    name: &str,
+    parent_id: Option<Uuid>,
+    moderated: bool,
+) -> Uuid {
+    CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: name.into(),
+                slug: name.to_ascii_lowercase().replace(' ', "-"),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id,
+                position: None,
+                moderated,
+            },
+        )
+        .await
+        .expect("category should be created")
+        .id
+}
+
+async fn create_topic(
+    topics: &TopicService,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    security: SecurityContext,
+    title: &str,
+) -> Uuid {
+    topics
+        .create(
+            tenant_id,
+            security,
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id,
+                title: title.into(),
+                slug: Some(title.to_ascii_lowercase().replace(' ', "-")),
+                body: format!("{title} body"),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: vec![],
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created")
+        .id
+}
+
+async fn add_two_public_replies_and_revision(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+    author: SecurityContext,
+    reader: SecurityContext,
+) {
+    let replies = ReplyService::new(db.clone(), event_bus.clone());
+    for content in ["First reply", "Second reply"] {
+        replies
+            .create(
+                tenant_id,
+                reader.clone(),
+                topic_id,
+                CreateReplyInput {
+                    locale: "en".into(),
+                    content: content.into(),
+                    content_format: "markdown".into(),
+                    content_json: None,
+                    parent_reply_id: None,
+                },
+            )
+            .await
+            .expect("public reply should be created");
+    }
+    TopicService::new(db.clone(), event_bus.clone())
+        .update(
+            tenant_id,
+            topic_id,
+            author,
+            UpdateTopicInput {
+                locale: "en".into(),
+                title: Some(format!("Updated {topic_id}")),
+                body: Some("Updated topic body".into()),
+                body_format: Some("markdown".into()),
+                content_json: None,
+                metadata: None,
+                tags: None,
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic revision should be created");
+}
+
+async fn finish_category_read(
+    service: &ForumTopicReadStateService,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    reader: SecurityContext,
+    first_cursor: Option<String>,
+) -> u64 {
+    let mut processed = 0;
+    let mut cursor = first_cursor;
+    loop {
+        let page = service
+            .mark_category_read(
+                tenant_id,
+                category_id,
+                reader.clone(),
+                MarkForumTopicsReadBatchInput {
+                    cursor,
+                    limit: Some(1),
+                },
+            )
+            .await
+            .expect("category read page should succeed");
+        processed += page.processed;
+        if !page.has_more {
+            assert_eq!(page.next_cursor, None);
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+    processed
+}
+
+async fn finish_all_read(
+    service: &ForumTopicReadStateService,
+    tenant_id: Uuid,
+    reader: SecurityContext,
+) -> u64 {
+    let mut processed = 0;
+    let mut cursor = None;
+    loop {
+        let page = service
+            .mark_all_read(
+                tenant_id,
+                reader.clone(),
+                MarkForumTopicsReadBatchInput {
+                    cursor,
+                    limit: Some(2),
+                },
+            )
+            .await
+            .expect("tenant read page should succeed");
+        processed += page.processed;
+        if !page.has_more {
+            assert_eq!(page.next_cursor, None);
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+    processed
+}
+
+#[tokio::test]
+async fn category_and_all_read_are_bounded_resumable_and_scope_safe() {
+    let (db, event_bus, tenant_id) = setup().await;
+    let author = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let reader_id = Uuid::new_v4();
+    let reader = SecurityContext::new(UserRole::Customer, Some(reader_id));
+    let anonymous = SecurityContext::new(UserRole::Customer, None);
+
+    let root = create_category(
+        &db,
+        tenant_id,
+        author.clone(),
+        "Root category",
+        None,
+        false,
+    )
+    .await;
+    let child = create_category(
+        &db,
+        tenant_id,
+        author.clone(),
+        "Child category",
+        Some(root),
+        false,
+    )
+    .await;
+    let other = create_category(
+        &db,
+        tenant_id,
+        author.clone(),
+        "Other category",
+        None,
+        false,
+    )
+    .await;
+
+    let topics = TopicService::new(db.clone(), event_bus.clone());
+    let root_topic = create_topic(
+        &topics,
+        tenant_id,
+        root,
+        author.clone(),
+        "Root topic",
+    )
+    .await;
+    let child_topic_one = create_topic(
+        &topics,
+        tenant_id,
+        child,
+        author.clone(),
+        "Child topic one",
+    )
+    .await;
+    let child_topic_two = create_topic(
+        &topics,
+        tenant_id,
+        child,
+        author.clone(),
+        "Child topic two",
+    )
+    .await;
+    let other_topic = create_topic(
+        &topics,
+        tenant_id,
+        other,
+        author.clone(),
+        "Other topic",
+    )
+    .await;
+    for topic_id in [root_topic, child_topic_one, child_topic_two, other_topic] {
+        add_two_public_replies_and_revision(
+            &db,
+            &event_bus,
+            tenant_id,
+            topic_id,
+            author.clone(),
+            reader.clone(),
+        )
+        .await;
+    }
+
+    let service = ForumTopicReadStateService::new(db.clone());
+    let first = service
+        .mark_category_read(
+            tenant_id,
+            root,
+            reader.clone(),
+            MarkForumTopicsReadBatchInput {
+                cursor: None,
+                limit: Some(1),
+            },
+        )
+        .await
+        .expect("first category read page should succeed");
+    assert_eq!(first.processed, 1);
+    assert!(first.has_more);
+    let category_cursor = first
+        .next_cursor
+        .clone()
+        .expect("first category page should continue");
+
+    let late_topic = create_topic(
+        &topics,
+        tenant_id,
+        root,
+        author.clone(),
+        "Created after category snapshot",
+    )
+    .await;
+    let remaining_processed = finish_category_read(
+        &service,
+        tenant_id,
+        root,
+        reader.clone(),
+        Some(category_cursor.clone()),
+    )
+    .await;
+    assert_eq!(first.processed + remaining_processed, 3);
+
+    let category_states = forum_topic_read_state::Entity::find()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(reader_id))
+        .order_by_asc(forum_topic_read_state::Column::TopicId)
+        .all(&db)
+        .await
+        .expect("category read states should load");
+    let category_topic_ids = category_states
+        .iter()
+        .map(|state| state.topic_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        category_topic_ids,
+        HashSet::from([root_topic, child_topic_one, child_topic_two])
+    );
+    assert!(!category_topic_ids.contains(&other_topic));
+    assert!(!category_topic_ids.contains(&late_topic));
+    for state in &category_states {
+        assert_eq!(state.last_read_position, 2);
+        assert!(state.last_read_revision > 0);
+    }
+
+    let cross_scope_cursor = service
+        .mark_all_read(
+            tenant_id,
+            reader.clone(),
+            MarkForumTopicsReadBatchInput {
+                cursor: Some(category_cursor),
+                limit: Some(2),
+            },
+        )
+        .await;
+    assert!(
+        cross_scope_cursor.is_err(),
+        "category cursors must not be accepted by the tenant-wide command"
+    );
+
+    let all_processed = finish_all_read(&service, tenant_id, reader.clone()).await;
+    assert_eq!(all_processed, 5);
+    let all_states = forum_topic_read_state::Entity::find()
+        .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+        .filter(forum_topic_read_state::Column::UserId.eq(reader_id))
+        .all(&db)
+        .await
+        .expect("tenant read states should load");
+    assert_eq!(all_states.len(), 5);
+
+    let replay_processed = finish_all_read(&service, tenant_id, reader.clone()).await;
+    assert_eq!(replay_processed, 5);
+    assert_eq!(
+        forum_topic_read_state::Entity::find()
+            .filter(forum_topic_read_state::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic_read_state::Column::UserId.eq(reader_id))
+            .all(&db)
+            .await
+            .expect("replayed states should load")
+            .len(),
+        5
+    );
+
+    let anonymous_result = service
+        .mark_all_read(
+            tenant_id,
+            anonymous,
+            MarkForumTopicsReadBatchInput::default(),
+        )
+        .await;
+    assert!(anonymous_result.is_err());
+    let oversized_result = service
+        .mark_all_read(
+            tenant_id,
+            reader.clone(),
+            MarkForumTopicsReadBatchInput {
+                cursor: None,
+                limit: Some(101),
+            },
+        )
+        .await;
+    assert!(oversized_result.is_err());
+    let foreign_category_result = service
+        .mark_category_read(
+            Uuid::new_v4(),
+            root,
+            reader,
+            MarkForumTopicsReadBatchInput::default(),
+        )
+        .await;
+    assert!(foreign_category_result.is_err());
+}
+
+#[tokio::test]
+async fn repeated_topic_mark_clears_late_approval_without_regression() {
+    let (db, event_bus, tenant_id) = setup().await;
+    let author = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let reader = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+    let category = create_category(
+        &db,
+        tenant_id,
+        author.clone(),
+        "Moderated category",
+        None,
+        true,
+    )
+    .await;
+    let topics = TopicService::new(db.clone(), event_bus.clone());
+    let topic_id = create_topic(
+        &topics,
+        tenant_id,
+        category,
+        author.clone(),
+        "Late approval topic",
+    )
+    .await;
+    let replies = ReplyService::new(db.clone(), event_bus.clone());
+    let first_pending = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            topic_id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Pending position one".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("first pending reply should be created");
+    let second_pending = replies
+        .create(
+            tenant_id,
+            reader.clone(),
+            topic_id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Pending position two".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("second pending reply should be created");
+    let moderation = ModerationService::new(db.clone(), event_bus);
+    moderation
+        .approve_reply(tenant_id, second_pending.id, topic_id, author.clone())
+        .await
+        .expect("position two should be approved first");
+
+    let read_state = ForumTopicReadStateService::new(db.clone());
+    read_state
+        .mark_topic_read(
+            tenant_id,
+            topic_id,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: 2,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("position two should be marked read");
+    moderation
+        .approve_reply(tenant_id, first_pending.id, topic_id, author)
+        .await
+        .expect("position one should be approved later");
+
+    let projection = ForumReadModelService::new(db.clone());
+    let before_remark = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader.clone(),
+            TopicUnreadCursorQuery {
+                category_id: Some(category),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("late approval projection should load");
+    assert_eq!(before_remark.items.len(), 1);
+    assert_eq!(before_remark.items[0].unread_count, 1);
+
+    let remarked = read_state
+        .mark_topic_read(
+            tenant_id,
+            topic_id,
+            reader.clone(),
+            MarkForumTopicReadInput {
+                last_read_position: 2,
+                last_read_revision: 0,
+            },
+        )
+        .await
+        .expect("equal high-water mark should refresh the read snapshot");
+    assert_eq!(remarked.last_read_position, 2);
+    assert_eq!(remarked.last_read_revision, 0);
+
+    let after_remark = projection
+        .list_topics_with_unread(
+            tenant_id,
+            reader,
+            TopicUnreadCursorQuery {
+                category_id: Some(category),
+                unread_only: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("projection after repeated mark should load");
+    assert!(after_remark.items.is_empty());
+}


### PR DESCRIPTION
## Summary

- add authenticated `mark_category_read` and `mark_all_read` owner commands without opening REST, GraphQL, storefront, realtime, migration, or CI surfaces
- process at most 100 topics per transaction and return an exact resumable cursor bound to tenant, user, command scope, snapshot timestamp, topic creation timestamp, and topic identity
- mark the current category subtree using the existing 512-node category-tree bound, or the complete tenant topic scope
- fix the first-page topic snapshot so topics created later are deferred to a subsequent idempotent pass
- aggregate latest approved reply positions and immutable topic revisions per bounded page before monotonic read-state upserts
- refresh a non-stale equal high-water snapshot so late moderator approval below an already-read position can be acknowledged without permitting regression
- add SQLite owner scenarios for subtree pagination, snapshot exclusion, cursor scope isolation, tenant-wide replay, bounds, anonymous rejection, foreign scope, and late approval acknowledgement
- record FORUM-16C in the canonical implementation plan while keeping transport composition and PostgreSQL concurrency/query-plan evidence open

Category membership is revalidated on each resumed page; a subsequent idempotent pass converges after a concurrent category move.

## Validation

Not run by request; the repository owner will run the targeted Forum SQLite scenarios and module validation locally.