### PR TITLE
feat(forum): add inherited category visibility policy

### DIFF
--- a/crates/rustok-forum/contracts/forum-category-visibility-policy.json
+++ b/crates/rustok-forum/contracts/forum-category-visibility-policy.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20B",
+  "scope": "Forum-owned inherited category visibility policy foundation",
+  "enum_file": "crates/rustok-forum/src/visibility.rs",
+  "entity_file": "crates/rustok-forum/src/entities/forum_category_policy.rs",
+  "owner_file": "crates/rustok-forum/src/services/category_visibility.rs",
+  "migration_file": "crates/rustok-forum/src/migrations/m20260724_000002_add_forum_category_visibility_policy.rs",
+  "migration_registry_file": "crates/rustok-forum/src/migrations/mod.rs",
+  "topic_policy_file": "crates/rustok-forum/src/services/category_policy.rs",
+  "services_file": "crates/rustok-forum/src/services/mod.rs",
+  "crate_file": "crates/rustok-forum/src/lib.rs",
+  "test_file": "crates/rustok-forum/tests/category_visibility_policy_sqlite.rs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "category_bound": 512,
+  "maximum_depth": 16,
+  "policy": {
+    "root_default": "public",
+    "stored_override": "authenticated",
+    "missing_override": "inherit from the nearest authenticated ancestor or remain public",
+    "broadening_rule": "public clears a local override only beneath an effective public parent",
+    "database_rule": "visibility_override is null or authenticated"
+  },
+  "compatibility": {
+    "existing_category_rows_require_backfill": false,
+    "allows_topics_preserved": true,
+    "transport_changes": false,
+    "storefront_changes": false,
+    "topic_visibility_scope_changes": false
+  },
+  "not_delivered": [
+    "topic read composition",
+    "reply read composition",
+    "authenticated storefront filtering",
+    "role visibility",
+    "trust-level visibility",
+    "group membership visibility",
+    "explicit allow and deny",
+    "visibility-scoped category and all-read mutations",
+    "search notification SEO and deep-link migration",
+    "PostgreSQL inheritance runtime evidence"
+  ],
+  "verification": {
+    "command": "cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture",
+    "source_verifier": "node scripts/verify/verify-forum-category-visibility-policy.mjs",
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A centralizes the existing open/public-or-exact-channel topic policy in a bounded exact owner scope and guards storefront topic facades; inherited category ACL, authenticated/role/trust/group rules, explicit allow/deny and cross-consumer composition remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A centralizes the existing open/public-or-exact-channel topic policy; FORUM-20B adds bounded inherited public/authenticated category policy storage and owner evaluation. Read composition, role/trust/group rules, explicit allow/deny and cross-consumer authorization remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1104,22 +1104,52 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - this slice adds no migration, transport field, endpoint or UI and does not
   claim category inheritance, roles, groups, trust or explicit allow/deny.
 
+### Delivered in `FORUM-20B`
+
+- `ForumCategoryVisibility` defines the typed effective category audience floor
+  currently supported by Forum: `public` and `authenticated`;
+- `forum_category_policies.visibility_override` is nullable and stores only the
+  narrowing `authenticated` override; PostgreSQL and SQLite reject an explicit
+  `public` row, so a descendant cannot broaden an authenticated ancestor through
+  direct persistence;
+- `ForumCategoryVisibilityPolicyService` resolves the complete tenant category
+  hierarchy within the existing 512-node and depth-16 bounds, reports the exact
+  category that supplies an inherited authenticated floor, and fails closed for
+  missing, foreign, cyclic or over-bound trees;
+- the owner `set` command is guarded by `forum_categories:manage`; requesting
+  `public` clears a local override only beneath an effective public parent, while
+  requesting `authenticated` narrows the category and all descendants;
+- the existing `allows_topics` policy shares the row without overwriting the new
+  visibility field, and existing categories require no backfill because absence
+  remains the public root default;
+- `forum-category-visibility-policy.json`,
+  `category_visibility_policy_sqlite` and
+  `verify-forum-category-visibility-policy.mjs` lock inheritance, tenant
+  isolation, monotonic narrowing and database enforcement;
+- the static audit also repairs the already-merged FORUM-20A storefront drift
+  error to construct the typed `rustok_core::Error` required by
+  `ForumError::Internal`;
+- this slice adds no transport, storefront, topic/reply read composition, role,
+  trust, group or explicit allow/deny behavior.
+
 ### Compatibility and degraded mode
 
-No migration or backfill is required. Existing public and exact-channel
-storefront results remain unchanged, and channel slugs retain the existing
-trim/lowercase behavior and schema-compatible 128-character limit without a new
-alphabet restriction. The existing SQL list selector remains a compatibility
-prefilter while the public facade performs the authoritative exact-page recheck.
-Missing optional future channel/group capability providers do not broaden the
-current public/exact-channel result; their membership semantics remain closed
-until explicit owner ports are composed.
+The new column is nullable and requires no backfill. Existing categories remain
+public until an owner command stores an authenticated floor, and existing
+`allows_topics` values remain unchanged. Current public/exact-channel storefront
+selection remains the FORUM-20A contract because FORUM-20B intentionally does
+not compose the category policy into topic/reply reads or transport entrypoints.
+Missing future channel/group capability providers cannot broaden results; their
+membership semantics remain closed until explicit owner ports are composed.
 
 ### Remaining scope
 
-- add typed category policy rows with inheritance and topic narrowing rules;
-- add authenticated-only, role, trust-level, group and explicit allow/deny
-  evaluation through owner capability ports;
+- compose inherited public/authenticated category policy into every topic/reply
+  owner read and add authenticated storefront filtering without page/count drift;
+- add role, trust-level, channel-member, group-member and explicit allow/deny
+  evaluation through bounded owner capability ports;
+- add create/reply/moderate audience policies and topic narrowing that cannot
+  broaden the effective category policy;
 - migrate all Forum reads, notifications, search/index, SEO and deep-link open
   authorization to the same owner policy;
 - add visibility-scoped category and all-read commands only after the owner can
@@ -1136,14 +1166,17 @@ profiles.
 
 ```bash
 cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
+node scripts/verify/verify-forum-category-visibility-policy.mjs
 cargo xtask module validate forum
 npm run verify:forum:storefront-boundary
 ```
 
-Tests, Cargo, verifiers and CI were not run while publishing this source-ready
-owner-scope slice. `FORUM-20` remains `in_progress` until inherited ACL and all
-consumer paths use the complete policy.
+Tests, Cargo, verifiers and CI were not run while publishing the source-ready
+FORUM-20B owner-policy slice. `FORUM-20` remains `in_progress` until inherited
+policy is composed into reads and all remaining audience/cross-consumer paths
+use the complete policy.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -1846,6 +1879,7 @@ cargo test -p rustok-forum --test storefront_read_state_contract -- --nocapture
 cargo test -p rustok-forum --test storefront_read_state_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_read_state_postgres -- --nocapture --test-threads=1
 cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1865,6 +1899,7 @@ node scripts/verify/verify-forum-quote-commands.mjs
 node scripts/verify/verify-forum-mention-runtime-proof.mjs
 node scripts/verify/verify-forum-read-state-runtime-proof.mjs
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
+node scripts/verify/verify-forum-category-visibility-policy.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -1916,8 +1951,9 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` with inherited typed category ACL, owner capability ports
-    and migration of reads, notifications, search, SEO and deep-link checks;
+12. continue `FORUM-20` by composing inherited public/authenticated category
+    policy into owner reads, then add role/trust/group/allow-deny capability ports
+    and migrate notifications, search, SEO and deep-link checks;
 13. `FORUM-23`: index projections;
 14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.

--- a/crates/rustok-forum/src/entities/forum_category_policy.rs
+++ b/crates/rustok-forum/src/entities/forum_category_policy.rs
@@ -2,6 +2,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::visibility::ForumCategoryVisibility;
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "forum_category_policies")]
 pub struct Model {
@@ -9,6 +11,7 @@ pub struct Model {
     pub category_id: Uuid,
     pub tenant_id: Uuid,
     pub allows_topics: bool,
+    pub visibility_override: Option<ForumCategoryVisibility>,
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -23,6 +23,7 @@ mod seo_targets;
 pub mod services;
 pub mod state_machine;
 pub mod subscription;
+pub mod visibility;
 
 pub use constants::*;
 pub use dto::*;
@@ -31,16 +32,19 @@ pub use error::{ForumError, ForumResult};
 pub use graphql::{ForumMutation, ForumQuery};
 pub use mentions::*;
 pub use services::{
-    CategoryService, ForumEventService, ForumQuoteCommandService, ForumReadModelService,
-    ForumRelationReadService, ForumStorefrontReadStateService, ForumStorefrontUnreadTopic,
-    ForumStorefrontUnreadTopicPage, ForumTopicReadState, ForumTopicReadStateService,
-    ForumTopicUnreadSummary, ForumTopicVisibilityScope, ForumTopicVisibilityService,
-    ForumWidgetContractService, MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES, MarkForumTopicReadInput,
+    CategoryService, ForumCategoryVisibilityPolicy, ForumCategoryVisibilityPolicyService,
+    ForumEventService, ForumQuoteCommandService, ForumReadModelService, ForumRelationReadService,
+    ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage,
+    ForumTopicReadState, ForumTopicReadStateService, ForumTopicUnreadSummary,
+    ForumTopicVisibilityScope, ForumTopicVisibilityService, ForumWidgetContractService,
+    MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES, MarkForumTopicReadInput,
     MarkForumTopicsReadBatchInput, MarkForumTopicsReadBatchResult, ModerationService, ReplyService,
-    RevisionService, SubscriptionService, TopicService, UserStatsService, VoteService,
+    RevisionService, SetForumCategoryVisibilityPolicyInput, SubscriptionService, TopicService,
+    UserStatsService, VoteService,
 };
 pub use state_machine::{ReplyStatus, TopicStatus};
 pub use subscription::{ForumDigestMode, ForumSubscriptionLevel, ForumSubscriptionPreferences};
+pub use visibility::ForumCategoryVisibility;
 
 pub struct ForumModule;
 

--- a/crates/rustok-forum/src/migrations/m20260724_000002_add_forum_category_visibility_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260724_000002_add_forum_category_visibility_policy.rs
@@ -1,0 +1,117 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("forum_category_policies"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("visibility_override")).string_len(32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => up_postgres(manager).await,
+            DatabaseBackend::Sqlite => up_sqlite(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum category visibility migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => down_postgres(manager).await?,
+            DatabaseBackend::Sqlite => down_sqlite(manager).await?,
+            backend => {
+                return Err(DbErr::Custom(format!(
+                    "rustok-forum category visibility migration does not support {backend:?}"
+                )));
+            }
+        }
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("forum_category_policies"))
+                    .drop_column(Alias::new("visibility_override"))
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+async fn up_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+ALTER TABLE forum_category_policies
+    DROP CONSTRAINT IF EXISTS ck_forum_category_visibility_override;
+ALTER TABLE forum_category_policies
+    ADD CONSTRAINT ck_forum_category_visibility_override
+    CHECK (
+        visibility_override IS NULL
+        OR visibility_override = 'authenticated'
+    );
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn down_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "ALTER TABLE forum_category_policies DROP CONSTRAINT IF EXISTS ck_forum_category_visibility_override",
+        )
+        .await?;
+    Ok(())
+}
+
+async fn up_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    for statement in [
+        "DROP TRIGGER IF EXISTS forum_category_visibility_override_insert",
+        "DROP TRIGGER IF EXISTS forum_category_visibility_override_update",
+        r#"CREATE TRIGGER forum_category_visibility_override_insert
+           BEFORE INSERT ON forum_category_policies
+           FOR EACH ROW
+           WHEN NEW.visibility_override IS NOT NULL
+             AND NEW.visibility_override <> 'authenticated'
+           BEGIN
+               SELECT RAISE(ABORT, 'forum category visibility override must narrow to authenticated');
+           END"#,
+        r#"CREATE TRIGGER forum_category_visibility_override_update
+           BEFORE UPDATE OF visibility_override ON forum_category_policies
+           FOR EACH ROW
+           WHEN NEW.visibility_override IS NOT NULL
+             AND NEW.visibility_override <> 'authenticated'
+           BEGIN
+               SELECT RAISE(ABORT, 'forum category visibility override must narrow to authenticated');
+           END"#,
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+    Ok(())
+}
+
+async fn down_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    for statement in [
+        "DROP TRIGGER IF EXISTS forum_category_visibility_override_update",
+        "DROP TRIGGER IF EXISTS forum_category_visibility_override_insert",
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+    Ok(())
+}

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -28,6 +28,7 @@ mod m20260722_000004_add_forum_mention_quote_relations;
 mod m20260722_000005_seed_forum_relation_revisions;
 mod m20260722_000006_add_forum_mention_events;
 mod m20260724_000001_add_forum_topic_read_states;
+mod m20260724_000002_add_forum_category_visibility_policy;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -64,6 +65,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260722_000005_seed_forum_relation_revisions::Migration),
         Box::new(m20260722_000006_add_forum_mention_events::Migration),
         Box::new(m20260724_000001_add_forum_topic_read_states::Migration),
+        Box::new(m20260724_000002_add_forum_category_visibility_policy::Migration),
     ]
 }
 

--- a/crates/rustok-forum/src/services/category_policy.rs
+++ b/crates/rustok-forum/src/services/category_policy.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use sea_orm::{
-    ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, TransactionTrait,
+    ActiveValue::{NotSet, Set},
+    ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, TransactionTrait,
     sea_query::OnConflict,
 };
 use uuid::Uuid;
@@ -61,6 +62,7 @@ impl CategoryTopicPolicyService {
             category_id: Set(category.id),
             tenant_id: Set(tenant_id),
             allows_topics: Set(input.allows_topics),
+            visibility_override: NotSet,
             updated_at: Set(Utc::now().into()),
         })
         .on_conflict(

--- a/crates/rustok-forum/src/services/category_visibility.rs
+++ b/crates/rustok-forum/src/services/category_visibility.rs
@@ -161,7 +161,7 @@ impl CategoryVisibilitySnapshot {
         {
             if let Some(visibility) = policy.visibility_override {
                 if visibility != ForumCategoryVisibility::Authenticated {
-                    return Err(ForumError::Internal(
+                    return Err(ForumError::Validation(
                         "Forum category visibility storage contains a broadening override"
                             .to_string(),
                     ));

--- a/crates/rustok-forum/src/services/category_visibility.rs
+++ b/crates/rustok-forum/src/services/category_visibility.rs
@@ -1,0 +1,250 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::Utc;
+use sea_orm::{
+    ActiveValue::{NotSet, Set},
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, TransactionTrait,
+    sea_query::OnConflict,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
+
+use crate::dto::{MAX_FORUM_CATEGORY_TREE_DEPTH, MAX_FORUM_CATEGORY_TREE_NODES};
+use crate::entities::{forum_category, forum_category_policy};
+use crate::error::{ForumError, ForumResult};
+use crate::services::rbac::enforce_scope;
+use crate::visibility::ForumCategoryVisibility;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumCategoryVisibilityPolicy {
+    pub category_id: Uuid,
+    pub configured_visibility: Option<ForumCategoryVisibility>,
+    pub effective_visibility: ForumCategoryVisibility,
+    pub effective_from_category_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SetForumCategoryVisibilityPolicyInput {
+    pub visibility: ForumCategoryVisibility,
+}
+
+/// Forum-owned category visibility policy.
+///
+/// The root default is public. A nullable row override may only narrow a category
+/// and its descendants to authenticated users. Clearing a local override is
+/// allowed only when the effective parent remains public, so a child can never
+/// broaden an authenticated ancestor.
+pub struct ForumCategoryVisibilityPolicyService {
+    db: DatabaseConnection,
+}
+
+impl ForumCategoryVisibilityPolicyService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn get(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<ForumCategoryVisibilityPolicy> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Read)?;
+        CategoryVisibilitySnapshot::load(&self.db, tenant_id)
+            .await?
+            .policy(category_id)
+    }
+
+    pub async fn set(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: SetForumCategoryVisibilityPolicyInput,
+    ) -> ForumResult<ForumCategoryVisibilityPolicy> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+
+        let txn = self.db.begin().await?;
+        let snapshot = CategoryVisibilitySnapshot::load(&txn, tenant_id).await?;
+        snapshot.policy(category_id)?;
+
+        let requested_override = match input.visibility {
+            ForumCategoryVisibility::Authenticated => {
+                Some(ForumCategoryVisibility::Authenticated)
+            }
+            ForumCategoryVisibility::Public => {
+                if snapshot.parent_effective(category_id)?.effective_visibility
+                    == ForumCategoryVisibility::Authenticated
+                {
+                    return Err(ForumError::Validation(
+                        "Forum category visibility cannot broaden an authenticated ancestor"
+                            .to_string(),
+                    ));
+                }
+                None
+            }
+        };
+
+        let existing = forum_category_policy::Entity::find_by_id(category_id)
+            .filter(forum_category_policy::Column::TenantId.eq(tenant_id))
+            .one(&txn)
+            .await?;
+
+        if requested_override.is_some() || existing.is_some() {
+            forum_category_policy::Entity::insert(forum_category_policy::ActiveModel {
+                category_id: Set(category_id),
+                tenant_id: Set(tenant_id),
+                allows_topics: existing
+                    .as_ref()
+                    .map(|policy| Set(policy.allows_topics))
+                    .unwrap_or(NotSet),
+                visibility_override: Set(requested_override),
+                updated_at: Set(Utc::now().into()),
+            })
+            .on_conflict(
+                OnConflict::column(forum_category_policy::Column::CategoryId)
+                    .update_columns([
+                        forum_category_policy::Column::TenantId,
+                        forum_category_policy::Column::VisibilityOverride,
+                        forum_category_policy::Column::UpdatedAt,
+                    ])
+                    .to_owned(),
+            )
+            .exec_without_returning(&txn)
+            .await?;
+        }
+
+        let result = CategoryVisibilitySnapshot::load(&txn, tenant_id)
+            .await?
+            .policy(category_id)?;
+        txn.commit().await?;
+        Ok(result)
+    }
+}
+
+struct CategoryVisibilitySnapshot {
+    parents: HashMap<Uuid, Option<Uuid>>,
+    overrides: HashMap<Uuid, ForumCategoryVisibility>,
+}
+
+impl CategoryVisibilitySnapshot {
+    async fn load<C>(db: &C, tenant_id: Uuid) -> ForumResult<Self>
+    where
+        C: ConnectionTrait,
+    {
+        let categories = forum_category::Entity::find()
+            .filter(forum_category::Column::TenantId.eq(tenant_id))
+            .order_by_asc(forum_category::Column::Id)
+            .limit(MAX_FORUM_CATEGORY_TREE_NODES + 1)
+            .all(db)
+            .await?;
+        if categories.len() > MAX_FORUM_CATEGORY_TREE_NODES as usize {
+            return Err(ForumError::Validation(format!(
+                "Forum category visibility tree exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
+            )));
+        }
+
+        let parents = categories
+            .into_iter()
+            .map(|category| (category.id, category.parent_id))
+            .collect::<HashMap<_, _>>();
+        let mut overrides = HashMap::new();
+        for policy in forum_category_policy::Entity::find()
+            .filter(forum_category_policy::Column::TenantId.eq(tenant_id))
+            .all(db)
+            .await?
+        {
+            if let Some(visibility) = policy.visibility_override {
+                if visibility != ForumCategoryVisibility::Authenticated {
+                    return Err(ForumError::Internal(
+                        "Forum category visibility storage contains a broadening override"
+                            .to_string(),
+                    ));
+                }
+                overrides.insert(policy.category_id, visibility);
+            }
+        }
+
+        let snapshot = Self { parents, overrides };
+        for category_id in snapshot.parents.keys().copied().collect::<Vec<_>>() {
+            snapshot.resolve(category_id)?;
+        }
+        Ok(snapshot)
+    }
+
+    fn policy(&self, category_id: Uuid) -> ForumResult<ForumCategoryVisibilityPolicy> {
+        let resolved = self.resolve(category_id)?;
+        Ok(ForumCategoryVisibilityPolicy {
+            category_id,
+            configured_visibility: self.overrides.get(&category_id).copied(),
+            effective_visibility: resolved.effective_visibility,
+            effective_from_category_id: resolved.effective_from_category_id,
+        })
+    }
+
+    fn parent_effective(&self, category_id: Uuid) -> ForumResult<ResolvedVisibility> {
+        let parent_id = self
+            .parents
+            .get(&category_id)
+            .copied()
+            .ok_or(ForumError::CategoryNotFound(category_id))?;
+        match parent_id {
+            Some(parent_id) => self.resolve(parent_id),
+            None => Ok(ResolvedVisibility {
+                effective_visibility: ForumCategoryVisibility::Public,
+                effective_from_category_id: None,
+            }),
+        }
+    }
+
+    fn resolve(&self, category_id: Uuid) -> ForumResult<ResolvedVisibility> {
+        if !self.parents.contains_key(&category_id) {
+            return Err(ForumError::CategoryNotFound(category_id));
+        }
+
+        let mut current = Some(category_id);
+        let mut visited = HashSet::new();
+        let mut depth = 0usize;
+        while let Some(current_id) = current {
+            if depth > MAX_FORUM_CATEGORY_TREE_DEPTH {
+                return Err(ForumError::Validation(format!(
+                    "Forum category visibility tree exceeds the maximum depth of {MAX_FORUM_CATEGORY_TREE_DEPTH}"
+                )));
+            }
+            if !visited.insert(current_id) {
+                return Err(ForumError::Validation(
+                    "Forum category visibility tree contains a hierarchy cycle".to_string(),
+                ));
+            }
+            if self.overrides.get(&current_id)
+                == Some(&ForumCategoryVisibility::Authenticated)
+            {
+                return Ok(ResolvedVisibility {
+                    effective_visibility: ForumCategoryVisibility::Authenticated,
+                    effective_from_category_id: Some(current_id),
+                });
+            }
+            current = self.parents.get(&current_id).copied().ok_or_else(|| {
+                ForumError::Validation(format!(
+                    "Forum category visibility tree references missing or foreign category {current_id}"
+                ))
+            })?;
+            depth += 1;
+        }
+
+        Ok(ResolvedVisibility {
+            effective_visibility: ForumCategoryVisibility::Public,
+            effective_from_category_id: None,
+        })
+    }
+}
+
+struct ResolvedVisibility {
+    effective_visibility: ForumCategoryVisibility,
+    effective_from_category_id: Option<Uuid>,
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -8,6 +8,7 @@ mod category_lifecycle;
 mod category_owner;
 mod category_policy;
 mod category_tree;
+mod category_visibility;
 pub mod event;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation;
@@ -52,6 +53,10 @@ pub mod vote;
 pub mod widget_contract;
 
 pub use category_owner::CategoryService;
+pub use category_visibility::{
+    ForumCategoryVisibilityPolicy, ForumCategoryVisibilityPolicyService,
+    SetForumCategoryVisibilityPolicyInput,
+};
 pub use event::ForumEventService;
 #[allow(unused_imports)]
 pub(crate) use mention_relation::MentionRelationService;

--- a/crates/rustok-forum/src/services/topic_facade.rs
+++ b/crates/rustok-forum/src/services/topic_facade.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DatabaseConnection, DatabaseTransaction};
 use uuid::Uuid;
 
-use rustok_core::SecurityContext;
+use rustok_core::{Error as CoreError, SecurityContext};
 use rustok_outbox::TransactionalEventBus;
 
 use crate::dto::{
@@ -192,10 +192,10 @@ impl TopicService {
             .filter_visible_topic_ids(tenant_id, &candidate_ids, &scope)
             .await?;
         if visible_ids != candidate_ids {
-            return Err(ForumError::Internal(
+            return Err(ForumError::Internal(CoreError::Validation(
                 "Forum storefront topic selection diverged from the owner visibility scope"
                     .to_string(),
-            ));
+            )));
         }
         require_localized_topic_page(page)
     }

--- a/crates/rustok-forum/src/services/topic_facade.rs
+++ b/crates/rustok-forum/src/services/topic_facade.rs
@@ -1,7 +1,7 @@
 use sea_orm::{DatabaseConnection, DatabaseTransaction};
 use uuid::Uuid;
 
-use rustok_core::{Error as CoreError, SecurityContext};
+use rustok_core::SecurityContext;
 use rustok_outbox::TransactionalEventBus;
 
 use crate::dto::{
@@ -192,7 +192,7 @@ impl TopicService {
             .filter_visible_topic_ids(tenant_id, &candidate_ids, &scope)
             .await?;
         if visible_ids != candidate_ids {
-            return Err(ForumError::Internal(CoreError::Validation(
+            return Err(ForumError::Internal(rustok_core::Error::External(
                 "Forum storefront topic selection diverged from the owner visibility scope"
                     .to_string(),
             )));

--- a/crates/rustok-forum/src/visibility.rs
+++ b/crates/rustok-forum/src/visibility.rs
@@ -1,0 +1,48 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Effective audience floor for a Forum category.
+///
+/// Category persistence stores only the narrowing `authenticated` override.
+/// `public` is the inherited root default and therefore cannot be written below
+/// an authenticated ancestor to broaden its audience.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    EnumIter,
+    DeriveActiveEnum,
+    Serialize,
+    Deserialize,
+    ToSchema,
+)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(32))")]
+#[serde(rename_all = "snake_case")]
+pub enum ForumCategoryVisibility {
+    #[default]
+    #[sea_orm(string_value = "public")]
+    Public,
+    #[sea_orm(string_value = "authenticated")]
+    Authenticated,
+}
+
+impl ForumCategoryVisibility {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Authenticated => "authenticated",
+        }
+    }
+
+    pub const fn allows(self, is_authenticated: bool) -> bool {
+        match self {
+            Self::Public => true,
+            Self::Authenticated => is_authenticated,
+        }
+    }
+}

--- a/crates/rustok-forum/tests/category_visibility_policy_sqlite.rs
+++ b/crates/rustok-forum/tests/category_visibility_policy_sqlite.rs
@@ -1,0 +1,248 @@
+use chrono::Utc;
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, ForumCategoryVisibility,
+    ForumCategoryVisibilityPolicyService, ForumModule, SetForumCategoryVisibilityPolicyInput,
+    UpdateCategoryTopicPolicyInput, entities::forum_category_policy,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ActiveModelTrait,
+    ActiveValue::Set,
+    ConnectOptions, Database, DatabaseConnection,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn setup() -> DatabaseConnection {
+    let db_url = format!(
+        "sqlite:file:forum_category_visibility_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum category visibility sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    db
+}
+
+async fn create_category(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    security: SecurityContext,
+    slug: &str,
+    parent_id: Option<Uuid>,
+) -> Uuid {
+    CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: slug.replace('-', " "),
+                slug: slug.into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created")
+        .id
+}
+
+#[tokio::test]
+async fn authenticated_visibility_inherits_and_cannot_be_broadened() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let foreign_tenant_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let reader = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+
+    let root = create_category(&db, tenant_id, admin.clone(), "root", None).await;
+    let child = create_category(&db, tenant_id, admin.clone(), "child", Some(root)).await;
+    let grandchild =
+        create_category(&db, tenant_id, admin.clone(), "grandchild", Some(child)).await;
+    let sibling = create_category(&db, tenant_id, admin.clone(), "sibling", Some(root)).await;
+    let foreign = create_category(
+        &db,
+        foreign_tenant_id,
+        admin.clone(),
+        "foreign",
+        None,
+    )
+    .await;
+
+    let service = ForumCategoryVisibilityPolicyService::new(db.clone());
+    let default_policy = service
+        .get(tenant_id, grandchild, reader.clone())
+        .await
+        .expect("missing overrides should resolve to public");
+    assert_eq!(
+        default_policy.effective_visibility,
+        ForumCategoryVisibility::Public
+    );
+    assert_eq!(default_policy.configured_visibility, None);
+    assert_eq!(default_policy.effective_from_category_id, None);
+
+    let child_policy = service
+        .set(
+            tenant_id,
+            child,
+            admin.clone(),
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Authenticated,
+            },
+        )
+        .await
+        .expect("child should narrow to authenticated");
+    assert_eq!(
+        child_policy.configured_visibility,
+        Some(ForumCategoryVisibility::Authenticated)
+    );
+    assert_eq!(
+        child_policy.effective_from_category_id,
+        Some(child)
+    );
+
+    let inherited = service
+        .get(tenant_id, grandchild, reader.clone())
+        .await
+        .expect("grandchild should inherit the authenticated floor");
+    assert_eq!(
+        inherited.effective_visibility,
+        ForumCategoryVisibility::Authenticated
+    );
+    assert_eq!(inherited.configured_visibility, None);
+    assert_eq!(inherited.effective_from_category_id, Some(child));
+
+    let sibling_policy = service
+        .get(tenant_id, sibling, reader.clone())
+        .await
+        .expect("unrelated sibling should remain public");
+    assert_eq!(
+        sibling_policy.effective_visibility,
+        ForumCategoryVisibility::Public
+    );
+
+    let broaden_error = service
+        .set(
+            tenant_id,
+            grandchild,
+            admin.clone(),
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Public,
+            },
+        )
+        .await
+        .expect_err("child must not broaden an authenticated ancestor");
+    assert!(broaden_error.to_string().contains("cannot broaden"));
+
+    CategoryService::new(db.clone())
+        .set_topic_policy(
+            tenant_id,
+            child,
+            admin.clone(),
+            UpdateCategoryTopicPolicyInput {
+                allows_topics: false,
+            },
+        )
+        .await
+        .expect("topic placement policy should update independently");
+    let preserved = service
+        .get(tenant_id, child, reader.clone())
+        .await
+        .expect("topic policy write must preserve visibility");
+    assert_eq!(
+        preserved.configured_visibility,
+        Some(ForumCategoryVisibility::Authenticated)
+    );
+
+    service
+        .set(
+            tenant_id,
+            child,
+            admin.clone(),
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Public,
+            },
+        )
+        .await
+        .expect("local override may clear beneath a public parent");
+    assert_eq!(
+        service
+            .get(tenant_id, grandchild, reader.clone())
+            .await
+            .expect("cleared subtree should become public")
+            .effective_visibility,
+        ForumCategoryVisibility::Public
+    );
+
+    service
+        .set(
+            tenant_id,
+            root,
+            admin.clone(),
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Authenticated,
+            },
+        )
+        .await
+        .expect("root should narrow the entire hierarchy");
+    let root_inherited = service
+        .get(tenant_id, grandchild, reader.clone())
+        .await
+        .expect("root floor should propagate");
+    assert_eq!(root_inherited.effective_from_category_id, Some(root));
+    assert_eq!(
+        root_inherited.effective_visibility,
+        ForumCategoryVisibility::Authenticated
+    );
+
+    assert!(
+        service
+            .set(
+                tenant_id,
+                child,
+                admin.clone(),
+                SetForumCategoryVisibilityPolicyInput {
+                    visibility: ForumCategoryVisibility::Public,
+                },
+            )
+            .await
+            .is_err()
+    );
+    assert!(service.get(tenant_id, foreign, reader).await.is_err());
+
+    let direct_public_override = forum_category_policy::ActiveModel {
+        category_id: Set(sibling),
+        tenant_id: Set(tenant_id),
+        allows_topics: Set(true),
+        visibility_override: Set(Some(ForumCategoryVisibility::Public)),
+        updated_at: Set(Utc::now().into()),
+    }
+    .insert(&db)
+    .await
+    .expect_err("database must reject a broadening public override");
+    assert!(direct_public_override.to_string().contains("must narrow"));
+}

--- a/scripts/verify/verify-forum-category-visibility-policy.mjs
+++ b/scripts/verify/verify-forum-category-visibility-policy.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-category-visibility-policy.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const visibility = read(contract.enum_file ?? "");
+const entity = read(contract.entity_file ?? "");
+const owner = read(contract.owner_file ?? "");
+const migration = read(contract.migration_file ?? "");
+const migrations = read(contract.migration_registry_file ?? "");
+const topicPolicy = read(contract.topic_policy_file ?? "");
+const services = read(contract.services_file ?? "");
+const crate = read(contract.crate_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+const topicVisibilityContract = JSON.parse(
+  read("crates/rustok-forum/contracts/forum-topic-visibility-scope.json") || "{}",
+);
+
+if (contract.schema_version !== 1) {
+  failures.push("category visibility contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20B") {
+  failures.push("category visibility contract must belong to FORUM-20B");
+}
+if (contract.category_bound !== 512 || contract.maximum_depth !== 16) {
+  failures.push("category visibility bounds must match the canonical category tree");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted visibility evidence");
+}
+if (topicVisibilityContract.task !== "FORUM-20A") {
+  failures.push("FORUM-20B must not rewrite the existing topic visibility contract");
+}
+for (const residual of [
+  "topic read composition",
+  "role visibility",
+  "group membership visibility",
+  "explicit allow and deny",
+  "visibility-scoped category and all-read mutations",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`category visibility contract must keep ${residual} explicitly open`);
+  }
+}
+
+for (const marker of [
+  "pub enum ForumCategoryVisibility",
+  "ForumCategoryVisibility::Public",
+  "ForumCategoryVisibility::Authenticated",
+  '#[sea_orm(string_value = "public")]',
+  '#[sea_orm(string_value = "authenticated")]',
+  "pub const fn allows(self, is_authenticated: bool) -> bool",
+]) {
+  requireText(visibility, marker, `category visibility enum is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub visibility_override: Option<ForumCategoryVisibility>",
+  "use crate::visibility::ForumCategoryVisibility",
+]) {
+  requireText(entity, marker, `category policy entity is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub struct ForumCategoryVisibilityPolicyService",
+  "pub struct ForumCategoryVisibilityPolicy",
+  "pub struct SetForumCategoryVisibilityPolicyInput",
+  "MAX_FORUM_CATEGORY_TREE_NODES + 1",
+  "MAX_FORUM_CATEGORY_TREE_DEPTH",
+  "Forum category visibility cannot broaden an authenticated ancestor",
+  "ForumCategoryVisibility::Authenticated =>",
+  "ForumCategoryVisibility::Public =>",
+  "effective_from_category_id: Some(current_id)",
+  "visibility_override: Set(requested_override)",
+  "Column::VisibilityOverride",
+  "snapshot.resolve(category_id)?",
+]) {
+  requireText(owner, marker, `category visibility owner is missing ${marker}`);
+}
+for (const forbidden of [
+  "rustok_profiles",
+  "rustok_groups",
+  "rustok_channels",
+  "ForumTopicVisibilityService",
+  "forum_topic::Entity",
+]) {
+  rejectText(owner, forbidden, `category visibility owner must not compose premature dependency ${forbidden}`);
+}
+
+for (const marker of [
+  'add_column(',
+  'Alias::new("visibility_override")',
+  "visibility_override = 'authenticated'",
+  "forum_category_visibility_override_insert",
+  "forum_category_visibility_override_update",
+  "must narrow to authenticated",
+]) {
+  requireText(migration, marker, `category visibility migration is missing ${marker}`);
+}
+requireText(
+  migrations,
+  "m20260724_000002_add_forum_category_visibility_policy",
+  "Forum migration registry must include the category visibility migration",
+);
+
+for (const marker of [
+  "visibility_override: NotSet",
+  "Column::AllowsTopics",
+]) {
+  requireText(topicPolicy, marker, `topic placement policy must preserve visibility: ${marker}`);
+}
+
+for (const marker of [
+  "mod category_visibility;",
+  "ForumCategoryVisibilityPolicyService",
+  "SetForumCategoryVisibilityPolicyInput",
+]) {
+  requireText(services, marker, `services export is missing ${marker}`);
+}
+for (const marker of [
+  "pub mod visibility;",
+  "ForumCategoryVisibilityPolicyService",
+  "pub use visibility::ForumCategoryVisibility;",
+]) {
+  requireText(crate, marker, `crate export is missing ${marker}`);
+}
+
+for (const marker of [
+  "authenticated_visibility_inherits_and_cannot_be_broadened",
+  "effective_from_category_id, Some(child)",
+  "cannot broaden",
+  "topic policy write must preserve visibility",
+  "database must reject a broadening public override",
+  "ForumCategoryVisibility::Authenticated",
+  "ForumCategoryVisibility::Public",
+]) {
+  requireText(testSource, marker, `category visibility SQLite scenario is missing ${marker}`);
+}
+
+for (const marker of [
+  "Delivered in `FORUM-20B`",
+  "ForumCategoryVisibilityPolicyService",
+  "forum-category-visibility-policy.json",
+  "category_visibility_policy_sqlite",
+  "verify-forum-category-visibility-policy.mjs",
+]) {
+  requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum category visibility policy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum category visibility policy contract is source-ready.");


### PR DESCRIPTION
## Summary

- deliver the FORUM-20B foundation for typed category visibility with `public` and `authenticated` audience floors
- persist only narrowing `authenticated` overrides with PostgreSQL and SQLite database guards
- add a bounded Forum-owned inheritance evaluator using the existing 512-node / depth-16 category limits
- preserve the existing `allows_topics` policy while sharing the category policy row
- add a source-ready SQLite scenario, machine-readable contract, verifier, and canonical plan update

## Compatibility

- existing categories remain public without backfill
- no REST, GraphQL, storefront, topic/reply read, notification, search, SEO, or deep-link behavior changes in this slice
- role, trust-level, group, channel-membership, and explicit allow/deny policy remain open

## Validation

Not run at the maintainer's request. The PR records the intended commands without claiming execution:

```bash
cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
node scripts/verify/verify-forum-category-visibility-policy.mjs
cargo xtask module validate forum
```
