### PR TITLE
fix(index): bind storage ADR to observed database settings

### DIFF
--- a/.github/workflows/index-storage-scale-evidence.yml
+++ b/.github/workflows/index-storage-scale-evidence.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.test.mjs"
+      - "scripts/verify/index-storage-database-settings-contract.mjs"
       - "scripts/verify/index-storage-standalone-tools.test.mjs"
       - "scripts/verify/verify-index-storage-standalone-tools.mjs"
       - "scripts/verify/hash-index-storage-comparison.mjs"
@@ -49,6 +50,7 @@ on:
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.test.mjs"
+      - "scripts/verify/index-storage-database-settings-contract.mjs"
       - "scripts/verify/index-storage-standalone-tools.test.mjs"
       - "scripts/verify/verify-index-storage-standalone-tools.mjs"
       - "scripts/verify/hash-index-storage-comparison.mjs"
@@ -112,6 +114,7 @@ jobs:
           node --check scripts/verify/validate-index-storage-evidence-core.mjs
       - name: Verify cross-scale comparator syntax
         run: |
+          node --check scripts/verify/index-storage-database-settings-contract.mjs
           node --check scripts/verify/compare-index-storage-evidence.mjs
           node --check scripts/verify/compare-index-storage-evidence-core.mjs
       - name: Verify storage decision and ADR tooling syntax

--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
+      - "scripts/verify/index-storage-database-settings-contract.mjs"
       - "scripts/verify/index-storage-standalone-tools.test.mjs"
       - "scripts/verify/verify-index-storage-standalone-tools.mjs"
       - "scripts/verify/hash-index-storage-comparison.mjs"
@@ -45,6 +46,7 @@ on:
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
+      - "scripts/verify/index-storage-database-settings-contract.mjs"
       - "scripts/verify/index-storage-standalone-tools.test.mjs"
       - "scripts/verify/verify-index-storage-standalone-tools.mjs"
       - "scripts/verify/hash-index-storage-comparison.mjs"
@@ -100,6 +102,7 @@ jobs:
             node --check scripts/verify/verify-index-storage-read-ordering-contract.mjs
             node --check scripts/verify/validate-index-storage-evidence.mjs
             node --check scripts/verify/validate-index-storage-evidence-core.mjs
+            node --check scripts/verify/index-storage-database-settings-contract.mjs
             node --check scripts/verify/compare-index-storage-evidence.mjs
             node --check scripts/verify/compare-index-storage-evidence-core.mjs
             node --check scripts/verify/index-storage-standalone-tools.test.mjs

--- a/scripts/verify/compare-index-storage-evidence.mjs
+++ b/scripts/verify/compare-index-storage-evidence.mjs
@@ -4,20 +4,12 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs';
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
 
 const prefix = '[compare-index-storage-evidence]';
