### PR TITLE
fix(index): require observed database settings in ADR renderer

### DIFF
--- a/scripts/verify/render-index-storage-adr.mjs
+++ b/scripts/verify/render-index-storage-adr.mjs
@@ -4,6 +4,8 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { requireComparisonDatabaseSettingsMethodology } from './index-storage-database-settings-contract.mjs';
+
 const prefix = '[render-index-storage-adr]';
 const fail = (message) => {
   console.error(`${prefix} ${message}`);
@@ -219,6 +221,7 @@ const validateScaleShape = (scale) => {
 
 const validateComparison = (comparison) => {
   requireObject(comparison, 'comparison');
+  requireComparisonDatabaseSettingsMethodology(comparison, fail);
   if (comparison.decision_ready !== true) fail('comparison is not decision-ready');
   const decisionContract = requireObject(comparison.decision_contract, 'comparison.decision_contract');
   for (const field of requiredDecisionFlags) {

--- a/scripts/verify/render-index-storage-adr.test.mjs
+++ b/scripts/verify/render-index-storage-adr.test.mjs
@@ -8,6 +8,11 @@ import path from 'node:path';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
 const script = path.resolve('scripts/verify/render-index-storage-adr.mjs');
 const commit = '0123456789abcdef0123456789abcdef01234567';
 const prototypes = ['jsonb', 'typed_eav', 'hot_projection'];
@@ -92,7 +97,11 @@ const ratios = {
 
 const validComparison = () => ({
   generated_at: '2026-07-24T12:00:00Z',
-  methodology: { automatic_winner_selection: false },
+  methodology: {
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
   decision_ready: true,
   decision_contract: { ...decisionFlags },
   scales: [scale('100k', 1), scale('1m', 10)],
@@ -159,6 +168,19 @@ test('renders a manual same-commit storage ADR', () => {
     assert.match(markdown, /Comparison SHA-256/u);
     assert.match(markdown, /## Rejected alternatives/u);
     assert.match(markdown, /renderer does not infer or rank a winning prototype/u);
+  });
+});
+
+test('rejects core-only comparison without observed database-settings methodology', () => {
+  withFixture((root) => {
+    const comparison = validComparison();
+    comparison.methodology = { automatic_winner_selection: false };
+    const { result } = run(root, comparison, validDecision(comparison));
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract/u,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- make the standalone storage ADR renderer require the shared ten-field PostgreSQL database-settings methodology before accepting a comparison;
- update the renderer fixture to source the canonical field list and observed-session provenance from the shared contract;
- add a fail-closed scenario reproducing the old byte-preserved core-only comparison output.

## Why

Decision preparation and the official ADR finalizer already reject comparisons that omit the observed PostgreSQL session methodology, but the public renderer still validated only `decision_ready`, decision flags, and the older comparison shape. A direct renderer invocation could therefore accept a comparison produced without the official wrapper metadata. This change closes the last rendering boundary with the same shared contract.

## Scope

Storage ADR rendering and its fixture only. No benchmark execution code, candidate SQL, dataset shape, production Index API, comparator core, storage decision, or migration is changed.

## Validation

Tests, Node commands, Cargo commands, formatting, verifier execution, workflow runs, and benchmarks were not run by the implementation agent, per repository-owner instruction. The two-file diff was reviewed statically; the 466-line renderer changed by exactly three added lines, and the fixture adds the canonical methodology plus one core-only negative case. Parallel `main` changes are unrelated SEO/commerce work.