### PR TITLE
fix(index): compare observed PostgreSQL session settings

### DIFF
--- a/scripts/verify/compare-index-storage-evidence.mjs
+++ b/scripts/verify/compare-index-storage-evidence.mjs
@@ -1,31 +1,111 @@
 #!/usr/bin/env node
 
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
 import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs';
 
 const prefix = '[compare-index-storage-evidence]';
+const comparableDatabaseFields = [
+  'server_version_num',
+  'shared_buffers',
+  'effective_cache_size',
+  'work_mem',
+  'random_page_cost',
+  'jit',
+  'standard_conforming_strings',
+  'timezone',
+  'date_style',
+  'extra_float_digits',
+];
 
-const preflightInputs = (args) => {
+const preflightArgs = (args) => {
   const inputs = [];
+  let output = 'evidence/index-storage/comparison';
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') return null;
     if (argument === '--input' && args[index + 1] && !args[index + 1].startsWith('--')) {
       inputs.push(args[++index]);
     } else if (argument === '--output' && args[index + 1] && !args[index + 1].startsWith('--')) {
-      index += 1;
+      output = args[++index];
     } else {
       return null;
     }
   }
-  return inputs;
+  return { inputs, output };
+};
+
+const readJson = (filename, label) => {
+  try {
+    return JSON.parse(readFileSync(filename, 'utf8'));
+  } catch (error) {
+    throw new Error(`unable to read ${label} ${filename}: ${error.message}`);
+  }
+};
+
+const requireObject = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+};
+
+const finalizeDatabaseSettingsContract = ({ inputs, output }) => {
+  const packets = inputs.map((input) => {
+    const provenance = requireObject(
+      readJson(path.join(input, 'provenance.json'), 'evidence provenance'),
+      `${input} provenance`,
+    );
+    const read = requireObject(
+      readJson(path.join(input, 'read-report.json'), 'read evidence'),
+      `${input} read report`,
+    );
+    const database = requireObject(read.database, `${input} read.database`);
+    for (const field of comparableDatabaseFields) {
+      if (typeof database[field] !== 'string' || database[field].length === 0) {
+        throw new Error(`${input} read.database.${field} must be a non-empty string`);
+      }
+    }
+    return { scale: provenance.scale, database };
+  });
+
+  const lower = packets.find((packet) => packet.scale === '100k');
+  const upper = packets.find((packet) => packet.scale === '1m');
+  if (lower && upper) {
+    for (const field of comparableDatabaseFields) {
+      if (lower.database[field] !== upper.database[field]) {
+        throw new Error(`cross-scale database setting ${field} mismatch`);
+      }
+    }
+  }
+
+  const comparisonPath = path.join(output, 'comparison.json');
+  const report = requireObject(readJson(comparisonPath, 'comparison report'), 'comparison report');
+  const methodology = requireObject(report.methodology, 'comparison methodology');
+  methodology.comparable_database_fields = comparableDatabaseFields;
+  methodology.database_settings_source =
+    'read-report.json database metadata observed from the active PostgreSQL benchmark session';
+  writeFileSync(comparisonPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  const markdownPath = path.join(output, 'comparison.md');
+  const lines = readFileSync(markdownPath, 'utf8').split('\n');
+  const settingsLine = lines.findIndex((line) => line.startsWith('- Same PostgreSQL image/settings:'));
+  if (settingsLine < 0) {
+    throw new Error('comparison markdown is missing the PostgreSQL image/settings decision line');
+  }
+  const comparedFields = comparableDatabaseFields.map((field) => `\`${field}\``).join(', ');
+  lines.splice(settingsLine + 1, 0, `- Compared PostgreSQL fields: ${comparedFields}`);
+  writeFileSync(markdownPath, lines.join('\n'));
 };
 
 const main = async () => {
-  const inputs = preflightInputs(process.argv.slice(2));
-  if (inputs !== null) {
-    for (const input of inputs) validatePacketReadOrdering(input);
+  const parsed = preflightArgs(process.argv.slice(2));
+  if (parsed !== null) {
+    for (const input of parsed.inputs) validatePacketReadOrdering(input);
   }
   await import('./compare-index-storage-evidence-core.mjs');
+  if (parsed !== null) finalizeDatabaseSettingsContract(parsed);
 };
 
 try {

--- a/scripts/verify/compare-index-storage-evidence.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence.test.mjs
@@ -29,6 +29,18 @@ const readWorkloads = [
   'exact_count',
 ];
 const mutationWorkloads = ['update_product_batch', 'delete_product_batch'];
+const comparableDatabaseFields = [
+  'server_version_num',
+  'shared_buffers',
+  'effective_cache_size',
+  'work_mem',
+  'random_page_cost',
+  'jit',
+  'standard_conforming_strings',
+  'timezone',
+  'date_style',
+  'extra_float_digits',
+];
 const scaleValues = {
   '100k': {
     serialized: 'rows100k', debug: 'Rows100k', tenants: 10, productsPerTenant: 5_000,
@@ -283,6 +295,10 @@ test('same-commit complete 100k and 1m evidence is decision-ready', () => {
     assert.equal(report.decision_contract.same_result_digest_contract, true);
     assert.equal(report.scales[0].provenance.result_digest_contract, resultDigestContract);
     assert.equal(report.methodology.result_digest, resultDigestContract);
+    assert.deepEqual(report.methodology.comparable_database_fields, comparableDatabaseFields);
+    assert.match(report.methodology.database_settings_source, /observed from the active PostgreSQL benchmark session/u);
+    const markdown = readFileSync(path.join(output, 'comparison.md'), 'utf8');
+    for (const field of comparableDatabaseFields) assert.match(markdown, new RegExp(`\\\`${field}\\\``, 'u'));
     assert.equal(report.cross_scale_ratios.source_workloads[0].result_rows_ratio_1m_to_100k, 10);
   });
 });
@@ -296,6 +312,7 @@ test('one valid scale remains non-decision-ready', () => {
     const report = JSON.parse(readFileSync(path.join(output, 'comparison.json'), 'utf8'));
     assert.equal(report.decision_ready, false);
     assert.equal(report.decision_contract.same_result_digest_contract, null);
+    assert.deepEqual(report.methodology.comparable_database_fields, comparableDatabaseFields);
   });
 });
 
@@ -364,5 +381,15 @@ test('rejects cross-scale commit mismatch', () => {
     const result = runComparator([lower, upper], path.join(root, 'comparison'));
     assert.notEqual(result.status, 0, 'expected comparator to fail closed');
     assert.match(result.stderr, /cross-scale commit mismatch/);
+  });
+});
+
+test('rejects observed session metadata drift before comparison output is accepted', () => {
+  withFixture((root) => {
+    const lower = writePacket(root, '100k');
+    const upper = writePacket(root, '1m', { database: { timezone: 'Europe/Moscow' } });
+    const result = runComparator([lower, upper], path.join(root, 'comparison'));
+    assert.notEqual(result.status, 0, 'expected comparator to fail closed');
+    assert.match(result.stderr, /read\.database\.timezone must be UTC; got Europe\/Moscow/u);
   });
 });

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -38,6 +38,18 @@ const sessionMetadataMarkers = [
   "date_style: 'ISO, YMD'",
   "extra_float_digits: '3'",
 ];
