### PR TITLE
feat(forum): add bounded audience capability ports

### DIFF
--- a/crates/rustok-forum/contracts/forum-audience-capability-ports.json
+++ b/crates/rustok-forum/contracts/forum-audience-capability-ports.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20F",
+  "scope": "Bounded role, trust, channel membership, group membership, and explicit allow/deny audience contract",
+  "contract_file": "crates/rustok-forum/src/audience.rs",
+  "crate_file": "crates/rustok-forum/src/lib.rs",
+  "test_file": "crates/rustok-forum/tests/audience_capability_contract.rs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "limits": {
+    "roles": 4,
+    "channels": 32,
+    "groups": 32,
+    "explicit_allow_users": 100,
+    "explicit_deny_users": 100,
+    "maximum_trust_level": 100,
+    "channel_slug_characters": 128
+  },
+  "policy": {
+    "composition_order": "inherited public/authenticated floor then additional audience constraints",
+    "positive_selectors": "union",
+    "explicit_deny": "wins over explicit allow and every positive selector",
+    "empty_constraints": "no additional narrowing",
+    "public_actor": "cannot satisfy role trust channel group or explicit-user selectors",
+    "owner_facts": "exact requested actor and candidate subset only",
+    "provider_absence": "local deny allow and role decisions remain available; otherwise authenticated external-fact evaluation fails closed with a typed capability error"
+  },
+  "port": {
+    "trait": "ForumAudienceFactsPort",
+    "request": "ForumAudienceFactsRequest",
+    "response": "ForumAudienceFacts",
+    "requires_read_deadline": true,
+    "direct_group_dependency": false,
+    "direct_channel_dependency": false,
+    "direct_owner_table_access": false
+  },
+  "composition": {
+    "storage": false,
+    "category_policy": false,
+    "topic_policy": false,
+    "reply_policy": false,
+    "transport": false,
+    "notifications": false,
+    "search_index": false,
+    "seo_deep_links": false
+  },
+  "not_delivered": [
+    "audience policy persistence and inheritance",
+    "category topic and reply read composition",
+    "create reply and moderate audience write policy",
+    "topic narrowing commands",
+    "channel and group provider adapters",
+    "trust-level owner provider",
+    "visibility-scoped category and all-read mutations",
+    "notification search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test audience_capability_contract -- --nocapture",
+      "node scripts/verify/verify-forum-audience-capability-ports.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/contracts/forum-audience-capability-ports.json
+++ b/crates/rustok-forum/contracts/forum-audience-capability-ports.json
@@ -21,7 +21,9 @@
     "explicit_deny": "wins over explicit allow and every positive selector",
     "empty_constraints": "no additional narrowing",
     "public_actor": "cannot satisfy role trust channel group or explicit-user selectors",
-    "owner_facts": "exact requested actor and candidate subset only",
+    "owner_facts": "exact requested tenant actor and candidate subset only",
+    "context_binding": "port tenant and user actor must match the requested tenant and SecurityContext user",
+    "nil_identifiers": "rejected before normalization",
     "provider_absence": "local deny allow and role decisions remain available; otherwise authenticated external-fact evaluation fails closed with a typed capability error"
   },
   "port": {
@@ -29,6 +31,8 @@
     "request": "ForumAudienceFactsRequest",
     "response": "ForumAudienceFacts",
     "requires_read_deadline": true,
+    "echoes_tenant_and_actor": true,
+    "validates_context_identity": true,
     "direct_group_dependency": false,
     "direct_channel_dependency": false,
     "direct_owner_table_access": false

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A-E provide typed inherited public/authenticated policy plus storefront and category/topic/reply owner-read composition. Richer role/trust/membership/allow-deny rules, write audiences, remaining consumers and runtime evidence remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A-F provide inherited public/authenticated policy, category/topic/reply owner-read composition and a bounded richer-audience capability/evaluator contract. Persistence and read composition of richer rules, write audiences, remaining consumers and runtime evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1177,24 +1177,56 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
   `verify-forum-category-owner-read-visibility.mjs` lock exact, page and tree
   composition.
 
+### Delivered in `FORUM-20F`
+
+- `ForumAudienceConstraints` models additional role, minimum-trust,
+  channel-member, group-member and explicit user allow/deny selectors after the
+  inherited public/authenticated floor; positive selectors form a union and
+  explicit deny always wins;
+- raw input is capped before normalization at four roles, 32 channel candidates,
+  32 group candidates and 100 allow plus 100 deny user IDs; trust is bounded to
+  0..100 and channel slugs to 128 characters;
+- `ForumAudienceFactsRequest` and `ForumAudienceFacts` form an exact actor-scoped
+  request/response pair, rejecting unrequested trust, channel or group facts;
+- `ForumAudienceFactsPort` is a transport-neutral optional owner boundary with
+  mandatory read-deadline semantics and no direct Forum dependency on Channel,
+  Groups or their private tables;
+- `ForumAudienceFactsResolver` skips the optional provider when local
+  deny/allow/role facts already decide the union, returns empty facts for public
+  or non-user actors, and otherwise fails closed with typed capability errors;
+- `ForumAudienceEvaluator` validates exact facts and returns an explainable
+  decision reason for unrestricted, deny, allow, role, trust, channel, group,
+  authentication-required or no-match outcomes;
+- `forum-audience-capability-ports.json`, `audience_capability_contract` and
+  `verify-forum-audience-capability-ports.mjs` lock bounds, precedence, exact
+  subsets, deadline semantics and residual composition work;
+- this slice adds no storage, migration, owner-read composition, write policy,
+  transport, provider adapter or cross-consumer behavior.
+
 ### Compatibility and degraded mode
 
-The nullable policy column still requires no backfill. Existing categories stay
+The nullable category floor still requires no backfill. Existing categories stay
 public until an owner command narrows an ancestor. Public category/topic/reply
-reads now treat inherited authenticated targets as absent; authenticated reads
-continue to expose public and authenticated categories. Storefront topic reads
-add the existing open/exact-channel policy on top of the same category floor.
-No transport field, migration or write behavior changes in FORUM-20C-E. Missing
-future role/trust/channel/group capability providers cannot broaden results;
-their membership semantics remain closed until explicit bounded owner ports are
-composed.
+reads treat inherited authenticated targets as absent; authenticated reads expose
+public and authenticated categories. Storefront topic reads add the existing
+open/exact-channel policy on top of the same category floor. FORUM-20F adds only
+public Rust contract types and source-ready evidence: no current read, write or
+transport calls the richer evaluator yet. A missing optional facts provider can
+never broaden a decision; locally decidable role/explicit rules do not require
+one, while unresolved trust/channel/group facts return a typed failure. Host
+adapters may compose owner ports later without adding direct Forum dependencies
+on Channel or Groups implementations.
 
 ### Remaining scope
 
-- add role, trust-level, channel-member, group-member and explicit allow/deny
-  evaluation through bounded owner capability ports;
-- add create/reply/moderate audience policies and topic narrowing that cannot
-  broaden the effective category policy;
+- persist and inherit the bounded FORUM-20F constraints for categories and topic
+  narrowing, then compose them into category/topic/reply owner reads without
+  count, pagination or existence-oracle drift;
+- provide host adapters for Forum-owned trust state plus Channel and Groups owner
+  membership ports, preserving exact request bounds and optional-capability
+  failure semantics;
+- add create/reply/moderate audience policies and topic narrowing commands that
+  cannot broaden the effective category policy;
 - compose the owner policy into remaining Forum reads and migrate notifications,
   search/index, SEO and deep-link open authorization to the same decision;
 - add visibility-scoped category and all-read commands only after the complete
@@ -1215,18 +1247,20 @@ cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocaptu
 cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
 node scripts/verify/verify-forum-category-owner-read-visibility.mjs
+node scripts/verify/verify-forum-audience-capability-ports.mjs
 cargo xtask module validate forum
 npm run verify:forum:storefront-boundary
 ```
 
 Tests, Cargo, verifiers and CI were not run while publishing the source-ready
-FORUM-20C-E read-composition slices. `FORUM-20` remains `in_progress` until the
-complete audience policy and all remaining cross-consumer paths are delivered
-with maintainer runtime evidence.
+FORUM-20C-F read-composition and capability-contract slices. `FORUM-20` remains
+`in_progress` until richer policy persistence/composition, write audiences and
+all cross-consumer paths are delivered with maintainer runtime evidence.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -1933,6 +1967,7 @@ cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocaptu
 cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
+cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1955,6 +1990,7 @@ node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
 node scripts/verify/verify-forum-category-owner-read-visibility.mjs
+node scripts/verify/verify-forum-audience-capability-ports.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -2006,9 +2042,9 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` with bounded role/trust/channel-membership/group-membership/
-    explicit allow-deny capability ports, then compose write audiences and migrate
-    remaining reads, notifications, search, SEO and deep-link checks;
+12. continue `FORUM-20` by persisting and inheriting the bounded FORUM-20F
+    constraints, composing them into owner reads with exact provider adapters,
+    then add write audiences and migrate remaining consumers;
 13. `FORUM-23`: index projections;
 14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.

--- a/crates/rustok-forum/src/audience.rs
+++ b/crates/rustok-forum/src/audience.rs
@@ -70,7 +70,7 @@ impl ForumAudienceConstraints {
             )));
         }
 
