### PR TITLE
security(seo): authorize worker and operator entry points

### DIFF
--- a/apps/server/src/services/app_lifecycle.rs
+++ b/apps/server/src/services/app_lifecycle.rs
@@ -13,9 +13,9 @@ use crate::services::event_transport_factory::{
 use crate::services::server_runtime_context::ServerRuntimeContext;
 use rustok_modules::ModuleControlPlane;
 #[cfg(feature = "mod-seo")]
-use rustok_seo::SeoApplicationServices;
+use rustok_seo::{SeoApplicationServices, SeoWorkerAuthorization};
 
-// в”Ђв”Ђ Graceful-shutdown handle в”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђв”Ђ
+// ── Graceful-shutdown handle ─────────────────────────────────────────────────
 
 /// Stored in `ServerRuntimeContext`; `on_shutdown` calls `stop()` to abort workers.
 #[derive(Clone)]
@@ -32,7 +32,7 @@ impl StopHandle {
     /// Create a new `Receiver` subscribed to the shutdown signal.
     ///
     /// The returned receiver immediately sees the current value and will be
-    /// notified when [`StopHandle::stop`] is called.  Clone it once per background worker
+    /// notified when [`StopHandle::stop`] is called. Clone it once per background worker
     /// so each worker gets its own independent view of the channel.
     pub fn subscribe(&self) -> tokio::sync::watch::Receiver<bool> {
         self.stop_tx.subscribe()
@@ -181,8 +181,8 @@ pub async fn connect_runtime_workers_with_runtime(runtime_ctx: ServerRuntimeCont
     }
 
     // Obtain a stop receiver from the stored handle so workers can observe
-    // the shutdown signal.  `subscribe()` creates a new independent receiver
-    // from the existing sender вЂ” safe to call multiple times.
+    // the shutdown signal. `subscribe()` creates a new independent receiver
+    // from the existing sender — safe to call multiple times.
     let stop_handle = runtime_ctx
         .shared_get::<StopHandle>()
         .expect("StopHandle must be registered before spawning workers");
@@ -210,9 +210,20 @@ pub async fn connect_runtime_workers_with_runtime(runtime_ctx: ServerRuntimeCont
 
     #[cfg(feature = "mod-seo")]
     if seo_bulk_worker_enabled && !runtime_ctx.shared_contains::<SeoBulkWorkerHandle>() {
+        let authorization = SeoWorkerAuthorization::from_runtime_config(
+            settings.runtime.runs_background_workers(),
+            seo_bulk_worker_enabled,
+        )
+        .map_err(|_| {
+            Error::Message(
+                "SEO worker execution is not authorized by runtime background-worker settings"
+                    .to_string(),
+            )
+        })?;
         runtime_ctx.shared_insert(spawn_seo_bulk_worker_handle(
             runtime_ctx.clone(),
             stop_rx.clone(),
+            authorization,
         ));
     } else if !seo_bulk_worker_enabled {
         tracing::info!("SEO bulk worker disabled by runtime.background_workers config");
@@ -270,12 +281,17 @@ fn spawn_remote_executor_reaper_handle(
 fn spawn_seo_bulk_worker_handle(
     runtime_ctx: ServerRuntimeContext,
     stop_rx: tokio::sync::watch::Receiver<bool>,
+    authorization: SeoWorkerAuthorization,
 ) -> SeoBulkWorkerHandle {
     let instance_id = SEO_BULK_WORKER_INSTANCE_IDS.fetch_add(1, Ordering::Relaxed);
     tracing::info!(worker = "seo_bulk", instance_id, "Starting runtime worker");
     SeoBulkWorkerHandle {
         instance_id,
-        _handle: tokio::spawn(seo_bulk_worker_loop(runtime_ctx, stop_rx)),
+        _handle: tokio::spawn(seo_bulk_worker_loop(
+            runtime_ctx,
+            stop_rx,
+            authorization,
+        )),
     }
 }
 
@@ -319,6 +335,7 @@ async fn remote_executor_reaper_loop(
 async fn seo_bulk_worker_loop(
     runtime_ctx: ServerRuntimeContext,
     mut stop_rx: tokio::sync::watch::Receiver<bool>,
+    authorization: SeoWorkerAuthorization,
 ) {
     let event_bus = transactional_event_bus_from_context(&runtime_ctx);
     let runtime_extensions = module_runtime_extensions_from_ctx(&runtime_ctx);
@@ -341,7 +358,11 @@ async fn seo_bulk_worker_loop(
             return;
         }
 
-        match service.bulk().execute_next_bulk_job().await {
+        match service
+            .bulk()
+            .execute_next_bulk_job(&authorization)
+            .await
+        {
             Ok(Some(job)) => tracing::info!(
                 job_id = %job.id,
                 operation = %job.operation_kind.as_str(),

--- a/crates/rustok-seo/src/authorization.rs
+++ b/crates/rustok-seo/src/authorization.rs
@@ -1,0 +1,37 @@
+use crate::{SeoError, SeoResult};
+
+/// Opaque proof that the host explicitly enabled the durable SEO worker runtime.
+///
+/// Worker execution is intentionally separated from request/operator authorization. The host may
+/// construct this grant only after both the process host mode and the SEO worker switch permit
+/// background execution. Application worker entry points require a reference to this value.
+#[derive(Debug, Clone)]
+pub struct SeoWorkerAuthorization {
+    _private: (),
+}
+
+impl SeoWorkerAuthorization {
+    pub fn from_runtime_config(
+        host_runs_background_workers: bool,
+        seo_worker_enabled: bool,
+    ) -> SeoResult<Self> {
+        if !host_runs_background_workers || !seo_worker_enabled {
+            return Err(SeoError::PermissionDenied);
+        }
+
+        Ok(Self { _private: () })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_authorization_requires_host_mode_and_worker_switch() {
+        assert!(SeoWorkerAuthorization::from_runtime_config(true, true).is_ok());
+        assert!(SeoWorkerAuthorization::from_runtime_config(false, true).is_err());
+        assert!(SeoWorkerAuthorization::from_runtime_config(true, false).is_err());
+        assert!(SeoWorkerAuthorization::from_runtime_config(false, false).is_err());
+    }
+}

--- a/crates/rustok-seo/src/controllers/mod.rs
+++ b/crates/rustok-seo/src/controllers/mod.rs
@@ -231,27 +231,14 @@ pub async fn sitemap_index(
         return Err(SeoHttpError::not_found("SEO sitemap index is disabled"));
     }
 
-    let file = match service
+    // Public sitemap delivery is read-only. Generation is an operator action and must be queued
+    // through the explicitly authorized GraphQL or native admin entry point.
+    let file = service
         .sitemaps()
         .latest_sitemap_index(tenant.id)
         .await
         .map_err(map_seo_http_error)?
-    {
-        Some(file) => file,
-        None => {
-            service
-                .sitemaps()
-                .generate_sitemaps(&tenant)
-                .await
-                .map_err(map_seo_http_error)?;
-            service
-                .sitemaps()
-                .latest_sitemap_index(tenant.id)
-                .await
-                .map_err(map_seo_http_error)?
-                .ok_or_else(|| SeoHttpError::not_found("SEO sitemap index not found"))?
-        }
-    };
+        .ok_or_else(|| SeoHttpError::not_found("SEO sitemap index not found"))?;
 
     Ok((
         [(CONTENT_TYPE, "application/xml; charset=utf-8")],

--- a/crates/rustok-seo/src/lib.rs
+++ b/crates/rustok-seo/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "server")]
+mod authorization;
+#[cfg(feature = "server")]
 pub mod controllers;
 pub mod dto;
 #[cfg(feature = "server")]
@@ -21,6 +23,8 @@ use rustok_core::{MigrationSource, RusToKModule};
 #[cfg(feature = "server")]
 use sea_orm_migration::MigrationTrait;
 
+#[cfg(feature = "server")]
+pub use authorization::SeoWorkerAuthorization;
 pub use dto::{
     SeoAlternateLink, SeoBulkApplyInput, SeoBulkApplyMode, SeoBulkArtifactRecord,
     SeoBulkBoolFieldPatch, SeoBulkExportInput, SeoBulkFieldPatchMode, SeoBulkImportInput,

--- a/crates/rustok-seo/src/services/applications.rs
+++ b/crates/rustok-seo/src/services/applications.rs
@@ -11,7 +11,6 @@ use rustok_seo_targets::{
     SeoTargetCapabilityKind, SeoTargetRegistry, SeoTargetRegistryEntry, SeoTargetSlug,
 };
 
-use crate::SeoResult;
 use crate::dto::{
     SeoBulkApplyInput, SeoBulkExportInput, SeoBulkImportInput, SeoBulkJobRecord, SeoBulkJobStatus,
     SeoBulkListInput, SeoBulkPage, SeoBulkSelectionInput, SeoBulkSelectionPreviewRecord,
@@ -21,6 +20,7 @@ use crate::dto::{
     SeoSitemapJobRecord, SeoSitemapStatusRecord,
 };
 use crate::entities::{seo_bulk_job_artifact, seo_sitemap_file};
+use crate::{SeoResult, SeoWorkerAuthorization};
 
 use super::SeoService;
 
@@ -258,7 +258,10 @@ impl SeoSitemapService {
         self.runtime.queue_sitemap_generation_background(tenant).await
     }
 
-    pub async fn execute_next_sitemap_job(&self) -> SeoResult<Option<SeoSitemapJobRecord>> {
+    pub async fn execute_next_sitemap_job(
+        &self,
+        _authorization: &SeoWorkerAuthorization,
+    ) -> SeoResult<Option<SeoSitemapJobRecord>> {
         self.runtime.execute_next_sitemap_job_background().await
     }
 
@@ -401,7 +404,10 @@ impl SeoBulkService {
             .await
     }
 
-    pub async fn execute_next_bulk_job(&self) -> SeoResult<Option<SeoBulkJobRecord>> {
+    pub async fn execute_next_bulk_job(
+        &self,
+        _authorization: &SeoWorkerAuthorization,
+    ) -> SeoResult<Option<SeoBulkJobRecord>> {
         self.runtime.execute_next_bulk_job_with_bounded_io().await
     }
 }
@@ -453,6 +459,7 @@ impl SeoOperationsService {
 
     pub async fn execute_next_index_repair_replay_job(
         &self,
+        _authorization: &SeoWorkerAuthorization,
     ) -> SeoResult<Option<SeoIndexRepairReplayResultRecord>> {
         self.runtime
             .execute_next_index_repair_replay_job_background()

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -42,7 +42,7 @@ Automated verification is recorded separately because direct pushes currently do
   - [x] Snapshot bulk-export targets and checkpoint export/import work at most 50 rows per worker invocation. (#2095)
   - [x] Queue sitemap generation and submission outside request paths and execute one durable phase per worker invocation. (#2098)
   - [x] Queue bounded index repair/replay jobs outside request paths and resume durable worker execution. (#2100)
-- [ ] Require explicit authorization for worker and operator entry points.
+- [x] Require explicit authorization for worker and operator entry points. (#2107)
 - [ ] Classify retryable, terminal, validation, and configuration failures explicitly.
 
 ## Verification status
@@ -53,4 +53,4 @@ Automated verification is recorded separately because direct pushes currently do
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
 - [ ] Confirm GitHub Actions status checks for the hardening commits.
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, and #2100 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, #2100, and #2107 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-entrypoint-authorization.mjs
+++ b/scripts/verify/verify-seo-entrypoint-authorization.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const sliceBetween = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const authorization = read('crates/rustok-seo/src/authorization.rs');
+const applications = read('crates/rustok-seo/src/services/applications.rs');
+const lifecycle = read('apps/server/src/services/app_lifecycle.rs');
+const controllers = read('crates/rustok-seo/src/controllers/mod.rs');
+const graphql = read('crates/rustok-seo/src/graphql/mod.rs');
+const nativeAdmin = read(
+  'crates/rustok-seo/admin/src/transport/native_server_adapter.rs',
+);
+
+for (const [value, label] of [
+  ['pub struct SeoWorkerAuthorization', 'opaque worker grant'],
+  ['_private: ()', 'private worker grant field'],
+  ['pub fn from_runtime_config(', 'config-backed grant factory'],
+  ['if !host_runs_background_workers || !seo_worker_enabled', 'fail-closed runtime authorization'],
+  ['return Err(SeoError::PermissionDenied);', 'worker authorization rejection'],
+]) {
+  requireText(authorization, value, label);
+}
+
+for (const [signature, label] of [
+  ['pub async fn execute_next_sitemap_job(', 'sitemap worker facade'],
+  ['pub async fn execute_next_bulk_job(', 'bulk worker facade'],
+  ['pub async fn execute_next_index_repair_replay_job(', 'index worker facade'],
+]) {
+  const block = sliceBetween(applications, signature, '\n    }', label);
+  requireText(block, '_authorization: &SeoWorkerAuthorization', `${label} grant`);
+}
+
+for (const [value, label] of [
+  ['SeoWorkerAuthorization::from_runtime_config(', 'host grant construction'],
+  ['settings.runtime.runs_background_workers()', 'host worker-mode authorization'],
+  ['seo_bulk_worker_enabled', 'SEO worker-switch authorization'],
+  ['authorization: SeoWorkerAuthorization', 'grant ownership in worker loop'],
+  ['.execute_next_bulk_job(&authorization)', 'authorized worker execution'],
+]) {
+  requireText(lifecycle, value, label);
+}
+forbidText(
+  lifecycle,
+  'service.bulk().execute_next_bulk_job().await',
+  'unauthorized worker call',
+);
+
+const sitemapIndex = sliceBetween(
+  controllers,
+  'pub async fn sitemap_index(',
+  '\npub async fn sitemap_file(',
+  'public sitemap index',
+);
+requireText(
+  sitemapIndex,
+  'SeoHttpError::not_found("SEO sitemap index not found")',
+  'missing sitemap fail closed',
+);
+forbidText(sitemapIndex, '.generate_sitemaps(', 'public GET sitemap generation');
+
+const restIndexRepair = sliceBetween(
+  controllers,
+  'pub async fn index_repair_replay_json(',
+  '\npub async fn bulk_artifact_download(',
+  'REST index operator',
+);
+requireText(restIndexRepair, 'auth: AuthContext', 'REST authenticated operator');
+requireText(restIndexRepair, 'Permission::SEO_MANAGE', 'REST index manage permission');
+
+const graphqlSitemap = sliceBetween(
+  graphql,
+  'async fn generate_seo_sitemaps(',
+  '\n    async fn queue_seo_bulk_apply(',
+  'GraphQL sitemap operator',
+);
+requireText(graphqlSitemap, 'Permission::SEO_GENERATE', 'GraphQL sitemap generate permission');
+const graphqlIndex = sliceBetween(
+  graphql,
+  'async fn run_seo_index_repair_replay(',
+  '\n}',
+  'GraphQL index operator',
+);
+requireText(graphqlIndex, 'Permission::SEO_MANAGE', 'GraphQL index manage permission');
+for (const forbidden of [
+  'execute_next_bulk_job',
+  'execute_next_sitemap_job',
+  'execute_next_index_repair_replay_job',
+]) {
+  forbidText(graphql, forbidden, 'GraphQL worker execution');
+}
+
+const nativeSitemap = sliceBetween(
+  nativeAdmin,
+  'pub(super) async fn seo_generate_sitemaps_native(',
+  '\n#[server(prefix = "/api/fn", endpoint = "seo/settings")]',
+  'native sitemap operator',
+);
+requireText(nativeSitemap, 'Permission::SEO_GENERATE', 'native sitemap generate permission');
+const nativeIndex = sliceBetween(
+  nativeAdmin,
+  'pub(super) async fn seo_index_repair_replay_native(',
+  '\n#[cfg(all(test, feature = "ssr"))]',
+  'native index operator',
+);
+requireText(nativeIndex, 'Permission::SEO_MANAGE', 'native index manage permission');
+
+if (failures.length > 0) {
+  console.error('SEO entrypoint authorization verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ SEO worker execution requires an explicit runtime grant and external operator entry points remain RBAC-gated',
+);

--- a/scripts/verify/verify-seo-index-repair-background-worker.mjs
+++ b/scripts/verify/verify-seo-index-repair-background-worker.mjs
@@ -47,6 +47,11 @@ requireText(
 );
 requireText(
   applications,
+  '_authorization: &SeoWorkerAuthorization',
+  'worker authorization grant',
+);
+requireText(
+  applications,
   '.execute_next_index_repair_replay_job_background()',
   'worker runtime routing',
 );
@@ -73,11 +78,14 @@ for (const [value, label] of [
 ]) {
   requireText(compatibilityPoller, value, label);
 }
-requireText(
-  hostLifecycle,
-  'service.bulk().execute_next_bulk_job().await',
-  'server SEO poller lifecycle',
-);
+for (const [value, label] of [
+  ['SeoWorkerAuthorization::from_runtime_config(', 'host worker authorization'],
+  ['settings.runtime.runs_background_workers()', 'host-mode authorization input'],
+  ['seo_bulk_worker_enabled', 'SEO worker switch authorization input'],
+  ['.execute_next_bulk_job(&authorization)', 'authorized server SEO poller lifecycle'],
+]) {
+  requireText(hostLifecycle, value, label);
+}
 requireText(
   migrations,
   'mod m20260724_000008_create_seo_index_repair_jobs;',
@@ -103,6 +111,11 @@ forbidText(
   'execute_next_index_repair_replay_job',
   'worker execution from GraphQL request path',
 );
+forbidText(
+  hostLifecycle,
+  'service.bulk().execute_next_bulk_job().await',
+  'unauthorized server worker execution',
+);
 
 const queueStart = worker.indexOf('pub(super) async fn queue_index_repair_replay_background(');
 const workerStart = worker.indexOf(
@@ -122,5 +135,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ index repair/replay requests enqueue durable jobs and the configured server SEO poller advances bulk, sitemap, and index queues',
+  '✔ index repair/replay requests enqueue durable jobs and the explicitly authorized server SEO poller advances all durable queues',
 );

--- a/scripts/verify/verify-seo-sitemap-background-worker.mjs
+++ b/scripts/verify/verify-seo-sitemap-background-worker.mjs
@@ -34,8 +34,13 @@ requireText(
 );
 requireText(
   applications,
-  'pub async fn execute_next_sitemap_job(&self)',
+  'pub async fn execute_next_sitemap_job(',
   'worker application boundary',
+);
+requireText(
+  applications,
+  '_authorization: &SeoWorkerAuthorization',
+  'worker authorization grant',
 );
 requireText(
   applications,
@@ -96,5 +101,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ sitemap mutations only enqueue and one worker invocation executes one durable generation or submission phase',
+  '✔ sitemap mutations only enqueue and authorized worker invocations execute one durable generation or submission phase',
 );


### PR DESCRIPTION
## Summary

- require an explicit `SeoWorkerAuthorization` grant before public application worker facades can execute bulk, sitemap, or index repair/replay jobs;
- derive that grant in the server lifecycle only when the process runs background workers and `runtime.background_workers.seo_bulk_enabled` is enabled;
- pass the grant through the existing SEO poller instead of exposing no-argument worker execution;
- make public `/sitemap.xml` delivery read-only so an unauthenticated GET cannot enqueue sitemap generation;
- preserve and source-guard the existing operator RBAC boundaries: `seo:generate` for sitemap generation and `seo:manage` for index repair/replay across GraphQL, REST, and native admin transports;
- add a permanent authorization verifier and extend the existing sitemap/index worker guards.

## Security boundary

`SeoWorkerAuthorization` is a process-local API capability derived from host configuration. It makes worker execution explicit at compile time and fails closed when the host mode or SEO worker switch is disabled. This is an in-process application boundary, not a cryptographic credential between mutually hostile Rust crates.

Public sitemap requests now return `404` when no generated index exists. Generation must be requested through an authenticated operator entry point and completed by the authorized worker runtime.

## Concurrency review

The branch was rebuilt as one commit on fresh `main`. Concurrent commits touched Commerce, Forum, and internal SEO worker implementation files, but did not overlap the authorization, application facade, controller, lifecycle, roadmap, or verifier files in this slice.

## Validation

Tests, formatting commands, migrations, and verifier execution were not run at the repository owner's request. The reconstructed Rust files, permission checks, worker grant flow, public sitemap behavior, and final source diff were reviewed statically.