### PR TITLE
perf(seo): queue index repair and replay work

### DIFF
--- a/crates/rustok-seo/docs/replay-repair-runbook.md
+++ b/crates/rustok-seo/docs/replay-repair-runbook.md
@@ -9,17 +9,19 @@
 ## Operational order (tenant-safe)
 
 1. Capture the current status: `seoIndexDeliveryStatus` or `GET /api/seo/index/tracking`.
-2. If there are `failed`/`dead_letter` entries, first run `repair_only` (`runSeoIndexRepairReplay` with `replayHistorical=false`).
-3. For historical backfill, run `repair + historical replay` (`replayHistorical=true`).
-4. Re-running replay is now idempotent: already sent historical transitions are not duplicated.
-5. Verify the cursor timeline: expect forward-only progression (`not_started -> repair_only -> replay_requested -> replaying -> replay_completed`) without backward transitions.
+2. If there are `failed`/`dead_letter` entries, queue `repair_only` (`runSeoIndexRepairReplay` with `replayHistorical=false`). The mutation validates and persists the job; it no longer performs repair work in the request.
+3. Ensure the server SEO background worker is enabled through `runtime.background_workers.seo_bulk_enabled`. The existing poller advances at most one bulk job, one sitemap phase, and one index repair/replay job per poll.
+4. Re-check index tracking after the worker completes the queued job. For historical backfill, then queue `repair + historical replay` (`replayHistorical=true`).
+5. Re-running replay is idempotent: already sent historical transitions are not duplicated.
+6. Verify the cursor timeline: expect forward-only progression (`not_started -> repair_only -> replay_requested -> replaying -> replay_completed`) without backward transitions.
 
 ## Troubleshooting
 
+- **Queued work does not progress**: confirm the host runs background workers and `runtime.background_workers.seo_bulk_enabled` is enabled.
 - **`PERMISSION_DENIED`**: the operator needs `seo:manage`.
 - **`BAD_USER_INPUT`**: check `target_type` (`content|product`) and `limit` (`1..500`).
-- **`dead_letter` remains after replay**: run `repair_only`, then re-check the health of the index consumer/outbox relay.
-- **Repeated replay returns `replayed_count=0`**: this is expected with dedup (no new historical transitions).
+- **`dead_letter` remains after replay**: queue `repair_only`, then re-check the health of the index consumer/outbox relay.
+- **Repeated replay produces no new deliveries**: this is expected with dedup when there are no new historical transitions.
 
 ## Verification evidence (last batch)
 

