### PR TITLE
fix(index): require cross-report PostgreSQL metadata

### DIFF
--- a/scripts/verify/check-index-storage-read-ordering.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.mjs
@@ -78,11 +78,8 @@ const requireDatabaseMetadata = (report, label) => {
   return database;
 };
 
-const requireSessionMetadata = (read, directory) => {
-  const database = requireDatabaseMetadata(read, `${directory} read`);
-  requireCanonicalSessionMetadata(database, `${directory} read.database`);
-  return database;
-};
+const requireSessionMetadata = (read, directory) =>
+  requireDatabaseMetadata(read, `${directory} read`);
 
 const requireSameDatabaseMetadata = (expected, actual, label) => {
   for (const field of canonicalDatabaseMetadataFields) {
@@ -215,7 +212,6 @@ const readReport = (directory, filename = 'read-report.json') => {
 export const validatePacketReadOrdering = (directory) => {
   const read = requireObject(readReport(directory), `${directory} read report`);
   const readDatabase = requireSessionMetadata(read, directory);
-  requireSessionMetadata(read, directory);
   requireExactNames(read.source_workloads, canonicalReadWorkloads, `${directory} source workload order`);
   for (const workload of read.source_workloads) {
     requireObject(workload, `${directory} source/${workload?.name ?? 'unknown'}`);

--- a/scripts/verify/check-index-storage-read-ordering.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.mjs
@@ -4,6 +4,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { comparableDatabaseFields } from './index-storage-database-settings-contract.mjs';
+
 const prefix = '[check-index-storage-read-ordering]';
 const canonicalPrototypes = ['jsonb', 'typed_eav', 'hot_projection'];
 const canonicalReadWorkloads = [
@@ -28,6 +30,11 @@ const canonicalSessionMetadata = new Map([
   ['date_style', 'ISO, YMD'],
   ['extra_float_digits', '3'],
 ]);
+const canonicalDatabaseMetadataFields = Object.freeze([
+  'version',
+  ...comparableDatabaseFields,
+]);
+const canonicalDatabaseMetadataFieldSet = [...canonicalDatabaseMetadataFields].sort();
 
 const fail = (message) => {
   throw new Error(message);
@@ -51,11 +58,38 @@ const requireObject = (value, label) => {
   return value;
 };
 
-const requireSessionMetadata = (read, directory) => {
-  const database = requireObject(read.database, `${directory} read.database`);
+const requireCanonicalSessionMetadata = (database, label) => {
   for (const [field, expected] of canonicalSessionMetadata) {
     if (database[field] !== expected) {
-      fail(`${directory} read.database.${field} must be ${expected}; got ${database[field]}`);
+      fail(`${label}.${field} must be ${expected}; got ${database[field]}`);
+    }
+  }
+};
+
+const requireDatabaseMetadata = (report, label) => {
+  const database = requireObject(report.database, `${label}.database`);
+  const actualFields = Object.keys(database).sort();
+  if (!sameJson(actualFields, canonicalDatabaseMetadataFieldSet)) {
+    fail(
+      `${label}.database fields mismatch: expected ${canonicalDatabaseMetadataFields.join(', ')}, got ${actualFields.join(', ')}`,
+    );
+  }
+  requireCanonicalSessionMetadata(database, `${label}.database`);
+  return database;
+};
+
+const requireSessionMetadata = (read, directory) => {
+  const database = requireDatabaseMetadata(read, `${directory} read`);
+  requireCanonicalSessionMetadata(database, `${directory} read.database`);
+  return database;
+};
+
+const requireSameDatabaseMetadata = (expected, actual, label) => {
+  for (const field of canonicalDatabaseMetadataFields) {
+    if (actual[field] !== expected[field]) {
+      fail(
+        `${label}.database.${field} must match read-report.json database metadata; expected ${expected[field]}, got ${actual[field]}`,
+      );
     }
   }
 };
@@ -168,18 +202,19 @@ export const requireTerminalReadOrdering = (sql, workloadName, label) => {
   }
 };
 
-const readReport = (directory) => {
-  const filename = path.join(directory, 'read-report.json');
-  if (!existsSync(filename)) fail(`missing evidence file: ${filename}`);
+const readReport = (directory, filename = 'read-report.json') => {
+  const reportPath = path.join(directory, filename);
+  if (!existsSync(reportPath)) fail(`missing evidence file: ${reportPath}`);
   try {
-    return JSON.parse(readFileSync(filename, 'utf8'));
+    return JSON.parse(readFileSync(reportPath, 'utf8'));
   } catch (error) {
-    fail(`invalid JSON in ${filename}: ${error.message}`);
+    fail(`invalid JSON in ${reportPath}: ${error.message}`);
   }
 };
 
 export const validatePacketReadOrdering = (directory) => {
   const read = requireObject(readReport(directory), `${directory} read report`);
+  const readDatabase = requireSessionMetadata(read, directory);
   requireSessionMetadata(read, directory);
   requireExactNames(read.source_workloads, canonicalReadWorkloads, `${directory} source workload order`);
   for (const workload of read.source_workloads) {
@@ -203,6 +238,12 @@ export const validatePacketReadOrdering = (directory) => {
         `${directory} ${prototype.prototype}/${workload.name}`,
       );
     }
+  }
+
+  for (const filename of ['mutation-report.json', 'maintenance-report.json']) {
+    const report = requireObject(readReport(directory, filename), `${directory} ${filename}`);
+    const database = requireDatabaseMetadata(report, `${directory} ${filename}`);
+    requireSameDatabaseMetadata(readDatabase, database, `${directory} ${filename}`);
   }
 };
 
@@ -232,7 +273,7 @@ const main = () => {
   const inputs = parseArgs();
   if (inputs === null) return;
   for (const input of inputs) validatePacketReadOrdering(input);
-  console.log(`${prefix} deterministic session metadata and executable terminal ordering verified for ${inputs.length} evidence packet(s)`);
+  console.log(`${prefix} deterministic session metadata and executable terminal ordering verified across read, mutation, and maintenance reports for ${inputs.length} evidence packet(s)`);
 };
 
 const isMain = process.argv[1]

--- a/scripts/verify/check-index-storage-read-ordering.test.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -21,6 +21,19 @@ const workloads = [
   'keyset_page',
   'exact_count',
 ];
+const databaseMetadata = () => ({
+  version: 'PostgreSQL 16 fixture',
+  server_version_num: '160000',
+  shared_buffers: '128MB',
+  effective_cache_size: '4GB',
+  work_mem: '4MB',
+  random_page_cost: '4',
+  jit: 'off',
+  standard_conforming_strings: 'on',
+  timezone: 'UTC',
+  date_style: 'ISO, YMD',
+  extra_float_digits: '3',
+});
 
 const sql = (relation, workload) => {
   if (workload === 'exact_count') {
@@ -33,12 +46,7 @@ const sql = (relation, workload) => {
 };
 
 const report = () => ({
-  database: {
-    standard_conforming_strings: 'on',
-    timezone: 'UTC',
-    date_style: 'ISO, YMD',
-    extra_float_digits: '3',
-  },
+  database: databaseMetadata(),
   source_workloads: workloads.map((name) => ({
     name,
     sql: `${sql('idx_bench_source.product', name)}   \n`,
@@ -55,10 +63,14 @@ const report = () => ({
 const withPacket = (mutate, callback) => {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-read-ordering-'));
   try {
-    const value = report();
-    mutate?.(value);
+    const read = report();
+    const mutation = { database: databaseMetadata() };
+    const maintenance = { database: databaseMetadata() };
+    mutate?.(read, mutation, maintenance);
     mkdirSync(root, { recursive: true });
-    writeFileSync(path.join(root, 'read-report.json'), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    writeFileSync(path.join(root, 'read-report.json'), `${JSON.stringify(read, null, 2)}\n`, 'utf8');
+    writeFileSync(path.join(root, 'mutation-report.json'), `${JSON.stringify(mutation, null, 2)}\n`, 'utf8');
+    writeFileSync(path.join(root, 'maintenance-report.json'), `${JSON.stringify(maintenance, null, 2)}\n`, 'utf8');
     callback(root);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -85,13 +97,31 @@ test('accepts canonical terminal ordering with trailing whitespace', () => {
 test('rejects missing deterministic session metadata', () => {
   expectFailure((value) => {
     delete value.database.standard_conforming_strings;
-  }, /read\.database\.standard_conforming_strings must be on; got undefined/u);
+  }, /read\.database fields mismatch/u);
 });
 
 test('rejects deterministic session metadata drift', () => {
   expectFailure((value) => {
     value.database.timezone = 'Europe/Moscow';
   }, /read\.database\.timezone must be UTC; got Europe\/Moscow/u);
+});
+
+test('rejects mutation database metadata drift from the read session', () => {
+  expectFailure((_read, mutation) => {
+    mutation.database.work_mem = '8MB';
+  }, /mutation-report\.json\.database\.work_mem must match read-report\.json database metadata/u);
+});
+
+test('rejects maintenance report without exact database metadata fields', () => {
+  expectFailure((_read, _mutation, maintenance) => {
+    delete maintenance.database.version;
+  }, /maintenance-report\.json\.database fields mismatch/u);
+});
+
+test('rejects a mutation report without observed database metadata', () => {
+  expectFailure((_read, mutation) => {
+    delete mutation.database;
+  }, /mutation-report\.json\.database must be an object/u);
 });
 
 test('accepts comment tokens inside strings and comments after executable ordering', () => {

--- a/scripts/verify/compare-index-storage-evidence.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence.test.mjs
@@ -54,6 +54,20 @@ const scaleValues = {
   },
 };
 
+const databaseMetadata = (overrides = {}) => ({
+  version: 'PostgreSQL 16 fixture',
+  server_version_num: '160000',
+  shared_buffers: '128MB',
+  effective_cache_size: '4GB',
+  work_mem: '4MB',
+  random_page_cost: '4',
+  jit: 'off',
+  standard_conforming_strings: 'on',
+  timezone: 'UTC',
+  date_style: 'ISO, YMD',
+  extra_float_digits: '3',
+  ...overrides,
+});
 const digest = (workloadIndex, scale) => {
   const offset = scale === '100k' ? 1 : 8;
   return ((workloadIndex + offset) % 16).toString(16).repeat(32);
@@ -137,20 +151,7 @@ function writePacket(root, scale, overrides = {}) {
   const read = {
     generated_at: generatedAt,
     result_digest_contract: overrides.readDigestContract ?? resultDigestContract,
-    database: {
-      version: 'PostgreSQL 16 fixture',
-      server_version_num: '160000',
-      shared_buffers: '128MB',
-      effective_cache_size: '4GB',
-      work_mem: '4MB',
-      random_page_cost: '4',
-      jit: 'off',
-      standard_conforming_strings: 'on',
-      timezone: 'UTC',
-      date_style: 'ISO, YMD',
-      extra_float_digits: '3',
-      ...overrides.database,
-    },
+    database: databaseMetadata(overrides.database),
     dataset: {
       scale: values.serialized,
       tenants: values.tenants,
@@ -191,6 +192,7 @@ function writePacket(root, scale, overrides = {}) {
 
   const mutation = {
     generated_at: generatedAt,
+    database: databaseMetadata({ ...overrides.database, ...overrides.mutationDatabase }),
     dataset_scale: values.debug,
     repetitions: 3,
     prototypes: prototypes.map((prototype) => ({
@@ -212,6 +214,7 @@ function writePacket(root, scale, overrides = {}) {
 
   const maintenance = {
     generated_at: generatedAt,
+    database: databaseMetadata({ ...overrides.database, ...overrides.maintenanceDatabase }),
     dataset_scale: values.serialized,
     cycles: overrides.maintenanceCycles ?? 5,
     prototypes: prototypes.map((prototype, index) => {
@@ -392,4 +395,10 @@ test('rejects observed session metadata drift before comparison output is accept
     assert.notEqual(result.status, 0, 'expected comparator to fail closed');
     assert.match(result.stderr, /read\.database\.timezone must be UTC; got Europe\/Moscow/u);
   });
+});
+
+test('rejects mutation session metadata drift within one packet', () => {
+  withFixture((root) => expectFailure(root, {
+    mutationDatabase: { work_mem: '8MB' },
+  }, /mutation-report\.json\.database\.work_mem must match read-report\.json database metadata/u));
 });

--- a/scripts/verify/index-storage-standalone-tools.test.mjs
+++ b/scripts/verify/index-storage-standalone-tools.test.mjs
@@ -18,6 +18,19 @@ const workloads = [
   'keyset_page',
   'exact_count',
 ];
+const databaseMetadata = () => ({
+  version: 'PostgreSQL 16 fixture',
+  server_version_num: '160000',
+  shared_buffers: '128MB',
+  effective_cache_size: '4GB',
+  work_mem: '4MB',
+  random_page_cost: '4',
+  jit: 'off',
+  standard_conforming_strings: 'on',
+  timezone: 'UTC',
+  date_style: 'ISO, YMD',
+  extra_float_digits: '3',
+});
 
 const readSql = (relation, workload) => {
   if (workload === 'exact_count') return `SELECT count(*)::bigint AS result_count FROM ${relation}`;
@@ -28,12 +41,7 @@ const readSql = (relation, workload) => {
 };
 
 const report = () => ({
-  database: {
-    standard_conforming_strings: 'on',
-    timezone: 'UTC',
-    date_style: 'ISO, YMD',
-    extra_float_digits: '3',
-  },
+  database: databaseMetadata(),
   source_workloads: workloads.map((name) => ({
     name,
     sql: readSql('idx_bench_source.product', name),
@@ -53,6 +61,13 @@ const withPacket = (mutate, callback) => {
     const value = report();
     mutate?.(value);
     writeFileSync(path.join(root, 'read-report.json'), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    for (const filename of ['mutation-report.json', 'maintenance-report.json']) {
+      writeFileSync(
+        path.join(root, filename),
+        `${JSON.stringify({ database: databaseMetadata() }, null, 2)}\n`,
+        'utf8',
+      );
+    }
     callback(root);
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/verify/index-storage-tooling.test.mjs
+++ b/scripts/verify/index-storage-tooling.test.mjs
@@ -21,6 +21,19 @@ const prototypes = [
   { prototype: 'typed_eav', relation: 'idx_bench_eav.entity' },
   { prototype: 'hot_projection', relation: 'idx_bench_hot.product' },
 ];
+const databaseMetadata = () => ({
+  version: 'PostgreSQL 16 fixture',
+  server_version_num: '160000',
+  shared_buffers: '128MB',
+  effective_cache_size: '4GB',
+  work_mem: '4MB',
+  random_page_cost: '4',
+  jit: 'off',
+  standard_conforming_strings: 'on',
+  timezone: 'UTC',
+  date_style: 'ISO, YMD',
+  extra_float_digits: '3',
+});
 
 const run = (...args) => spawnSync(process.execPath, [script, ...args], {
   encoding: 'utf8',
@@ -37,12 +50,7 @@ const readSql = (relation, workload) => {
 };
 
 const orderingReport = () => ({
-  database: {
-    standard_conforming_strings: 'on',
-    timezone: 'UTC',
-    date_style: 'ISO, YMD',
-    extra_float_digits: '3',
-  },
+  database: databaseMetadata(),
   source_workloads: readWorkloads.map((name) => ({
     name,
     sql: readSql('idx_bench_source.product', name),
@@ -59,6 +67,13 @@ const withOrderingPacket = (mutate, callback) => {
     const report = orderingReport();
     mutate(report);
     writeFileSync(path.join(root, 'read-report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    for (const filename of ['mutation-report.json', 'maintenance-report.json']) {
+      writeFileSync(
+        path.join(root, filename),
+        `${JSON.stringify({ database: databaseMetadata() }, null, 2)}\n`,
+        'utf8',
+      );
+    }
     callback(root);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- extend the official Index packet preflight to require exact PostgreSQL database/session metadata fields in read, mutation, and maintenance reports;
- require all eleven archived fields (`version` plus the ten comparison fields) to match the read session exactly;
- keep deterministic session-value checks and executable terminal-ordering checks ahead of the byte-preserved validator/comparator cores;
- update direct, routed, standalone, and comparison fixtures to model the three-session packet contract and reject intra-packet drift.

## Why

Mutation and maintenance evidence now archive metadata from their own PostgreSQL sessions, but the packet preflight still inspected only `read-report.json`. A packet could therefore carry different planner/session settings for mutation or maintenance measurements and still reach the canonical evidence core. This change closes that gap fail-closed.

## Scope

Five verifier/fixture files. No Rust benchmark workload, packet provenance version, byte-preserved validator/comparator core, candidate SQL, production Index API, storage decision, or migration is changed.

## Validation

Tests, Node/Cargo commands, formatting, verifier execution, workflow runs, and benchmarks were not run, per repository-owner instruction. The diff was reviewed statically for the exact field set, cross-report comparison order, preserved SQL lexer behavior, existing guard markers, and fixture parity.