### PR TITLE
Harden refund reconciliation GraphQL errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/reconciliation.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/reconciliation.rs
@@ -1,10 +1,87 @@
-use async_graphql::{Context, Object, Result};
+use async_graphql::{Context, ErrorExtensions, Object, Result};
 use rustok_api::{Permission, graphql::require_module_enabled};
+use rustok_payment::error::PaymentError;
 use uuid::Uuid;
 
+use crate::PaymentOrchestrationError;
 use crate::graphql_runtime::refund_reconciliation_from_context;
 
 use super::super::{MODULE_SLUG, require_commerce_permission, types::GqlRefund};
+
+fn public_reconciliation_graphql_error(
+    message: &'static str,
+    code: &'static str,
+    retryable: bool,
+) -> async_graphql::Error {
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
+fn payment_error_envelope(error: &PaymentError) -> (&'static str, &'static str, bool) {
+    match error {
+        PaymentError::Validation(_) => (
+            "Payment reconciliation request is invalid",
+            "PAYMENT_RECONCILIATION_REQUEST_INVALID",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            "Payment resource was not found",
+            "PAYMENT_RESOURCE_NOT_FOUND",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            "Payment reconciliation conflicts with the current state",
+            "PAYMENT_RECONCILIATION_STATE_CONFLICT",
+            false,
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+            "Payment reconciliation is temporarily unavailable",
+            "PAYMENT_RECONCILIATION_TEMPORARILY_UNAVAILABLE",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            "Payment reconciliation is not configured",
+            "PAYMENT_CONFIGURATION_ERROR",
+            false,
+        ),
+    }
+}
+
+fn reconciliation_graphql_error(
+    tenant_id: Uuid,
+    refund_id: Uuid,
+    operation: &'static str,
+    error: PaymentOrchestrationError,
+) -> async_graphql::Error {
+    tracing::error!(
+        error = ?error,
+        tenant_id = %tenant_id,
+        refund_id = %refund_id,
+        operation,
+        "commerce GraphQL refund reconciliation failed"
+    );
+
+    let (message, code, retryable) = match &error {
+        PaymentOrchestrationError::Provider(source)
+        | PaymentOrchestrationError::Payment(source) => payment_error_envelope(source),
+        PaymentOrchestrationError::ProviderAfterRefundReservation { .. } => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
+            false,
+        ),
+    };
+    public_reconciliation_graphql_error(message, code, retryable)
+}
 
 #[derive(Default)]
 pub struct CommerceReconciliationMutation;
@@ -30,7 +107,14 @@ impl CommerceReconciliationMutation {
         let refund = refund_reconciliation_from_context(ctx, db.clone())
             .retry_refund_provider(tenant_id, refund_id)
             .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+            .map_err(|error| {
+                reconciliation_graphql_error(
+                    tenant_id,
+                    refund_id,
+                    "retry_refund_provider",
+                    error,
+                )
+            })?;
 
         Ok(refund.into())
     }

--- a/scripts/verify/verify-commerce-graphql-reconciliation-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-reconciliation-error-safety.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const source = read('crates/rustok-commerce/src/graphql/mutations/reconciliation.rs');
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'FieldError::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+]) {
+  forbidText(value, 'refund reconciliation public boundary');
+}
+
+for (const [value, label] of [
+  ['ErrorExtensions', 'GraphQL extension support'],
+  ['fn public_reconciliation_graphql_error(', 'public envelope constructor'],
+  ['fn payment_error_envelope(', 'payment error mapper'],
+  ['fn reconciliation_graphql_error(', 'reconciliation logger'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['refund_id = %refund_id', 'refund logging'],
+  ['operation,', 'operation logging'],
+  ['extensions.set("code", code)', 'stable code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['PaymentError::Validation(_)', 'validation mapping'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found mapping'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found mapping'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found mapping'],
+  ['PaymentError::InvalidTransition { .. }', 'transition mapping'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider outage mapping'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejection mapping'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'invalid response mapping'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'unknown outcome mapping'],
+  ['PaymentError::ProviderConfiguration { .. }', 'configuration mapping'],
+  ['PaymentError::Database(_)', 'database mapping'],
+  ['PaymentOrchestrationError::Provider(source)', 'provider orchestration mapping'],
+  ['PaymentOrchestrationError::Payment(source)', 'payment orchestration mapping'],
+  ['PaymentOrchestrationError::ProviderAfterRefundReservation { .. }', 'post-reservation mapping'],
+  ['"PAYMENT_RECONCILIATION_REQUEST_INVALID"', 'validation code'],
+  ['"PAYMENT_RESOURCE_NOT_FOUND"', 'resource code'],
+  ['"PAYMENT_RECONCILIATION_STATE_CONFLICT"', 'state conflict code'],
+  ['"PAYMENT_RECONCILIATION_TEMPORARILY_UNAVAILABLE"', 'temporary code'],
+  ['"PAYMENT_RECONCILIATION_REQUIRED"', 'reconciliation code'],
+  ['"PAYMENT_CONFIGURATION_ERROR"', 'configuration code'],
+  ['"retry_refund_provider"', 'operation label'],
+  ['async fn retry_refund_provider(', 'mutation preservation'],
+]) {
+  requireText(value, label);
+}
+
+const mapperCalls = source.match(/reconciliation_graphql_error\(/g) ?? [];
+if (mapperCalls.length !== 2) {
+  failures.push(`expected reconciliation mapper definition plus one call, found ${mapperCalls.length}`);
+}
+
+const reconciliationCodeOccurrences = source.match(/"PAYMENT_RECONCILIATION_REQUIRED"/g) ?? [];
+if (reconciliationCodeOccurrences.length !== 2) {
+  failures.push(
+    `expected unknown-outcome and post-reservation reconciliation mappings, found ${reconciliationCodeOccurrences.length}`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL refund reconciliation error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL refund reconciliation exposes stable public envelopes with non-retryable unknown-outcome handling',
+);


### PR DESCRIPTION
## Summary

- replace the remaining `error.to_string()` passthrough in the commerce GraphQL refund reconciliation mutation with stable public envelopes;
- map every current `PaymentError` and `PaymentOrchestrationError` variant without publishing provider IDs, operation details, refund/collection identifiers, transition values, database causes, journal state, or validation text;
- keep raw errors in structured logs with tenant, refund, and operation context;
- return provider/database outages as retryable, while invalid/unknown provider outcomes and any `ProviderAfterRefundReservation` failure remain non-retryable reconciliation cases;
- preserve the mutation signature, module and permission checks, runtime registry use, service call, and response conversion;
- add a dedicated static verifier for forbidden constructors, exhaustive enum coverage, stable codes, operation labeling, and mapper call count.

## Scope

Two files only: `graphql/mutations/reconciliation.rs` and its verifier. No reconciliation service, provider registry, payment owner service, journal, permission, or GraphQL schema behavior changes beyond public error serialization.

## Public envelopes

The boundary now uses `PAYMENT_RECONCILIATION_REQUEST_INVALID`, `PAYMENT_RESOURCE_NOT_FOUND`, `PAYMENT_RECONCILIATION_STATE_CONFLICT`, `PAYMENT_RECONCILIATION_TEMPORARILY_UNAVAILABLE`, `PAYMENT_RECONCILIATION_REQUIRED`, and `PAYMENT_CONFIGURATION_ERROR`.

## Validation

- source and compare audit completed against current `main`;
- branch is directly based on current `main` and changes two files;
- exhaustive matches reviewed against the current payment and payment-orchestration enums;
- verified one reconciliation mapper call;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.