--- a/crates/rustok-seo/src/migrations/m20260724_000008_create_seo_index_repair_jobs.rs
+++ b/crates/rustok-seo/src/migrations/m20260724_000008_create_seo_index_repair_jobs.rs
@@ -1,0 +1,123 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(SeoIndexRepairJobs::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(SeoIndexRepairJobs::TenantId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::Status)
+                            .string_len(32)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SeoIndexRepairJobs::TargetType).string_len(64))
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::Limit)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::ReplayHistorical)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::RepairedCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::ReplayedCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::HistoricalEventsScanned)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(ColumnDef::new(SeoIndexRepairJobs::ReplayRunId).uuid())
+                    .col(ColumnDef::new(SeoIndexRepairJobs::LastError).string_len(2048))
+                    .col(ColumnDef::new(SeoIndexRepairJobs::StartedAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(SeoIndexRepairJobs::CompletedAt).timestamp_with_time_zone())
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SeoIndexRepairJobs::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_seo_index_repair_jobs_status_created")
+                    .table(SeoIndexRepairJobs::Table)
+                    .col(SeoIndexRepairJobs::Status)
+                    .col(SeoIndexRepairJobs::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_seo_index_repair_jobs_tenant_created")
+                    .table(SeoIndexRepairJobs::Table)
+                    .col(SeoIndexRepairJobs::TenantId)
+                    .col(SeoIndexRepairJobs::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(SeoIndexRepairJobs::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum SeoIndexRepairJobs {
+    Table,
+    Id,
+    TenantId,
+    Status,
+    TargetType,
+    Limit,
+    ReplayHistorical,
+    RepairedCount,
+    ReplayedCount,
+    HistoricalEventsScanned,
+    ReplayRunId,
+    LastError,
+    StartedAt,
+    CompletedAt,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/rustok-seo/src/migrations/mod.rs
+++ b/crates/rustok-seo/src/migrations/mod.rs
@@ -4,6 +4,7 @@ mod m20260420_000004_create_seo_bulk_tables;
 mod m20260421_000005_create_seo_event_deliveries;
 mod m20260602_000006_create_seo_index_tracking;
 mod m20260716_000007_add_redirect_cache_cursor_index;
+mod m20260724_000008_create_seo_index_repair_jobs;
 
 use sea_orm_migration::prelude::*;
 
@@ -15,5 +16,6 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260421_000005_create_seo_event_deliveries::Migration),
         Box::new(m20260602_000006_create_seo_index_tracking::Migration),
         Box::new(m20260716_000007_add_redirect_cache_cursor_index::Migration),
+        Box::new(m20260724_000008_create_seo_index_repair_jobs::Migration),
     ]
 }

--- a/crates/rustok-seo/src/services/applications.rs
+++ b/crates/rustok-seo/src/services/applications.rs
@@ -442,7 +442,20 @@ impl SeoOperationsService {
         replay_historical: bool,
     ) -> SeoResult<SeoIndexRepairReplayResultRecord> {
         self.runtime
-            .run_index_repair_replay(tenant_id, target_type, limit, replay_historical)
+            .queue_index_repair_replay_background(
+                tenant_id,
+                target_type,
+                limit,
+                replay_historical,
+            )
+            .await
+    }
+
+    pub async fn execute_next_index_repair_replay_job(
+        &self,
+    ) -> SeoResult<Option<SeoIndexRepairReplayResultRecord>> {
+        self.runtime
+            .execute_next_index_repair_replay_job_background()
             .await
     }
 }

--- a/crates/rustok-seo/src/services/bulk.rs
+++ b/crates/rustok-seo/src/services/bulk.rs
@@ -3,6 +3,7 @@ include!("bulk_bounded_execution.rs");
 include!("bulk_io_bounded_execution.rs");
 include!("bulk_io_bounded_compat.rs");
 include!("sitemap_background.rs");
+include!("index_repair_background.rs");
 
 #[cfg(test)]
 mod bulk_read_model {

--- a/crates/rustok-seo/src/services/bulk_io_bounded_compat.rs
+++ b/crates/rustok-seo/src/services/bulk_io_bounded_compat.rs
@@ -2,6 +2,40 @@ impl SeoService {
     pub(super) async fn execute_next_bulk_job_with_bounded_io(
         &self,
     ) -> SeoResult<Option<SeoBulkJobRecord>> {
+        // The server already owns one configured SEO poller. Keep that stable lifecycle boundary,
+        // but let every poll advance at most one bounded job from each durable SEO queue.
+        let bulk_result = self.execute_next_bulk_job_only_with_bounded_io().await;
+        let sitemap_result = self.execute_next_sitemap_job_background().await;
+        let index_result = self
+            .execute_next_index_repair_replay_job_background()
+            .await;
+
+        if let Ok(Some(job)) = &sitemap_result {
+            tracing::info!(
+                job_id = %job.id,
+                status = %job.status,
+                "Executed queued SEO sitemap job phase"
+            );
+        }
+        if let Ok(Some(result)) = &index_result {
+            tracing::info!(
+                target_type = ?result.target_type,
+                replay_mode = %result.replay_mode.as_str(),
+                repaired_count = result.repaired_count,
+                replayed_count = result.replayed_count,
+                "Executed queued SEO index repair/replay job"
+            );
+        }
+
+        let bulk_job = bulk_result?;
+        sitemap_result?;
+        index_result?;
+        Ok(bulk_job)
+    }
+
+    async fn execute_next_bulk_job_only_with_bounded_io(
+        &self,
+    ) -> SeoResult<Option<SeoBulkJobRecord>> {
         let running = seo_bulk_job::Entity::find()
             .filter(seo_bulk_job::Column::Status.eq(SeoBulkJobStatus::Running.as_str()))
             .filter(seo_bulk_job::Column::OperationKind.is_in([

--- a/crates/rustok-seo/src/services/index_repair_background.rs
+++ b/crates/rustok-seo/src/services/index_repair_background.rs
@@ -1,0 +1,241 @@
+mod index_repair_background_impl {
+    use super::*;
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{
+        ActiveModelTrait as _, ColumnTrait as _, EntityTrait as _, QueryFilter as _,
+        QueryOrder as _,
+    };
+
+    const INDEX_REPAIR_JOB_QUEUED: &str = "queued";
+    const INDEX_REPAIR_JOB_RUNNING: &str = "running";
+    const INDEX_REPAIR_JOB_COMPLETED: &str = "completed";
+    const INDEX_REPAIR_JOB_FAILED: &str = "failed";
+    const INDEX_REPAIR_JOB_MAX_LIMIT: usize = 500;
+
+    mod job_entity {
+        use sea_orm::entity::prelude::*;
+        use serde::{Deserialize, Serialize};
+        use uuid::Uuid;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+        #[sea_orm(table_name = "seo_index_repair_jobs")]
+        pub struct Model {
+            #[sea_orm(primary_key, auto_increment = false)]
+            pub id: Uuid,
+            pub tenant_id: Uuid,
+            pub status: String,
+            pub target_type: Option<String>,
+            pub limit: i32,
+            pub replay_historical: bool,
+            pub repaired_count: i32,
+            pub replayed_count: i32,
+            pub historical_events_scanned: i32,
+            pub replay_run_id: Option<Uuid>,
+            pub last_error: Option<String>,
+            pub started_at: Option<DateTimeWithTimeZone>,
+            pub completed_at: Option<DateTimeWithTimeZone>,
+            pub created_at: DateTimeWithTimeZone,
+            pub updated_at: DateTimeWithTimeZone,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
+    impl SeoService {
+        pub(super) async fn queue_index_repair_replay_background(
+            &self,
+            tenant_id: Uuid,
+            target_type: Option<&str>,
+            limit: usize,
+            replay_historical: bool,
+        ) -> SeoResult<crate::dto::SeoIndexRepairReplayResultRecord> {
+            let target_type = normalize_background_index_target_type(target_type)?;
+            let bounded_limit = limit.clamp(1, INDEX_REPAIR_JOB_MAX_LIMIT);
+
+            let active = job_entity::Entity::find()
+                .filter(job_entity::Column::TenantId.eq(tenant_id))
+                .filter(
+                    job_entity::Column::Status
+                        .is_in([INDEX_REPAIR_JOB_QUEUED, INDEX_REPAIR_JOB_RUNNING]),
+                )
+                .order_by_asc(job_entity::Column::CreatedAt)
+                .one(&self.db)
+                .await?;
+            if let Some(active) = active {
+                return Ok(map_background_index_repair_job(&active));
+            }
+
+            let now = chrono::Utc::now().fixed_offset();
+            let job = job_entity::ActiveModel {
+                id: Set(Uuid::new_v4()),
+                tenant_id: Set(tenant_id),
+                status: Set(INDEX_REPAIR_JOB_QUEUED.to_string()),
+                target_type: Set(target_type),
+                limit: Set(bounded_limit as i32),
+                replay_historical: Set(replay_historical),
+                repaired_count: Set(0),
+                replayed_count: Set(0),
+                historical_events_scanned: Set(0),
+                replay_run_id: Set(None),
+                last_error: Set(None),
+                started_at: Set(None),
+                completed_at: Set(None),
+                created_at: Set(now),
+                updated_at: Set(now),
+            }
+            .insert(&self.db)
+            .await?;
+
+            Ok(map_background_index_repair_job(&job))
+        }
+
+        pub(super) async fn execute_next_index_repair_replay_job_background(
+            &self,
+        ) -> SeoResult<Option<crate::dto::SeoIndexRepairReplayResultRecord>> {
+            let running = job_entity::Entity::find()
+                .filter(job_entity::Column::Status.eq(INDEX_REPAIR_JOB_RUNNING))
+                .order_by_asc(job_entity::Column::UpdatedAt)
+                .one(&self.db)
+                .await?;
+
+            let job = if let Some(running) = running {
+                running
+            } else {
+                let Some(queued) = job_entity::Entity::find()
+                    .filter(job_entity::Column::Status.eq(INDEX_REPAIR_JOB_QUEUED))
+                    .order_by_asc(job_entity::Column::CreatedAt)
+                    .one(&self.db)
+                    .await?
+                else {
+                    return Ok(None);
+                };
+
+                let now = chrono::Utc::now().fixed_offset();
+                let mut active: job_entity::ActiveModel = queued.into();
+                active.status = Set(INDEX_REPAIR_JOB_RUNNING.to_string());
+                active.started_at = Set(Some(now));
+                active.completed_at = Set(None);
+                active.last_error = Set(None);
+                active.updated_at = Set(now);
+                active.update(&self.db).await?
+            };
+
+            let result = self
+                .run_index_repair_replay(
+                    job.tenant_id,
+                    job.target_type.as_deref(),
+                    job.limit.clamp(1, INDEX_REPAIR_JOB_MAX_LIMIT as i32) as usize,
+                    job.replay_historical,
+                )
+                .await;
+
+            let result = match result {
+                Ok(result) => result,
+                Err(error) => {
+                    self.fail_background_index_repair_job(&job, error.to_string())
+                        .await?;
+                    return Err(error);
+                }
+            };
+
+            let current = job_entity::Entity::find_by_id(job.id)
+                .one(&self.db)
+                .await?
+                .ok_or(SeoError::NotFound)?;
+            let now = chrono::Utc::now().fixed_offset();
+            let mut active: job_entity::ActiveModel = current.into();
+            active.status = Set(INDEX_REPAIR_JOB_COMPLETED.to_string());
+            active.repaired_count = Set(result.repaired_count);
+            active.replayed_count = Set(result.replayed_count);
+            active.historical_events_scanned = Set(result.historical_events_scanned);
+            active.replay_run_id = Set(result.replay_run_id);
+            active.last_error = Set(None);
+            active.completed_at = Set(Some(now));
+            active.updated_at = Set(now);
+            let completed = active.update(&self.db).await?;
+
+            Ok(Some(map_background_index_repair_job(&completed)))
+        }
+
+        async fn fail_background_index_repair_job(
+            &self,
+            job: &job_entity::Model,
+            message: String,
+        ) -> SeoResult<()> {
+            let current = job_entity::Entity::find_by_id(job.id)
+                .one(&self.db)
+                .await?
+                .ok_or(SeoError::NotFound)?;
+            let now = chrono::Utc::now().fixed_offset();
+            let mut active: job_entity::ActiveModel = current.into();
+            active.status = Set(INDEX_REPAIR_JOB_FAILED.to_string());
+            active.last_error = Set(Some(rustok_core::truncate(message.trim(), 2048)));
+            active.completed_at = Set(Some(now));
+            active.updated_at = Set(now);
+            active.update(&self.db).await?;
+            Ok(())
+        }
+    }
+
+    fn normalize_background_index_target_type(
+        target_type: Option<&str>,
+    ) -> SeoResult<Option<String>> {
+        let Some(value) = target_type else {
+            return Ok(None);
+        };
+        let normalized = value.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return Ok(None);
+        }
+        match normalized.as_str() {
+            "content" | "product" => Ok(Some(normalized)),
+            _ => Err(SeoError::validation(format!(
+                "unsupported index target_type `{}`; expected `content` or `product`",
+                value.trim()
+            ))),
+        }
+    }
+
+    fn map_background_index_repair_job(
+        job: &job_entity::Model,
+    ) -> crate::dto::SeoIndexRepairReplayResultRecord {
+        let replay_mode = if job.status == INDEX_REPAIR_JOB_COMPLETED {
+            if job.replay_historical {
+                crate::dto::SeoIndexReplayMode::ReplayCompleted
+            } else {
+                crate::dto::SeoIndexReplayMode::RepairOnly
+            }
+        } else {
+            crate::dto::SeoIndexReplayMode::NotStarted
+        };
+        crate::dto::SeoIndexRepairReplayResultRecord {
+            target_type: job.target_type.clone(),
+            limit: job.limit,
+            replay_mode,
+            repaired_count: job.repaired_count,
+            replayed_count: job.replayed_count,
+            historical_events_scanned: job.historical_events_scanned,
+            replay_run_id: job.replay_run_id,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn worker_limit_matches_existing_operator_bound() {
+            assert_eq!(INDEX_REPAIR_JOB_MAX_LIMIT, 500);
+        }
+
+        #[test]
+        fn worker_states_are_durable_and_distinct() {
+            assert_ne!(INDEX_REPAIR_JOB_QUEUED, INDEX_REPAIR_JOB_RUNNING);
+            assert_ne!(INDEX_REPAIR_JOB_RUNNING, INDEX_REPAIR_JOB_COMPLETED);
+            assert_ne!(INDEX_REPAIR_JOB_COMPLETED, INDEX_REPAIR_JOB_FAILED);
+        }
+    }
+}

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -37,11 +37,11 @@ Automated verification is recorded separately because direct pushes currently do
   - [x] Load bulk-list explicit metadata and translations in bounded batches and reuse one settings/module snapshot. (#2082)
   - [x] Reuse the batched full projection for bulk selection, preview, queue sizing, and CSV export execution. (#2083)
   - [x] Batch diagnostics metadata and page-context reads while retaining the current single-target owner-provider contract. (#2085)
-- [ ] Move synchronous in-memory SEO pipelines to bounded background execution.
+- [x] Move synchronous in-memory SEO pipelines to bounded background execution.
   - [x] Snapshot bulk-apply targets and checkpoint at most 50 targets per worker invocation. (#2092)
   - [x] Snapshot bulk-export targets and checkpoint export/import work at most 50 rows per worker invocation. (#2095)
   - [x] Queue sitemap generation and submission outside request paths and execute one durable phase per worker invocation. (#2098)
-  - [ ] Move index repair and replay execution outside request paths.
+  - [x] Queue bounded index repair/replay jobs outside request paths and resume durable worker execution. (#2100)
 - [ ] Require explicit authorization for worker and operator entry points.
 - [ ] Classify retryable, terminal, validation, and configuration failures explicitly.
 
@@ -53,4 +53,4 @@ Automated verification is recorded separately because direct pushes currently do
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
 - [ ] Confirm GitHub Actions status checks for the hardening commits.
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, and #2098 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, and #2100 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-index-repair-background-worker.mjs
+++ b/scripts/verify/verify-seo-index-repair-background-worker.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const applications = read('crates/rustok-seo/src/services/applications.rs');
+const bulkModule = read('crates/rustok-seo/src/services/bulk.rs');
+const compatibilityPoller = read(
+  'crates/rustok-seo/src/services/bulk_io_bounded_compat.rs',
+);
+const worker = read('crates/rustok-seo/src/services/index_repair_background.rs');
+const migrations = read('crates/rustok-seo/src/migrations/mod.rs');
+const migration = read(
+  'crates/rustok-seo/src/migrations/m20260724_000008_create_seo_index_repair_jobs.rs',
+);
+const graphql = read('crates/rustok-seo/src/graphql/mod.rs');
+const hostLifecycle = read('apps/server/src/services/app_lifecycle.rs');
+
+requireText(
+  bulkModule,
+  'include!("index_repair_background.rs");',
+  'background index repair include',
+);
+requireText(
+  applications,
+  '.queue_index_repair_replay_background(',
+  'request-path enqueue routing',
+);
+requireText(
+  applications,
+  'pub async fn execute_next_index_repair_replay_job(',
+  'worker application boundary',
+);
+requireText(
+  applications,
+  '.execute_next_index_repair_replay_job_background()',
+  'worker runtime routing',
+);
+for (const [value, label] of [
+  ['const INDEX_REPAIR_JOB_QUEUED: &str = "queued";', 'queued state'],
+  ['const INDEX_REPAIR_JOB_RUNNING: &str = "running";', 'running state'],
+  ['const INDEX_REPAIR_JOB_COMPLETED: &str = "completed";', 'completed state'],
+  ['const INDEX_REPAIR_JOB_FAILED: &str = "failed";', 'failed state'],
+  ['const INDEX_REPAIR_JOB_MAX_LIMIT: usize = 500;', 'bounded worker limit'],
+  ['pub(super) async fn queue_index_repair_replay_background(', 'queue implementation'],
+  ['pub(super) async fn execute_next_index_repair_replay_job_background(', 'worker implementation'],
+  ['job_entity::Column::Status.eq(INDEX_REPAIR_JOB_RUNNING)', 'running job resume'],
+  ['job_entity::Column::Status.eq(INDEX_REPAIR_JOB_QUEUED)', 'queued job claim'],
+  ['.run_index_repair_replay(', 'bounded legacy execution inside worker'],
+  ['active.status = Set(INDEX_REPAIR_JOB_COMPLETED.to_string());', 'terminal checkpoint'],
+  ['fail_background_index_repair_job', 'durable failure checkpoint'],
+]) {
+  requireText(worker, value, label);
+}
+for (const [value, label] of [
+  ['execute_next_bulk_job_only_with_bounded_io()', 'bounded bulk poll'],
+  ['execute_next_sitemap_job_background()', 'sitemap queue poll'],
+  ['execute_next_index_repair_replay_job_background()', 'index queue poll'],
+]) {
+  requireText(compatibilityPoller, value, label);
+}
+requireText(
+  hostLifecycle,
+  'service.bulk().execute_next_bulk_job().await',
+  'server SEO poller lifecycle',
+);
+requireText(
+  migrations,
+  'mod m20260724_000008_create_seo_index_repair_jobs;',
+  'migration module registration',
+);
+requireText(
+  migration,
+  '.table(SeoIndexRepairJobs::Table)',
+  'durable job table',
+);
+requireText(
+  migration,
+  'idx_seo_index_repair_jobs_status_created',
+  'worker claim index',
+);
+forbidText(
+  applications,
+  '.run_index_repair_replay(tenant_id, target_type, limit, replay_historical)',
+  'synchronous application routing',
+);
+forbidText(
+  graphql,
+  'execute_next_index_repair_replay_job',
+  'worker execution from GraphQL request path',
+);
+
+const queueStart = worker.indexOf('pub(super) async fn queue_index_repair_replay_background(');
+const workerStart = worker.indexOf(
+  'pub(super) async fn execute_next_index_repair_replay_job_background(',
+);
+if (queueStart < 0 || workerStart < 0 || workerStart <= queueStart) {
+  failures.push('unable to isolate index repair queue implementation');
+} else {
+  const queueBody = worker.slice(queueStart, workerStart);
+  forbidText(queueBody, '.run_index_repair_replay(', 'request-path repair/replay execution');
+}
+
+if (failures.length > 0) {
+  console.error('SEO index repair background-worker verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ index repair/replay requests enqueue durable jobs and the configured server SEO poller advances bulk, sitemap, and index queues',
+);


### PR DESCRIPTION
## Summary

- replace synchronous index repair/replay application execution with a durable queued job;
- persist job parameters, lifecycle timestamps, bounded counters, replay run ID, and terminal errors in a dedicated `seo_index_repair_jobs` table;
- deduplicate tenant-local `queued` and `running` operator requests so repeated mutations do not create an unbounded active queue;
- add an explicit worker boundary that resumes the oldest running job before claiming another queued job;
- execute the existing repair/replay implementation only from the worker, preserving its `limit <= 500` bound and existing delivery/cursor idempotency behavior;
- extend the configured server SEO poller so every poll advances at most one bulk job, one sitemap phase, and one index repair/replay job;
- checkpoint `completed` counts and replay metadata after success, or `failed` state and a bounded error after failure;
- keep the existing GraphQL and native operator mutation shape: queued work returns the existing result record with `not_started` mode and zero persisted counters;
- update the replay/repair runbook for queued execution and the required worker configuration;
- add a permanent source guard preventing synchronous application routing, GraphQL worker execution, or an unconnected durable queue.

## Boundary

One worker invocation executes one persisted repair/replay job. The underlying implementation already bounds repair deliveries and historical event scans to at most 500 rows. If a process crashes after idempotent delivery work but before the job terminal checkpoint, the running job is retried; deterministic delivery keys prevent duplicate reindex transitions, although retry-visible counters can reflect only the final pass.

The existing result DTO has no job-status or job-ID fields. This isolated slice preserves that public contract rather than expanding every Rust and TypeScript client. Durable lifecycle data is persisted in the new table and the queued response uses `replay_mode = not_started`.

The host keeps its existing `runtime.background_workers.seo_bulk_enabled` lifecycle switch. Under that stable configuration boundary, the poller now advances all three SEO durable queues rather than leaving sitemap or index jobs stranded.

## Concurrency review

The branch was rebuilt as one commit on fresh `main`. Intervening commits changed Index evidence tooling and Commerce admin shipping only; none touched the SEO files in this slice.

## Validation

Tests, formatting commands, migrations, and verifier execution were not run at the repository owner's request. Migration/entity alignment, request routing, worker claim order, tenant-local deduplication, host poller wiring, failure persistence, the existing 500-row bound, and the final diff were reviewed statically.