### PR TITLE
Migrate storefront line item tests to typed boundary

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
+++ b/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
@@ -9,7 +9,7 @@ use rustok_web::{HttpError, HttpResult};
 use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
 use uuid::Uuid;
 
-use super::super::{ResolvedStoreLineItemInput, StoreLineItemResolution};
+use crate::controllers::store::{ResolvedStoreLineItemInput, StoreLineItemResolution};
 use crate::{
     CommerceError,
     dto::AddCartLineItemInput,
@@ -193,7 +193,7 @@ pub(super) async fn resolve_store_line_item_input(
 
     let resolved_price: rustok_pricing::ResolvedPrice = pricing_read_port
         .resolve_product_price(
-            super::super::store_line_item_pricing_port_context(
+            crate::controllers::store::store_line_item_pricing_port_context(
                 tenant_id,
                 variant.id,
                 locale,
@@ -214,7 +214,10 @@ pub(super) async fn resolve_store_line_item_input(
         .map_err(rustok_web::port_error_to_http_error)?
         .into();
     let (base_unit_price, pricing_adjustment) =
-        super::super::storefront_cart_pricing_snapshot(input.quantity, &resolved_price);
+        crate::controllers::store::storefront_cart_pricing_snapshot(
+            input.quantity,
+            &resolved_price,
+        );
     validate_store_variant_inventory(
         db,
         tenant_id,
@@ -224,16 +227,19 @@ pub(super) async fn resolve_store_line_item_input(
     )
     .await?;
 
-    let base_title =
-        super::super::pick_product_translation(&product_translation_models, locale, default_locale)
-            .map(|translation| translation.title.clone())
-            .unwrap_or_else(|| {
-                variant
-                    .sku
-                    .clone()
-                    .unwrap_or_else(|| format!("Variant {}", variant.id))
-            });
-    let title = match super::super::pick_variant_translation(
+    let base_title = crate::controllers::store::pick_product_translation(
+        &product_translation_models,
+        locale,
+        default_locale,
+    )
+    .map(|translation| translation.title.clone())
+    .unwrap_or_else(|| {
+        variant
+            .sku
+            .clone()
+            .unwrap_or_else(|| format!("Variant {}", variant.id))
+    });
+    let title = match crate::controllers::store::pick_variant_translation(
         &variant_translation_models,
         locale,
         default_locale,
@@ -259,9 +265,11 @@ pub(super) async fn resolve_store_line_item_input(
             title,
             quantity: input.quantity,
             unit_price: base_unit_price,
-            metadata: super::super::merge_metadata(
+            metadata: crate::controllers::store::merge_metadata(
                 input.metadata,
-                super::super::seller_snapshot_metadata(product_model.seller_id.as_deref()),
+                crate::controllers::store::seller_snapshot_metadata(
+                    product_model.seller_id.as_deref(),
+                ),
             ),
         },
         pricing_adjustment,

--- a/crates/rustok-commerce/src/controllers/store/tests/products.rs
+++ b/crates/rustok-commerce/src/controllers/store/tests/products.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+#[path = "../line_item_resolution.rs"]
+mod line_item_resolution;
+use line_item_resolution::resolve_store_line_item_input;
+
 #[tokio::test]
 async fn store_products_transport_rejects_disabled_channel_module() {
     let db = setup_test_db().await;
@@ -374,14 +378,8 @@ async fn storefront_line_item_resolution_rejects_quantity_above_channel_visible_
     .expect_err("hidden inventory should reject storefront line item resolution");
 
     assert_eq!(error.status, StatusCode::BAD_REQUEST);
-    assert_eq!(error.code, "commerce_store_invalid");
-    assert_eq!(
-        error.message,
-        format!(
-            "Variant {} does not have enough available inventory for the current channel",
-            variant.id
-        )
-    );
+    assert_eq!(error.code, "commerce_store_inventory_insufficient");
+    assert_eq!(error.message, "Requested quantity is not available");
 }
 
 #[tokio::test]

--- a/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
@@ -16,6 +16,7 @@ const boundary = read(
 );
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const inventoryOwner = read('crates/rustok-inventory/src/services/public_channel.rs');
+const productTests = read('crates/rustok-commerce/src/controllers/store/tests/products.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -88,6 +89,29 @@ for (const [value, label] of [
   ['CommerceError', 'typed inventory error import'],
   ['boundary = "commerce_storefront_line_item_http"', 'line-item boundary name'],
 ]) requireText(boundary, value, label);
+
+for (const [value, label] of [
+  ['use crate::controllers::store::{ResolvedStoreLineItemInput, StoreLineItemResolution};', 'context-independent store imports'],
+  ['crate::controllers::store::store_line_item_pricing_port_context(', 'absolute pricing context helper'],
+  ['crate::controllers::store::storefront_cart_pricing_snapshot(', 'absolute pricing snapshot helper'],
+  ['crate::controllers::store::pick_product_translation(', 'absolute product translation helper'],
+  ['crate::controllers::store::pick_variant_translation(', 'absolute variant translation helper'],
+  ['crate::controllers::store::merge_metadata(', 'absolute metadata merge helper'],
+  ['crate::controllers::store::seller_snapshot_metadata(', 'absolute seller snapshot helper'],
+]) requireText(boundary, value, label);
+forbidText(boundary, 'super::super::', 'context-dependent line-item helper path');
+
+for (const [value, label] of [
+  ['#[path = "../line_item_resolution.rs"]', 'typed test module path'],
+  ['mod line_item_resolution;', 'typed test module declaration'],
+  ['use line_item_resolution::resolve_store_line_item_input;', 'typed test resolver import'],
+  ['"commerce_store_inventory_insufficient"', 'typed inventory test code'],
+  ['"Requested quantity is not available"', 'typed inventory test message'],
+]) requireText(productTests, value, label);
+for (const value of [
+  '"commerce_store_invalid"',
+  'does not have enough available inventory for the current channel',
+]) forbidText(productTests, value, 'legacy inventory test contract');
 
 for (const [value, label] of [
   ['owner = "rustok_product.persistence"', 'catalog persistence owner'],


### PR DESCRIPTION
## Summary

- make the storefront line-item resolution source independent of its module nesting by replacing relative `super::super` helper paths with explicit store-module paths;
- include the same typed resolution source in storefront product tests instead of exercising the legacy duplicate helpers in `store/mod.rs`;
- update the channel-hidden inventory assertion to the stable `400 commerce_store_inventory_insufficient` contract and static public message introduced by the production boundary;
- extend the focused verifier to require typed test wiring, context-independent helper paths, and removal of the legacy dynamic inventory expectation.

## Scope

Three files only: the typed line-item boundary, its existing product tests, and the existing focused verifier. Production cart routing, pricing, catalog visibility, translation fallback, shipping profiles, metadata, inventory calculation, router registration, and DTOs are unchanged.

The legacy duplicate helpers in `controllers/store/mod.rs` remain temporarily, but no direct product test now depends on their resolver implementation. Their removal is intentionally left as a mechanical follow-up.

## Validation

- reconstructed source bytes were checked against the original Git blob SHAs before modification;
- branch is directly ahead of current `main` by one commit and changes only the intended three files;
- source-level review confirmed production and test modules resolve through the same explicit store helper paths;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.