### PR TITLE
fix(index): archive deterministic session metadata

### DIFF
--- a/ops/benches/src/bin/index_storage_benchmark.rs
+++ b/ops/benches/src/bin/index_storage_benchmark.rs
@@ -1,10 +1,12 @@
-use rustok_benchmarks::index_storage::{BenchmarkConfig, run, write_report};
+use rustok_benchmarks::index_storage::{
+    BenchmarkConfig, run, write_report_with_session_metadata,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report(&config.output_path, &report)?;
+    write_report_with_session_metadata(&config.output_path, &report)?;
 
     println!(
         "index storage benchmark complete: scale={:?}, product_rows={}, output={}",

--- a/ops/benches/src/index_storage/connection.rs
+++ b/ops/benches/src/index_storage/connection.rs
@@ -27,7 +27,9 @@ pub async fn connect(database_url: &str) -> Result<DatabaseConnection> {
         .context("failed to connect to PostgreSQL with a single benchmark session")?;
     db.execute_unprepared(BENCHMARK_SESSION_SQL)
         .await
-        .context("failed to pin deterministic PostgreSQL benchmark session")?;
+        .context(
+            "failed to pin deterministic PostgreSQL benchmark session (failed to pin PostgreSQL standard-conforming string semantics)",
+        )?;
     Ok(db)
 }
 

--- a/ops/benches/src/index_storage/connection.rs
+++ b/ops/benches/src/index_storage/connection.rs
@@ -1,6 +1,13 @@
 use anyhow::{Context, Result};
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
 
+pub(crate) const BENCHMARK_SESSION_METADATA: [(&str, &str); 4] = [
+    ("standard_conforming_strings", "on"),
+    ("timezone", "UTC"),
+    ("date_style", "ISO, YMD"),
+    ("extra_float_digits", "3"),
+];
+
 const BENCHMARK_SESSION_SQL: &str = concat!(
     "SET standard_conforming_strings = on;",
     " SET TIME ZONE 'UTC';",
@@ -20,25 +27,33 @@ pub async fn connect(database_url: &str) -> Result<DatabaseConnection> {
         .context("failed to connect to PostgreSQL with a single benchmark session")?;
     db.execute_unprepared(BENCHMARK_SESSION_SQL)
         .await
-        .context("failed to pin PostgreSQL standard-conforming string semantics")?;
+        .context("failed to pin deterministic PostgreSQL benchmark session")?;
     Ok(db)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::BENCHMARK_SESSION_SQL;
+    use super::{BENCHMARK_SESSION_METADATA, BENCHMARK_SESSION_SQL};
 
     #[test]
     fn benchmark_session_contract_is_explicit_and_deterministic() {
-        for setting in [
-            "SET standard_conforming_strings = on;",
-            "SET TIME ZONE 'UTC';",
-            "SET DateStyle = 'ISO, YMD';",
-            "SET extra_float_digits = 3;",
+        for (field, value, statement) in [
+            (
+                "standard_conforming_strings",
+                "on",
+                "SET standard_conforming_strings = on;",
+            ),
+            ("timezone", "UTC", "SET TIME ZONE 'UTC';"),
+            ("date_style", "ISO, YMD", "SET DateStyle = 'ISO, YMD';"),
+            ("extra_float_digits", "3", "SET extra_float_digits = 3;"),
         ] {
             assert!(
-                BENCHMARK_SESSION_SQL.contains(setting),
-                "benchmark session contract is missing {setting}"
+                BENCHMARK_SESSION_SQL.contains(statement),
+                "benchmark session SQL is missing {statement}"
+            );
+            assert!(
+                BENCHMARK_SESSION_METADATA.contains(&(field, value)),
+                "benchmark session metadata is missing {field}={value}"
             );
         }
         assert!(!BENCHMARK_SESSION_SQL.contains("standard_conforming_strings = off"));

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -1,3 +1,8 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
 mod config;
 mod connection;
 mod explain;
@@ -7,7 +12,7 @@ mod runner;
 mod sql;
 
 pub use config::{BenchmarkConfig, DatasetConfig, DatasetScale};
-pub(crate) use connection::connect as connect_benchmark_database;
+pub(crate) use connection::{BENCHMARK_SESSION_METADATA, connect as connect_benchmark_database};
 pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
@@ -20,9 +25,34 @@ pub use sql::{
     vacuum_statements, workloads,
 };
 
+fn write_report_with_session_metadata(path: &Path, report: &BenchmarkReport) -> Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create benchmark output directory {parent:?}"))?;
+    }
+
+    let mut json = serde_json::to_value(report).context("failed to serialize benchmark report")?;
+    let database = json
+        .get_mut("database")
+        .and_then(Value::as_object_mut)
+        .context("benchmark report database metadata must be an object")?;
+    for (field, setting_value) in BENCHMARK_SESSION_METADATA {
+        database.insert(field.to_owned(), Value::String(setting_value.to_owned()));
+    }
+
+    let bytes = serde_json::to_vec_pretty(&json)
+        .context("failed to serialize benchmark report with session metadata")?;
+    fs::write(path, bytes)
+        .with_context(|| format!("failed to write benchmark report to {path:?}"))?;
+    Ok(())
+}
+
 pub async fn run_from_env() -> anyhow::Result<BenchmarkReport> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report(&config.output_path, &report)?;
+    write_report_with_session_metadata(&config.output_path, &report)?;
     Ok(report)
 }

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -25,7 +25,7 @@ pub use sql::{
     vacuum_statements, workloads,
 };
 
-fn write_report_with_session_metadata(path: &Path, report: &BenchmarkReport) -> Result<()> {
+pub fn write_report_with_session_metadata(path: &Path, report: &BenchmarkReport) -> Result<()> {
     if let Some(parent) = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())

--- a/scripts/verify/check-index-storage-read-ordering.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.mjs
@@ -22,6 +22,12 @@ const readOrderMarkers = new Map([
   ['keyset_page', 'ORDER BY price_minor, entity_id LIMIT 100'],
   ['exact_count', null],
 ]);
+const canonicalSessionMetadata = new Map([
+  ['standard_conforming_strings', 'on'],
+  ['timezone', 'UTC'],
+  ['date_style', 'ISO, YMD'],
+  ['extra_float_digits', '3'],
+]);
 
 const fail = (message) => {
   throw new Error(message);
@@ -43,6 +49,15 @@ const requireObject = (value, label) => {
     fail(`${label} must be an object`);
   }
   return value;
+};
+
+const requireSessionMetadata = (read, directory) => {
+  const database = requireObject(read.database, `${directory} read.database`);
+  for (const [field, expected] of canonicalSessionMetadata) {
+    if (database[field] !== expected) {
+      fail(`${directory} read.database.${field} must be ${expected}; got ${database[field]}`);
+    }
+  }
 };
 
 const requireExactNames = (items, expected, label, field = 'name') => {
@@ -165,6 +180,7 @@ const readReport = (directory) => {
 
 export const validatePacketReadOrdering = (directory) => {
   const read = requireObject(readReport(directory), `${directory} read report`);
+  requireSessionMetadata(read, directory);
   requireExactNames(read.source_workloads, canonicalReadWorkloads, `${directory} source workload order`);
   for (const workload of read.source_workloads) {
     requireObject(workload, `${directory} source/${workload?.name ?? 'unknown'}`);
@@ -216,7 +232,7 @@ const main = () => {
   const inputs = parseArgs();
   if (inputs === null) return;
   for (const input of inputs) validatePacketReadOrdering(input);
-  console.log(`${prefix} executable terminal ordering verified for ${inputs.length} evidence packet(s)`);
+  console.log(`${prefix} deterministic session metadata and executable terminal ordering verified for ${inputs.length} evidence packet(s)`);
 };
 
 const isMain = process.argv[1]

--- a/scripts/verify/check-index-storage-read-ordering.test.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -33,6 +33,12 @@ const sql = (relation, workload) => {
 };
 
 const report = () => ({
+  database: {
+    standard_conforming_strings: 'on',
+    timezone: 'UTC',
+    date_style: 'ISO, YMD',
+    extra_float_digits: '3',
+  },
   source_workloads: workloads.map((name) => ({
     name,
     sql: `${sql('idx_bench_source.product', name)}   \n`,
@@ -64,7 +70,7 @@ const run = (root) => spawnSync(process.execPath, [script, '--input', root], { e
 const expectFailure = (mutate, pattern) => {
   withPacket(mutate, (root) => {
     const result = run(root);
-    assert.notEqual(result.status, 0, 'expected terminal ordering preflight to fail');
+    assert.notEqual(result.status, 0, 'expected evidence preflight to fail');
     assert.match(result.stderr, pattern);
   });
 };
@@ -74,6 +80,18 @@ test('accepts canonical terminal ordering with trailing whitespace', () => {
     const result = run(root);
     assert.equal(result.status, 0, result.stderr || result.stdout);
   });
+});
+
+test('rejects missing deterministic session metadata', () => {
+  expectFailure((value) => {
+    delete value.database.standard_conforming_strings;
+  }, /read\.database\.standard_conforming_strings must be on; got undefined/u);
+});
+
+test('rejects deterministic session metadata drift', () => {
+  expectFailure((value) => {
+    value.database.timezone = 'Europe/Moscow';
+  }, /read\.database\.timezone must be UTC; got Europe\/Moscow/u);
 });
 
 test('accepts comment tokens inside strings and comments after executable ordering', () => {

--- a/scripts/verify/compare-index-storage-evidence.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence.test.mjs
@@ -133,6 +133,10 @@ function writePacket(root, scale, overrides = {}) {
       work_mem: '4MB',
       random_page_cost: '4',
       jit: 'off',
+      standard_conforming_strings: 'on',
+      timezone: 'UTC',
+      date_style: 'ISO, YMD',
+      extra_float_digits: '3',
       ...overrides.database,
     },
     dataset: {

--- a/scripts/verify/index-storage-standalone-tools.test.mjs
+++ b/scripts/verify/index-storage-standalone-tools.test.mjs
@@ -28,6 +28,12 @@ const readSql = (relation, workload) => {
 };
 
 const report = () => ({
+  database: {
+    standard_conforming_strings: 'on',
+    timezone: 'UTC',
+    date_style: 'ISO, YMD',
+    extra_float_digits: '3',
+  },
   source_workloads: workloads.map((name) => ({
     name,
     sql: readSql('idx_bench_source.product', name),

--- a/scripts/verify/index-storage-tooling.test.mjs
+++ b/scripts/verify/index-storage-tooling.test.mjs
@@ -37,6 +37,12 @@ const readSql = (relation, workload) => {
 };
 
 const orderingReport = () => ({
+  database: {
+    standard_conforming_strings: 'on',
+    timezone: 'UTC',
+    date_style: 'ISO, YMD',
+    extra_float_digits: '3',
+  },
   source_workloads: readWorkloads.map((name) => ({
     name,
     sql: readSql('idx_bench_source.product', name),

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -14,6 +14,7 @@ const benchmarkBinary = read('ops/benches/src/bin/index_storage_benchmark.rs');
 const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
+const comparatorFixture = read('scripts/verify/compare-index-storage-evidence.test.mjs');
 const validatorWrapper = read('scripts/verify/validate-index-storage-evidence.mjs');
 const comparatorWrapper = read('scripts/verify/compare-index-storage-evidence.mjs');
 const standaloneFixture = read('scripts/verify/index-storage-standalone-tools.test.mjs');
@@ -29,6 +30,13 @@ const requireMarkers = (content, label, markers) => {
     if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
   }
 };
+
+const sessionMetadataMarkers = [
+  "standard_conforming_strings: 'on'",
+  "timezone: 'UTC'",
+  "date_style: 'ISO, YMD'",
+  "extra_float_digits: '3'",
+];
 
 requireMarkers(connection, 'benchmark session contract', [
   'pub(crate) const BENCHMARK_SESSION_METADATA',
@@ -102,6 +110,7 @@ for (const forbidden of ['sql.includes(marker)', 'sql.trimEnd().endsWith(marker)
 }
 
 requireMarkers(fixture, 'read ordering fixture', [
+  ...sessionMetadataMarkers,
   "test('accepts canonical terminal ordering with trailing whitespace'",
   "test('rejects missing deterministic session metadata'",
   "test('rejects deterministic session metadata drift'",
@@ -113,6 +122,11 @@ requireMarkers(fixture, 'read ordering fixture', [
   "test('rejects an ordering marker hidden after an escaped quote in an E string'",
   "test('rejects unterminated SQL comments before ordering validation'",
   "test('rejects workload order drift before checking SQL text'",
+]);
+requireMarkers(comparatorFixture, 'comparison evidence fixture', [
+  ...sessionMetadataMarkers,
+  'function writePacket(root, scale, overrides = {})',
+  "test('same-commit complete 100k and 1m evidence is decision-ready'",
 ]);
 
 requireMarkers(validatorWrapper, 'standalone validator wrapper', [
@@ -143,6 +157,7 @@ if (standaloneCompareOrdering < 0 || standaloneComparatorCore < 0
 }
 
 requireMarkers(standaloneFixture, 'standalone evidence fixture', [
+  ...sessionMetadataMarkers,
   "test('direct validator rejects non-executable terminal ordering before its core'",
   "test('direct comparator rejects nested-only terminal ordering before its core'",
   "test('direct validator reaches the byte-preserved core after a valid preflight'",
@@ -179,6 +194,7 @@ if (compareOrdering < 0 || comparator < 0 || compareOrdering > comparator) {
 }
 
 requireMarkers(routerFixture, 'storage tooling router fixture', [
+  ...sessionMetadataMarkers,
   "test('packet runs terminal ordering preflight before the canonical validator'",
   "test('compare runs terminal ordering preflight before the canonical comparator'",
   'assert.doesNotMatch(result.stderr, /missing evidence file: .*mutation-report\\.json/u)',
@@ -206,4 +222,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, session-aware evidence entrypoint, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, session-aware evidence entrypoint, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -9,6 +9,8 @@ const fail = (message) => {
   process.exit(1);
 };
 
+const benchmarkModule = read('ops/benches/src/index_storage/mod.rs');
+const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
 const validatorWrapper = read('scripts/verify/validate-index-storage-evidence.mjs');
@@ -27,6 +29,28 @@ const requireMarkers = (content, label, markers) => {
   }
 };
 
+requireMarkers(connection, 'benchmark session contract', [
+  'pub(crate) const BENCHMARK_SESSION_METADATA',
+  '("standard_conforming_strings", "on")',
+  '("timezone", "UTC")',
+  '("date_style", "ISO, YMD")',
+  '("extra_float_digits", "3")',
+  'SET standard_conforming_strings = on;',
+  "SET TIME ZONE 'UTC';",
+  "SET DateStyle = 'ISO, YMD';",
+  'SET extra_float_digits = 3;',
+  'failed to pin deterministic PostgreSQL benchmark session',
+  'BENCHMARK_SESSION_METADATA.contains(&(field, value))',
+]);
+
+requireMarkers(benchmarkModule, 'benchmark report writer', [
+  'BENCHMARK_SESSION_METADATA',
+  'fn write_report_with_session_metadata',
+  'serde_json::to_value(report)',
+  'database.insert(field.to_owned(), Value::String(setting_value.to_owned()))',
+  'write_report_with_session_metadata(&config.output_path, &report)?',
+]);
+
 requireMarkers(preflight, 'read ordering preflight', [
   "const canonicalPrototypes = ['jsonb', 'typed_eav', 'hot_projection']",
   "'status_equality'",
@@ -35,6 +59,14 @@ requireMarkers(preflight, 'read ordering preflight', [
   "'two_hop_channel_filter'",
   "'keyset_page'",
   "'exact_count'",
+  'const canonicalSessionMetadata = new Map',
+  "['standard_conforming_strings', 'on']",
+  "['timezone', 'UTC']",
+  "['date_style', 'ISO, YMD']",
+  "['extra_float_digits', '3']",
+  'const requireSessionMetadata = (read, directory) =>',
+  'requireSessionMetadata(read, directory);',
+  'deterministic session metadata and executable terminal ordering verified',
   'const maskSqlText = (text) =>',
   'const identifierContinuation = /[A-Za-z0-9_$]/u',
   'const isEscapeStringQuote = (sql, quoteIndex) =>',
@@ -63,6 +95,8 @@ for (const forbidden of ['sql.includes(marker)', 'sql.trimEnd().endsWith(marker)
 
 requireMarkers(fixture, 'read ordering fixture', [
   "test('accepts canonical terminal ordering with trailing whitespace'",
+  "test('rejects missing deterministic session metadata'",
+  "test('rejects deterministic session metadata drift'",
   "test('accepts comment tokens inside strings and comments after executable ordering'",
   "test('rejects a source ordering marker that exists only in a nested query'",
   "test('rejects a candidate ordering marker that exists only in a block comment'",
@@ -164,4 +198,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -10,6 +10,7 @@ const fail = (message) => {
 };
 
 const benchmarkModule = read('ops/benches/src/index_storage/mod.rs');
+const benchmarkBinary = read('ops/benches/src/bin/index_storage_benchmark.rs');
 const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
@@ -45,11 +46,18 @@ requireMarkers(connection, 'benchmark session contract', [
 
 requireMarkers(benchmarkModule, 'benchmark report writer', [
   'BENCHMARK_SESSION_METADATA',
-  'fn write_report_with_session_metadata',
+  'pub fn write_report_with_session_metadata',
   'serde_json::to_value(report)',
   'database.insert(field.to_owned(), Value::String(setting_value.to_owned()))',
   'write_report_with_session_metadata(&config.output_path, &report)?',
 ]);
+requireMarkers(benchmarkBinary, 'read evidence executable', [
+  'write_report_with_session_metadata',
+  'write_report_with_session_metadata(&config.output_path, &report)?',
+]);
+if (benchmarkBinary.includes('write_report(&config.output_path, &report)?')) {
+  fail('read evidence executable bypasses deterministic session metadata serialization');
+}
 
 requireMarkers(preflight, 'read ordering preflight', [
   "const canonicalPrototypes = ['jsonb', 'typed_eav', 'hot_projection']",
@@ -198,4 +206,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, session-aware evidence entrypoint, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, direct and router fixtures, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- expose the canonical PostgreSQL benchmark session metadata beside the shared session SQL;
- make the actual `index-storage-benchmark` executable write `standard_conforming_strings`, `timezone`, `date_style`, and `extra_float_digits` into `read-report.json`;
- require those exact values in the public evidence preflight before the byte-preserved validator or comparator core runs;
- update ordering, standalone, router, and comparison packet fixtures and statically guard the complete runtime-to-evidence chain.

## Why

The benchmark already pinned deterministic session settings, but archived evidence did not describe them. A packet could therefore be accepted without proving the string, timezone, date rendering, and float-output contract assumed by the SQL lexer and result-digest tooling.

## Scope

Benchmark/evidence tooling only. No candidate SQL, production migration, runtime Index API, storage model selection, or byte-preserved validator/comparator core changes.

## Validation

Tests, Node commands, Cargo commands, formatting, verifier execution, and benchmark runs were not run by the implementation agent, per repository-owner instruction. The implementation was re-audited statically; that audit caught and fixed the original executable writer bypass and synchronized every synthetic packet builder.