### PR TITLE
Harden commerce GraphQL query dynamic errors

### DIFF
--- a/crates/rustok-commerce/src/graphql/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mod.rs
@@ -1,5 +1,6 @@
 mod marketplace_financial;
 mod mutations;
+#[path = "safe_query.rs"]
 mod query;
 mod types;
 

--- a/crates/rustok-commerce/src/graphql/safe_query.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query.rs
@@ -1,0 +1,390 @@
+mod query_error_boundary {
+    use ::async_graphql::{Error, ErrorExtensions};
+    use ::rustok_fulfillment::error::FulfillmentError;
+    use ::rustok_order::error::OrderError;
+    use ::rustok_payment::error::PaymentError;
+
+    #[derive(Clone, Debug)]
+    pub(crate) enum BoundaryError {
+        Graphql(Error),
+        Public {
+            message: &'static str,
+            code: &'static str,
+            retryable: bool,
+        },
+    }
+
+    pub(crate) trait QueryGraphqlMessage {
+        fn into_query_boundary(self) -> BoundaryError;
+    }
+
+    impl BoundaryError {
+        pub(crate) fn new<M>(message: M) -> Self
+        where
+            M: QueryGraphqlMessage,
+        {
+            message.into_query_boundary()
+        }
+
+        fn public(
+            message: &'static str,
+            code: &'static str,
+            retryable: bool,
+        ) -> Self {
+            Self::Public {
+                message,
+                code,
+                retryable,
+            }
+        }
+    }
+
+    impl QueryGraphqlMessage for String {
+        fn into_query_boundary(self) -> BoundaryError {
+            tracing::error!(
+                error_message = %self,
+                public_code = "COMMERCE_QUERY_OPERATION_FAILED",
+                retryable = false,
+                boundary = "commerce_graphql_query",
+                "commerce GraphQL query dynamic error was redacted"
+            );
+            BoundaryError::public(
+                "Commerce query could not be completed safely",
+                "COMMERCE_QUERY_OPERATION_FAILED",
+                false,
+            )
+        }
+    }
+
+    impl QueryGraphqlMessage for &str {
+        fn into_query_boundary(self) -> BoundaryError {
+            BoundaryError::Graphql(Error::new(self))
+        }
+    }
+
+    impl QueryGraphqlMessage for BoundaryError {
+        fn into_query_boundary(self) -> BoundaryError {
+            self
+        }
+    }
+
+    impl From<Error> for BoundaryError {
+        fn from(error: Error) -> Self {
+            Self::Graphql(error)
+        }
+    }
+
+    impl From<String> for BoundaryError {
+        fn from(message: String) -> Self {
+            message.into_query_boundary()
+        }
+    }
+
+    impl From<sea_orm::DbErr> for BoundaryError {
+        fn from(error: sea_orm::DbErr) -> Self {
+            tracing::error!(
+                error = ?error,
+                owner = "sea_orm",
+                error_kind = "database",
+                public_code = "COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE",
+                retryable = true,
+                boundary = "commerce_graphql_query",
+                "commerce GraphQL query database operation failed"
+            );
+            Self::public(
+                "Commerce data is temporarily unavailable",
+                "COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE",
+                true,
+            )
+        }
+    }
+
+    impl From<crate::CommerceError> for BoundaryError {
+        fn from(error: crate::CommerceError) -> Self {
+            Self::Graphql(super::super::map_product_service_error(
+                error,
+                "commerce_query",
+            ))
+        }
+    }
+
+    impl From<FulfillmentError> for BoundaryError {
+        fn from(error: FulfillmentError) -> Self {
+            let (message, code, retryable, error_kind) = match &error {
+                FulfillmentError::Validation(_) => (
+                    "Fulfillment query is invalid",
+                    "FULFILLMENT_REQUEST_INVALID",
+                    false,
+                    "validation",
+                ),
+                FulfillmentError::ShippingOptionNotFound(_)
+                | FulfillmentError::FulfillmentNotFound(_) => (
+                    "Fulfillment resource was not found",
+                    "FULFILLMENT_RESOURCE_NOT_FOUND",
+                    false,
+                    "not_found",
+                ),
+                FulfillmentError::InvalidTransition { .. } => (
+                    "Fulfillment state conflicts with this query",
+                    "FULFILLMENT_STATE_CONFLICT",
+                    false,
+                    "invalid_transition",
+                ),
+                FulfillmentError::Database(_) => (
+                    "Fulfillment data is temporarily unavailable",
+                    "FULFILLMENT_TEMPORARILY_UNAVAILABLE",
+                    true,
+                    "database",
+                ),
+            };
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_fulfillment",
+                error_kind,
+                public_code = code,
+                retryable,
+                boundary = "commerce_graphql_query",
+                "commerce GraphQL fulfillment query failed"
+            );
+            Self::public(message, code, retryable)
+        }
+    }
+
+    impl From<OrderError> for BoundaryError {
+        fn from(error: OrderError) -> Self {
+            let (message, code, retryable, error_kind) = match &error {
+                OrderError::Validation(_) => (
+                    "Order query is invalid",
+                    "ORDER_REQUEST_INVALID",
+                    false,
+                    "validation",
+                ),
+                OrderError::OrderNotFound(_)
+                | OrderError::OrderReturnNotFound(_)
+                | OrderError::OrderChangeNotFound(_) => (
+                    "Order resource was not found",
+                    "ORDER_RESOURCE_NOT_FOUND",
+                    false,
+                    "not_found",
+                ),
+                OrderError::InvalidTransition { .. } => (
+                    "Order state conflicts with this query",
+                    "ORDER_STATE_CONFLICT",
+                    false,
+                    "invalid_transition",
+                ),
+                OrderError::Database(_) => (
+                    "Order data is temporarily unavailable",
+                    "ORDER_TEMPORARILY_UNAVAILABLE",
+                    true,
+                    "database",
+                ),
+                OrderError::Core(_) => (
+                    "Order query could not be completed safely",
+                    "ORDER_OPERATION_FAILED",
+                    false,
+                    "core",
+                ),
+            };
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_order",
+                error_kind,
+                public_code = code,
+                retryable,
+                boundary = "commerce_graphql_query",
+                "commerce GraphQL order query failed"
+            );
+            Self::public(message, code, retryable)
+        }
+    }
+
+    impl From<PaymentError> for BoundaryError {
+        fn from(error: PaymentError) -> Self {
+            let (message, code, retryable, error_kind) = match &error {
+                PaymentError::Validation(_) => (
+                    "Payment query is invalid",
+                    "PAYMENT_REQUEST_INVALID",
+                    false,
+                    "validation",
+                ),
+                PaymentError::PaymentCollectionNotFound(_)
+                | PaymentError::PaymentNotFound(_)
+                | PaymentError::RefundNotFound(_) => (
+                    "Payment resource was not found",
+                    "PAYMENT_RESOURCE_NOT_FOUND",
+                    false,
+                    "not_found",
+                ),
+                PaymentError::InvalidTransition { .. }
+                | PaymentError::ProviderRejected { .. } => (
+                    "Payment state conflicts with this query",
+                    "PAYMENT_STATE_CONFLICT",
+                    false,
+                    "state_conflict",
+                ),
+                PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+                    "Payment data is temporarily unavailable",
+                    "PAYMENT_TEMPORARILY_UNAVAILABLE",
+                    true,
+                    "temporarily_unavailable",
+                ),
+                PaymentError::ProviderInvalidResponse { .. }
+                | PaymentError::ProviderOutcomeUnknown { .. } => (
+                    "Payment state requires reconciliation",
+                    "PAYMENT_RECONCILIATION_REQUIRED",
+                    false,
+                    "reconciliation_required",
+                ),
+                PaymentError::ProviderConfiguration { .. } => (
+                    "Payment provider configuration is invalid",
+                    "PAYMENT_CONFIGURATION_ERROR",
+                    false,
+                    "configuration",
+                ),
+            };
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_payment",
+                error_kind,
+                public_code = code,
+                retryable,
+                boundary = "commerce_graphql_query",
+                "commerce GraphQL payment query failed"
+            );
+            Self::public(message, code, retryable)
+        }
+    }
+
+    impl From<BoundaryError> for Error {
+        fn from(error: BoundaryError) -> Self {
+            match error {
+                BoundaryError::Graphql(error) => error,
+                BoundaryError::Public {
+                    message,
+                    code,
+                    retryable,
+                } => Error::new(message).extend_with(|_, extensions| {
+                    extensions.set("code", code);
+                    extensions.set("retryable", retryable);
+                }),
+            }
+        }
+    }
+}
+
+pub(crate) const MODULE_SLUG: &str = super::MODULE_SLUG;
+pub(crate) const PRODUCT_MODULE_SLUG: &str = super::PRODUCT_MODULE_SLUG;
+
+pub(crate) mod types {
+    pub(crate) use super::super::types::*;
+}
+
+pub(crate) fn map_product_service_error(
+    error: rustok_commerce_foundation::CommerceError,
+    operation: &'static str,
+) -> query_error_boundary::BoundaryError {
+    super::map_product_service_error(error, operation).into()
+}
+
+pub(crate) fn product_query_tenant(
+    ctx: &::async_graphql::Context<'_>,
+    requested_tenant_id: uuid::Uuid,
+) -> Result<uuid::Uuid, query_error_boundary::BoundaryError> {
+    super::product_query_tenant(ctx, requested_tenant_id).map_err(Into::into)
+}
+
+pub(crate) fn require_commerce_permission(
+    ctx: &::async_graphql::Context<'_>,
+    permissions: &[::rustok_api::Permission],
+    message: &str,
+) -> Result<::rustok_api::AuthContext, query_error_boundary::BoundaryError> {
+    super::require_commerce_permission(ctx, permissions, message).map_err(Into::into)
+}
+
+pub(crate) async fn require_storefront_channel_enabled(
+    ctx: &::async_graphql::Context<'_>,
+) -> Result<(), query_error_boundary::BoundaryError> {
+    super::require_storefront_channel_enabled(ctx)
+        .await
+        .map_err(Into::into)
+}
+
+mod source {
+    mod async_graphql_shim {
+        pub use ::async_graphql::{Context, Object};
+
+        pub type Error = super::super::query_error_boundary::BoundaryError;
+        pub type FieldError = super::super::query_error_boundary::BoundaryError;
+        pub type Result<T> =
+            std::result::Result<T, super::super::query_error_boundary::BoundaryError>;
+    }
+
+    use self::async_graphql_shim as async_graphql;
+
+    mod rustok_api_shim {
+        pub use ::rustok_api::{
+            AuthContext, Permission, PortActor, PortContext, PortErrorKind, RequestContext,
+            TenantContext, locale_tags_match,
+        };
+
+        pub mod graphql {
+            use super::super::super::query_error_boundary::BoundaryError;
+
+            pub trait GraphQLError {
+                fn unauthenticated() -> BoundaryError;
+                fn permission_denied(message: &str) -> BoundaryError;
+                fn internal_error(message: &str) -> BoundaryError;
+                fn bad_user_input(message: &str) -> BoundaryError;
+                fn not_found(message: &str) -> BoundaryError;
+            }
+
+            impl GraphQLError for BoundaryError {
+                fn unauthenticated() -> BoundaryError {
+                    BoundaryError::from(
+                        <::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::unauthenticated(),
+                    )
+                }
+
+                fn permission_denied(message: &str) -> BoundaryError {
+                    BoundaryError::from(
+                        <::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::permission_denied(message),
+                    )
+                }
+
+                fn internal_error(message: &str) -> BoundaryError {
+                    BoundaryError::from(
+                        <::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::internal_error(message),
+                    )
+                }
+
+                fn bad_user_input(message: &str) -> BoundaryError {
+                    BoundaryError::from(
+                        <::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::bad_user_input(message),
+                    )
+                }
+
+                fn not_found(message: &str) -> BoundaryError {
+                    BoundaryError::from(
+                        <::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::not_found(message),
+                    )
+                }
+            }
+
+            pub async fn require_module_enabled(
+                ctx: &::async_graphql::Context<'_>,
+                module_slug: &str,
+            ) -> Result<(), BoundaryError> {
+                ::rustok_api::graphql::require_module_enabled(ctx, module_slug)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    use self::rustok_api_shim as rustok_api;
+
+    include!("query.rs");
+}
+
+pub use source::CommerceQuery;

--- a/scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const routing = read('crates/rustok-commerce/src/graphql/mod.rs');
+const facade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const source = read('crates/rustok-commerce/src/graphql/query.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+requireText(
+  routing,
+  '#[path = "safe_query.rs"]\nmod query;',
+  'safe query module routing',
+);
+const queryModuleDeclarations = routing.match(/\bmod query;/g) ?? [];
+if (queryModuleDeclarations.length !== 1) {
+  failures.push(`expected one query module declaration, found ${queryModuleDeclarations.length}`);
+}
+
+for (const [value, label] of [
+  ['mod query_error_boundary {', 'query boundary module'],
+  ['#[derive(Clone, Debug)]', 'async GraphQL clone requirement'],
+  ['pub(crate) enum BoundaryError {', 'local boundary error'],
+  ['Graphql(Error)', 'existing GraphQL pass-through variant'],
+  ['Public {', 'static public envelope variant'],
+  ['pub(crate) trait QueryGraphqlMessage', 'dynamic constructor policy'],
+  ['impl QueryGraphqlMessage for String', 'owned string redaction'],
+  ['impl QueryGraphqlMessage for &str', 'static message preservation'],
+  ['impl From<Error> for BoundaryError', 'GraphQL error pass-through'],
+  ['impl From<String> for BoundaryError', 'string Into redaction'],
+  ['impl From<sea_orm::DbErr> for BoundaryError', 'database conversion'],
+  ['impl From<crate::CommerceError> for BoundaryError', 'commerce conversion'],
+  ['impl From<FulfillmentError> for BoundaryError', 'fulfillment conversion'],
+  ['impl From<OrderError> for BoundaryError', 'order conversion'],
+  ['impl From<PaymentError> for BoundaryError', 'payment conversion'],
+  ['impl From<BoundaryError> for Error', 'GraphQL restoration'],
+  ['extensions.set("code", code)', 'stable code extension'],
+  ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['"COMMERCE_QUERY_OPERATION_FAILED"', 'redacted dynamic code'],
+  ['"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE"', 'database temporary code'],
+  ['error_message = %self', 'raw dynamic string logging'],
+  ['boundary = "commerce_graphql_query"', 'query boundary logging'],
+  ['pub(crate) const MODULE_SLUG: &str = super::MODULE_SLUG;', 'module slug forwarding'],
+  ['pub(crate) const PRODUCT_MODULE_SLUG: &str = super::PRODUCT_MODULE_SLUG;', 'product slug forwarding'],
+  ['pub(crate) mod types {', 'type forwarding module'],
+  ['pub(crate) fn map_product_service_error(', 'product mapper forwarding'],
+  ['pub(crate) fn product_query_tenant(', 'tenant helper forwarding'],
+  ['pub(crate) fn require_commerce_permission(', 'permission helper forwarding'],
+  ['pub(crate) async fn require_storefront_channel_enabled(', 'channel helper forwarding'],
+  ['mod source {', 'isolated source module'],
+  ['mod async_graphql_shim {', 'async GraphQL shim'],
+  ['use self::async_graphql_shim as async_graphql;', 'async GraphQL shim alias'],
+  ['pub type Error = super::super::query_error_boundary::BoundaryError;', 'custom Error alias'],
+  ['pub type FieldError = super::super::query_error_boundary::BoundaryError;', 'custom FieldError alias'],
+  ['pub type Result<T> =', 'custom Result alias'],
+  ['mod rustok_api_shim {', 'rustok API shim'],
+  ['use self::rustok_api_shim as rustok_api;', 'rustok API shim alias'],
+  ['AuthContext, Permission, PortActor, PortContext, PortErrorKind, RequestContext,', 'rustok API type forwarding'],
+  ['TenantContext, locale_tags_match,', 'rustok API context forwarding'],
+  ['pub trait GraphQLError {', 'safe GraphQL helper trait'],
+  ['pub async fn require_module_enabled(', 'module guard forwarding'],
+  ['include!("query.rs");', 'unchanged query source inclusion'],
+  ['pub use source::CommerceQuery;', 'query type export'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const value of [
+  'BoundaryError::Graphql(error) => error',
+  'BoundaryError::Graphql(Error::new(self))',
+  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::unauthenticated()',
+  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::permission_denied(message)',
+  '::rustok_api::graphql::require_module_enabled(ctx, module_slug)',
+]) {
+  requireText(facade, value, 'existing GraphQL contract preservation');
+}
+
+for (const value of [
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'Error::new(format!("{error}"))',
+]) {
+  forbidText(facade, value, 'facade dynamic public constructor');
+}
+
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'fulfillment state mapping'],
+  ['FulfillmentError::Database(_)', 'fulfillment database mapping'],
+  ['"FULFILLMENT_REQUEST_INVALID"', 'fulfillment validation code'],
+  ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'fulfillment not-found code'],
+  ['"FULFILLMENT_STATE_CONFLICT"', 'fulfillment state code'],
+  ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'fulfillment temporary code'],
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  ['OrderError::OrderReturnNotFound(_)', 'order-return not-found mapping'],
+  ['OrderError::OrderChangeNotFound(_)', 'order-change not-found mapping'],
+  ['OrderError::InvalidTransition { .. }', 'order state mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order core mapping'],
+  ['"ORDER_REQUEST_INVALID"', 'order validation code'],
+  ['"ORDER_RESOURCE_NOT_FOUND"', 'order not-found code'],
+  ['"ORDER_STATE_CONFLICT"', 'order state code'],
+  ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order temporary code'],
+  ['"ORDER_OPERATION_FAILED"', 'order safe fallback code'],
+  ['PaymentError::Validation(_)', 'payment validation mapping'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found mapping'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found mapping'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found mapping'],
+  ['PaymentError::InvalidTransition { .. }', 'payment state mapping'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider outage mapping'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejection mapping'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'invalid provider response mapping'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'unknown provider outcome mapping'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration mapping'],
+  ['PaymentError::Database(_)', 'payment database mapping'],
+  ['"PAYMENT_REQUEST_INVALID"', 'payment validation code'],
+  ['"PAYMENT_RESOURCE_NOT_FOUND"', 'payment not-found code'],
+  ['"PAYMENT_STATE_CONFLICT"', 'payment state code'],
+  ['"PAYMENT_TEMPORARILY_UNAVAILABLE"', 'payment temporary code'],
+  ['"PAYMENT_RECONCILIATION_REQUIRED"', 'payment reconciliation code'],
+  ['"PAYMENT_CONFIGURATION_ERROR"', 'payment configuration code'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
+  [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
+  [paymentErrors, 'RefundNotFound(Uuid)', 'owner refund variant'],
+  [paymentErrors, 'ProviderUnavailable {', 'owner provider outage variant'],
+  [paymentErrors, 'ProviderRejected {', 'owner provider rejection variant'],
+  [paymentErrors, 'ProviderInvalidResponse {', 'owner invalid response variant'],
+  [paymentErrors, 'ProviderOutcomeUnknown {', 'owner unknown outcome variant'],
+  [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner configuration variant'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
+]) {
+  requireText(ownerSource, value, label);
+}
+
+for (const [value, label] of [
+  ['async fn storefront_returns(', 'storefront returns resolver'],
+  ['async fn storefront_refunds(', 'storefront refunds resolver'],
+  ['async fn storefront_order_changes(', 'storefront order changes resolver'],
+  ['async fn storefront_payment_collection(', 'storefront payment collection resolver'],
+  ['async fn order(', 'admin order resolver'],
+  ['async fn orders(', 'admin orders resolver'],
+  ['async fn payment_collection(', 'admin payment collection resolver'],
+  ['async fn refunds(', 'admin refunds resolver'],
+  ['async fn shipping_option(', 'admin shipping option resolver'],
+  ['async fn fulfillments(', 'admin fulfillments resolver'],
+  ['async fn load_storefront_customer_order(', 'storefront ownership helper'],
+]) {
+  requireText(source, value, label);
+}
+
+const dynamicStringPatterns = [
+  /async_graphql::Error::new\(err\.to_string\(\)\)/g,
+  /async_graphql::Error::new\(error\.message\)/g,
+  /err\.to_string\(\)\.into\(\)/g,
+  /error\.message\.into\(\)/g,
+  /async_graphql::Error::new\(format!\(/g,
+];
+const dynamicStringSites = dynamicStringPatterns.reduce(
+  (total, pattern) => total + (source.match(pattern) ?? []).length,
+  0,
+);
+if (dynamicStringSites < 10) {
+  failures.push(`expected legacy dynamic query errors to remain isolated behind facade, found ${dynamicStringSites}`);
+}
+
+const sourceIncludes = facade.match(/include!\("query\.rs"\)/g) ?? [];
+if (sourceIncludes.length !== 1) {
+  failures.push(`expected one unchanged query include, found ${sourceIncludes.length}`);
+}
+
+const temporaryTrueMappings = [
+  '"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE",\n                true,',
+  '"FULFILLMENT_TEMPORARILY_UNAVAILABLE",\n                    true,',
+  '"ORDER_TEMPORARILY_UNAVAILABLE",\n                    true,',
+  '"PAYMENT_TEMPORARILY_UNAVAILABLE",\n                    true,',
+];
+for (const value of temporaryTrueMappings) {
+  requireText(facade, value, 'retryable temporary envelope');
+}
+requireText(
+  facade,
+  '"PAYMENT_RECONCILIATION_REQUIRED",\n                    false,',
+  'non-retryable reconciliation envelope',
+);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL query error-boundary verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL query errors are isolated behind stable envelopes while the resolver source remains unchanged',
+);


### PR DESCRIPTION
## Summary

- route the commerce GraphQL query root through a thin safe include-facade while retaining the existing `query.rs` resolver implementation unchanged;
- preserve already-constructed GraphQL errors, authentication/permission codes, module-enabled checks, static validation messages, query fields, access checks, pagination, DTO conversion, and service calls;
- redact legacy type-erased `String` error paths to a stable non-retryable `COMMERCE_QUERY_OPERATION_FAILED` envelope instead of publishing owner messages, identifiers, provider details, database causes, or internal state;
- add typed query-boundary conversions for direct `DbErr`, `CommerceError`, `FulfillmentError`, `OrderError`, and `PaymentError` propagation, including retryable temporary-unavailable envelopes and non-retryable payment reconciliation cases;
- keep the raw dynamic string or typed owner error only in structured internal logging;
- add a static verifier for routing, include-source preservation, explicit async-graphql/rustok-api shims, pass-through behavior, current owner enum coverage, retryability policy, and the existing storefront/admin query surface.

## Scope

Three files only: query module routing, the new safe query facade, and its verifier. The 2,596-line `query.rs` source blob is unchanged. No resolver signatures, tenant/permission/channel checks, storefront ownership checks, filters, pagination, service arguments, response shapes, or query semantics were edited.

## Public policy

- legacy dynamic strings: `COMMERCE_QUERY_OPERATION_FAILED`, `retryable: false`;
- direct database failures: `COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE`, `retryable: true`;
- direct fulfillment/order/payment errors: stable owner-specific validation, not-found, state-conflict, temporary-unavailable, configuration, reconciliation, and safe-fallback codes;
- payment invalid/unknown provider outcomes remain `PAYMENT_RECONCILIATION_REQUIRED` with `retryable: false`;
- existing static GraphQL and permission errors pass through unchanged.

## Validation

- branch is one commit directly above current `main`;
- unified source audit completed across the full query file and current owner error enums;
- explicit shim aliases follow the existing `safe_checkout.rs` pattern;
- original query blob SHA remains `2b8e2063e967642a25cedfff69a779da986f7808`;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.