### PR TITLE
Harden checkout shipping service GraphQL errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -4,6 +4,7 @@ use super::marketplace_financial::MarketplaceFinancialMutation;
 
 pub mod cart;
 pub mod catalog;
+#[path = "safe_checkout.rs"]
 pub mod checkout;
 pub mod fulfillment;
 #[path = "helpers.rs"]

--- a/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
@@ -1,0 +1,180 @@
+mod checkout_boundary {
+    use ::async_graphql::{Error, ErrorExtensions};
+    use ::rustok_fulfillment::error::FulfillmentError;
+
+    use crate::CommerceError;
+
+    #[derive(Clone)]
+    pub(crate) enum BoundaryError {
+        Graphql(Error),
+        Public {
+            message: &'static str,
+            code: &'static str,
+            retryable: bool,
+        },
+    }
+
+    impl From<Error> for BoundaryError {
+        fn from(error: Error) -> Self {
+            Self::Graphql(error)
+        }
+    }
+
+    fn public_graphql_error(
+        message: &'static str,
+        code: &'static str,
+        retryable: bool,
+    ) -> Error {
+        Error::new(message).extend_with(|_, extensions| {
+            extensions.set("code", code);
+            extensions.set("retryable", retryable);
+        })
+    }
+
+    fn commerce_error_envelope(
+        error: &CommerceError,
+    ) -> (&'static str, &'static str, bool, &'static str) {
+        match error {
+            CommerceError::Validation(_)
+            | CommerceError::InvalidPrice(_)
+            | CommerceError::InvalidOptionCombination
+            | CommerceError::NoVariants => (
+                "Shipping profile request is invalid",
+                "SHIPPING_PROFILE_REQUEST_INVALID",
+                false,
+                "validation",
+            ),
+            CommerceError::ShippingProfileNotFound(_) => (
+                "Shipping profile was not found",
+                "SHIPPING_PROFILE_NOT_FOUND",
+                false,
+                "not_found",
+            ),
+            CommerceError::DuplicateShippingProfileSlug(_) => (
+                "Shipping profile conflicts with the current state",
+                "SHIPPING_PROFILE_STATE_CONFLICT",
+                false,
+                "conflict",
+            ),
+            CommerceError::Database(_) => (
+                "Shipping profile service is temporarily unavailable",
+                "SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE",
+                true,
+                "database",
+            ),
+            CommerceError::ProductNotFound(_)
+            | CommerceError::VariantNotFound(_)
+            | CommerceError::DuplicateHandle { .. }
+            | CommerceError::DuplicateSku(_)
+            | CommerceError::InsufficientInventory { .. }
+            | CommerceError::CannotDeletePublished
+            | CommerceError::Rich(_)
+            | CommerceError::Core(_) => (
+                "Shipping profile operation could not be completed safely",
+                "SHIPPING_PROFILE_OPERATION_FAILED",
+                false,
+                "unexpected_owner_error",
+            ),
+        }
+    }
+
+    fn fulfillment_error_envelope(
+        error: &FulfillmentError,
+    ) -> (&'static str, &'static str, bool, &'static str) {
+        match error {
+            FulfillmentError::Validation(_) => (
+                "Shipping option request is invalid",
+                "SHIPPING_OPTION_REQUEST_INVALID",
+                false,
+                "validation",
+            ),
+            FulfillmentError::ShippingOptionNotFound(_) => (
+                "Shipping option was not found",
+                "SHIPPING_OPTION_NOT_FOUND",
+                false,
+                "not_found",
+            ),
+            FulfillmentError::InvalidTransition { .. } => (
+                "Shipping option operation conflicts with the current state",
+                "SHIPPING_OPTION_STATE_CONFLICT",
+                false,
+                "conflict",
+            ),
+            FulfillmentError::Database(_) => (
+                "Shipping option service is temporarily unavailable",
+                "SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE",
+                true,
+                "database",
+            ),
+            FulfillmentError::FulfillmentNotFound(_) => (
+                "Shipping option operation could not be completed safely",
+                "SHIPPING_OPTION_OPERATION_FAILED",
+                false,
+                "unexpected_owner_error",
+            ),
+        }
+    }
+
+    impl From<CommerceError> for BoundaryError {
+        fn from(error: CommerceError) -> Self {
+            let (message, code, retryable, error_kind) = commerce_error_envelope(&error);
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_commerce",
+                error_kind,
+                public_code = code,
+                retryable,
+                boundary = "commerce_graphql_checkout",
+                "commerce GraphQL checkout shipping profile operation failed"
+            );
+            Self::Public {
+                message,
+                code,
+                retryable,
+            }
+        }
+    }
+
+    impl From<FulfillmentError> for BoundaryError {
+        fn from(error: FulfillmentError) -> Self {
+            let (message, code, retryable, error_kind) = fulfillment_error_envelope(&error);
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_fulfillment",
+                error_kind,
+                public_code = code,
+                retryable,
+                boundary = "commerce_graphql_checkout",
+                "commerce GraphQL checkout shipping option operation failed"
+            );
+            Self::Public {
+                message,
+                code,
+                retryable,
+            }
+        }
+    }
+
+    impl From<BoundaryError> for Error {
+        fn from(error: BoundaryError) -> Self {
+            match error {
+                BoundaryError::Graphql(error) => error,
+                BoundaryError::Public {
+                    message,
+                    code,
+                    retryable,
+                } => public_graphql_error(message, code, retryable),
+            }
+        }
+    }
+}
+
+mod async_graphql_shim {
+    pub use ::async_graphql::{Context, Error, ErrorExtensions, Object};
+
+    pub type Result<T> = std::result::Result<T, super::checkout_boundary::BoundaryError>;
+}
+
+use self::async_graphql_shim as async_graphql;
+
+include!("checkout.rs");

