### PR TITLE
feat(forum): persist inherited category audience policy

### DIFF
--- a/crates/rustok-forum/contracts/forum-audience-capability-ports.json
+++ b/crates/rustok-forum/contracts/forum-audience-capability-ports.json
@@ -1,8 +1,10 @@
 {
   "schema_version": 1,
   "task": "FORUM-20F",
+  "delivered_through": "FORUM-20G",
   "scope": "Bounded role, trust, channel membership, group membership, and explicit allow/deny audience contract",
   "contract_file": "crates/rustok-forum/src/audience.rs",
+  "persistence_contract": "crates/rustok-forum/contracts/forum-category-audience-policy.json",
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "test_file": "crates/rustok-forum/tests/audience_capability_contract.rs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
@@ -38,8 +40,8 @@
     "direct_owner_table_access": false
   },
   "composition": {
-    "storage": false,
-    "category_policy": false,
+    "storage": true,
+    "category_policy": true,
     "topic_policy": false,
     "reply_policy": false,
     "transport": false,
@@ -48,7 +50,6 @@
     "seo_deep_links": false
   },
   "not_delivered": [
-    "audience policy persistence and inheritance",
     "category topic and reply read composition",
     "create reply and moderate audience write policy",
     "topic narrowing commands",
@@ -61,7 +62,9 @@
   "verification": {
     "commands": [
       "cargo test -p rustok-forum --test audience_capability_contract -- --nocapture",
+      "cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-audience-capability-ports.mjs",
+      "node scripts/verify/verify-forum-category-audience-policy.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-category-audience-policy.json
+++ b/crates/rustok-forum/contracts/forum-category-audience-policy.json
@@ -35,7 +35,8 @@
     "empty_input": "deletes the local layer and restores inheritance",
     "child_broadening": "impossible because every inherited layer remains independently required",
     "storage": "normalized typed tables without JSON",
-    "relation_updates": "immutable; owner replacement uses delete plus insert",
+    "policy_details_scope": "forum categories manage",
+    "policy_and_relation_updates": "immutable; owner replacement uses delete plus insert",
     "tenant_integrity": "tenant-composite category and policy foreign keys"
   },
   "composition": {

--- a/crates/rustok-forum/contracts/forum-category-audience-policy.json
+++ b/crates/rustok-forum/contracts/forum-category-audience-policy.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20G",
+  "scope": "Normalized persistence and conjunctive inheritance for category audience layers",
+  "owner_file": "crates/rustok-forum/src/services/category_audience.rs",
+  "audience_contract_file": "crates/rustok-forum/src/audience.rs",
+  "migration_file": "crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs",
+  "migration_registry_file": "crates/rustok-forum/src/migrations/mod.rs",
+  "entities_file": "crates/rustok-forum/src/entities/mod.rs",
+  "services_file": "crates/rustok-forum/src/services/mod.rs",
+  "crate_file": "crates/rustok-forum/src/lib.rs",
+  "test_file": "crates/rustok-forum/tests/category_audience_policy_sqlite.rs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "tables": [
+    "forum_category_audience_policies",
+    "forum_category_audience_roles",
+    "forum_category_audience_channels",
+    "forum_category_audience_groups",
+    "forum_category_audience_users"
+  ],
+  "bounds": {
+    "category_tree_nodes": 512,
+    "category_tree_depth": 16,
+    "roles_per_layer": 4,
+    "channels_per_layer": 32,
+    "groups_per_layer": 32,
+    "allow_users_per_layer": 100,
+    "deny_users_per_layer": 100,
+    "maximum_trust_level": 100
+  },
+  "policy": {
+    "local_positive_selectors": "union",
+    "local_explicit_deny": "wins",
+    "inheritance": "root-to-target conjunction of non-empty local layers",
+    "empty_input": "deletes the local layer and restores inheritance",
+    "child_broadening": "impossible because every inherited layer remains independently required",
+    "storage": "normalized typed tables without JSON",
+    "relation_updates": "immutable; owner replacement uses delete plus insert",
+    "tenant_integrity": "tenant-composite category and policy foreign keys"
+  },
+  "composition": {
+    "category_storage": true,
+    "category_inheritance": true,
+    "topic_narrowing_storage": false,
+    "category_topic_reply_reads": false,
+    "write_audiences": false,
+    "provider_adapters": false,
+    "notifications_search_seo_deep_links": false
+  },
+  "not_delivered": [
+    "topic narrowing persistence and commands",
+    "category topic and reply read composition",
+    "create reply and moderate audience write policy",
+    "channel and group provider adapters",
+    "trust-level owner provider",
+    "visibility-scoped category and all-read mutations",
+    "notification search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-category-audience-policy.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A-F provide inherited public/authenticated policy, category/topic/reply owner-read composition and a bounded richer-audience capability/evaluator contract. Persistence and read composition of richer rules, write audiences, remaining consumers and runtime evidence remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A-G provide inherited public/authenticated policy, category/topic/reply owner-read composition, the bounded richer-audience evaluator contract and normalized conjunctive category audience persistence. Topic narrowing, richer read composition, write audiences, provider adapters, remaining consumers and runtime evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1186,47 +1186,72 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - raw input is capped before normalization at four roles, 32 channel candidates,
   32 group candidates and 100 allow plus 100 deny user IDs; trust is bounded to
   0..100 and channel slugs to 128 characters;
-- `ForumAudienceFactsRequest` and `ForumAudienceFacts` form an exact actor-scoped
-  request/response pair, rejecting unrequested trust, channel or group facts;
+- `ForumAudienceFactsRequest` and `ForumAudienceFacts` form an exact tenant- and
+  actor-scoped request/response pair, rejecting cross-identity or unrequested
+  trust, channel or group facts;
 - `ForumAudienceFactsPort` is a transport-neutral optional owner boundary with
   mandatory read-deadline semantics and no direct Forum dependency on Channel,
   Groups or their private tables;
-- `ForumAudienceFactsResolver` skips the optional provider when local
-  deny/allow/role facts already decide the union, returns empty facts for public
-  or non-user actors, and otherwise fails closed with typed capability errors;
+- `ForumAudienceFactsResolver` binds the port context to the requested tenant and
+  user, skips the optional provider when local deny/allow/role facts already
+  decide the union, returns empty facts for public or non-user actors, and
+  otherwise fails closed with typed capability errors;
 - `ForumAudienceEvaluator` validates exact facts and returns an explainable
   decision reason for unrestricted, deny, allow, role, trust, channel, group,
   authentication-required or no-match outcomes;
 - `forum-audience-capability-ports.json`, `audience_capability_contract` and
   `verify-forum-audience-capability-ports.mjs` lock bounds, precedence, exact
-  subsets, deadline semantics and residual composition work;
+  subsets, identity/deadline semantics and residual composition work;
 - this slice adds no storage, migration, owner-read composition, write policy,
   transport, provider adapter or cross-consumer behavior.
 
+### Delivered in `FORUM-20G`
+
+- five normalized Forum-owned tables persist one optional local category layer
+  plus typed role, channel, group and explicit allow/deny relations without JSON;
+- every policy and relation is tenant/category scoped through composite foreign
+  keys, with typed checks for supported roles, trust `0..100`, canonical channel
+  slugs, non-nil identities and allow/deny effects;
+- direct channel/group/user inserts are bounded to the FORUM-20F limits and
+  relation updates are rejected; owner replacement uses delete plus insert;
+- `ForumCategoryAudiencePolicyService` reads and atomically replaces a local
+  layer under `forum_categories:read/manage` and the tenant category-tree lock;
+- an empty constraint set deletes only the local layer and restores inheritance;
+- effective policy is an ordered root-to-target conjunction of every non-empty
+  local layer, preserving the local union/deny semantics while making child
+  broadening impossible;
+- storage reads remain bounded to the 512-node/depth-16 hierarchy and fail closed
+  for cycles, foreign categories, orphan relations, empty stored layers or
+  oversized direct writes;
+- `forum-category-audience-policy.json`, `category_audience_policy_sqlite` and
+  `verify-forum-category-audience-policy.mjs` lock normalized persistence,
+  inheritance, atomic replacement, tenant isolation and direct database guards;
+- this slice adds no topic narrowing, category/topic/reply read composition,
+  provider adapter, write-audience transport or cross-consumer behavior.
+
 ### Compatibility and degraded mode
 
-The nullable category floor still requires no backfill. Existing categories stay
-public until an owner command narrows an ancestor. Public category/topic/reply
-reads treat inherited authenticated targets as absent; authenticated reads expose
-public and authenticated categories. Storefront topic reads add the existing
-open/exact-channel policy on top of the same category floor. FORUM-20F adds only
-public Rust contract types and source-ready evidence: no current read, write or
-transport calls the richer evaluator yet. A missing optional facts provider can
-never broaden a decision; locally decidable role/explicit rules do not require
-one, while unresolved trust/channel/group facts return a typed failure. Host
-adapters may compose owner ports later without adding direct Forum dependencies
-on Channel or Groups implementations.
+The nullable public/authenticated category floor still requires no backfill.
+FORUM-20G adds empty normalized audience tables, so existing categories and all
+current category/topic/reply reads remain unchanged until a later owner-read
+composition slice calls the richer evaluator. Existing stored local layers do
+not require Channel, Groups or trust providers merely to persist or inspect the
+policy. A missing optional facts provider can never broaden a decision; locally
+decidable role/explicit rules do not require one, while unresolved
+trust/channel/group evaluation remains a typed failure. Host adapters may later
+compose owner ports without adding direct Forum dependencies on Channel or
+Groups implementations.
 
 ### Remaining scope
 
-- persist and inherit the bounded FORUM-20F constraints for categories and topic
-  narrowing, then compose them into category/topic/reply owner reads without
-  count, pagination or existence-oracle drift;
+- add normalized topic narrowing persistence and owner commands that cannot
+  broaden any effective category layer;
 - provide host adapters for Forum-owned trust state plus Channel and Groups owner
   membership ports, preserving exact request bounds and optional-capability
   failure semantics;
-- add create/reply/moderate audience policies and topic narrowing commands that
-  cannot broaden the effective category policy;
+- compose inherited category and topic layers into category/topic/reply owner
+  reads without count, pagination or existence-oracle drift;
+- add create/reply/moderate audience policies and write commands;
 - compose the owner policy into remaining Forum reads and migrate notifications,
   search/index, SEO and deep-link open authorization to the same decision;
 - add visibility-scoped category and all-read commands only after the complete
@@ -1248,19 +1273,22 @@ cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --noc
 cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
+cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
 node scripts/verify/verify-forum-category-owner-read-visibility.mjs
 node scripts/verify/verify-forum-audience-capability-ports.mjs
+node scripts/verify/verify-forum-category-audience-policy.mjs
 cargo xtask module validate forum
 npm run verify:forum:storefront-boundary
 ```
 
 Tests, Cargo, verifiers and CI were not run while publishing the source-ready
-FORUM-20C-F read-composition and capability-contract slices. `FORUM-20` remains
-`in_progress` until richer policy persistence/composition, write audiences and
-all cross-consumer paths are delivered with maintainer runtime evidence.
+FORUM-20C-G read-composition, capability-contract and category-persistence
+slices. `FORUM-20` remains `in_progress` until topic narrowing, richer read
+composition, write audiences and all cross-consumer paths are delivered with
+maintainer runtime evidence.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -1968,6 +1996,7 @@ cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --noc
 cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
+cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -1991,6 +2020,7 @@ node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
 node scripts/verify/verify-forum-category-owner-read-visibility.mjs
 node scripts/verify/verify-forum-audience-capability-ports.mjs
+node scripts/verify/verify-forum-category-audience-policy.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -2042,9 +2072,10 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` by persisting and inheriting the bounded FORUM-20F
-    constraints, composing them into owner reads with exact provider adapters,
-    then add write audiences and migrate remaining consumers;
+12. continue `FORUM-20` with normalized topic narrowing persistence and commands,
+    exact trust/channel/group provider adapters, then compose inherited category
+    plus topic layers into owner reads before adding write audiences and remaining
+    consumers;
 13. `FORUM-23`: index projections;
 14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -1213,9 +1213,11 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
   keys, with typed checks for supported roles, trust `0..100`, canonical channel
   slugs, non-nil identities and allow/deny effects;
 - direct channel/group/user inserts are bounded to the FORUM-20F limits and
-  relation updates are rejected; owner replacement uses delete plus insert;
-- `ForumCategoryAudiencePolicyService` reads and atomically replaces a local
-  layer under `forum_categories:read/manage` and the tenant category-tree lock;
+  policy and relation updates are rejected; owner replacement uses delete plus
+  insert;
+- `ForumCategoryAudiencePolicyService` exposes managed policy inspection and
+  atomically replaces a local layer under `forum_categories:manage` and the
+  tenant category-tree lock;
 - an empty constraint set deletes only the local layer and restores inheritance;
 - effective policy is an ordered root-to-target conjunction of every non-empty
   local layer, preserving the local union/deny semantics while making child

--- a/crates/rustok-forum/src/entities/forum_category_audience_channel.rs
+++ b/crates/rustok-forum/src/entities/forum_category_audience_channel.rs
@@ -1,0 +1,34 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "forum_category_audience_channels")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub category_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub channel_slug: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::forum_category_audience_policy::Entity",
+        from = "Column::CategoryId",
+        to = "super::forum_category_audience_policy::Column::CategoryId",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Policy,
+}
+
+impl Related<super::forum_category_audience_policy::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Policy.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-forum/src/entities/forum_category_audience_group.rs
+++ b/crates/rustok-forum/src/entities/forum_category_audience_group.rs
@@ -1,0 +1,34 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "forum_category_audience_groups")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub category_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub group_id: Uuid,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::forum_category_audience_policy::Entity",
+        from = "Column::CategoryId",
+        to = "super::forum_category_audience_policy::Column::CategoryId",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Policy,
+}
+
+impl Related<super::forum_category_audience_policy::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Policy.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-forum/src/entities/forum_category_audience_policy.rs
+++ b/crates/rustok-forum/src/entities/forum_category_audience_policy.rs
@@ -1,0 +1,34 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "forum_category_audience_policies")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub category_id: Uuid,
+    pub minimum_trust_level: Option<i16>,
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::forum_category::Entity",
+        from = "Column::CategoryId",
+        to = "super::forum_category::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Category,
+}
+
+impl Related<super::forum_category::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Category.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-forum/src/entities/forum_category_audience_role.rs
+++ b/crates/rustok-forum/src/entities/forum_category_audience_role.rs
@@ -1,0 +1,36 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use rustok_core::UserRole;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "forum_category_audience_roles")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub category_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub role: UserRole,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::forum_category_audience_policy::Entity",
+        from = "Column::CategoryId",
+        to = "super::forum_category_audience_policy::Column::CategoryId",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Policy,
+}
+
+impl Related<super::forum_category_audience_policy::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Policy.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-forum/src/entities/forum_category_audience_user.rs
+++ b/crates/rustok-forum/src/entities/forum_category_audience_user.rs
@@ -1,0 +1,57 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    EnumIter,
+    DeriveActiveEnum,
+    Serialize,
+    Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
+#[serde(rename_all = "snake_case")]
+pub enum ForumCategoryAudienceUserEffect {
+    #[sea_orm(string_value = "allow")]
+    Allow,
+    #[sea_orm(string_value = "deny")]
+    Deny,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "forum_category_audience_users")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub category_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub user_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub effect: ForumCategoryAudienceUserEffect,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::forum_category_audience_policy::Entity",
+        from = "Column::CategoryId",
+        to = "super::forum_category_audience_policy::Column::CategoryId",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Policy,
+}
+
+impl Related<super::forum_category_audience_policy::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Policy.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-forum/src/entities/mod.rs
+++ b/crates/rustok-forum/src/entities/mod.rs
@@ -2,6 +2,11 @@
 
 pub mod forum_audience_mention;
 pub mod forum_category;
