### PR TITLE
fix(index): reject ordering hidden in PostgreSQL E strings

### DIFF
--- a/scripts/verify/check-index-storage-read-ordering.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.mjs
@@ -29,6 +29,14 @@ const fail = (message) => {
 
 const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 const maskSqlText = (text) => text.replace(/[^\r\n]/gu, ' ');
+const identifierContinuation = /[A-Za-z0-9_$]/u;
+
+const isEscapeStringQuote = (sql, quoteIndex) => {
+  const prefixIndex = quoteIndex - 1;
+  if (prefixIndex < 0 || (sql[prefixIndex] !== 'E' && sql[prefixIndex] !== 'e')) return false;
+  const beforePrefix = sql[prefixIndex - 1];
+  return beforePrefix === undefined || !identifierContinuation.test(beforePrefix);
+};
 
 const requireObject = (value, label) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -81,9 +89,17 @@ const executableSqlText = (sql, label) => {
     const quote = sql[index];
     if (quote === "'" || quote === '"') {
       const start = index;
+      const escapeString = quote === "'" && isEscapeStringQuote(sql, index);
       index += 1;
       let closed = false;
       while (index < sql.length) {
+        if (escapeString && sql[index] === '\\') {
+          if (index + 1 >= sql.length) {
+            fail(`${label}.sql contains an unterminated escape string literal`);
+          }
+          index += 2;
+          continue;
+        }
         if (sql[index] === quote) {
           if (sql[index + 1] === quote) {
             index += 2;
@@ -96,7 +112,9 @@ const executableSqlText = (sql, label) => {
         index += 1;
       }
       if (!closed) {
-        const kind = quote === "'" ? 'string literal' : 'quoted identifier';
+        const kind = quote === "'"
+          ? (escapeString ? 'escape string literal' : 'string literal')
+          : 'quoted identifier';
         fail(`${label}.sql contains an unterminated ${kind}`);
       }
       output += maskSqlText(sql.slice(start, index));

--- a/scripts/verify/check-index-storage-read-ordering.test.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -130,6 +130,12 @@ test('rejects an ordering marker hidden in a dollar-quoted string', () => {
   }, /typed_eav\/status_equality\.sql must end with canonical ordering marker/u);
 });
 
+test('rejects an ordering marker hidden after an escaped quote in an E string', () => {
+  expectFailure((value) => {
+    value.source_workloads[0].sql = "SELECT E'payload\\' ORDER BY entity_id LIMIT 100' --'";
+  }, /source\/status_equality\.sql must end with canonical ordering marker/u);
+});
+
 test('rejects unterminated SQL comments before ordering validation', () => {
   expectFailure((value) => {
     value.prototypes[2].workloads[0].sql = [

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -36,11 +36,16 @@ requireMarkers(preflight, 'read ordering preflight', [
   "'keyset_page'",
   "'exact_count'",
   'const maskSqlText = (text) =>',
+  'const identifierContinuation = /[A-Za-z0-9_$]/u',
+  'const isEscapeStringQuote = (sql, quoteIndex) =>',
   'const executableSqlText = (sql, label) =>',
   "sql.startsWith('--', index)",
   "sql.startsWith('/*', index)",
   'unterminated block comment',
-  "const kind = quote === \"'\" ? 'string literal' : 'quoted identifier'",
+  "const escapeString = quote === \"'\" && isEscapeStringQuote(sql, index)",
+  "escapeString && sql[index] === '\\\\'",
+  'unterminated escape string literal',
+  "? (escapeString ? 'escape string literal' : 'string literal')",
   'contains an unterminated ${kind}',
   'unterminated dollar-quoted string',
   'executableSql.trimEnd().endsWith(marker)',
@@ -63,6 +68,7 @@ requireMarkers(fixture, 'read ordering fixture', [
   "test('rejects a candidate ordering marker that exists only in a block comment'",
   "test('rejects a terminal ordering marker hidden in a line comment'",
   "test('rejects an ordering marker hidden in a dollar-quoted string'",
+  "test('rejects an ordering marker hidden after an escaped quote in an E string'",
   "test('rejects unterminated SQL comments before ordering validation'",
   "test('rejects workload order drift before checking SQL text'",
 ]);
@@ -158,4 +164,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] executable SQL lexer, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- recognize PostgreSQL `E'…'` escape-string literals in the standalone Index evidence SQL-ordering lexer;
- skip backslash-escaped characters so `\'` cannot terminate the masked string early;
- reject evidence where the canonical terminal `ORDER BY … LIMIT 100` marker exists only inside an escape string;
- add a focused regression fixture for the previously accepted bypass;
- extend the permanent read-ordering contract guard so escape-string handling and fixture coverage cannot be removed silently.

## Audit result

The canonical Index implementation plan still correctly keeps M2 open: replacement same-commit 100k/1m PostgreSQL evidence and the storage ADR remain required before M3 production persistence. The previously completed source-oracle, result-digest, provenance, standalone-wrapper, and terminal-ordering boundaries were re-read statically. The escape-string lexer gap was the actionable defect found in the latest ordering-preflight slice.

## Scope

Three verification files only. No benchmark SQL, evidence schema, production crate, migration, workflow, or runtime behavior changes.

## Validation

Tests, Node commands, formatting commands, benchmark runs, and CI were not run, per repository-owner instruction. The exploit shape, parser transition, guard markers, branch diff, and concurrent `main` change were reviewed statically.