### PR TITLE
Harden storefront cart HTTP errors

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/carts.rs
+++ b/crates/rustok-commerce/src/controllers/store/carts.rs
@@ -3,8 +3,8 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
-use rustok_api::{OptionalAuthContext, RequestContext, TenantContext};
-use rustok_web::{HttpError, HttpResult};
+use rustok_api::{OptionalAuthContext, PortError, RequestContext, TenantContext};
+use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use uuid::Uuid;
 
 use super::{
@@ -20,8 +20,27 @@ use rustok_cart::{
 };
 use rustok_pricing::{ResolveProductPriceRequest, in_process_pricing_read_port};
 
-fn map_cart_port_error(error: rustok_api::PortError) -> HttpError {
-    rustok_web::port_error_to_http_error(error)
+fn map_cart_port_error(
+    error: PortError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    cart_id: Option<Uuid>,
+) -> HttpError {
+    let public = port_error_to_http_error(error.clone());
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_cart",
+        operation,
+        tenant_id = %tenant_id,
+        cart_id = ?cart_id,
+        error_kind = ?error.kind,
+        retryable = error.retryable,
+        public_code = %public.code,
+        status = %public.status,
+        boundary = "commerce_storefront_cart_http",
+        "storefront cart port operation failed"
+    );
+    public
 }
 
 /// Create a storefront cart
@@ -62,9 +81,8 @@ pub async fn create_cart(
         .or(input.currency_code.clone())
         .ok_or_else(|| {
             HttpError::bad_request(
-                "commerce_operation_failed",
-                "currency_code is required unless it can be resolved from region/country"
-                    .to_string(),
+                "commerce_store_cart_context_invalid",
+                "Currency code is required unless it can be resolved from region or country",
             )
         })?;
 
@@ -94,7 +112,7 @@ pub async fn create_cart(
             },
         )
         .await
-        .map_err(rustok_web::port_error_to_http_error)?;
+        .map_err(|error| map_cart_port_error(error, "create_cart", tenant.id, None))?;
     let cart = super::enrich_storefront_cart_for_db(
         runtime.db(),
         tenant.id,
@@ -146,7 +164,7 @@ pub async fn get_cart(
             CartStorefrontReadRequest { cart_id: id },
         )
         .await
-        .map_err(rustok_web::port_error_to_http_error)?;
+        .map_err(|error| map_cart_port_error(error, "get_cart", tenant.id, Some(id)))?;
     super::ensure_store_cart_access(&cart, customer_id)?;
     Ok(Json(
         super::enrich_storefront_cart_for_db(
@@ -198,7 +216,9 @@ pub async fn update_cart_context(
             CartStorefrontReadRequest { cart_id: id },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| {
+            map_cart_port_error(error, "update_cart_context_read", tenant.id, Some(id))
+        })?;
     super::ensure_store_cart_access(&cart, customer_id)?;
 
     let updated = super::apply_cart_context_patch_for_db(
@@ -266,7 +286,9 @@ pub async fn add_cart_line_item(
             CartStorefrontReadRequest { cart_id: id },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| {
+            map_cart_port_error(error, "add_cart_line_item_read", tenant.id, Some(id))
+        })?;
     super::ensure_store_cart_access(&existing, customer_id)?;
     let event_bus = runtime.event_bus();
     let pricing_read_port = in_process_pricing_read_port(runtime.db_clone(), event_bus.clone());
@@ -308,7 +330,7 @@ pub async fn add_cart_line_item(
             },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| map_cart_port_error(error, "add_cart_line_item", tenant.id, Some(id)))?;
     Ok(Json(
         super::enrich_storefront_cart_for_db(
             runtime.db(),
@@ -363,7 +385,9 @@ pub async fn update_cart_line_item(
             CartStorefrontReadRequest { cart_id: id },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| {
+            map_cart_port_error(error, "update_cart_line_item_read", tenant.id, Some(id))
+        })?;
     super::ensure_store_cart_access(&existing, customer_id)?;
     let event_bus = runtime.event_bus();
     if let Some(existing_line_item) = existing.line_items.iter().find(|item| item.id == line_id) {
@@ -408,7 +432,7 @@ pub async fn update_cart_line_item(
                 },
             )
             .await
-            .map_err(rustok_web::port_error_to_http_error)?
+            .map_err(port_error_to_http_error)?
             .into();
 
         let pricing_update =
@@ -432,7 +456,14 @@ pub async fn update_cart_line_item(
                 },
             )
             .await
-            .map_err(map_cart_port_error)?
+            .map_err(|error| {
+                map_cart_port_error(
+                    error,
+                    "update_cart_line_item_pricing",
+                    tenant.id,
+                    Some(id),
+                )
+            })?
     } else {
         storefront_port
             .update_storefront_line_item_quantity(
@@ -451,7 +482,14 @@ pub async fn update_cart_line_item(
                 },
             )
             .await
-            .map_err(map_cart_port_error)?
+            .map_err(|error| {
+                map_cart_port_error(
+                    error,
+                    "update_cart_line_item_quantity",
+                    tenant.id,
+                    Some(id),
+                )
+            })?
     };
     Ok(Json(
         super::enrich_storefront_cart_for_db(
@@ -505,7 +543,9 @@ pub async fn remove_cart_line_item(
             CartStorefrontReadRequest { cart_id: id },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| {
+            map_cart_port_error(error, "remove_cart_line_item_read", tenant.id, Some(id))
+        })?;
     super::ensure_store_cart_access(&existing, customer_id)?;
 
     let cart = storefront_port
@@ -524,7 +564,9 @@ pub async fn remove_cart_line_item(
             },
         )
         .await
-        .map_err(map_cart_port_error)?;
+        .map_err(|error| {
+            map_cart_port_error(error, "remove_cart_line_item", tenant.id, Some(id))
+        })?;
     Ok(Json(
         super::enrich_storefront_cart_for_db(
             runtime.db(),

--- a/scripts/verify/verify-commerce-storefront-cart-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-cart-http-error-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/carts.rs');
+const apiPorts = read('crates/rustok-api/src/ports.rs');
+const webErrors = read('crates/rustok-web/src/lib.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  controller,
+  'fn map_cart_port_error(',
+  '/// Create a storefront cart',
+  'storefront cart port mapper',
+);
+const createHandler = between(
+  controller,
+  'pub async fn create_cart(',
+  '/// Get storefront cart',
+  'create cart handler',
+);
+const updateLineHandler = between(
+  controller,
+  'pub async fn update_cart_line_item(',
+  '/// Remove storefront cart line item',
+  'update line item handler',
+);
+
+for (const [value, label] of [
+  ['OptionalAuthContext, PortError, RequestContext, TenantContext', 'typed port error import'],
+  ['port_error_to_http_error', 'shared port HTTP mapper import'],
+  ['fn map_cart_port_error(', 'cart port mapper'],
+  ['error = ?error', 'raw internal error logging'],
+  ['owner = "rustok_cart"', 'cart owner logging'],
+  ['operation,', 'operation logging'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['cart_id = ?cart_id', 'optional cart logging'],
+  ['error_kind = ?error.kind', 'typed error-kind logging'],
+  ['retryable = error.retryable', 'retryability logging'],
+  ['public_code = %public.code', 'public-code logging'],
+  ['status = %public.status', 'status logging'],
+  ['boundary = "commerce_storefront_cart_http"', 'cart HTTP boundary logging'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [value, label] of [
+  ['let public = port_error_to_http_error(error.clone());', 'shared safe mapping'],
+  ['"storefront cart port operation failed"', 'boundary log message'],
+  ['public\n}', 'mapped error return'],
+]) {
+  requireText(mapper, value, label);
+}
+
+for (const value of [
+  'commerce_operation_failed',
+  'error.message',
+  'err.to_string()',
+  'error.to_string()',
+  'map_err(rustok_web::port_error_to_http_error)',
+]) {
+  forbidText(controller, value, 'unsafe storefront cart public conversion');
+}
+
+for (const [value, label] of [
+  ['"commerce_store_cart_context_invalid"', 'cart-context validation code'],
+  ['"Currency code is required unless it can be resolved from region or country"', 'static currency message'],
+  ['super::resolve_context_for_db(', 'store context resolution'],
+  ['context.currency_code', 'resolved currency preference'],
+  ['CartStorefrontCreateRequest {', 'typed create request'],
+  ['customer_id,', 'customer identity propagation'],
+  ['region_id: context.region.as_ref().map(|region| region.id)', 'resolved region propagation'],
+  ['locale_code: Some(context.locale.clone())', 'resolved locale propagation'],
+  ['channel_id: request_context.channel_id', 'channel ID propagation'],
+  ['channel_slug: request_context.channel_slug.clone()', 'channel slug propagation'],
+  ['StatusCode::CREATED', 'created response status'],
+]) {
+  requireText(createHandler, value, label);
+}
+
+for (const operation of [
+  '"create_cart"',
+  '"get_cart"',
+  '"update_cart_context_read"',
+  '"add_cart_line_item_read"',
+  '"add_cart_line_item"',
+  '"update_cart_line_item_read"',
+  '"update_cart_line_item_pricing"',
+  '"update_cart_line_item_quantity"',
+  '"remove_cart_line_item_read"',
+  '"remove_cart_line_item"',
+]) {
+  requireText(controller, operation, 'cart diagnostic operation label');
+}
+
+const mapperUses = controller.match(/map_cart_port_error\(/g) ?? [];
+if (mapperUses.length !== 11) {
+  failures.push(`expected mapper definition plus ten cart-owned callsites, found ${mapperUses.length}`);
+}
+const directSharedMapperUses = controller.match(/\.map_err\(port_error_to_http_error\)\?/g) ?? [];
+if (directSharedMapperUses.length !== 1) {
+  failures.push(
+    `expected exactly one direct shared mapper use for the pricing owner, found ${directSharedMapperUses.length}`,
+  );
+}
+
+for (const [value, label] of [
+  ['pub async fn create_cart(', 'create handler'],
+  ['pub async fn get_cart(', 'get handler'],
+  ['pub async fn update_cart_context(', 'context update handler'],
+  ['pub async fn add_cart_line_item(', 'add line handler'],
+  ['pub async fn update_cart_line_item(', 'update line handler'],
+  ['pub async fn remove_cart_line_item(', 'remove line handler'],
+  ['ensure_storefront_channel_enabled_for_db(', 'channel guard'],
+  ['current_customer_id_for_db(', 'customer lookup'],
+  ['ensure_store_cart_access(', 'cart ownership guard'],
+  ['enrich_storefront_cart_for_db(', 'cart enrichment'],
+  ['storefront_cart_port_context(', 'cart port context'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [value, label] of [
+  ['CartStorefrontReadRequest { cart_id: id }', 'typed cart read'],
+  ['CartStorefrontAddLineItemRequest {', 'typed add-line request'],
+  ['CartStorefrontLineItemPricingRequest {', 'typed pricing update request'],
+  ['CartStorefrontLineItemQuantityRequest {', 'typed quantity update request'],
+  ['CartStorefrontRemoveLineItemRequest {', 'typed remove-line request'],
+  ['resolve_store_line_item_input(', 'line-item resolution'],
+  ['validate_store_line_item_quantity(', 'inventory quantity validation'],
+  ['build_store_pricing_context(', 'pricing context'],
+  ['ResolveProductPriceRequest {', 'typed pricing request'],
+  ['storefront_cart_pricing_update(', 'pricing snapshot update'],
+]) {
+  requireText(controller, value, label);
+}
+
+for (const [value, label] of [
+  ['.resolve_product_price(', 'pricing resolution call'],
+  ['.map_err(port_error_to_http_error)?', 'pricing owner shared mapper'],
+  ['product_id: existing', 'existing product identity'],
+  ['variant_id,', 'variant identity'],
+  ['quantity: pricing_context.quantity', 'pricing quantity'],
+  ['currency_code: pricing_context.currency_code', 'pricing currency'],
+]) {
+  requireText(updateLineHandler, value, label);
+}
+
+for (const [content, value, label] of [
+  [apiPorts, 'pub struct PortError {', 'owner port error type'],
+  [apiPorts, 'pub kind: PortErrorKind', 'owner port kind'],
+  [apiPorts, 'pub code: String', 'owner port code'],
+  [apiPorts, 'pub message: String', 'owner port message'],
+  [apiPorts, 'pub retryable: bool', 'owner port retryability'],
+  [webErrors, 'pub fn port_error_to_http_error(error: PortError)', 'shared port HTTP mapper'],
+  [webErrors, 'PortErrorKind::Validation => StatusCode::BAD_REQUEST', 'validation status'],
+  [webErrors, 'PortErrorKind::NotFound => StatusCode::NOT_FOUND', 'not-found status'],
+  [webErrors, 'PortErrorKind::Conflict => StatusCode::CONFLICT', 'conflict status'],
+  [webErrors, 'PortErrorKind::Forbidden => StatusCode::FORBIDDEN', 'forbidden status'],
+  [webErrors, 'PortErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  [webErrors, 'PortErrorKind::Timeout => StatusCode::GATEWAY_TIMEOUT', 'timeout status'],
+  [webErrors, 'PortErrorKind::InvariantViolation => StatusCode::INTERNAL_SERVER_ERROR', 'invariant status'],
+  [webErrors, '"The requested service is temporarily unavailable"', 'safe unavailable message'],
+  [webErrors, '"The requested operation could not be completed"', 'safe invariant message'],
+]) {
+  requireText(content, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront cart HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Storefront cart handlers use typed safe public envelopes and diagnostics');


### PR DESCRIPTION
## Summary

- replace the remaining storefront cart `commerce_operation_failed` validation envelope with a stable cart-context code and static message;
- route all ten cart-owned port callsites through one typed boundary mapper;
- preserve `PortError` status/code semantics through `port_error_to_http_error` while logging raw owner evidence internally;
- record owner, operation, tenant, optional cart, error kind, retryability, public code, and status for cart port failures;
- keep the pricing read on its separate shared port mapper;
- add a focused source verifier for cart callsite count, operation labels, shared port safety, context propagation, access checks, pricing, inventory validation, and cart enrichment.

## Scope

Two files only: `controllers/store/carts.rs` and one verifier. Routes, request DTOs, customer lookup, channel guard, cart access, context resolution, channel propagation, line-item resolution, pricing inputs, inventory validation, cart enrichment, response DTOs, and success statuses are unchanged.

## Public policy

- unresolved required currency: `400 commerce_store_cart_context_invalid` with a static message;
- cart port validation/not-found/conflict/forbidden failures preserve their typed public status and code;
- cart port unavailable, timeout, and invariant failures use the shared sanitized `503`, `504`, and `500` envelopes.

## Validation

- source-level audit completed against the current `PortError` and `port_error_to_http_error` contracts;
- branch is directly ahead of current `main` and changes only the intended controller plus verifier;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.