+pub mod forum_category_audience_channel;
+pub mod forum_category_audience_group;
+pub mod forum_category_audience_policy;
+pub mod forum_category_audience_role;
+pub mod forum_category_audience_user;
 pub mod forum_category_lifecycle;
 pub mod forum_category_policy;
 pub mod forum_category_subscription;
@@ -27,6 +32,7 @@ pub mod forum_user_mention;
 pub mod forum_user_stat;
 
 pub use forum_category::Entity as ForumCategory;
+pub use forum_category_audience_policy::Entity as ForumCategoryAudiencePolicyEntity;
 pub use forum_category_lifecycle::Entity as ForumCategoryLifecycle;
 pub use forum_category_policy::Entity as ForumCategoryPolicy;
 pub use forum_domain_event::Entity as ForumDomainEvent;

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -41,15 +41,17 @@ pub use error::{ForumError, ForumResult};
 pub use graphql::{ForumMutation, ForumQuery};
 pub use mentions::*;
 pub use services::{
-    CategoryService, ForumCategoryVisibilityPolicy, ForumCategoryVisibilityPolicyService,
-    ForumEventService, ForumQuoteCommandService, ForumReadModelService, ForumRelationReadService,
-    ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage,
-    ForumTopicReadState, ForumTopicReadStateService, ForumTopicUnreadSummary,
-    ForumTopicVisibilityScope, ForumTopicVisibilityService, ForumWidgetContractService,
-    MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES, MarkForumTopicReadInput,
-    MarkForumTopicsReadBatchInput, MarkForumTopicsReadBatchResult, ModerationService, ReplyService,
-    RevisionService, SetForumCategoryVisibilityPolicyInput, SubscriptionService, TopicService,
-    UserStatsService, VoteService,
+    CategoryService, ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
+    ForumCategoryAudiencePolicyService, ForumCategoryVisibilityPolicy,
+    ForumCategoryVisibilityPolicyService, ForumEventService, ForumQuoteCommandService,
+    ForumReadModelService, ForumRelationReadService, ForumStorefrontReadStateService,
+    ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage, ForumTopicReadState,
+    ForumTopicReadStateService, ForumTopicUnreadSummary, ForumTopicVisibilityScope,
+    ForumTopicVisibilityService, ForumWidgetContractService, MAX_FORUM_TOPIC_VISIBILITY_CANDIDATES,
+    MarkForumTopicReadInput, MarkForumTopicsReadBatchInput, MarkForumTopicsReadBatchResult,
+    ModerationService, ReplyService, RevisionService, SetForumCategoryAudiencePolicyInput,
+    SetForumCategoryVisibilityPolicyInput, SubscriptionService, TopicService, UserStatsService,
+    VoteService,
 };
 pub use state_machine::{ReplyStatus, TopicStatus};
 pub use subscription::{ForumDigestMode, ForumSubscriptionLevel, ForumSubscriptionPreferences};

--- a/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
@@ -167,9 +167,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS forum_category_audience_policy_identity_update ON forum_category_audience_policies;
-CREATE TRIGGER forum_category_audience_policy_identity_update
-BEFORE UPDATE OF tenant_id, category_id ON forum_category_audience_policies
+DROP TRIGGER IF EXISTS forum_category_audience_policy_update ON forum_category_audience_policies;
+CREATE TRIGGER forum_category_audience_policy_update
+BEFORE UPDATE ON forum_category_audience_policies
 FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
 
 DROP TRIGGER IF EXISTS forum_category_audience_roles_update ON forum_category_audience_roles;
