### PR TITLE
Harden workflow HTTP errors

### DIFF
--- a/crates/rustok-workflow/src/controllers/workflows.rs
+++ b/crates/rustok-workflow/src/controllers/workflows.rs
@@ -1,6 +1,7 @@
 use axum::{
     Json,
     extract::{Path, State},
+    http::StatusCode,
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext, has_any_effective_permission};
@@ -10,9 +11,82 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
-    CreateWorkflowInput, UpdateWorkflowInput, WorkflowResponse, WorkflowService, WorkflowSummary,
-    entities::WorkflowStatus,
+    CreateWorkflowInput, UpdateWorkflowInput, WorkflowError, WorkflowResponse, WorkflowService,
+    WorkflowSummary, entities::WorkflowStatus,
 };
+
+fn map_workflow_error(
+    error: WorkflowError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    workflow_id: Option<Uuid>,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        WorkflowError::NotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "workflow_not_found",
+            "Workflow was not found",
+            "workflow_not_found",
+        ),
+        WorkflowError::StepNotFound(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_operation_failed",
+            "Workflow operation could not be completed safely",
+            "unexpected_step_not_found",
+        ),
+        WorkflowError::ExecutionNotFound(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_operation_failed",
+            "Workflow operation could not be completed safely",
+            "unexpected_execution_not_found",
+        ),
+        WorkflowError::NotActive(_) => (
+            StatusCode::CONFLICT,
+            "workflow_state_conflict",
+            "Workflow operation conflicts with the current state",
+            "state_conflict",
+        ),
+        WorkflowError::UnknownStepType(_)
+        | WorkflowError::InvalidTriggerConfig(_)
+        | WorkflowError::InvalidStepConfig(_) => (
+            StatusCode::BAD_REQUEST,
+            "workflow_invalid",
+            "Workflow request is invalid",
+            "validation",
+        ),
+        WorkflowError::StepFailed(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_execution_failed",
+            "Workflow execution could not be completed safely",
+            "step_failed",
+        ),
+        WorkflowError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "workflow_storage_unavailable",
+            "Workflow storage is temporarily unavailable",
+            "database",
+        ),
+        WorkflowError::Serialization(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_operation_failed",
+            "Workflow operation could not be completed safely",
+            "serialization",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_workflow.workflow_service",
+        operation,
+        tenant_id = %tenant_id,
+        workflow_id = ?workflow_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "workflow_http",
+        "workflow operation failed"
+    );
+    HttpError::new(status, code, message)
+}
 
 pub async fn list(
     State(runtime): State<crate::controllers::WorkflowHttpRuntime>,
@@ -29,7 +103,7 @@ pub async fn list(
     let workflows = service
         .list(tenant.id)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "list", tenant.id, None))?;
     Ok(Json(workflows))
 }
 
@@ -49,7 +123,7 @@ pub async fn get(
     let workflow = service
         .get(tenant.id, id)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "get", tenant.id, Some(id)))?;
     Ok(Json(workflow))
 }
 
@@ -69,7 +143,7 @@ pub async fn create(
     let id = service
         .create(tenant.id, auth.human_user_id(), input)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "create", tenant.id, None))?;
     Ok(Json(serde_json::json!({ "id": id })))
 }
 
@@ -90,7 +164,7 @@ pub async fn update(
     service
         .update(tenant.id, id, auth.human_user_id(), input)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "update", tenant.id, Some(id)))?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -110,7 +184,7 @@ pub async fn delete_workflow(
     service
         .delete(tenant.id, id)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "delete", tenant.id, Some(id)))?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -138,7 +212,7 @@ pub async fn activate(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "activate", tenant.id, Some(id)))?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -166,7 +240,7 @@ pub async fn pause(
             },
         )
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "pause", tenant.id, Some(id)))?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -201,7 +275,7 @@ pub async fn trigger_manual(
             input.force,
         )
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| map_workflow_error(error, "trigger_manual", tenant.id, Some(id)))?;
     Ok(Json(serde_json::json!({ "execution_id": execution_id })))
 }
 

