### PR TITLE
Harden admin shipping HTTP errors

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/shipping.rs
+++ b/crates/rustok-commerce/src/controllers/admin/shipping.rs
@@ -15,13 +15,85 @@ use super::{
     ListShippingOptionsParams, ListShippingProfilesParams,
 };
 use crate::{
-    ShippingProfileService,
+    CommerceError, ShippingProfileService,
     dto::{
         CreateShippingOptionInput, CreateShippingProfileInput, ListShippingProfilesInput,
         ShippingOptionResponse, ShippingProfileResponse, UpdateShippingOptionInput,
         UpdateShippingProfileInput,
     },
 };
+
+fn map_shipping_profile_error(error: CommerceError) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        CommerceError::ShippingProfileNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        CommerceError::DuplicateShippingProfileSlug(_) => (
+            StatusCode::CONFLICT,
+            "commerce_admin_shipping_profile_conflict",
+            "A shipping profile with this slug already exists",
+            "duplicate_slug",
+        ),
+        CommerceError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_shipping_profile_invalid",
+            "Shipping profile request is invalid",
+            "validation",
+        ),
+        CommerceError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_shipping_profile_storage_unavailable",
+            "Shipping profile storage is temporarily unavailable",
+            "database",
+        ),
+        CommerceError::ProductNotFound(_)
+        | CommerceError::VariantNotFound(_)
+        | CommerceError::DuplicateHandle { .. }
+        | CommerceError::DuplicateSku(_)
+        | CommerceError::InvalidPrice(_)
+        | CommerceError::InsufficientInventory { .. }
+        | CommerceError::InvalidOptionCombination
+        | CommerceError::NoVariants
+        | CommerceError::CannotDeletePublished
+        | CommerceError::Rich(_)
+        | CommerceError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_shipping_profile_failed",
+            "Shipping profile operation could not be completed safely",
+            "unexpected_commerce_error",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_commerce.shipping_profile",
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_admin_shipping_http",
+        "commerce admin shipping profile operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+async fn validate_shipping_option_profile_inputs(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    allowed_shipping_profile_slugs: Option<&Vec<String>>,
+) -> HttpResult<()> {
+    let Some(slugs) = allowed_shipping_profile_slugs else {
+        return Ok(());
+    };
+
+    ShippingProfileService::new(db.clone())
+        .ensure_shipping_profile_slugs_exist(tenant_id, slugs.iter())
+        .await
+        .map_err(map_shipping_profile_error)?;
+
+    Ok(())
+}
 
 /// List admin shipping profiles
 #[utoipa::path(
