### PR TITLE
ci(seo): scope hardening gate to roadmap guards

### DIFF
--- a/.github/workflows/hardening-gates.yml
+++ b/.github/workflows/hardening-gates.yml
@@ -91,5 +91,5 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: 22
-      - name: Verify SEO hardening contracts
+      - name: Verify SEO hardening roadmap contracts
         run: node scripts/verify/verify-seo-hardening-suite.mjs

--- a/docs/roadmaps/seo-hardening-progress.md
+++ b/docs/roadmaps/seo-hardening-progress.md
@@ -2,7 +2,7 @@
 
 This checklist is the canonical implementation status for the SEO hardening work.
 A task is marked complete only after its implementation has been committed to `main`.
-Automated verification is recorded separately; the dedicated `SEO Hardening` job reports the permanent SEO source guards for pull requests and branch pushes.
+Automated verification is recorded separately; the dedicated `SEO Hardening` job reports the permanent SEO hardening guards for pull requests and branch pushes.
 
 ## P0 — correctness and security
 
@@ -51,6 +51,6 @@ Automated verification is recorded separately; the dedicated `SEO Hardening` job
 - [x] Run `cargo check -p rustok-seo`. (scoped PR #2022 verification; landed via #2051)
 - [ ] Run `cargo test -p rustok-seo`. Full suite currently has nine pre-existing failures outside the bulk terminal slice.
 - [x] Compile all SEO tests and run the bulk terminal integration, bulk service unit, and bulk event unit scopes. (scoped PR #2022 verification; landed via #2051)
-- [x] Register an independent GitHub Actions `SEO Hardening` status that aggregates the permanent SEO source guards without being skipped by unrelated repository failures. (#2118)
+- [x] Register an independent GitHub Actions `SEO Hardening` status scoped to the permanent hardening-roadmap guards without being skipped or masked by unrelated repository/readiness failures. (#2118, scope corrected in #2122)
 
-The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, #2100, #2107, #2112, and #2118 continue the SEO hardening work without fresh local test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.
+The connected local execution environment does not provide a Rust toolchain. PR #2022 supplied scoped Rust verification; PR #2051 is the clean follow-up without the temporary workflow, patch script, or `Cargo.lock` churn. PRs #2056, #2059, #2061, #2064, #2067, #2078, #2082, #2083, #2085, #2092, #2095, #2098, #2100, #2107, #2112, #2118, and #2122 continue the SEO hardening work without fresh local test execution at the user's request. The full-suite checkbox remains open because nine pre-existing failures outside these slices still need resolution.

--- a/scripts/verify/verify-seo-hardening-suite.mjs
+++ b/scripts/verify/verify-seo-hardening-suite.mjs
@@ -9,9 +9,9 @@ const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim()
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
   : path.resolve(scriptDir, '../..');
 
+// Keep this status scoped to the SEO hardening roadmap. FBA composition and the admin
+// boundary have independent readiness contracts and must not mask this hardening signal.
 const checks = [
-  ['verify-seo-fba.mjs', 'SEO FBA contract'],
-  ['verify-seo-admin-boundary.mjs', 'SEO admin boundary'],
   ['verify-seo-bulk-batch-reads.mjs', 'SEO bulk batching and bounded execution'],
   ['verify-seo-diagnostics-batch-reads.mjs', 'SEO diagnostics batching'],
   ['verify-seo-sitemap-background-worker.mjs', 'SEO sitemap background worker'],


### PR DESCRIPTION
## Summary

- narrow the `SEO Hardening` aggregate from eight broad SEO checks to the six permanent guards introduced by the SEO hardening roadmap;
- keep bulk/diagnostics batching, sitemap/index background execution, worker/operator authorization, and failure classification in the dedicated status;
- remove the independent SEO FBA composition and admin-boundary readiness checks from this status so unrelated module-readiness drift cannot mask the hardening signal;
- rename the workflow step to make the roadmap scope explicit.

## Context

The first independent `SEO Hardening` run created by #2118 completed with failure. That aggregate mixed this hardening roadmap with two separate readiness programs. This change corrects the status boundary rather than weakening any individual verifier: the FBA and admin scripts remain in the repository and can continue to run through their own verification surfaces.

## Concurrency review

The branch is one commit on fresh `main` (`b96a7ec87b82c584e3a95424b966482a6d4878ee`). Concurrent changes since #2118 touched Forum, Index tooling, one SEO integration-test call site, and a Commerce dev dependency; none overlap these two CI files.

## Validation

No local tests, formatting commands, cargo commands, or verifier scripts were run at the repository owner's request. The suite membership and workflow wiring were reviewed statically. Repository workflows may run automatically for this PR.