@@ -299,8 +299,8 @@ CREATE TABLE IF NOT EXISTS forum_category_audience_users (
     CHECK (effect IN ('allow', 'deny'))
 );
 
-CREATE TRIGGER IF NOT EXISTS forum_category_audience_policy_identity_update
-BEFORE UPDATE OF tenant_id, category_id ON forum_category_audience_policies
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_policy_update
+BEFORE UPDATE ON forum_category_audience_policies
 BEGIN
     SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
 END;
@@ -380,7 +380,7 @@ DROP TRIGGER IF EXISTS forum_category_audience_groups_insert;
 DROP TRIGGER IF EXISTS forum_category_audience_channels_update;
 DROP TRIGGER IF EXISTS forum_category_audience_channels_insert;
 DROP TRIGGER IF EXISTS forum_category_audience_roles_update;
-DROP TRIGGER IF EXISTS forum_category_audience_policy_identity_update;
+DROP TRIGGER IF EXISTS forum_category_audience_policy_update;
 DROP TABLE IF EXISTS forum_category_audience_users;
 DROP TABLE IF EXISTS forum_category_audience_groups;
 DROP TABLE IF EXISTS forum_category_audience_channels;

--- a/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
@@ -1,0 +1,201 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => up_postgres(manager).await,
+            DatabaseBackend::Sqlite => up_sqlite(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum category audience migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"
+DROP TABLE IF EXISTS forum_category_audience_users;
+DROP TABLE IF EXISTS forum_category_audience_groups;
+DROP TABLE IF EXISTS forum_category_audience_channels;
+DROP TABLE IF EXISTS forum_category_audience_roles;
+DROP TABLE IF EXISTS forum_category_audience_policies;
+"#,
+                    )
+                    .await?;
+                Ok(())
+            }
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum category audience migration does not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn up_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+CREATE TABLE IF NOT EXISTS forum_category_audience_policies (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    minimum_trust_level SMALLINT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT pk_forum_category_audience_policies
+        PRIMARY KEY (tenant_id, category_id),
+    CONSTRAINT fk_forum_category_audience_policy_category
+        FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_categories (tenant_id, id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT ck_forum_category_audience_minimum_trust
+        CHECK (minimum_trust_level IS NULL OR minimum_trust_level BETWEEN 0 AND 100)
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_roles (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    role VARCHAR(32) NOT NULL,
+    CONSTRAINT pk_forum_category_audience_roles
+        PRIMARY KEY (tenant_id, category_id, role),
+    CONSTRAINT fk_forum_category_audience_roles_policy
+        FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT ck_forum_category_audience_role
+        CHECK (role IN ('super_admin', 'admin', 'manager', 'customer'))
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_channels (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    channel_slug VARCHAR(128) NOT NULL,
+    CONSTRAINT pk_forum_category_audience_channels
+        PRIMARY KEY (tenant_id, category_id, channel_slug),
+    CONSTRAINT fk_forum_category_audience_channels_policy
+        FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT ck_forum_category_audience_channel_slug
+        CHECK (
+            length(channel_slug) BETWEEN 1 AND 128
+            AND channel_slug = lower(channel_slug)
+            AND channel_slug = btrim(channel_slug)
+        )
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_groups (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    group_id UUID NOT NULL,
+    CONSTRAINT pk_forum_category_audience_groups
+        PRIMARY KEY (tenant_id, category_id, group_id),
+    CONSTRAINT fk_forum_category_audience_groups_policy
+        FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT ck_forum_category_audience_group_id
+        CHECK (group_id <> '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_users (
+    tenant_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    effect VARCHAR(16) NOT NULL,
+    CONSTRAINT pk_forum_category_audience_users
+        PRIMARY KEY (tenant_id, category_id, user_id, effect),
+    CONSTRAINT fk_forum_category_audience_users_policy
+        FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT ck_forum_category_audience_user_id
+        CHECK (user_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT ck_forum_category_audience_user_effect
+        CHECK (effect IN ('allow', 'deny'))
+);
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn up_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+CREATE TABLE IF NOT EXISTS forum_category_audience_policies (
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    minimum_trust_level INTEGER NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, category_id),
+    FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_categories (tenant_id, id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CHECK (minimum_trust_level IS NULL OR minimum_trust_level BETWEEN 0 AND 100)
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_roles (
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, category_id, role),
+    FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CHECK (role IN ('super_admin', 'admin', 'manager', 'customer'))
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_channels (
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    channel_slug TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, category_id, channel_slug),
+    FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CHECK (
+        length(channel_slug) BETWEEN 1 AND 128
+        AND channel_slug = lower(channel_slug)
+        AND channel_slug = trim(channel_slug)
+    )
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_groups (
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    group_id TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, category_id, group_id),
+    FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CHECK (group_id <> '00000000-0000-0000-0000-000000000000')
+);
+
+CREATE TABLE IF NOT EXISTS forum_category_audience_users (
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    effect TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, category_id, user_id, effect),
+    FOREIGN KEY (tenant_id, category_id)
+        REFERENCES forum_category_audience_policies (tenant_id, category_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CHECK (user_id <> '00000000-0000-0000-0000-000000000000'),
+    CHECK (effect IN ('allow', 'deny'))
+);
+"#,
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
@@ -114,6 +114,7 @@ CREATE OR REPLACE FUNCTION forum_reject_category_audience_relation_update()
 RETURNS trigger AS $$
 BEGIN
     RAISE EXCEPTION 'forum category audience relation rows are immutable';
+    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -233,6 +234,9 @@ async fn up_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
         .get_connection()
         .execute_unprepared(
             r#"
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forum_categories_tenant_id
+    ON forum_categories (tenant_id, id);
+
 CREATE TABLE IF NOT EXISTS forum_category_audience_policies (
     tenant_id TEXT NOT NULL,
     category_id TEXT NOT NULL,
@@ -382,6 +386,7 @@ DROP TABLE IF EXISTS forum_category_audience_groups;
 DROP TABLE IF EXISTS forum_category_audience_channels;
 DROP TABLE IF EXISTS forum_category_audience_roles;
 DROP TABLE IF EXISTS forum_category_audience_policies;
+DROP INDEX IF EXISTS uq_forum_categories_tenant_id;
 "#,
         )
         .await?;

--- a/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260725_000001_add_forum_category_audience_policy.rs
@@ -18,21 +18,8 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         match manager.get_database_backend() {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        r#"
-DROP TABLE IF EXISTS forum_category_audience_users;
-DROP TABLE IF EXISTS forum_category_audience_groups;
-DROP TABLE IF EXISTS forum_category_audience_channels;
-DROP TABLE IF EXISTS forum_category_audience_roles;
-DROP TABLE IF EXISTS forum_category_audience_policies;
-"#,
-                    )
-                    .await?;
-                Ok(())
-            }
+            DatabaseBackend::Postgres => down_postgres(manager).await,
+            DatabaseBackend::Sqlite => down_sqlite(manager).await,
             backend => Err(DbErr::Custom(format!(
                 "rustok-forum category audience migration does not support {backend:?}"
             ))),
@@ -122,6 +109,119 @@ CREATE TABLE IF NOT EXISTS forum_category_audience_users (
     CONSTRAINT ck_forum_category_audience_user_effect
         CHECK (effect IN ('allow', 'deny'))
 );
+
+CREATE OR REPLACE FUNCTION forum_reject_category_audience_relation_update()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'forum category audience relation rows are immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION forum_validate_category_audience_channel_insert()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(NEW.tenant_id::text, 4));
+    IF (
+        SELECT count(*)
+        FROM forum_category_audience_channels item
+        WHERE item.tenant_id = NEW.tenant_id
+          AND item.category_id = NEW.category_id
+    ) >= 32 THEN
+        RAISE EXCEPTION 'forum category audience channels exceed bounded limit';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION forum_validate_category_audience_group_insert()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(NEW.tenant_id::text, 4));
+    IF (
+        SELECT count(*)
+        FROM forum_category_audience_groups item
+        WHERE item.tenant_id = NEW.tenant_id
+          AND item.category_id = NEW.category_id
+    ) >= 32 THEN
+        RAISE EXCEPTION 'forum category audience groups exceed bounded limit';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION forum_validate_category_audience_user_insert()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(NEW.tenant_id::text, 4));
+    IF (
+        SELECT count(*)
+        FROM forum_category_audience_users item
+        WHERE item.tenant_id = NEW.tenant_id
+          AND item.category_id = NEW.category_id
+          AND item.effect = NEW.effect
+    ) >= 100 THEN
+        RAISE EXCEPTION 'forum category audience users exceed bounded limit';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_category_audience_policy_identity_update ON forum_category_audience_policies;
+CREATE TRIGGER forum_category_audience_policy_identity_update
+BEFORE UPDATE OF tenant_id, category_id ON forum_category_audience_policies
+FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
+
+DROP TRIGGER IF EXISTS forum_category_audience_roles_update ON forum_category_audience_roles;
+CREATE TRIGGER forum_category_audience_roles_update
+BEFORE UPDATE ON forum_category_audience_roles
+FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
+
+DROP TRIGGER IF EXISTS forum_category_audience_channels_insert ON forum_category_audience_channels;
+CREATE TRIGGER forum_category_audience_channels_insert
+BEFORE INSERT ON forum_category_audience_channels
+FOR EACH ROW EXECUTE FUNCTION forum_validate_category_audience_channel_insert();
+DROP TRIGGER IF EXISTS forum_category_audience_channels_update ON forum_category_audience_channels;
+CREATE TRIGGER forum_category_audience_channels_update
+BEFORE UPDATE ON forum_category_audience_channels
+FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
+
+DROP TRIGGER IF EXISTS forum_category_audience_groups_insert ON forum_category_audience_groups;
+CREATE TRIGGER forum_category_audience_groups_insert
+BEFORE INSERT ON forum_category_audience_groups
+FOR EACH ROW EXECUTE FUNCTION forum_validate_category_audience_group_insert();
+DROP TRIGGER IF EXISTS forum_category_audience_groups_update ON forum_category_audience_groups;
+CREATE TRIGGER forum_category_audience_groups_update
+BEFORE UPDATE ON forum_category_audience_groups
+FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
+
+DROP TRIGGER IF EXISTS forum_category_audience_users_insert ON forum_category_audience_users;
+CREATE TRIGGER forum_category_audience_users_insert
+BEFORE INSERT ON forum_category_audience_users
+FOR EACH ROW EXECUTE FUNCTION forum_validate_category_audience_user_insert();
+DROP TRIGGER IF EXISTS forum_category_audience_users_update ON forum_category_audience_users;
+CREATE TRIGGER forum_category_audience_users_update
+BEFORE UPDATE ON forum_category_audience_users
+FOR EACH ROW EXECUTE FUNCTION forum_reject_category_audience_relation_update();
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn down_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DROP TABLE IF EXISTS forum_category_audience_users;
+DROP TABLE IF EXISTS forum_category_audience_groups;
+DROP TABLE IF EXISTS forum_category_audience_channels;
+DROP TABLE IF EXISTS forum_category_audience_roles;
+DROP TABLE IF EXISTS forum_category_audience_policies;
+DROP FUNCTION IF EXISTS forum_validate_category_audience_user_insert();
+DROP FUNCTION IF EXISTS forum_validate_category_audience_group_insert();
+DROP FUNCTION IF EXISTS forum_validate_category_audience_channel_insert();
+DROP FUNCTION IF EXISTS forum_reject_category_audience_relation_update();
 "#,
         )
         .await?;
@@ -194,6 +294,94 @@ CREATE TABLE IF NOT EXISTS forum_category_audience_users (
     CHECK (user_id <> '00000000-0000-0000-0000-000000000000'),
     CHECK (effect IN ('allow', 'deny'))
 );
+
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_policy_identity_update
+BEFORE UPDATE OF tenant_id, category_id ON forum_category_audience_policies
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_roles_update
+BEFORE UPDATE ON forum_category_audience_roles
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_channels_insert
+BEFORE INSERT ON forum_category_audience_channels
+WHEN (
+    SELECT count(*)
+    FROM forum_category_audience_channels item
+    WHERE item.tenant_id = NEW.tenant_id
+      AND item.category_id = NEW.category_id
+) >= 32
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience channels exceed bounded limit');
+END;
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_channels_update
+BEFORE UPDATE ON forum_category_audience_channels
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_groups_insert
+BEFORE INSERT ON forum_category_audience_groups
+WHEN (
+    SELECT count(*)
+    FROM forum_category_audience_groups item
+    WHERE item.tenant_id = NEW.tenant_id
+      AND item.category_id = NEW.category_id
+) >= 32
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience groups exceed bounded limit');
+END;
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_groups_update
+BEFORE UPDATE ON forum_category_audience_groups
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_users_insert
+BEFORE INSERT ON forum_category_audience_users
+WHEN (
+    SELECT count(*)
+    FROM forum_category_audience_users item
+    WHERE item.tenant_id = NEW.tenant_id
+      AND item.category_id = NEW.category_id
+      AND item.effect = NEW.effect
+) >= 100
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience users exceed bounded limit');
+END;
+CREATE TRIGGER IF NOT EXISTS forum_category_audience_users_update
+BEFORE UPDATE ON forum_category_audience_users
+BEGIN
+    SELECT RAISE(ABORT, 'forum category audience relation rows are immutable');
+END;
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn down_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DROP TRIGGER IF EXISTS forum_category_audience_users_update;
+DROP TRIGGER IF EXISTS forum_category_audience_users_insert;
+DROP TRIGGER IF EXISTS forum_category_audience_groups_update;
+DROP TRIGGER IF EXISTS forum_category_audience_groups_insert;
+DROP TRIGGER IF EXISTS forum_category_audience_channels_update;
+DROP TRIGGER IF EXISTS forum_category_audience_channels_insert;
+DROP TRIGGER IF EXISTS forum_category_audience_roles_update;
+DROP TRIGGER IF EXISTS forum_category_audience_policy_identity_update;
+DROP TABLE IF EXISTS forum_category_audience_users;
+DROP TABLE IF EXISTS forum_category_audience_groups;
+DROP TABLE IF EXISTS forum_category_audience_channels;
+DROP TABLE IF EXISTS forum_category_audience_roles;
+DROP TABLE IF EXISTS forum_category_audience_policies;
 "#,
         )
         .await?;

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -29,6 +29,7 @@ mod m20260722_000005_seed_forum_relation_revisions;
 mod m20260722_000006_add_forum_mention_events;
 mod m20260724_000001_add_forum_topic_read_states;
 mod m20260724_000002_add_forum_category_visibility_policy;
+mod m20260725_000001_add_forum_category_audience_policy;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -66,6 +67,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260722_000006_add_forum_mention_events::Migration),
         Box::new(m20260724_000001_add_forum_topic_read_states::Migration),
         Box::new(m20260724_000002_add_forum_category_visibility_policy::Migration),
+        Box::new(m20260725_000001_add_forum_category_audience_policy::Migration),
     ]
 }
 