@@ -62,7 +134,7 @@ pub async fn list_shipping_profiles(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok(Json(PaginatedResponse {
         data: items,
@@ -96,7 +168,7 @@ pub async fn create_shipping_profile(
     let profile = ShippingProfileService::new(runtime.db_clone())
         .create_shipping_profile(tenant.id, input)
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok((StatusCode::CREATED, Json(profile)))
 }
@@ -134,7 +206,7 @@ pub async fn show_shipping_profile(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok(Json(profile))
 }
@@ -168,7 +240,7 @@ pub async fn update_shipping_profile(
     let profile = ShippingProfileService::new(runtime.db_clone())
         .update_shipping_profile(tenant.id, id, input)
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok(Json(profile))
 }
@@ -200,7 +272,7 @@ pub async fn deactivate_shipping_profile(
     let profile = ShippingProfileService::new(runtime.db_clone())
         .deactivate_shipping_profile(tenant.id, id)
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok(Json(profile))
 }
@@ -232,7 +304,7 @@ pub async fn reactivate_shipping_profile(
     let profile = ShippingProfileService::new(runtime.db_clone())
         .reactivate_shipping_profile(tenant.id, id)
         .await
-        .map_err(super::map_shipping_profile_error)?;
+        .map_err(map_shipping_profile_error)?;
 
     Ok(Json(profile))
 }
@@ -269,7 +341,7 @@ pub async fn list_shipping_options(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_fulfillment_error)?;
     if let Some(active) = params.active {
         items.retain(|option| option.active == active);
     }
@@ -321,7 +393,7 @@ pub async fn create_shipping_option(
         "Permission denied: fulfillments:create required",
     )?;
 
-    super::validate_shipping_option_profile_inputs(
+    validate_shipping_option_profile_inputs(
         runtime.db(),
         tenant.id,
         input.allowed_shipping_profile_slugs.as_ref(),
@@ -331,7 +403,7 @@ pub async fn create_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .create_shipping_option(tenant.id, input)
         .await
-        .map_err(|err| HttpError::bad_request("commerce_operation_failed", err.to_string()))?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok((StatusCode::CREATED, Json(option)))
 }
@@ -369,12 +441,7 @@ pub async fn show_shipping_option(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(|err| match err {
-            rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_) => {
-                HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-            }
-            other => HttpError::bad_request("commerce_operation_failed", other.to_string()),
-        })?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(option))
 }
@@ -405,7 +472,7 @@ pub async fn update_shipping_option(
         "Permission denied: fulfillments:update required",
     )?;
 
-    super::validate_shipping_option_profile_inputs(
+    validate_shipping_option_profile_inputs(
         runtime.db(),
         tenant.id,
         input.allowed_shipping_profile_slugs.as_ref(),
@@ -415,12 +482,7 @@ pub async fn update_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .update_shipping_option(tenant.id, id, input)
         .await
-        .map_err(|err| match err {
-            rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_) => {
-                HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-            }
-            other => HttpError::bad_request("commerce_operation_failed", other.to_string()),
-        })?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(option))
 }
@@ -452,12 +514,7 @@ pub async fn deactivate_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .deactivate_shipping_option(tenant.id, id)
         .await
-        .map_err(|err| match err {
-            rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_) => {
-                HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-            }
-            other => HttpError::bad_request("commerce_operation_failed", other.to_string()),
-        })?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(option))
 }
@@ -489,12 +546,7 @@ pub async fn reactivate_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .reactivate_shipping_option(tenant.id, id)
         .await
-        .map_err(|err| match err {
-            rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_) => {
-                HttpError::not_found("commerce_admin_not_found", "Commerce resource not found")
-            }
-            other => HttpError::bad_request("commerce_operation_failed", other.to_string()),
-        })?;
+        .map_err(super::map_fulfillment_error)?;
 
     Ok(Json(option))
 }

