### PR TITLE
Harden storefront order HTTP errors

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -3,12 +3,12 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::{RequestContext, TenantContext};
+use rustok_api::{PortError, RequestContext, TenantContext};
 use rustok_customer::dto::CustomerResponse;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
-use rustok_order::OrderService;
-use rustok_payment::PaymentService;
-use rustok_web::{HttpError, HttpResult};
+use rustok_order::{OrderService, error::OrderError};
+use rustok_payment::{PaymentService, error::PaymentError};
+use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use uuid::Uuid;
 
 use super::{
@@ -22,6 +22,202 @@ use crate::dto::{
     CreateOrderReturnInput, ListOrderChangesInput, ListOrderReturnsInput, ListRefundsInput,
     OrderChangeResponse, OrderResponse, OrderReturnResponse, RefundResponse,
 };
+
+fn map_storefront_customer_port_error(
+    error: PortError,
+    operation: &'static str,
+    tenant_id: Uuid,
+) -> HttpError {
+    tracing::error!(
+        error = ?error,
+        operation,
+        tenant_id = %tenant_id,
+        boundary = "commerce_storefront_order_http",
+        "storefront customer read failed"
+    );
+    port_error_to_http_error(error)
+}
+
+fn map_storefront_order_error(
+    error: OrderError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    order_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        OrderError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_store_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_store_order_not_found",
+            "Order resource was not found",
+            "not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_store_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        OrderError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_order_unavailable",
+            "Order service is temporarily unavailable",
+            "database",
+        ),
+        OrderError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_order_failed",
+            "Order operation could not be completed safely",
+            "core",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        operation,
+        tenant_id = %tenant_id,
+        order_id = %order_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_order_http",
+        "storefront order operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_storefront_payment_error(
+    error: PaymentError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    order_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        PaymentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_store_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_store_payment_not_found",
+            "Payment resource was not found",
+            "not_found",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_store_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::BAD_GATEWAY,
+            "commerce_store_payment_provider_invalid_response",
+            "Payment provider returned an invalid response",
+            "provider_invalid_response",
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_store_payment_reconciliation_required",
+            "Payment state requires reconciliation",
+            "reconciliation_required",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        PaymentError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_payment_unavailable",
+            "Payment service is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        operation,
+        tenant_id = %tenant_id,
+        order_id = %order_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_order_http",
+        "storefront payment read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+async fn current_storefront_customer_id(
+    runtime: &CommerceHttpRuntime,
+    tenant_id: Uuid,
+    auth: &rustok_api::AuthContext,
+    operation: &'static str,
+) -> HttpResult<Option<Uuid>> {
+    match in_process_customer_read_port(runtime.db_clone())
+        .read_customer_projection_by_user(
+            super::storefront_customer_port_context(tenant_id, auth.user_id),
+            CustomerUserProjectionRequest {
+                user_id: auth.user_id,
+            },
+        )
+        .await
+    {
+        Ok(customer) => Ok(Some(customer.id)),
+        Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None),
+        Err(error) => Err(map_storefront_customer_port_error(
+            error, operation, tenant_id,
+        )),
+    }
+}
+
+async fn ensure_customer_owns_order(
+    runtime: &CommerceHttpRuntime,
+    tenant_id: Uuid,
+    auth: &rustok_api::AuthContext,
+    order_id: Uuid,
+    operation: &'static str,
+) -> HttpResult<()> {
+    let customer_id = current_storefront_customer_id(runtime, tenant_id, auth, operation)
+        .await?
+        .ok_or_else(|| {
+            HttpError::unauthorized(
+                "commerce_store_customer_required",
+                "Customer account required",
+            )
+        })?;
+    let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
+        .get_order(tenant_id, order_id)
+        .await
+        .map_err(|error| {
+            map_storefront_order_error(error, operation, tenant_id, order_id)
+        })?;
+
+    if order.customer_id != Some(customer_id) {
+        return Err(HttpError::unauthorized(
+            "commerce_store_order_access_denied",
+            "Order does not belong to the current customer",
+        ));
+    }
+
+    Ok(())
+}
 
 /// Get current storefront customer
 #[utoipa::path(
@@ -49,7 +245,9 @@ pub async fn get_me(
             },
         )
         .await