--- a/crates/rustok-forum/src/services/category_audience.rs
+++ b/crates/rustok-forum/src/services/category_audience.rs
@@ -1,0 +1,453 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait,
+    ActiveValue::Set,
+    ColumnTrait,
+    ConnectionTrait,
+    DatabaseBackend,
+    DatabaseConnection,
+    DatabaseTransaction,
+    EntityTrait,
+    QueryFilter,
+    QueryOrder,
+    QuerySelect,
+    Statement,
+    TransactionTrait,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
+
+use crate::audience::ForumAudienceConstraints;
+use crate::dto::{MAX_FORUM_CATEGORY_TREE_DEPTH, MAX_FORUM_CATEGORY_TREE_NODES};
+use crate::entities::{
+    forum_category,
+    forum_category_audience_channel,
+    forum_category_audience_group,
+    forum_category_audience_policy,
+    forum_category_audience_role,
+    forum_category_audience_user::{self, ForumCategoryAudienceUserEffect},
+};
+use crate::error::{ForumError, ForumResult};
+use crate::services::rbac::enforce_scope;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumCategoryAudiencePolicyLayer {
+    pub category_id: Uuid,
+    pub constraints: ForumAudienceConstraints,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumCategoryAudiencePolicy {
+    pub category_id: Uuid,
+    pub configured_constraints: Option<ForumAudienceConstraints>,
+    /// Root-to-target non-empty layers. Every layer must allow the viewer.
+    pub effective_layers: Vec<ForumCategoryAudiencePolicyLayer>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SetForumCategoryAudiencePolicyInput {
+    /// An empty constraint set clears the local layer and restores inheritance.
+    pub constraints: ForumAudienceConstraints,
+}
+
+/// Forum-owned persistence for richer category audience layers.
+///
+/// Each category contributes at most one normalized local layer. Layers inherit
+/// root-to-leaf as a conjunction, so a child layer can narrow but never broaden
+/// an ancestor. Evaluation and owner-read composition remain separate slices.
+pub struct ForumCategoryAudiencePolicyService {
+    db: DatabaseConnection,
+}
+
+impl ForumCategoryAudiencePolicyService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn get(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<ForumCategoryAudiencePolicy> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Read)?;
+        load_category_audience_policy(&self.db, tenant_id, category_id).await
+    }
+
+    pub async fn set(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: SetForumCategoryAudiencePolicyInput,
+    ) -> ForumResult<ForumCategoryAudiencePolicy> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        let constraints = input.constraints.normalize()?;
+
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+        load_category_ancestor_ids(&txn, tenant_id, category_id).await?;
+
+        forum_category_audience_policy::Entity::delete_many()
+            .filter(forum_category_audience_policy::Column::TenantId.eq(tenant_id))
+            .filter(forum_category_audience_policy::Column::CategoryId.eq(category_id))
+            .exec(&txn)
+            .await?;
+
+        if !constraints_are_empty(&constraints) {
+            forum_category_audience_policy::ActiveModel {
+                tenant_id: Set(tenant_id),
+                category_id: Set(category_id),
+                minimum_trust_level: Set(constraints.minimum_trust_level.map(i16::from)),
+                updated_at: Set(Utc::now().into()),
+            }
+            .insert(&txn)
+            .await?;
+
+            insert_roles(&txn, tenant_id, category_id, &constraints).await?;
+            insert_channels(&txn, tenant_id, category_id, &constraints).await?;
+            insert_groups(&txn, tenant_id, category_id, &constraints).await?;
+            insert_users(&txn, tenant_id, category_id, &constraints).await?;
+        }
+
+        let result = load_category_audience_policy(&txn, tenant_id, category_id).await?;
+        txn.commit().await?;
+        Ok(result)
+    }
+}
+
+async fn insert_roles(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    constraints: &ForumAudienceConstraints,
+) -> ForumResult<()> {
+    if constraints.roles_any.is_empty() {
+        return Ok(());
+    }
+    forum_category_audience_role::Entity::insert_many(
+        constraints
+            .roles_any
+            .iter()
+            .cloned()
+            .map(|role| forum_category_audience_role::ActiveModel {
+                tenant_id: Set(tenant_id),
+                category_id: Set(category_id),
+                role: Set(role),
+            })
+            .collect::<Vec<_>>(),
+    )
+    .exec(txn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_channels(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    constraints: &ForumAudienceConstraints,
+) -> ForumResult<()> {
+    if constraints.channel_members_any.is_empty() {
+        return Ok(());
+    }
+    forum_category_audience_channel::Entity::insert_many(
+        constraints
+            .channel_members_any
+            .iter()
+            .cloned()
+            .map(|channel_slug| forum_category_audience_channel::ActiveModel {
+                tenant_id: Set(tenant_id),
+                category_id: Set(category_id),
+                channel_slug: Set(channel_slug),
+            })
+            .collect::<Vec<_>>(),
+    )
+    .exec(txn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_groups(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    constraints: &ForumAudienceConstraints,
+) -> ForumResult<()> {
+    if constraints.group_members_any.is_empty() {
+        return Ok(());
+    }
+    forum_category_audience_group::Entity::insert_many(
+        constraints
+            .group_members_any
+            .iter()
+            .copied()
+            .map(|group_id| forum_category_audience_group::ActiveModel {
+                tenant_id: Set(tenant_id),
+                category_id: Set(category_id),
+                group_id: Set(group_id),
+            })
+            .collect::<Vec<_>>(),
+    )
+    .exec(txn)
+    .await?;
+    Ok(())
+}
+
+async fn insert_users(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    constraints: &ForumAudienceConstraints,
+) -> ForumResult<()> {
+    let mut rows = Vec::with_capacity(
+        constraints.allow_user_ids.len() + constraints.deny_user_ids.len(),
+    );
+    rows.extend(constraints.allow_user_ids.iter().copied().map(|user_id| {
+        forum_category_audience_user::ActiveModel {
+            tenant_id: Set(tenant_id),
+            category_id: Set(category_id),
+            user_id: Set(user_id),
+            effect: Set(ForumCategoryAudienceUserEffect::Allow),
+        }
+    }));
+    rows.extend(constraints.deny_user_ids.iter().copied().map(|user_id| {
+        forum_category_audience_user::ActiveModel {
+            tenant_id: Set(tenant_id),
+            category_id: Set(category_id),
+            user_id: Set(user_id),
+            effect: Set(ForumCategoryAudienceUserEffect::Deny),
+        }
+    }));
+    if rows.is_empty() {
+        return Ok(());
+    }
+    forum_category_audience_user::Entity::insert_many(rows)
+        .exec(txn)
+        .await?;
+    Ok(())
+}
+
+async fn load_category_audience_policy<C>(
+    db: &C,
+    tenant_id: Uuid,
+    category_id: Uuid,
+) -> ForumResult<ForumCategoryAudiencePolicy>
+where
+    C: ConnectionTrait,
+{
+    let ancestor_ids = load_category_ancestor_ids(db, tenant_id, category_id).await?;
+    let layers = load_local_layers(db, tenant_id, &ancestor_ids).await?;
+    let configured_constraints = layers.get(&category_id).cloned();
+    let effective_layers = ancestor_ids
+        .into_iter()
+        .filter_map(|ancestor_id| {
+            layers
+                .get(&ancestor_id)
+                .cloned()
+                .map(|constraints| ForumCategoryAudiencePolicyLayer {
+                    category_id: ancestor_id,
+                    constraints,
+                })
+        })
+        .collect();
+
+    Ok(ForumCategoryAudiencePolicy {
+        category_id,
+        configured_constraints,
+        effective_layers,
+    })
+}
+
+async fn load_category_ancestor_ids<C>(
+    db: &C,
+    tenant_id: Uuid,
+    category_id: Uuid,
+) -> ForumResult<Vec<Uuid>>
+where
+    C: ConnectionTrait,
+{
+    let categories = forum_category::Entity::find()
+        .filter(forum_category::Column::TenantId.eq(tenant_id))
+        .order_by_asc(forum_category::Column::Id)
+        .limit(MAX_FORUM_CATEGORY_TREE_NODES + 1)
+        .all(db)
+        .await?;
+    if categories.len() > MAX_FORUM_CATEGORY_TREE_NODES as usize {
+        return Err(ForumError::Validation(format!(
+            "Forum category audience tree exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
+        )));
+    }
+
+    let parents = categories
+        .into_iter()
+        .map(|category| (category.id, category.parent_id))
+        .collect::<HashMap<_, _>>();
+    if !parents.contains_key(&category_id) {
+        return Err(ForumError::CategoryNotFound(category_id));
+    }
+
+    let mut current = Some(category_id);
+    let mut ancestors = Vec::new();
+    let mut visited = HashSet::new();
+    let mut depth = 0usize;
+    while let Some(current_id) = current {
+        if depth > MAX_FORUM_CATEGORY_TREE_DEPTH {
+            return Err(ForumError::Validation(format!(
+                "Forum category audience tree exceeds the maximum depth of {MAX_FORUM_CATEGORY_TREE_DEPTH}"
+            )));
+        }
+        if !visited.insert(current_id) {
+            return Err(ForumError::Validation(
+                "Forum category audience tree contains a hierarchy cycle".to_string(),
+            ));
+        }
+        ancestors.push(current_id);
+        current = parents.get(&current_id).copied().ok_or_else(|| {
+            ForumError::Validation(format!(
+                "Forum category audience tree references missing or foreign category {current_id}"
+            ))
+        })?;
+        depth += 1;
+    }
+    ancestors.reverse();
+    Ok(ancestors)
+}
+
+async fn load_local_layers<C>(
+    db: &C,
+    tenant_id: Uuid,
+    category_ids: &[Uuid],
+) -> ForumResult<HashMap<Uuid, ForumAudienceConstraints>>
+where
+    C: ConnectionTrait,
+{
+    if category_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let policies = forum_category_audience_policy::Entity::find()
+        .filter(forum_category_audience_policy::Column::TenantId.eq(tenant_id))
+        .filter(forum_category_audience_policy::Column::CategoryId.is_in(category_ids.to_vec()))
+        .all(db)
+        .await?;
+    let mut layers = HashMap::with_capacity(policies.len());
+    for policy in policies {
+        let minimum_trust_level = policy
+            .minimum_trust_level
+            .map(|level| {
+                u8::try_from(level).map_err(|_| {
+                    ForumError::Validation(
+                        "Forum category audience storage contains an invalid trust level"
+                            .to_string(),
+                    )
+                })
+            })
+            .transpose()?;
+        layers.insert(
+            policy.category_id,
+            ForumAudienceConstraints {
+                minimum_trust_level,
+                ..ForumAudienceConstraints::default()
+            },
+        );
+    }
+
+    for row in forum_category_audience_role::Entity::find()
+        .filter(forum_category_audience_role::Column::TenantId.eq(tenant_id))
+        .filter(forum_category_audience_role::Column::CategoryId.is_in(category_ids.to_vec()))
+        .all(db)
+        .await?
+    {
+        layer_mut(&mut layers, row.category_id)?.roles_any.push(row.role);
+    }
+    for row in forum_category_audience_channel::Entity::find()
+        .filter(forum_category_audience_channel::Column::TenantId.eq(tenant_id))
+        .filter(forum_category_audience_channel::Column::CategoryId.is_in(category_ids.to_vec()))
+        .all(db)
+        .await?
+    {
+        layer_mut(&mut layers, row.category_id)?
+            .channel_members_any
+            .push(row.channel_slug);
+    }
+    for row in forum_category_audience_group::Entity::find()
+        .filter(forum_category_audience_group::Column::TenantId.eq(tenant_id))
+        .filter(forum_category_audience_group::Column::CategoryId.is_in(category_ids.to_vec()))
+        .all(db)
+        .await?
+    {
+        layer_mut(&mut layers, row.category_id)?
+            .group_members_any
+            .push(row.group_id);
+    }
+    for row in forum_category_audience_user::Entity::find()
+        .filter(forum_category_audience_user::Column::TenantId.eq(tenant_id))
+        .filter(forum_category_audience_user::Column::CategoryId.is_in(category_ids.to_vec()))
+        .all(db)
+        .await?
+    {
+        let layer = layer_mut(&mut layers, row.category_id)?;
+        match row.effect {
+            ForumCategoryAudienceUserEffect::Allow => layer.allow_user_ids.push(row.user_id),
+            ForumCategoryAudienceUserEffect::Deny => layer.deny_user_ids.push(row.user_id),
+        }
+    }
+
+    for constraints in layers.values_mut() {
+        *constraints = constraints.clone().normalize()?;
+        if constraints_are_empty(constraints) {
+            return Err(ForumError::Validation(
+                "Forum category audience storage contains an empty local layer".to_string(),
+            ));
+        }
+    }
+    Ok(layers)
+}
+
+fn layer_mut(
+    layers: &mut HashMap<Uuid, ForumAudienceConstraints>,
+    category_id: Uuid,
+) -> ForumResult<&mut ForumAudienceConstraints> {
+    layers.get_mut(&category_id).ok_or_else(|| {
+        ForumError::Validation(
+            "Forum category audience relation is missing its local policy layer".to_string(),
+        )
+    })
+}
+
+fn constraints_are_empty(constraints: &ForumAudienceConstraints) -> bool {
+    constraints.roles_any.is_empty()
+        && constraints.minimum_trust_level.is_none()
+        && constraints.channel_members_any.is_empty()
+        && constraints.group_members_any.is_empty()
+        && constraints.allow_user_ids.is_empty()
+        && constraints.deny_user_ids.is_empty()
+}
+
+async fn lock_category_tree_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+) -> ForumResult<()> {
+    match txn.get_database_backend() {
+        DatabaseBackend::Postgres => {
+            txn.execute(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                [tenant_id.to_string().into()],
+            ))
+            .await?;
+            Ok(())
+        }
+        DatabaseBackend::Sqlite => Ok(()),
+        backend => Err(ForumError::Validation(format!(
+            "Forum category audience policy does not support {backend:?}"
+        ))),
+    }
+}

--- a/crates/rustok-forum/src/services/category_audience.rs
+++ b/crates/rustok-forum/src/services/category_audience.rs
@@ -74,14 +74,20 @@ impl ForumCategoryAudiencePolicyService {
         Self { db }
     }
 
+    /// Policy details may contain explicit user and group identifiers and are
+    /// therefore restricted to category managers rather than public readers.
     pub async fn get(
         &self,
         tenant_id: Uuid,
         category_id: Uuid,
         security: SecurityContext,
     ) -> ForumResult<ForumCategoryAudiencePolicy> {
-        enforce_scope(&security, Resource::ForumCategories, Action::Read)?;
-        load_category_audience_policy(&self.db, tenant_id, category_id).await
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+        let result = load_category_audience_policy(&txn, tenant_id, category_id).await?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn set(

--- a/crates/rustok-forum/src/services/category_audience.rs
+++ b/crates/rustok-forum/src/services/category_audience.rs
@@ -23,7 +23,11 @@ use uuid::Uuid;
 use rustok_api::{Action, Resource};
 use rustok_core::SecurityContext;
 
-use crate::audience::ForumAudienceConstraints;
+use crate::audience::{
+    ForumAudienceConstraints, MAX_FORUM_AUDIENCE_CHANNELS,
+    MAX_FORUM_AUDIENCE_EXPLICIT_USERS, MAX_FORUM_AUDIENCE_GROUPS,
+    MAX_FORUM_AUDIENCE_ROLES,
+};
 use crate::dto::{MAX_FORUM_CATEGORY_TREE_DEPTH, MAX_FORUM_CATEGORY_TREE_NODES};
 use crate::entities::{
     forum_category,
@@ -335,8 +339,11 @@ where
     let policies = forum_category_audience_policy::Entity::find()
         .filter(forum_category_audience_policy::Column::TenantId.eq(tenant_id))
         .filter(forum_category_audience_policy::Column::CategoryId.is_in(category_ids.to_vec()))
+        .limit((category_ids.len() + 1) as u64)
         .all(db)
         .await?;
+    ensure_storage_bound(policies.len(), category_ids.len(), "policy layers")?;
+
     let mut layers = HashMap::with_capacity(policies.len());
     for policy in policies {
         let minimum_trust_level = policy
@@ -359,40 +366,55 @@ where
         );
     }
 
-    for row in forum_category_audience_role::Entity::find()
+    let maximum_roles = category_ids.len() * MAX_FORUM_AUDIENCE_ROLES;
+    let roles = forum_category_audience_role::Entity::find()
         .filter(forum_category_audience_role::Column::TenantId.eq(tenant_id))
         .filter(forum_category_audience_role::Column::CategoryId.is_in(category_ids.to_vec()))
+        .limit((maximum_roles + 1) as u64)
         .all(db)
-        .await?
-    {
+        .await?;
+    ensure_storage_bound(roles.len(), maximum_roles, "role relations")?;
+    for row in roles {
         layer_mut(&mut layers, row.category_id)?.roles_any.push(row.role);
     }
-    for row in forum_category_audience_channel::Entity::find()
+
+    let maximum_channels = category_ids.len() * MAX_FORUM_AUDIENCE_CHANNELS;
+    let channels = forum_category_audience_channel::Entity::find()
         .filter(forum_category_audience_channel::Column::TenantId.eq(tenant_id))
         .filter(forum_category_audience_channel::Column::CategoryId.is_in(category_ids.to_vec()))
+        .limit((maximum_channels + 1) as u64)
         .all(db)
-        .await?
-    {
+        .await?;
+    ensure_storage_bound(channels.len(), maximum_channels, "channel relations")?;
+    for row in channels {
         layer_mut(&mut layers, row.category_id)?
             .channel_members_any
             .push(row.channel_slug);
     }
-    for row in forum_category_audience_group::Entity::find()
+
+    let maximum_groups = category_ids.len() * MAX_FORUM_AUDIENCE_GROUPS;
+    let groups = forum_category_audience_group::Entity::find()
         .filter(forum_category_audience_group::Column::TenantId.eq(tenant_id))
         .filter(forum_category_audience_group::Column::CategoryId.is_in(category_ids.to_vec()))
+        .limit((maximum_groups + 1) as u64)
         .all(db)
-        .await?
-    {
+        .await?;
+    ensure_storage_bound(groups.len(), maximum_groups, "group relations")?;
+    for row in groups {
         layer_mut(&mut layers, row.category_id)?
             .group_members_any
             .push(row.group_id);
     }
-    for row in forum_category_audience_user::Entity::find()
+
+    let maximum_users = category_ids.len() * MAX_FORUM_AUDIENCE_EXPLICIT_USERS * 2;
+    let users = forum_category_audience_user::Entity::find()
         .filter(forum_category_audience_user::Column::TenantId.eq(tenant_id))
         .filter(forum_category_audience_user::Column::CategoryId.is_in(category_ids.to_vec()))
+        .limit((maximum_users + 1) as u64)
         .all(db)
-        .await?
-    {
+        .await?;
+    ensure_storage_bound(users.len(), maximum_users, "explicit user relations")?;
+    for row in users {
         let layer = layer_mut(&mut layers, row.category_id)?;
         match row.effect {
             ForumCategoryAudienceUserEffect::Allow => layer.allow_user_ids.push(row.user_id),
@@ -420,6 +442,15 @@ fn layer_mut(
             "Forum category audience relation is missing its local policy layer".to_string(),
         )
     })
+}
+
+fn ensure_storage_bound(actual: usize, maximum: usize, label: &str) -> ForumResult<()> {
+    if actual > maximum {
+        return Err(ForumError::Validation(format!(
+            "Forum category audience storage exceeds the bounded {label} limit of {maximum}"
+        )));
+    }
+    Ok(())
 }
 
 fn constraints_are_empty(constraints: &ForumAudienceConstraints) -> bool {

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -5,6 +5,7 @@ mod category {
     include!("category.rs");
     include!("category_visibility_list.rs");
 }
+mod category_audience;
 #[allow(clippy::collapsible_if)]
 mod category_command;
 mod category_lifecycle;
@@ -59,6 +60,10 @@ pub mod user_stats;
 pub mod vote;
 pub mod widget_contract;
 
+pub use category_audience::{
+    ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
+    ForumCategoryAudiencePolicyService, SetForumCategoryAudiencePolicyInput,
+};
 pub use category_owner::CategoryService;
 pub use category_visibility::{
     ForumCategoryVisibilityPolicy, ForumCategoryVisibilityPolicyService,

--- a/crates/rustok-forum/tests/category_audience_policy_sqlite.rs
+++ b/crates/rustok-forum/tests/category_audience_policy_sqlite.rs
@@ -131,6 +131,12 @@ async fn category_audience_layers_inherit_conjunctively_and_remain_bounded() {
             .channel_members_any,
         root_channels
     );
+    assert!(matches!(
+        policies
+            .get(tenant_id, root, SecurityContext::public_read())
+            .await,
+        Err(ForumError::Forbidden(_))
+    ));
 
     let group_id = Uuid::new_v4();
     let allowed_user_id = Uuid::new_v4();
@@ -236,7 +242,7 @@ async fn category_audience_layers_inherit_conjunctively_and_remain_bounded() {
         "database must reject a thirty-third channel relation"
     );
 
-    let direct_update = db
+    let direct_relation_update = db
         .execute(Statement::from_sql_and_values(
             DatabaseBackend::Sqlite,
             "UPDATE forum_category_audience_channels SET channel_slug = ? WHERE tenant_id = ? AND category_id = ? AND channel_slug = ?",
@@ -249,8 +255,24 @@ async fn category_audience_layers_inherit_conjunctively_and_remain_bounded() {
         ))
         .await;
     assert!(
-        direct_update.is_err(),
+        direct_relation_update.is_err(),
         "database must reject mutable relation-row updates"
+    );
+
+    let direct_policy_update = db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "UPDATE forum_category_audience_policies SET minimum_trust_level = ? WHERE tenant_id = ? AND category_id = ?",
+            [
+                9.into(),
+                tenant_id.to_string().into(),
+                root.to_string().into(),
+            ],
+        ))
+        .await;
+    assert!(
+        direct_policy_update.is_err(),
+        "database must reject mutable policy-row updates"
     );
 
     let cross_tenant_policy = db

--- a/crates/rustok-forum/tests/category_audience_policy_sqlite.rs
+++ b/crates/rustok-forum/tests/category_audience_policy_sqlite.rs
@@ -1,0 +1,271 @@
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, ForumAudienceConstraints, ForumCategoryAudiencePolicyService,
+    ForumError, ForumModule, SetForumCategoryAudiencePolicyInput,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn setup() -> DatabaseConnection {
+    let db_url = format!(
+        "sqlite:file:forum_category_audience_policy_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("forum category audience sqlite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    db
+}
+
+async fn create_category(
+    service: &CategoryService,
+    tenant_id: Uuid,
+    security: SecurityContext,
+    slug: &str,
+    parent_id: Option<Uuid>,
+) -> Uuid {
+    service
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: slug.replace('-', " "),
+                slug: slug.into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created")
+        .id
+}
+
+#[tokio::test]
+async fn category_audience_layers_inherit_conjunctively_and_remain_bounded() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let foreign_tenant_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+    let categories = CategoryService::new(db.clone());
+    let policies = ForumCategoryAudiencePolicyService::new(db.clone());
+
+    let root = create_category(&categories, tenant_id, admin.clone(), "root", None).await;
+    let child = create_category(
+        &categories,
+        tenant_id,
+        admin.clone(),
+        "child",
+        Some(root),
+    )
+    .await;
+    let leaf = create_category(
+        &categories,
+        tenant_id,
+        admin.clone(),
+        "leaf",
+        Some(child),
+    )
+    .await;
+    create_category(
+        &categories,
+        foreign_tenant_id,
+        admin.clone(),
+        "foreign-root",
+        None,
+    )
+    .await;
+
+    let root_channels = (0..32)
+        .map(|index| format!("channel-{index:02}"))
+        .collect::<Vec<_>>();
+    let root_policy = policies
+        .set(
+            tenant_id,
+            root,
+            admin.clone(),
+            SetForumCategoryAudiencePolicyInput {
+                constraints: ForumAudienceConstraints {
+                    roles_any: vec![UserRole::Admin, UserRole::Manager],
+                    channel_members_any: root_channels.clone(),
+                    ..ForumAudienceConstraints::default()
+                },
+            },
+        )
+        .await
+        .expect("root local audience layer should persist");
+    assert_eq!(root_policy.effective_layers.len(), 1);
+    assert_eq!(
+        root_policy.effective_layers[0].constraints.roles_any,
+        vec![UserRole::Manager, UserRole::Admin]
+    );
+    assert_eq!(
+        root_policy.effective_layers[0]
+            .constraints
+            .channel_members_any,
+        root_channels
+    );
+
+    let group_id = Uuid::new_v4();
+    let allowed_user_id = Uuid::new_v4();
+    let denied_user_id = Uuid::new_v4();
+    policies
+        .set(
+            tenant_id,
+            child,
+            admin.clone(),
+            SetForumCategoryAudiencePolicyInput {
+                constraints: ForumAudienceConstraints {
+                    minimum_trust_level: Some(7),
+                    group_members_any: vec![group_id],
+                    allow_user_ids: vec![allowed_user_id],
+                    deny_user_ids: vec![denied_user_id],
+                    ..ForumAudienceConstraints::default()
+                },
+            },
+        )
+        .await
+        .expect("child local audience layer should persist");
+
+    let inherited = policies
+        .get(tenant_id, leaf, admin.clone())
+        .await
+        .expect("leaf effective audience should resolve");
+    assert!(inherited.configured_constraints.is_none());
+    assert_eq!(
+        inherited
+            .effective_layers
+            .iter()
+            .map(|layer| layer.category_id)
+            .collect::<Vec<_>>(),
+        vec![root, child]
+    );
+    assert_eq!(
+        inherited.effective_layers[1]
+            .constraints
+            .minimum_trust_level,
+        Some(7)
+    );
+    assert_eq!(
+        inherited.effective_layers[1].constraints.group_members_any,
+        vec![group_id]
+    );
+    assert_eq!(
+        inherited.effective_layers[1].constraints.allow_user_ids,
+        vec![allowed_user_id]
+    );
+    assert_eq!(
+        inherited.effective_layers[1].constraints.deny_user_ids,
+        vec![denied_user_id]
+    );
+
+    let cleared = policies
+        .set(
+            tenant_id,
+            child,
+            admin.clone(),
+            SetForumCategoryAudiencePolicyInput {
+                constraints: ForumAudienceConstraints::default(),
+            },
+        )
+        .await
+        .expect("empty constraints should clear the local layer");
+    assert!(cleared.configured_constraints.is_none());
+    assert_eq!(
+        cleared
+            .effective_layers
+            .iter()
+            .map(|layer| layer.category_id)
+            .collect::<Vec<_>>(),
+        vec![root]
+    );
+    assert_eq!(
+        policies
+            .get(tenant_id, leaf, admin.clone())
+            .await
+            .expect("leaf should inherit only the root after clear")
+            .effective_layers
+            .len(),
+        1
+    );
+
+    assert!(matches!(
+        policies.get(foreign_tenant_id, root, admin.clone()).await,
+        Err(ForumError::CategoryNotFound(id)) if id == root
+    ));
+
+    let direct_overflow = db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO forum_category_audience_channels (tenant_id, category_id, channel_slug) VALUES (?, ?, ?)",
+            [
+                tenant_id.to_string().into(),
+                root.to_string().into(),
+                "channel-32".into(),
+            ],
+        ))
+        .await;
+    assert!(
+        direct_overflow.is_err(),
+        "database must reject a thirty-third channel relation"
+    );
+
+    let direct_update = db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "UPDATE forum_category_audience_channels SET channel_slug = ? WHERE tenant_id = ? AND category_id = ? AND channel_slug = ?",
+            [
+                "changed".into(),
+                tenant_id.to_string().into(),
+                root.to_string().into(),
+                "channel-00".into(),
+            ],
+        ))
+        .await;
+    assert!(
+        direct_update.is_err(),
+        "database must reject mutable relation-row updates"
+    );
+
+    let cross_tenant_policy = db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO forum_category_audience_policies (tenant_id, category_id, minimum_trust_level, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
+            [
+                foreign_tenant_id.to_string().into(),
+                root.to_string().into(),
+                1.into(),
+            ],
+        ))
+        .await;
+    assert!(
+        cross_tenant_policy.is_err(),
+        "database must reject a cross-tenant category policy relation"
+    );
+}

--- a/scripts/verify/verify-forum-audience-capability-ports.mjs
+++ b/scripts/verify/verify-forum-audience-capability-ports.mjs
@@ -51,6 +51,12 @@ if (contract.schema_version !== 1) {
 if (contract.task !== "FORUM-20F") {
   failures.push("forum audience capability contract must belong to FORUM-20F");
 }
+if (contract.delivered_through !== "FORUM-20G") {
+  failures.push("forum audience capability contract must be reconciled through FORUM-20G");
+}
+if (contract.composition?.storage !== true || contract.composition?.category_policy !== true) {
+  failures.push("forum audience capability contract must record delivered category persistence");
+}
 for (const [key, expected] of Object.entries({
   roles: 4,
   channels: 32,
@@ -80,7 +86,6 @@ if (contract.verification?.execution_status !== "not_run_by_implementation_agent
   failures.push("source publication must not claim unexecuted audience evidence");
 }
 for (const residual of [
-  "audience policy persistence and inheritance",
   "category topic and reply read composition",
   "create reply and moderate audience write policy",
   "topic narrowing commands",
@@ -93,6 +98,9 @@ for (const residual of [
   if (!contract.not_delivered?.includes(residual)) {
     failures.push(`forum audience capability contract must keep ${residual} open`);
   }
+}
+if (contract.not_delivered?.includes("audience policy persistence and inheritance")) {
+  failures.push("delivered category audience persistence must not remain open");
 }
 
 for (const marker of [
@@ -242,6 +250,7 @@ for (const marker of [
 
 for (const marker of [
   "Delivered in `FORUM-20F`",
+  "Delivered in `FORUM-20G`",
   "ForumAudienceFactsPort",
   "forum-audience-capability-ports.json",
   "audience_capability_contract",

--- a/scripts/verify/verify-forum-category-audience-policy.mjs
+++ b/scripts/verify/verify-forum-category-audience-policy.mjs
@@ -98,6 +98,7 @@ for (const table of contract.tables ?? []) {
   requireText(migration, table, `category audience migration is missing ${table}`);
 }
 for (const marker of [
+  "CREATE UNIQUE INDEX IF NOT EXISTS uq_forum_categories_tenant_id",
   "FOREIGN KEY (tenant_id, category_id)",
   "REFERENCES forum_categories (tenant_id, id)",
   "REFERENCES forum_category_audience_policies (tenant_id, category_id)",

--- a/scripts/verify/verify-forum-category-audience-policy.mjs
+++ b/scripts/verify/verify-forum-category-audience-policy.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-category-audience-policy.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const owner = read(contract.owner_file ?? "");
+const audience = read(contract.audience_contract_file ?? "");
+const migration = read(contract.migration_file ?? "");
+const migrations = read(contract.migration_registry_file ?? "");
+const entities = read(contract.entities_file ?? "");
+const services = read(contract.services_file ?? "");
+const crate = read(contract.crate_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("category audience policy contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20G") {
+  failures.push("category audience policy contract must belong to FORUM-20G");
+}
+for (const [key, expected] of Object.entries({
+  category_tree_nodes: 512,
+  category_tree_depth: 16,
+  roles_per_layer: 4,
+  channels_per_layer: 32,
+  groups_per_layer: 32,
+  allow_users_per_layer: 100,
+  deny_users_per_layer: 100,
+  maximum_trust_level: 100,
+})) {
+  if (contract.bounds?.[key] !== expected) {
+    failures.push(`category audience bound ${key} must remain ${expected}`);
+  }
+}
+if (contract.policy?.inheritance !== "root-to-target conjunction of non-empty local layers") {
+  failures.push("category audience inheritance must remain conjunctive root-to-target layers");
+}
+if (contract.policy?.storage !== "normalized typed tables without JSON") {
+  failures.push("category audience persistence must remain normalized and typed");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted category audience evidence");
+}
+for (const residual of [
+  "topic narrowing persistence and commands",
+  "category topic and reply read composition",
+  "create reply and moderate audience write policy",
+  "channel and group provider adapters",
+  "trust-level owner provider",
+  "visibility-scoped category and all-read mutations",
+  "notification search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`category audience contract must keep ${residual} open`);
+  }
+}
+
+for (const table of contract.tables ?? []) {
+  requireText(migration, table, `category audience migration is missing ${table}`);
+}
+for (const marker of [
+  "FOREIGN KEY (tenant_id, category_id)",
+  "REFERENCES forum_categories (tenant_id, id)",
+  "REFERENCES forum_category_audience_policies (tenant_id, category_id)",
+  "minimum_trust_level BETWEEN 0 AND 100",
+  "role IN ('super_admin', 'admin', 'manager', 'customer')",
+  "effect IN ('allow', 'deny')",
+  "forum_validate_category_audience_channel_insert",
+  "forum_validate_category_audience_group_insert",
+  "forum_validate_category_audience_user_insert",
+  "forum_reject_category_audience_relation_update",
+  "forum category audience channels exceed bounded limit",
+  "forum category audience groups exceed bounded limit",
+  "forum category audience users exceed bounded limit",
+]) {
+  requireText(migration, marker, `category audience migration is missing ${marker}`);
+}
+for (const forbidden of ["JSONB", "jsonb", "serde_json", "metadata"]) {
+  rejectText(migration, forbidden, `category audience migration must not use ${forbidden}`);
+}
+requireText(
+  migrations,
+  "m20260725_000001_add_forum_category_audience_policy",
+  "Forum migration registry must include the category audience migration",
+);
+
+for (const marker of [
+  "pub mod forum_category_audience_channel;",
+  "pub mod forum_category_audience_group;",
+  "pub mod forum_category_audience_policy;",
+  "pub mod forum_category_audience_role;",
+  "pub mod forum_category_audience_user;",
+]) {
+  requireText(entities, marker, `category audience entity registry is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub struct ForumCategoryAudiencePolicyLayer",
+  "pub struct ForumCategoryAudiencePolicy",
+  "pub struct SetForumCategoryAudiencePolicyInput",
+  "pub struct ForumCategoryAudiencePolicyService",
+  "pub async fn get(",
+  "pub async fn set(",
+  "enforce_scope(&security, Resource::ForumCategories, Action::Manage)?",
+  "lock_category_tree_in_tx(&txn, tenant_id).await?",
+  "forum_category_audience_policy::Entity::delete_many()",
+  "insert_roles(&txn, tenant_id, category_id, &constraints).await?",
+  "insert_channels(&txn, tenant_id, category_id, &constraints).await?",
+  "insert_groups(&txn, tenant_id, category_id, &constraints).await?",
+  "insert_users(&txn, tenant_id, category_id, &constraints).await?",
+  "ancestors.reverse()",
+  "effective_layers",
+  "Root-to-target non-empty layers. Every layer must allow the viewer.",
+  "ensure_storage_bound(",
+  "MAX_FORUM_CATEGORY_TREE_NODES + 1",
+  "MAX_FORUM_CATEGORY_TREE_DEPTH",
+]) {
+  requireText(owner, marker, `category audience owner is missing ${marker}`);
+}
+const setBlock = between(
+  owner,
+  "pub async fn set(",
+  "async fn insert_roles(",
+  "category audience owner set",
+);
+const deleteIndex = setBlock.indexOf("forum_category_audience_policy::Entity::delete_many()");
+const policyInsertIndex = setBlock.indexOf("forum_category_audience_policy::ActiveModel");
+const commitIndex = setBlock.indexOf("txn.commit().await?");
+if (
+  deleteIndex < 0 ||
+  policyInsertIndex < 0 ||
+  commitIndex < 0 ||
+  deleteIndex > policyInsertIndex ||
+  policyInsertIndex > commitIndex
+) {
+  failures.push("category audience owner must replace local layers atomically with delete then insert");
+}
+for (const forbidden of [
+  "rustok_groups",
+  "rustok_channel",
+  "groups::",
+  "channel::",
+  "forum_user_stat",
+  "serde_json::Value",
+]) {
+  rejectText(owner, forbidden, `category audience owner must not depend on ${forbidden}`);
+}
+
+for (const marker of [
+  "pub struct ForumAudienceConstraints",
+  "MAX_FORUM_AUDIENCE_CHANNELS",
+  "MAX_FORUM_AUDIENCE_GROUPS",
+  "MAX_FORUM_AUDIENCE_EXPLICIT_USERS",
+]) {
+  requireText(audience, marker, `shared audience contract is missing ${marker}`);
+}
+
+for (const marker of [
+  "mod category_audience;",
+  "ForumCategoryAudiencePolicyService",
+  "SetForumCategoryAudiencePolicyInput",
+]) {
+  requireText(services, marker, `services export is missing ${marker}`);
+}
+for (const marker of [
+  "ForumCategoryAudiencePolicy",
+  "ForumCategoryAudiencePolicyLayer",
+  "ForumCategoryAudiencePolicyService",
+  "SetForumCategoryAudiencePolicyInput",
+]) {
+  requireText(crate, marker, `crate export is missing ${marker}`);
+}
+
+for (const marker of [
+  "category_audience_layers_inherit_conjunctively_and_remain_bounded",
+  "vec![root, child]",
+  "empty constraints should clear the local layer",
+  "database must reject a thirty-third channel relation",
+  "database must reject mutable relation-row updates",
+  "database must reject a cross-tenant category policy relation",
+]) {
+  requireText(testSource, marker, `category audience SQLite scenario is missing ${marker}`);
+}
+
+for (const marker of [
+  "Delivered in `FORUM-20F`",
+  "Delivered in `FORUM-20G`",
+  "ForumCategoryAudiencePolicyService",
+  "forum-category-audience-policy.json",
+  "category_audience_policy_sqlite",
+  "verify-forum-category-audience-policy.mjs",
+]) {
+  requireText(plan, marker, `canonical FORUM-20 plan is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum category audience policy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum category audience policy contract is source-ready.");

--- a/scripts/verify/verify-forum-category-audience-policy.mjs
+++ b/scripts/verify/verify-forum-category-audience-policy.mjs
@@ -109,6 +109,7 @@ for (const marker of [
   "forum_validate_category_audience_group_insert",
   "forum_validate_category_audience_user_insert",
   "forum_reject_category_audience_relation_update",
+  "forum_category_audience_policy_update",
   "forum category audience channels exceed bounded limit",
   "forum category audience groups exceed bounded limit",
   "forum category audience users exceed bounded limit",
@@ -142,6 +143,7 @@ for (const marker of [
   "pub async fn get(",
   "pub async fn set(",
   "enforce_scope(&security, Resource::ForumCategories, Action::Manage)?",
+  "Policy details may contain explicit user and group identifiers",
   "lock_category_tree_in_tx(&txn, tenant_id).await?",
   "forum_category_audience_policy::Entity::delete_many()",
   "insert_roles(&txn, tenant_id, category_id, &constraints).await?",
@@ -156,6 +158,20 @@ for (const marker of [
   "MAX_FORUM_CATEGORY_TREE_DEPTH",
 ]) {
   requireText(owner, marker, `category audience owner is missing ${marker}`);
+}
+const getBlock = between(
+  owner,
+  "pub async fn get(",
+  "pub async fn set(",
+  "category audience owner get",
+);
+for (const marker of [
+  "Action::Manage",
+  "let txn = self.db.begin().await?",
+  "lock_category_tree_in_tx(&txn, tenant_id).await?",
+  "txn.commit().await?",
+]) {
+  requireText(getBlock, marker, `managed category audience get is missing ${marker}`);
 }
 const setBlock = between(
   owner,
@@ -214,9 +230,12 @@ for (const marker of [
 for (const marker of [
   "category_audience_layers_inherit_conjunctively_and_remain_bounded",
   "vec![root, child]",
+  "SecurityContext::public_read()",
+  "Err(ForumError::Forbidden(_))",
   "empty constraints should clear the local layer",
   "database must reject a thirty-third channel relation",
   "database must reject mutable relation-row updates",
+  "database must reject mutable policy-row updates",
   "database must reject a cross-tenant category policy relation",
 ]) {
   requireText(testSource, marker, `category audience SQLite scenario is missing ${marker}`);


### PR DESCRIPTION
## Summary

- deliver FORUM-20G normalized category audience persistence and inheritance
- persist one optional local category audience layer plus typed role, channel, group, explicit allow and explicit deny relations without JSON
- enforce tenant-composite category/policy integrity, typed role/trust/effect checks, canonical channel slugs, non-nil identities and bounded direct inserts
- make policy and relation rows immutable; owner replacement uses one delete-plus-insert transaction under the tenant category-tree lock
- resolve effective policy as a root-to-target conjunction of non-empty local layers so a child cannot broaden an ancestor
- treat an empty input as clearing only the local layer and restoring inheritance
- restrict policy details containing explicit user/group identifiers to `forum_categories:manage`
- add source-ready SQLite owner evidence, machine contracts, cumulative FORUM-20F reconciliation, verifiers and canonical-plan synchronization

## Compatibility

- the migration creates empty normalized tables and requires no backfill
- existing category/topic/reply reads and writes remain unchanged because richer audience layers are not composed into owner reads yet
- no transport field, endpoint or UI is added
- no direct dependency on Channel, Groups or their private tables is introduced
- missing optional trust/channel/group adapters cannot broaden a future decision
- topic narrowing, provider adapters, richer read composition, write audiences, remaining consumers and runtime evidence remain open

## Validation

Not run at the maintainer's request. Intended commands:

```bash
cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture
node scripts/verify/verify-forum-audience-capability-ports.mjs
node scripts/verify/verify-forum-category-audience-policy.mjs
node scripts/verify/verify-forum-topic-visibility-scope.mjs
node scripts/verify/verify-forum-category-visibility-policy.mjs
node scripts/verify/verify-forum-owner-read-visibility.mjs
node scripts/verify/verify-forum-category-owner-read-visibility.mjs
cargo xtask module validate forum
```