-const comparableDatabaseFields = [
-  'server_version_num',
-  'shared_buffers',
-  'effective_cache_size',
-  'work_mem',
-  'random_page_cost',
-  'jit',
-  'standard_conforming_strings',
-  'timezone',
-  'date_style',
-  'extra_float_digits',
-];
 
 const preflightArgs = (args) => {
   const inputs = [];
@@ -84,8 +76,7 @@ const finalizeDatabaseSettingsContract = ({ inputs, output }) => {
   const report = requireObject(readJson(comparisonPath, 'comparison report'), 'comparison report');
   const methodology = requireObject(report.methodology, 'comparison methodology');
   methodology.comparable_database_fields = comparableDatabaseFields;
-  methodology.database_settings_source =
-    'read-report.json database metadata observed from the active PostgreSQL benchmark session';
+  methodology.database_settings_source = databaseSettingsSource;
   writeFileSync(comparisonPath, `${JSON.stringify(report, null, 2)}\n`);
 
   const markdownPath = path.join(output, 'comparison.md');

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -15,6 +15,8 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+import { requireComparisonDatabaseSettingsMethodology } from './index-storage-database-settings-contract.mjs';
+
 const prefix = '[finalize-index-storage-adr]';
 const placeholderPrefix = 'TODO(index-storage-decision):';
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -147,6 +149,7 @@ const main = () => {
 
   const comparison = readJsonBytes(args.comparison, 'comparison');
   const decision = readJsonBytes(args.decision, 'decision');
+  requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
   requireDecisionEnvelope(decision.value);
   rejectPlaceholders(decision.value);
 

--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -1,0 +1,35 @@
+export const comparableDatabaseFields = Object.freeze([
+  'server_version_num',
+  'shared_buffers',
+  'effective_cache_size',
+  'work_mem',
+  'random_page_cost',
+  'jit',
+  'standard_conforming_strings',
+  'timezone',
+  'date_style',
+  'extra_float_digits',
+]);
+
+export const databaseSettingsSource =
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session';
+
+const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
+export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) => {
+  const methodology = comparison?.methodology;
+  if (!methodology || typeof methodology !== 'object' || Array.isArray(methodology)) {
+    fail('comparison.methodology must be an object');
+  }
+  if (!sameJson(methodology.comparable_database_fields, comparableDatabaseFields)) {
+    fail(
+      'comparison methodology comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
+    );
+  }
+  if (methodology.database_settings_source !== databaseSettingsSource) {
+    fail(
+      'comparison methodology database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+    );
+  }
+  return methodology;
+};

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import assert from 'node:assert/strict';
@@ -16,6 +16,20 @@ const prototypes = ['jsonb', 'typed_eav', 'hot_projection'];
 const readWorkloads = ['status_equality', 'price_range_sort'];
 const mutationWorkloads = ['update_product_batch', 'delete_product_batch'];
 const markdownCode = String.fromCharCode(96);
+const comparableDatabaseFields = [
+  'server_version_num',
+  'shared_buffers',
+  'effective_cache_size',
+  'work_mem',
+  'random_page_cost',
+  'jit',
+  'standard_conforming_strings',
+  'timezone',
+  'date_style',
+  'extra_float_digits',
+];
+const databaseSettingsSource =
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session';
 const decisionFlags = {
   required_scales_present: true,
   same_packet_contract_version: true,
@@ -70,7 +84,11 @@ const scale = (name, factor) => ({
 
 const comparison = () => ({
   generated_at: '2026-07-24T12:00:00Z',
-  methodology: { automatic_winner_selection: false },
+  methodology: {
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
   decision_ready: true,
   decision_contract: { ...decisionFlags },
   scales: [scale('100k', 1), scale('1m', 10)],
@@ -165,6 +183,26 @@ test('prepares an exact-comparison-bound manual decision draft', () => {
   });
 });
 
+test('rejects a comparison without the canonical database-settings methodology', () => {
+  withFixture((root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const value = comparison();
+    delete value.methodology.comparable_database_fields;
+    writeJson(comparisonPath, value);
+    const result = run(prepareScript, [
+      '--comparison', comparisonPath,
+      '--selected', 'typed_eav',
+      '--owner', 'Index maintainers',
+      '--date', '2026-07-24',
+      '--output', decisionPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract/u);
+    assert.equal(existsSync(decisionPath), false);
+  });
+});
+
 test('refuses to overwrite an existing decision without force', () => {
   withFixture((root) => {
     const fixture = prepare(root);
@@ -210,6 +248,28 @@ test('rejects an unedited prepared decision', () => {
     ]);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /still contains a preparation placeholder/u);
+  });
+});
+
+test('finalizer rejects database-settings provenance drift with a matching comparison digest', () => {
+  withFixture((root) => {
+    const fixture = prepare(root);
+    assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+    const comparisonValue = JSON.parse(readFileSync(fixture.comparisonPath, 'utf8'));
+    comparisonValue.methodology.database_settings_source = 'declared benchmark constants';
+    const comparisonBytes = writeJson(fixture.comparisonPath, comparisonValue);
+    const decision = completeDecision(JSON.parse(readFileSync(fixture.decisionPath, 'utf8')));
+    decision.comparison_sha256 = sha256(comparisonBytes);
+    writeJson(fixture.decisionPath, decision);
+    const outputPath = path.join(root, 'adr.md');
+    const result = run(finalizeScript, [
+      '--comparison', fixture.comparisonPath,
+      '--decision', fixture.decisionPath,
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /database_settings_source must identify metadata observed from the active PostgreSQL benchmark session/u);
+    assert.equal(existsSync(outputPath), false);
   });
 });
 

--- a/scripts/verify/prepare-index-storage-decision.mjs
+++ b/scripts/verify/prepare-index-storage-decision.mjs
@@ -11,6 +11,8 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 
+import { requireComparisonDatabaseSettingsMethodology } from './index-storage-database-settings-contract.mjs';
+
 const prefix = '[prepare-index-storage-decision]';
 const prototypes = ['jsonb', 'typed_eav', 'hot_projection'];
 const requiredDecisionFlags = [
@@ -105,6 +107,7 @@ const readComparison = (filename) => {
 
 const comparisonCommit = (comparison) => {
   requireObject(comparison, 'comparison');
+  requireComparisonDatabaseSettingsMethodology(comparison, fail);
   if (comparison.decision_ready !== true) fail('comparison is not decision-ready');
   if (comparison.methodology?.automatic_winner_selection !== false) {
     fail('comparison must explicitly disable automatic winner selection');

--- a/scripts/verify/verify-index-storage-adr-tooling.mjs
+++ b/scripts/verify/verify-index-storage-adr-tooling.mjs
@@ -11,6 +11,7 @@ const fail = (message) => {
 
 const router = read('scripts/verify/index-storage-tooling.mjs');
 const routerFixture = read('scripts/verify/index-storage-tooling.test.mjs');
+const databaseSettingsContract = read('scripts/verify/index-storage-database-settings-contract.mjs');
 const decisionPreparer = read('scripts/verify/prepare-index-storage-decision.mjs');
 const adrFinalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
 const decisionFixture = read('scripts/verify/index-storage-decision-tooling.test.mjs');
@@ -74,8 +75,33 @@ for (const marker of [
 }
 
 for (const marker of [
+  'export const comparableDatabaseFields = Object.freeze([',
+  "'server_version_num'",
+  "'shared_buffers'",
+  "'effective_cache_size'",
+  "'work_mem'",
+  "'random_page_cost'",
+  "'jit'",
+  "'standard_conforming_strings'",
+  "'timezone'",
+  "'date_style'",
+  "'extra_float_digits'",
+  'export const databaseSettingsSource =',
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session',
+  'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
+  'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
+  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+]) {
+  if (!databaseSettingsContract.includes(marker)) {
+    fail(`database settings contract is missing marker: ${marker}`);
+  }
+}
+
+for (const marker of [
   "const placeholderPrefix = 'TODO(index-storage-decision):'",
   "const prototypes = ['jsonb', 'typed_eav', 'hot_projection']",
+  "from './index-storage-database-settings-contract.mjs'",
+  'requireComparisonDatabaseSettingsMethodology(comparison, fail);',
   'comparison.decision_ready !== true',
   'comparison.methodology?.automatic_winner_selection !== false',
   'comparison decision contract ${field} is not satisfied',
@@ -99,8 +125,10 @@ for (const forbidden of [
 
 for (const marker of [
   "const placeholderPrefix = 'TODO(index-storage-decision):'",
+  "from './index-storage-database-settings-contract.mjs'",
   'const readJsonBytes = (filename, label) =>',
   "createHash('sha256').update(bytes).digest('hex')",
+  'requireComparisonDatabaseSettingsMethodology(comparison.value, fail);',
   'still contains a preparation placeholder',
   'writeFileSync(comparisonPath, comparison.bytes)',
   'writeFileSync(decisionPath, decision.bytes)',
@@ -119,9 +147,13 @@ for (const forbidden of ['shell: true', 'execSync(', 'execFileSync(']) {
 
 for (const marker of [
   "test('prepares an exact-comparison-bound manual decision draft'",
+  "test('rejects a comparison without the canonical database-settings methodology'",
   "test('refuses to overwrite an existing decision without force'",
   "test('rejects an unedited prepared decision'",
+  "test('finalizer rejects database-settings provenance drift with a matching comparison digest'",
   "test('finalizes an ADR bound to exact comparison and decision bytes'",
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  'database_settings_source: databaseSettingsSource',
   'Comparison SHA-256:',
   'Decision SHA-256:',
 ]) {
@@ -165,7 +197,7 @@ for (const marker of [
   "createHash('sha256')",
   'exactly one comparison.json path is required',
   'readFileSync(filename)',
-  'process.stdout.write(`${digest}\\n`)',
+  'process.stdout.write(`${digest}\n`)',
 ]) {
   if (!digestHelper.includes(marker)) fail(`comparison digest helper is missing marker: ${marker}`);
 }
@@ -279,9 +311,11 @@ for (const forbidden of [
 
 for (const [name, workflow, markers] of [
   ['smoke', smokeWorkflow, [
+    'scripts/verify/index-storage-database-settings-contract.mjs',
     'scripts/verify/prepare-index-storage-decision.mjs',
     'scripts/verify/finalize-index-storage-adr.mjs',
     'scripts/verify/index-storage-decision-tooling.test.mjs',
+    'node --check scripts/verify/index-storage-database-settings-contract.mjs',
     'node --check scripts/verify/prepare-index-storage-decision.mjs',
     'node --check scripts/verify/finalize-index-storage-adr.mjs',
     'node --test scripts/verify/index-storage-decision-tooling.test.mjs',
@@ -291,9 +325,11 @@ for (const [name, workflow, markers] of [
     '--root evidence/index-storage/smoke',
   ]],
   ['scale evidence', scaleWorkflow, [
+    'scripts/verify/index-storage-database-settings-contract.mjs',
     'scripts/verify/prepare-index-storage-decision.mjs',
     'scripts/verify/finalize-index-storage-adr.mjs',
     'scripts/verify/index-storage-decision-tooling.test.mjs',
+    'node --check scripts/verify/index-storage-database-settings-contract.mjs',
     'node --check scripts/verify/prepare-index-storage-decision.mjs',
     'node --check scripts/verify/finalize-index-storage-adr.mjs',
     'node scripts/verify/index-storage-tooling.mjs contract',
@@ -318,4 +354,4 @@ for (const [name, workflow, legacy] of [
   if (workflow.includes(legacy)) fail(`${name} workflow restored a direct packet-validator invocation`);
 }
 
-console.log('[verify-index-storage-adr-tooling] command router, workflows, decision preparation, byte-bound ADR finalization, schema, examples, fixtures, and guide are consistent');
+console.log('[verify-index-storage-adr-tooling] command router, workflows, shared database-settings methodology, decision preparation, byte-bound ADR finalization, schema, examples, fixtures, and guide are consistent');

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -16,6 +16,10 @@ const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
 const comparatorFixture = read('scripts/verify/compare-index-storage-evidence.test.mjs');
+const databaseSettingsContract = read('scripts/verify/index-storage-database-settings-contract.mjs');
+const prepareDecision = read('scripts/verify/prepare-index-storage-decision.mjs');
+const finalizeAdr = read('scripts/verify/finalize-index-storage-adr.mjs');
+const decisionFixture = read('scripts/verify/index-storage-decision-tooling.test.mjs');
 const validatorWrapper = read('scripts/verify/validate-index-storage-evidence.mjs');
 const comparatorWrapper = read('scripts/verify/compare-index-storage-evidence.mjs');
 const standaloneFixture = read('scripts/verify/index-storage-standalone-tools.test.mjs');
@@ -167,6 +171,45 @@ requireMarkers(comparatorFixture, 'comparison evidence fixture', [
   "test('rejects observed session metadata drift before comparison output is accepted'",
 ]);
 
+requireMarkers(databaseSettingsContract, 'shared database settings contract', [
+  'export const comparableDatabaseFields = Object.freeze([',
+  ...comparableDatabaseFieldMarkers,
+  'export const databaseSettingsSource =',
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session',
+  'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
+  'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
+  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+]);
+requireMarkers(prepareDecision, 'decision preparation database settings gate', [
+  "from './index-storage-database-settings-contract.mjs'",
+  'requireComparisonDatabaseSettingsMethodology(comparison, fail);',
+]);
+requireMarkers(finalizeAdr, 'ADR finalization database settings gate', [
+  "from './index-storage-database-settings-contract.mjs'",
+  'requireComparisonDatabaseSettingsMethodology(comparison.value, fail);',
+]);
+requireMarkers(decisionFixture, 'decision tooling database settings fixture', [
+  ...comparableDatabaseFieldMarkers,
+  'databaseSettingsSource',
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  "test('rejects a comparison without the canonical database-settings methodology'",
+  "test('finalizer rejects database-settings provenance drift with a matching comparison digest'",
+]);
+const prepareDatabaseGate = prepareDecision.indexOf(
+  'requireComparisonDatabaseSettingsMethodology(comparison, fail);',
+);
+const prepareDecisionWrite = prepareDecision.indexOf('const decision = {');
+if (prepareDatabaseGate < 0 || prepareDecisionWrite < 0 || prepareDatabaseGate > prepareDecisionWrite) {
+  fail('decision preparation must validate database-settings methodology before creating a decision');
+}
+const finalizeDatabaseGate = finalizeAdr.indexOf(
+  'requireComparisonDatabaseSettingsMethodology(comparison.value, fail);',
+);
+const finalizeRenderer = finalizeAdr.indexOf("path.join(scriptDirectory, 'render-index-storage-adr.mjs')");
+if (finalizeDatabaseGate < 0 || finalizeRenderer < 0 || finalizeDatabaseGate > finalizeRenderer) {
+  fail('ADR finalization must validate database-settings methodology before invoking the renderer');
+}
+
 requireMarkers(validatorWrapper, 'standalone validator wrapper', [
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
   'validatePacketReadOrdering(evidenceRoot);',
@@ -182,13 +225,14 @@ requireMarkers(comparatorWrapper, 'standalone comparator wrapper', [
   "import { readFileSync, writeFileSync } from 'node:fs'",
   "import path from 'node:path'",
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-  'const comparableDatabaseFields = [',
-  ...comparableDatabaseFieldMarkers,
+  "from './index-storage-database-settings-contract.mjs'",
+  'comparableDatabaseFields,',
+  'databaseSettingsSource,',
   'const finalizeDatabaseSettingsContract = ({ inputs, output }) =>',
   'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
   'cross-scale database setting ${field} mismatch',
   'methodology.comparable_database_fields = comparableDatabaseFields;',
-  'database_settings_source',
+  'methodology.database_settings_source = databaseSettingsSource;',
   'Compared PostgreSQL fields:',
   "await import('./compare-index-storage-evidence-core.mjs')",
   'if (parsed !== null) finalizeDatabaseSettingsContract(parsed);',
@@ -276,4 +320,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, canonical evidence writer, full cross-scale database settings, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, shared cross-scale database settings, ADR-bound comparison methodology, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- introduce one shared contract for the ten PostgreSQL database fields compared across 100k and 1m evidence and for the observed-session provenance string;
- make the comparator write methodology from that shared contract;
- require the exact methodology in both decision preparation and ADR finalization;
- add fail-closed fixtures for direct core output and for a manually re-hashed decision bypass attempt;
- include the shared module in Index workflow path filters, syntax checks, and permanent source guards.

## Why

The comparator now records the complete observed PostgreSQL context, but the decision and ADR tooling previously trusted only `same_database_settings`. A comparison generated directly by the byte-preserved core omitted the new methodology fields yet could still be accepted by `prepare-index-storage-decision`. This change binds the manual storage decision and final ADR to the exact database-settings contract used by the official comparator path.

## Scope

Evidence comparison and storage-decision tooling only. No benchmark execution code, candidate SQL, dataset topology, production Index API, migration, comparator core, or storage winner is changed.

## Validation

Tests, Node commands, Cargo commands, formatting, verifier execution, workflow runs, and benchmarks were not run by the implementation agent, per repository-owner instruction. The nine-file diff was audited statically, including shared imports, exact field order, negative fixture construction, prepare/finalize ordering, workflow path triggers, syntax-check registration, and both permanent source guards. Parallel `main` changes are unrelated storefront and SEO work.