### PR TITLE
refactor(profiles): isolate privacy read model

### DIFF
--- a/apps/server/src/services/notification_recipient_policy.rs
+++ b/apps/server/src/services/notification_recipient_policy.rs
@@ -13,7 +13,7 @@ use rustok_notifications::{
 };
 use rustok_profiles::{
     ProfilePrivacyDecision, ProfilePrivacyReadPort, ProfilePrivacyReadRequest,
-    ProfilePrivacyRuntime, ProfileService,
+    ProfilePrivacyRuntime, ProfilePrivacyService,
 };
 use rustok_social_graph::{
     SocialGraphPairRequest, SocialGraphPrivacyReadPort, SocialGraphPrivacyRuntime,
@@ -91,7 +91,7 @@ impl ServerNotificationRecipientPolicy {
         extensions: &ModuleRuntimeExtensions,
     ) -> NotificationRecipientPolicyRuntime {
         let profile_port: Arc<dyn ProfilePrivacyReadPort> =
-            Arc::new(ProfileService::new(db.clone()));
+            Arc::new(ProfilePrivacyService::new(db.clone()));
         let graph_port: Arc<dyn SocialGraphPrivacyReadPort> = Arc::new(SocialGraphService::new(db));
         let graph = SocialGraphPrivacyRuntime::new(graph_port);
         let blocks = extensions

--- a/crates/rustok-profiles/README.md
+++ b/crates/rustok-profiles/README.md
@@ -11,6 +11,7 @@
 - Own profile storage (`profiles`, `profile_translations`), migrations, and the reusable profile service contract.
 - Own profile-to-taxonomy relation storage via `profile_tags`.
 - Provide batched profile summary lookup for downstream author/member presentation without per-user fan-out.
+- Provide a tenant-scoped base-row privacy read adapter whose decisions do not depend on localized copy, tags, or media joins.
 - Provide explicit backfill helpers for provisioning missing profiles from existing user/customer data.
 - Expose a request-scoped GraphQL `ProfileSummaryLoader` for host applications that need DataLoader-based batching and caching.
 - Expose module-owned GraphQL transport for self-service and public profile lookups, including targeted profile update mutations.
@@ -27,6 +28,7 @@
 - Must not collapse `customer`, `seller`, or staff/admin roles into one profile record.
 - Is intended to become the canonical source for public author/member cards across host applications and module-owned UI packages.
 - Already serves `rustok-blog` and `rustok-forum` through `ProfilesReader` with batched summary resolution.
+- Serves notification recipient policy through `ProfilePrivacyReadPort` and the minimal `ProfilePrivacyService` owner adapter.
 - Uses `rustok-events` + `rustok-outbox` for downstream synchronization after profile mutations.
 
 ## Entry points
@@ -34,6 +36,8 @@
 - `ProfilesModule`
 - `ProfileService`
 - `ProfilesReader`
+- `ProfilePrivacyService`
+- `ProfilePrivacyReadPort`
 - `ProfileSummaryLoader`
 - `ProfileSummaryLoaderKey`
 - `graphql::*`

--- a/crates/rustok-profiles/docs/README.md
+++ b/crates/rustok-profiles/docs/README.md
@@ -8,12 +8,14 @@ without mixing auth identity, customer and future seller/merchant surfaces.
 
 - publish the canonical profile runtime contract for public profile and author/member summary;
 - keep storage, service layer and transport boundary of profiles inside a separate module;
-- provide downstream modules with a single source for author/member presentation without a direct dependency on `users`.
+- provide downstream modules with a single source for author/member presentation without a direct dependency on `users`;
+- provide privacy/access-policy reads from the tenant-scoped base profile row without coupling decisions to localized presentation data.
 
 ## Scope
 
 - profile aggregate: `profiles`, `profile_translations`, `profile_tags`;
 - `ProfileService`, `ProfilesReader`, `ProfileSummary` and related DTO/enum contracts;
+- `ProfilePrivacyReadPort` and the owner-local `ProfilePrivacyService` base-row adapter;
 - public handle, display name, bio, avatar/banner references, locale and visibility policy;
 - GraphQL read/write surfaces for public profile lookup and self-service edit path;
 - event contract `profile.updated` and backfill path for existing users.
@@ -23,13 +25,14 @@ without mixing auth identity, customer and future seller/merchant surfaces.
 - `users` remains the identity/security boundary and does not become the public profile source;
 - `rustok-customer` remains a separate commerce-domain profile with optional linkage to `user_id`;
 - `rustok-blog` and `rustok-forum` already use `ProfilesReader` for author presentation;
+- notification recipient policy consumes the privacy owner port without reading profile translations, tags, or foreign tables;
 - `rustok-taxonomy` provides a shared dictionary for `profile_tags`, but ownership of the bindings remains with the profiles module.
 
 ## Verification
 
 - `cargo xtask module validate profiles`
 - `cargo xtask module test profiles`
-- targeted tests for handle policy, locale fallback, summary batching, GraphQL self-service path and profile backfill
+- targeted tests for handle policy, locale fallback, summary batching, GraphQL self-service path, profile backfill, and privacy base-row tenant isolation
 
 ## Related documents
 

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -5,11 +5,15 @@
 `rustok-profiles` owns the public profile domain over platform users: profile
 storage/translations, profile tags, handle and visibility policy,
 `ProfileService`, `ProfilesReader`, summary batching, GraphQL read/self-service
-write surfaces, `profile.updated`, and backfill helpers.
+write surfaces, `profile.updated`, backfill helpers, and the recipient privacy
+owner port.
 
 It is not an auth identity, customer, seller, or staff-role aggregate. Blog and
 forum consume `ProfilesReader` for author presentation; taxonomy supplies the
-tag dictionary while profile-tag bindings remain module-owned.
+tag dictionary while profile-tag bindings remain module-owned. Notification
+recipient policy consumes `ProfilePrivacyReadPort`, whose owner adapter reads
+only the tenant-scoped base `profiles` row and does not depend on translations,
+tags, media joins, or downstream models.
 
 ## FFA/FBA boundary
 
@@ -19,21 +23,31 @@ tag dictionary while profile-tag bindings remain module-owned.
 - The module has GraphQL and reader contracts but no module-owned UI or FBA
   provider port yet.
 
-## Open results
+## Results and next work
 
-1. **Decide and implement the required read model.** Determine whether direct
-   profile/translations reads remain sufficient for downstream summaries or a
-   dedicated projection is needed.
-   **Depends on:** measured consumer query patterns and summary latency needs.
-   **Done when:** the selected model has tenant/locale semantics, batching
-   behavior, and a documented ownership boundary.
+1. **Use owner-local direct reads for the current read model.**
+   **Status:** completed for the current consumer shape. Localized author/member
+   summaries remain on the tenant-scoped batched `ProfilesReader` path; a
+   dedicated projection table is not justified while blog/forum consume bounded
+   summary batches and no measured latency requirement exceeds that contract.
+   Privacy decisions use a separate minimal base-row adapter so presentation
+   integrity cannot make access-policy reads unavailable.
+   **Revisit when:** production query telemetry shows sustained summary latency,
+   fan-out, or denormalization requirements that the batched owner read cannot
+   meet.
+   **Ownership boundary:** profile rows, translations, tag bindings, locale
+   fallback, batching, and privacy state remain owned by `rustok-profiles`.
 
 2. **Finish profile visibility, media, and handle policy.** Resolve remaining
-   public/private visibility, avatar/banner reference, and tenant-scoped handle
-   uniqueness decisions without merging customer or seller concerns.
-   **Depends on:** public-profile product requirements and media contract.
-   **Done when:** GraphQL, `ProfilesReader`, backfill, and downstream author
-   cards expose the same policy with targeted tests.
+   public/private visibility, authenticated/followers semantics, avatar/banner
+   reference validation, and tenant-scoped handle uniqueness decisions without
+   merging customer or seller concerns. The notification privacy adapter now
+   reads status/visibility independently from localized copy; downstream public
+   profile and author-card enforcement still needs one documented policy.
+   **Depends on:** public-profile product requirements, social-graph follower
+   capability, and the media owner contract.
+   **Done when:** GraphQL, `ProfilesReader`, privacy ports, backfill, and
+   downstream author cards expose the same policy with targeted tests.
 
 3. **Add UI and operational capabilities only after the domain stabilizes.**
    Introduce a module-owned profile UI, audit trail, observability, and rollout
@@ -42,33 +56,28 @@ tag dictionary while profile-tag bindings remain module-owned.
    **Done when:** the new surface has an owner package, public transport
    contract, profile-conflict recovery guidance, and no auth/customer leakage.
 
-4. **Move profile backfill to an owner-local operations adapter.** The current
-   legacy server task has a neutral execution chain and reads users through the
-   auth-owned `AuthUserBackfillReadPort`, but tenant reads remain platform
-   concerns and optional customer enrichment remains customer-owned. Define
-   explicit CLI runtime inputs before adding `profiles
-   backfill` to a module CLI; the profiles module must not import server models
-   or query customer internals directly.
-   **Depends on:** the auth-owned `AuthUserBackfillReadPort`, the existing
-   `TenantReadPort`, and the customer-owned profile-enrichment projection.
-   **Done when:** `rustok-cli profiles backfill` is provided by a
-   `rustok-profiles/cli` adapter, preserves dry-run/event semantics, and the
-   task is deleted. **Completed:** the provider uses owner-owned auth,
-   tenant and customer reads plus `OutboxTransport` for optional event
-   publishing; compiled CLI/runtime evidence remains the next verification
-   step.
+4. **Move profile backfill to an owner-local operations adapter.**
+   **Status:** source-complete; compiled/runtime verification pending. The module
+   CLI provider uses owner-owned auth, tenant, and customer reads plus
+   `OutboxTransport` for optional event publishing, preserves dry-run/event
+   semantics, and does not import server models or query customer internals
+   directly. The legacy task has been removed.
+   **Next verification:** compile and exercise `rustok-cli profiles backfill`
+   against the supported runtime inputs.
 
 ## Verification
 
 - `cargo xtask module validate profiles`
 - `cargo xtask module test profiles`
 - Targeted handle policy, locale fallback, summary batching, GraphQL
-  self-service, backfill, and event tests.
+  self-service, backfill, event, and privacy base-row/tenant-isolation tests.
 
 ## Change rules
 
 1. Keep public profile policy and storage in this module.
-2. Update local docs, `rustok-module.toml`, and blog/forum consumer docs with a
+2. Keep privacy/access-policy reads independent from localized presentation
+   integrity and foreign domain tables.
+3. Update local docs, `rustok-module.toml`, and blog/forum consumer docs with a
    public-profile contract change.
-3. Update `docs/modules/registry.md` and this status block with an FFA/FBA or
+4. Update `docs/modules/registry.md` and this status block with an FFA/FBA or
    module-owned UI boundary change.

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -19,7 +19,7 @@ pub use error::{ProfileError, ProfileResult};
 pub use loader::{ProfileSummaryLoader, ProfileSummaryLoaderKey};
 pub use privacy::{
     ProfilePrivacyDecision, ProfilePrivacyReadPort, ProfilePrivacyReadRequest,
-    ProfilePrivacyRuntime,
+    ProfilePrivacyRuntime, ProfilePrivacyService,
 };
 pub use reader::ProfilesReader;
 pub use services::{ProfileBackfillResult, ProfileService};

--- a/crates/rustok-profiles/src/privacy.rs
+++ b/crates/rustok-profiles/src/privacy.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustok_api::{PortCallPolicy, PortContext, PortError};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{ProfileError, ProfileService, ProfileStatus, ProfileVisibility};
+use crate::{entities, ProfileStatus, ProfileVisibility};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProfilePrivacyReadRequest {
@@ -45,8 +46,57 @@ impl ProfilePrivacyRuntime {
     }
 }
 
+/// Owner-local read adapter for privacy decisions.
+///
+/// Privacy evaluation deliberately reads only the base `profiles` row. It must
+/// not depend on localized presentation copy, taxonomy labels, or media joins.
+#[derive(Clone, Debug)]
+pub struct ProfilePrivacyService {
+    db: DatabaseConnection,
+}
+
+impl ProfilePrivacyService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    async fn find_state(
+        &self,
+        tenant_id: Uuid,
+        recipient_id: Uuid,
+    ) -> Result<Option<ProfilePrivacyState>, PortError> {
+        let profile = entities::profile::Entity::find_by_id(recipient_id)
+            .filter(entities::profile::Column::TenantId.eq(tenant_id))
+            .one(&self.db)
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    tenant_id = %tenant_id,
+                    recipient_id = %recipient_id,
+                    error = %error,
+                    "Profile privacy state read failed"
+                );
+                PortError::unavailable(
+                    "profiles.privacy_read_unavailable",
+                    "profile privacy state is temporarily unavailable",
+                )
+            })?;
+
+        Ok(profile.map(|profile| ProfilePrivacyState {
+            status: profile.status,
+            visibility: profile.visibility,
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ProfilePrivacyState {
+    status: ProfileStatus,
+    visibility: ProfileVisibility,
+}
+
 #[async_trait]
-impl ProfilePrivacyReadPort for ProfileService {
+impl ProfilePrivacyReadPort for ProfilePrivacyService {
     async fn evaluate_profile_privacy(
         &self,
         context: PortContext,
@@ -60,35 +110,11 @@ impl ProfilePrivacyReadPort for ProfileService {
             )
         })?;
 
-        let profile = match self
-            .get_profile(tenant_id, request.recipient_id, None, None)
-            .await
-        {
-            Ok(profile) => profile,
-            Err(ProfileError::ProfileNotFound(_)) => {
-                return Ok(ProfilePrivacyDecision::RecipientUnavailable);
-            }
-            Err(ProfileError::LocalizedCopyNotFound(_)) => {
-                return Err(PortError::unavailable(
-                    "profiles.privacy_projection_incomplete",
-                    "profile privacy projection is temporarily incomplete",
-                ));
-            }
-            Err(ProfileError::Database(_)) => {
-                return Err(PortError::unavailable(
-                    "profiles.privacy_read_unavailable",
-                    "profile privacy state is temporarily unavailable",
-                ));
-            }
-            Err(_) => {
-                return Err(PortError::validation(
-                    "profiles.privacy_read_invalid",
-                    "profile privacy state could not be evaluated",
-                ));
-            }
+        let Some(state) = self.find_state(tenant_id, request.recipient_id).await? else {
+            return Ok(ProfilePrivacyDecision::RecipientUnavailable);
         };
 
-        if profile.status != ProfileStatus::Active {
+        if state.status != ProfileStatus::Active {
             return Ok(ProfilePrivacyDecision::RecipientUnavailable);
         }
 
@@ -96,7 +122,7 @@ impl ProfilePrivacyReadPort for ProfileService {
             return Ok(ProfilePrivacyDecision::Allow);
         }
 
-        match profile.visibility {
+        match state.visibility {
             ProfileVisibility::Public | ProfileVisibility::Authenticated => {
                 Ok(ProfilePrivacyDecision::Allow)
             }

--- a/crates/rustok-profiles/tests/profile_privacy_test.rs
+++ b/crates/rustok-profiles/tests/profile_privacy_test.rs
@@ -1,0 +1,102 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_profiles::entities;
+use rustok_profiles::{
+    ProfilePrivacyDecision, ProfilePrivacyReadPort, ProfilePrivacyReadRequest,
+    ProfilePrivacyService, ProfileStatus, ProfileVisibility,
+};
+use sea_orm::{ActiveModelTrait, Set};
+use uuid::Uuid;
+
+mod support;
+
+#[tokio::test]
+async fn privacy_read_uses_base_profile_without_localized_copy() {
+    let db = support::setup_profiles_test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    let now = Utc::now();
+
+    entities::profile::ActiveModel {
+        user_id: Set(recipient_id),
+        tenant_id: Set(tenant_id),
+        handle: Set("privacy-owner".to_string()),
+        avatar_media_id: Set(None),
+        banner_media_id: Set(None),
+        preferred_locale: Set(None),
+        visibility: Set(ProfileVisibility::Public),
+        status: Set(ProfileStatus::Active),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+    }
+    .insert(&db)
+    .await
+    .unwrap();
+
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service("profile-privacy-test"),
+        "und",
+        "profile-privacy-base-row",
+    )
+    .with_deadline(Duration::from_secs(1));
+    let decision = ProfilePrivacyService::new(db)
+        .evaluate_profile_privacy(
+            context,
+            ProfilePrivacyReadRequest {
+                recipient_id,
+                actor_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(decision, ProfilePrivacyDecision::Allow);
+}
+
+#[tokio::test]
+async fn privacy_read_keeps_tenant_scope_on_base_profile() {
+    let db = support::setup_profiles_test_db().await;
+    let owner_tenant_id = Uuid::new_v4();
+    let other_tenant_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    let now = Utc::now();
+
+    entities::profile::ActiveModel {
+        user_id: Set(recipient_id),
+        tenant_id: Set(owner_tenant_id),
+        handle: Set("tenant-owner".to_string()),
+        avatar_media_id: Set(None),
+        banner_media_id: Set(None),
+        preferred_locale: Set(None),
+        visibility: Set(ProfileVisibility::Public),
+        status: Set(ProfileStatus::Active),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+    }
+    .insert(&db)
+    .await
+    .unwrap();
+
+    let context = PortContext::new(
+        other_tenant_id.to_string(),
+        PortActor::service("profile-privacy-test"),
+        "und",
+        "profile-privacy-tenant-scope",
+    )
+    .with_deadline(Duration::from_secs(1));
+    let decision = ProfilePrivacyService::new(db)
+        .evaluate_profile_privacy(
+            context,
+            ProfilePrivacyReadRequest {
+                recipient_id,
+                actor_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(decision, ProfilePrivacyDecision::RecipientUnavailable);
+}


### PR DESCRIPTION
## Summary

- reconcile the canonical `rustok-profiles` implementation plan with the current batched reader, CLI backfill, and recipient-privacy state;
- retain the existing owner-local batched direct read model for localized author/member summaries instead of introducing an unjustified projection table;
- add `ProfilePrivacyService`, a tenant-scoped owner adapter that reads only `status` and `visibility` from the base `profiles` row;
- switch notification recipient policy composition from the full localized `ProfileService` path to the minimal privacy adapter;
- add regression coverage proving privacy evaluation works without `profile_translations` and remains tenant-scoped;
- align crate and module documentation with the new privacy read boundary.

## Rechecked state

- `ProfilesReader::find_profile_summaries` already batches profile, localized copy, and tag resolution for blog/forum consumers;
- handle normalization and tenant-scoped uniqueness checks are implemented;
- GraphQL self-service update surfaces, `profile.updated`, and owner-local CLI backfill source are present;
- compiled/runtime evidence for `rustok-cli profiles backfill` remains pending;
- authenticated/followers visibility semantics, media-owner validation, module-owned UI, audit/observability, and rollout guidance remain open.

## Behavior

Visibility decisions are unchanged. Active public/authenticated profiles remain allowed, active followers-only/private profiles remain restricted for non-self actors, and hidden/blocked or absent profiles remain unavailable. The change removes localized-copy and taxonomy availability from that decision path.

## Scope

Seven files under `rustok-profiles` plus the existing server notification-policy composition. No migration, schema, GraphQL field, event payload, handle policy, media policy, FFA/FBA status, or foreign-domain table access is added.

## Validation

Tests, Cargo commands, formatting commands, and verifier execution were not run, per maintainer request. The branch was reviewed statically for tenant filtering, stable public errors, unchanged decision semantics, exported API wiring, server composition, and exact file scope.