### PR TITLE
Remove legacy storefront line item test import

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/tests/mod.rs
+++ b/crates/rustok-commerce/src/controllers/store/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::{
     MODULE_SLUG, RequestedCartContext, StoreAddCartLineItemInput, StoreCartContextPatch,
     StoreLineItemResolution, cart_context_metadata, checkout_actor_id, ensure_store_cart_access,
-    merge_metadata, requested_cart_context, resolve_store_line_item_input,
+    merge_metadata, requested_cart_context,
 };
 use axum::Router;
 use axum::body::{Body, to_bytes};

--- a/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
@@ -17,6 +17,7 @@ const boundary = read(
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const inventoryOwner = read('crates/rustok-inventory/src/services/public_channel.rs');
 const productTests = read('crates/rustok-commerce/src/controllers/store/tests/products.rs');
+const testRoot = read('crates/rustok-commerce/src/controllers/store/tests/mod.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -112,6 +113,17 @@ for (const value of [
   '"commerce_store_invalid"',
   'does not have enough available inventory for the current channel',
 ]) forbidText(productTests, value, 'legacy inventory test contract');
+
+forbidText(
+  testRoot,
+  'resolve_store_line_item_input,',
+  'legacy line-item resolver test-root import',
+);
+requireText(
+  testRoot,
+  'StoreLineItemResolution,',
+  'shared line-item resolution input test import',
+);
 
 for (const [value, label] of [
   ['owner = "rustok_product.persistence"', 'catalog persistence owner'],


### PR DESCRIPTION
## Summary

- remove the stale `resolve_store_line_item_input` re-export from the storefront test root after product tests migrated to the typed `line_item_resolution.rs` source;
- preserve the shared `StoreLineItemResolution` input type import used by those tests;
- extend the existing storefront line-item verifier to reject reintroducing the legacy resolver import while requiring the shared input type.

## Why

PR #2137 made `tests/products.rs` include and import the typed line-item resolver directly. The parent test module still imported the legacy resolver with the same name, leaving an unnecessary dependency on the duplicate implementation and a potential name conflict in the child test module.

## Scope

Two files only. No production controller, router, pricing, catalog, inventory, DTO, or runtime behavior changes.

## Validation

- branch is directly ahead of current `main` by one commit;
- `tests/mod.rs` changes by one import entry only;
- verifier changes only add the test-root source read and two import assertions;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.