### PR TITLE
fix(index): capture observed benchmark session metadata

### DIFF
--- a/ops/benches/src/bin/index_storage_benchmark.rs
+++ b/ops/benches/src/bin/index_storage_benchmark.rs
@@ -1,12 +1,10 @@
-use rustok_benchmarks::index_storage::{
-    BenchmarkConfig, run, write_report_with_session_metadata,
-};
+use rustok_benchmarks::index_storage::{BenchmarkConfig, run, write_report};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report_with_session_metadata(&config.output_path, &report)?;
+    write_report(&config.output_path, &report)?;
 
     println!(
         "index storage benchmark complete: scale={:?}, product_rows={}, output={}",

--- a/ops/benches/src/index_storage/connection.rs
+++ b/ops/benches/src/index_storage/connection.rs
@@ -1,13 +1,6 @@
 use anyhow::{Context, Result};
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
 
-pub(crate) const BENCHMARK_SESSION_METADATA: [(&str, &str); 4] = [
-    ("standard_conforming_strings", "on"),
-    ("timezone", "UTC"),
-    ("date_style", "ISO, YMD"),
-    ("extra_float_digits", "3"),
-];
-
 const BENCHMARK_SESSION_SQL: &str = concat!(
     "SET standard_conforming_strings = on;",
     " SET TIME ZONE 'UTC';",
@@ -35,27 +28,19 @@ pub async fn connect(database_url: &str) -> Result<DatabaseConnection> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BENCHMARK_SESSION_METADATA, BENCHMARK_SESSION_SQL};
+    use super::BENCHMARK_SESSION_SQL;
 
     #[test]
     fn benchmark_session_contract_is_explicit_and_deterministic() {
-        for (field, value, statement) in [
-            (
-                "standard_conforming_strings",
-                "on",
-                "SET standard_conforming_strings = on;",
-            ),
-            ("timezone", "UTC", "SET TIME ZONE 'UTC';"),
-            ("date_style", "ISO, YMD", "SET DateStyle = 'ISO, YMD';"),
-            ("extra_float_digits", "3", "SET extra_float_digits = 3;"),
+        for statement in [
+            "SET standard_conforming_strings = on;",
+            "SET TIME ZONE 'UTC';",
+            "SET DateStyle = 'ISO, YMD';",
+            "SET extra_float_digits = 3;",
         ] {
             assert!(
                 BENCHMARK_SESSION_SQL.contains(statement),
                 "benchmark session SQL is missing {statement}"
-            );
-            assert!(
-                BENCHMARK_SESSION_METADATA.contains(&(field, value)),
-                "benchmark session metadata is missing {field}={value}"
             );
         }
         assert!(!BENCHMARK_SESSION_SQL.contains("standard_conforming_strings = off"));

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -1,8 +1,3 @@
-use std::{fs, path::Path};
-
-use anyhow::{Context, Result};
-use serde_json::Value;
-
 mod config;
 mod connection;
 mod explain;
@@ -12,12 +7,12 @@ mod runner;
 mod sql;
 
 pub use config::{BenchmarkConfig, DatasetConfig, DatasetScale};
-pub(crate) use connection::{BENCHMARK_SESSION_METADATA, connect as connect_benchmark_database};
+pub(crate) use connection::connect as connect_benchmark_database;
 pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
-pub use runner::{BenchmarkReport, run};
+pub use runner::{BenchmarkReport, run, write_report};
 pub(crate) use sql::read_workload_contract;
 pub use sql::{
     MutationWorkload, Prototype, RESULT_DIGEST_CONTRACT, Workload, analyze_sql, churn_cycle_sql,
@@ -25,50 +20,9 @@ pub use sql::{
     vacuum_statements, workloads,
 };
 
-pub fn write_report_with_session_metadata(path: &Path, report: &BenchmarkReport) -> Result<()> {
-    if let Some(parent) = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create benchmark output directory {parent:?}"))?;
-    }
-
-    let mut json = serde_json::to_value(report).context("failed to serialize benchmark report")?;
-    let database = json
-        .get_mut("database")
-        .and_then(Value::as_object_mut)
-        .context("benchmark report database metadata must be an object")?;
-    for (field, setting_value) in BENCHMARK_SESSION_METADATA {
-        database.insert(field.to_owned(), Value::String(setting_value.to_owned()));
-    }
-
-    let bytes = serde_json::to_vec_pretty(&json)
-        .context("failed to serialize benchmark report with session metadata")?;
-    fs::write(path, bytes)
-        .with_context(|| format!("failed to write benchmark report to {path:?}"))?;
-    Ok(())
-}
-
 pub async fn run_from_env() -> anyhow::Result<BenchmarkReport> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report_with_session_metadata(&config.output_path, &report)?;
+    write_report(&config.output_path, &report)?;
     Ok(report)
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn raw_report_writer_is_not_publicly_reexported() {
-        let source = include_str!("mod.rs");
-        assert!(
-            !source.lines().any(|line| {
-                line.trim_start().starts_with("pub use runner::")
-                    && line.contains("write_report")
-            }),
-            "the raw runner report writer must remain private to the benchmark module"
-        );
-        assert!(source.contains("pub fn write_report_with_session_metadata"));
-    }
 }

--- a/ops/benches/src/index_storage/runner.rs
+++ b/ops/benches/src/index_storage/runner.rs
@@ -12,6 +12,20 @@ use super::{
     read_workload_contract, source_dataset_sql, source_workloads, workloads,
 };
 
+const DATABASE_METADATA_SQL: &str = concat!(
+    "SELECT version() AS version,",
+    " current_setting('server_version_num') AS server_version_num,",
+    " current_setting('shared_buffers') AS shared_buffers,",
+    " current_setting('effective_cache_size') AS effective_cache_size,",
+    " current_setting('work_mem') AS work_mem,",
+    " current_setting('random_page_cost') AS random_page_cost,",
+    " current_setting('jit') AS jit,",
+    " current_setting('standard_conforming_strings') AS standard_conforming_strings,",
+    " current_setting('TimeZone') AS timezone,",
+    " current_setting('DateStyle') AS date_style,",
+    " current_setting('extra_float_digits') AS extra_float_digits",
+);
+
 #[derive(Debug, Serialize)]
 pub struct BenchmarkReport {
     pub generated_at: DateTime<Utc>,
@@ -34,6 +48,10 @@ pub struct DatabaseMetadata {
     pub work_mem: String,
     pub random_page_cost: String,
     pub jit: String,
+    pub standard_conforming_strings: String,
+    pub timezone: String,
+    pub date_style: String,
+    pub extra_float_digits: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -286,7 +304,7 @@ async fn read_database_metadata(db: &DatabaseConnection) -> Result<DatabaseMetad
     let row = db
         .query_one(Statement::from_string(
             DbBackend::Postgres,
-            "SELECT version() AS version, current_setting('server_version_num') AS server_version_num, current_setting('shared_buffers') AS shared_buffers, current_setting('effective_cache_size') AS effective_cache_size, current_setting('work_mem') AS work_mem, current_setting('random_page_cost') AS random_page_cost, current_setting('jit') AS jit".to_owned(),
+            DATABASE_METADATA_SQL.to_owned(),
         ))
         .await?
         .context("database metadata query returned no row")?;
@@ -299,6 +317,10 @@ async fn read_database_metadata(db: &DatabaseConnection) -> Result<DatabaseMetad
         work_mem: row.try_get("", "work_mem")?,
         random_page_cost: row.try_get("", "random_page_cost")?,
         jit: row.try_get("", "jit")?,
+        standard_conforming_strings: row.try_get("", "standard_conforming_strings")?,
+        timezone: row.try_get("", "timezone")?,
+        date_style: row.try_get("", "date_style")?,
+        extra_float_digits: row.try_get("", "extra_float_digits")?,
     })
 }
 
@@ -425,5 +447,20 @@ mod tests {
         assert_eq!(dataset.total_entity_rows(), 1_216);
         assert_eq!(dataset.total_eav_field_rows(), 5_632);
         assert_eq!(dataset.total_link_rows(), 2_400);
+    }
+
+    #[test]
+    fn database_metadata_query_observes_deterministic_session() {
+        for marker in [
+            "current_setting('standard_conforming_strings') AS standard_conforming_strings",
+            "current_setting('TimeZone') AS timezone",
+            "current_setting('DateStyle') AS date_style",
+            "current_setting('extra_float_digits') AS extra_float_digits",
+        ] {
+            assert!(
+                DATABASE_METADATA_SQL.contains(marker),
+                "database metadata query is missing {marker}"
+            );
+        }
     }
 }

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -11,6 +11,7 @@ const fail = (message) => {
 
 const benchmarkModule = read('ops/benches/src/index_storage/mod.rs');
 const benchmarkBinary = read('ops/benches/src/bin/index_storage_benchmark.rs');
+const benchmarkRunner = read('ops/benches/src/index_storage/runner.rs');
 const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
@@ -52,19 +53,44 @@ requireMarkers(connection, 'benchmark session contract', [
   'BENCHMARK_SESSION_METADATA.contains(&(field, value))',
 ]);
 
+requireMarkers(benchmarkRunner, 'observed database metadata', [
+  'const DATABASE_METADATA_SQL',
+  'pub struct DatabaseMetadata',
+  'pub standard_conforming_strings: String',
+  'pub timezone: String',
+  'pub date_style: String',
+  'pub extra_float_digits: String',
+  "current_setting('standard_conforming_strings') AS standard_conforming_strings",
+  "current_setting('TimeZone') AS timezone",
+  "current_setting('DateStyle') AS date_style",
+  "current_setting('extra_float_digits') AS extra_float_digits",
+  'standard_conforming_strings: row.try_get("", "standard_conforming_strings")?',
+  'timezone: row.try_get("", "timezone")?',
+  'date_style: row.try_get("", "date_style")?',
+  'extra_float_digits: row.try_get("", "extra_float_digits")?',
+  'fn database_metadata_query_observes_deterministic_session()',
+]);
 requireMarkers(benchmarkModule, 'benchmark report writer', [
-  'BENCHMARK_SESSION_METADATA',
-  'pub fn write_report_with_session_metadata',
-  'serde_json::to_value(report)',
-  'database.insert(field.to_owned(), Value::String(setting_value.to_owned()))',
-  'write_report_with_session_metadata(&config.output_path, &report)?',
+  'pub use runner::{BenchmarkReport, run, write_report};',
+  'write_report(&config.output_path, &report)?',
 ]);
 requireMarkers(benchmarkBinary, 'read evidence executable', [
-  'write_report_with_session_metadata',
-  'write_report_with_session_metadata(&config.output_path, &report)?',
+  'BenchmarkConfig, run, write_report',
+  'write_report(&config.output_path, &report)?',
 ]);
-if (benchmarkBinary.includes('write_report(&config.output_path, &report)?')) {
-  fail('read evidence executable bypasses deterministic session metadata serialization');
+for (const [label, content] of [
+  ['benchmark module', benchmarkModule],
+  ['read evidence executable', benchmarkBinary],
+]) {
+  for (const forbidden of [
+    'write_report_with_session_metadata',
+    'serde_json::to_value(report)',
+    'database.insert(field.to_owned()',
+  ]) {
+    if (content.includes(forbidden)) {
+      fail(`${label} restored post-hoc deterministic session metadata injection: ${forbidden}`);
+    }
+  }
 }
 
 requireMarkers(preflight, 'read ordering preflight', [
@@ -222,4 +248,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] deterministic PostgreSQL session metadata, session-aware evidence entrypoint, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] observed PostgreSQL session metadata, canonical evidence writer, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -113,7 +113,7 @@ requireMarkers(preflight, 'read ordering preflight', [
   "sql.startsWith('/*', index)",
   'unterminated block comment',
   "const escapeString = quote === \"'\" && isEscapeStringQuote(sql, index)",
-  "escapeString && sql[index] === '\\'",
+  "escapeString && sql[index] === '\\\\'",
   'unterminated escape string literal',
   "? (escapeString ? 'escape string literal' : 'string literal')",
   'contains an unterminated ${kind}',

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -40,17 +40,13 @@ const sessionMetadataMarkers = [
 ];
 
 requireMarkers(connection, 'benchmark session contract', [
-  'pub(crate) const BENCHMARK_SESSION_METADATA',
-  '("standard_conforming_strings", "on")',
-  '("timezone", "UTC")',
-  '("date_style", "ISO, YMD")',
-  '("extra_float_digits", "3")',
+  'const BENCHMARK_SESSION_SQL',
   'SET standard_conforming_strings = on;',
   "SET TIME ZONE 'UTC';",
   "SET DateStyle = 'ISO, YMD';",
   'SET extra_float_digits = 3;',
   'failed to pin deterministic PostgreSQL benchmark session',
-  'BENCHMARK_SESSION_METADATA.contains(&(field, value))',
+  'fn benchmark_session_contract_is_explicit_and_deterministic()',
 ]);
 
 requireMarkers(benchmarkRunner, 'observed database metadata', [
@@ -117,7 +113,7 @@ requireMarkers(preflight, 'read ordering preflight', [
   "sql.startsWith('/*', index)",
   'unterminated block comment',
   "const escapeString = quote === \"'\" && isEscapeStringQuote(sql, index)",
-  "escapeString && sql[index] === '\\\\'",
+  "escapeString && sql[index] === '\\'",
   'unterminated escape string literal',
   "? (escapeString ? 'escape string literal' : 'string literal')",
   'contains an unterminated ${kind}',
@@ -248,4 +244,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] observed PostgreSQL session metadata, canonical evidence writer, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, canonical evidence writer, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- read `standard_conforming_strings`, `TimeZone`, `DateStyle`, and `extra_float_digits` from the active PostgreSQL benchmark connection via `current_setting(...)`;
- serialize those observed values directly as part of `DatabaseMetadata` in `read-report.json`;
- remove the post-hoc JSON mutation writer and restore one canonical `write_report` entrypoint;
- keep the enforced session SQL and observed metadata query as separate guarded contracts.

## Why

The prior implementation wrote expected session values from Rust constants after the benchmark completed. Although the connection pinned those settings, the archived packet did not independently contain values observed from PostgreSQL. This change makes the evidence describe the actual session used after all benchmark `SET` statements and before dataset/workload execution.

## Scope

Benchmark/evidence tooling only. No candidate SQL, dataset topology, production migration, runtime Index API, byte-preserved validator/comparator core, or storage decision changes.

## Validation

Tests, Node commands, Cargo commands, formatting, verifier execution, and benchmark runs were not run by the implementation agent, per repository-owner instruction. The five-file diff was re-audited statically; the audit removed a now-unused synthetic metadata constant and confirmed parallel `main` changes are unrelated storefront/SEO work.