### PR TITLE
security(seo): classify failure categories

### DIFF
--- a/crates/rustok-seo/src/error.rs
+++ b/crates/rustok-seo/src/error.rs
@@ -1,7 +1,94 @@
 use sea_orm::DbErr;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub type SeoResult<T> = Result<T, SeoError>;
+
+const SEO_FAILURE_MESSAGE_PREFIX: &str = "[seo_failure class=";
+
+/// Stable operational category for every SEO failure.
+///
+/// Classification is deliberately separate from retry policy. `Retryable` means the underlying
+/// failure may succeed on a later attempt; callers must still apply an explicit bounded retry
+/// policy before rescheduling work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SeoFailureClass {
+    Retryable,
+    Terminal,
+    Validation,
+    Configuration,
+}
+
+impl SeoFailureClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Retryable => "retryable",
+            Self::Terminal => "terminal",
+            Self::Validation => "validation",
+            Self::Configuration => "configuration",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "retryable" => Some(Self::Retryable),
+            "terminal" => Some(Self::Terminal),
+            "validation" => Some(Self::Validation),
+            "configuration" => Some(Self::Configuration),
+            _ => None,
+        }
+    }
+
+    pub const fn is_retryable(self) -> bool {
+        matches!(self, Self::Retryable)
+    }
+}
+
+/// Machine-readable failure envelope suitable for logs, job `last_error` fields, and operator
+/// diagnostics without coupling storage to the concrete [`SeoError`] representation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeoFailure {
+    pub class: SeoFailureClass,
+    pub code: String,
+    pub message: String,
+}
+
+impl SeoFailure {
+    pub fn new(
+        class: SeoFailureClass,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            class,
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Encode the class and stable code while retaining a readable message.
+    pub fn durable_message(&self) -> String {
+        format!(
+            "{SEO_FAILURE_MESSAGE_PREFIX}{} code={}] {}",
+            self.class.as_str(),
+            self.code,
+            self.message
+        )
+    }
+
+    /// Parse a value produced by [`SeoFailure::durable_message`].
+    pub fn parse_durable_message(value: &str) -> Option<Self> {
+        let payload = value.strip_prefix(SEO_FAILURE_MESSAGE_PREFIX)?;
+        let (class, payload) = payload.split_once(" code=")?;
+        let (code, message) = payload.split_once("] ")?;
+        Some(Self::new(
+            SeoFailureClass::parse(class)?,
+            code,
+            message,
+        ))
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum SeoError {
@@ -24,5 +111,88 @@ impl SeoError {
 
     pub fn configuration(message: impl Into<String>) -> Self {
         Self::Configuration(message.into())
+    }
+
+    /// Return the explicit operational class for this failure.
+    pub const fn failure_class(&self) -> SeoFailureClass {
+        match self {
+            Self::Validation(_) => SeoFailureClass::Validation,
+            Self::Configuration(_) => SeoFailureClass::Configuration,
+            Self::NotFound | Self::PermissionDenied => SeoFailureClass::Terminal,
+            Self::Database(_) => SeoFailureClass::Retryable,
+        }
+    }
+
+    /// Return a stable code that does not depend on display text.
+    pub const fn stable_code(&self) -> &'static str {
+        match self {
+            Self::Validation(_) => "validation",
+            Self::Configuration(_) => "configuration",
+            Self::NotFound => "not_found",
+            Self::PermissionDenied => "permission_denied",
+            Self::Database(_) => "database",
+        }
+    }
+
+    pub const fn is_retryable(&self) -> bool {
+        self.failure_class().is_retryable()
+    }
+
+    pub fn failure(&self) -> SeoFailure {
+        SeoFailure::new(self.failure_class(), self.stable_code(), self.to_string())
+    }
+
+    pub fn durable_message(&self) -> String {
+        self.failure().durable_message()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_error_variant_has_an_explicit_failure_class() {
+        let cases = [
+            (
+                SeoError::validation("invalid locale"),
+                SeoFailureClass::Validation,
+                "validation",
+            ),
+            (
+                SeoError::configuration("missing public origin"),
+                SeoFailureClass::Configuration,
+                "configuration",
+            ),
+            (SeoError::NotFound, SeoFailureClass::Terminal, "not_found"),
+            (
+                SeoError::PermissionDenied,
+                SeoFailureClass::Terminal,
+                "permission_denied",
+            ),
+            (
+                SeoError::Database(DbErr::Custom("temporarily unavailable".to_string())),
+                SeoFailureClass::Retryable,
+                "database",
+            ),
+        ];
+
+        for (error, class, code) in cases {
+            assert_eq!(error.failure_class(), class);
+            assert_eq!(error.stable_code(), code);
+            assert_eq!(error.is_retryable(), class == SeoFailureClass::Retryable);
+        }
+    }
+
+    #[test]
+    fn durable_failure_message_round_trips_class_code_and_message() {
+        let error = SeoError::Database(DbErr::Custom("connection reset".to_string()));
+        let encoded = error.durable_message();
+        let decoded = SeoFailure::parse_durable_message(encoded.as_str())
+            .expect("classified SEO failure should parse");
+
+        assert_eq!(decoded.class, SeoFailureClass::Retryable);
+        assert_eq!(decoded.code, "database");
+        assert!(decoded.message.contains("connection reset"));
     }
 }

--- a/crates/rustok-seo/src/lib.rs
+++ b/crates/rustok-seo/src/lib.rs
@@ -44,7 +44,7 @@ pub use dto::{
     SeoVerificationTag,
 };
 #[cfg(feature = "server")]
-pub use error::{SeoError, SeoResult};
+pub use error::{SeoError, SeoFailure, SeoFailureClass, SeoResult};
 #[cfg(feature = "server")]
 pub use graphql::{SeoMutation, SeoQuery};
 #[cfg(feature = "server")]

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -43,7 +43,7 @@ Automated verification is recorded separately because direct pushes currently do
   - [x] Queue sitemap generation and submission outside request paths and execute one durable phase per worker invocation. (#2098)
   - [x] Queue bounded index repair/replay jobs outside request paths and resume durable worker execution. (#2100)
 - [x] Require explicit authorization for worker and operator entry points. (#2107)
-- [ ] Classify retryable, terminal, validation, and configuration failures explicitly.
+- [x] Classify retryable, terminal, validation, and configuration failures explicitly. (#2112)
 
 ## Verification status
 
@@ -53,4 +53,4 @@ Automated verification is recorded separately because direct pushes currently do
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
 - [ ] Confirm GitHub Actions status checks for the hardening commits.
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, #2100, and #2107 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, #2100, #2107, and #2112 continue the SEO hardening work without fresh test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-failure-classification.mjs
+++ b/scripts/verify/verify-seo-failure-classification.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const sliceBetween = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const errorSource = read('crates/rustok-seo/src/error.rs');
+const libSource = read('crates/rustok-seo/src/lib.rs');
+
+for (const [value, label] of [
+  ['pub enum SeoFailureClass {', 'failure class enum'],
+  ['Retryable,', 'retryable class'],
+  ['Terminal,', 'terminal class'],
+  ['Validation,', 'validation class'],
+  ['Configuration,', 'configuration class'],
+  ['pub struct SeoFailure {', 'failure envelope'],
+  ['pub class: SeoFailureClass,', 'failure envelope class'],
+  ['pub code: String,', 'failure stable code'],
+  ['pub message: String,', 'failure message'],
+  ['pub fn durable_message(&self) -> String', 'durable failure encoding'],
+  ['pub fn parse_durable_message(value: &str) -> Option<Self>', 'durable failure parsing'],
+  ['pub const fn failure_class(&self) -> SeoFailureClass', 'error classification method'],
+  ['pub const fn stable_code(&self) -> &\'static str', 'stable error code method'],
+  ['pub const fn is_retryable(&self) -> bool', 'retryability method'],
+  ['pub fn failure(&self) -> SeoFailure', 'failure envelope conversion'],
+]) {
+  requireText(errorSource, value, label);
+}
+
+const classification = sliceBetween(
+  errorSource,
+  'pub const fn failure_class(&self) -> SeoFailureClass {',
+  '\n    }',
+  'failure classification mapping',
+);
+for (const [value, label] of [
+  ['Self::Validation(_) => SeoFailureClass::Validation', 'validation mapping'],
+  ['Self::Configuration(_) => SeoFailureClass::Configuration', 'configuration mapping'],
+  ['Self::NotFound | Self::PermissionDenied => SeoFailureClass::Terminal', 'terminal mapping'],
+  ['Self::Database(_) => SeoFailureClass::Retryable', 'retryable mapping'],
+]) {
+  requireText(classification, value, label);
+}
+forbidText(classification, '_ =>', 'implicit failure classification fallback');
+
+const stableCodes = sliceBetween(
+  errorSource,
+  'pub const fn stable_code(&self) -> &\'static str {',
+  '\n    }',
+  'stable code mapping',
+);
+for (const value of [
+  'Self::Validation(_) => "validation"',
+  'Self::Configuration(_) => "configuration"',
+  'Self::NotFound => "not_found"',
+  'Self::PermissionDenied => "permission_denied"',
+  'Self::Database(_) => "database"',
+]) {
+  requireText(stableCodes, value, 'stable code mapping');
+}
+forbidText(stableCodes, '_ =>', 'implicit stable code fallback');
+
+for (const [value, label] of [
+  ['pub use error::{SeoError, SeoFailure, SeoFailureClass, SeoResult};', 'public failure contract'],
+  ['every_error_variant_has_an_explicit_failure_class', 'classification regression test'],
+  ['durable_failure_message_round_trips_class_code_and_message', 'durable encoding regression test'],
+]) {
+  requireText(errorSource + libSource, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('SEO failure-classification verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ every SEO error maps explicitly to retryable, terminal, validation, or configuration with a stable durable envelope',
+);


### PR DESCRIPTION
## Summary

- introduce the public `SeoFailureClass` taxonomy with the explicit categories `retryable`, `terminal`, `validation`, and `configuration`;
- map every existing `SeoError` variant exhaustively: database failures are retryable, not-found and permission failures are terminal, and validation/configuration retain their dedicated classes;
- add stable failure codes independent of display text;
- add a machine-readable `SeoFailure` envelope with a readable durable encoding and parser for logs, job `last_error` fields, and operator diagnostics;
- expose retryability as an explicit query while documenting that classification does not itself authorize or schedule retries;
- add unit-level source fixtures in `error.rs` and a permanent source verifier that rejects wildcard/fallback classification mappings.

## Boundary

This PR establishes the classification contract only. It deliberately does not change job statuses or automatically requeue retryable failures: retry scheduling requires a separate bounded policy with attempt limits and backoff. Existing callers remain source-compatible, and the durable envelope is available for incremental adoption by worker persistence paths.

## Concurrency review

The branch was rebuilt as one commit on fresh `main`. The concurrent commit touched only Commerce storefront error handling and did not overlap this SEO error-contract slice.

## Validation

Tests, formatting commands, cargo checks, and verifier execution were not run at the repository owner's request. The Rust taxonomy, exhaustive mappings, durable encoding/parser, public exports, and verifier conditions were reviewed statically.