### PR TITLE
feat(index): archive mutation and maintenance session metadata

### DIFF
--- a/ops/benches/src/index_storage/database_metadata.rs
+++ b/ops/benches/src/index_storage/database_metadata.rs
@@ -1,0 +1,97 @@
+use anyhow::{Context, Result, ensure};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde::Serialize;
+
+const DATABASE_METADATA_SQL: &str = concat!(
+    "SELECT version() AS version,",
+    " current_setting('server_version_num') AS server_version_num,",
+    " current_setting('shared_buffers') AS shared_buffers,",
+    " current_setting('effective_cache_size') AS effective_cache_size,",
+    " current_setting('work_mem') AS work_mem,",
+    " current_setting('random_page_cost') AS random_page_cost,",
+    " current_setting('jit') AS jit,",
+    " current_setting('standard_conforming_strings') AS standard_conforming_strings,",
+    " current_setting('TimeZone') AS timezone,",
+    " current_setting('DateStyle') AS date_style,",
+    " current_setting('extra_float_digits') AS extra_float_digits",
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DatabaseMetadata {
+    pub version: String,
+    pub server_version_num: String,
+    pub shared_buffers: String,
+    pub effective_cache_size: String,
+    pub work_mem: String,
+    pub random_page_cost: String,
+    pub jit: String,
+    pub standard_conforming_strings: String,
+    pub timezone: String,
+    pub date_style: String,
+    pub extra_float_digits: String,
+}
+
+pub(crate) async fn read_database_metadata(db: &DatabaseConnection) -> Result<DatabaseMetadata> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            DATABASE_METADATA_SQL.to_owned(),
+        ))
+        .await?
+        .context("database metadata query returned no row")?;
+
+    Ok(DatabaseMetadata {
+        version: row.try_get("", "version")?,
+        server_version_num: row.try_get("", "server_version_num")?,
+        shared_buffers: row.try_get("", "shared_buffers")?,
+        effective_cache_size: row.try_get("", "effective_cache_size")?,
+        work_mem: row.try_get("", "work_mem")?,
+        random_page_cost: row.try_get("", "random_page_cost")?,
+        jit: row.try_get("", "jit")?,
+        standard_conforming_strings: row.try_get("", "standard_conforming_strings")?,
+        timezone: row.try_get("", "timezone")?,
+        date_style: row.try_get("", "date_style")?,
+        extra_float_digits: row.try_get("", "extra_float_digits")?,
+    })
+}
+
+pub(crate) async fn ensure_database_metadata_stable(
+    db: &DatabaseConnection,
+    expected: &DatabaseMetadata,
+    benchmark: &str,
+) -> Result<()> {
+    let actual = read_database_metadata(db)
+        .await
+        .with_context(|| format!("failed to re-read {benchmark} database metadata"))?;
+    ensure!(
+        &actual == expected,
+        "{benchmark} PostgreSQL database/session metadata drifted during evidence collection: expected {expected:?}, got {actual:?}"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DATABASE_METADATA_SQL;
+
+    #[test]
+    fn database_metadata_query_observes_comparable_session_settings() {
+        for marker in [
+            "current_setting('server_version_num') AS server_version_num",
+            "current_setting('shared_buffers') AS shared_buffers",
+            "current_setting('effective_cache_size') AS effective_cache_size",
+            "current_setting('work_mem') AS work_mem",
+            "current_setting('random_page_cost') AS random_page_cost",
+            "current_setting('jit') AS jit",
+            "current_setting('standard_conforming_strings') AS standard_conforming_strings",
+            "current_setting('TimeZone') AS timezone",
+            "current_setting('DateStyle') AS date_style",
+            "current_setting('extra_float_digits') AS extra_float_digits",
+        ] {
+            assert!(
+                DATABASE_METADATA_SQL.contains(marker),
+                "database metadata query is missing {marker}"
+            );
+        }
+    }
+}

--- a/ops/benches/src/index_storage/maintenance_runner.rs
+++ b/ops/benches/src/index_storage/maintenance_runner.rs
@@ -6,13 +6,15 @@ use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Transac
 use serde::Serialize;
 
 use super::{
-    BenchmarkConfig, DatasetConfig, DatasetScale, Prototype, analyze_sql, churn_cycle_sql,
-    connect_benchmark_database, full_prototype_sql, source_dataset_sql, vacuum_statements,
+    BenchmarkConfig, DatabaseMetadata, DatasetConfig, DatasetScale, Prototype, analyze_sql,
+    churn_cycle_sql, connect_benchmark_database, ensure_database_metadata_stable,
+    full_prototype_sql, read_database_metadata, source_dataset_sql, vacuum_statements,
 };
 
 #[derive(Debug, Serialize)]
 pub struct MaintenanceBenchmarkReport {
     pub generated_at: DateTime<Utc>,
+    pub database: DatabaseMetadata,
     pub dataset_scale: DatasetScale,
     pub cycles: u32,
     pub prototypes: Vec<PrototypeMaintenanceReport>,
@@ -72,6 +74,9 @@ pub async fn run_maintenance(
     db.execute_unprepared("SET jit = off; SET statement_timeout = '30min';")
         .await
         .context("failed to configure maintenance benchmark session")?;
+    let database = read_database_metadata(&db)
+        .await
+        .context("failed to capture maintenance benchmark database metadata")?;
     db.execute_unprepared(&source_dataset_sql(&config.dataset))
         .await
         .context("failed to create maintenance benchmark source dataset")?;
@@ -121,9 +126,11 @@ pub async fn run_maintenance(
             after_vacuum,
         });
     }
+    ensure_database_metadata_stable(&db, &database, "maintenance benchmark").await?;
 
     Ok(MaintenanceBenchmarkReport {
         generated_at: Utc::now(),
+        database,
         dataset_scale: config.dataset.scale,
         cycles,
         prototypes,

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod connection;
+mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
@@ -8,6 +9,10 @@ mod sql;
 
 pub use config::{BenchmarkConfig, DatasetConfig, DatasetScale};
 pub(crate) use connection::connect as connect_benchmark_database;
+pub use database_metadata::DatabaseMetadata;
+pub(crate) use database_metadata::{
+    ensure_database_metadata_stable, read_database_metadata,
+};
 pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };

--- a/ops/benches/src/index_storage/mutation_runner.rs
+++ b/ops/benches/src/index_storage/mutation_runner.rs
@@ -10,14 +10,15 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::{
-    BenchmarkConfig, MutationWorkload, Prototype, connect_benchmark_database,
-    explain::parse_mutation_explain_metrics, full_prototype_sql, mutation_workloads,
-    source_dataset_sql,
+    BenchmarkConfig, DatabaseMetadata, MutationWorkload, Prototype, connect_benchmark_database,
+    ensure_database_metadata_stable, explain::parse_mutation_explain_metrics, full_prototype_sql,
+    mutation_workloads, read_database_metadata, source_dataset_sql,
 };
 
 #[derive(Debug, Serialize)]
 pub struct MutationBenchmarkReport {
     pub generated_at: DateTime<Utc>,
+    pub database: DatabaseMetadata,
     pub dataset_scale: String,
     pub repetitions: u32,
     pub prototypes: Vec<PrototypeMutationReport>,
@@ -66,6 +67,9 @@ pub async fn run_mutations(config: &BenchmarkConfig) -> Result<MutationBenchmark
     db.execute_unprepared("SET jit = off; SET statement_timeout = '30min';")
         .await
         .context("failed to configure mutation benchmark session")?;
+    let database = read_database_metadata(&db)
+        .await
+        .context("failed to capture mutation benchmark database metadata")?;
     db.execute_unprepared(&source_dataset_sql(&config.dataset))
         .await
         .context("failed to create mutation benchmark source dataset")?;
@@ -86,9 +90,11 @@ pub async fn run_mutations(config: &BenchmarkConfig) -> Result<MutationBenchmark
         });
     }
     validate_mutation_shape(&prototypes)?;
