### PR TITLE
Add product GraphQL retryability envelopes

### DIFF
--- a/crates/rustok-commerce/src/graphql/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mod.rs
@@ -43,58 +43,84 @@ pub(crate) fn map_product_service_error(
 ) -> async_graphql::Error {
     use rustok_commerce_foundation::CommerceError;
 
-    tracing::error!(error = ?error, operation, "product service operation failed");
-    let (public_message, code) = match error {
+    let (public_message, code, retryable) = match &error {
         CommerceError::Database(_) => (
             "Product data is temporarily unavailable",
             "PRODUCT_TEMPORARILY_UNAVAILABLE",
+            true,
         ),
-        CommerceError::ProductNotFound(_) => ("Product was not found", "PRODUCT_NOT_FOUND"),
+        CommerceError::ProductNotFound(_) => {
+            ("Product was not found", "PRODUCT_NOT_FOUND", false)
+        }
         CommerceError::VariantNotFound(_) => {
-            ("Product variant was not found", "VARIANT_NOT_FOUND")
+            ("Product variant was not found", "VARIANT_NOT_FOUND", false)
         }
         CommerceError::DuplicateHandle { .. } => (
             "Product handle conflicts with an existing product",
             "DUPLICATE_HANDLE",
+            false,
         ),
         CommerceError::DuplicateSku(_) => (
             "Product SKU conflicts with an existing product",
             "DUPLICATE_SKU",
+            false,
         ),
-        CommerceError::InvalidPrice(_) => ("Product price is invalid", "INVALID_PRICE"),
+        CommerceError::InvalidPrice(_) => {
+            ("Product price is invalid", "INVALID_PRICE", false)
+        }
         CommerceError::InsufficientInventory { .. } => (
             "Product inventory is insufficient",
             "INSUFFICIENT_INVENTORY",
+            false,
         ),
         CommerceError::InvalidOptionCombination => (
             "Product option combination is invalid",
             "INVALID_OPTIONS",
+            false,
         ),
-        CommerceError::Validation(_) => ("Product request is invalid", "PRODUCT_VALIDATION"),
+        CommerceError::Validation(_) => {
+            ("Product request is invalid", "PRODUCT_VALIDATION", false)
+        }
         CommerceError::ShippingProfileNotFound(_) => (
             "Shipping profile was not found",
             "SHIPPING_PROFILE_NOT_FOUND",
+            false,
         ),
         CommerceError::DuplicateShippingProfileSlug(_) => (
             "Shipping profile slug conflicts with an existing profile",
             "DUPLICATE_SHIPPING_PROFILE_SLUG",
+            false,
         ),
         CommerceError::NoVariants => (
             "Product requires at least one variant",
             "NO_VARIANTS",
+            false,
         ),
         CommerceError::CannotDeletePublished => (
             "Published products must be archived before removal",
             "CANNOT_DELETE_PUBLISHED",
+            false,
         ),
         CommerceError::Rich(_) | CommerceError::Core(_) => (
             "Product operation could not be completed safely",
             "PRODUCT_OPERATION_FAILED",
+            false,
         ),
     };
 
-    async_graphql::Error::new(public_message)
-        .extend_with(|_, extensions| extensions.set("code", code))
+    tracing::error!(
+        error = ?error,
+        operation,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_product",
+        "product service operation failed"
+    );
+
+    async_graphql::Error::new(public_message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
 }
 
 pub(crate) fn current_tenant_scope(

--- a/scripts/verify/verify-commerce-graphql-product-retryability.mjs
+++ b/scripts/verify/verify-commerce-graphql-product-retryability.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const graphqlRoot = read('crates/rustok-commerce/src/graphql/mod.rs');
+const catalogMutations = read('crates/rustok-commerce/src/graphql/mutations/catalog.rs');
+const queries = read('crates/rustok-commerce/src/graphql/query.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['pub(crate) fn map_product_service_error(', 'shared product mapper'],
+  ['let (public_message, code, retryable) = match &error {', 'typed public envelope'],
+  ['CommerceError::Database(_) => (', 'database mapping'],
+  ['"PRODUCT_TEMPORARILY_UNAVAILABLE"', 'temporary-unavailable code'],
+  ['CommerceError::ProductNotFound(_)', 'product not-found mapping'],
+  ['"PRODUCT_NOT_FOUND"', 'product not-found code'],
+  ['CommerceError::VariantNotFound(_)', 'variant not-found mapping'],
+  ['"VARIANT_NOT_FOUND"', 'variant not-found code'],
+  ['CommerceError::DuplicateHandle { .. }', 'duplicate-handle mapping'],
+  ['"DUPLICATE_HANDLE"', 'duplicate-handle code'],
+  ['CommerceError::DuplicateSku(_)', 'duplicate-SKU mapping'],
+  ['"DUPLICATE_SKU"', 'duplicate-SKU code'],
+  ['CommerceError::InvalidPrice(_)', 'invalid-price mapping'],
+  ['"INVALID_PRICE"', 'invalid-price code'],
+  ['CommerceError::InsufficientInventory { .. }', 'inventory mapping'],
+  ['"INSUFFICIENT_INVENTORY"', 'inventory code'],
+  ['CommerceError::InvalidOptionCombination', 'option mapping'],
+  ['"INVALID_OPTIONS"', 'option code'],
+  ['CommerceError::Validation(_)', 'validation mapping'],
+  ['"PRODUCT_VALIDATION"', 'validation code'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'shipping-profile mapping'],
+  ['"SHIPPING_PROFILE_NOT_FOUND"', 'shipping-profile code'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping-profile conflict mapping'],
+  ['"DUPLICATE_SHIPPING_PROFILE_SLUG"', 'shipping-profile conflict code'],
+  ['CommerceError::NoVariants', 'no-variants mapping'],
+  ['"NO_VARIANTS"', 'no-variants code'],
+  ['CommerceError::CannotDeletePublished', 'published-delete mapping'],
+  ['"CANNOT_DELETE_PUBLISHED"', 'published-delete code'],
+  ['CommerceError::Rich(_) | CommerceError::Core(_)', 'safe fallback mapping'],
+  ['"PRODUCT_OPERATION_FAILED"', 'safe fallback code'],
+  ['public_code = code', 'public code logging'],
+  ['retryable,', 'retryability logging'],
+  ['boundary = "commerce_graphql_product"', 'boundary logging'],
+  ['extensions.set("code", code)', 'code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+]) {
+  requireText(graphqlRoot, value, label);
+}
+
+forbidText(
+  graphqlRoot,
+  'let (public_message, code) = match error {',
+  'legacy code-only product envelope',
+);
+
+const databaseBlock = graphqlRoot.match(
+  /CommerceError::Database\(_\) => \([\s\S]*?"PRODUCT_TEMPORARILY_UNAVAILABLE",\s*true,\s*\)/,
+);
+if (!databaseBlock) {
+  failures.push('database mapping must be the retryable PRODUCT_TEMPORARILY_UNAVAILABLE envelope');
+}
+
+const retryableTrueOccurrences = graphqlRoot.match(/\btrue,\s*\)/g) ?? [];
+if (retryableTrueOccurrences.length !== 1) {
+  failures.push(`expected exactly one retryable product envelope, found ${retryableTrueOccurrences.length}`);
+}
+
+const retryableExtensionOccurrences =
+  graphqlRoot.match(/extensions\.set\("retryable", retryable\)/g) ?? [];
+if (retryableExtensionOccurrences.length !== 1) {
+  failures.push(
+    `expected one product retryability extension, found ${retryableExtensionOccurrences.length}`,
+  );
+}
+
+for (const [content, value, label] of [
+  [catalogMutations, 'map_product_service_error(error, "product_catalog_mutation")', 'catalog mutation mapper use'],
+  [queries, 'map_product_service_error(err, "product_query")', 'product query mapper use'],
+  [queries, 'map_product_service_error(err, "products_query")', 'products query mapper use'],
+]) {
+  requireText(content, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL product retryability verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL product service errors expose stable codes and retryability across queries and mutations',
+);

--- a/scripts/verify/verify-commerce-graphql-product-retryability.mjs
+++ b/scripts/verify/verify-commerce-graphql-product-retryability.mjs
@@ -22,6 +22,15 @@ const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
 
+const mapperStart = graphqlRoot.indexOf('pub(crate) fn map_product_service_error(');
+const mapperEnd = graphqlRoot.indexOf('\npub(crate) fn current_tenant_scope(', mapperStart);
+if (mapperStart < 0 || mapperEnd < 0) {
+  failures.push('unable to isolate shared product mapper');
+}
+const mapper = mapperStart >= 0 && mapperEnd >= 0
+  ? graphqlRoot.slice(mapperStart, mapperEnd)
+  : graphqlRoot;
+
 for (const [value, label] of [
   ['pub(crate) fn map_product_service_error(', 'shared product mapper'],
   ['let (public_message, code, retryable) = match &error {', 'typed public envelope'],
@@ -59,41 +68,54 @@ for (const [value, label] of [
   ['extensions.set("code", code)', 'code extension'],
   ['extensions.set("retryable", retryable)', 'retryability extension'],
 ]) {
-  requireText(graphqlRoot, value, label);
+  requireText(mapper, value, label);
 }
 
 forbidText(
-  graphqlRoot,
+  mapper,
   'let (public_message, code) = match error {',
   'legacy code-only product envelope',
 );
 
-const databaseBlock = graphqlRoot.match(
+const databaseBlock = mapper.match(
   /CommerceError::Database\(_\) => \([\s\S]*?"PRODUCT_TEMPORARILY_UNAVAILABLE",\s*true,\s*\)/,
 );
 if (!databaseBlock) {
   failures.push('database mapping must be the retryable PRODUCT_TEMPORARILY_UNAVAILABLE envelope');
 }
 
-const retryableTrueOccurrences = graphqlRoot.match(/\btrue,\s*\)/g) ?? [];
+const retryableTrueOccurrences = mapper.match(/\btrue,\s*\)/g) ?? [];
 if (retryableTrueOccurrences.length !== 1) {
   failures.push(`expected exactly one retryable product envelope, found ${retryableTrueOccurrences.length}`);
 }
 
 const retryableExtensionOccurrences =
-  graphqlRoot.match(/extensions\.set\("retryable", retryable\)/g) ?? [];
+  mapper.match(/extensions\.set\("retryable", retryable\)/g) ?? [];
 if (retryableExtensionOccurrences.length !== 1) {
   failures.push(
     `expected one product retryability extension, found ${retryableExtensionOccurrences.length}`,
   );
 }
 
-for (const [content, value, label] of [
-  [catalogMutations, 'map_product_service_error(error, "product_catalog_mutation")', 'catalog mutation mapper use'],
-  [queries, 'map_product_service_error(err, "product_query")', 'product query mapper use'],
-  [queries, 'map_product_service_error(err, "products_query")', 'products query mapper use'],
-]) {
-  requireText(content, value, label);
+requireText(
+  catalogMutations,
+  'map_product_service_error(error, "product_catalog_mutation")',
+  'catalog mutation mapper use',
+);
+requireText(queries, 'map_product_service_error(err, "product_query")', 'product detail mapper use');
+requireText(
+  queries,
+  'map_product_service_error(error, "product_query")',
+  'product schema query mapper use',
+);
+
+const catalogMapperUses = catalogMutations.match(/map_product_service_error\(/g) ?? [];
+if (catalogMapperUses.length < 5) {
+  failures.push(`expected shared mapper across catalog mutations, found ${catalogMapperUses.length} uses`);
+}
+const queryMapperUses = queries.match(/map_product_service_error\(/g) ?? [];
+if (queryMapperUses.length < 5) {
+  failures.push(`expected shared mapper across product queries, found ${queryMapperUses.length} uses`);
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary

- extend the shared commerce product GraphQL error mapper from `(message, code)` to `(message, code, retryable)`;
- mark only `CommerceError::Database` as retryable and keep every validation, not-found, conflict, inventory, invariant, rich, and core failure non-retryable;
- preserve all existing stable public messages and codes used by catalog mutations and product queries;
- add `retryable` to GraphQL extensions and include public code, retryability, operation, and boundary in structured raw-error logging;
- add a dedicated static verifier for exhaustive current enum coverage, the single retryable branch, shared query/mutation usage, and removal of the legacy code-only envelope.

## Scope

Two files only: the shared GraphQL root mapper and its verifier. Product services, query and mutation resolvers, permissions, tenant checks, DTOs, GraphQL field signatures, and existing public codes/messages are unchanged.

## Validation

- source audit completed against current `main`;
- branch is directly based on current `main`;
- exhaustive mapping reviewed against every current `CommerceError` variant handled by the mapper;
- confirmed database is the only retryable public envelope;
- confirmed the shared mapper remains used across catalog mutations and product/schema queries;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.