-        .map_err(|error| HttpError::bad_request("commerce_operation_failed", error.message))?;
+        .map_err(|error| {
+            map_storefront_customer_port_error(error, "get_me", tenant.id)
+        })?;
     Ok(Json(customer))
 }
 
@@ -74,12 +272,12 @@ pub async fn get_order(
 ) -> HttpResult<Json<OrderResponse>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    let customer_id = super::current_customer_id_for_db(runtime.db(), tenant.id, Some(&auth))
+    let customer_id = current_storefront_customer_id(&runtime, tenant.id, &auth, "get_order")
         .await?
         .ok_or_else(|| {
             HttpError::unauthorized(
-                "commerce_permission_denied",
-                "Customer account required".to_string(),
+                "commerce_store_customer_required",
+                "Customer account required",
             )
         })?;
     let service = OrderService::new(runtime.db_clone(), runtime.event_bus());
@@ -91,12 +289,12 @@ pub async fn get_order(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(|error| map_storefront_order_error(error, "get_order", tenant.id, id))?;
 
     if order.customer_id != Some(customer_id) {
         return Err(HttpError::unauthorized(
-            "commerce_permission_denied",
-            "Order does not belong to the current customer".to_string(),
+            "commerce_store_order_access_denied",
+            "Order does not belong to the current customer",
         ));
     }
 
@@ -126,19 +324,21 @@ pub async fn create_order_return(
 ) -> HttpResult<(StatusCode, Json<OrderReturnResponse>)> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    super::ensure_customer_owns_order_for_db(
-        runtime.db(),
-        runtime.event_bus(),
+    ensure_customer_owns_order(
+        &runtime,
         tenant.id,
-        Some(&auth),
+        &auth,
         id,
+        "create_order_return_access",
     )
     .await?;
 
     let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .create_return(tenant.id, id, input)
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_storefront_order_error(error, "create_order_return", tenant.id, id)
+        })?;
 
     Ok((StatusCode::CREATED, Json(created)))
 }
