### PR TITLE
refactor(index): share read database metadata

### DIFF
--- a/ops/benches/src/index_storage/runner.rs
+++ b/ops/benches/src/index_storage/runner.rs
@@ -7,24 +7,11 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::{
-    BenchmarkConfig, DatasetConfig, Prototype, RESULT_DIGEST_CONTRACT, Workload,
-    connect_benchmark_database, explain::parse_read_explain_metrics, full_prototype_sql,
+    BenchmarkConfig, DatabaseMetadata, DatasetConfig, Prototype, RESULT_DIGEST_CONTRACT, Workload,
+    connect_benchmark_database, ensure_database_metadata_stable,
+    explain::parse_read_explain_metrics, full_prototype_sql, read_database_metadata,
     read_workload_contract, source_dataset_sql, source_workloads, workloads,
 };
-
-const DATABASE_METADATA_SQL: &str = concat!(
-    "SELECT version() AS version,",
-    " current_setting('server_version_num') AS server_version_num,",
-    " current_setting('shared_buffers') AS shared_buffers,",
-    " current_setting('effective_cache_size') AS effective_cache_size,",
-    " current_setting('work_mem') AS work_mem,",
-    " current_setting('random_page_cost') AS random_page_cost,",
-    " current_setting('jit') AS jit,",
-    " current_setting('standard_conforming_strings') AS standard_conforming_strings,",
-    " current_setting('TimeZone') AS timezone,",
-    " current_setting('DateStyle') AS date_style,",
-    " current_setting('extra_float_digits') AS extra_float_digits",
-);
 
 #[derive(Debug, Serialize)]
 pub struct BenchmarkReport {
@@ -37,21 +24,6 @@ pub struct BenchmarkReport {
     pub source_link_rows: i64,
     pub source_workloads: Vec<SourceWorkloadReport>,
     pub prototypes: Vec<PrototypeReport>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct DatabaseMetadata {
-    pub version: String,
-    pub server_version_num: String,
-    pub shared_buffers: String,
-    pub effective_cache_size: String,
-    pub work_mem: String,
-    pub random_page_cost: String,
-    pub jit: String,
-    pub standard_conforming_strings: String,
-    pub timezone: String,
-    pub date_style: String,
-    pub extra_float_digits: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -124,6 +96,7 @@ pub async fn run(config: &BenchmarkConfig) -> Result<BenchmarkReport> {
         prototypes.push(run_prototype(&db, prototype, config).await?);
     }
     validate_semantic_parity(&source_workload_reports, &prototypes)?;
+    ensure_database_metadata_stable(&db, &database, "read benchmark").await?;
 
     Ok(BenchmarkReport {
         generated_at: Utc::now(),
@@ -300,30 +273,6 @@ async fn configure_session(db: &DatabaseConnection) -> Result<()> {
     Ok(())
 }
 
-async fn read_database_metadata(db: &DatabaseConnection) -> Result<DatabaseMetadata> {
-    let row = db
-        .query_one(Statement::from_string(
-            DbBackend::Postgres,
-            DATABASE_METADATA_SQL.to_owned(),
-        ))
-        .await?
-        .context("database metadata query returned no row")?;
-
-    Ok(DatabaseMetadata {
-        version: row.try_get("", "version")?,
-        server_version_num: row.try_get("", "server_version_num")?,
-        shared_buffers: row.try_get("", "shared_buffers")?,
-        effective_cache_size: row.try_get("", "effective_cache_size")?,
-        work_mem: row.try_get("", "work_mem")?,
-        random_page_cost: row.try_get("", "random_page_cost")?,
-        jit: row.try_get("", "jit")?,
-        standard_conforming_strings: row.try_get("", "standard_conforming_strings")?,
-        timezone: row.try_get("", "timezone")?,
-        date_style: row.try_get("", "date_style")?,
-        extra_float_digits: row.try_get("", "extra_float_digits")?,
-    })
-}
-
 async fn schema_size_bytes(db: &DatabaseConnection, schema: &str) -> Result<i64> {
     let statement = Statement::from_sql_and_values(
         DbBackend::Postgres,
@@ -447,20 +396,5 @@ mod tests {
         assert_eq!(dataset.total_entity_rows(), 1_216);
         assert_eq!(dataset.total_eav_field_rows(), 5_632);
         assert_eq!(dataset.total_link_rows(), 2_400);
-    }
-
-    #[test]
-    fn database_metadata_query_observes_deterministic_session() {
-        for marker in [
-            "current_setting('standard_conforming_strings') AS standard_conforming_strings",
-            "current_setting('TimeZone') AS timezone",
-            "current_setting('DateStyle') AS date_style",
-            "current_setting('extra_float_digits') AS extra_float_digits",
-        ] {
-            assert!(
-                DATABASE_METADATA_SQL.contains(marker),
-                "database metadata query is missing {marker}"
-            );
-        }
     }
 }

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -12,6 +12,9 @@ const fail = (message) => {
 const benchmarkModule = read('ops/benches/src/index_storage/mod.rs');
 const benchmarkBinary = read('ops/benches/src/bin/index_storage_benchmark.rs');
 const benchmarkRunner = read('ops/benches/src/index_storage/runner.rs');
+const databaseMetadata = read('ops/benches/src/index_storage/database_metadata.rs');
+const mutationRunner = read('ops/benches/src/index_storage/mutation_runner.rs');
+const maintenanceRunner = read('ops/benches/src/index_storage/maintenance_runner.rs');
 const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
@@ -65,8 +68,9 @@ requireMarkers(connection, 'benchmark session contract', [
   'fn benchmark_session_contract_is_explicit_and_deterministic()',
 ]);
 
-requireMarkers(benchmarkRunner, 'observed database metadata', [
+requireMarkers(databaseMetadata, 'shared observed database metadata', [
   'const DATABASE_METADATA_SQL',
+  '#[derive(Debug, Clone, PartialEq, Eq, Serialize)]',
   'pub struct DatabaseMetadata',
   'pub standard_conforming_strings: String',
   'pub timezone: String',
@@ -80,9 +84,35 @@ requireMarkers(benchmarkRunner, 'observed database metadata', [
   'timezone: row.try_get("", "timezone")?',
   'date_style: row.try_get("", "date_style")?',
   'extra_float_digits: row.try_get("", "extra_float_digits")?',
-  'fn database_metadata_query_observes_deterministic_session()',
+  'pub(crate) async fn read_database_metadata',
+  'pub(crate) async fn ensure_database_metadata_stable',
+  'fn database_metadata_query_observes_comparable_session_settings()',
 ]);
+for (const [label, content, benchmark] of [
+  ['read runner', benchmarkRunner, 'read benchmark'],
+  ['mutation runner', mutationRunner, 'mutation benchmark'],
+  ['maintenance runner', maintenanceRunner, 'maintenance benchmark'],
+]) {
+  requireMarkers(content, `${label} shared database metadata`, [
+    'DatabaseMetadata',
+    'read_database_metadata',
+    'ensure_database_metadata_stable',
+    'pub database: DatabaseMetadata',
+    `ensure_database_metadata_stable(&db, &database, "${benchmark}").await?;`,
+  ]);
+  for (const forbidden of [
+    'const DATABASE_METADATA_SQL',
+    'pub struct DatabaseMetadata',
+    'async fn read_database_metadata',
+  ]) {
+    if (content.includes(forbidden)) {
+      fail(`${label} duplicated shared PostgreSQL metadata ownership: ${forbidden}`);
+    }
+  }
+}
 requireMarkers(benchmarkModule, 'benchmark report writer', [
+  'pub use database_metadata::DatabaseMetadata;',
+  'ensure_database_metadata_stable, read_database_metadata',
   'pub use runner::{BenchmarkReport, run, write_report};',
   'write_report(&config.output_path, &report)?',
 ]);
@@ -152,6 +182,9 @@ requireMarkers(fixture, 'read ordering fixture', [
   "test('accepts canonical terminal ordering with trailing whitespace'",
   "test('rejects missing deterministic session metadata'",
   "test('rejects deterministic session metadata drift'",
+  "test('rejects mutation database metadata drift from the read session'",
+  "test('rejects maintenance report without exact database metadata fields'",
+  "test('rejects a mutation report without observed database metadata'",
   "test('accepts comment tokens inside strings and comments after executable ordering'",
   "test('rejects a source ordering marker that exists only in a nested query'",
   "test('rejects a candidate ordering marker that exists only in a block comment'",
@@ -169,6 +202,7 @@ requireMarkers(comparatorFixture, 'comparison evidence fixture', [
   'assert.deepEqual(report.methodology.comparable_database_fields, comparableDatabaseFields);',
   'database_settings_source',
   "test('rejects observed session metadata drift before comparison output is accepted'",
+  "test('rejects mutation session metadata drift within one packet'",
 ]);
 
 requireMarkers(databaseSettingsContract, 'shared database settings contract', [
@@ -320,4 +354,4 @@ requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);
 
-console.log('[verify-index-storage-read-ordering-contract] enforced and observed PostgreSQL session metadata, shared cross-scale database settings, ADR-bound comparison methodology, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');
+console.log('[verify-index-storage-read-ordering-contract] shared Rust PostgreSQL metadata ownership, start/end session stability, cross-report equality, cross-scale database settings, ADR-bound comparison methodology, session-complete fixtures, executable SQL lexer, PostgreSQL escape strings, standalone entrypoints, public command order, and workflows are consistent');


### PR DESCRIPTION
## Summary

- remove the duplicate `DatabaseMetadata` type and metadata SQL from the read benchmark runner;
- use the shared Rust metadata reader already used by mutation and maintenance evidence;
- re-read and compare the read session metadata after all source and prototype workloads before serializing `read-report.json`;
- strengthen the permanent contract guard so all three runners must use the shared owner and cannot reintroduce local metadata implementations.

## Why

After mutation and maintenance moved to a shared metadata module, the read runner still maintained a parallel type, query, and test. That created schema-drift risk between the three reports and left read evidence without the same end-of-run session stability check. This refactor establishes one Rust owner for all archived PostgreSQL database/session metadata while preserving the report JSON shape.

## Scope

Two files. No workload SQL, evidence schema, packet version, byte-preserved validator/comparator core, workflow, production Index API, storage decision, or migration is changed.

## Validation

Tests, Cargo/Node commands, formatting, verifier execution, workflow runs, and benchmarks were not run, per repository-owner instruction. The diff was reviewed statically for shared imports, report field compatibility, start/end metadata ordering, duplicate-owner removal, and guard marker accuracy.