-        self.roles_any.sort_by_key(UserRole::privilege_rank);
+        self.roles_any.sort_by_key(|role| role.privilege_rank());
         self.roles_any.dedup();
         self.channel_members_any = normalize_channel_slugs(self.channel_members_any)?;
         normalize_uuid_list(&mut self.group_members_any);
@@ -199,9 +199,9 @@ pub trait ForumAudienceFactsPort: Send + Sync {
 
 pub type SharedForumAudienceFactsPort = Arc<dyn ForumAudienceFactsPort>;
 
-/// Fail-closed capability composition. Provider absence is harmless for rules
-/// that need only local role/explicit-user facts, but is a typed error for an
-/// authenticated actor when trust or membership facts are required.
+/// Fail-closed capability composition. Provider absence is harmless when local
+/// deny/allow/role facts already decide the request, but is a typed error for an
+/// authenticated actor when trust or membership facts are still required.
 #[derive(Clone, Default)]
 pub struct ForumAudienceFactsResolver {
     port: Option<SharedForumAudienceFactsPort>,
@@ -219,13 +219,20 @@ impl ForumAudienceFactsResolver {
         constraints: &ForumAudienceConstraints,
     ) -> ForumResult<ForumAudienceFacts> {
         let constraints = constraints.clone().normalize()?;
-        if !constraints.requires_owner_facts() {
+        let user_id = security.user_id;
+        if !constraints.requires_owner_facts()
+            || security.is_public_read()
+            || user_id.is_none()
+            || user_id.is_some_and(|id| {
+                constraints.deny_user_ids.binary_search(&id).is_ok()
+                    || constraints.allow_user_ids.binary_search(&id).is_ok()
+            })
+            || constraints.roles_any.contains(&security.role)
+        {
             return Ok(ForumAudienceFacts::default());
         }
 
-        let Some(user_id) = security.user_id else {
-            return Ok(ForumAudienceFacts::default());
-        };
+        let user_id = user_id.expect("checked above");
         let request = ForumAudienceFactsRequest::for_constraints(user_id, &constraints)?;
         let Some(port) = &self.port else {
             return Err(ForumError::capability_unavailable(
@@ -316,6 +323,13 @@ impl ForumAudienceEvaluator {
                 ForumAudienceDecisionReason::Role,
             ));
         }
+
+        let facts = match user_id {
+            Some(user_id) => facts.clone().validate_for_request(
+                &ForumAudienceFactsRequest::for_constraints(user_id, &constraints)?,
+            )?,
+            None => ForumAudienceFacts::default(),
+        };
         if constraints
             .minimum_trust_level
             .is_some_and(|minimum| facts.trust_level.is_some_and(|level| level >= minimum))

--- a/crates/rustok-forum/src/audience.rs
+++ b/crates/rustok-forum/src/audience.rs
@@ -1,0 +1,400 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_core::{SecurityContext, UserRole};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+pub const MAX_FORUM_AUDIENCE_ROLES: usize = 4;
+pub const MAX_FORUM_AUDIENCE_CHANNELS: usize = 32;
+pub const MAX_FORUM_AUDIENCE_GROUPS: usize = 32;
+pub const MAX_FORUM_AUDIENCE_EXPLICIT_USERS: usize = 100;
+pub const MAX_FORUM_AUDIENCE_TRUST_LEVEL: u8 = 100;
+pub const FORUM_AUDIENCE_FACTS_CAPABILITY: &str = "forum_audience_facts";
+pub const FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE: &str =
+    "FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE";
+
+const MAX_FORUM_AUDIENCE_CHANNEL_SLUG_LEN: usize = 128;
+
+/// Additional audience narrowing applied after the inherited category
+/// `public` / `authenticated` floor.
+///
+/// Positive selectors are a union: a matching role, trust threshold, channel
+/// membership, group membership or explicit user allow is sufficient. Explicit
+/// deny always wins. An empty constraint set adds no narrowing.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumAudienceConstraints {
+    pub roles_any: Vec<UserRole>,
+    pub minimum_trust_level: Option<u8>,
+    pub channel_members_any: Vec<String>,
+    pub group_members_any: Vec<Uuid>,
+    pub allow_user_ids: Vec<Uuid>,
+    pub deny_user_ids: Vec<Uuid>,
+}
+
+impl ForumAudienceConstraints {
+    pub fn normalize(mut self) -> ForumResult<Self> {
+        validate_raw_len(
+            self.roles_any.len(),
+            MAX_FORUM_AUDIENCE_ROLES,
+            "roles",
+        )?;
+        validate_raw_len(
+            self.channel_members_any.len(),
+            MAX_FORUM_AUDIENCE_CHANNELS,
+            "channel memberships",
+        )?;
+        validate_raw_len(
+            self.group_members_any.len(),
+            MAX_FORUM_AUDIENCE_GROUPS,
+            "group memberships",
+        )?;
+        validate_raw_len(
+            self.allow_user_ids.len(),
+            MAX_FORUM_AUDIENCE_EXPLICIT_USERS,
+            "explicit allow users",
+        )?;
+        validate_raw_len(
+            self.deny_user_ids.len(),
+            MAX_FORUM_AUDIENCE_EXPLICIT_USERS,
+            "explicit deny users",
+        )?;
+        if self.minimum_trust_level > Some(MAX_FORUM_AUDIENCE_TRUST_LEVEL) {
+            return Err(ForumError::Validation(format!(
+                "Forum audience trust level must not exceed {MAX_FORUM_AUDIENCE_TRUST_LEVEL}"
+            )));
+        }
+
+        self.roles_any.sort_by_key(UserRole::privilege_rank);
+        self.roles_any.dedup();
+        self.channel_members_any = normalize_channel_slugs(self.channel_members_any)?;
+        normalize_uuid_list(&mut self.group_members_any);
+        normalize_uuid_list(&mut self.allow_user_ids);
+        normalize_uuid_list(&mut self.deny_user_ids);
+        Ok(self)
+    }
+
+    pub fn requires_owner_facts(&self) -> bool {
+        self.minimum_trust_level.is_some()
+            || !self.channel_members_any.is_empty()
+            || !self.group_members_any.is_empty()
+    }
+
+    pub fn has_positive_selectors(&self) -> bool {
+        !self.roles_any.is_empty()
+            || self.minimum_trust_level.is_some()
+            || !self.channel_members_any.is_empty()
+            || !self.group_members_any.is_empty()
+            || !self.allow_user_ids.is_empty()
+    }
+}
+
+/// Exact bounded request to owner capability adapters.
+///
+/// Providers must resolve only the requested actor and candidate memberships;
+/// they must not discover or return additional channels or groups.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumAudienceFactsRequest {
+    pub user_id: Uuid,
+    pub include_trust_level: bool,
+    pub channel_slugs: Vec<String>,
+    pub group_ids: Vec<Uuid>,
+}
+
+impl ForumAudienceFactsRequest {
+    pub fn for_constraints(
+        user_id: Uuid,
+        constraints: &ForumAudienceConstraints,
+    ) -> ForumResult<Self> {
+        let constraints = constraints.clone().normalize()?;
+        Ok(Self {
+            user_id,
+            include_trust_level: constraints.minimum_trust_level.is_some(),
+            channel_slugs: constraints.channel_members_any,
+            group_ids: constraints.group_members_any,
+        })
+    }
+}
+
+/// Exact owner facts for one actor and one bounded request.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumAudienceFacts {
+    pub trust_level: Option<u8>,
+    pub channel_memberships: Vec<String>,
+    pub group_memberships: Vec<Uuid>,
+}
+
+impl ForumAudienceFacts {
+    pub fn validate_for_request(
+        mut self,
+        request: &ForumAudienceFactsRequest,
+    ) -> ForumResult<Self> {
+        validate_raw_len(
+            self.channel_memberships.len(),
+            MAX_FORUM_AUDIENCE_CHANNELS,
+            "resolved channel memberships",
+        )?;
+        validate_raw_len(
+            self.group_memberships.len(),
+            MAX_FORUM_AUDIENCE_GROUPS,
+            "resolved group memberships",
+        )?;
+        if self.trust_level > Some(MAX_FORUM_AUDIENCE_TRUST_LEVEL) {
+            return Err(ForumError::Validation(format!(
+                "Forum audience resolved trust level must not exceed {MAX_FORUM_AUDIENCE_TRUST_LEVEL}"
+            )));
+        }
+        if !request.include_trust_level && self.trust_level.is_some() {
+            return Err(ForumError::Validation(
+                "Forum audience facts returned an unrequested trust level".to_string(),
+            ));
+        }
+
+        self.channel_memberships = normalize_channel_slugs(self.channel_memberships)?;
+        normalize_uuid_list(&mut self.group_memberships);
+
+        let requested_channels = request
+            .channel_slugs
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        if self
+            .channel_memberships
+            .iter()
+            .any(|slug| !requested_channels.contains(slug))
+        {
+            return Err(ForumError::Validation(
+                "Forum audience facts returned an unrequested channel membership".to_string(),
+            ));
+        }
+
+        let requested_groups = request.group_ids.iter().copied().collect::<HashSet<_>>();
+        if self
+            .group_memberships
+            .iter()
+            .any(|group_id| !requested_groups.contains(group_id))
+        {
+            return Err(ForumError::Validation(
+                "Forum audience facts returned an unrequested group membership".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+}
+
+/// Optional adapter boundary for trust/channel/group owner facts.
+#[async_trait]
+pub trait ForumAudienceFactsPort: Send + Sync {
+    async fn resolve_forum_audience_facts(
+        &self,
+        context: PortContext,
+        request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError>;
+}
+
+pub type SharedForumAudienceFactsPort = Arc<dyn ForumAudienceFactsPort>;
+
+/// Fail-closed capability composition. Provider absence is harmless for rules
+/// that need only local role/explicit-user facts, but is a typed error for an
+/// authenticated actor when trust or membership facts are required.
+#[derive(Clone, Default)]
+pub struct ForumAudienceFactsResolver {
+    port: Option<SharedForumAudienceFactsPort>,
+}
+
+impl ForumAudienceFactsResolver {
+    pub fn new(port: Option<SharedForumAudienceFactsPort>) -> Self {
+        Self { port }
+    }
+
+    pub async fn resolve_for_constraints(
+        &self,
+        context: PortContext,
+        security: &SecurityContext,
+        constraints: &ForumAudienceConstraints,
+    ) -> ForumResult<ForumAudienceFacts> {
+        let constraints = constraints.clone().normalize()?;
+        if !constraints.requires_owner_facts() {
+            return Ok(ForumAudienceFacts::default());
+        }
+
+        let Some(user_id) = security.user_id else {
+            return Ok(ForumAudienceFacts::default());
+        };
+        let request = ForumAudienceFactsRequest::for_constraints(user_id, &constraints)?;
+        let Some(port) = &self.port else {
+            return Err(ForumError::capability_unavailable(
+                FORUM_AUDIENCE_FACTS_CAPABILITY,
+                FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE,
+            ));
+        };
+
+        context
+            .require_policy(PortCallPolicy::read())
+            .map_err(map_audience_port_error)?;
+        port.resolve_forum_audience_facts(context, request.clone())
+            .await
+            .map_err(map_audience_port_error)?
+            .validate_for_request(&request)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumAudienceDecisionReason {
+    Unrestricted,
+    ExplicitDeny,
+    ExplicitAllow,
+    Role,
+    TrustLevel,
+    ChannelMembership,
+    GroupMembership,
+    AuthenticationRequired,
+    NoMatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumAudienceDecision {
+    pub allowed: bool,
+    pub reason: ForumAudienceDecisionReason,
+}
+
+impl ForumAudienceDecision {
+    const fn allow(reason: ForumAudienceDecisionReason) -> Self {
+        Self {
+            allowed: true,
+            reason,
+        }
+    }
+
+    const fn deny(reason: ForumAudienceDecisionReason) -> Self {
+        Self {
+            allowed: false,
+            reason,
+        }
+    }
+}
+
+pub struct ForumAudienceEvaluator;
+
+impl ForumAudienceEvaluator {
+    pub fn decide(
+        constraints: &ForumAudienceConstraints,
+        security: &SecurityContext,
+        facts: &ForumAudienceFacts,
+    ) -> ForumResult<ForumAudienceDecision> {
+        let constraints = constraints.clone().normalize()?;
+        let user_id = security.user_id;
+
+        if user_id.is_some_and(|id| constraints.deny_user_ids.binary_search(&id).is_ok()) {
+            return Ok(ForumAudienceDecision::deny(
+                ForumAudienceDecisionReason::ExplicitDeny,
+            ));
+        }
+        if user_id.is_some_and(|id| constraints.allow_user_ids.binary_search(&id).is_ok()) {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::ExplicitAllow,
+            ));
+        }
+        if !constraints.has_positive_selectors() {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::Unrestricted,
+            ));
+        }
+        if security.is_public_read() {
+            return Ok(ForumAudienceDecision::deny(
+                ForumAudienceDecisionReason::AuthenticationRequired,
+            ));
+        }
+        if constraints.roles_any.contains(&security.role) {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::Role,
+            ));
+        }
+        if constraints
+            .minimum_trust_level
+            .is_some_and(|minimum| facts.trust_level.is_some_and(|level| level >= minimum))
+        {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::TrustLevel,
+            ));
+        }
+        if intersects_strings(
+            &constraints.channel_members_any,
+            &facts.channel_memberships,
+        ) {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::ChannelMembership,
+            ));
+        }
+        if intersects_uuids(&constraints.group_members_any, &facts.group_memberships) {
+            return Ok(ForumAudienceDecision::allow(
+                ForumAudienceDecisionReason::GroupMembership,
+            ));
+        }
+
+        Ok(ForumAudienceDecision::deny(
+            ForumAudienceDecisionReason::NoMatch,
+        ))
+    }
+}
+
+fn validate_raw_len(actual: usize, maximum: usize, label: &str) -> ForumResult<()> {
+    if actual > maximum {
+        return Err(ForumError::Validation(format!(
+            "Forum audience {label} must not exceed {maximum} candidates"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_channel_slugs(slugs: Vec<String>) -> ForumResult<Vec<String>> {
+    let mut normalized = Vec::with_capacity(slugs.len());
+    let mut seen = HashSet::with_capacity(slugs.len());
+    for slug in slugs {
+        let slug = slug.trim();
+        if slug.is_empty() {
+            return Err(ForumError::Validation(
+                "Forum audience channel slug must not be empty".to_string(),
+            ));
+        }
+        if slug.chars().count() > MAX_FORUM_AUDIENCE_CHANNEL_SLUG_LEN {
+            return Err(ForumError::Validation(format!(
+                "Forum audience channel slug must not exceed {MAX_FORUM_AUDIENCE_CHANNEL_SLUG_LEN} characters"
+            )));
+        }
+        let slug = slug.to_ascii_lowercase();
+        if seen.insert(slug.clone()) {
+            normalized.push(slug);
+        }
+    }
+    normalized.sort();
+    Ok(normalized)
+}
+
+fn normalize_uuid_list(ids: &mut Vec<Uuid>) {
+    ids.sort_unstable();
+    ids.dedup();
+}
+
+fn intersects_strings(left: &[String], right: &[String]) -> bool {
+    left.iter().any(|candidate| right.contains(candidate))
+}
+
+fn intersects_uuids(left: &[Uuid], right: &[Uuid]) -> bool {
+    left.iter().any(|candidate| right.contains(candidate))
+}
+
+fn map_audience_port_error(error: PortError) -> ForumError {
+    ForumError::capability_failure(
+        FORUM_AUDIENCE_FACTS_CAPABILITY,
+        error.code,
+        error.message,
+        error.retryable,
+    )
+}

--- a/crates/rustok-forum/src/audience.rs
+++ b/crates/rustok-forum/src/audience.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
 use rustok_core::{SecurityContext, UserRole};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -73,9 +73,9 @@ impl ForumAudienceConstraints {
         self.roles_any.sort_by_key(|role| role.privilege_rank());
         self.roles_any.dedup();
         self.channel_members_any = normalize_channel_slugs(self.channel_members_any)?;
-        normalize_uuid_list(&mut self.group_members_any);
-        normalize_uuid_list(&mut self.allow_user_ids);
-        normalize_uuid_list(&mut self.deny_user_ids);
+        normalize_uuid_list(&mut self.group_members_any, "group memberships")?;
+        normalize_uuid_list(&mut self.allow_user_ids, "explicit allow users")?;
+        normalize_uuid_list(&mut self.deny_user_ids, "explicit deny users")?;
         Ok(self)
     }
 
@@ -96,10 +96,11 @@ impl ForumAudienceConstraints {
 
 /// Exact bounded request to owner capability adapters.
 ///
-/// Providers must resolve only the requested actor and candidate memberships;
-/// they must not discover or return additional channels or groups.
+/// Providers must resolve only the requested tenant, actor and candidate
+/// memberships; they must not discover or return additional channels or groups.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct ForumAudienceFactsRequest {
+    pub tenant_id: Uuid,
     pub user_id: Uuid,
     pub include_trust_level: bool,
     pub channel_slugs: Vec<String>,
@@ -108,11 +109,13 @@ pub struct ForumAudienceFactsRequest {
 
 impl ForumAudienceFactsRequest {
     pub fn for_constraints(
+        tenant_id: Uuid,
         user_id: Uuid,
         constraints: &ForumAudienceConstraints,
     ) -> ForumResult<Self> {
         let constraints = constraints.clone().normalize()?;
         Self {
+            tenant_id,
             user_id,
             include_trust_level: constraints.minimum_trust_level.is_some(),
             channel_slugs: constraints.channel_members_any,
@@ -122,6 +125,8 @@ impl ForumAudienceFactsRequest {
     }
 
     pub fn normalize(mut self) -> ForumResult<Self> {
+        validate_identity(self.tenant_id, "fact request tenant")?;
+        validate_identity(self.user_id, "fact request user")?;
         validate_raw_len(
             self.channel_slugs.len(),
             MAX_FORUM_AUDIENCE_CHANNELS,
@@ -133,14 +138,16 @@ impl ForumAudienceFactsRequest {
             "fact request groups",
         )?;
         self.channel_slugs = normalize_channel_slugs(self.channel_slugs)?;
-        normalize_uuid_list(&mut self.group_ids);
+        normalize_uuid_list(&mut self.group_ids, "fact request groups")?;
         Ok(self)
     }
 }
 
-/// Exact owner facts for one actor and one bounded request.
+/// Exact owner facts for one tenant and actor.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct ForumAudienceFacts {
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
     pub trust_level: Option<u8>,
     pub channel_memberships: Vec<String>,
     pub group_memberships: Vec<Uuid>,
@@ -152,6 +159,11 @@ impl ForumAudienceFacts {
         request: &ForumAudienceFactsRequest,
     ) -> ForumResult<Self> {
         let request = request.clone().normalize()?;
+        if self.tenant_id != request.tenant_id || self.user_id != request.user_id {
+            return Err(ForumError::Validation(
+                "Forum audience facts returned a different tenant or actor".to_string(),
+            ));
+        }
         validate_raw_len(
             self.channel_memberships.len(),
             MAX_FORUM_AUDIENCE_CHANNELS,
@@ -174,7 +186,10 @@ impl ForumAudienceFacts {
         }
 
         self.channel_memberships = normalize_channel_slugs(self.channel_memberships)?;
-        normalize_uuid_list(&mut self.group_memberships);
+        normalize_uuid_list(
+            &mut self.group_memberships,
+            "resolved group memberships",
+        )?;
 
         let requested_channels = request
             .channel_slugs
@@ -232,10 +247,12 @@ impl ForumAudienceFactsResolver {
 
     pub async fn resolve_for_constraints(
         &self,
+        tenant_id: Uuid,
         context: PortContext,
         security: &SecurityContext,
         constraints: &ForumAudienceConstraints,
     ) -> ForumResult<ForumAudienceFacts> {
+        validate_identity(tenant_id, "tenant")?;
         let constraints = constraints.clone().normalize()?;
         let user_id = security.user_id;
         if !constraints.requires_owner_facts()
@@ -251,7 +268,8 @@ impl ForumAudienceFactsResolver {
         }
 
         let user_id = user_id.expect("checked above");
-        let request = ForumAudienceFactsRequest::for_constraints(user_id, &constraints)?;
+        validate_port_context(&context, tenant_id, user_id)?;
+        let request = ForumAudienceFactsRequest::for_constraints(tenant_id, user_id, &constraints)?;
         let Some(port) = &self.port else {
             return Err(ForumError::capability_unavailable(
                 FORUM_AUDIENCE_FACTS_CAPABILITY,
@@ -309,10 +327,12 @@ pub struct ForumAudienceEvaluator;
 
 impl ForumAudienceEvaluator {
     pub fn decide(
+        tenant_id: Uuid,
         constraints: &ForumAudienceConstraints,
         security: &SecurityContext,
         facts: &ForumAudienceFacts,
     ) -> ForumResult<ForumAudienceDecision> {
+        validate_identity(tenant_id, "tenant")?;
         let constraints = constraints.clone().normalize()?;
         let user_id = security.user_id;
 
@@ -344,7 +364,11 @@ impl ForumAudienceEvaluator {
 
         let facts = match user_id {
             Some(user_id) => facts.clone().validate_for_request(
-                &ForumAudienceFactsRequest::for_constraints(user_id, &constraints)?,
+                &ForumAudienceFactsRequest::for_constraints(
+                    tenant_id,
+                    user_id,
+                    &constraints,
+                )?,
             )?,
             None => ForumAudienceFacts::default(),
         };
@@ -385,6 +409,44 @@ fn validate_raw_len(actual: usize, maximum: usize, label: &str) -> ForumResult<(
     Ok(())
 }
 
+fn validate_identity(id: Uuid, label: &str) -> ForumResult<()> {
+    if id.is_nil() {
+        return Err(ForumError::Validation(format!(
+            "Forum audience {label} must not be nil"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_port_context(
+    context: &PortContext,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> ForumResult<()> {
+    let context_tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        ForumError::Validation("Forum audience port context tenant is invalid".to_string())
+    })?;
+    if context_tenant_id != tenant_id {
+        return Err(ForumError::Validation(
+            "Forum audience port context tenant does not match the requested tenant".to_string(),
+        ));
+    }
+    if context.actor.kind != PortActorKind::User {
+        return Err(ForumError::Validation(
+            "Forum audience owner facts require a user port actor".to_string(),
+        ));
+    }
+    let context_user_id = Uuid::parse_str(&context.actor.id).map_err(|_| {
+        ForumError::Validation("Forum audience port context actor is invalid".to_string())
+    })?;
+    if context_user_id != user_id {
+        return Err(ForumError::Validation(
+            "Forum audience port context actor does not match the requested user".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn normalize_channel_slugs(slugs: Vec<String>) -> ForumResult<Vec<String>> {
     let mut normalized = Vec::with_capacity(slugs.len());
     let mut seen = HashSet::with_capacity(slugs.len());
@@ -409,9 +471,15 @@ fn normalize_channel_slugs(slugs: Vec<String>) -> ForumResult<Vec<String>> {
     Ok(normalized)
 }
 
-fn normalize_uuid_list(ids: &mut Vec<Uuid>) {
+fn normalize_uuid_list(ids: &mut Vec<Uuid>, label: &str) -> ForumResult<()> {
+    if ids.iter().any(Uuid::is_nil) {
+        return Err(ForumError::Validation(format!(
+            "Forum audience {label} must not contain nil identifiers"
+        )));
+    }
     ids.sort_unstable();
     ids.dedup();
+    Ok(())
 }
 
 fn intersects_strings(left: &[String], right: &[String]) -> bool {

--- a/crates/rustok-forum/src/audience.rs
+++ b/crates/rustok-forum/src/audience.rs
@@ -112,12 +112,29 @@ impl ForumAudienceFactsRequest {
         constraints: &ForumAudienceConstraints,
     ) -> ForumResult<Self> {
         let constraints = constraints.clone().normalize()?;
-        Ok(Self {
+        Self {
             user_id,
             include_trust_level: constraints.minimum_trust_level.is_some(),
             channel_slugs: constraints.channel_members_any,
             group_ids: constraints.group_members_any,
-        })
+        }
+        .normalize()
+    }
+
+    pub fn normalize(mut self) -> ForumResult<Self> {
+        validate_raw_len(
+            self.channel_slugs.len(),
+            MAX_FORUM_AUDIENCE_CHANNELS,
+            "fact request channels",
+        )?;
+        validate_raw_len(
+            self.group_ids.len(),
+            MAX_FORUM_AUDIENCE_GROUPS,
+            "fact request groups",
+        )?;
+        self.channel_slugs = normalize_channel_slugs(self.channel_slugs)?;
+        normalize_uuid_list(&mut self.group_ids);
+        Ok(self)
     }
 }
 
@@ -134,6 +151,7 @@ impl ForumAudienceFacts {
         mut self,
         request: &ForumAudienceFactsRequest,
     ) -> ForumResult<Self> {
+        let request = request.clone().normalize()?;
         validate_raw_len(
             self.channel_memberships.len(),
             MAX_FORUM_AUDIENCE_CHANNELS,

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -5,6 +5,7 @@ use rustok_notifications_api::register_notification_source_provider_factory;
 use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
+pub mod audience;
 pub mod category_presentation;
 pub mod constants;
 pub mod controllers;
@@ -25,6 +26,14 @@ pub mod state_machine;
 pub mod subscription;
 pub mod visibility;
 
+pub use audience::{
+    FORUM_AUDIENCE_FACTS_CAPABILITY, FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE,
+    ForumAudienceConstraints, ForumAudienceDecision, ForumAudienceDecisionReason,
+    ForumAudienceEvaluator, ForumAudienceFacts, ForumAudienceFactsPort, ForumAudienceFactsRequest,
+    ForumAudienceFactsResolver, MAX_FORUM_AUDIENCE_CHANNELS, MAX_FORUM_AUDIENCE_EXPLICIT_USERS,
+    MAX_FORUM_AUDIENCE_GROUPS, MAX_FORUM_AUDIENCE_ROLES, MAX_FORUM_AUDIENCE_TRUST_LEVEL,
+    SharedForumAudienceFactsPort,
+};
 pub use constants::*;
 pub use dto::*;
 pub use entities::*;

--- a/crates/rustok-forum/tests/audience_capability_contract.rs
+++ b/crates/rustok-forum/tests/audience_capability_contract.rs
@@ -40,6 +40,7 @@ fn read_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
 
 #[test]
 fn audience_constraints_are_bounded_and_canonical() {
+    let tenant_id = Uuid::new_v4();
     let group_id = Uuid::new_v4();
     let user_id = Uuid::new_v4();
     let normalized = ForumAudienceConstraints {
@@ -54,7 +55,10 @@ fn audience_constraints_are_bounded_and_canonical() {
     .expect("bounded audience constraints should normalize");
 
     assert_eq!(normalized.roles_any, vec![UserRole::Manager, UserRole::Admin]);
-    assert_eq!(normalized.channel_members_any, vec!["team"]);
+    assert_eq!(
+        normalized.channel_members_any,
+        vec!["team".to_string()]
+    );
     assert_eq!(normalized.group_members_any, vec![group_id]);
     assert_eq!(normalized.allow_user_ids, vec![user_id]);
     assert_eq!(normalized.deny_user_ids, vec![user_id]);
@@ -72,6 +76,7 @@ fn audience_constraints_are_bounded_and_canonical() {
     ));
 
     let oversized_request = ForumAudienceFactsRequest {
+        tenant_id,
         user_id,
         include_trust_level: false,
         channel_slugs: (0..=MAX_FORUM_AUDIENCE_CHANNELS)
@@ -84,10 +89,21 @@ fn audience_constraints_are_bounded_and_canonical() {
         Err(ForumError::Validation(message))
             if message.contains("fact request channels")
     ));
+
+    assert!(matches!(
+        ForumAudienceConstraints {
+            group_members_any: vec![Uuid::nil()],
+            ..ForumAudienceConstraints::default()
+        }
+        .normalize(),
+        Err(ForumError::Validation(message))
+            if message.contains("nil identifiers")
+    ));
 }
 
 #[test]
 fn explicit_deny_wins_and_positive_selectors_are_a_union() {
+    let tenant_id = Uuid::new_v4();
     let user_id = Uuid::new_v4();
     let security = SecurityContext::new(UserRole::Manager, Some(user_id));
     let constraints = ForumAudienceConstraints {
@@ -98,6 +114,7 @@ fn explicit_deny_wins_and_positive_selectors_are_a_union() {
         ..ForumAudienceConstraints::default()
     };
     let denied = ForumAudienceEvaluator::decide(
+        tenant_id,
         &constraints,
         &security,
         &ForumAudienceFacts::default(),
@@ -107,6 +124,7 @@ fn explicit_deny_wins_and_positive_selectors_are_a_union() {
     assert_eq!(denied.reason, ForumAudienceDecisionReason::ExplicitDeny);
 
     let role_allowed = ForumAudienceEvaluator::decide(
+        tenant_id,
         &ForumAudienceConstraints {
             roles_any: vec![UserRole::Manager],
             minimum_trust_level: Some(50),
@@ -120,6 +138,7 @@ fn explicit_deny_wins_and_positive_selectors_are_a_union() {
     assert_eq!(role_allowed.reason, ForumAudienceDecisionReason::Role);
 
     let public_denied = ForumAudienceEvaluator::decide(
+        tenant_id,
         &ForumAudienceConstraints {
             roles_any: vec![UserRole::Customer],
             ..ForumAudienceConstraints::default()
@@ -136,11 +155,13 @@ fn explicit_deny_wins_and_positive_selectors_are_a_union() {
 }
 
 #[test]
-fn exact_owner_facts_reject_unrequested_memberships() {
+fn exact_owner_facts_reject_wrong_identity_and_unrequested_memberships() {
+    let tenant_id = Uuid::new_v4();
     let user_id = Uuid::new_v4();
     let requested_group = Uuid::new_v4();
     let unrequested_group = Uuid::new_v4();
     let request = ForumAudienceFactsRequest::for_constraints(
+        tenant_id,
         user_id,
         &ForumAudienceConstraints {
             minimum_trust_level: Some(1),
@@ -153,6 +174,20 @@ fn exact_owner_facts_reject_unrequested_memberships() {
 
     assert!(matches!(
         ForumAudienceFacts {
+            tenant_id: Uuid::new_v4(),
+            user_id,
+            trust_level: Some(10),
+            channel_memberships: vec!["members".into()],
+            group_memberships: vec![requested_group],
+        }
+        .validate_for_request(&request),
+        Err(ForumError::Validation(message))
+            if message.contains("different tenant or actor")
+    ));
+    assert!(matches!(
+        ForumAudienceFacts {
+            tenant_id,
+            user_id,
             trust_level: Some(10),
             channel_memberships: vec!["other".into()],
             group_memberships: vec![requested_group],
@@ -163,6 +198,8 @@ fn exact_owner_facts_reject_unrequested_memberships() {
     ));
     assert!(matches!(
         ForumAudienceFacts {
+            tenant_id,
+            user_id,
             trust_level: Some(10),
             channel_memberships: vec!["members".into()],
             group_memberships: vec![unrequested_group],
@@ -174,7 +211,7 @@ fn exact_owner_facts_reject_unrequested_memberships() {
 }
 
 #[tokio::test]
-async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
+async fn resolver_is_fail_closed_and_requires_matching_read_context() {
     let tenant_id = Uuid::new_v4();
     let user_id = Uuid::new_v4();
     let constraints = ForumAudienceConstraints {
@@ -185,6 +222,7 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
 
     let public_facts = ForumAudienceFactsResolver::default()
         .resolve_for_constraints(
+            tenant_id,
             read_context(tenant_id, user_id),
             &SecurityContext::public_read(),
             &constraints,
@@ -196,6 +234,7 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
     let authenticated = SecurityContext::new(UserRole::Customer, Some(user_id));
     let locally_decided = ForumAudienceFactsResolver::default()
         .resolve_for_constraints(
+            tenant_id,
             read_context(tenant_id, user_id),
             &authenticated,
             &ForumAudienceConstraints {
@@ -211,6 +250,7 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
     assert!(matches!(
         ForumAudienceFactsResolver::default()
             .resolve_for_constraints(
+                tenant_id,
                 read_context(tenant_id, user_id),
                 &authenticated,
                 &constraints,
@@ -222,6 +262,8 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
 
     let resolver = ForumAudienceFactsResolver::new(Some(Arc::new(StaticFactsPort {
         facts: ForumAudienceFacts {
+            tenant_id,
+            user_id,
             trust_level: Some(8),
             channel_memberships: vec!["MEMBERS".into()],
             group_memberships: Vec::new(),
@@ -229,6 +271,7 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
     })));
     let facts = resolver
         .resolve_for_constraints(
+            tenant_id,
             read_context(tenant_id, user_id),
             &authenticated,
             &constraints,
@@ -236,7 +279,21 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
         .await
         .expect("exact owner facts should resolve");
     assert_eq!(facts.trust_level, Some(8));
-    assert_eq!(facts.channel_memberships, vec!["members"]);
+    assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
+
+    let wrong_actor_context = read_context(tenant_id, Uuid::new_v4());
+    assert!(matches!(
+        resolver
+            .resolve_for_constraints(
+                tenant_id,
+                wrong_actor_context,
+                &authenticated,
+                &constraints,
+            )
+            .await,
+        Err(ForumError::Validation(message))
+            if message.contains("actor does not match")
+    ));
 
     let missing_deadline = PortContext::new(
         tenant_id.to_string(),
@@ -246,7 +303,12 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
     );
     assert!(matches!(
         resolver
-            .resolve_for_constraints(missing_deadline, &authenticated, &constraints)
+            .resolve_for_constraints(
+                tenant_id,
+                missing_deadline,
+                &authenticated,
+                &constraints,
+            )
             .await,
         Err(ForumError::CapabilityFailure { source_code, .. })
             if source_code == "port.deadline_required"

--- a/crates/rustok-forum/tests/audience_capability_contract.rs
+++ b/crates/rustok-forum/tests/audience_capability_contract.rs
@@ -70,6 +70,20 @@ fn audience_constraints_are_bounded_and_canonical() {
         Err(ForumError::Validation(message))
             if message.contains("channel memberships")
     ));
+
+    let oversized_request = ForumAudienceFactsRequest {
+        user_id,
+        include_trust_level: false,
+        channel_slugs: (0..=MAX_FORUM_AUDIENCE_CHANNELS)
+            .map(|index| format!("channel-{index}"))
+            .collect(),
+        group_ids: Vec::new(),
+    };
+    assert!(matches!(
+        oversized_request.normalize(),
+        Err(ForumError::Validation(message))
+            if message.contains("fact request channels")
+    ));
 }
 
 #[test]
@@ -180,6 +194,20 @@ async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
     assert_eq!(public_facts, ForumAudienceFacts::default());
 
     let authenticated = SecurityContext::new(UserRole::Customer, Some(user_id));
+    let locally_decided = ForumAudienceFactsResolver::default()
+        .resolve_for_constraints(
+            read_context(tenant_id, user_id),
+            &authenticated,
+            &ForumAudienceConstraints {
+                roles_any: vec![UserRole::Customer],
+                minimum_trust_level: Some(99),
+                ..ForumAudienceConstraints::default()
+            },
+        )
+        .await
+        .expect("a matching local role must not require an optional facts provider");
+    assert_eq!(locally_decided, ForumAudienceFacts::default());
+
     assert!(matches!(
         ForumAudienceFactsResolver::default()
             .resolve_for_constraints(

--- a/crates/rustok-forum/tests/audience_capability_contract.rs
+++ b/crates/rustok-forum/tests/audience_capability_contract.rs
@@ -1,0 +1,226 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rustok_api::{PortActor, PortContext, PortError};
+use rustok_core::{SecurityContext, UserRole};
+use rustok_forum::{
+    FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE, ForumAudienceConstraints,
+    ForumAudienceDecisionReason, ForumAudienceEvaluator, ForumAudienceFacts,
+    ForumAudienceFactsPort, ForumAudienceFactsRequest, ForumAudienceFactsResolver, ForumError,
+    MAX_FORUM_AUDIENCE_CHANNELS,
+};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct StaticFactsPort {
+    facts: ForumAudienceFacts,
+}
+
+#[async_trait]
+impl ForumAudienceFactsPort for StaticFactsPort {
+    async fn resolve_forum_audience_facts(
+        &self,
+        _context: PortContext,
+        _request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError> {
+        Ok(self.facts.clone())
+    }
+}
+
+fn read_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        "forum-audience-contract",
+    )
+    .with_deadline(Duration::from_secs(1))
+}
+
+#[test]
+fn audience_constraints_are_bounded_and_canonical() {
+    let group_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let normalized = ForumAudienceConstraints {
+        roles_any: vec![UserRole::Manager, UserRole::Manager, UserRole::Admin],
+        minimum_trust_level: Some(7),
+        channel_members_any: vec!["  Team  ".into(), "team".into()],
+        group_members_any: vec![group_id, group_id],
+        allow_user_ids: vec![user_id, user_id],
+        deny_user_ids: vec![user_id, user_id],
+    }
+    .normalize()
+    .expect("bounded audience constraints should normalize");
+
+    assert_eq!(normalized.roles_any, vec![UserRole::Manager, UserRole::Admin]);
+    assert_eq!(normalized.channel_members_any, vec!["team"]);
+    assert_eq!(normalized.group_members_any, vec![group_id]);
+    assert_eq!(normalized.allow_user_ids, vec![user_id]);
+    assert_eq!(normalized.deny_user_ids, vec![user_id]);
+
+    let oversized = ForumAudienceConstraints {
+        channel_members_any: (0..=MAX_FORUM_AUDIENCE_CHANNELS)
+            .map(|index| format!("channel-{index}"))
+            .collect(),
+        ..ForumAudienceConstraints::default()
+    };
+    assert!(matches!(
+        oversized.normalize(),
+        Err(ForumError::Validation(message))
+            if message.contains("channel memberships")
+    ));
+}
+
+#[test]
+fn explicit_deny_wins_and_positive_selectors_are_a_union() {
+    let user_id = Uuid::new_v4();
+    let security = SecurityContext::new(UserRole::Manager, Some(user_id));
+    let constraints = ForumAudienceConstraints {
+        roles_any: vec![UserRole::Manager],
+        minimum_trust_level: Some(50),
+        allow_user_ids: vec![user_id],
+        deny_user_ids: vec![user_id],
+        ..ForumAudienceConstraints::default()
+    };
+    let denied = ForumAudienceEvaluator::decide(
+        &constraints,
+        &security,
+        &ForumAudienceFacts::default(),
+    )
+    .expect("audience decision should resolve");
+    assert!(!denied.allowed);
+    assert_eq!(denied.reason, ForumAudienceDecisionReason::ExplicitDeny);
+
+    let role_allowed = ForumAudienceEvaluator::decide(
+        &ForumAudienceConstraints {
+            roles_any: vec![UserRole::Manager],
+            minimum_trust_level: Some(50),
+            ..ForumAudienceConstraints::default()
+        },
+        &security,
+        &ForumAudienceFacts::default(),
+    )
+    .expect("role audience should resolve");
+    assert!(role_allowed.allowed);
+    assert_eq!(role_allowed.reason, ForumAudienceDecisionReason::Role);
+
+    let public_denied = ForumAudienceEvaluator::decide(
+        &ForumAudienceConstraints {
+            roles_any: vec![UserRole::Customer],
+            ..ForumAudienceConstraints::default()
+        },
+        &SecurityContext::public_read(),
+        &ForumAudienceFacts::default(),
+    )
+    .expect("public audience decision should resolve");
+    assert!(!public_denied.allowed);
+    assert_eq!(
+        public_denied.reason,
+        ForumAudienceDecisionReason::AuthenticationRequired
+    );
+}
+
+#[test]
+fn exact_owner_facts_reject_unrequested_memberships() {
+    let user_id = Uuid::new_v4();
+    let requested_group = Uuid::new_v4();
+    let unrequested_group = Uuid::new_v4();
+    let request = ForumAudienceFactsRequest::for_constraints(
+        user_id,
+        &ForumAudienceConstraints {
+            minimum_trust_level: Some(1),
+            channel_members_any: vec!["members".into()],
+            group_members_any: vec![requested_group],
+            ..ForumAudienceConstraints::default()
+        },
+    )
+    .expect("facts request should normalize");
+
+    assert!(matches!(
+        ForumAudienceFacts {
+            trust_level: Some(10),
+            channel_memberships: vec!["other".into()],
+            group_memberships: vec![requested_group],
+        }
+        .validate_for_request(&request),
+        Err(ForumError::Validation(message))
+            if message.contains("unrequested channel membership")
+    ));
+    assert!(matches!(
+        ForumAudienceFacts {
+            trust_level: Some(10),
+            channel_memberships: vec!["members".into()],
+            group_memberships: vec![unrequested_group],
+        }
+        .validate_for_request(&request),
+        Err(ForumError::Validation(message))
+            if message.contains("unrequested group membership")
+    ));
+}
+
+#[tokio::test]
+async fn resolver_is_fail_closed_and_requires_read_deadline_semantics() {
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let constraints = ForumAudienceConstraints {
+        minimum_trust_level: Some(5),
+        channel_members_any: vec!["members".into()],
+        ..ForumAudienceConstraints::default()
+    };
+
+    let public_facts = ForumAudienceFactsResolver::default()
+        .resolve_for_constraints(
+            read_context(tenant_id, user_id),
+            &SecurityContext::public_read(),
+            &constraints,
+        )
+        .await
+        .expect("public actors should fail closed without calling an optional provider");
+    assert_eq!(public_facts, ForumAudienceFacts::default());
+
+    let authenticated = SecurityContext::new(UserRole::Customer, Some(user_id));
+    assert!(matches!(
+        ForumAudienceFactsResolver::default()
+            .resolve_for_constraints(
+                read_context(tenant_id, user_id),
+                &authenticated,
+                &constraints,
+            )
+            .await,
+        Err(ForumError::CapabilityUnavailable { code, .. })
+            if code == FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE
+    ));
+
+    let resolver = ForumAudienceFactsResolver::new(Some(Arc::new(StaticFactsPort {
+        facts: ForumAudienceFacts {
+            trust_level: Some(8),
+            channel_memberships: vec!["MEMBERS".into()],
+            group_memberships: Vec::new(),
+        },
+    })));
+    let facts = resolver
+        .resolve_for_constraints(
+            read_context(tenant_id, user_id),
+            &authenticated,
+            &constraints,
+        )
+        .await
+        .expect("exact owner facts should resolve");
+    assert_eq!(facts.trust_level, Some(8));
+    assert_eq!(facts.channel_memberships, vec!["members"]);
+
+    let missing_deadline = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        "forum-audience-contract-no-deadline",
+    );
+    assert!(matches!(
+        resolver
+            .resolve_for_constraints(missing_deadline, &authenticated, &constraints)
+            .await,
+        Err(ForumError::CapabilityFailure { source_code, .. })
+            if source_code == "port.deadline_required"
+    ));
+}

--- a/scripts/verify/verify-forum-audience-capability-ports.mjs
+++ b/scripts/verify/verify-forum-audience-capability-ports.mjs
@@ -27,6 +27,16 @@ function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
 
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
 const contractPath =
   "crates/rustok-forum/contracts/forum-audience-capability-ports.json";
 const contract = JSON.parse(read(contractPath) || "{}");
@@ -56,6 +66,15 @@ for (const [key, expected] of Object.entries({
 }
 if (contract.policy?.positive_selectors !== "union") {
   failures.push("forum audience positive selectors must remain a documented union");
+}
+if (contract.policy?.owner_facts !== "exact requested tenant actor and candidate subset only") {
+  failures.push("forum audience owner facts must remain exact by tenant, actor, and candidates");
+}
+if (
+  contract.port?.echoes_tenant_and_actor !== true ||
+  contract.port?.validates_context_identity !== true
+) {
+  failures.push("forum audience port must echo and validate exact tenant/actor identity");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted audience evidence");
@@ -120,7 +139,12 @@ if (
 }
 
 for (const marker of [
-  "Providers must resolve only the requested actor and candidate memberships",
+  "Providers must resolve only the requested tenant, actor and candidate",
+  "pub tenant_id: Uuid",
+  "pub user_id: Uuid",
+  "validate_identity(self.tenant_id, \"fact request tenant\")?",
+  "validate_identity(self.user_id, \"fact request user\")?",
+  "Forum audience facts returned a different tenant or actor",
   "Forum audience facts returned an unrequested trust level",
   "Forum audience facts returned an unrequested channel membership",
   "Forum audience facts returned an unrequested group membership",
@@ -130,6 +154,12 @@ for (const marker of [
 }
 
 for (const marker of [
+  "fn validate_port_context(",
+  "context_tenant_id != tenant_id",
+  "context.actor.kind != PortActorKind::User",
+  "context_user_id != user_id",
+  "port context tenant does not match",
+  "port context actor does not match",
   ".require_policy(PortCallPolicy::read())",
   "FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE",
   "ForumError::capability_unavailable(",
@@ -140,12 +170,26 @@ for (const marker of [
   requireText(audience, marker, `fail-closed audience resolver is missing ${marker}`);
 }
 
-const denyIndex = audience.indexOf("ForumAudienceDecisionReason::ExplicitDeny");
-const allowIndex = audience.indexOf("ForumAudienceDecisionReason::ExplicitAllow");
-const roleIndex = audience.indexOf("ForumAudienceDecisionReason::Role");
-const trustIndex = audience.indexOf("ForumAudienceDecisionReason::TrustLevel");
-const channelIndex = audience.indexOf("ForumAudienceDecisionReason::ChannelMembership");
-const groupIndex = audience.indexOf("ForumAudienceDecisionReason::GroupMembership");
+for (const marker of [
+  "must not be nil",
+  "must not contain nil identifiers",
+  "ids.iter().any(Uuid::is_nil)",
+]) {
+  requireText(audience, marker, `nil audience identity guard is missing ${marker}`);
+}
+
+const evaluator = between(
+  audience,
+  "impl ForumAudienceEvaluator {",
+  "fn validate_raw_len(",
+  "forum audience evaluator",
+);
+const denyIndex = evaluator.indexOf("ForumAudienceDecisionReason::ExplicitDeny");
+const allowIndex = evaluator.indexOf("ForumAudienceDecisionReason::ExplicitAllow");
+const roleIndex = evaluator.indexOf("ForumAudienceDecisionReason::Role");
+const trustIndex = evaluator.indexOf("ForumAudienceDecisionReason::TrustLevel");
+const channelIndex = evaluator.indexOf("ForumAudienceDecisionReason::ChannelMembership");
+const groupIndex = evaluator.indexOf("ForumAudienceDecisionReason::GroupMembership");
 if (
   denyIndex < 0 ||
   allowIndex < 0 ||
@@ -186,10 +230,12 @@ for (const marker of [
 for (const marker of [
   "audience_constraints_are_bounded_and_canonical",
   "explicit_deny_wins_and_positive_selectors_are_a_union",
-  "exact_owner_facts_reject_unrequested_memberships",
-  "resolver_is_fail_closed_and_requires_read_deadline_semantics",
+  "exact_owner_facts_reject_wrong_identity_and_unrequested_memberships",
+  "resolver_is_fail_closed_and_requires_matching_read_context",
   "FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE",
   "port.deadline_required",
+  "actor does not match",
+  "different tenant or actor",
 ]) {
   requireText(testSource, marker, `audience capability test is missing ${marker}`);
 }

--- a/scripts/verify/verify-forum-audience-capability-ports.mjs
+++ b/scripts/verify/verify-forum-audience-capability-ports.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-audience-capability-ports.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const audience = read(contract.contract_file ?? "");
+const crate = read(contract.crate_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum audience capability contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20F") {
+  failures.push("forum audience capability contract must belong to FORUM-20F");
+}
+for (const [key, expected] of Object.entries({
+  roles: 4,
+  channels: 32,
+  groups: 32,
+  explicit_allow_users: 100,
+  explicit_deny_users: 100,
+  maximum_trust_level: 100,
+  channel_slug_characters: 128,
+})) {
+  if (contract.limits?.[key] !== expected) {
+    failures.push(`forum audience capability limit ${key} must remain ${expected}`);
+  }
+}
+if (contract.policy?.positive_selectors !== "union") {
+  failures.push("forum audience positive selectors must remain a documented union");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted audience evidence");
+}
+for (const residual of [
+  "audience policy persistence and inheritance",
+  "category topic and reply read composition",
+  "create reply and moderate audience write policy",
+  "topic narrowing commands",
+  "channel and group provider adapters",
+  "trust-level owner provider",
+  "visibility-scoped category and all-read mutations",
+  "notification search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum audience capability contract must keep ${residual} open`);
+  }
+}
+
+for (const marker of [
+  "pub const MAX_FORUM_AUDIENCE_ROLES: usize = 4",
+  "pub const MAX_FORUM_AUDIENCE_CHANNELS: usize = 32",
+  "pub const MAX_FORUM_AUDIENCE_GROUPS: usize = 32",
+  "pub const MAX_FORUM_AUDIENCE_EXPLICIT_USERS: usize = 100",
+  "pub const MAX_FORUM_AUDIENCE_TRUST_LEVEL: u8 = 100",
+  "const MAX_FORUM_AUDIENCE_CHANNEL_SLUG_LEN: usize = 128",
+  "pub struct ForumAudienceConstraints",
+  "pub roles_any: Vec<UserRole>",
+  "pub minimum_trust_level: Option<u8>",
+  "pub channel_members_any: Vec<String>",
+  "pub group_members_any: Vec<Uuid>",
+  "pub allow_user_ids: Vec<Uuid>",
+  "pub deny_user_ids: Vec<Uuid>",
+  "pub fn normalize(mut self) -> ForumResult<Self>",
+  "pub struct ForumAudienceFactsRequest",
+  "pub struct ForumAudienceFacts",
+  "pub trait ForumAudienceFactsPort: Send + Sync",
+  "pub type SharedForumAudienceFactsPort = Arc<dyn ForumAudienceFactsPort>",
+  "pub struct ForumAudienceFactsResolver",
+  "pub struct ForumAudienceEvaluator",
+  "pub enum ForumAudienceDecisionReason",
+]) {
+  requireText(audience, marker, `forum audience contract is missing ${marker}`);
+}
+
+const firstRoleBound = audience.indexOf("self.roles_any.len()");
+const firstRoleDedup = audience.indexOf("self.roles_any.dedup()");
+const firstChannelBound = audience.indexOf("self.channel_members_any.len()");
+const firstChannelNormalize = audience.indexOf(
+  "self.channel_members_any = normalize_channel_slugs",
+);
+if (
+  firstRoleBound < 0 ||
+  firstRoleDedup < 0 ||
+  firstRoleBound > firstRoleDedup ||
+  firstChannelBound < 0 ||
+  firstChannelNormalize < 0 ||
+  firstChannelBound > firstChannelNormalize
+) {
+  failures.push("raw audience candidates must be bounded before deduplication or normalization");
+}
+
+for (const marker of [
+  "Providers must resolve only the requested actor and candidate memberships",
+  "Forum audience facts returned an unrequested trust level",
+  "Forum audience facts returned an unrequested channel membership",
+  "Forum audience facts returned an unrequested group membership",
+  ".validate_for_request(&request)",
+]) {
+  requireText(audience, marker, `exact owner-facts contract is missing ${marker}`);
+}
+
+for (const marker of [
+  ".require_policy(PortCallPolicy::read())",
+  "FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE",
+  "ForumError::capability_unavailable(",
+  "ForumError::capability_failure(",
+  "constraints.roles_any.contains(&security.role)",
+  "security.is_public_read()",
+]) {
+  requireText(audience, marker, `fail-closed audience resolver is missing ${marker}`);
+}
+
+const denyIndex = audience.indexOf("ForumAudienceDecisionReason::ExplicitDeny");
+const allowIndex = audience.indexOf("ForumAudienceDecisionReason::ExplicitAllow");
+const roleIndex = audience.indexOf("ForumAudienceDecisionReason::Role");
+const trustIndex = audience.indexOf("ForumAudienceDecisionReason::TrustLevel");
+const channelIndex = audience.indexOf("ForumAudienceDecisionReason::ChannelMembership");
+const groupIndex = audience.indexOf("ForumAudienceDecisionReason::GroupMembership");
+if (
+  denyIndex < 0 ||
+  allowIndex < 0 ||
+  roleIndex < 0 ||
+  trustIndex < 0 ||
+  channelIndex < 0 ||
+  groupIndex < 0 ||
+  denyIndex > allowIndex ||
+  allowIndex > roleIndex ||
+  roleIndex > trustIndex ||
+  trustIndex > channelIndex ||
+  channelIndex > groupIndex
+) {
+  failures.push("audience evaluator precedence must remain deny, allow, local role, trust, channel, group");
+}
+
+for (const forbidden of [
+  "rustok_groups",
+  "rustok_channel",
+  "forum_group",
+  "forum_channel_member",
+  "forum_user_stats::Entity",
+  "serde_json::Value",
+]) {
+  rejectText(audience, forbidden, `forum audience contract must not depend on ${forbidden}`);
+}
+
+for (const marker of [
+  "pub mod audience;",
+  "ForumAudienceConstraints",
+  "ForumAudienceFactsPort",
+  "ForumAudienceFactsResolver",
+  "ForumAudienceEvaluator",
+]) {
+  requireText(crate, marker, `crate export is missing ${marker}`);
+}
+
+for (const marker of [
+  "audience_constraints_are_bounded_and_canonical",
+  "explicit_deny_wins_and_positive_selectors_are_a_union",
+  "exact_owner_facts_reject_unrequested_memberships",
+  "resolver_is_fail_closed_and_requires_read_deadline_semantics",
+  "FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE",
+  "port.deadline_required",
+]) {
+  requireText(testSource, marker, `audience capability test is missing ${marker}`);
+}
+
+for (const marker of [
+  "Delivered in `FORUM-20F`",
+  "ForumAudienceFactsPort",
+  "forum-audience-capability-ports.json",
+  "audience_capability_contract",
+  "verify-forum-audience-capability-ports.mjs",
+]) {
+  requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum audience capability verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum audience capability port contract is source-ready.");


### PR DESCRIPTION
## Summary

- deliver the FORUM-20F richer-audience contract foundation
- add bounded role, minimum-trust, channel-membership, group-membership, explicit allow, and explicit deny selectors after the inherited public/authenticated category floor
- define union semantics for positive selectors with explicit deny taking precedence
- cap raw candidates before normalization: 4 roles, 32 channels, 32 groups, 100 allow users, 100 deny users, trust level 0..100, and 128-character channel slugs
- add an exact tenant/user-scoped `ForumAudienceFactsPort` request/response contract that rejects unrequested or cross-identity facts
- bind `PortContext` tenant and user actor to the requested tenant and `SecurityContext` user and require read-deadline semantics
- keep local explicit deny/allow and role decisions independent from the optional facts provider; unresolved trust/channel/group decisions fail closed with typed capability errors
- add an explainable evaluator, source-ready contract tests, machine contract, verifier, crate exports, and canonical-plan synchronization

## Compatibility

- no migration, persistence, backfill, transport field, endpoint, or UI change
- no current category/topic/reply read or write path calls the richer evaluator yet
- no direct Forum dependency on Channel, Groups, or their private tables
- existing public/authenticated category floor and FORUM-20C-E owner-read behavior remain unchanged
- audience persistence/inheritance, provider adapters, owner-read composition, write audiences, remaining consumers, and runtime evidence remain open

## Validation

Not run at the maintainer's request. Intended commands:

```bash
cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
node scripts/verify/verify-forum-audience-capability-ports.mjs
node scripts/verify/verify-forum-topic-visibility-scope.mjs
node scripts/verify/verify-forum-category-visibility-policy.mjs
node scripts/verify/verify-forum-owner-read-visibility.mjs
node scripts/verify/verify-forum-category-owner-read-visibility.mjs
cargo xtask module validate forum
```
