### PR TITLE
Harden storefront line item HTTP errors

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/carts.rs
+++ b/crates/rustok-commerce/src/controllers/store/carts.rs
@@ -20,6 +20,9 @@ use rustok_cart::{
 };
 use rustok_pricing::{ResolveProductPriceRequest, in_process_pricing_read_port};
 
+#[path = "line_item_resolution.rs"]
+mod line_item_resolution;
+
 fn map_cart_port_error(
     error: PortError,
     operation: &'static str,
@@ -296,7 +299,7 @@ pub async fn add_cart_line_item(
         super::build_store_pricing_context(&existing, &request_context, input.quantity);
     let public_channel_slug =
         super::storefront_public_channel_slug_for_cart(&existing, &request_context);
-    let resolved_input = super::resolve_store_line_item_input(
+    let resolved_input = line_item_resolution::resolve_store_line_item_input(
         runtime.db(),
         tenant.id,
         super::StoreLineItemResolution {
@@ -392,7 +395,7 @@ pub async fn update_cart_line_item(
     let event_bus = runtime.event_bus();
     if let Some(existing_line_item) = existing.line_items.iter().find(|item| item.id == line_id) {
         if let Some(variant_id) = existing_line_item.variant_id {
-            super::validate_store_line_item_quantity(
+            line_item_resolution::validate_store_line_item_quantity(
                 runtime.db(),
                 tenant.id,
                 variant_id,

--- a/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
+++ b/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
@@ -1,0 +1,340 @@
+use rustok_inventory::{
+    PublicChannelInventoryVariantProjectionInput, check_variant_availability_for_public_channel,
+};
+use rustok_pricing::ResolveProductPriceRequest;
+use rustok_product::entities::{
+    product, product_translation, product_variant, variant_translation,
+};
+use rustok_web::{HttpError, HttpResult};
+use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
+use uuid::Uuid;
+
+use super::super::{ResolvedStoreLineItemInput, StoreLineItemResolution};
+use crate::{
+    CommerceError,
+    dto::AddCartLineItemInput,
+    storefront_channel::is_metadata_visible_for_public_channel,
+    storefront_shipping::effective_shipping_profile_slug,
+};
+
+fn map_storefront_line_item_database_error(
+    error: DbErr,
+    operation: &'static str,
+    tenant_id: Uuid,
+    variant_id: Option<Uuid>,
+    product_id: Option<Uuid>,
+) -> HttpError {
+    let status = axum::http::StatusCode::SERVICE_UNAVAILABLE;
+    let code = "commerce_store_catalog_unavailable";
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_product.persistence",
+        operation,
+        tenant_id = %tenant_id,
+        variant_id = ?variant_id,
+        product_id = ?product_id,
+        error_kind = "database",
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_line_item_http",
+        "storefront line item catalog read failed"
+    );
+    HttpError::new(status, code, "Store catalog is temporarily unavailable")
+}
+
+fn map_storefront_line_item_inventory_error(
+    error: CommerceError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    variant_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        CommerceError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_store_inventory_invalid",
+            "Inventory request is invalid",
+            "validation",
+        ),
+        CommerceError::ProductNotFound(_)
+        | CommerceError::VariantNotFound(_)
+        | CommerceError::ShippingProfileNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_store_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        CommerceError::InsufficientInventory { .. } => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_store_inventory_insufficient",
+            "Requested quantity is not available",
+            "insufficient_inventory",
+        ),
+        CommerceError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_inventory_unavailable",
+            "Inventory service is temporarily unavailable",
+            "database",
+        ),
+        CommerceError::DuplicateHandle { .. }
+        | CommerceError::DuplicateSku(_)
+        | CommerceError::InvalidPrice(_)
+        | CommerceError::InvalidOptionCombination
+        | CommerceError::DuplicateShippingProfileSlug(_)
+        | CommerceError::NoVariants
+        | CommerceError::CannotDeletePublished
+        | CommerceError::Rich(_)
+        | CommerceError::Core(_) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_inventory_failed",
+            "Inventory operation could not be completed safely",
+            "unexpected_owner_error",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_inventory.public_channel",
+        operation,
+        tenant_id = %tenant_id,
+        variant_id = %variant_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_line_item_http",
+        "storefront line item inventory operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+pub(super) async fn resolve_store_line_item_input(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    resolution: StoreLineItemResolution<'_>,
+) -> HttpResult<ResolvedStoreLineItemInput> {
+    let StoreLineItemResolution {
+        pricing_read_port,
+        pricing_context,
+        locale,
+        default_locale,
+        public_channel_slug,
+        input,
+    } = resolution;
+
+    let variant = product_variant::Entity::find_by_id(input.variant_id)
+        .filter(product_variant::Column::TenantId.eq(tenant_id))
+        .one(db)
+        .await
+        .map_err(|error| {
+            map_storefront_line_item_database_error(
+                error,
+                "load_variant",
+                tenant_id,
+                Some(input.variant_id),
+                None,
+            )
+        })?
+        .ok_or(HttpError::not_found(
+            "commerce_store_not_found",
+            "Commerce resource not found",
+        ))?;
+
+    let product_model = product::Entity::find_by_id(variant.product_id)
+        .filter(product::Column::TenantId.eq(tenant_id))
+        .one(db)
+        .await
+        .map_err(|error| {
+            map_storefront_line_item_database_error(
+                error,
+                "load_product",
+                tenant_id,
+                Some(variant.id),
+                Some(variant.product_id),
+            )
+        })?
+        .ok_or(HttpError::not_found(
+            "commerce_store_not_found",
+            "Commerce resource not found",
+        ))?;
+    if product_model.status != product::ProductStatus::Active
+        || product_model.published_at.is_none()
+        || !is_metadata_visible_for_public_channel(&product_model.metadata, public_channel_slug)
+    {
+        return Err(HttpError::not_found(
+            "commerce_store_not_found",
+            "Commerce resource not found",
+        ));
+    }
+
+    let product_translation_models = product_translation::Entity::find()
+        .filter(product_translation::Column::ProductId.eq(product_model.id))
+        .all(db)
+        .await
+        .map_err(|error| {
+            map_storefront_line_item_database_error(
+                error,
+                "load_product_translations",
+                tenant_id,
+                Some(variant.id),
+                Some(product_model.id),
+            )
+        })?;
+    let variant_translation_models = variant_translation::Entity::find()
+        .filter(variant_translation::Column::VariantId.eq(variant.id))
+        .all(db)
+        .await
+        .map_err(|error| {
+            map_storefront_line_item_database_error(
+                error,
+                "load_variant_translations",
+                tenant_id,
+                Some(variant.id),
+                Some(product_model.id),
+            )
+        })?;
+
+    let resolved_price: rustok_pricing::ResolvedPrice = pricing_read_port
+        .resolve_product_price(
+            super::super::store_line_item_pricing_port_context(
+                tenant_id,
+                variant.id,
+                locale,
+                pricing_context,
+            ),
+            ResolveProductPriceRequest {
+                product_id: Some(product_model.id),
+                variant_id: variant.id,
+                region_id: pricing_context.region_id,
+                channel_id: pricing_context.channel_id,
+                channel_slug: pricing_context.channel_slug.clone(),
+                price_list_id: pricing_context.price_list_id,
+                quantity: pricing_context.quantity,
+                currency_code: pricing_context.currency_code.clone(),
+            },
+        )
+        .await
+        .map_err(rustok_web::port_error_to_http_error)?
+        .into();
+    let (base_unit_price, pricing_adjustment) =
+        super::super::storefront_cart_pricing_snapshot(input.quantity, &resolved_price);
+    validate_store_variant_inventory(
+        db,
+        tenant_id,
+        &variant,
+        input.quantity,
+        public_channel_slug,
+    )
+    .await?;
+
+    let base_title =
+        super::super::pick_product_translation(&product_translation_models, locale, default_locale)
+            .map(|translation| translation.title.clone())
+            .unwrap_or_else(|| {
+                variant
+                    .sku
+                    .clone()
+                    .unwrap_or_else(|| format!("Variant {}", variant.id))
+            });
+    let title = match super::super::pick_variant_translation(
+        &variant_translation_models,
+        locale,
+        default_locale,
+    )
+    .and_then(|translation| translation.title.clone())
+    {
+        Some(variant_title) if !variant_title.trim().is_empty() => {
+            format!("{base_title} / {}", variant_title.trim())
+        }
+        _ => base_title,
+    };
+
+    Ok(ResolvedStoreLineItemInput {
+        add_line_item: AddCartLineItemInput {
+            product_id: Some(product_model.id),
+            variant_id: Some(variant.id),
+            shipping_profile_slug: Some(effective_shipping_profile_slug(
+                product_model.shipping_profile_slug.as_deref(),
+                &product_model.metadata,
+                variant.shipping_profile_slug.as_deref(),
+            )),
+            sku: variant.sku.clone(),
+            title,
+            quantity: input.quantity,
+            unit_price: base_unit_price,
+            metadata: super::super::merge_metadata(
+                input.metadata,
+                super::super::seller_snapshot_metadata(product_model.seller_id.as_deref()),
+            ),
+        },
+        pricing_adjustment,
+    })
+}
+
+pub(super) async fn validate_store_line_item_quantity(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    variant_id: Uuid,
+    requested_quantity: i32,
+    public_channel_slug: Option<&str>,
+) -> HttpResult<()> {
+    let variant = product_variant::Entity::find_by_id(variant_id)
+        .filter(product_variant::Column::TenantId.eq(tenant_id))
+        .one(db)
+        .await
+        .map_err(|error| {
+            map_storefront_line_item_database_error(
+                error,
+                "load_variant_for_quantity_validation",
+                tenant_id,
+                Some(variant_id),
+                None,
+            )
+        })?
+        .ok_or(HttpError::not_found(
+            "commerce_store_not_found",
+            "Commerce resource not found",
+        ))?;
+
+    validate_store_variant_inventory(
+        db,
+        tenant_id,
+        &variant,
+        requested_quantity,
+        public_channel_slug,
+    )
+    .await
+}
+
+async fn validate_store_variant_inventory(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    variant: &product_variant::Model,
+    requested_quantity: i32,
+    public_channel_slug: Option<&str>,
+) -> HttpResult<()> {
+    let available = check_variant_availability_for_public_channel(
+        db,
+        tenant_id,
+        PublicChannelInventoryVariantProjectionInput {
+            variant_id: variant.id,
+            inventory_policy: &variant.inventory_policy,
+        },
+        requested_quantity,
+        public_channel_slug,
+    )
+    .await
+    .map_err(|error| {
+        map_storefront_line_item_inventory_error(
+            error,
+            "check_variant_availability",
+            tenant_id,
+            variant.id,
+        )
+    })?;
+    if !available {
+        return Err(HttpError::bad_request(
+            "commerce_store_inventory_insufficient",
+            "Requested quantity is not available",
+        ));
+    }
+
+    Ok(())
+}

--- a/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const carts = read('crates/rustok-commerce/src/controllers/store/carts.rs');
+const boundary = read(
+  'crates/rustok-commerce/src/controllers/store/line_item_resolution.rs',
+);
+const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
+const inventoryOwner = read('crates/rustok-inventory/src/services/public_channel.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const databaseMapper = between(
+  boundary,
+  'fn map_storefront_line_item_database_error(',
+  'fn map_storefront_line_item_inventory_error(',
+  'line-item database mapper',
+);
+const inventoryMapper = between(
+  boundary,
+  'fn map_storefront_line_item_inventory_error(',
+  'pub(super) async fn resolve_store_line_item_input(',
+  'line-item inventory mapper',
+);
+const resolver = between(
+  boundary,
+  'pub(super) async fn resolve_store_line_item_input(',
+  'pub(super) async fn validate_store_line_item_quantity(',
+  'line-item resolver',
+);
+const quantityValidator = between(
+  boundary,
+  'pub(super) async fn validate_store_line_item_quantity(',
+  'async fn validate_store_variant_inventory(',
+  'line-item quantity validator',
+);
+const inventoryValidator = from(
+  boundary,
+  'async fn validate_store_variant_inventory(',
+  'line-item inventory validator',
+);
+
+for (const [value, label] of [
+  ['#[path = "line_item_resolution.rs"]', 'line-item module path'],
+  ['mod line_item_resolution;', 'line-item module declaration'],
+  ['line_item_resolution::resolve_store_line_item_input(', 'safe add-line resolver'],
+  ['line_item_resolution::validate_store_line_item_quantity(', 'safe quantity validator'],
+]) requireText(carts, value, label);
+for (const value of [
+  'super::resolve_store_line_item_input(',
+  'super::validate_store_line_item_quantity(',
+]) forbidText(carts, value, 'legacy unsafe production helper call');
+
+for (const [value, label] of [
+  ['DbErr', 'typed database error import'],
+  ['CommerceError', 'typed inventory error import'],
+  ['boundary = "commerce_storefront_line_item_http"', 'line-item boundary name'],
+]) requireText(boundary, value, label);
+
+for (const [value, label] of [
+  ['owner = "rustok_product.persistence"', 'catalog persistence owner'],
+  ['operation,', 'database operation logging'],
+  ['tenant_id = %tenant_id', 'database tenant logging'],
+  ['variant_id = ?variant_id', 'database variant logging'],
+  ['product_id = ?product_id', 'database product logging'],
+  ['error_kind = "database"', 'database error kind'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'database unavailable status'],
+  ['"commerce_store_catalog_unavailable"', 'catalog unavailable code'],
+  ['"Store catalog is temporarily unavailable"', 'static catalog message'],
+  ['HttpError::new(status, code,', 'static database envelope'],
+]) requireText(databaseMapper, value, label);
+
+for (const [value, label] of [
+  ['CommerceError::Validation(_)', 'inventory validation variant'],
+  ['CommerceError::ProductNotFound(_)', 'inventory product-not-found variant'],
+  ['CommerceError::VariantNotFound(_)', 'inventory variant-not-found variant'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'inventory profile-not-found variant'],
+  ['CommerceError::InsufficientInventory { .. }', 'inventory insufficient variant'],
+  ['CommerceError::Database(_)', 'inventory database variant'],
+  ['CommerceError::DuplicateHandle { .. }', 'unexpected duplicate handle variant'],
+  ['CommerceError::DuplicateSku(_)', 'unexpected duplicate sku variant'],
+  ['CommerceError::InvalidPrice(_)', 'unexpected invalid price variant'],
+  ['CommerceError::InvalidOptionCombination', 'unexpected option variant'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'unexpected profile conflict variant'],
+  ['CommerceError::NoVariants', 'unexpected no-variants variant'],
+  ['CommerceError::CannotDeletePublished', 'unexpected delete variant'],
+  ['CommerceError::Rich(_)', 'unexpected rich variant'],
+  ['CommerceError::Core(_)', 'unexpected core variant'],
+  ['StatusCode::BAD_REQUEST', 'inventory invalid status'],
+  ['StatusCode::NOT_FOUND', 'inventory not-found status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'inventory unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'inventory fail-closed status'],
+  ['"commerce_store_inventory_invalid"', 'inventory invalid code'],
+  ['"commerce_store_not_found"', 'inventory not-found code'],
+  ['"commerce_store_inventory_insufficient"', 'inventory insufficient code'],
+  ['"commerce_store_inventory_unavailable"', 'inventory unavailable code'],
+  ['"commerce_store_inventory_failed"', 'inventory fail-closed code'],
+  ['owner = "rustok_inventory.public_channel"', 'inventory owner logging'],
+  ['variant_id = %variant_id', 'inventory variant logging'],
+  ['error_kind,', 'inventory error-kind logging'],
+  ['public_code = code', 'inventory public-code logging'],
+  ['status = %status', 'inventory status logging'],
+  ['HttpError::new(status, code, message)', 'static inventory envelope'],
+]) requireText(inventoryMapper, value, label);
+
+for (const [value, label] of [
+  ['product_variant::Entity::find_by_id(input.variant_id)', 'variant lookup'],
+  ['product::Entity::find_by_id(variant.product_id)', 'product lookup'],
+  ['product_translation::Entity::find()', 'product translation lookup'],
+  ['variant_translation::Entity::find()', 'variant translation lookup'],
+  ['"load_variant"', 'variant operation label'],
+  ['"load_product"', 'product operation label'],
+  ['"load_product_translations"', 'product translation operation label'],
+  ['"load_variant_translations"', 'variant translation operation label'],
+  ['product_model.status != product::ProductStatus::Active', 'active product guard'],
+  ['product_model.published_at.is_none()', 'published product guard'],
+  ['is_metadata_visible_for_public_channel', 'channel visibility guard'],
+  ['.resolve_product_price(', 'pricing resolution'],
+  ['.map_err(rustok_web::port_error_to_http_error)?', 'pricing shared mapper'],
+  ['storefront_cart_pricing_snapshot', 'pricing snapshot'],
+  ['validate_store_variant_inventory(', 'inventory validation'],
+  ['pick_product_translation(', 'product title fallback'],
+  ['pick_variant_translation(', 'variant title fallback'],
+  ['effective_shipping_profile_slug(', 'shipping profile resolution'],
+  ['seller_snapshot_metadata(', 'seller snapshot'],
+  ['merge_metadata(', 'metadata merge'],
+]) requireText(resolver, value, label);
+
+for (const [value, label] of [
+  ['product_variant::Entity::find_by_id(variant_id)', 'quantity variant lookup'],
+  ['"load_variant_for_quantity_validation"', 'quantity lookup operation'],
+  ['validate_store_variant_inventory(', 'quantity inventory validation'],
+  ['"commerce_store_not_found"', 'quantity not-found code'],
+]) requireText(quantityValidator, value, label);
+
+for (const [value, label] of [
+  ['check_variant_availability_for_public_channel(', 'public-channel inventory check'],
+  ['PublicChannelInventoryVariantProjectionInput {', 'typed inventory projection'],
+  ['inventory_policy: &variant.inventory_policy', 'inventory policy propagation'],
+  ['requested_quantity,', 'requested quantity propagation'],
+  ['public_channel_slug,', 'public channel propagation'],
+  ['"check_variant_availability"', 'inventory operation label'],
+  ['map_storefront_line_item_inventory_error(', 'typed inventory mapper use'],
+  ['if !available {', 'insufficient availability branch'],
+  ['"commerce_store_inventory_insufficient"', 'stable insufficient code'],
+  ['"Requested quantity is not available"', 'static insufficient message'],
+]) requireText(inventoryValidator, value, label);
+
+for (const value of [
+  'err.to_string()',
+  'error.to_string()',
+  'HttpError::bad_request("commerce_store_invalid", error',
+  'HttpError::bad_request("commerce_store_invalid", err',
+]) forbidText(boundary, value, 'unsafe line-item public conversion');
+
+for (const [content, value, label] of [
+  [commerceErrors, 'pub enum CommerceError {', 'commerce owner enum'],
+  [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'commerce database variant'],
+  [commerceErrors, 'ProductNotFound(Uuid)', 'commerce product variant'],
+  [commerceErrors, 'VariantNotFound(Uuid)', 'commerce variant variant'],
+  [commerceErrors, 'InsufficientInventory { requested: i32, available: i32 }', 'commerce inventory variant'],
+  [commerceErrors, 'Validation(String)', 'commerce validation variant'],
+  [commerceErrors, 'ShippingProfileNotFound(Uuid)', 'commerce profile variant'],
+  [commerceErrors, 'Rich(#[source] Box<RichError>)', 'commerce rich variant'],
+  [commerceErrors, 'Core(#[from] CoreError)', 'commerce core variant'],
+  [inventoryOwner, '-> CommerceResult<bool>', 'inventory typed result'],
+  [inventoryOwner, 'check_public_channel_inventory_request(', 'inventory request validation'],
+  [inventoryOwner, 'load_available_inventory_for_variant_in_public_channel(', 'inventory storage read'],
+  [inventoryOwner, 'Ok(available_inventory >= requested_quantity)', 'availability semantics'],
+]) requireText(content, value, label);
+
+const databaseMapperUses = boundary.match(/map_storefront_line_item_database_error\(/g) ?? [];
+if (databaseMapperUses.length !== 6) {
+  failures.push(`expected database mapper definition plus five uses, found ${databaseMapperUses.length}`);
+}
+const inventoryMapperUses = boundary.match(/map_storefront_line_item_inventory_error\(/g) ?? [];
+if (inventoryMapperUses.length !== 2) {
+  failures.push(`expected inventory mapper definition plus one use, found ${inventoryMapperUses.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront line-item HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Storefront line-item catalog and inventory errors use typed safe envelopes');


### PR DESCRIPTION
## Summary

- route storefront add-line and quantity-validation handlers through a dedicated typed line-item boundary;
- replace five SeaORM `DbErr::to_string()` public conversions with static `503 commerce_store_catalog_unavailable` envelopes and structured diagnostics;
- map inventory `CommerceError` exhaustively: validation `400`, missing resources `404`, storage outage `503`, and unexpected owner variants fail-closed `500`;
- replace the dynamic insufficient-stock response with stable `400 commerce_store_inventory_insufficient` and a static message;
- preserve pricing resolution, product publication/channel visibility, translation fallback, shipping-profile resolution, seller snapshots, metadata merging, and public-channel inventory semantics;
- add a focused verifier for handler routing, owner enum coverage, five catalog read operations, inventory mapping, and preserved line-item behavior.

## Scope

Three files only: `controllers/store/carts.rs`, a new `controllers/store/line_item_resolution.rs`, and one verifier. `carts.rs` changes only by declaring the new module and switching two production callsites. Existing test-facing helpers in `controllers/store/mod.rs` remain unchanged for compatibility and can be removed in a separate cleanup once their direct tests migrate.

## Public policy

- catalog persistence failure: `503 commerce_store_catalog_unavailable`;
- inventory request validation: `400 commerce_store_inventory_invalid`;
- missing product, variant, or shipping profile: `404 commerce_store_not_found`;
- insufficient inventory: `400 commerce_store_inventory_insufficient`;
- inventory storage outage: `503 commerce_store_inventory_unavailable`;
- unexpected inventory owner variants: fail-closed `500 commerce_store_inventory_failed`.

All public messages are static. Raw errors are retained only in structured logs with operation, tenant, variant/product context, typed error kind, public code, and status.

## Validation

- source-level audit completed against current `CommerceError`, public-channel inventory, SeaORM, pricing, product visibility, translation, and cart handler contracts;
- branch is directly ahead of current `main` by one commit and changes only the intended three files;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.