### PR TITLE
feat(forum): guard category owner reads by visibility

### DIFF
--- a/crates/rustok-forum/contracts/forum-category-owner-read-visibility.json
+++ b/crates/rustok-forum/contracts/forum-category-owner-read-visibility.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20E",
+  "scope": "Inherited public/authenticated visibility in exact, paginated and tree category owner reads",
+  "category_visibility_owner_file": "crates/rustok-forum/src/services/category_visibility.rs",
+  "category_facade_file": "crates/rustok-forum/src/services/category_owner.rs",
+  "category_selector_file": "crates/rustok-forum/src/services/category_visibility_list.rs",
+  "category_tree_filter_file": "crates/rustok-forum/src/services/category_tree_visibility.rs",
+  "services_file": "crates/rustok-forum/src/services/mod.rs",
+  "test_file": "crates/rustok-forum/tests/category_owner_visibility_sqlite.rs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": "pending_current_pr",
+  "category_tree_bound": 512,
+  "category_depth_bound": 16,
+  "policy": {
+    "public_exact_read": "authenticated-category targets resolve as category not found",
+    "public_page": "authenticated categories are excluded before count and pagination",
+    "public_tree": "authenticated subtrees are removed and visible structural metadata is recomputed",
+    "authenticated_reads": "public and inherited authenticated categories remain readable",
+    "missing_foreign_or_denied": "absent without an existence oracle"
+  },
+  "composition": {
+    "exact_read_authorizes_before_visibility_and_hydration": true,
+    "page_filters_before_count_and_pagination": true,
+    "tree_prunes_monotonic_hidden_subtrees_before_response": true,
+    "tree_recomputes_total_depth_and_child_metadata": true,
+    "topic_and_reply_owner_read_composition_remains_intact": true
+  },
+  "not_delivered": [
+    "role visibility",
+    "trust-level visibility",
+    "channel membership visibility",
+    "group membership visibility",
+    "explicit allow and deny",
+    "create reply and moderate audience policy",
+    "remaining non-category-topic-reply read composition",
+    "search notification SEO and deep-link migration to the owner scope",
+    "visibility-scoped category and all-read mutations",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-category-owner-read-visibility.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/contracts/forum-category-owner-read-visibility.json
+++ b/crates/rustok-forum/contracts/forum-category-owner-read-visibility.json
@@ -9,7 +9,7 @@
   "services_file": "crates/rustok-forum/src/services/mod.rs",
   "test_file": "crates/rustok-forum/tests/category_owner_visibility_sqlite.rs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
-  "canonical_plan_sync": "pending_current_pr",
+  "canonical_plan_sync": "included",
   "category_tree_bound": 512,
   "category_depth_bound": 16,
   "policy": {

--- a/crates/rustok-forum/contracts/forum-category-visibility-policy.json
+++ b/crates/rustok-forum/contracts/forum-category-visibility-policy.json
@@ -25,17 +25,17 @@
     "existing_category_rows_require_backfill": false,
     "allows_topics_preserved": true,
     "transport_changes": false,
-    "storefront_changes": false,
-    "topic_visibility_scope_changes": false
+    "storefront_changes_in_forum_20b": false,
+    "topic_visibility_scope_changes_in_forum_20b": false
   },
   "not_delivered": [
-    "topic read composition",
-    "reply read composition",
-    "authenticated storefront filtering",
     "role visibility",
     "trust-level visibility",
+    "channel membership visibility",
     "group membership visibility",
     "explicit allow and deny",
+    "create reply and moderate audience policy",
+    "remaining non-category-topic-reply read composition",
     "visibility-scoped category and all-read mutations",
     "search notification SEO and deep-link migration",
     "PostgreSQL inheritance runtime evidence"

--- a/crates/rustok-forum/contracts/forum-owner-read-visibility.json
+++ b/crates/rustok-forum/contracts/forum-owner-read-visibility.json
@@ -32,7 +32,6 @@
     "channel membership visibility",
     "group membership visibility",
     "explicit allow and deny",
-    "category owner read filtering",
     "create reply and moderate audience policy",
     "search notification SEO and deep-link migration to the owner scope",
     "visibility-scoped category and all-read mutations"

--- a/crates/rustok-forum/contracts/forum-owner-read-visibility.json
+++ b/crates/rustok-forum/contracts/forum-owner-read-visibility.json
@@ -8,7 +8,7 @@
   "reply_facade_file": "crates/rustok-forum/src/services/reply_facade.rs",
   "test_file": "crates/rustok-forum/tests/topic_reply_owner_visibility_sqlite.rs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
-  "canonical_plan_sync": "pending_conflict_safe_full_file_update",
+  "canonical_plan_sync": "included",
   "category_tree_bound": 512,
   "category_depth_bound": 16,
   "policy": {

--- a/crates/rustok-forum/contracts/forum-topic-visibility-scope.json
+++ b/crates/rustok-forum/contracts/forum-topic-visibility-scope.json
@@ -35,7 +35,7 @@
     "channel membership visibility",
     "group membership visibility",
     "explicit allow and deny",
-    "category owner read filtering and remaining non-topic-reply read composition",
+    "remaining non-category-topic-reply read composition",
     "visibility-scoped category and all-read mutations",
     "search notification SEO and deep-link migration to the owner scope"
   ],

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -6,7 +6,7 @@ status: active
 owners:
   - rustok-forum
   - rustok-notifications-program
-last_reviewed: 2026-07-24
+last_reviewed: 2026-07-25
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A centralizes the existing open/public-or-exact-channel topic policy; FORUM-20B adds bounded inherited public/authenticated category policy storage and owner evaluation. Read composition, role/trust/group rules, explicit allow/deny and cross-consumer authorization remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A-E provide typed inherited public/authenticated policy plus storefront and category/topic/reply owner-read composition. Richer role/trust/membership/allow-deny rules, write audiences, remaining consumers and runtime evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1132,28 +1132,73 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - this slice adds no transport, storefront, topic/reply read composition, role,
   trust, group or explicit allow/deny behavior.
 
+### Delivered in `FORUM-20C`
+
+- storefront topic exact and paginated reads compose the inherited category
+  floor with the existing open/exact-channel policy through the Forum owner;
+- public viewers see public categories only, while authenticated viewers may see
+  both public and inherited authenticated categories without page/count drift;
+- category exclusions are applied before storefront count and pagination and the
+  exact selected page is rechecked by the bounded visibility evaluator;
+- `topic_authenticated_visibility_sqlite` and the cumulative storefront contract
+  preserve non-oracular missing/denied behavior and tenant-scoped channel checks.
+
+### Delivered in `FORUM-20D`
+
+- exact topic reads authorize, evaluate the inherited category floor and only
+  then hydrate localized content; denied public targets resolve as
+  `TopicNotFound`;
+- ordinary topic pages exclude inherited authenticated categories before count
+  and pagination, while authenticated owner reads preserve existing behavior;
+- exact reply reads evaluate their parent topic before body/vote enrichment and
+  denied public targets resolve as `ReplyNotFound`;
+- reply pages reject a denied parent as `TopicNotFound` before reply count and
+  pagination;
+- `forum-owner-read-visibility.json`,
+  `topic_reply_owner_visibility_sqlite` and
+  `verify-forum-owner-read-visibility.mjs` lock the owner-read order and residual
+  scope.
+
+### Delivered in `FORUM-20E`
+
+- exact category reads authorize and evaluate the inherited category floor
+  before localization/subscription hydration; denied public targets resolve as
+  `CategoryNotFound`;
+- flat category pages exclude inherited authenticated categories before count
+  and pagination;
+- the bounded canonical category tree removes authenticated subtrees for public
+  viewers and recomputes visible `total_nodes`, `max_depth`, `children_count` and
+  `has_children` metadata;
+- monotonic inheritance guarantees that pruning a hidden node cannot orphan a
+  visible descendant, while authenticated tree reads retain the complete bounded
+  hierarchy;
+- `forum-category-owner-read-visibility.json`,
+  `category_owner_visibility_sqlite` and
+  `verify-forum-category-owner-read-visibility.mjs` lock exact, page and tree
+  composition.
+
 ### Compatibility and degraded mode
 
-The new column is nullable and requires no backfill. Existing categories remain
-public until an owner command stores an authenticated floor, and existing
-`allows_topics` values remain unchanged. Current public/exact-channel storefront
-selection remains the FORUM-20A contract because FORUM-20B intentionally does
-not compose the category policy into topic/reply reads or transport entrypoints.
-Missing future channel/group capability providers cannot broaden results; their
-membership semantics remain closed until explicit owner ports are composed.
+The nullable policy column still requires no backfill. Existing categories stay
+public until an owner command narrows an ancestor. Public category/topic/reply
+reads now treat inherited authenticated targets as absent; authenticated reads
+continue to expose public and authenticated categories. Storefront topic reads
+add the existing open/exact-channel policy on top of the same category floor.
+No transport field, migration or write behavior changes in FORUM-20C-E. Missing
+future role/trust/channel/group capability providers cannot broaden results;
+their membership semantics remain closed until explicit bounded owner ports are
+composed.
 
 ### Remaining scope
 
-- compose inherited public/authenticated category policy into every topic/reply
-  owner read and add authenticated storefront filtering without page/count drift;
 - add role, trust-level, channel-member, group-member and explicit allow/deny
   evaluation through bounded owner capability ports;
 - add create/reply/moderate audience policies and topic narrowing that cannot
   broaden the effective category policy;
-- migrate all Forum reads, notifications, search/index, SEO and deep-link open
-  authorization to the same owner policy;
-- add visibility-scoped category and all-read commands only after the owner can
-  page an exact category/tenant scope under the complete policy;
+- compose the owner policy into remaining Forum reads and migrate notifications,
+  search/index, SEO and deep-link open authorization to the same decision;
+- add visibility-scoped category and all-read commands only after the complete
+  policy can page an exact category/tenant scope;
 - add PostgreSQL concurrency, inheritance and cross-consumer runtime evidence.
 
 ### Definition of done
@@ -1167,16 +1212,21 @@ profiles.
 ```bash
 cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
+node scripts/verify/verify-forum-owner-read-visibility.mjs
+node scripts/verify/verify-forum-category-owner-read-visibility.mjs
 cargo xtask module validate forum
 npm run verify:forum:storefront-boundary
 ```
 
 Tests, Cargo, verifiers and CI were not run while publishing the source-ready
-FORUM-20B owner-policy slice. `FORUM-20` remains `in_progress` until inherited
-policy is composed into reads and all remaining audience/cross-consumer paths
-use the complete policy.
+FORUM-20C-E read-composition slices. `FORUM-20` remains `in_progress` until the
+complete audience policy and all remaining cross-consumer paths are delivered
+with maintainer runtime evidence.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -1880,6 +1930,9 @@ cargo test -p rustok-forum --test storefront_read_state_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_read_state_postgres -- --nocapture --test-threads=1
 cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1900,6 +1953,8 @@ node scripts/verify/verify-forum-mention-runtime-proof.mjs
 node scripts/verify/verify-forum-read-state-runtime-proof.mjs
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
+node scripts/verify/verify-forum-owner-read-visibility.mjs
+node scripts/verify/verify-forum-category-owner-read-visibility.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -1951,9 +2006,9 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` by composing inherited public/authenticated category
-    policy into owner reads, then add role/trust/group/allow-deny capability ports
-    and migrate notifications, search, SEO and deep-link checks;
+12. continue `FORUM-20` with bounded role/trust/channel-membership/group-membership/
+    explicit allow-deny capability ports, then compose write audiences and migrate
+    remaining reads, notifications, search, SEO and deep-link checks;
 13. `FORUM-23`: index projections;
 14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.

--- a/crates/rustok-forum/src/services/category_owner.rs
+++ b/crates/rustok-forum/src/services/category_owner.rs
@@ -1,6 +1,7 @@
 use sea_orm::{DatabaseConnection, DatabaseTransaction};
 use uuid::Uuid;
 
+use rustok_api::{Action, Resource};
 use rustok_core::SecurityContext;
 
 use crate::dto::{
@@ -12,6 +13,8 @@ use crate::dto::{
 };
 use crate::error::{ForumError, ForumResult};
 
+use super::category_visibility::ForumCategoryVisibilityPolicyService;
+use super::rbac::enforce_scope;
 use super::{category, category_command, category_lifecycle, category_policy, category_tree};
 
 /// Public owner facade for forum categories.
@@ -25,6 +28,7 @@ pub struct CategoryService {
     lifecycle: category_lifecycle::CategoryLifecycleService,
     policy: category_policy::CategoryTopicPolicyService,
     tree: category_tree::CategoryTreeService,
+    visibility: ForumCategoryVisibilityPolicyService,
 }
 
 impl CategoryService {
@@ -34,7 +38,8 @@ impl CategoryService {
             commands: category_command::CategoryCommandService::new(db.clone()),
             lifecycle: category_lifecycle::CategoryLifecycleService::new(db.clone()),
             policy: category_policy::CategoryTopicPolicyService::new(db.clone()),
-            tree: category_tree::CategoryTreeService::new(db),
+            tree: category_tree::CategoryTreeService::new(db.clone()),
+            visibility: ForumCategoryVisibilityPolicyService::new(db),
         }
     }
 
@@ -54,8 +59,7 @@ impl CategoryService {
         category_id: Uuid,
         locale: &str,
     ) -> ForumResult<CategoryResponse> {
-        self.inner
-            .get(tenant_id, security, category_id, locale)
+        self.get_with_locale_fallback(tenant_id, security, category_id, locale, None)
             .await
     }
 
@@ -67,6 +71,18 @@ impl CategoryService {
         locale: &str,
         fallback_locale: Option<&str>,
     ) -> ForumResult<CategoryResponse> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Read)?;
+        if !self
+            .visibility
+            .is_category_visible_to_viewer(
+                tenant_id,
+                category_id,
+                !security.is_public_read(),
+            )
+            .await?
+        {
+            return Err(ForumError::CategoryNotFound(category_id));
+        }
         self.inner
             .get_with_locale_fallback(tenant_id, security, category_id, locale, fallback_locale)
             .await
@@ -92,7 +108,14 @@ impl CategoryService {
         security: SecurityContext,
         query: CategoryTreeQuery,
     ) -> ForumResult<CategoryTreeResponse> {
-        self.tree.read(tenant_id, security, query).await
+        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
+        let hidden_category_ids = self
+            .visibility
+            .hidden_category_ids_for_viewer(tenant_id, !security.is_public_read())
+            .await?;
+        self.tree
+            .read_with_hidden_categories(tenant_id, security, query, &hidden_category_ids)
+            .await
     }
 
     pub async fn archive_subtree(
@@ -186,7 +209,6 @@ impl CategoryService {
         locale: &str,
     ) -> ForumResult<Vec<CategoryListItem>> {
         let (items, _) = self
-            .inner
             .list_paginated_with_locale_fallback(
                 tenant_id,
                 security,
@@ -207,7 +229,6 @@ impl CategoryService {
         fallback_locale: Option<&str>,
     ) -> ForumResult<Vec<CategoryListItem>> {
         let (items, _) = self
-            .inner
             .list_paginated_with_locale_fallback(
                 tenant_id,
                 security,
@@ -229,14 +250,20 @@ impl CategoryService {
         per_page: u64,
         fallback_locale: Option<&str>,
     ) -> ForumResult<(Vec<CategoryListItem>, u64)> {
+        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
+        let hidden_category_ids = self
+            .visibility
+            .hidden_category_ids_for_viewer(tenant_id, !security.is_public_read())
+            .await?;
         self.inner
-            .list_paginated_with_locale_fallback(
+            .list_paginated_with_locale_fallback_and_hidden_categories(
                 tenant_id,
                 security,
                 locale,
                 page,
                 bounded_forum_read_limit(Some(per_page)),
                 fallback_locale,
+                &hidden_category_ids,
             )
             .await
     }

--- a/crates/rustok-forum/src/services/category_tree_visibility.rs
+++ b/crates/rustok-forum/src/services/category_tree_visibility.rs
@@ -1,0 +1,40 @@
+impl CategoryTreeService {
+    pub(super) async fn read_with_hidden_categories(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        query: CategoryTreeQuery,
+        hidden_category_ids: &[Uuid],
+    ) -> ForumResult<CategoryTreeResponse> {
+        let mut response = self.read(tenant_id, security, query).await?;
+        if hidden_category_ids.is_empty() || response.roots.is_empty() {
+            return Ok(response);
+        }
+
+        let hidden = hidden_category_ids.iter().copied().collect::<HashSet<_>>();
+        let (total_nodes, max_depth) = retain_visible_category_nodes(&mut response.roots, &hidden);
+        response.total_nodes = total_nodes;
+        response.max_depth = max_depth;
+        Ok(response)
+    }
+}
+
+fn retain_visible_category_nodes(
+    nodes: &mut Vec<CategoryTreeNode>,
+    hidden: &HashSet<Uuid>,
+) -> (u32, u16) {
+    nodes.retain(|node| !hidden.contains(&node.id));
+
+    let mut total_nodes = 0u32;
+    let mut max_depth = 0u16;
+    for node in nodes {
+        let (child_total, child_max_depth) =
+            retain_visible_category_nodes(&mut node.children, hidden);
+        node.children_count = node.children.len() as u32;
+        node.has_children = !node.children.is_empty();
+        total_nodes = total_nodes.saturating_add(1).saturating_add(child_total);
+        max_depth = max_depth.max(node.depth).max(child_max_depth);
+    }
+
+    (total_nodes, max_depth)
+}

--- a/crates/rustok-forum/src/services/category_visibility.rs
+++ b/crates/rustok-forum/src/services/category_visibility.rs
@@ -147,6 +147,31 @@ impl ForumCategoryVisibilityPolicyService {
         hidden.sort_unstable();
         Ok(hidden)
     }
+
+    /// Resolves one exact category without exposing whether a denied target exists.
+    pub(crate) async fn is_category_visible_to_viewer(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        is_authenticated: bool,
+    ) -> ForumResult<bool> {
+        if is_authenticated {
+            return Ok(forum_category::Entity::find_by_id(category_id)
+                .filter(forum_category::Column::TenantId.eq(tenant_id))
+                .one(&self.db)
+                .await?
+                .is_some());
+        }
+
+        let snapshot = CategoryVisibilitySnapshot::load(&self.db, tenant_id).await?;
+        match snapshot.resolve(category_id) {
+            Ok(resolved) => Ok(
+                resolved.effective_visibility == ForumCategoryVisibility::Public,
+            ),
+            Err(ForumError::CategoryNotFound(_)) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 struct CategoryVisibilitySnapshot {

--- a/crates/rustok-forum/src/services/category_visibility_list.rs
+++ b/crates/rustok-forum/src/services/category_visibility_list.rs
@@ -1,0 +1,83 @@
+impl CategoryService {
+    #[instrument(skip(self, security, hidden_category_ids))]
+    pub(crate) async fn list_paginated_with_locale_fallback_and_hidden_categories(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        locale: &str,
+        page: u64,
+        per_page: u64,
+        fallback_locale: Option<&str>,
+        hidden_category_ids: &[Uuid],
+    ) -> ForumResult<(Vec<CategoryListItem>, u64)> {
+        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
+        let locale = normalize_locale(locale)?;
+        let fallback_locale = fallback_locale.map(normalize_locale).transpose()?;
+        let mut query = forum_category::Entity::find()
+            .filter(forum_category::Column::TenantId.eq(tenant_id))
+            .filter(
+                Expr::col((forum_category::Entity, forum_category::Column::Id))
+                    .not_in_subquery(archived_category_ids_subquery(tenant_id)),
+            );
+        if !hidden_category_ids.is_empty() {
+            query = query.filter(
+                forum_category::Column::Id.is_not_in(hidden_category_ids.to_vec()),
+            );
+        }
+        let paginator = query
+            .order_by_asc(forum_category::Column::Position)
+            .paginate(&self.db, per_page.max(1));
+        let total = paginator.num_items().await?;
+        let categories = paginator.fetch_page(page.saturating_sub(1)).await?;
+        let category_ids: Vec<Uuid> = categories.iter().map(|item| item.id).collect();
+        let translations_by_category_id = self
+            .load_translations_map_for_categories(tenant_id, &category_ids)
+            .await?;
+        let subscription_flags = SubscriptionService::new(self.db.clone())
+            .category_subscription_flags(tenant_id, &category_ids, security.user_id)
+            .await?;
+
+        let mut items = Vec::with_capacity(categories.len());
+        for category in categories {
+            let localized = translations_by_category_id
+                .get(&category.id)
+                .cloned()
+                .unwrap_or_default();
+            let resolved = resolve_by_locale_with_fallback(
+                &localized,
+                &locale,
+                fallback_locale.as_deref(),
+                |translation| translation.locale.as_str(),
+            );
+            let translation = resolved.item.ok_or_else(|| {
+                ForumError::Validation(format!(
+                    "Forum category {} has no localized translation",
+                    category.id
+                ))
+            })?;
+
+            items.push(CategoryListItem {
+                id: category.id,
+                requested_locale: locale.clone(),
+                locale: locale.clone(),
+                effective_locale: resolved.effective_locale,
+                available_locales: available_locales_from(&localized, |translation| {
+                    translation.locale.as_str()
+                }),
+                name: translation.name.clone(),
+                slug: translation.slug.clone(),
+                description: translation.description.clone(),
+                icon: category.icon.clone(),
+                color: category.color.clone(),
+                topic_count: category.topic_count,
+                reply_count: category.reply_count,
+                is_subscribed: subscription_flags
+                    .get(&category.id)
+                    .copied()
+                    .unwrap_or(false),
+            });
+        }
+
+        Ok((items, total))
+    }
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -1,13 +1,19 @@
 #![allow(dead_code)]
 
 mod bounded_compat;
-mod category;
+mod category {
+    include!("category.rs");
+    include!("category_visibility_list.rs");
+}
 #[allow(clippy::collapsible_if)]
 mod category_command;
 mod category_lifecycle;
 mod category_owner;
 mod category_policy;
-mod category_tree;
+mod category_tree {
+    include!("category_tree.rs");
+    include!("category_tree_visibility.rs");
+}
 mod category_visibility;
 pub mod event;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]

--- a/crates/rustok-forum/tests/category_owner_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/category_owner_visibility_sqlite.rs
@@ -1,16 +1,14 @@
 use std::collections::HashSet;
 
-use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
 use rustok_forum::{
     CategoryService, CategoryTreeQuery, CreateCategoryInput, ForumCategoryVisibility,
     ForumCategoryVisibilityPolicyService, ForumError, ForumModule,
     SetForumCategoryVisibilityPolicyInput,
 };
-use rustok_outbox::TransactionalEventBus;
 use rustok_taxonomy::TaxonomyModule;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 use sea_orm_migration::SchemaManager;
-use std::sync::Arc;
 use uuid::Uuid;
 
 async fn setup() -> DatabaseConnection {
@@ -39,7 +37,6 @@ async fn setup() -> DatabaseConnection {
             .await
             .expect("forum migration should apply");
     }
-    let _event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
     db
 }
 

--- a/crates/rustok-forum/tests/category_owner_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/category_owner_visibility_sqlite.rs
@@ -1,0 +1,233 @@
+use std::collections::HashSet;
+
+use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CategoryTreeQuery, CreateCategoryInput, ForumCategoryVisibility,
+    ForumCategoryVisibilityPolicyService, ForumError, ForumModule,
+    SetForumCategoryVisibilityPolicyInput,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn setup() -> DatabaseConnection {
+    let db_url = format!(
+        "sqlite:file:forum_category_owner_visibility_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum category owner visibility sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    let _event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    db
+}
+
+async fn create_category(
+    service: &CategoryService,
+    tenant_id: Uuid,
+    security: SecurityContext,
+    slug: &str,
+    parent_id: Option<Uuid>,
+) -> Uuid {
+    service
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: slug.replace('-', " "),
+                slug: slug.into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created")
+        .id
+}
+
+#[tokio::test]
+async fn inherited_authenticated_floor_guards_category_exact_page_and_tree_reads() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let authenticated = SecurityContext::new(UserRole::Customer, Some(Uuid::new_v4()));
+    let public = SecurityContext::public_read();
+    let categories = CategoryService::new(db.clone());
+
+    let root = create_category(&categories, tenant_id, admin.clone(), "root", None).await;
+    let public_child = create_category(
+        &categories,
+        tenant_id,
+        admin.clone(),
+        "public-child",
+        Some(root),
+    )
+    .await;
+    let restricted_child = create_category(
+        &categories,
+        tenant_id,
+        admin.clone(),
+        "members-child",
+        Some(root),
+    )
+    .await;
+    let restricted_grandchild = create_category(
+        &categories,
+        tenant_id,
+        admin.clone(),
+        "members-grandchild",
+        Some(restricted_child),
+    )
+    .await;
+
+    ForumCategoryVisibilityPolicyService::new(db)
+        .set(
+            tenant_id,
+            restricted_child,
+            admin,
+            SetForumCategoryVisibilityPolicyInput {
+                visibility: ForumCategoryVisibility::Authenticated,
+            },
+        )
+        .await
+        .expect("child category should narrow to authenticated viewers");
+
+    assert!(
+        matches!(
+            categories
+                .get_with_locale_fallback(
+                    tenant_id,
+                    public.clone(),
+                    restricted_child,
+                    "en",
+                    Some("en"),
+                )
+                .await,
+            Err(ForumError::CategoryNotFound(id)) if id == restricted_child
+        ),
+        "public exact category read must not expose an inherited authenticated target"
+    );
+    assert_eq!(
+        categories
+            .get_with_locale_fallback(
+                tenant_id,
+                authenticated.clone(),
+                restricted_grandchild,
+                "en",
+                Some("en"),
+            )
+            .await
+            .expect("authenticated exact category read should resolve")
+            .id,
+        restricted_grandchild
+    );
+
+    let (public_page, public_total) = categories
+        .list_paginated_with_locale_fallback(
+            tenant_id,
+            public.clone(),
+            "en",
+            1,
+            20,
+            Some("en"),
+        )
+        .await
+        .expect("public category page should resolve");
+    assert_eq!(public_total, 2);
+    assert_eq!(
+        public_page
+            .iter()
+            .map(|category| category.id)
+            .collect::<HashSet<_>>(),
+        HashSet::from([root, public_child])
+    );
+
+    let (authenticated_page, authenticated_total) = categories
+        .list_paginated_with_locale_fallback(
+            tenant_id,
+            authenticated.clone(),
+            "en",
+            1,
+            20,
+            Some("en"),
+        )
+        .await
+        .expect("authenticated category page should resolve");
+    assert_eq!(authenticated_total, 4);
+    assert_eq!(
+        authenticated_page
+            .iter()
+            .map(|category| category.id)
+            .collect::<HashSet<_>>(),
+        HashSet::from([root, public_child, restricted_child, restricted_grandchild])
+    );
+
+    let public_tree = categories
+        .tree(
+            tenant_id,
+            public,
+            CategoryTreeQuery {
+                locale: Some("en".into()),
+                fallback_locale: Some("en".into()),
+            },
+        )
+        .await
+        .expect("public category tree should resolve");
+    assert_eq!(public_tree.total_nodes, 2);
+    assert_eq!(public_tree.max_depth, 1);
+    assert_eq!(public_tree.roots.len(), 1);
+    assert_eq!(public_tree.roots[0].id, root);
+    assert!(public_tree.roots[0].has_children);
+    assert_eq!(public_tree.roots[0].children_count, 1);
+    assert_eq!(public_tree.roots[0].children[0].id, public_child);
+
+    let authenticated_tree = categories
+        .tree(
+            tenant_id,
+            authenticated,
+            CategoryTreeQuery {
+                locale: Some("en".into()),
+                fallback_locale: Some("en".into()),
+            },
+        )
+        .await
+        .expect("authenticated category tree should resolve");
+    assert_eq!(authenticated_tree.total_nodes, 4);
+    assert_eq!(authenticated_tree.max_depth, 2);
+    let root_node = &authenticated_tree.roots[0];
+    assert_eq!(root_node.id, root);
+    assert_eq!(root_node.children_count, 2);
+    let restricted_node = root_node
+        .children
+        .iter()
+        .find(|node| node.id == restricted_child)
+        .expect("authenticated tree should contain restricted child");
+    assert_eq!(restricted_node.children_count, 1);
+    assert_eq!(restricted_node.children[0].id, restricted_grandchild);
+}

--- a/scripts/verify/verify-forum-category-owner-read-visibility.mjs
+++ b/scripts/verify/verify-forum-category-owner-read-visibility.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-category-owner-read-visibility.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const visibilityOwner = read(contract.category_visibility_owner_file ?? "");
+const categoryFacade = read(contract.category_facade_file ?? "");
+const categorySelector = read(contract.category_selector_file ?? "");
+const categoryTreeFilter = read(contract.category_tree_filter_file ?? "");
+const services = read(contract.services_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("category owner visibility contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20E") {
+  failures.push("category owner visibility contract must belong to FORUM-20E");
+}
+if (contract.canonical_plan_sync !== "included") {
+  failures.push("FORUM-20E must be synchronized into the canonical plan");
+}
+if (contract.category_tree_bound !== 512 || contract.category_depth_bound !== 16) {
+  failures.push("category owner visibility bounds must remain 512 nodes and depth 16");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted category-read evidence");
+}
+for (const residual of [
+  "role visibility",
+  "trust-level visibility",
+  "channel membership visibility",
+  "group membership visibility",
+  "explicit allow and deny",
+  "create reply and moderate audience policy",
+  "remaining non-category-topic-reply read composition",
+  "search notification SEO and deep-link migration to the owner scope",
+  "visibility-scoped category and all-read mutations",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`category owner visibility contract must keep ${residual} open`);
+  }
+}
+
+for (const marker of [
+  "pub(crate) async fn hidden_category_ids_for_viewer(",
+  "pub(crate) async fn is_category_visible_to_viewer(",
+  "forum_category::Column::TenantId.eq(tenant_id)",
+  "CategoryVisibilitySnapshot::load(&self.db, tenant_id)",
+  "Err(ForumError::CategoryNotFound(_)) => Ok(false)",
+  "ForumCategoryVisibility::Public",
+]) {
+  requireText(visibilityOwner, marker, `category visibility owner is missing ${marker}`);
+}
+for (const forbidden of [
+  "rustok_profiles",
+  "rustok_channels",
+  "rustok_groups",
+  "forum_category::Column::Metadata",
+]) {
+  rejectText(
+    visibilityOwner,
+    forbidden,
+    `category visibility owner must not depend on premature policy input ${forbidden}`,
+  );
+}
+
+const exactRead = between(
+  categoryFacade,
+  "pub async fn get_with_locale_fallback(",
+  "/// Archive the complete category subtree",
+  "category exact owner read",
+);
+for (const marker of [
+  "enforce_scope(&security, Resource::ForumCategories, Action::Read)?",
+  ".is_category_visible_to_viewer(",
+  "!security.is_public_read()",
+  "return Err(ForumError::CategoryNotFound(category_id))",
+  ".get_with_locale_fallback(tenant_id, security, category_id, locale, fallback_locale)",
+]) {
+  requireText(exactRead, marker, `category exact owner read is missing ${marker}`);
+}
+const exactAuthIndex = exactRead.indexOf("enforce_scope(");
+const exactVisibilityIndex = exactRead.indexOf(".is_category_visible_to_viewer(");
+const exactHydrationIndex = exactRead.indexOf(".get_with_locale_fallback(");
+if (
+  exactAuthIndex < 0 ||
+  exactVisibilityIndex < 0 ||
+  exactHydrationIndex < 0 ||
+  exactAuthIndex > exactVisibilityIndex ||
+  exactVisibilityIndex > exactHydrationIndex
+) {
+  failures.push("category exact read must authorize, evaluate visibility, then hydrate");
+}
+
+const pageRead = between(
+  categoryFacade,
+  "pub async fn list_paginated_with_locale_fallback(",
+  "pub(crate) async fn find_category_in_tx(",
+  "category paginated owner read",
+);
+for (const marker of [
+  "enforce_scope(&security, Resource::ForumCategories, Action::List)?",
+  ".hidden_category_ids_for_viewer(tenant_id, !security.is_public_read())",
+  ".list_paginated_with_locale_fallback_and_hidden_categories(",
+]) {
+  requireText(pageRead, marker, `category paginated owner read is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub(crate) async fn list_paginated_with_locale_fallback_and_hidden_categories(",
+  "forum_category::Column::Id.is_not_in(hidden_category_ids.to_vec())",
+  "let paginator = query",
+  "let total = paginator.num_items().await?",
+  "let categories = paginator.fetch_page",
+]) {
+  requireText(categorySelector, marker, `category selector is missing ${marker}`);
+}
+const categoryFilterIndex = categorySelector.indexOf(
+  "forum_category::Column::Id.is_not_in(hidden_category_ids.to_vec())",
+);
+const categoryPaginatorIndex = categorySelector.indexOf("let paginator = query");
+if (
+  categoryFilterIndex < 0 ||
+  categoryPaginatorIndex < 0 ||
+  categoryFilterIndex > categoryPaginatorIndex
+) {
+  failures.push("category visibility must be filtered before count and pagination");
+}
+
+for (const marker of [
+  "pub(super) async fn read_with_hidden_categories(",
+  "let mut response = self.read(tenant_id, security, query).await?",
+  "retain_visible_category_nodes(&mut response.roots, &hidden)",
+  "response.total_nodes = total_nodes",
+  "response.max_depth = max_depth",
+  "nodes.retain(|node| !hidden.contains(&node.id))",
+  "node.children_count = node.children.len() as u32",
+  "node.has_children = !node.children.is_empty()",
+]) {
+  requireText(categoryTreeFilter, marker, `category tree visibility is missing ${marker}`);
+}
+
+for (const marker of [
+  "include!(\"category_visibility_list.rs\");",
+  "include!(\"category_tree_visibility.rs\");",
+]) {
+  requireText(services, marker, `services composition is missing ${marker}`);
+}
+
+for (const marker of [
+  "inherited_authenticated_floor_guards_category_exact_page_and_tree_reads",
+  "ForumCategoryVisibility::Authenticated",
+  "SecurityContext::public_read()",
+  "Err(ForumError::CategoryNotFound(id)) if id == restricted_child",
+  "assert_eq!(public_total, 2)",
+  "assert_eq!(authenticated_total, 4)",
+  "assert_eq!(public_tree.total_nodes, 2)",
+  "assert_eq!(public_tree.max_depth, 1)",
+  "assert_eq!(public_tree.roots[0].children_count, 1)",
+  "assert_eq!(authenticated_tree.total_nodes, 4)",
+  "assert_eq!(authenticated_tree.max_depth, 2)",
+]) {
+  requireText(testSource, marker, `category owner SQLite scenario is missing ${marker}`);
+}
+
+for (const marker of [
+  "Delivered in `FORUM-20C`",
+  "Delivered in `FORUM-20D`",
+  "Delivered in `FORUM-20E`",
+  "category_owner_visibility_sqlite",
+  "verify-forum-category-owner-read-visibility.mjs",
+]) {
+  requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum category owner read visibility verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum category owner read visibility contract is source-ready.");

--- a/scripts/verify/verify-forum-category-visibility-policy.mjs
+++ b/scripts/verify/verify-forum-category-visibility-policy.mjs
@@ -56,14 +56,17 @@ if (contract.category_bound !== 512 || contract.maximum_depth !== 16) {
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted visibility evidence");
 }
-if (topicVisibilityContract.task !== "FORUM-20A") {
-  failures.push("FORUM-20B must not rewrite the existing topic visibility contract");
+if (topicVisibilityContract.task !== "FORUM-20C") {
+  failures.push("the cumulative topic visibility contract must remain at FORUM-20C");
 }
 for (const residual of [
-  "topic read composition",
   "role visibility",
+  "trust-level visibility",
+  "channel membership visibility",
   "group membership visibility",
   "explicit allow and deny",
+  "create reply and moderate audience policy",
+  "remaining non-category-topic-reply read composition",
   "visibility-scoped category and all-read mutations",
 ]) {
   if (!contract.not_delivered?.includes(residual)) {
@@ -116,7 +119,7 @@ for (const forbidden of [
 }
 
 for (const marker of [
-  'add_column(',
+  "add_column(",
   'Alias::new("visibility_override")',
   "visibility_override = 'authenticated'",
   "forum_category_visibility_override_insert",
@@ -167,6 +170,8 @@ for (const marker of [
 
 for (const marker of [
   "Delivered in `FORUM-20B`",
+  "Delivered in `FORUM-20C`",
+  "Delivered in `FORUM-20E`",
   "ForumCategoryVisibilityPolicyService",
   "forum-category-visibility-policy.json",
   "category_visibility_policy_sqlite",

--- a/scripts/verify/verify-forum-owner-read-visibility.mjs
+++ b/scripts/verify/verify-forum-owner-read-visibility.mjs
@@ -52,8 +52,8 @@ if (contract.schema_version !== 1) {
 if (contract.task !== "FORUM-20D") {
   failures.push("owner read visibility contract must belong to FORUM-20D");
 }
-if (contract.canonical_plan_sync !== "pending_conflict_safe_full_file_update") {
-  failures.push("owner read visibility contract must report the pending canonical plan synchronization honestly");
+if (contract.canonical_plan_sync !== "included") {
+  failures.push("owner read visibility contract must be synchronized into the canonical plan");
 }
 if (contract.category_tree_bound !== 512 || contract.category_depth_bound !== 16) {
   failures.push("owner read visibility category bounds must remain 512 nodes and depth 16");
@@ -226,10 +226,12 @@ for (const marker of [
 
 for (const marker of [
   "## `FORUM-20` — ACL and visibility inheritance",
-  "Delivered in `FORUM-20A`",
-  "Delivered in `FORUM-20B`",
+  "Delivered in `FORUM-20C`",
+  "Delivered in `FORUM-20D`",
+  "topic_reply_owner_visibility_sqlite",
+  "verify-forum-owner-read-visibility.mjs",
 ]) {
-  requireText(plan, marker, `canonical FORUM-20 plan is missing its existing baseline ${marker}`);
+  requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);
 }
 
 if (failures.length > 0) {
@@ -238,4 +240,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Forum owner read visibility contract is source-ready; canonical plan sync remains explicit.");
+console.log("Forum owner read visibility contract is source-ready.");

--- a/scripts/verify/verify-forum-owner-read-visibility.mjs
+++ b/scripts/verify/verify-forum-owner-read-visibility.mjs
@@ -67,7 +67,6 @@ for (const residual of [
   "channel membership visibility",
   "group membership visibility",
   "explicit allow and deny",
-  "category owner read filtering",
   "create reply and moderate audience policy",
   "search notification SEO and deep-link migration to the owner scope",
   "visibility-scoped category and all-read mutations",

--- a/scripts/verify/verify-forum-topic-visibility-scope.mjs
+++ b/scripts/verify/verify-forum-topic-visibility-scope.mjs
@@ -61,7 +61,7 @@ for (const residual of [
   "channel membership visibility",
   "group membership visibility",
   "explicit allow and deny",
-  "category owner read filtering and remaining non-topic-reply read composition",
+  "remaining non-category-topic-reply read composition",
   "visibility-scoped category and all-read mutations",
 ]) {
   if (!contract.not_delivered?.includes(residual)) {


### PR DESCRIPTION
## Summary

- deliver the FORUM-20E category owner-read visibility slice
- guard exact category reads with the inherited `public` / `authenticated` category floor and return `CategoryNotFound` for denied public targets
- exclude authenticated-only categories from flat public category pages before count and pagination
- prune inherited authenticated subtrees from the bounded public category tree and recompute visible node/depth/child metadata
- preserve complete category reads for authenticated callers
- synchronize the canonical implementation plan through FORUM-20C/D/E and close the prior FORUM-20D plan debt
- reconcile stale FORUM-20B/C/D residual contracts and verifiers
- add a source-ready SQLite scenario, machine contract, and static verifier

## Compatibility

- no migration or backfill is required
- no transport field, endpoint, or write behavior changes
- existing categories remain public until an authenticated override is stored
- authenticated category reads retain the complete public plus authenticated hierarchy
- storefront topic channel/status policy remains additive on top of the category floor
- roles, trust, channel/group membership, explicit allow/deny, write audiences, remaining consumers, visibility-scoped bulk commands, and runtime evidence remain open

## Validation

Not run at the maintainer's request. Intended commands:

```bash
cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
node scripts/verify/verify-forum-category-visibility-policy.mjs
node scripts/verify/verify-forum-topic-visibility-scope.mjs
node scripts/verify/verify-forum-owner-read-visibility.mjs
node scripts/verify/verify-forum-category-owner-read-visibility.mjs
cargo xtask module validate forum
npm run verify:forum:storefront-boundary
```
