### PR TITLE
Harden workflow step HTTP errors

### DIFF
--- a/crates/rustok-workflow/src/controllers/steps.rs
+++ b/crates/rustok-workflow/src/controllers/steps.rs
@@ -1,13 +1,91 @@
 use axum::{
     Json,
     extract::{Path, State},
+    http::StatusCode,
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext, has_any_effective_permission};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
-use crate::{CreateWorkflowStepInput, UpdateWorkflowStepInput, WorkflowService};
+use crate::{
+    CreateWorkflowStepInput, UpdateWorkflowStepInput, WorkflowError, WorkflowService,
+};
+
+fn map_workflow_step_error(
+    error: WorkflowError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    workflow_id: Uuid,
+    step_id: Option<Uuid>,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        WorkflowError::NotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "workflow_not_found",
+            "Workflow was not found",
+            "workflow_not_found",
+        ),
+        WorkflowError::StepNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "workflow_step_not_found",
+            "Workflow step was not found",
+            "step_not_found",
+        ),
+        WorkflowError::ExecutionNotFound(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_step_failed",
+            "Workflow step operation could not be completed safely",
+            "unexpected_execution_not_found",
+        ),
+        WorkflowError::NotActive(_) => (
+            StatusCode::CONFLICT,
+            "workflow_state_conflict",
+            "Workflow operation conflicts with the current state",
+            "state_conflict",
+        ),
+        WorkflowError::UnknownStepType(_)
+        | WorkflowError::InvalidTriggerConfig(_)
+        | WorkflowError::InvalidStepConfig(_) => (
+            StatusCode::BAD_REQUEST,
+            "workflow_step_invalid",
+            "Workflow step request is invalid",
+            "validation",
+        ),
+        WorkflowError::StepFailed(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_step_failed",
+            "Workflow step operation could not be completed safely",
+            "step_failed",
+        ),
+        WorkflowError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "workflow_storage_unavailable",
+            "Workflow storage is temporarily unavailable",
+            "database",
+        ),
+        WorkflowError::Serialization(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_step_failed",
+            "Workflow step operation could not be completed safely",
+            "serialization",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_workflow.workflow_service",
+        operation,
+        tenant_id = %tenant_id,
+        workflow_id = %workflow_id,
+        step_id = ?step_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "workflow_step_http",
+        "workflow step operation failed"
+    );
+    HttpError::new(status, code, message)
+}
 
 pub async fn add_step(
     State(runtime): State<crate::controllers::WorkflowHttpRuntime>,
@@ -22,7 +100,7 @@ pub async fn add_step(
     let step_id = service
         .add_step(tenant.id, id, input)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_step_error(error, "add_step", tenant.id, id, None))?;
     Ok(Json(serde_json::json!({ "id": step_id })))
 }
 
@@ -39,7 +117,9 @@ pub async fn update_step(
     service
         .update_step(tenant.id, id, step_id, input)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_workflow_step_error(error, "update_step", tenant.id, id, Some(step_id))
+        })?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -55,7 +135,9 @@ pub async fn delete_step(
     service
         .delete_step(tenant.id, id, step_id)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_workflow_step_error(error, "delete_step", tenant.id, id, Some(step_id))
+        })?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 

