### PR TITLE
perf(seo): checkpoint bulk apply worker chunks

### DIFF
--- a/crates/rustok-seo/src/services/bulk.rs
+++ b/crates/rustok-seo/src/services/bulk.rs
@@ -1,5 +1,5 @@
 include!("bulk_legacy.rs");
-include!("bulk_batch_execution.rs");
+include!("bulk_bounded_execution.rs");
 
 #[cfg(test)]
 mod bulk_read_model {

--- a/crates/rustok-seo/src/services/bulk_bounded_execution.rs
+++ b/crates/rustok-seo/src/services/bulk_bounded_execution.rs
@@ -1,3 +1,19 @@
+const BULK_APPLY_CHUNK_SIZE: usize = 50;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct QueuedBulkApplyPayload {
+    input: SeoBulkApplyInput,
+    target_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BulkJobProgress {
+    processed: i32,
+    succeeded: i32,
+    failed: i32,
+    artifacts: i32,
+}
+
 #[derive(Debug, Clone)]
 struct BatchedBulkSelectionResolution {
     filter: NormalizedBulkListFilter,
@@ -28,6 +44,15 @@ impl SeoService {
         let resolution = self
             .resolve_bulk_selection_batched(tenant, input.selection.clone())
             .await?;
+        let target_ids = resolution
+            .rows
+            .iter()
+            .map(|row| row.target_id)
+            .collect::<Vec<_>>();
+        let queued_payload = QueuedBulkApplyPayload {
+            input: input.clone(),
+            target_ids: target_ids.clone(),
+        };
         let now = Utc::now().fixed_offset();
         let model = seo_bulk_job::ActiveModel {
             id: Set(Uuid::new_v4()),
@@ -39,11 +64,11 @@ impl SeoService {
             filter_payload: Set(serde_json::to_value(&resolution.filter).map_err(|err| {
                 SeoError::validation(format!("failed to serialize bulk filter: {err}"))
             })?),
-            input_payload: Set(serde_json::to_value(&input).map_err(|err| {
-                SeoError::validation(format!("failed to serialize bulk apply input: {err}"))
+            input_payload: Set(serde_json::to_value(&queued_payload).map_err(|err| {
+                SeoError::validation(format!("failed to serialize bounded bulk apply payload: {err}"))
             })?),
             publish_after_write: Set(input.publish_after_write),
-            matched_count: Set(resolution.rows.len() as i32),
+            matched_count: Set(target_ids.len() as i32),
             processed_count: Set(0),
             succeeded_count: Set(0),
             failed_count: Set(0),
@@ -110,26 +135,39 @@ impl SeoService {
     pub(super) async fn execute_next_bulk_job_batched(
         &self,
     ) -> SeoResult<Option<SeoBulkJobRecord>> {
-        let Some(job) = seo_bulk_job::Entity::find()
-            .filter(seo_bulk_job::Column::Status.eq(SeoBulkJobStatus::Queued.as_str()))
-            .order_by_asc(seo_bulk_job::Column::CreatedAt)
+        let running_apply = seo_bulk_job::Entity::find()
+            .filter(seo_bulk_job::Column::Status.eq(SeoBulkJobStatus::Running.as_str()))
+            .filter(
+                seo_bulk_job::Column::OperationKind.eq(SeoBulkJobOperationKind::Apply.as_str()),
+            )
+            .order_by_asc(seo_bulk_job::Column::UpdatedAt)
             .one(&self.db)
-            .await?
-        else {
-            return Ok(None);
-        };
+            .await?;
 
-        let now = Utc::now().fixed_offset();
-        let mut active: seo_bulk_job::ActiveModel = job.clone().into();
-        active.status = Set(SeoBulkJobStatus::Running.as_str().to_string());
-        active.started_at = Set(Some(now));
-        active.updated_at = Set(now);
-        active.last_error = Set(None);
-        let running = active.update(&self.db).await?;
+        let running = if let Some(job) = running_apply {
+            job
+        } else {
+            let Some(job) = seo_bulk_job::Entity::find()
+                .filter(seo_bulk_job::Column::Status.eq(SeoBulkJobStatus::Queued.as_str()))
+                .order_by_asc(seo_bulk_job::Column::CreatedAt)
+                .one(&self.db)
+                .await?
+            else {
+                return Ok(None);
+            };
+
+            let now = Utc::now().fixed_offset();
+            let mut active: seo_bulk_job::ActiveModel = job.into();
+            active.status = Set(SeoBulkJobStatus::Running.as_str().to_string());
+            active.started_at = Set(Some(now));
+            active.updated_at = Set(now);
+            active.last_error = Set(None);
+            active.update(&self.db).await?
+        };
 
         let result = match SeoBulkJobOperationKind::parse(running.operation_kind.as_str()) {
             Some(SeoBulkJobOperationKind::Apply) => {
-                self.execute_apply_job_batched(&running).await
+                self.execute_apply_job_chunk(&running).await
             }
             Some(SeoBulkJobOperationKind::ExportCsv) => {
                 self.execute_export_job_batched(&running).await
@@ -183,60 +221,71 @@ impl SeoService {
         .await
     }
 
-    async fn execute_apply_job_batched(&self, job: &seo_bulk_job::Model) -> SeoResult<()> {
+    async fn execute_apply_job_chunk(&self, job: &seo_bulk_job::Model) -> SeoResult<()> {
         let tenant = self.load_tenant_context(job.tenant_id).await?;
-        let input = serde_json::from_value::<SeoBulkApplyInput>(job.input_payload.clone())
-            .map_err(|err| {
-                SeoError::validation(format!("failed to decode bulk apply payload: {err}"))
-            })?;
-        let resolution = self
-            .resolve_bulk_selection_batched(&tenant, input.selection)
+        let payload = self.decode_bounded_apply_payload(&tenant, job).await?;
+        let processed_items = seo_bulk_job_item::Entity::find()
+            .filter(seo_bulk_job_item::Column::JobId.eq(job.id))
+            .order_by_asc(seo_bulk_job_item::Column::CreatedAt)
+            .all(&self.db)
             .await?;
-        let mut succeeded = 0_i32;
-        let mut failed = 0_i32;
+        let processed_ids = processed_items
+            .iter()
+            .map(|item| item.target_id)
+            .collect::<HashSet<_>>();
+        let chunk = payload
+            .target_ids
+            .iter()
+            .copied()
+            .filter(|target_id| !processed_ids.contains(target_id))
+            .take(BULK_APPLY_CHUNK_SIZE)
+            .collect::<Vec<_>>();
+
+        if chunk.is_empty() {
+            let progress = self.load_bulk_job_progress(job.id).await?;
+            return self
+                .finish_bulk_job(
+                    job,
+                    progress.processed,
+                    progress.succeeded,
+                    progress.failed,
+                    progress.artifacts,
+                    None,
+                )
+                .await;
+        }
+
+        let chunk_start = processed_ids.len() + 1;
+        let chunk_end = chunk_start + chunk.len() - 1;
         let mut preview_rows = Vec::<Vec<String>>::new();
         let mut failure_rows = Vec::new();
 
-        for row in resolution.rows {
-            let target_id = row.target_id;
-            if input.apply_mode == SeoBulkApplyMode::PreviewOnly {
-                preview_rows.push(export_bulk_projection_row(
-                    resolution.filter.target_kind.clone(),
-                    target_id,
-                    resolution.filter.locale.as_str(),
-                    &row.projection,
-                ));
-                succeeded += 1;
-                self.insert_bulk_job_item(job, target_id, None, None)
-                    .await?;
-                continue;
-            }
+        if payload.input.apply_mode == SeoBulkApplyMode::PreviewOnly {
+            let resolution = self
+                .resolve_bulk_selection_batched(&tenant, payload.input.selection.clone())
+                .await?;
+            let projections = resolution
+                .rows
+                .into_iter()
+                .map(|row| (row.target_id, row.projection))
+                .collect::<HashMap<_, _>>();
 
-            match self
-                .apply_bulk_patch_to_target(
-                    &tenant,
-                    job.id,
-                    resolution.filter.target_kind.clone(),
-                    resolution.filter.locale.as_str(),
-                    target_id,
-                    &input.patch,
-                    input.apply_mode,
-                    job.publish_after_write,
-                )
-                .await
-            {
-                Ok(revision) => {
-                    succeeded += 1;
-                    self.insert_bulk_job_item(job, target_id, None, revision)
+            for target_id in chunk {
+                if let Some(projection) = projections.get(&target_id) {
+                    preview_rows.push(export_bulk_projection_row(
+                        resolution.filter.target_kind.clone(),
+                        target_id,
+                        resolution.filter.locale.as_str(),
+                        projection,
+                    ));
+                    self.insert_bulk_job_item(job, target_id, None, None)
                         .await?;
-                }
-                Err(error) => {
-                    failed += 1;
-                    let message = error.to_string();
+                } else {
+                    let message = "SEO target not found".to_string();
                     self.insert_bulk_job_item(job, target_id, Some(message.clone()), None)
                         .await?;
                     failure_rows.push((
-                        empty_csv_row(
+                        preview_failure_row(
                             resolution.filter.target_kind.as_str(),
                             target_id,
                             resolution.filter.locale.as_str(),
@@ -245,36 +294,166 @@ impl SeoService {
                     ));
                 }
             }
+        } else {
+            let filter = normalize_bulk_list_input(
+                payload
+                    .input
+                    .selection
+                    .filter
+                    .clone()
+                    .ok_or_else(|| SeoError::validation("bulk selection filter is required"))?,
+                tenant.default_locale.as_str(),
+            )?;
+            for target_id in chunk {
+                match self
+                    .apply_bulk_patch_to_target(
+                        &tenant,
+                        job.id,
+                        filter.target_kind.clone(),
+                        filter.locale.as_str(),
+                        target_id,
+                        &payload.input.patch,
+                        payload.input.apply_mode,
+                        job.publish_after_write,
+                    )
+                    .await
+                {
+                    Ok(revision) => {
+                        self.insert_bulk_job_item(job, target_id, None, revision)
+                            .await?;
+                    }
+                    Err(error) => {
+                        let message = error.to_string();
+                        self.insert_bulk_job_item(job, target_id, Some(message.clone()), None)
+                            .await?;
+                        failure_rows.push((
+                            empty_csv_row(
+                                filter.target_kind.as_str(),
+                                target_id,
+                                filter.locale.as_str(),
+                            ),
+                            message,
+                        ));
+                    }
+                }
+            }
         }
 
-        let mut artifacts = 0_i32;
         if !preview_rows.is_empty() {
             let content = build_preview_csv(&preview_rows)?;
             self.insert_bulk_job_artifact(
                 job,
                 "preview_report",
-                format!("seo-bulk-preview-{}.csv", job.id),
+                format!(
+                    "seo-bulk-preview-{}-{}-{}.csv",
+                    job.id, chunk_start, chunk_end
+                ),
                 CSV_MIME_TYPE,
                 content,
             )
             .await?;
-            artifacts += 1;
         }
         if !failure_rows.is_empty() {
             let content = build_failure_csv(&failure_rows)?;
             self.insert_bulk_job_artifact(
                 job,
                 "failure_report",
-                format!("seo-bulk-apply-failures-{}.csv", job.id),
+                format!(
+                    "seo-bulk-apply-failures-{}-{}-{}.csv",
+                    job.id, chunk_start, chunk_end
+                ),
                 CSV_MIME_TYPE,
                 content,
             )
             .await?;
-            artifacts += 1;
         }
 
-        self.finish_bulk_job(job, succeeded + failed, succeeded, failed, artifacts, None)
+        let progress = self.load_bulk_job_progress(job.id).await?;
+        if progress.processed as usize >= payload.target_ids.len() {
+            self.finish_bulk_job(
+                job,
+                progress.processed,
+                progress.succeeded,
+                progress.failed,
+                progress.artifacts,
+                None,
+            )
             .await
+        } else {
+            self.checkpoint_bulk_apply_job(job, payload.target_ids.len(), progress)
+                .await
+        }
+    }
+
+    async fn decode_bounded_apply_payload(
+        &self,
+        tenant: &TenantContext,
+        job: &seo_bulk_job::Model,
+    ) -> SeoResult<QueuedBulkApplyPayload> {
+        if let Ok(payload) =
+            serde_json::from_value::<QueuedBulkApplyPayload>(job.input_payload.clone())
+        {
+            return Ok(payload);
+        }
+
+        let input = serde_json::from_value::<SeoBulkApplyInput>(job.input_payload.clone())
+            .map_err(|err| {
+                SeoError::validation(format!("failed to decode bulk apply payload: {err}"))
+            })?;
+        let resolution = self
+            .resolve_bulk_selection_batched(tenant, input.selection.clone())
+            .await?;
+        Ok(QueuedBulkApplyPayload {
+            input,
+            target_ids: resolution.rows.into_iter().map(|row| row.target_id).collect(),
+        })
+    }
+
+    async fn load_bulk_job_progress(&self, job_id: Uuid) -> SeoResult<BulkJobProgress> {
+        let items = seo_bulk_job_item::Entity::find()
+            .filter(seo_bulk_job_item::Column::JobId.eq(job_id))
+            .all(&self.db)
+            .await?;
+        let succeeded = items
+            .iter()
+            .filter(|item| item.status == "completed")
+            .count() as i32;
+        let failed = items
+            .iter()
+            .filter(|item| item.status == "failed")
+            .count() as i32;
+        let artifacts = seo_bulk_job_artifact::Entity::find()
+            .filter(seo_bulk_job_artifact::Column::JobId.eq(job_id))
+            .all(&self.db)
+            .await?
+            .len() as i32;
+        Ok(BulkJobProgress {
+            processed: items.len() as i32,
+            succeeded,
+            failed,
+            artifacts,
+        })
+    }
+
+    async fn checkpoint_bulk_apply_job(
+        &self,
+        job: &seo_bulk_job::Model,
+        matched_count: usize,
+        progress: BulkJobProgress,
+    ) -> SeoResult<()> {
+        let now = Utc::now().fixed_offset();
+        let mut active: seo_bulk_job::ActiveModel = job.clone().into();
+        active.status = Set(SeoBulkJobStatus::Running.as_str().to_string());
+        active.matched_count = Set(matched_count as i32);
+        active.processed_count = Set(progress.processed);
+        active.succeeded_count = Set(progress.succeeded);
+        active.failed_count = Set(progress.failed);
+        active.artifact_count = Set(progress.artifacts);
+        active.last_error = Set(None);
+        active.completed_at = Set(None);
+        active.updated_at = Set(now);
+        active.update(&self.db).await?;
+        Ok(())
     }
 
     async fn execute_export_job_batched(&self, job: &seo_bulk_job::Model) -> SeoResult<()> {
@@ -362,7 +541,7 @@ fn export_bulk_projection_row(
 }
 
 #[cfg(test)]
-mod batched_execution_tests {
+mod bounded_execution_tests {
     use super::*;
 
     #[test]
@@ -394,5 +573,10 @@ mod batched_execution_tests {
         assert_eq!(row[10], "{\"@type\":\"WebPage\"}");
         assert_eq!(row[11], "true");
         assert_eq!(row[12], "false");
+    }
+
+    #[test]
+    fn apply_chunk_size_stays_bounded() {
+        assert_eq!(BULK_APPLY_CHUNK_SIZE, 50);
     }
 }

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -38,6 +38,10 @@ Automated verification is recorded separately because direct pushes currently do
   - [x] Reuse the batched full projection for bulk selection, preview, queue sizing, and CSV export execution. (#2083)
   - [x] Batch diagnostics metadata and page-context reads while retaining the current single-target owner-provider contract. (#2085)
 - [ ] Move synchronous in-memory SEO pipelines to bounded background execution.
+  - [x] Snapshot bulk-apply targets and checkpoint at most 50 targets per worker invocation. (#2092)
+  - [ ] Bound bulk export and import execution.
+  - [ ] Queue sitemap generation and submission outside request paths.
+  - [ ] Move index repair and replay execution outside request paths.
 - [ ] Require explicit authorization for worker and operator entry points.
 - [ ] Classify retryable, terminal, validation, and configuration failures explicitly.
 
@@ -49,4 +53,4 @@ Automated verification is recorded separately because direct pushes currently do
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
 - [ ] Confirm GitHub Actions status checks for the hardening commits.
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, and #2085 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, and #2092 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-bulk-batch-reads.mjs
+++ b/scripts/verify/verify-seo-bulk-batch-reads.mjs
@@ -16,7 +16,7 @@ const services = read('crates/rustok-seo/src/services/mod.rs');
 const bulkModule = read('crates/rustok-seo/src/services/bulk.rs');
 const legacy = read('crates/rustok-seo/src/services/bulk_legacy.rs');
 const readModel = read('crates/rustok-seo/src/services/bulk_read_model.rs');
-const execution = read('crates/rustok-seo/src/services/bulk_batch_execution.rs');
+const execution = read('crates/rustok-seo/src/services/bulk_bounded_execution.rs');
 const failures = [];
 
 const requireText = (source, value, label) => {
@@ -28,10 +28,13 @@ const forbidText = (source, value, label) => {
 
 requireText(services, 'mod bulk_read_model;', 'shared read-model registration');
 requireText(bulkModule, 'include!("bulk_legacy.rs");', 'legacy bulk include');
-requireText(bulkModule, 'include!("bulk_batch_execution.rs");', 'batched execution include');
+requireText(bulkModule, 'include!("bulk_bounded_execution.rs");', 'bounded execution include');
 requireText(legacy, 'pub async fn execute_next_bulk_job(', 'legacy implementation preservation');
 if (exists('crates/rustok-seo/src/services/applications/bulk_reads.rs')) {
   failures.push('application-local bulk reader must be removed after shared extraction');
+}
+if (exists('crates/rustok-seo/src/services/bulk_batch_execution.rs')) {
+  failures.push('superseded unbounded batch execution file must be removed');
 }
 
 for (const [value, label] of [
@@ -45,9 +48,9 @@ for (const [value, label] of [
 }
 
 for (const [value, label] of [
-  ['const BULK_META_BATCH_SIZE: usize = 256;', 'bounded batch size'],
+  ['const BULK_META_BATCH_SIZE: usize = 256;', 'bounded metadata batch size'],
   ['pub(super) async fn collect_bulk_read_rows(', 'shared batch collector'],
-  ['target_ids.chunks(BULK_META_BATCH_SIZE)', 'bounded target chunks'],
+  ['target_ids.chunks(BULK_META_BATCH_SIZE)', 'bounded metadata target chunks'],
   ['seo_meta::Column::TargetId.is_in(', 'metadata batch predicate'],
   ['meta_translation::Column::MetaId.is_in(', 'translation batch predicate'],
   ['let settings = self.load_settings(tenant.id).await?;', 'single settings snapshot'],
@@ -58,12 +61,14 @@ for (const [value, label] of [
 }
 
 for (const [value, label] of [
-  ['pub(super) async fn preview_bulk_selection_count_batched(', 'batched preview count'],
-  ['pub(super) async fn queue_bulk_apply_batched(', 'batched apply queue'],
-  ['pub(super) async fn queue_bulk_export_batched(', 'batched export queue'],
-  ['pub(super) async fn execute_next_bulk_job_batched(', 'batched worker'],
-  ['self.collect_bulk_read_rows(', 'shared collector reuse'],
-  ['self.execute_apply_job_batched(&running).await', 'batched apply execution'],
+  ['const BULK_APPLY_CHUNK_SIZE: usize = 50;', 'bounded apply chunk size'],
+  ['struct QueuedBulkApplyPayload', 'persisted apply snapshot payload'],
+  ['target_ids: Vec<Uuid>', 'persisted target snapshot'],
+  ['.take(BULK_APPLY_CHUNK_SIZE)', 'bounded worker slice'],
+  ['SeoBulkJobStatus::Running.as_str()', 'running job resume'],
+  ['self.execute_apply_job_chunk(&running).await', 'chunked apply execution'],
+  ['async fn checkpoint_bulk_apply_job(', 'persisted progress checkpoint'],
+  ['async fn load_bulk_job_progress(', 'item-derived progress recovery'],
   ['self.execute_export_job_batched(&running).await', 'batched export execution'],
   ['fn export_bulk_projection_row(', 'projection CSV serializer'],
 ]) {
@@ -74,7 +79,7 @@ for (const [source, value, label] of [
   [readModel, '.seo_meta(', 'read-model per-target metadata service call'],
   [readModel, 'load_explicit_meta(', 'read-model per-target explicit query'],
   [readModel, 'meta_translation::Column::MetaId.eq(', 'read-model per-meta translation query'],
-  [execution, '.seo_meta(', 'worker per-target metadata service call'],
+  [execution, 'self.execute_apply_job_batched(&running).await', 'superseded unbounded apply execution'],
   [applications, '.preview_bulk_selection_count(tenant, selection)', 'legacy selection routing'],
   [applications, '.queue_bulk_export(tenant, created_by, input)', 'legacy export routing'],
   [applications, 'self.runtime.execute_next_bulk_job().await', 'legacy worker routing'],
@@ -88,11 +93,11 @@ if (settingsLoads.length !== 1) {
 }
 
 if (failures.length > 0) {
-  console.error('SEO bulk batch-read verification failed:');
+  console.error('SEO bulk bounded-worker verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ SEO bulk list, selection, preview, and export use the shared bounded metadata read model',
+  '✔ SEO bulk reads stay batched and apply jobs checkpoint at most 50 targets per worker invocation',
 );


### PR DESCRIPTION
## Summary

- snapshot the resolved bulk-apply target IDs into the persisted job payload at enqueue time so later worker passes do not expand or reorder the job scope;
- process at most 50 apply targets per `execute_next_bulk_job` invocation and leave incomplete jobs in `running` state with persisted counters;
- resume the oldest running apply job before claiming another queued job;
- recover progress from durable job-item and artifact rows, skip already processed targets after interruption, and publish the existing terminal event only after the final chunk;
- emit preview and failure artifacts per chunk with deterministic target-range suffixes;
- retain compatibility with already queued legacy apply payloads by resolving a fallback target snapshot;
- leave export and import execution unchanged for separate bounded-execution slices;
- replace the superseded unbounded execution include and update the permanent source guard.

## Concurrency review

The branch was rebuilt as one commit on current `main` at `2a4f3eb6cd39b378a32aba97f3a23bba1d21c2a6` after concurrent Index, storefront, forum, and commerce commits landed. The intervening changes did not touch this SEO scope, and the final branch is directly ahead of `main` with no missing commits. No other open SEO pull request was found immediately before merge.

## Validation

Tests, formatting commands, and verifier execution were not run at the repository owner's request. The payload compatibility, include visibility, 50-target bound, interruption recovery, progress checkpoint, artifact accounting, terminal-event boundary, and final diff were reviewed statically.