--- a/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const routing = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs');
+const source = read('crates/rustok-commerce/src/graphql/mutations/checkout.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+requireText(
+  routing,
+  '#[path = "safe_checkout.rs"]\npub mod checkout;',
+  'checkout safe module routing',
+);
+const checkoutModuleDeclarations = routing.match(/pub mod checkout;/g) ?? [];
+if (checkoutModuleDeclarations.length !== 1) {
+  failures.push(`expected one checkout module declaration, found ${checkoutModuleDeclarations.length}`);
+}
+
+for (const [value, label] of [
+  ['mod checkout_boundary {', 'checkout boundary module'],
+  ['#[derive(Clone)]', 'async GraphQL clone requirement'],
+  ['pub(crate) enum BoundaryError {', 'local boundary error'],
+  ['Graphql(Error)', 'GraphQL pass-through variant'],
+  ['Public {', 'cloneable public envelope variant'],
+  ['impl From<Error> for BoundaryError', 'GraphQL conversion'],
+  ['impl From<CommerceError> for BoundaryError', 'commerce conversion'],
+  ['impl From<FulfillmentError> for BoundaryError', 'fulfillment conversion'],
+  ['Self::Public {', 'owner error envelope storage'],
+  ['impl From<BoundaryError> for Error', 'public GraphQL conversion'],
+  ['BoundaryError::Graphql(error) => error', 'existing GraphQL error preservation'],
+  ['BoundaryError::Public {', 'public envelope restoration'],
+  ['fn commerce_error_envelope(', 'shipping profile mapper'],
+  ['fn fulfillment_error_envelope(', 'shipping option mapper'],
+  ['extensions.set("code", code)', 'stable code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['owner = "rustok_commerce"', 'commerce owner logging'],
+  ['owner = "rustok_fulfillment"', 'fulfillment owner logging'],
+  ['error_kind,', 'owner error kind logging'],
+  ['public_code = code', 'public code logging'],
+  ['boundary = "commerce_graphql_checkout"', 'checkout boundary logging'],
+  ['mod async_graphql_shim {', 'async GraphQL result shim'],
+  ['pub use ::async_graphql::{Context, Error, ErrorExtensions, Object};', 'GraphQL API re-export'],
+  [
+    'pub type Result<T> = std::result::Result<T, super::checkout_boundary::BoundaryError>;',
+    'custom checkout result',
+  ],
+  ['use self::async_graphql_shim as async_graphql;', 'shim alias'],
+  ['include!("checkout.rs");', 'unchanged checkout resolver inclusion'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const value of [
+  'Commerce(CommerceError)',
+  'Fulfillment(FulfillmentError)',
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'format!("{error}")',
+]) {
+  forbidText(facade, value, 'checkout facade public boundary');
+}
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'format!("{error}")',
+]) {
+  forbidText(source, value, 'checkout resolver public boundary');
+}
+
+for (const [value, label] of [
+  ['CommerceError::Validation(_)', 'commerce validation mapping'],
+  ['CommerceError::InvalidPrice(_)', 'commerce invalid-price mapping'],
+  ['CommerceError::InvalidOptionCombination', 'commerce option mapping'],
+  ['CommerceError::NoVariants', 'commerce no-variants mapping'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'profile conflict mapping'],
+  ['CommerceError::Database(_)', 'profile database mapping'],
+  ['CommerceError::ProductNotFound(_)', 'commerce product fallback'],
+  ['CommerceError::VariantNotFound(_)', 'commerce variant fallback'],
+  ['CommerceError::DuplicateHandle { .. }', 'commerce handle fallback'],
+  ['CommerceError::DuplicateSku(_)', 'commerce SKU fallback'],
+  ['CommerceError::InsufficientInventory { .. }', 'commerce inventory fallback'],
+  ['CommerceError::CannotDeletePublished', 'commerce published fallback'],
+  ['CommerceError::Rich(_)', 'commerce rich fallback'],
+  ['CommerceError::Core(_)', 'commerce core fallback'],
+  ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'shipping option conflict mapping'],
+  ['FulfillmentError::Database(_)', 'shipping option database mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment fallback mapping'],
+  ['"SHIPPING_PROFILE_REQUEST_INVALID"', 'profile validation code'],
+  ['"SHIPPING_PROFILE_NOT_FOUND"', 'profile not-found code'],
+  ['"SHIPPING_PROFILE_STATE_CONFLICT"', 'profile conflict code'],
+  ['"SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE"', 'profile temporary code'],
+  ['"SHIPPING_PROFILE_OPERATION_FAILED"', 'profile fallback code'],
+  ['"SHIPPING_OPTION_REQUEST_INVALID"', 'option validation code'],
+  ['"SHIPPING_OPTION_NOT_FOUND"', 'option not-found code'],
+  ['"SHIPPING_OPTION_STATE_CONFLICT"', 'option conflict code'],
+  ['"SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE"', 'option temporary code'],
+  ['"SHIPPING_OPTION_OPERATION_FAILED"', 'option fallback code'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const [value, label] of [
+  ['use async_graphql::{Context, ErrorExtensions, Object, Result};', 'resolver Result import'],
+  ['use crate::ShippingProfileService;', 'shipping profile service import'],
+  ['use rustok_fulfillment::FulfillmentService;', 'fulfillment service import'],
+  ['async fn create_shipping_option(', 'create shipping option mutation'],
+  ['async fn update_shipping_option(', 'update shipping option mutation'],
+  ['async fn deactivate_shipping_option(', 'deactivate shipping option mutation'],
+  ['async fn reactivate_shipping_option(', 'reactivate shipping option mutation'],
+  ['async fn create_shipping_profile(', 'create shipping profile mutation'],
+  ['async fn update_shipping_profile(', 'update shipping profile mutation'],
+  ['async fn deactivate_shipping_profile(', 'deactivate shipping profile mutation'],
+  ['async fn reactivate_shipping_profile(', 'reactivate shipping profile mutation'],
+]) {
+  requireText(source, value, label);
+}
+
+const fulfillmentServiceCalls = source.match(/FulfillmentService::new\(/g) ?? [];
+if (fulfillmentServiceCalls.length !== 4) {
+  failures.push(`expected four shipping-option service call sites, found ${fulfillmentServiceCalls.length}`);
+}
+const shippingProfileServiceCalls = source.match(/ShippingProfileService::new\(/g) ?? [];
+if (shippingProfileServiceCalls.length !== 4) {
+  failures.push(`expected four shipping-profile service call sites, found ${shippingProfileServiceCalls.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL checkout service error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL checkout shipping services use cloneable typed public envelopes while preserving existing GraphQL errors',
+);


### PR DESCRIPTION
## Summary

- route the commerce checkout mutation module through a thin safe include-facade while keeping the existing `checkout.rs` resolver implementation unchanged;
- replace the implicit public serialization of four `FulfillmentError` shipping-option paths and four `CommerceError` shipping-profile paths with typed stable envelopes;
- preserve already-constructed cart, payment, staged-checkout, validation, context, permission, and metadata GraphQL errors byte-for-byte by passing `async_graphql::Error` through unchanged;
- use a cloneable local resolver error type, as required by async-graphql's `Result<T, E>` output contract, and store only static public message/code/retryable fields after logging the raw owner error;
- map every current `CommerceError` and `FulfillmentError` variant without publishing IDs, slugs, transition values, database causes, validation text, rich/core details, or inventory state;
- add a dedicated static verifier for module routing, cloneability, conversion coverage, public codes, owner logging, resolver preservation, and the eight service call sites.

## Scope

Three files only: mutation module routing, the new safe checkout facade, and its verifier. `checkout.rs`, checkout orchestration, service calls, DTO construction, permission checks, parsing, GraphQL field signatures, and response conversion are unchanged.

## Public envelopes

Shipping profiles use `SHIPPING_PROFILE_REQUEST_INVALID`, `SHIPPING_PROFILE_NOT_FOUND`, `SHIPPING_PROFILE_STATE_CONFLICT`, `SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE`, and `SHIPPING_PROFILE_OPERATION_FAILED`.

Shipping options use `SHIPPING_OPTION_REQUEST_INVALID`, `SHIPPING_OPTION_NOT_FOUND`, `SHIPPING_OPTION_STATE_CONFLICT`, `SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE`, and `SHIPPING_OPTION_OPERATION_FAILED`.

Only database failures are retryable.

## Validation

- source and compare audit completed against current `main`;
- branch is directly based on current `main` and changes three files;
- async-graphql 7.2.1 custom result requirements reviewed (`Into<Error> + Send + Sync + Clone`);
- exhaustive matches reviewed against the current commerce and fulfillment owner enums;
- original checkout resolver blob remains unchanged;
- verified four fulfillment-service and four shipping-profile-service call sites;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.