@@ -169,12 +369,12 @@ pub async fn list_order_returns(
 ) -> HttpResult<Json<PaginatedResponse<OrderReturnResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    super::ensure_customer_owns_order_for_db(
-        runtime.db(),
-        runtime.event_bus(),
+    ensure_customer_owns_order(
+        &runtime,
         tenant.id,
-        Some(&auth),
+        &auth,
         id,
+        "list_order_returns_access",
     )
     .await?;
 
@@ -189,7 +389,9 @@ pub async fn list_order_returns(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_storefront_order_error(error, "list_order_returns", tenant.id, id)
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: items,
@@ -223,25 +425,14 @@ pub async fn list_order_refunds(
 ) -> HttpResult<Json<PaginatedResponse<RefundResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    let customer_id = super::current_customer_id_for_db(runtime.db(), tenant.id, Some(&auth))
-        .await?
-        .ok_or_else(|| {
-            HttpError::unauthorized(
-                "commerce_permission_denied",
-                "Customer account required".to_string(),
-            )
-        })?;
-    let order_service = OrderService::new(runtime.db_clone(), runtime.event_bus());
-    let order = order_service
-        .get_order(tenant.id, id)
-        .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
-    if order.customer_id != Some(customer_id) {
-        return Err(HttpError::unauthorized(
-            "commerce_permission_denied",
-            "Order does not belong to the current customer".to_string(),
-        ));
-    }
+    ensure_customer_owns_order(
+        &runtime,
+        tenant.id,
+        &auth,
+        id,
+        "list_order_refunds_access",
+    )
+    .await?;
 
     let payment_service = PaymentService::new(runtime.db_clone());
     let (items, total) = payment_service
@@ -256,7 +447,9 @@ pub async fn list_order_refunds(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_storefront_payment_error(error, "list_order_refunds", tenant.id, id)
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: items,
@@ -291,12 +484,12 @@ pub async fn list_order_changes(
 ) -> HttpResult<Json<PaginatedResponse<OrderChangeResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    super::ensure_customer_owns_order_for_db(
-        runtime.db(),
-        runtime.event_bus(),
+    ensure_customer_owns_order(
+        &runtime,
         tenant.id,
-        Some(&auth),
+        &auth,
         id,
+        "list_order_changes_access",
     )
     .await?;
 
@@ -312,7 +505,9 @@ pub async fn list_order_changes(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_storefront_order_error(error, "list_order_changes", tenant.id, id)
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: items,

--- a/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const webErrors = read('crates/rustok-web/src/lib.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['use rustok_api::{PortError, RequestContext, TenantContext};', 'typed customer port error import'],
+  ['use rustok_order::{OrderService, error::OrderError};', 'typed order error import'],
+  ['use rustok_payment::{PaymentService, error::PaymentError};', 'typed payment error import'],
+  ['port_error_to_http_error', 'safe port HTTP mapper'],
+  ['fn map_storefront_customer_port_error(', 'customer port mapper'],
+  ['fn map_storefront_order_error(', 'order mapper'],
+  ['fn map_storefront_payment_error(', 'payment mapper'],
+  ['async fn current_storefront_customer_id(', 'safe customer lookup'],
+  ['async fn ensure_customer_owns_order(', 'safe ownership helper'],
+  ['boundary = "commerce_storefront_order_http"', 'structured boundary name'],
+  ['operation,', 'operation logging'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['order_id = %order_id', 'order logging'],
+  ['public_code = code', 'public code logging'],
+  ['status = %status', 'HTTP status logging'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found mapping'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found mapping'],
+  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order core mapping'],
+  ['StatusCode::BAD_REQUEST', 'bad request status'],
+  ['StatusCode::NOT_FOUND', 'not found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'internal status'],
+  ['"commerce_store_order_invalid"', 'order invalid code'],
+  ['"commerce_store_order_not_found"', 'order not-found code'],
+  ['"commerce_store_order_state_conflict"', 'order state code'],
+  ['"commerce_store_order_unavailable"', 'order unavailable code'],
+  ['"commerce_store_order_failed"', 'order fail-closed code'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [value, label] of [
+  ['PaymentError::Validation(_)', 'payment validation mapping'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found mapping'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found mapping'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found mapping'],
+  ['PaymentError::InvalidTransition { .. }', 'payment transition mapping'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable mapping'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected mapping'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'provider invalid response mapping'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'provider unknown outcome mapping'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration mapping'],
+  ['PaymentError::Database(_)', 'payment database mapping'],
+  ['StatusCode::BAD_GATEWAY', 'bad gateway status'],
+  ['"commerce_store_payment_invalid"', 'payment invalid code'],
+  ['"commerce_store_payment_not_found"', 'payment not-found code'],
+  ['"commerce_store_payment_state_conflict"', 'payment state code'],
+  ['"commerce_store_payment_provider_unavailable"', 'payment provider unavailable code'],
+  ['"commerce_store_payment_provider_invalid_response"', 'payment invalid response code'],
+  ['"commerce_store_payment_reconciliation_required"', 'payment reconciliation code'],
+  ['"commerce_store_payment_provider_not_configured"', 'payment configuration code'],
+  ['"commerce_store_payment_unavailable"', 'payment unavailable code'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [paymentErrors, 'Validation(String)', 'owner payment validation variant'],
+  [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
+  [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
+  [paymentErrors, 'RefundNotFound(Uuid)', 'owner refund variant'],
+  [paymentErrors, 'ProviderUnavailable {', 'owner provider unavailable variant'],
+  [paymentErrors, 'ProviderRejected {', 'owner provider rejected variant'],
+  [paymentErrors, 'ProviderInvalidResponse {', 'owner invalid response variant'],
+  [paymentErrors, 'ProviderOutcomeUnknown {', 'owner unknown outcome variant'],
+  [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner provider configuration variant'],
+  [paymentErrors, 'Database(#[from] DbErr)', 'owner payment database variant'],
+]) {
+  requireText(ownerSource, value, label);
+}
+
+for (const [value, label] of [
+  ['pub async fn get_me(', 'customer resolver'],
+  ['pub async fn get_order(', 'order resolver'],
+  ['pub async fn create_order_return(', 'create return resolver'],
+  ['pub async fn list_order_returns(', 'list returns resolver'],
+  ['pub async fn list_order_refunds(', 'list refunds resolver'],
+  ['pub async fn list_order_changes(', 'list changes resolver'],
+  ['get_order_with_locale_fallback(', 'localized order read'],
+  ['create_return(tenant.id, id, input)', 'return creation call'],
+  ['ListOrderReturnsInput {', 'return pagination input'],
+  ['ListRefundsInput {', 'refund pagination input'],
+  ['ListOrderChangesInput {', 'change pagination input'],
+  ['page: params.pagination.page', 'page forwarding'],
+  ['per_page: params.pagination.per_page', 'per-page forwarding'],
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)', 'pagination metadata'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const operation of [
+  '"get_me"',
+  '"get_order"',
+  '"create_order_return_access"',
+  '"create_order_return"',
+  '"list_order_returns_access"',
+  '"list_order_returns"',
+  '"list_order_refunds_access"',
+  '"list_order_refunds"',
+  '"list_order_changes_access"',
+  '"list_order_changes"',
+]) {
+  requireText(controller, operation, 'diagnostic operation label');
+}
+
+for (const value of [
+  'err.to_string()',
+  'error.to_string()',
+  'error.message',
+  'HttpError::bad_request("commerce_operation_failed"',
+  'super::current_customer_id_for_db',
+  'super::ensure_customer_owns_order_for_db',
+]) {
+  forbidText(controller, value, 'unsafe storefront order public conversion');
+}
+
+const orderMapperUses = controller.match(/map_storefront_order_error\(/g) ?? [];
+if (orderMapperUses.length !== 6) {
+  failures.push(`expected order mapper definition plus five uses, found ${orderMapperUses.length}`);
+}
+const paymentMapperUses = controller.match(/map_storefront_payment_error\(/g) ?? [];
+if (paymentMapperUses.length !== 2) {
+  failures.push(`expected payment mapper definition plus one use, found ${paymentMapperUses.length}`);
+}
+const customerMapperUses = controller.match(/map_storefront_customer_port_error\(/g) ?? [];
+if (customerMapperUses.length !== 3) {
+  failures.push(`expected customer mapper definition plus two uses, found ${customerMapperUses.length}`);
+}
+
+for (const value of [
+  'PortErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE',
+  'PortErrorKind::Timeout => StatusCode::GATEWAY_TIMEOUT',
+  'PortErrorKind::InvariantViolation => StatusCode::INTERNAL_SERVER_ERROR',
+  '"The requested service is temporarily unavailable"',
+  '"The requested operation could not be completed"',
+]) {
+  requireText(webErrors, value, 'shared port HTTP safety contract');
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront order HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce storefront order and refund HTTP errors use stable typed public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace storefront order/refund controller `err.to_string()` and raw `error.message` responses with stable typed HTTP envelopes;
- map `OrderError` exhaustively to validation, not-found, state-conflict, temporary-unavailable, and fail-closed responses;
- map `PaymentError` exhaustively to validation, not-found, conflict, provider outage, invalid response, reconciliation-required, configuration, and storage-unavailable responses;
- route customer read `PortError` through the shared `port_error_to_http_error` contract so unavailable, timeout, and invariant details remain redacted;
- keep raw owner errors only in structured internal logs with `operation`, `tenant_id`, `order_id`, public code, and status;
- replace the shared ownership/customer helpers only inside this controller so their existing raw conversions are not reachable from these routes;
- add a static verifier for owner enum coverage, stable codes/statuses, route and pagination preservation, operation labels, and forbidden public string conversions.

## Scope

Two files only: `controllers/store/orders.rs` and its verifier. The existing routes, request/response DTOs, customer ownership checks, service calls, locale fallback, filters, pagination inputs, pagination metadata, and success responses are unchanged.

## Public policy

- order validation: `400 commerce_store_order_invalid`;
- order not found: `404 commerce_store_order_not_found`;
- order state conflict: `409 commerce_store_order_state_conflict`;
- order database outage: `503 commerce_store_order_unavailable`;
- order core failure: `500 commerce_store_order_failed`;
- payment provider invalid response: `502 commerce_store_payment_provider_invalid_response`;
- payment unknown outcome: `409 commerce_store_payment_reconciliation_required`;
- payment/provider/storage outages: stable `503` envelopes;
- customer port infrastructure failures use the shared safe HTTP mapper.

## Validation

- current storefront controller blob on `main` was unchanged during rebases;
- source-level audit completed against current `OrderError`, `PaymentError`, and `rustok-web` HTTP contracts;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.