### PR TITLE
fix(index): pin deterministic benchmark session settings

### DIFF
--- a/ops/benches/src/index_storage/connection.rs
+++ b/ops/benches/src/index_storage/connection.rs
@@ -1,6 +1,13 @@
 use anyhow::{Context, Result};
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
 
+const BENCHMARK_SESSION_SQL: &str = concat!(
+    "SET standard_conforming_strings = on;",
+    " SET TIME ZONE 'UTC';",
+    " SET DateStyle = 'ISO, YMD';",
+    " SET extra_float_digits = 3;",
+);
+
 pub async fn connect(database_url: &str) -> Result<DatabaseConnection> {
     let mut options = ConnectOptions::new(database_url.to_owned());
     options
@@ -11,8 +18,29 @@ pub async fn connect(database_url: &str) -> Result<DatabaseConnection> {
     let db = Database::connect(options)
         .await
         .context("failed to connect to PostgreSQL with a single benchmark session")?;
-    db.execute_unprepared("SET standard_conforming_strings = on;")
+    db.execute_unprepared(BENCHMARK_SESSION_SQL)
         .await
         .context("failed to pin PostgreSQL standard-conforming string semantics")?;
     Ok(db)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BENCHMARK_SESSION_SQL;
+
+    #[test]
+    fn benchmark_session_contract_is_explicit_and_deterministic() {
+        for setting in [
+            "SET standard_conforming_strings = on;",
+            "SET TIME ZONE 'UTC';",
+            "SET DateStyle = 'ISO, YMD';",
+            "SET extra_float_digits = 3;",
+        ] {
+            assert!(
+                BENCHMARK_SESSION_SQL.contains(setting),
+                "benchmark session contract is missing {setting}"
+            );
+        }
+        assert!(!BENCHMARK_SESSION_SQL.contains("standard_conforming_strings = off"));
+    }
 }


### PR DESCRIPTION
## Summary

- centralize the M2 PostgreSQL benchmark session contract in one constant;
- keep `standard_conforming_strings = on` and additionally pin `TimeZone = UTC`, `DateStyle = ISO, YMD`, and `extra_float_digits = 3`;
- add a focused unit contract that fails if any deterministic session setting is removed or string semantics are restored to `off`.

## Why

The benchmark uses serialized PostgreSQL values, JSON evidence, and repeated plans. Server, database, or role defaults for timezone, date rendering, and float output could otherwise make evidence differ across runners even when the generated dataset and SQL are identical.

## Scope

One benchmark connection module only. No candidate SQL, evidence schema, production migration, workflow, runtime Index API, or storage decision changes.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, and benchmark runs were not run by the implementation agent, per repository-owner instruction. The final file and branch diff were reviewed statically against the current `main`.