--- a/scripts/verify/verify-workflow-step-http-error-safety.mjs
+++ b/scripts/verify/verify-workflow-step-http-error-safety.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-workflow/src/controllers/steps.rs');
+const ownerError = read('crates/rustok-workflow/src/error.rs');
+const ownerService = read('crates/rustok-workflow/src/services/workflow_service.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  controller,
+  'fn map_workflow_step_error(',
+  'pub async fn add_step(',
+  'workflow step error mapper',
+);
+
+for (const [value, label] of [
+  ['WorkflowError::NotFound(_)', 'workflow not-found variant'],
+  ['WorkflowError::StepNotFound(_)', 'step not-found variant'],
+  ['WorkflowError::ExecutionNotFound(_)', 'unexpected execution variant'],
+  ['WorkflowError::NotActive(_)', 'state conflict variant'],
+  ['WorkflowError::StepFailed(_)', 'step failure variant'],
+  ['WorkflowError::UnknownStepType(_)', 'unknown step type variant'],
+  ['WorkflowError::InvalidTriggerConfig(_)', 'invalid trigger variant'],
+  ['WorkflowError::InvalidStepConfig(_)', 'invalid step config variant'],
+  ['WorkflowError::Database(_)', 'database variant'],
+  ['WorkflowError::Serialization(_)', 'serialization variant'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::CONFLICT', 'state conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"workflow_not_found"', 'workflow not-found code'],
+  ['"workflow_step_not_found"', 'step not-found code'],
+  ['"workflow_step_invalid"', 'step invalid code'],
+  ['"workflow_state_conflict"', 'state conflict code'],
+  ['"workflow_storage_unavailable"', 'storage unavailable code'],
+  ['"workflow_step_failed"', 'step failure code'],
+  ['owner = "rustok_workflow.workflow_service"', 'owner logging'],
+  ['operation,', 'operation logging'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['workflow_id = %workflow_id', 'workflow logging'],
+  ['step_id = ?step_id', 'step logging'],
+  ['error_kind,', 'error kind logging'],
+  ['public_code = code', 'public code logging'],
+  ['status = %status', 'status logging'],
+  ['boundary = "workflow_step_http"', 'boundary logging'],
+  ['HttpError::new(status, code, message)', 'static public envelope'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['map_workflow_step_error(error, "add_step", tenant.id, id, None)', 'add-step mapper'],
+  ['map_workflow_step_error(error, "update_step", tenant.id, id, Some(step_id))', 'update-step mapper'],
+  ['map_workflow_step_error(error, "delete_step", tenant.id, id, Some(step_id))', 'delete-step mapper'],
+  ['Permission::WORKFLOWS_UPDATE', 'workflow update permission'],
+  ['"workflow_permission_denied"', 'permission code'],
+]) requireText(controller, value, label);
+
+for (const value of [
+  'err.to_string()',
+  'error.to_string()',
+  'HttpError::bad_request("workflow_operation_failed"',
+]) forbidText(controller, value, 'unsafe workflow step public conversion');
+
+for (const [value, label] of [
+  ['pub enum WorkflowError {', 'workflow owner enum'],
+  ['NotFound(Uuid)', 'owner workflow not-found variant'],
+  ['StepNotFound(Uuid)', 'owner step not-found variant'],
+  ['ExecutionNotFound(Uuid)', 'owner execution not-found variant'],
+  ['NotActive(String)', 'owner not-active variant'],
+  ['StepFailed(String)', 'owner step-failed variant'],
+  ['UnknownStepType(String)', 'owner unknown-step variant'],
+  ['InvalidTriggerConfig(String)', 'owner invalid-trigger variant'],
+  ['InvalidStepConfig(String)', 'owner invalid-step variant'],
+  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
+  ['Serialization(#[from] serde_json::Error)', 'owner serialization variant'],
+]) requireText(ownerError, value, label);
+
+for (const [value, label] of [
+  ['pub async fn add_step(', 'owner add-step operation'],
+  ['pub async fn update_step(', 'owner update-step operation'],
+  ['pub async fn delete_step(', 'owner delete-step operation'],
+  ['.ok_or(WorkflowError::NotFound(workflow_id))?', 'owner workflow ownership guard'],
+  ['.ok_or(WorkflowError::StepNotFound(step_id))?', 'owner step ownership guard'],
+]) requireText(ownerService, value, label);
+
+const mapperUses = controller.match(/map_workflow_step_error\(/g) ?? [];
+if (mapperUses.length !== 4) {
+  failures.push(`expected mapper definition plus three uses, found ${mapperUses.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Workflow step HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Workflow step owner errors use typed safe HTTP envelopes');


### PR DESCRIPTION
## Summary

- replace three dynamic `WorkflowError::to_string()` HTTP conversions in workflow step add/update/delete handlers with one exhaustive typed mapper;
- return stable public envelopes for workflow/step not-found, invalid step requests, state conflicts, storage unavailability, and fail-closed unexpected owner errors;
- log the raw owner error with operation, tenant, workflow, optional step, error kind, public code/status, and the `workflow_step_http` boundary;
- add a focused verifier covering all current `WorkflowError` variants, the three controller callsites, service ownership guards, mapper-use count, and the absence of dynamic public conversions.

## Scope

Two files only: `crates/rustok-workflow/src/controllers/steps.rs` and a new focused verifier. Workflow service behavior, DTOs, routing, permissions, database queries, and response success payloads are unchanged.

## Public error contract

- workflow or step not found: 404;
- invalid step input/type: 400;
- workflow state conflict: 409;
- database/storage failure: 503;
- execution, serialization, or runtime step failure reaching this boundary: 500 fail-closed.

All public messages are static. Raw owner details remain in structured logs only.

## Validation

- branch is directly ahead of current `main` by one commit;
- source review confirmed exhaustive matching of all ten current `WorkflowError` variants and exactly three mapper callsites;
- full branch scope is two files (`+208/-4`);
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.