### PR TITLE
Harden admin order and fulfillment HTTP errors

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
+++ b/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
@@ -6,7 +6,7 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_fulfillment::FulfillmentService;
-use rustok_web::{HttpError, HttpResult};
+use rustok_web::HttpResult;
 use uuid::Uuid;
 
 use super::{
@@ -59,7 +59,7 @@ pub async fn list_fulfillments(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(PaginatedResponse {
         data: fulfillments,

--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -18,6 +18,8 @@ pub use shipping::*;
 mod tests;
 
 use rust_decimal::Decimal;
+use rustok_fulfillment::error::FulfillmentError;
+use rustok_order::error::OrderError;
 use rustok_payment::PaymentError;
 use rustok_web::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
@@ -324,6 +326,29 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
 }
 
+fn admin_public_error<E>(
+    error: &E,
+    owner: &'static str,
+    error_kind: &'static str,
+    status: axum::http::StatusCode,
+    code: &'static str,
+    message: &'static str,
+) -> HttpError
+where
+    E: std::fmt::Debug,
+{
+    tracing::error!(
+        error = ?error,
+        owner,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_admin_http",
+        "commerce admin operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
 pub(crate) fn map_payment_orchestration_error(
     error: crate::PaymentOrchestrationError,
 ) -> HttpError {
@@ -399,61 +424,147 @@ fn map_reserved_refund_provider_error(error: PaymentError) -> HttpError {
     }
 }
 
-pub(crate) fn map_order_error(error: rustok_order::error::OrderError) -> HttpError {
-    match error {
-        rustok_order::error::OrderError::OrderNotFound(_)
-        | rustok_order::error::OrderError::OrderReturnNotFound(_)
-        | rustok_order::error::OrderError::OrderChangeNotFound(_) => {
-            HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-        }
-        other => HttpError::bad_request("commerce_admin_invalid", other.to_string()),
-    }
+pub(crate) fn map_order_error(error: OrderError) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        OrderError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        OrderError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "database",
+        ),
+        OrderError::Core(_) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "core",
+        ),
+    };
+    admin_public_error(
+        &error,
+        "rustok_order",
+        error_kind,
+        status,
+        code,
+        message,
+    )
 }
 
-pub(crate) fn map_fulfillment_error(
-    error: rustok_fulfillment::error::FulfillmentError,
-) -> HttpError {
-    match error {
-        rustok_fulfillment::error::FulfillmentError::FulfillmentNotFound(_) => {
-            HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-        }
-        other => HttpError::bad_request("commerce_admin_invalid", other.to_string()),
-    }
+pub(crate) fn map_fulfillment_error(error: FulfillmentError) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_)
+        | FulfillmentError::FulfillmentNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        FulfillmentError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    admin_public_error(
+        &error,
+        "rustok_fulfillment",
+        error_kind,
+        status,
+        code,
+        message,
+    )
 }
 
 pub(crate) fn map_fulfillment_orchestration_error(
     error: FulfillmentOrchestrationError,
 ) -> HttpError {
     match error {
-        FulfillmentOrchestrationError::OrderNotFound(_) => {
-            HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
+        FulfillmentOrchestrationError::Fulfillment(error) => map_fulfillment_error(error),
+        error @ FulfillmentOrchestrationError::OrderNotFound(_) => admin_public_error(
+            &error,
+            "rustok_commerce",
+            "order_not_found",
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+        ),
+        error @ FulfillmentOrchestrationError::Database(_) => admin_public_error(
+            &error,
+            "rustok_commerce",
+            "database",
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+        ),
+        error @ FulfillmentOrchestrationError::Validation(_) => admin_public_error(
+            &error,
+            "rustok_commerce",
+            "validation",
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+        ),
+        error @ FulfillmentOrchestrationError::ProviderAfterPersistence { .. }
+        | error @ FulfillmentOrchestrationError::PersistenceAfterProvider { .. } => {
+            admin_public_error(
+                &error,
+                "rustok_commerce",
+                "reconciliation_required",
+                axum::http::StatusCode::CONFLICT,
+                "commerce_admin_fulfillment_reconciliation_required",
+                "Fulfillment operation requires reconciliation",
+            )
         }
-        other => HttpError::bad_request("commerce_admin_invalid", other.to_string()),
     }
 }
 
 pub(crate) fn map_post_order_orchestration_error(error: PostOrderOrchestrationError) -> HttpError {
     match error {
-        PostOrderOrchestrationError::Order(
-            rustok_order::error::OrderError::OrderNotFound(_)
-            | rustok_order::error::OrderError::OrderReturnNotFound(_)
-            | rustok_order::error::OrderError::OrderChangeNotFound(_),
-        )
-        | PostOrderOrchestrationError::Payment(
-            PaymentError::PaymentCollectionNotFound(_)
-            | PaymentError::PaymentNotFound(_)
-            | PaymentError::RefundNotFound(_),
-        ) => HttpError::not_found("commerce_admin_not_found", "Commerce resource not found"),
-        PostOrderOrchestrationError::Order(other) => {
-            HttpError::bad_request("commerce_admin_invalid", other.to_string())
-        }
+        PostOrderOrchestrationError::Order(error) => map_order_error(error),
         PostOrderOrchestrationError::Payment(error) => map_payment_error(error),
         PostOrderOrchestrationError::PaymentOrchestration(error) => {
             map_payment_orchestration_error(error)
         }
-        PostOrderOrchestrationError::Validation(_) => {
-            HttpError::bad_request("commerce_admin_invalid", "Post-order request is invalid")
-        }
+        error @ PostOrderOrchestrationError::Validation(_) => admin_public_error(
+            &error,
+            "rustok_commerce",
+            "validation",
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_post_order_invalid",
+            "Post-order request is invalid",
+        ),
     }
 }
 

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -7,7 +7,7 @@ use rustok_api::{AuthContext, TenantContext};
 use rustok_fulfillment::FulfillmentService;
 use rustok_order::OrderService;
 use rustok_payment::PaymentService;
-use rustok_web::{HttpError, HttpResult};
+use rustok_web::HttpResult;
 use uuid::Uuid;
 
 use super::{
@@ -57,7 +57,7 @@ pub async fn list_orders(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_order_error)?;
 
     Ok(Json(PaginatedResponse {
         data: orders,
@@ -97,22 +97,15 @@ pub async fn show_order(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(|err| match err {
-            rustok_order::error::OrderError::OrderNotFound(_)
-            | rustok_order::error::OrderError::OrderReturnNotFound(_)
-            | rustok_order::error::OrderError::OrderChangeNotFound(_) => {
-                HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-            }
-            other => HttpError::bad_request("commerce_operation_failed", other.to_string()),
-        })?;
+        .map_err(super::map_order_error)?;
     let payment_collection = PaymentService::new(runtime.db_clone())
         .find_latest_collection_by_order(tenant.id, id)
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_payment_error)?;
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .find_by_order(tenant.id, id)
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(AdminOrderDetailResponse {
         order,

--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const orders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const fulfillments = read('crates/rustok-commerce/src/controllers/admin/fulfillments.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const fulfillmentOrchestration = read(
+  'crates/rustok-commerce/src/services/fulfillment_orchestration.rs',
+);
+const postOrder = read('crates/rustok-commerce/src/services/post_order.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['use rustok_fulfillment::error::FulfillmentError;', 'typed fulfillment error import'],
+  ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['fn admin_public_error<E>(', 'shared safe HTTP constructor'],
+  ['E: std::fmt::Debug', 'raw error logging bound'],
+  ['error = ?error', 'raw internal error logging'],
+  ['owner,', 'owner logging'],
+  ['error_kind,', 'error-kind logging'],
+  ['public_code = code', 'public-code logging'],
+  ['status = %status', 'status logging'],
+  ['boundary = "commerce_admin_http"', 'admin HTTP boundary logging'],
+  ['HttpError::new(status, code, message)', 'static HTTP envelope construction'],
+  ['pub(crate) fn map_order_error(error: OrderError)', 'order mapper'],
+  ['pub(crate) fn map_fulfillment_error(error: FulfillmentError)', 'fulfillment mapper'],
+  ['pub(crate) fn map_fulfillment_orchestration_error(', 'fulfillment orchestration mapper'],
+  ['pub(crate) fn map_post_order_orchestration_error(', 'post-order mapper'],
+]) {
+  requireText(admin, value, label);
+}
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found mapping'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found mapping'],
+  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order core mapping'],
+  ['"commerce_admin_order_invalid"', 'order invalid code'],
+  ['"commerce_admin_not_found"', 'shared not-found code'],
+  ['"commerce_admin_order_state_conflict"', 'order conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'order storage code'],
+  ['"commerce_admin_order_failed"', 'order fail-closed code'],
+  ['axum::http::StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['axum::http::StatusCode::NOT_FOUND', 'not-found status'],
+  ['axum::http::StatusCode::CONFLICT', 'conflict status'],
+  ['axum::http::StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['axum::http::StatusCode::INTERNAL_SERVER_ERROR', 'internal status'],
+]) {
+  requireText(admin, value, label);
+}
+
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'fulfillment transition mapping'],
+  ['FulfillmentError::Database(_)', 'fulfillment database mapping'],
+  ['"commerce_admin_fulfillment_invalid"', 'fulfillment invalid code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'fulfillment conflict code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'fulfillment storage code'],
+  ['FulfillmentOrchestrationError::OrderNotFound(_)', 'orchestration order-not-found mapping'],
+  ['FulfillmentOrchestrationError::Fulfillment(error)', 'orchestration owner delegation'],
+  ['FulfillmentOrchestrationError::Validation(_)', 'orchestration validation mapping'],
+  ['FulfillmentOrchestrationError::ProviderAfterPersistence { .. }', 'provider-after-persistence mapping'],
+  ['FulfillmentOrchestrationError::PersistenceAfterProvider { .. }', 'persistence-after-provider mapping'],
+  ['"commerce_admin_fulfillment_reconciliation_required"', 'fulfillment reconciliation code'],
+  ['"Fulfillment operation requires reconciliation"', 'fulfillment reconciliation message'],
+]) {
+  requireText(admin, value, label);
+}
+
+for (const [value, label] of [
+  ['PostOrderOrchestrationError::Order(error) => map_order_error(error)', 'post-order order delegation'],
+  ['PostOrderOrchestrationError::Payment(error) => map_payment_error(error)', 'post-order payment delegation'],
+  ['PostOrderOrchestrationError::PaymentOrchestration(error)', 'post-order payment orchestration delegation'],
+  ['PostOrderOrchestrationError::Validation(_)', 'post-order validation mapping'],
+  ['"commerce_admin_post_order_invalid"', 'post-order validation code'],
+]) {
+  requireText(admin, value, label);
+}
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [fulfillmentErrors, 'Validation(String)', 'owner fulfillment validation variant'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
+  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'owner fulfillment transition variant'],
+  [fulfillmentErrors, 'Database(#[from] DbErr)', 'owner fulfillment database variant'],
+  [fulfillmentOrchestration, 'OrderNotFound(Uuid)', 'orchestration order-not-found variant'],
+  [fulfillmentOrchestration, 'Database(#[from] sea_orm::DbErr)', 'orchestration database variant'],
+  [fulfillmentOrchestration, 'Fulfillment(#[from] rustok_fulfillment::error::FulfillmentError)', 'orchestration fulfillment variant'],
+  [fulfillmentOrchestration, 'Validation(String)', 'orchestration validation variant'],
+  [fulfillmentOrchestration, 'ProviderAfterPersistence {', 'orchestration provider-after-persistence variant'],
+  [fulfillmentOrchestration, 'PersistenceAfterProvider {', 'orchestration persistence-after-provider variant'],
+  [postOrder, 'Order(#[from] rustok_order::error::OrderError)', 'post-order order variant'],
+  [postOrder, 'Payment(#[from] rustok_payment::error::PaymentError)', 'post-order payment variant'],
+  [postOrder, 'PaymentOrchestration(#[from] PaymentOrchestrationError)', 'post-order payment orchestration variant'],
+  [postOrder, 'Validation(String)', 'post-order validation variant'],
+]) {
+  requireText(ownerSource, value, label);
+}
+
+for (const [value, label] of [
+  ['pub async fn list_orders(', 'admin list-orders handler'],
+  ['pub async fn show_order(', 'admin show-order handler'],
+  ['list_orders_with_locale_fallback(', 'localized order list'],
+  ['get_order_with_locale_fallback(', 'localized order detail'],
+  ['find_latest_collection_by_order(tenant.id, id)', 'payment collection detail read'],
+  ['find_by_order(tenant.id, id)', 'fulfillment detail read'],
+  ['.map_err(super::map_payment_error)?;', 'typed payment detail mapping'],
+  ['.map_err(super::map_fulfillment_error)?;', 'typed fulfillment detail mapping'],
+  ['page: pagination.page', 'order page forwarding'],
+  ['per_page: pagination.limit()', 'order page-size forwarding'],
+]) {
+  requireText(orders, value, label);
+}
+
+for (const [value, label] of [
+  ['pub async fn list_order_returns(', 'admin return list'],
+  ['pub async fn show_order_return(', 'admin return detail'],
+  ['pub async fn create_order_return(', 'admin return create'],
+  ['pub async fn cancel_order_return(', 'admin return cancel'],
+  ['.map_err(super::map_order_error)?;', 'typed return owner mapping'],
+  ['.map_err(super::map_post_order_orchestration_error)?;', 'typed return orchestration mapping'],
+  ['ListOrderReturnsInput {', 'return list input'],
+  ['page: pagination.page', 'return page forwarding'],
+  ['per_page: pagination.limit()', 'return page-size forwarding'],
+]) {
+  requireText(returns, value, label);
+}
+
+for (const [value, label] of [
+  ['pub async fn list_fulfillments(', 'admin fulfillment list'],
+  ['pub async fn show_fulfillment(', 'admin fulfillment detail'],
+  ['ListFulfillmentsInput {', 'fulfillment list input'],
+  ['page: pagination.page', 'fulfillment page forwarding'],
+  ['per_page: pagination.limit()', 'fulfillment page-size forwarding'],
+  ['.map_err(super::map_fulfillment_error)?;', 'typed fulfillment owner mapping'],
+  ['.map_err(super::map_fulfillment_orchestration_error)?;', 'typed fulfillment orchestration mapping'],
+]) {
+  requireText(fulfillments, value, label);
+}
+
+for (const [content, label] of [
+  [orders, 'admin order reads'],
+  [returns, 'admin return endpoints'],
+  [fulfillments, 'admin fulfillment endpoints'],
+]) {
+  for (const value of [
+    'err.to_string()',
+    'error.to_string()',
+    'other.to_string()',
+    'HttpError::bad_request("commerce_operation_failed"',
+  ]) {
+    forbidText(content, value, `${label} unsafe public conversion`);
+  }
+}
+
+const orderMapperUses = (orders.match(/\.map_err\(super::map_order_error\)\?;/g) ?? []).length
+  + (returns.match(/\.map_err\(super::map_order_error\)\?;/g) ?? []).length;
+if (orderMapperUses !== 10) {
+  failures.push(`expected ten order/return owner mapper callsites, found ${orderMapperUses}`);
+}
+
+const fulfillmentMapperUses =
+  fulfillments.match(/\.map_err\(super::map_fulfillment_error\)\?;/g) ?? [];
+if (fulfillmentMapperUses.length !== 4) {
+  failures.push(`expected four fulfillment owner mapper callsites, found ${fulfillmentMapperUses.length}`);
+}
+
+const fulfillmentOrchestrationUses =
+  fulfillments.match(/\.map_err\(super::map_fulfillment_orchestration_error\)\?;/g) ?? [];
+if (fulfillmentOrchestrationUses.length !== 4) {
+  failures.push(`expected four fulfillment orchestration mapper callsites, found ${fulfillmentOrchestrationUses.length}`);
+}
+
+const postOrderUses =
+  returns.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
+if (postOrderUses.length !== 2) {
+  failures.push(`expected two post-order orchestration mapper callsites, found ${postOrderUses.length}`);
+}
+
+const remainingAdminDynamicStrings = admin.match(/other\.to_string\(\)/g) ?? [];
+if (remainingAdminDynamicStrings.length !== 1) {
+  failures.push(
+    `expected only the separately scoped shipping-profile mapper to retain other.to_string(), found ${remainingAdminDynamicStrings.length}`,
+  );
+}
+requireText(
+  admin,
+  'pub(crate) fn map_shipping_profile_error(error: crate::CommerceError)',
+  'separately scoped shipping-profile mapper',
+);
+
+if (failures.length > 0) {
+  console.error('Commerce admin order/fulfillment HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order, return, and fulfillment HTTP errors use stable typed public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace generic `other.to_string()` handling in the shared admin order, fulfillment, fulfillment-orchestration, and post-order mappers with exhaustive typed HTTP envelopes;
- preserve the established payment mapper and delegate nested payment/order/fulfillment owner errors to their typed mappers;
- map order validation/not-found/state-conflict/database/core failures to stable 400/404/409/503/500 responses;
- map fulfillment validation/not-found/state-conflict/database failures to stable 400/404/409/503 responses;
- map provider-after-persistence and persistence-after-provider fulfillment failures to a stable reconciliation-required 409 response, matching the existing GraphQL policy;
- keep raw owner errors only in structured internal logging with owner, error kind, public code, status, and boundary;
- route admin order list/detail reads and fulfillment list/detail reads through the shared typed mappers;
- add a verifier for owner enum coverage, status/code policy, orchestration variants, mapper callsite counts, pagination preservation, and forbidden raw public conversions.

## Scope

Four files only: the shared admin controller mappers, admin order reads, admin fulfillment reads, and one verifier. Routes, permission checks, locale fallback, service arguments, DTOs, filters, pagination, orchestration ownership, and success responses are unchanged. The separately scoped shipping-profile mapper remains untouched.

## Public policy

- order validation: `400 commerce_admin_order_invalid`;
- order not found: `404 commerce_admin_not_found`;
- order state conflict: `409 commerce_admin_order_state_conflict`;
- order storage outage: `503 commerce_admin_order_storage_unavailable`;
- order core failure: `500 commerce_admin_order_failed`;
- fulfillment validation: `400 commerce_admin_fulfillment_invalid`;
- fulfillment not found: `404 commerce_admin_not_found`;
- fulfillment state conflict: `409 commerce_admin_fulfillment_state_conflict`;
- fulfillment storage outage: `503 commerce_admin_fulfillment_storage_unavailable`;
- fulfillment external/local partial-success cases: `409 commerce_admin_fulfillment_reconciliation_required`;
- post-order validation: `400 commerce_admin_post_order_invalid`.

## Validation

- branch is one commit directly above current `main`;
- source-level audit completed against current `OrderError`, `FulfillmentError`, `FulfillmentOrchestrationError`, and `PostOrderOrchestrationError` enums;
- existing commerce admin transport guard does not pin the previous generic error strings;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.