### PR TITLE
ci(seo): expose hardening guard results

### DIFF
--- a/.github/workflows/hardening-gates.yml
+++ b/.github/workflows/hardening-gates.yml
@@ -83,13 +83,40 @@ jobs:
       - name: Verify development container topology
         run: node scripts/verify/verify-development-container-topology.mjs
 
-  seo-hardening:
-    name: SEO Hardening
+  seo-hardening-guard:
+    name: SEO Hardening / ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Bulk batching
+            script: verify-seo-bulk-batch-reads.mjs
+          - name: Diagnostics batching
+            script: verify-seo-diagnostics-batch-reads.mjs
+          - name: Sitemap worker
+            script: verify-seo-sitemap-background-worker.mjs
+          - name: Index repair worker
+            script: verify-seo-index-repair-background-worker.mjs
+          - name: Entrypoint authorization
+            script: verify-seo-entrypoint-authorization.mjs
+          - name: Failure classification
+            script: verify-seo-failure-classification.mjs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: 22
-      - name: Verify SEO hardening roadmap contracts
-        run: node scripts/verify/verify-seo-hardening-suite.mjs
+      - name: Verify ${{ matrix.name }}
+        run: node scripts/verify/${{ matrix.script }}
+
+  seo-hardening:
+    name: SEO Hardening
+    needs: seo-hardening-guard
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce SEO hardening roadmap result
+        env:
+          GUARD_RESULT: ${{ needs.seo-hardening-guard.result }}
+        run: test "$GUARD_RESULT" = "success"


### PR DESCRIPTION
## Summary

- run the six SEO hardening roadmap guards as independent matrix jobs with `fail-fast: false`;
- preserve the single collector status named `SEO Hardening` for branch protection and roadmap reporting;
- make each guard's result visible directly in Actions job metadata, avoiding dependence on truncated aggregate logs;
- keep the existing local aggregate script available without using it as the opaque workflow step.

## Context

After #2124 aligned the stale sitemap assertion, the aggregate status remained red, but the connector-visible log was truncated before the failure summary. Splitting guards into independently named jobs makes the next failure deterministic and directly queryable while retaining one final status.

## Concurrency review

The branch is one commit on fresh `main` (`8bc13b7a47a8491f8798fda8078069cfc58f498e`) and changes only `.github/workflows/hardening-gates.yml`.

## Validation

No local verifier, test, formatting, or cargo command was run at the repository owner's request. The matrix topology, fail-fast behavior, scripts, and collector dependency were reviewed statically. GitHub Actions may run automatically for this PR.