### PR TITLE
feat(forum): enforce authenticated category topic visibility

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-visibility-scope.json
+++ b/crates/rustok-forum/contracts/forum-topic-visibility-scope.json
@@ -1,16 +1,22 @@
 {
-  "schema_version": 1,
-  "task": "FORUM-20A",
-  "scope": "Forum-owned exact current storefront topic visibility",
+  "schema_version": 2,
+  "task": "FORUM-20C",
+  "scope": "Forum-owned storefront topic visibility with inherited public/authenticated categories",
   "owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
+  "category_owner_file": "crates/rustok-forum/src/services/category_visibility.rs",
   "facade_file": "crates/rustok-forum/src/services/topic_facade.rs",
   "storefront_read_state_file": "crates/rustok-forum/src/services/storefront_read_state.rs",
-  "compatibility_selector_file": "crates/rustok-forum/src/services/topic.rs",
+  "compatibility_selector_file": "crates/rustok-forum/src/services/topic_visibility_list.rs",
   "test_file": "crates/rustok-forum/tests/topic_visibility_sqlite.rs",
+  "authenticated_test_file": "crates/rustok-forum/tests/topic_authenticated_visibility_sqlite.rs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "candidate_bound": 100,
+  "category_tree_bound": 512,
+  "category_depth_bound": 16,
   "current_policy": {
     "topic_status": "open",
+    "public_category_visibility": "public categories only",
+    "authenticated_category_visibility": "public plus inherited authenticated categories",
     "without_channel_context": "topics without channel restrictions",
     "with_channel_context": "unrestricted topics plus topics matching the exact normalized channel slug",
     "missing_foreign_or_denied": "absent without an existence oracle",
@@ -18,22 +24,26 @@
   },
   "composition": {
     "single_topic_facade_guarded": true,
+    "storefront_list_filters_category_policy_before_count_and_pagination": true,
     "storefront_list_facade_rechecks_exact_candidates": true,
     "storefront_read_state_consumes_guarded_facade": true,
-    "compatibility_sql_selector_remains_prefilter": true
+    "channel_subqueries_are_tenant_scoped": true
   },
   "not_delivered": [
-    "category inheritance",
-    "authenticated-only visibility",
     "role visibility",
     "trust-level visibility",
+    "channel membership visibility",
     "group membership visibility",
     "explicit allow and deny",
+    "reply and non-storefront owner read composition",
     "visibility-scoped category and all-read mutations",
-    "search notification and SEO migration to the owner scope"
+    "search notification SEO and deep-link migration to the owner scope"
   ],
   "verification": {
-    "command": "cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture",
+    "commands": [
+      "cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture"
+    ],
     "source_verifier": "node scripts/verify/verify-forum-topic-visibility-scope.mjs",
     "execution_status": "not_run_by_implementation_agent"
   }

--- a/crates/rustok-forum/src/services/category_visibility.rs
+++ b/crates/rustok-forum/src/services/category_visibility.rs
@@ -125,6 +125,28 @@ impl ForumCategoryVisibilityPolicyService {
         txn.commit().await?;
         Ok(result)
     }
+
+    pub(crate) async fn hidden_category_ids_for_viewer(
+        &self,
+        tenant_id: Uuid,
+        is_authenticated: bool,
+    ) -> ForumResult<Vec<Uuid>> {
+        if is_authenticated {
+            return Ok(Vec::new());
+        }
+
+        let snapshot = CategoryVisibilitySnapshot::load(&self.db, tenant_id).await?;
+        let mut hidden = Vec::new();
+        for category_id in snapshot.parents.keys().copied() {
+            if snapshot.resolve(category_id)?.effective_visibility
+                == ForumCategoryVisibility::Authenticated
+            {
+                hidden.push(category_id);
+            }
+        }
+        hidden.sort_unstable();
+        Ok(hidden)
+    }
 }
 
 struct CategoryVisibilitySnapshot {

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -41,6 +41,7 @@ pub mod subscription;
 mod topic {
     include!("topic.rs");
     include!("topic_inline.rs");
+    include!("topic_visibility_list.rs");
 }
 mod topic_facade;
 mod topic_owner {

--- a/crates/rustok-forum/src/services/topic_facade.rs
+++ b/crates/rustok-forum/src/services/topic_facade.rs
@@ -92,7 +92,10 @@ impl TopicService {
         fallback_locale: Option<&str>,
         channel_slug: Option<&str>,
     ) -> ForumResult<Option<TopicResponse>> {
-        let scope = ForumTopicVisibilityScope::storefront(channel_slug)?;
+        let scope = ForumTopicVisibilityScope::storefront_for_viewer(
+            channel_slug,
+            !security.is_public_read(),
+        )?;
         let topic = match self
             .get_with_locale_fallback(tenant_id, security, topic_id, locale, fallback_locale)
             .await
@@ -176,19 +179,27 @@ impl TopicService {
         fallback_locale: Option<&str>,
         channel_slug: Option<&str>,
     ) -> ForumResult<(Vec<TopicListItem>, u64)> {
-        let scope = ForumTopicVisibilityScope::storefront(channel_slug)?;
+        let scope = ForumTopicVisibilityScope::storefront_for_viewer(
+            channel_slug,
+            !security.is_public_read(),
+        )?;
+        let visibility = ForumTopicVisibilityService::new(self.db.clone());
+        let hidden_category_ids = visibility
+            .hidden_category_ids_for_scope(tenant_id, &scope)
+            .await?;
         let page = self
             .inner
-            .list_storefront_visible_with_locale_fallback(
+            .list_storefront_visible_with_locale_fallback_and_hidden_categories(
                 tenant_id,
                 security,
                 filter,
                 fallback_locale,
                 scope.channel_slug(),
+                &hidden_category_ids,
             )
             .await?;
         let candidate_ids = page.0.iter().map(|topic| topic.id).collect::<Vec<_>>();
-        let visible_ids = ForumTopicVisibilityService::new(self.db.clone())
+        let visible_ids = visibility
             .filter_visible_topic_ids(tenant_id, &candidate_ids, &scope)
             .await?;
         if visible_ids != candidate_ids {

--- a/crates/rustok-forum/src/services/topic_visibility.rs
+++ b/crates/rustok-forum/src/services/topic_visibility.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::entities::{forum_topic, forum_topic_channel_access};
 use crate::error::{ForumError, ForumResult};
+use crate::services::category_visibility::ForumCategoryVisibilityPolicyService;
 use crate::state_machine::TopicStatus;
 
 pub const MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES: usize = 100;
@@ -15,29 +16,45 @@ const MAX_FORUM_CHANNEL_SLUG_LEN: usize = 128;
 
 /// Exact current storefront visibility scope owned by Forum.
 ///
-/// FORUM-20 will extend this value with inherited ACL, role, trust, group and
-/// explicit allow/deny inputs. Until those owner contracts exist, this scope is
-/// deliberately limited to the already-supported public/exact-channel policy.
+/// The scope combines the existing public/exact-channel rule with the
+/// public/authenticated category audience floor. Later FORUM-20 slices will add
+/// roles, trust, groups and explicit allow/deny inputs.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ForumTopicVisibilityScope {
     channel_slug: Option<String>,
+    is_authenticated: bool,
 }
 
 impl ForumTopicVisibilityScope {
     pub fn storefront(channel_slug: Option<&str>) -> ForumResult<Self> {
+        Self::storefront_for_viewer(channel_slug, false)
+    }
+
+    pub fn storefront_for_viewer(
+        channel_slug: Option<&str>,
+        is_authenticated: bool,
+    ) -> ForumResult<Self> {
         let channel_slug = normalize_channel_slug(channel_slug)?;
-        Ok(Self { channel_slug })
+        Ok(Self {
+            channel_slug,
+            is_authenticated,
+        })
     }
 
     pub fn channel_slug(&self) -> Option<&str> {
         self.channel_slug.as_deref()
     }
+
+    pub const fn is_authenticated(&self) -> bool {
+        self.is_authenticated
+    }
 }
 
 /// Forum-owned exact topic visibility evaluation.
 ///
-/// Missing, foreign-tenant, inactive and nonmatching channel targets all resolve
-/// to absent values so callers cannot turn the policy into an existence oracle.
+/// Missing, foreign-tenant, inactive, category-denied and nonmatching channel
+/// targets all resolve to absent values so callers cannot turn the policy into
+/// an existence oracle.
 pub struct ForumTopicVisibilityService {
     db: DatabaseConnection,
 }
@@ -47,18 +64,32 @@ impl ForumTopicVisibilityService {
         Self { db }
     }
 
+    pub(crate) async fn hidden_category_ids_for_scope(
+        &self,
+        tenant_id: Uuid,
+        scope: &ForumTopicVisibilityScope,
+    ) -> ForumResult<Vec<Uuid>> {
+        ForumCategoryVisibilityPolicyService::new(self.db.clone())
+            .hidden_category_ids_for_viewer(tenant_id, scope.is_authenticated())
+            .await
+    }
+
     pub async fn is_topic_visible(
         &self,
         tenant_id: Uuid,
         topic_id: Uuid,
         scope: &ForumTopicVisibilityScope,
     ) -> ForumResult<bool> {
+        let hidden_category_ids = self
+            .hidden_category_ids_for_scope(tenant_id, scope)
+            .await?;
         Ok(apply_storefront_visibility(
             forum_topic::Entity::find()
                 .filter(forum_topic::Column::TenantId.eq(tenant_id))
                 .filter(forum_topic::Column::Id.eq(topic_id)),
             tenant_id,
             scope,
+            &hidden_category_ids,
         )
         .one(&self.db)
         .await?
@@ -91,12 +122,16 @@ impl ForumTopicVisibilityService {
             }
         }
 
+        let hidden_category_ids = self
+            .hidden_category_ids_for_scope(tenant_id, scope)
+            .await?;
         let visible = apply_storefront_visibility(
             forum_topic::Entity::find()
                 .filter(forum_topic::Column::TenantId.eq(tenant_id))
                 .filter(forum_topic::Column::Id.is_in(unique_ids.clone())),
             tenant_id,
             scope,
+            &hidden_category_ids,
         )
         .all(&self.db)
         .await?
@@ -115,6 +150,7 @@ pub(crate) fn apply_storefront_visibility(
     select: Select<forum_topic::Entity>,
     tenant_id: Uuid,
     scope: &ForumTopicVisibilityScope,
+    hidden_category_ids: &[Uuid],
 ) -> Select<forum_topic::Entity> {
     let unrestricted = Expr::col((forum_topic::Entity, forum_topic::Column::Id))
         .not_in_subquery(all_topic_channel_access_subquery(tenant_id));
@@ -127,9 +163,15 @@ pub(crate) fn apply_storefront_visibility(
         None => Condition::all().add(unrestricted),
     };
 
-    select
+    let mut select = select
         .filter(forum_topic::Column::Status.eq(TopicStatus::Open))
-        .filter(channel_condition)
+        .filter(channel_condition);
+    if !hidden_category_ids.is_empty() {
+        select = select.filter(
+            forum_topic::Column::CategoryId.is_not_in(hidden_category_ids.to_vec()),
+        );
+    }
+    select
 }
 
 fn all_topic_channel_access_subquery(tenant_id: Uuid) -> SelectStatement {

--- a/crates/rustok-forum/src/services/topic_visibility_list.rs
+++ b/crates/rustok-forum/src/services/topic_visibility_list.rs
@@ -1,0 +1,109 @@
+impl TopicService {
+    #[instrument(skip(self, security, hidden_category_ids))]
+    pub(crate) async fn list_storefront_visible_with_locale_fallback_and_hidden_categories(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        filter: ListTopicsFilter,
+        fallback_locale: Option<&str>,
+        channel_slug: Option<&str>,
+        hidden_category_ids: &[Uuid],
+    ) -> ForumResult<(Vec<TopicListItem>, u64)> {
+        enforce_scope(&security, Resource::ForumTopics, Action::List)?;
+        let locale = filter
+            .locale
+            .clone()
+            .unwrap_or_else(|| PLATFORM_FALLBACK_LOCALE.to_string());
+        let locale = normalize_locale(&locale)?;
+        let fallback_locale = fallback_locale.map(normalize_locale).transpose()?;
+
+        let mut select = forum_topic::Entity::find()
+            .filter(forum_topic::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic::Column::Status.eq(TopicStatus::Open));
+        if let Some(category_id) = filter.category_id {
+            select = select.filter(forum_topic::Column::CategoryId.eq(category_id));
+        }
+        if !hidden_category_ids.is_empty() {
+            select = select.filter(
+                forum_topic::Column::CategoryId.is_not_in(hidden_category_ids.to_vec()),
+            );
+        }
+        select = apply_tenant_scoped_storefront_channel_filter(select, tenant_id, channel_slug);
+
+        let paginator = select
+            .order_by_desc(forum_topic::Column::IsPinned)
+            .order_by_desc(forum_topic::Column::LastReplyAt)
+            .order_by_desc(forum_topic::Column::UpdatedAt)
+            .paginate(&self.db, filter.per_page.max(1));
+        let total = paginator.num_items().await?;
+        let topics = paginator.fetch_page(filter.page.saturating_sub(1)).await?;
+        let items = self
+            .hydrate_topic_list_items(
+                tenant_id,
+                security.user_id,
+                topics,
+                &locale,
+                fallback_locale.as_deref(),
+            )
+            .await?;
+
+        Ok((items, total))
+    }
+}
+
+fn apply_tenant_scoped_storefront_channel_filter(
+    select: Select<forum_topic::Entity>,
+    tenant_id: Uuid,
+    channel_slug: Option<&str>,
+) -> Select<forum_topic::Entity> {
+    let unrestricted = Expr::col((forum_topic::Entity, forum_topic::Column::Id))
+        .not_in_subquery(tenant_topic_channel_access_subquery(tenant_id));
+    let condition = match normalize_public_channel_slug(channel_slug) {
+        Some(channel_slug) => Condition::any().add(unrestricted).add(
+            Expr::col((forum_topic::Entity, forum_topic::Column::Id)).in_subquery(
+                matching_tenant_topic_channel_access_subquery(tenant_id, &channel_slug),
+            ),
+        ),
+        None => Condition::all().add(unrestricted),
+    };
+
+    select.filter(condition)
+}
+
+fn tenant_topic_channel_access_subquery(tenant_id: Uuid) -> SelectStatement {
+    Query::select()
+        .column(forum_topic_channel_access::Column::TopicId)
+        .from(forum_topic_channel_access::Entity)
+        .and_where(
+            Expr::col((
+                forum_topic_channel_access::Entity,
+                forum_topic_channel_access::Column::TenantId,
+            ))
+            .eq(tenant_id),
+        )
+        .to_owned()
+}
+
+fn matching_tenant_topic_channel_access_subquery(
+    tenant_id: Uuid,
+    channel_slug: &str,
+) -> SelectStatement {
+    Query::select()
+        .column(forum_topic_channel_access::Column::TopicId)
+        .from(forum_topic_channel_access::Entity)
+        .and_where(
+            Expr::col((
+                forum_topic_channel_access::Entity,
+                forum_topic_channel_access::Column::TenantId,
+            ))
+            .eq(tenant_id),
+        )
+        .and_where(
+            Expr::col((
+                forum_topic_channel_access::Entity,
+                forum_topic_channel_access::Column::ChannelSlug,
+            ))
+            .eq(channel_slug),
+        )
+        .to_owned()
+}

--- a/crates/rustok-forum/tests/topic_authenticated_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_authenticated_visibility_sqlite.rs
@@ -1,0 +1,287 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateTopicInput, ForumCategoryVisibility,
+    ForumCategoryVisibilityPolicyService, ForumModule, ForumTopicVisibilityScope,
+    ForumTopicVisibilityService, ListTopicsFilter, SetForumCategoryVisibilityPolicyInput,
+    TopicService,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus) {
+    let db_url = format!(
+        "sqlite:file:forum_topic_authenticated_visibility_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum authenticated visibility sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus)
+}
+
+async fn create_category(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    security: SecurityContext,
+    slug: &str,
+    parent_id: Option<Uuid>,
+) -> Uuid {
+    CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: slug.replace('-', " "),
+                slug: slug.into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created")
+        .id
+}
+
+async fn create_topic(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    security: SecurityContext,
+    slug: &str,
+) -> Uuid {
+    TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id,
+                title: slug.replace('-', " "),
+                slug: Some(slug.into()),
+                body: "Authenticated visibility fixture".into(),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: vec![],
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created")
+        .id
+}
+
+fn topic_filter(category_id: Option<Uuid>) -> ListTopicsFilter {
+    ListTopicsFilter {
+        category_id,
+        status: None,
+        locale: Some("en".into()),
+        page: 1,
+        per_page: 20,
+    }
+}
+
+#[tokio::test]
+async fn inherited_authenticated_categories_filter_before_storefront_pagination() {
+    let (db, event_bus) = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let authenticated = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+    let public = SecurityContext::public_read();
+
+    let public_category =
+        create_category(&db, tenant_id, admin.clone(), "public", None).await;
+    let restricted_parent =
+        create_category(&db, tenant_id, admin.clone(), "members", None).await;
+    let restricted_child = create_category(
+        &db,
+        tenant_id,
+        admin.clone(),
+        "members-child",
+        Some(restricted_parent),
+    )
+    .await;
+
+    let public_topic = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        public_category,
+        admin.clone(),
+        "public-topic",
+    )
+    .await;
+    let restricted_topic = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        restricted_child,
+        admin.clone(),
+        "members-topic",
+    )
+    .await;
+
+    ForumCategoryVisibilityPolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            restricted_parent,
+            admin,
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Authenticated,
+            },
+        )
+        .await
+        .expect("parent category should narrow to authenticated viewers");
+
+    let visibility = ForumTopicVisibilityService::new(db.clone());
+    let public_scope = ForumTopicVisibilityScope::storefront(None).expect("public scope");
+    let authenticated_scope = ForumTopicVisibilityScope::storefront_for_viewer(None, true)
+        .expect("authenticated scope");
+    assert_eq!(
+        visibility
+            .filter_visible_topic_ids(
+                tenant_id,
+                &[restricted_topic, public_topic],
+                &public_scope,
+            )
+            .await
+            .expect("public exact visibility should resolve"),
+        vec![public_topic]
+    );
+    assert_eq!(
+        visibility
+            .filter_visible_topic_ids(
+                tenant_id,
+                &[restricted_topic, public_topic],
+                &authenticated_scope,
+            )
+            .await
+            .expect("authenticated exact visibility should resolve"),
+        vec![restricted_topic, public_topic]
+    );
+
+    let topics = TopicService::new(db.clone(), event_bus);
+    let (public_page, public_total) = topics
+        .list_storefront_visible_with_locale_fallback(
+            tenant_id,
+            public.clone(),
+            topic_filter(None),
+            Some("en"),
+            None,
+        )
+        .await
+        .expect("public storefront list should resolve");
+    assert_eq!(public_total, 1);
+    assert_eq!(
+        public_page
+            .iter()
+            .map(|topic| topic.id)
+            .collect::<HashSet<_>>(),
+        HashSet::from([public_topic])
+    );
+
+    let (authenticated_page, authenticated_total) = topics
+        .list_storefront_visible_with_locale_fallback(
+            tenant_id,
+            authenticated.clone(),
+            topic_filter(None),
+            Some("en"),
+            None,
+        )
+        .await
+        .expect("authenticated storefront list should resolve");
+    assert_eq!(authenticated_total, 2);
+    assert_eq!(
+        authenticated_page
+            .iter()
+            .map(|topic| topic.id)
+            .collect::<HashSet<_>>(),
+        HashSet::from([public_topic, restricted_topic])
+    );
+
+    let (public_restricted_page, public_restricted_total) = topics
+        .list_storefront_visible_with_locale_fallback(
+            tenant_id,
+            public.clone(),
+            topic_filter(Some(restricted_child)),
+            Some("en"),
+            None,
+        )
+        .await
+        .expect("public restricted-category page should resolve as empty");
+    assert!(public_restricted_page.is_empty());
+    assert_eq!(public_restricted_total, 0);
+
+    let (authenticated_restricted_page, authenticated_restricted_total) = topics
+        .list_storefront_visible_with_locale_fallback(
+            tenant_id,
+            authenticated.clone(),
+            topic_filter(Some(restricted_child)),
+            Some("en"),
+            None,
+        )
+        .await
+        .expect("authenticated restricted-category page should resolve");
+    assert_eq!(authenticated_restricted_total, 1);
+    assert_eq!(authenticated_restricted_page[0].id, restricted_topic);
+
+    assert!(
+        topics
+            .get_storefront_visible_with_locale_fallback(
+                tenant_id,
+                public,
+                restricted_topic,
+                "en",
+                Some("en"),
+                None,
+            )
+            .await
+            .expect("public restricted topic lookup should resolve")
+            .is_none()
+    );
+    assert!(
+        topics
+            .get_storefront_visible_with_locale_fallback(
+                tenant_id,
+                authenticated,
+                restricted_topic,
+                "en",
+                Some("en"),
+                None,
+            )
+            .await
+            .expect("authenticated restricted topic lookup should resolve")
+            .is_some()
+    );
+}

--- a/scripts/verify/verify-forum-topic-visibility-scope.mjs
+++ b/scripts/verify/verify-forum-topic-visibility-scope.mjs
@@ -226,10 +226,8 @@ for (const marker of [
 for (const marker of [
   "Delivered in `FORUM-20A`",
   "Delivered in `FORUM-20B`",
-  "Delivered in `FORUM-20C`",
   "ForumTopicVisibilityService",
   "forum-topic-visibility-scope.json",
-  "topic_authenticated_visibility_sqlite",
   "verify-forum-topic-visibility-scope.mjs",
 ]) {
   requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);

--- a/scripts/verify/verify-forum-topic-visibility-scope.mjs
+++ b/scripts/verify/verify-forum-topic-visibility-scope.mjs
@@ -30,35 +30,47 @@ function rejectText(source, marker, message) {
 const contractPath = "crates/rustok-forum/contracts/forum-topic-visibility-scope.json";
 const contract = JSON.parse(read(contractPath) || "{}");
 const owner = read(contract.owner_file ?? "");
+const categoryOwner = read(contract.category_owner_file ?? "");
 const facade = read(contract.facade_file ?? "");
 const storefrontReadState = read(contract.storefront_read_state_file ?? "");
 const compatibilitySelector = read(contract.compatibility_selector_file ?? "");
 const testSource = read(contract.test_file ?? "");
+const authenticatedTestSource = read(contract.authenticated_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 const services = read("crates/rustok-forum/src/services/mod.rs");
 const lib = read("crates/rustok-forum/src/lib.rs");
 
-if (contract.schema_version !== 1) {
-  failures.push("topic visibility scope contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("topic visibility scope contract must use schema_version=2");
 }
-if (contract.task !== "FORUM-20A") {
-  failures.push("topic visibility scope contract must belong to FORUM-20A");
+if (contract.task !== "FORUM-20C") {
+  failures.push("topic visibility scope contract must belong to FORUM-20C");
 }
 if (contract.candidate_bound !== 100) {
   failures.push("topic visibility candidate bound must remain 100");
+}
+if (contract.category_tree_bound !== 512 || contract.category_depth_bound !== 16) {
+  failures.push("topic visibility category bounds must remain 512 nodes and depth 16");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted visibility evidence");
 }
 for (const residual of [
-  "category inheritance",
   "role visibility",
+  "trust-level visibility",
+  "channel membership visibility",
   "group membership visibility",
   "explicit allow and deny",
+  "reply and non-storefront owner read composition",
   "visibility-scoped category and all-read mutations",
 ]) {
   if (!contract.not_delivered?.includes(residual)) {
     failures.push(`topic visibility contract must keep ${residual} explicitly open`);
+  }
+}
+for (const delivered of ["category inheritance", "authenticated-only visibility"]) {
+  if (contract.not_delivered?.includes(delivered)) {
+    failures.push(`topic visibility contract must not keep delivered scope open: ${delivered}`);
   }
 }
 
@@ -66,8 +78,14 @@ for (const marker of [
   "pub const MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES: usize = 100",
   "pub struct ForumTopicVisibilityScope",
   "channel_slug: Option<String>",
+  "is_authenticated: bool",
   "pub fn storefront(channel_slug: Option<&str>) -> ForumResult<Self>",
+  "pub fn storefront_for_viewer(",
+  "pub const fn is_authenticated(&self) -> bool",
   "pub struct ForumTopicVisibilityService",
+  "pub(crate) async fn hidden_category_ids_for_scope",
+  "ForumCategoryVisibilityPolicyService::new(self.db.clone())",
+  ".hidden_category_ids_for_viewer(tenant_id, scope.is_authenticated())",
   "pub async fn is_topic_visible",
   "pub async fn filter_visible_topic_ids",
   "topic_ids.len() > MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES",
@@ -75,6 +93,7 @@ for (const marker of [
   ".filter(|topic_id| visible.contains(topic_id))",
   "forum_topic::Column::TenantId.eq(tenant_id)",
   "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "forum_topic::Column::CategoryId.is_not_in(hidden_category_ids.to_vec())",
   "all_topic_channel_access_subquery(tenant_id)",
   "matching_topic_channel_access_subquery(tenant_id, channel_slug)",
   "forum_topic_channel_access::Column::TenantId",
@@ -94,8 +113,22 @@ for (const forbidden of [
 }
 
 for (const marker of [
-  "ForumTopicVisibilityScope::storefront(channel_slug)?",
+  "pub(crate) async fn hidden_category_ids_for_viewer(",
+  "if is_authenticated",
+  "CategoryVisibilitySnapshot::load(&self.db, tenant_id)",
+  "snapshot.resolve(category_id)?.effective_visibility",
+  "ForumCategoryVisibility::Authenticated",
+  "hidden.sort_unstable()",
+]) {
+  requireText(categoryOwner, marker, `category visibility owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "!security.is_public_read()",
   "ForumTopicVisibilityService::new(self.db.clone())",
+  ".hidden_category_ids_for_scope(tenant_id, &scope)",
+  ".list_storefront_visible_with_locale_fallback_and_hidden_categories(",
   ".is_topic_visible(tenant_id, topic_id, &scope)",
   ".filter_visible_topic_ids(tenant_id, &candidate_ids, &scope)",
   "if visible_ids != candidate_ids",
@@ -119,16 +152,29 @@ if (
 }
 
 for (const marker of [
-  "list_storefront_visible_with_locale_fallback",
-  "apply_public_topic_channel_filter(select, channel_slug)",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "list_storefront_visible_with_locale_fallback_and_hidden_categories",
+  "forum_topic::Column::CategoryId.is_not_in(hidden_category_ids.to_vec())",
+  "apply_tenant_scoped_storefront_channel_filter(select, tenant_id, channel_slug)",
+  "tenant_topic_channel_access_subquery(tenant_id)",
+  "matching_tenant_topic_channel_access_subquery(tenant_id, &channel_slug)",
+  "forum_topic_channel_access::Column::TenantId",
+  "let total = paginator.num_items().await?",
+  "let topics = paginator.fetch_page",
 ]) {
   requireText(
     compatibilitySelector,
     marker,
-    `compatibility topic selector is missing existing prefilter ${marker}`,
+    `storefront topic selector is missing pre-pagination visibility composition ${marker}`,
   );
 }
+const categoryFilterIndex = compatibilitySelector.indexOf(
+  "forum_topic::Column::CategoryId.is_not_in(hidden_category_ids.to_vec())",
+);
+const paginatorIndex = compatibilitySelector.indexOf("let paginator = select");
+if (categoryFilterIndex < 0 || paginatorIndex < 0 || categoryFilterIndex > paginatorIndex) {
+  failures.push("category visibility must be applied before storefront count and pagination");
+}
+
 for (const marker of [
   ".list_storefront_visible_with_locale_fallback(",
   ".get_storefront_visible_with_locale_fallback(",
@@ -140,6 +186,7 @@ for (const marker of [
   );
 }
 
+requireText(services, "include!(\"topic_visibility_list.rs\");", "services must include the storefront visibility selector");
 requireText(services, "pub mod topic_visibility;", "services must declare topic_visibility");
 for (const marker of [
   "ForumTopicVisibilityScope",
@@ -162,12 +209,27 @@ for (const marker of [
 ]) {
   requireText(testSource, marker, `topic visibility SQLite scenario is missing ${marker}`);
 }
+for (const marker of [
+  "inherited_authenticated_categories_filter_before_storefront_pagination",
+  "ForumCategoryVisibility::Authenticated",
+  "ForumTopicVisibilityScope::storefront_for_viewer(None, true)",
+  "assert_eq!(public_total, 1)",
+  "assert_eq!(authenticated_total, 2)",
+  "assert_eq!(public_restricted_total, 0)",
+  "assert_eq!(authenticated_restricted_total, 1)",
+  ".is_none()",
+  ".is_some()",
+]) {
+  requireText(authenticatedTestSource, marker, `authenticated topic visibility SQLite scenario is missing ${marker}`);
+}
 
 for (const marker of [
   "Delivered in `FORUM-20A`",
+  "Delivered in `FORUM-20B`",
+  "Delivered in `FORUM-20C`",
   "ForumTopicVisibilityService",
   "forum-topic-visibility-scope.json",
-  "topic_visibility_sqlite",
+  "topic_authenticated_visibility_sqlite",
   "verify-forum-topic-visibility-scope.mjs",
 ]) {
   requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);


### PR DESCRIPTION
## Summary

- deliver the FORUM-20C storefront composition slice for inherited `public` / `authenticated` category visibility
- keep the existing public/exact-channel topic rule and add an explicit authenticated viewer scope
- exclude inherited authenticated categories from public topic selection before count and pagination
- include those categories for authenticated storefront readers
- preserve the exact bounded owner recheck for single-topic and page results
- tenant-scope the compatibility channel-access subqueries
- add a source-ready SQLite scenario and advance the machine-readable topic visibility contract

## Compatibility

- `ForumTopicVisibilityScope::storefront` remains the public compatibility constructor
- existing public categories and exact-channel behavior are unchanged
- no migration or backfill is required
- roles, trust levels, channel/group membership, explicit allow/deny, reply/non-storefront reads, notifications, search, SEO, deep links, and visibility-scoped bulk read commands remain open

## Documentation note

The canonical implementation plan is a roughly 2,000-line shared file. The connected Contents API only supports full-file replacement, while `main` continued moving during this change. To avoid overwriting concurrent plan edits, this PR advances the machine contract to FORUM-20C and records the full residual scope here; the canonical plan text still needs a conflict-safe maintainer sync.

## Validation

Not run at the maintainer's request. Intended commands:

```bash
cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
node scripts/verify/verify-forum-topic-visibility-scope.mjs
cargo xtask module validate forum
npm run verify:forum:storefront-boundary
```