--- a/scripts/verify/verify-workflow-http-error-safety.mjs
+++ b/scripts/verify/verify-workflow-http-error-safety.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-workflow/src/controllers/workflows.rs');
+const ownerError = read('crates/rustok-workflow/src/error.rs');
+const ownerService = read('crates/rustok-workflow/src/services/workflow_service.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  controller,
+  'fn map_workflow_error(',
+  'pub async fn list(',
+  'workflow error mapper',
+);
+
+for (const [value, label] of [
+  ['WorkflowError::NotFound(_)', 'workflow not-found variant'],
+  ['WorkflowError::StepNotFound(_)', 'unexpected step variant'],
+  ['WorkflowError::ExecutionNotFound(_)', 'unexpected execution variant'],
+  ['WorkflowError::NotActive(_)', 'state conflict variant'],
+  ['WorkflowError::StepFailed(_)', 'execution failure variant'],
+  ['WorkflowError::UnknownStepType(_)', 'unknown step type variant'],
+  ['WorkflowError::InvalidTriggerConfig(_)', 'invalid trigger variant'],
+  ['WorkflowError::InvalidStepConfig(_)', 'invalid step config variant'],
+  ['WorkflowError::Database(_)', 'database variant'],
+  ['WorkflowError::Serialization(_)', 'serialization variant'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::CONFLICT', 'state conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"workflow_not_found"', 'workflow not-found code'],
+  ['"workflow_invalid"', 'workflow invalid code'],
+  ['"workflow_state_conflict"', 'state conflict code'],
+  ['"workflow_storage_unavailable"', 'storage unavailable code'],
+  ['"workflow_execution_failed"', 'execution failure code'],
+  ['"workflow_operation_failed"', 'operation failure code'],
+  ['owner = "rustok_workflow.workflow_service"', 'owner logging'],
+  ['operation,', 'operation logging'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['workflow_id = ?workflow_id', 'workflow logging'],
+  ['error_kind,', 'error kind logging'],
+  ['public_code = code', 'public code logging'],
+  ['status = %status', 'status logging'],
+  ['boundary = "workflow_http"', 'boundary logging'],
+  ['HttpError::new(status, code, message)', 'static public envelope'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['map_workflow_error(error, "list", tenant.id, None)', 'list mapper'],
+  ['map_workflow_error(error, "get", tenant.id, Some(id))', 'get mapper'],
+  ['map_workflow_error(error, "create", tenant.id, None)', 'create mapper'],
+  ['map_workflow_error(error, "update", tenant.id, Some(id))', 'update mapper'],
+  ['map_workflow_error(error, "delete", tenant.id, Some(id))', 'delete mapper'],
+  ['map_workflow_error(error, "activate", tenant.id, Some(id))', 'activate mapper'],
+  ['map_workflow_error(error, "pause", tenant.id, Some(id))', 'pause mapper'],
+  ['map_workflow_error(error, "trigger_manual", tenant.id, Some(id))', 'manual trigger mapper'],
+]) requireText(controller, value, label);
+
+for (const [value, label] of [
+  ['Permission::WORKFLOWS_LIST', 'list permission'],
+  ['Permission::WORKFLOWS_READ', 'read permission'],
+  ['Permission::WORKFLOWS_CREATE', 'create permission'],
+  ['Permission::WORKFLOWS_UPDATE', 'update permission'],
+  ['Permission::WORKFLOWS_DELETE', 'delete permission'],
+  ['Permission::WORKFLOWS_EXECUTE', 'execute permission'],
+  ['"workflow_permission_denied"', 'permission code'],
+  ['serde_json::json!({ "id": id })', 'create success payload'],
+  ['serde_json::json!({ "ok": true })', 'mutation success payload'],
+  ['serde_json::json!({ "execution_id": execution_id })', 'trigger success payload'],
+]) requireText(controller, value, label);
+
+for (const value of [
+  'err.to_string()',
+  'error.to_string()',
+  'HttpError::bad_request("workflow_operation_failed"',
+]) forbidText(controller, value, 'unsafe workflow public conversion');
+
+for (const [value, label] of [
+  ['pub enum WorkflowError {', 'workflow owner enum'],
+  ['NotFound(Uuid)', 'owner workflow not-found variant'],
+  ['StepNotFound(Uuid)', 'owner step not-found variant'],
+  ['ExecutionNotFound(Uuid)', 'owner execution not-found variant'],
+  ['NotActive(String)', 'owner not-active variant'],
+  ['StepFailed(String)', 'owner step-failed variant'],
+  ['UnknownStepType(String)', 'owner unknown-step variant'],
+  ['InvalidTriggerConfig(String)', 'owner invalid-trigger variant'],
+  ['InvalidStepConfig(String)', 'owner invalid-step variant'],
+  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
+  ['Serialization(#[from] serde_json::Error)', 'owner serialization variant'],
+]) requireText(ownerError, value, label);
+
+for (const [value, label] of [
+  ['pub async fn create(', 'owner create operation'],
+  ['pub async fn get(', 'owner get operation'],
+  ['pub async fn list(', 'owner list operation'],
+  ['pub async fn update(', 'owner update operation'],
+  ['pub async fn delete(', 'owner delete operation'],
+  ['pub async fn trigger_manual(', 'owner manual trigger operation'],
+  ['.ok_or(WorkflowError::NotFound(id))?', 'owner workflow guard'],
+  ['.ok_or(WorkflowError::NotFound(workflow_id))?', 'owner trigger guard'],
+  ['return Err(WorkflowError::NotActive(', 'owner active-state guard'],
+]) requireText(ownerService, value, label);
+
+const mapperUses = controller.match(/map_workflow_error\(/g) ?? [];
+if (mapperUses.length !== 9) {
+  failures.push(`expected mapper definition plus eight uses, found ${mapperUses.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Workflow HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Workflow owner errors use typed safe HTTP envelopes');


### PR DESCRIPTION
## Summary

- replace eight dynamic `WorkflowError::to_string()` HTTP conversions in workflow list/get/create/update/delete/activate/pause/manual-trigger handlers with one exhaustive typed mapper;
- return stable public envelopes for workflow not-found, invalid workflow requests, state conflicts, storage unavailability, execution failures, and fail-closed unexpected owner errors;
- log raw owner errors with operation, tenant, optional workflow ID, error kind, public code/status, and the `workflow_http` boundary;
- add a focused verifier covering all current `WorkflowError` variants, all eight controller callsites, permissions, success payloads, service guards, mapper-use count, and the absence of dynamic public conversions.

## Scope

Two files only: `crates/rustok-workflow/src/controllers/workflows.rs` and a new focused verifier. Workflow service behavior, DTOs, routing, permission requirements, database queries, and successful response payloads are unchanged.

## Public error contract

- workflow not found: 404;
- invalid trigger/step configuration or step type: 400;
- inactive workflow state conflict: 409;
- database/storage failure: 503;
- execution, serialization, unexpected step/execution lookup failures: 500 fail-closed.

All public messages are static. Raw owner details remain in structured logs only.

## Validation

- branch is directly ahead of current `main` by one commit;
- source review confirmed exhaustive matching of all ten current `WorkflowError` variants and exactly eight mapper callsites;
- full branch scope is two files (`+225/-10`);
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.