+    ensure_database_metadata_stable(&db, &database, "mutation benchmark").await?;
 
     Ok(MutationBenchmarkReport {
         generated_at: Utc::now(),
+        database,
         dataset_scale: format!("{:?}", config.dataset.scale),
         repetitions: config.repetitions,
         prototypes,


### PR DESCRIPTION
## Summary

- add a shared Rust PostgreSQL database/session metadata reader for the ten fields used by storage comparison;
- archive the observed metadata in `mutation-report.json` and `maintenance-report.json` from each runner's own physical session;
- re-read metadata after all mutation workloads or maintenance churn/VACUUM work and fail the evidence run if any value drifted;
- preserve existing mutation, WAL, churn, cardinality, and VACUUM measurement logic.

## Why

The read report already recorded PostgreSQL metadata, but mutation and maintenance evidence execute in separate sessions and did not record their own environment. That left two of the three evidence files unable to prove which deterministic settings governed their measurements. This change makes each of those reports self-describing and detects in-run session drift before serialization.

## Scope

This PR changes only Rust benchmark report generation. It intentionally does not yet migrate the read runner to the shared type or change the byte-preserved validator/comparator cores. A follow-up PR will make the official packet preflight require exact database metadata equality across read, mutation, and maintenance reports.

## Validation

Tests, Cargo/Node commands, formatting, verifier execution, workflow runs, and benchmarks were not run, per repository-owner instruction. The four-file diff was reviewed statically for imports, report serialization fields, and start/end metadata-check ordering.