### PR TITLE
perf(seo): queue sitemap generation and submission

### DIFF
--- a/crates/rustok-seo/src/services/applications.rs
+++ b/crates/rustok-seo/src/services/applications.rs
@@ -255,7 +255,11 @@ impl SeoSitemapService {
         &self,
         tenant: &TenantContext,
     ) -> SeoResult<SeoSitemapStatusRecord> {
-        self.runtime.generate_sitemaps(tenant).await
+        self.runtime.queue_sitemap_generation_background(tenant).await
+    }
+
+    pub async fn execute_next_sitemap_job(&self) -> SeoResult<Option<SeoSitemapJobRecord>> {
+        self.runtime.execute_next_sitemap_job_background().await
     }
 
     pub async fn sitemap_status(

--- a/crates/rustok-seo/src/services/bulk.rs
+++ b/crates/rustok-seo/src/services/bulk.rs
@@ -2,6 +2,7 @@ include!("bulk_legacy.rs");
 include!("bulk_bounded_execution.rs");
 include!("bulk_io_bounded_execution.rs");
 include!("bulk_io_bounded_compat.rs");
+include!("sitemap_background.rs");
 
 #[cfg(test)]
 mod bulk_read_model {

--- a/crates/rustok-seo/src/services/sitemap_background.rs
+++ b/crates/rustok-seo/src/services/sitemap_background.rs
@@ -1,0 +1,629 @@
+#[path = "sitemaps/index_generation.rs"]
+mod background_sitemap_index_generation;
+#[path = "sitemaps/submission_adapters.rs"]
+mod background_sitemap_submission_adapters;
+#[path = "sitemaps/submission_aggregation.rs"]
+mod background_sitemap_submission_aggregation;
+
+const SITEMAP_JOB_QUEUED: &str = "queued";
+const SITEMAP_JOB_RUNNING: &str = "running";
+const SITEMAP_JOB_SUBMITTING: &str = "submitting";
+const SITEMAP_JOB_COMPLETED: &str = "completed";
+const SITEMAP_JOB_FAILED: &str = "failed";
+const SITEMAP_BACKGROUND_SUBMIT_TIMEOUT_SECS: u64 = 5;
+const SITEMAP_BACKGROUND_DELIVERY_STATUS_SENT: &str = "sent";
+
+struct BackgroundSitemapEventPublication {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    event_type: String,
+    idempotency_key: String,
+    event: rustok_core::DomainEvent,
+    occurred_at: chrono::DateTime<chrono::FixedOffset>,
+}
+
+impl SeoService {
+    pub(super) async fn queue_sitemap_generation_background(
+        &self,
+        tenant: &TenantContext,
+    ) -> SeoResult<crate::dto::SeoSitemapStatusRecord> {
+        let settings = self.load_settings(tenant.id).await?;
+        if !settings.sitemap_enabled {
+            return Ok(background_disabled_sitemap_status());
+        }
+
+        // Validate the public origin while the caller can still receive a configuration error,
+        // but do not collect targets, render XML, or perform external submissions here.
+        self.robots_preview(tenant).await?;
+
+        let active = crate::entities::seo_sitemap_job::Entity::find()
+            .filter(crate::entities::seo_sitemap_job::Column::TenantId.eq(tenant.id))
+            .filter(crate::entities::seo_sitemap_job::Column::Status.is_in([
+                SITEMAP_JOB_QUEUED,
+                SITEMAP_JOB_RUNNING,
+                SITEMAP_JOB_SUBMITTING,
+            ]))
+            .order_by_asc(crate::entities::seo_sitemap_job::Column::CreatedAt)
+            .one(&self.db)
+            .await?;
+        if active.is_some() {
+            return self.sitemap_status(tenant).await;
+        }
+
+        let now = chrono::Utc::now().fixed_offset();
+        crate::entities::seo_sitemap_job::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant.id),
+            status: Set(SITEMAP_JOB_QUEUED.to_string()),
+            file_count: Set(0),
+            started_at: Set(None),
+            completed_at: Set(None),
+            last_error: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+
+        self.sitemap_status(tenant).await
+    }
+
+    pub(super) async fn execute_next_sitemap_job_background(
+        &self,
+    ) -> SeoResult<Option<crate::dto::SeoSitemapJobRecord>> {
+        let active = crate::entities::seo_sitemap_job::Entity::find()
+            .filter(crate::entities::seo_sitemap_job::Column::Status.is_in([
+                SITEMAP_JOB_RUNNING,
+                SITEMAP_JOB_SUBMITTING,
+            ]))
+            .order_by_asc(crate::entities::seo_sitemap_job::Column::UpdatedAt)
+            .one(&self.db)
+            .await?;
+
+        let job = if let Some(job) = active {
+            job
+        } else {
+            let Some(job) = crate::entities::seo_sitemap_job::Entity::find()
+                .filter(
+                    crate::entities::seo_sitemap_job::Column::Status.eq(SITEMAP_JOB_QUEUED),
+                )
+                .order_by_asc(crate::entities::seo_sitemap_job::Column::CreatedAt)
+                .one(&self.db)
+                .await?
+            else {
+                return Ok(None);
+            };
+
+            let now = chrono::Utc::now().fixed_offset();
+            let mut active: crate::entities::seo_sitemap_job::ActiveModel = job.into();
+            active.status = Set(SITEMAP_JOB_RUNNING.to_string());
+            active.started_at = Set(Some(now));
+            active.completed_at = Set(None);
+            active.last_error = Set(None);
+            active.updated_at = Set(now);
+            active.update(&self.db).await?
+        };
+
+        let result = if job.status == SITEMAP_JOB_SUBMITTING {
+            self.execute_sitemap_submission_phase(&job).await
+        } else {
+            self.execute_sitemap_generation_phase(&job).await
+        };
+        if let Err(error) = result {
+            self.fail_background_sitemap_job(&job, error.to_string())
+                .await?;
+        }
+
+        self.sitemap_job(job.tenant_id, job.id).await
+    }
+
+    async fn execute_sitemap_generation_phase(
+        &self,
+        job: &crate::entities::seo_sitemap_job::Model,
+    ) -> SeoResult<()> {
+        let tenant = self.load_background_sitemap_tenant(job.tenant_id).await?;
+        let settings = self.load_settings(tenant.id).await?;
+        if !settings.sitemap_enabled {
+            return Err(SeoError::configuration(
+                "sitemap generation was disabled after the job was queued",
+            ));
+        }
+
+        let preview = self.robots_preview(&tenant).await?;
+        let public_origin = preview
+            .public_url
+            .strip_suffix("/robots.txt")
+            .ok_or_else(|| SeoError::configuration("invalid SEO robots public URL"))?
+            .to_string();
+        let urls = self
+            .collect_background_sitemap_urls(&tenant, public_origin.as_str())
+            .await?;
+        let generated_at = chrono::Utc::now().fixed_offset();
+        self.persist_background_sitemap_generation(
+            job,
+            &tenant,
+            public_origin.as_str(),
+            urls.as_slice(),
+            !settings.sitemap_submission_endpoints.is_empty(),
+            generated_at,
+        )
+        .await
+    }
+
+    async fn execute_sitemap_submission_phase(
+        &self,
+        job: &crate::entities::seo_sitemap_job::Model,
+    ) -> SeoResult<()> {
+        let tenant = self.load_background_sitemap_tenant(job.tenant_id).await?;
+        let settings = self.load_settings(tenant.id).await?;
+        let preview = self.robots_preview(&tenant).await?;
+        let sitemap_index_url = preview
+            .public_url
+            .strip_suffix("/robots.txt")
+            .map(|origin| format!("{origin}/sitemap.xml"))
+            .ok_or_else(|| SeoError::configuration("invalid SEO robots public URL"))?;
+        let endpoint_count = settings.sitemap_submission_endpoints.len() as i32;
+        let error = if settings.sitemap_submission_endpoints.is_empty() {
+            None
+        } else {
+            match submit_background_sitemap_endpoints(
+                settings.sitemap_submission_endpoints.as_slice(),
+                sitemap_index_url.as_str(),
+            )
+            .await
+            {
+                Ok(()) => None,
+                Err(error) => {
+                    tracing::warn!(
+                        tenant_id = %tenant.id,
+                        job_id = %job.id,
+                        error = %error,
+                        "background SEO sitemap submission failed"
+                    );
+                    Some(error)
+                }
+            }
+        };
+
+        self.record_background_sitemap_submission(job, endpoint_count, error)
+            .await
+    }
+
+    async fn load_background_sitemap_tenant(
+        &self,
+        tenant_id: Uuid,
+    ) -> SeoResult<TenantContext> {
+        let tenant = rustok_tenant::entities::tenant::Entity::find_by_id(tenant_id)
+            .one(&self.db)
+            .await?
+            .ok_or(SeoError::NotFound)?;
+        Ok(TenantContext {
+            id: tenant.id,
+            name: tenant.name,
+            slug: tenant.slug,
+            domain: tenant.domain,
+            settings: tenant.settings,
+            default_locale: tenant.default_locale,
+            is_active: tenant.is_active,
+        })
+    }
+
+    async fn collect_background_sitemap_urls(
+        &self,
+        tenant: &TenantContext,
+        public_origin: &str,
+    ) -> SeoResult<Vec<String>> {
+        let mut urls = Vec::new();
+        for provider in self.registry.providers_with_capability(
+            rustok_seo_targets::SeoTargetCapabilityKind::Sitemaps,
+        ) {
+            let candidates = provider
+                .sitemap_candidates(
+                    &self.target_runtime(),
+                    rustok_seo_targets::SeoTargetSitemapRequest {
+                        tenant_id: tenant.id,
+                        default_locale: tenant.default_locale.as_str(),
+                    },
+                )
+                .await
+                .map_err(|error| {
+                    SeoError::validation(format!(
+                        "SEO target provider `{}` failed to collect sitemap candidates: {error}",
+                        provider.slug().as_str()
+                    ))
+                })?;
+            for candidate in candidates {
+                let locale = super::normalize_effective_locale(
+                    candidate.locale.as_str(),
+                    tenant.default_locale.as_str(),
+                )?;
+                urls.push(format!(
+                    "{public_origin}{}",
+                    super::routing::locale_prefixed_path(
+                        locale.as_str(),
+                        candidate.route.as_str(),
+                    )
+                ));
+            }
+        }
+
+        urls.sort();
+        urls.dedup();
+        Ok(urls)
+    }
+
+    async fn persist_background_sitemap_generation(
+        &self,
+        job: &crate::entities::seo_sitemap_job::Model,
+        tenant: &TenantContext,
+        public_origin: &str,
+        urls: &[String],
+        requires_submission: bool,
+        generated_at: chrono::DateTime<chrono::FixedOffset>,
+    ) -> SeoResult<()> {
+        let txn = self.db.begin().await?;
+        let file_count = background_sitemap_file_count(urls.len()) as i32;
+
+        crate::entities::seo_sitemap_file::Entity::delete_many()
+            .filter(crate::entities::seo_sitemap_file::Column::TenantId.eq(tenant.id))
+            .filter(crate::entities::seo_sitemap_file::Column::JobId.eq(job.id))
+            .exec(&txn)
+            .await?;
+        self.persist_background_sitemap_files(
+            &txn,
+            tenant,
+            public_origin,
+            job.id,
+            urls,
+            generated_at,
+        )
+        .await?;
+
+        let mut active: crate::entities::seo_sitemap_job::ActiveModel = job.clone().into();
+        active.status = Set(if requires_submission {
+            SITEMAP_JOB_SUBMITTING.to_string()
+        } else {
+            SITEMAP_JOB_COMPLETED.to_string()
+        });
+        active.file_count = Set(file_count);
+        active.last_error = Set(None);
+        active.completed_at = Set((!requires_submission).then_some(generated_at));
+        active.updated_at = Set(generated_at);
+        active.update(&txn).await?;
+
+        let event_type = "seo.sitemap.generated";
+        let idempotency_key = background_sitemap_event_key(
+            event_type,
+            tenant.id,
+            &[job.id.to_string(), file_count.to_string()],
+        );
+        self.publish_background_sitemap_event(
+            &txn,
+            BackgroundSitemapEventPublication {
+                tenant_id: tenant.id,
+                job_id: job.id,
+                event_type: event_type.to_string(),
+                idempotency_key: idempotency_key.clone(),
+                event: rustok_core::DomainEvent::SeoSitemapGenerated {
+                    job_id: job.id,
+                    file_count,
+                    idempotency_key,
+                },
+                occurred_at: generated_at,
+            },
+        )
+        .await?;
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn persist_background_sitemap_files(
+        &self,
+        txn: &sea_orm::DatabaseTransaction,
+        tenant: &TenantContext,
+        public_origin: &str,
+        job_id: Uuid,
+        urls: &[String],
+        now: chrono::DateTime<chrono::FixedOffset>,
+    ) -> SeoResult<()> {
+        let mut files = Vec::new();
+        for (index, chunk) in urls.chunks(super::SITEMAP_CHUNK_SIZE).enumerate() {
+            files.push(
+                crate::entities::seo_sitemap_file::ActiveModel {
+                    id: Set(Uuid::new_v4()),
+                    tenant_id: Set(tenant.id),
+                    job_id: Set(job_id),
+                    path: Set(format!("sitemap-{}.xml", index + 1)),
+                    url_count: Set(chunk.len() as i32),
+                    content: Set(background_sitemap_index_generation::render_sitemap_file(chunk)),
+                    created_at: Set(now),
+                    updated_at: Set(now),
+                }
+                .insert(txn)
+                .await?,
+            );
+        }
+
+        let index_urls = files
+            .iter()
+            .map(|file| format!("{public_origin}/sitemaps/{}", file.path))
+            .collect::<Vec<_>>();
+        crate::entities::seo_sitemap_file::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant.id),
+            job_id: Set(job_id),
+            path: Set("sitemap.xml".to_string()),
+            url_count: Set(urls.len() as i32),
+            content: Set(background_sitemap_index_generation::render_sitemap_index(
+                index_urls.as_slice(),
+            )),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(txn)
+        .await?;
+        Ok(())
+    }
+
+    async fn record_background_sitemap_submission(
+        &self,
+        job: &crate::entities::seo_sitemap_job::Model,
+        endpoint_count: i32,
+        error: Option<String>,
+    ) -> SeoResult<()> {
+        let txn = self.db.begin().await?;
+        let current = crate::entities::seo_sitemap_job::Entity::find_by_id(job.id)
+            .filter(crate::entities::seo_sitemap_job::Column::TenantId.eq(job.tenant_id))
+            .one(&txn)
+            .await?
+            .ok_or(SeoError::NotFound)?;
+        let now = chrono::Utc::now().fixed_offset();
+        let success = error.is_none();
+        let mut active: crate::entities::seo_sitemap_job::ActiveModel = current.into();
+        active.status = Set(SITEMAP_JOB_COMPLETED.to_string());
+        active.last_error = Set(error.clone());
+        active.completed_at = Set(Some(now));
+        active.updated_at = Set(now);
+        active.update(&txn).await?;
+
+        let event_type = "seo.sitemap.submitted";
+        let idempotency_key = background_sitemap_event_key(
+            event_type,
+            job.tenant_id,
+            &[
+                job.id.to_string(),
+                endpoint_count.to_string(),
+                success.to_string(),
+            ],
+        );
+        self.publish_background_sitemap_event(
+            &txn,
+            BackgroundSitemapEventPublication {
+                tenant_id: job.tenant_id,
+                job_id: job.id,
+                event_type: event_type.to_string(),
+                idempotency_key: idempotency_key.clone(),
+                event: rustok_core::DomainEvent::SeoSitemapSubmitted {
+                    job_id: job.id,
+                    endpoint_count,
+                    success,
+                    error,
+                    idempotency_key,
+                },
+                occurred_at: now,
+            },
+        )
+        .await?;
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn publish_background_sitemap_event(
+        &self,
+        txn: &sea_orm::DatabaseTransaction,
+        publication: BackgroundSitemapEventPublication,
+    ) -> SeoResult<()> {
+        let existing = crate::entities::seo_event_delivery::Entity::find()
+            .filter(
+                crate::entities::seo_event_delivery::Column::TenantId.eq(publication.tenant_id),
+            )
+            .filter(
+                crate::entities::seo_event_delivery::Column::IdempotencyKey
+                    .eq(publication.idempotency_key.as_str()),
+            )
+            .one(txn)
+            .await?;
+        if existing.is_some() {
+            return Ok(());
+        }
+
+        let outbox_event_id = self
+            .event_bus
+            .publish_in_tx_with_envelope_id(
+                txn,
+                publication.tenant_id,
+                None,
+                publication.event,
+            )
+            .await
+            .map_err(|error| background_sitemap_transactional_event_error(error))?;
+        crate::entities::seo_event_delivery::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(publication.tenant_id),
+            event_type: Set(publication.event_type),
+            idempotency_key: Set(publication.idempotency_key),
+            source_kind: Set(Some("sitemap_job".to_string())),
+            source_id: Set(Some(publication.job_id)),
+            status: Set(SITEMAP_BACKGROUND_DELIVERY_STATUS_SENT.to_string()),
+            outbox_event_id: Set(Some(outbox_event_id)),
+            last_error: Set(None),
+            created_at: Set(publication.occurred_at),
+            updated_at: Set(publication.occurred_at),
+            dispatched_at: Set(Some(publication.occurred_at)),
+        }
+        .insert(txn)
+        .await?;
+        Ok(())
+    }
+
+    async fn fail_background_sitemap_job(
+        &self,
+        job: &crate::entities::seo_sitemap_job::Model,
+        message: String,
+    ) -> SeoResult<()> {
+        let now = chrono::Utc::now().fixed_offset();
+        let mut active: crate::entities::seo_sitemap_job::ActiveModel = job.clone().into();
+        active.status = Set(SITEMAP_JOB_FAILED.to_string());
+        active.last_error = Set(Some(rustok_core::truncate(message.trim(), 2048)));
+        active.completed_at = Set(Some(now));
+        active.updated_at = Set(now);
+        active.update(&self.db).await?;
+        Ok(())
+    }
+}
+
+async fn submit_background_sitemap_endpoints(
+    endpoints: &[String],
+    sitemap_index_url: &str,
+) -> Result<(), String> {
+    let runtime = background_sitemap_submission_adapters::SitemapSubmissionRuntime::default_with_timeout(
+        SITEMAP_BACKGROUND_SUBMIT_TIMEOUT_SECS,
+    )?;
+    let mut summary =
+        background_sitemap_submission_aggregation::SitemapSubmissionSummary::default();
+    for endpoint in endpoints {
+        let Some(request_url) =
+            build_background_sitemap_submission_url(endpoint.as_str(), sitemap_index_url)
+        else {
+            background_sitemap_submission_aggregation::record_invalid_endpoint(
+                &mut summary,
+                endpoint.as_str(),
+            );
+            continue;
+        };
+        let request = background_sitemap_submission_adapters::SitemapSubmitEndpoint {
+            endpoint: endpoint.clone(),
+            request_url,
+        };
+        match runtime.adapter().submit_sitemap_index(request).await {
+            Ok(()) => background_sitemap_submission_aggregation::record_submission_success(
+                &mut summary,
+                endpoint.as_str(),
+            ),
+            Err(message) => {
+                background_sitemap_submission_aggregation::record_submission_failure(
+                    &mut summary,
+                    endpoint.as_str(),
+                    message,
+                );
+            }
+        }
+    }
+
+    let telemetry = summary.telemetry_snapshot();
+    tracing::debug!(
+        success_count = summary.success_count,
+        failure_count = summary.failure_count,
+        endpoint_status_count = telemetry.endpoint_statuses.len(),
+        omitted_endpoint_status_count = telemetry.omitted_endpoint_status_count,
+        "background SEO sitemap endpoint submission finished"
+    );
+    match summary.into_error() {
+        Some(message) => Err(message),
+        None => Ok(()),
+    }
+}
+
+fn build_background_sitemap_submission_url(
+    endpoint: &str,
+    sitemap_index_url: &str,
+) -> Option<String> {
+    let normalized = endpoint.trim();
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.contains("{sitemap_url}") {
+        let encoded: String =
+            url::form_urlencoded::byte_serialize(sitemap_index_url.as_bytes()).collect();
+        let replaced = normalized.replace("{sitemap_url}", encoded.as_str());
+        let parsed = url::Url::parse(replaced.as_str()).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+        return Some(parsed.to_string());
+    }
+    let mut parsed = url::Url::parse(normalized).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    if !parsed
+        .query_pairs()
+        .any(|(name, _)| name.eq_ignore_ascii_case("sitemap"))
+    {
+        parsed
+            .query_pairs_mut()
+            .append_pair("sitemap", sitemap_index_url);
+    }
+    Some(parsed.to_string())
+}
+
+fn background_sitemap_file_count(url_count: usize) -> usize {
+    if url_count == 0 {
+        1
+    } else {
+        ((url_count - 1) / super::SITEMAP_CHUNK_SIZE) + 2
+    }
+}
+
+fn background_sitemap_event_key(scope: &str, tenant_id: Uuid, parts: &[String]) -> String {
+    let mut payload = format!("{scope}|{tenant_id}");
+    for part in parts {
+        payload.push('|');
+        payload.push_str(part.as_str());
+    }
+    format!(
+        "{scope}:{:016x}",
+        rustok_core::simple_hash(payload.as_str())
+    )
+}
+
+fn background_sitemap_transactional_event_error(error: rustok_core::Error) -> SeoError {
+    SeoError::Database(sea_orm::DbErr::Custom(format!(
+        "failed to enqueue sitemap event transactionally: {error}"
+    )))
+}
+
+fn background_disabled_sitemap_status() -> crate::dto::SeoSitemapStatusRecord {
+    crate::dto::SeoSitemapStatusRecord {
+        enabled: false,
+        latest_job_id: None,
+        status: None,
+        file_count: 0,
+        generated_at: None,
+        files: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod sitemap_background_tests {
+    use super::*;
+
+    #[test]
+    fn background_file_count_keeps_the_index_and_chunks() {
+        assert_eq!(background_sitemap_file_count(0), 1);
+        assert_eq!(background_sitemap_file_count(1), 2);
+        assert_eq!(
+            background_sitemap_file_count(super::SITEMAP_CHUNK_SIZE + 1),
+            3
+        );
+    }
+
+    #[test]
+    fn background_job_states_are_phase_distinct() {
+        assert_ne!(SITEMAP_JOB_QUEUED, SITEMAP_JOB_RUNNING);
+        assert_ne!(SITEMAP_JOB_RUNNING, SITEMAP_JOB_SUBMITTING);
+        assert_ne!(SITEMAP_JOB_SUBMITTING, SITEMAP_JOB_COMPLETED);
+    }
+}

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -40,7 +40,7 @@ Automated verification is recorded separately because direct pushes currently do
 - [ ] Move synchronous in-memory SEO pipelines to bounded background execution.
   - [x] Snapshot bulk-apply targets and checkpoint at most 50 targets per worker invocation. (#2092)
   - [x] Snapshot bulk-export targets and checkpoint export/import work at most 50 rows per worker invocation. (#2095)
-  - [ ] Queue sitemap generation and submission outside request paths.
+  - [x] Queue sitemap generation and submission outside request paths and execute one durable phase per worker invocation. (#2098)
   - [ ] Move index repair and replay execution outside request paths.
 - [ ] Require explicit authorization for worker and operator entry points.
 - [ ] Classify retryable, terminal, validation, and configuration failures explicitly.
@@ -53,4 +53,4 @@ Automated verification is recorded separately because direct pushes currently do
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
 - [ ] Confirm GitHub Actions status checks for the hardening commits.
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, and #2095 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, and #2098 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-sitemap-background-worker.mjs
+++ b/scripts/verify/verify-seo-sitemap-background-worker.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const applications = read('crates/rustok-seo/src/services/applications.rs');
+const bulkModule = read('crates/rustok-seo/src/services/bulk.rs');
+const worker = read('crates/rustok-seo/src/services/sitemap_background.rs');
+const graphql = read('crates/rustok-seo/src/graphql/mod.rs');
+
+requireText(
+  bulkModule,
+  'include!("sitemap_background.rs");',
+  'background sitemap include',
+);
+requireText(
+  applications,
+  'self.runtime.queue_sitemap_generation_background(tenant).await',
+  'request-path enqueue routing',
+);
+requireText(
+  applications,
+  'pub async fn execute_next_sitemap_job(&self)',
+  'worker application boundary',
+);
+requireText(
+  applications,
+  'self.runtime.execute_next_sitemap_job_background().await',
+  'worker runtime routing',
+);
+for (const [value, label] of [
+  ['const SITEMAP_JOB_QUEUED: &str = "queued";', 'queued phase'],
+  ['const SITEMAP_JOB_RUNNING: &str = "running";', 'generation phase'],
+  ['const SITEMAP_JOB_SUBMITTING: &str = "submitting";', 'submission phase'],
+  ['pub(super) async fn queue_sitemap_generation_background(', 'queue implementation'],
+  ['pub(super) async fn execute_next_sitemap_job_background(', 'worker implementation'],
+  ['async fn execute_sitemap_generation_phase(', 'generation worker phase'],
+  ['async fn execute_sitemap_submission_phase(', 'submission worker phase'],
+  ['async fn persist_background_sitemap_generation(', 'transactional generation persistence'],
+  ['async fn record_background_sitemap_submission(', 'transactional submission persistence'],
+  ['SeoSitemapGenerated', 'generated event'],
+  ['SeoSitemapSubmitted', 'submitted event'],
+  ['SITEMAP_JOB_SUBMITTING.to_string()', 'generation-to-submission checkpoint'],
+  ['SITEMAP_JOB_COMPLETED.to_string()', 'terminal completion'],
+  ['SITEMAP_JOB_RUNNING,\n                SITEMAP_JOB_SUBMITTING', 'active job resume'],
+  ['active.is_some()', 'tenant-local queue deduplication'],
+  ['urls.chunks(super::SITEMAP_CHUNK_SIZE)', 'bounded sitemap files'],
+]) {
+  requireText(worker, value, label);
+}
+
+forbidText(
+  applications,
+  'self.runtime.generate_sitemaps(tenant).await',
+  'synchronous sitemap facade routing',
+);
+forbidText(
+  graphql,
+  'execute_next_sitemap_job',
+  'worker execution from GraphQL request path',
+);
+
+const queueStart = worker.indexOf('pub(super) async fn queue_sitemap_generation_background(');
+const workerStart = worker.indexOf('pub(super) async fn execute_next_sitemap_job_background(');
+if (queueStart < 0 || workerStart < 0 || workerStart <= queueStart) {
+  failures.push('unable to isolate sitemap queue implementation');
+} else {
+  const queueBody = worker.slice(queueStart, workerStart);
+  for (const forbidden of [
+    'collect_background_sitemap_urls(',
+    'persist_background_sitemap_generation(',
+    'submit_background_sitemap_endpoints(',
+  ]) {
+    forbidText(queueBody, forbidden, 'request-path sitemap work');
+  }
+}
+
+if (failures.length > 0) {
+  console.error('SEO sitemap background-worker verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ sitemap mutations only enqueue and one worker invocation executes one durable generation or submission phase',
+);


### PR DESCRIPTION
## Summary

- change the existing sitemap generation application call from synchronous generation/submission to a durable `queued` sitemap job;
- deduplicate tenant-local `queued`, `running`, and `submitting` requests so repeated mutations do not create an unbounded active queue;
- add an explicit sitemap worker entry point that executes exactly one durable phase of one job per invocation;
- split processing into `queued -> running -> submitting -> completed` phases, with `failed` terminal handling for generation/configuration failures;
- persist generated sitemap files, job phase, and the generated event in one transaction;
- perform external endpoint submissions only from the `submitting` worker phase, then persist the terminal outcome and submitted event transactionally;
- resume the oldest `running` or `submitting` job before claiming another queued job;
- preserve the current 500-URL sitemap file chunking and the existing SSRF-hardened submission adapter by compiling the established sitemap helpers into the worker module;
- keep the GraphQL mutation return type unchanged: it now returns status for the queued job instead of blocking on generation and HTTP calls;
- add a permanent source guard preventing synchronous runtime generation or worker execution from the GraphQL request path.

## Boundary

The current SEO target-provider contract returns a complete sitemap candidate list rather than a paged cursor. This PR therefore bounds execution by one persisted job phase per worker invocation and keeps XML files at 500 URLs each, while candidate discovery within the generation phase remains whole-scope. Provider-level paged discovery is a separate cross-crate contract change.

Submission endpoint settings are re-read during the submission phase because the existing sitemap job schema has no payload column. Adding an immutable endpoint snapshot would require a migration and is intentionally outside this isolated slice.

## Validation

Tests, formatting commands, and verifier execution were not run at the repository owner's request. Module visibility, SeaORM job transitions, transaction boundaries, crash-resume states, event idempotency, tenant scoping, GraphQL routing, public-origin validation, and the final diff were reviewed statically.