+const comparableDatabaseFieldMarkers = [
+  "'server_version_num'",
+  "'shared_buffers'",
+  "'effective_cache_size'",
+  "'work_mem'",
+  "'random_page_cost'",
+  "'jit'",
+  "'standard_conforming_strings'",
+  "'timezone'",
+  "'date_style'",
+  "'extra_float_digits'",
+];
 
 requireMarkers(connection, 'benchmark session contract', [
   'const BENCHMARK_SESSION_SQL',
@@ -147,8 +159,12 @@ requireMarkers(fixture, 'read ordering fixture', [
 ]);
 requireMarkers(comparatorFixture, 'comparison evidence fixture', [
   ...sessionMetadataMarkers,
+  ...comparableDatabaseFieldMarkers,
   'function writePacket(root, scale, overrides = {})',
   "test('same-commit complete 100k and 1m evidence is decision-ready'",
+  'assert.deepEqual(report.methodology.comparable_database_fields, comparableDatabaseFields);',
+  'database_settings_source',
+  "test('rejects observed session metadata drift before comparison output is accepted'",
 ]);
 
 requireMarkers(validatorWrapper, 'standalone validator wrapper', [
@@ -163,19 +179,35 @@ if (validatorOrdering < 0 || validatorCore < 0 || validatorOrdering > validatorC
 }
 
 requireMarkers(comparatorWrapper, 'standalone comparator wrapper', [
+  "import { readFileSync, writeFileSync } from 'node:fs'",
+  "import path from 'node:path'",
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-  'for (const input of inputs) validatePacketReadOrdering(input);',
+  'const comparableDatabaseFields = [',
+  ...comparableDatabaseFieldMarkers,
+  'const finalizeDatabaseSettingsContract = ({ inputs, output }) =>',
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
+  'cross-scale database setting ${field} mismatch',
+  'methodology.comparable_database_fields = comparableDatabaseFields;',
+  'database_settings_source',
+  'Compared PostgreSQL fields:',
   "await import('./compare-index-storage-evidence-core.mjs')",
+  'if (parsed !== null) finalizeDatabaseSettingsContract(parsed);',
 ]);
 const standaloneCompareOrdering = comparatorWrapper.indexOf(
-  'for (const input of inputs) validatePacketReadOrdering(input);',
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
 );
 const standaloneComparatorCore = comparatorWrapper.indexOf(
   "await import('./compare-index-storage-evidence-core.mjs')",
 );
+const standaloneComparatorFinalization = comparatorWrapper.indexOf(
+  'if (parsed !== null) finalizeDatabaseSettingsContract(parsed);',
+);
 if (standaloneCompareOrdering < 0 || standaloneComparatorCore < 0
     || standaloneCompareOrdering > standaloneComparatorCore) {
   fail('standalone comparator must preflight every input before importing its core');
+}
+if (standaloneComparatorFinalization < 0 || standaloneComparatorCore > standaloneComparatorFinalization) {
+  fail('standalone comparator must finalize the full database-settings contract after its core');
 }
 
 requireMarkers(standaloneFixture, 'standalone evidence fixture', [
@@ -244,4 +276,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, canonical evidence writer, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, canonical evidence writer, full cross-scale database settings, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- make the official cross-scale comparator wrapper validate the complete PostgreSQL database context, including observed `standard_conforming_strings`, `timezone`, `date_style`, and `extra_float_digits`;
- preserve the byte-pinned comparator core and its metric/decision calculations;
- record the exact ten compared database fields and their observed-session source in `comparison.json` and `comparison.md`;
- extend the comparator fixture and static guard for the full database-settings contract and wrapper execution order.

## Why

The read evidence now archives the active PostgreSQL session values, but the cross-scale comparison report only documented the older server/planner fields. The official comparator path should fail closed on the complete observed database context and make the scope of `same_database_settings` explicit for the storage ADR.

## Scope

Verifier and evidence-comparison tooling only. No benchmark execution code, candidate SQL, dataset topology, production migration, Index runtime API, byte-preserved comparator core, or storage decision is changed.

## Validation

Tests, Node commands, Cargo commands, formatting, verifier execution, and benchmark runs were not run by the implementation agent, per repository-owner instruction. The three-file diff was reviewed statically against current `main`, including wrapper argument handling, preflight/core/finalization order, JSON/Markdown output preservation, fixture syntax, and unchanged core hash pins.