--- a/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const shippingService = read('crates/rustok-commerce/src/services/shipping_profile.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['CommerceError, ShippingProfileService', 'typed commerce error import'],
+  ['fn map_shipping_profile_error(error: CommerceError)', 'local shipping profile mapper'],
+  ['async fn validate_shipping_option_profile_inputs(', 'local profile validation helper'],
+  ['error = ?error', 'raw internal error logging'],
+  ['owner = "rustok_commerce.shipping_profile"', 'owner logging'],
+  ['error_kind,', 'error-kind logging'],
+  ['public_code = code', 'public-code logging'],
+  ['status = %status', 'status logging'],
+  ['boundary = "commerce_admin_shipping_http"', 'shipping HTTP boundary logging'],
+  ['HttpError::new(status, code, message)', 'static public envelope construction'],
+]) {
+  requireText(shipping, value, label);
+}
+
+for (const [value, label] of [
+  ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'duplicate profile slug mapping'],
+  ['CommerceError::Validation(_)', 'profile validation mapping'],
+  ['CommerceError::Database(_)', 'profile database mapping'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"commerce_admin_not_found"', 'shared not-found code'],
+  ['"commerce_admin_shipping_profile_conflict"', 'profile conflict code'],
+  ['"commerce_admin_shipping_profile_invalid"', 'profile invalid code'],
+  ['"commerce_admin_shipping_profile_storage_unavailable"', 'profile storage code'],
+  ['"commerce_admin_shipping_profile_failed"', 'profile fail-closed code'],
+  ['"unexpected_commerce_error"', 'unexpected owner variant kind'],
+]) {
+  requireText(shipping, value, label);
+}
+
+for (const value of [
+  'CommerceError::ProductNotFound(_)',
+  'CommerceError::VariantNotFound(_)',
+  'CommerceError::DuplicateHandle { .. }',
+  'CommerceError::DuplicateSku(_)',
+  'CommerceError::InvalidPrice(_)',
+  'CommerceError::InsufficientInventory { .. }',
+  'CommerceError::InvalidOptionCombination',
+  'CommerceError::NoVariants',
+  'CommerceError::CannotDeletePublished',
+  'CommerceError::Rich(_)',
+  'CommerceError::Core(_)',
+]) {
+  requireText(shipping, value, 'fail-closed unrelated commerce variant');
+}
+
+for (const [value, label] of [
+  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
+  ['ProductNotFound(Uuid)', 'owner product variant'],
+  ['VariantNotFound(Uuid)', 'owner variant variant'],
+  ['DuplicateHandle { handle: String, locale: String }', 'owner duplicate handle variant'],
+  ['DuplicateSku(String)', 'owner duplicate SKU variant'],
+  ['InvalidPrice(String)', 'owner invalid price variant'],
+  ['InsufficientInventory { requested: i32, available: i32 }', 'owner inventory variant'],
+  ['InvalidOptionCombination', 'owner option-combination variant'],
+  ['Validation(String)', 'owner validation variant'],
+  ['ShippingProfileNotFound(Uuid)', 'owner shipping profile variant'],
+  ['DuplicateShippingProfileSlug(String)', 'owner duplicate profile slug variant'],
+  ['NoVariants', 'owner no-variants variant'],
+  ['CannotDeletePublished', 'owner published-delete variant'],
+  ['Rich(#[source] Box<RichError>)', 'owner rich variant'],
+  ['Core(#[from] CoreError)', 'owner core variant'],
+]) {
+  requireText(commerceErrors, value, label);
+}
+
+for (const [value, label] of [
+  ['Validation(String)', 'fulfillment validation variant'],
+  ['ShippingOptionNotFound(Uuid)', 'fulfillment shipping option variant'],
+  ['FulfillmentNotFound(Uuid)', 'fulfillment resource variant'],
+  ['InvalidTransition { from: String, to: String }', 'fulfillment transition variant'],
+  ['Database(#[from] DbErr)', 'fulfillment database variant'],
+]) {
+  requireText(fulfillmentErrors, value, label);
+}
+
+for (const [value, label] of [
+  ['CommerceError::Validation(error.to_string())', 'shipping service validation construction'],
+  ['CommerceError::ShippingProfileNotFound(shipping_profile_id)', 'shipping service not-found construction'],
+  ['CommerceError::DuplicateShippingProfileSlug(', 'shipping service conflict construction'],
+  ['active_profile.insert(&self.db).await?;', 'shipping service database propagation'],
+]) {
+  requireText(shippingService, value, label);
+}
+
+for (const [value, label] of [
+  ['pub async fn list_shipping_profiles(', 'profile list handler'],
+  ['pub async fn create_shipping_profile(', 'profile create handler'],
+  ['pub async fn show_shipping_profile(', 'profile detail handler'],
+  ['pub async fn update_shipping_profile(', 'profile update handler'],
+  ['pub async fn deactivate_shipping_profile(', 'profile deactivate handler'],
+  ['pub async fn reactivate_shipping_profile(', 'profile reactivate handler'],
+  ['pub async fn list_shipping_options(', 'option list handler'],
+  ['pub async fn create_shipping_option(', 'option create handler'],
+  ['pub async fn show_shipping_option(', 'option detail handler'],
+  ['pub async fn update_shipping_option(', 'option update handler'],
+  ['pub async fn deactivate_shipping_option(', 'option deactivate handler'],
+  ['pub async fn reactivate_shipping_option(', 'option reactivate handler'],
+  ['list_shipping_profiles(', 'profile list service call'],
+  ['create_shipping_profile(tenant.id, input)', 'profile create service call'],
+  ['get_shipping_profile(', 'profile detail service call'],
+  ['update_shipping_profile(tenant.id, id, input)', 'profile update service call'],
+  ['deactivate_shipping_profile(tenant.id, id)', 'profile deactivate service call'],
+  ['reactivate_shipping_profile(tenant.id, id)', 'profile reactivate service call'],
+  ['list_all_shipping_options(', 'option list service call'],
+  ['create_shipping_option(tenant.id, input)', 'option create service call'],
+  ['get_shipping_option(', 'option detail service call'],
+  ['update_shipping_option(tenant.id, id, input)', 'option update service call'],
+  ['deactivate_shipping_option(tenant.id, id)', 'option deactivate service call'],
+  ['reactivate_shipping_option(tenant.id, id)', 'option reactivate service call'],
+  ['page: pagination.page', 'pagination page forwarding'],
+  ['per_page: pagination.limit()', 'pagination size forwarding'],
+  ['items.retain(|option| option.active == active)', 'active filter'],
+  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
+  ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
+  ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
+]) {
+  requireText(shipping, value, label);
+}
+
+for (const value of [
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+  'super::map_shipping_profile_error',
+  'super::validate_shipping_option_profile_inputs',
+]) {
+  forbidText(shipping, value, 'unsafe admin shipping public conversion');
+}
+
+const profileMapperUses = shipping.match(/map_shipping_profile_error\(/g) ?? [];
+if (profileMapperUses.length !== 8) {
+  failures.push(`expected profile mapper definition plus seven uses, found ${profileMapperUses.length}`);
+}
+
+const fulfillmentMapperUses =
+  shipping.match(/\.map_err\(super::map_fulfillment_error\)\?;/g) ?? [];
+if (fulfillmentMapperUses.length !== 6) {
+  failures.push(`expected six shipping-option fulfillment mapper callsites, found ${fulfillmentMapperUses.length}`);
+}
+
+const localValidationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
+if (localValidationUses.length !== 3) {
+  failures.push(`expected local validation helper definition plus two uses, found ${localValidationUses.length}`);
+}
+
+requireText(
+  admin,
+  'pub(crate) fn map_fulfillment_error(error: FulfillmentError)',
+  'shared fulfillment mapper used by shipping options',
+);
+
+if (failures.length > 0) {
+  console.error('Commerce admin shipping HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin shipping profile and option errors use stable typed public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace all admin shipping-profile `CommerceError` string publication with a local exhaustive typed HTTP mapper;
- map profile not-found, duplicate slug, validation, and database failures to stable 404/409/400/503 envelopes;
- fail closed with a static 500 envelope for commerce variants that cannot originate from `ShippingProfileService`;
- keep raw owner errors only in structured internal logs with owner, error kind, public code, status, and boundary;
- use a local profile-slug validation helper so shipping-option create/update do not pass through the older unsafe shared mapper;
- route all six shipping-option owner error callsites through the existing exhaustive `map_fulfillment_error` mapper;
- add a verifier for owner enum coverage, stable status/code policy, handler/service-call preservation, filters, pagination, and forbidden dynamic public conversions.

## Scope

Two files only: the admin shipping controller and one static verifier. Routes, permissions, request/response DTOs, locale fallback, service arguments, shipping-profile validation order, option filtering, pagination, and success responses are unchanged.

## Public policy

- shipping profile not found: `404 commerce_admin_not_found`;
- duplicate shipping profile slug: `409 commerce_admin_shipping_profile_conflict`;
- shipping profile validation: `400 commerce_admin_shipping_profile_invalid`;
- shipping profile storage outage: `503 commerce_admin_shipping_profile_storage_unavailable`;
- impossible/unexpected commerce owner variant: `500 commerce_admin_shipping_profile_failed`;
- shipping option validation/not-found/state-conflict/storage failures reuse the shared typed fulfillment HTTP policy.

## Validation

- source-level audit completed against current `CommerceError`, `FulfillmentError`, and `ShippingProfileService` contracts;
- controller no longer contains `err.to_string()`, `other.to_string()`, `commerce_operation_failed`, or calls to the old shared shipping-profile mapper;
- tests, cargo commands, formatting commands, and verifier execution were not run, per request.