### PR TITLE
Harden workflow execution HTTP errors

### DIFF
--- a/crates/rustok-workflow/src/controllers/executions.rs
+++ b/crates/rustok-workflow/src/controllers/executions.rs
@@ -1,13 +1,89 @@
 use axum::{
     Json,
     extract::{Path, State},
+    http::StatusCode,
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext, has_any_effective_permission};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
-use crate::{WorkflowExecutionResponse, WorkflowService};
+use crate::{WorkflowError, WorkflowExecutionResponse, WorkflowService};
+
+fn map_workflow_execution_error(
+    error: WorkflowError,
+    operation: &'static str,
+    tenant_id: Uuid,
+    workflow_id: Option<Uuid>,
+    execution_id: Option<Uuid>,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        WorkflowError::NotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "workflow_not_found",
+            "Workflow was not found",
+            "workflow_not_found",
+        ),
+        WorkflowError::StepNotFound(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_execution_failed",
+            "Workflow execution could not be loaded safely",
+            "unexpected_step_not_found",
+        ),
+        WorkflowError::ExecutionNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "workflow_execution_not_found",
+            "Workflow execution was not found",
+            "execution_not_found",
+        ),
+        WorkflowError::NotActive(_) => (
+            StatusCode::CONFLICT,
+            "workflow_state_conflict",
+            "Workflow operation conflicts with the current state",
+            "state_conflict",
+        ),
+        WorkflowError::UnknownStepType(_)
+        | WorkflowError::InvalidTriggerConfig(_)
+        | WorkflowError::InvalidStepConfig(_) => (
+            StatusCode::BAD_REQUEST,
+            "workflow_execution_invalid",
+            "Workflow execution request is invalid",
+            "validation",
+        ),
+        WorkflowError::StepFailed(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_execution_failed",
+            "Workflow execution could not be loaded safely",
+            "step_failed",
+        ),
+        WorkflowError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "workflow_storage_unavailable",
+            "Workflow storage is temporarily unavailable",
+            "database",
+        ),
+        WorkflowError::Serialization(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow_execution_failed",
+            "Workflow execution could not be loaded safely",
+            "serialization",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_workflow.workflow_service",
+        operation,
+        tenant_id = %tenant_id,
+        workflow_id = ?workflow_id,
+        execution_id = ?execution_id,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "workflow_execution_http",
+        "workflow execution operation failed"
+    );
+    HttpError::new(status, code, message)
+}
 
 pub async fn list_executions(
     State(runtime): State<crate::controllers::WorkflowHttpRuntime>,
@@ -25,7 +101,15 @@ pub async fn list_executions(
     let executions = service
         .list_executions(tenant.id, workflow_id)
         .await
-        .map_err(|err| HttpError::bad_request("workflow_operation_failed", err.to_string()))?;
+        .map_err(|error| {
+            map_workflow_execution_error(
+                error,
+                "list_executions",
+                tenant.id,
+                Some(workflow_id),
+                None,
+            )
+        })?;
     Ok(Json(executions))
 }
 
@@ -45,12 +129,14 @@ pub async fn get_execution(
     let execution = service
         .get_execution(tenant.id, execution_id)
         .await
-        .map_err(|err| match err {
-            crate::WorkflowError::ExecutionNotFound(_) => HttpError::not_found(
-                "workflow_execution_not_found",
-                "Workflow execution not found",
-            ),
-            other => HttpError::bad_request("workflow_operation_failed", other.to_string()),
+        .map_err(|error| {
+            map_workflow_execution_error(
+                error,
+                "get_execution",
+                tenant.id,
+                None,
+                Some(execution_id),
+            )
         })?;
     Ok(Json(execution))
 }

--- a/scripts/verify/verify-workflow-execution-http-error-safety.mjs
+++ b/scripts/verify/verify-workflow-execution-http-error-safety.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-workflow/src/controllers/executions.rs');
+const ownerError = read('crates/rustok-workflow/src/error.rs');
+const ownerService = read('crates/rustok-workflow/src/services/workflow_service.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  controller,
+  'fn map_workflow_execution_error(',
+  'pub async fn list_executions(',
+  'workflow execution error mapper',
+);
+
+for (const [value, label] of [
+  ['WorkflowError::NotFound(_)', 'workflow not-found variant'],
+  ['WorkflowError::StepNotFound(_)', 'unexpected step variant'],
+  ['WorkflowError::ExecutionNotFound(_)', 'execution not-found variant'],
+  ['WorkflowError::NotActive(_)', 'state conflict variant'],
+  ['WorkflowError::StepFailed(_)', 'step failure variant'],
+  ['WorkflowError::UnknownStepType(_)', 'unknown step type variant'],
+  ['WorkflowError::InvalidTriggerConfig(_)', 'invalid trigger variant'],
+  ['WorkflowError::InvalidStepConfig(_)', 'invalid step config variant'],
+  ['WorkflowError::Database(_)', 'database variant'],
+  ['WorkflowError::Serialization(_)', 'serialization variant'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::CONFLICT', 'state conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"workflow_not_found"', 'workflow not-found code'],
+  ['"workflow_execution_not_found"', 'execution not-found code'],
+  ['"workflow_execution_invalid"', 'execution invalid code'],
+  ['"workflow_state_conflict"', 'state conflict code'],
+  ['"workflow_storage_unavailable"', 'storage unavailable code'],
+  ['"workflow_execution_failed"', 'execution failure code'],
+  ['owner = "rustok_workflow.workflow_service"', 'owner logging'],
+  ['operation,', 'operation logging'],
+  ['tenant_id = %tenant_id', 'tenant logging'],
+  ['workflow_id = ?workflow_id', 'workflow logging'],
+  ['execution_id = ?execution_id', 'execution logging'],
+  ['error_kind,', 'error kind logging'],
+  ['public_code = code', 'public code logging'],
+  ['status = %status', 'status logging'],
+  ['boundary = "workflow_execution_http"', 'boundary logging'],
+  ['HttpError::new(status, code, message)', 'static public envelope'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['"list_executions",', 'list operation label'],
+  ['Some(workflow_id),', 'list workflow context'],
+  ['"get_execution",', 'get operation label'],
+  ['Some(execution_id),', 'get execution context'],
+  ['Permission::WORKFLOW_EXECUTIONS_LIST', 'list permission'],
+  ['Permission::WORKFLOW_EXECUTIONS_READ', 'read permission'],
+  ['"workflow_permission_denied"', 'permission code'],
+  ['Ok(Json(executions))', 'list success payload'],
+  ['Ok(Json(execution))', 'get success payload'],
+]) requireText(controller, value, label);
+
+for (const value of [
+  'err.to_string()',
+  'other.to_string()',
+  'error.to_string()',
+  'HttpError::bad_request("workflow_operation_failed"',
+]) forbidText(controller, value, 'unsafe workflow execution public conversion');
+
+for (const [value, label] of [
+  ['pub enum WorkflowError {', 'workflow owner enum'],
+  ['NotFound(Uuid)', 'owner workflow not-found variant'],
+  ['StepNotFound(Uuid)', 'owner step not-found variant'],
+  ['ExecutionNotFound(Uuid)', 'owner execution not-found variant'],
+  ['NotActive(String)', 'owner not-active variant'],
+  ['StepFailed(String)', 'owner step-failed variant'],
+  ['UnknownStepType(String)', 'owner unknown-step variant'],
+  ['InvalidTriggerConfig(String)', 'owner invalid-trigger variant'],
+  ['InvalidStepConfig(String)', 'owner invalid-step variant'],
+  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
+  ['Serialization(#[from] serde_json::Error)', 'owner serialization variant'],
+]) requireText(ownerError, value, label);
+
+const ownerExecutionQueries = between(
+  ownerService,
+  'pub async fn list_executions(',
+  '// ── Webhook trigger',
+  'owner execution query operations',
+);
+for (const [value, label] of [
+  ['pub async fn list_executions(', 'owner list operation'],
+  ['pub async fn get_execution(', 'owner get operation'],
+  ['.filter(workflow_execution::Column::TenantId.eq(tenant_id))', 'tenant execution guard'],
+  ['.ok_or(WorkflowError::ExecutionNotFound(execution_id))?', 'owner execution guard'],
+]) requireText(ownerExecutionQueries, value, label);
+
+const mapperUses = controller.match(/map_workflow_execution_error\(/g) ?? [];
+if (mapperUses.length !== 3) {
+  failures.push(`expected mapper definition plus two uses, found ${mapperUses.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Workflow execution HTTP error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Workflow execution owner errors use typed safe HTTP envelopes');


### PR DESCRIPTION
## Summary

- replace the remaining dynamic `WorkflowError::to_string()` HTTP conversions in workflow execution list/detail handlers with one exhaustive typed mapper;
- return stable public envelopes for workflow/execution not-found, invalid execution requests, state conflicts, storage unavailability, and fail-closed unexpected owner errors;
- log raw owner errors with operation, tenant, optional workflow/execution IDs, error kind, public code/status, and the `workflow_execution_http` boundary;
- add a focused verifier covering all current `WorkflowError` variants, both controller callsites, permissions, success payloads, tenant-scoped service guards, mapper-use count, and the absence of dynamic public conversions.

## Scope

Two files only: `crates/rustok-workflow/src/controllers/executions.rs` and a new focused verifier. Workflow service behavior, DTOs, routing, permission requirements, database queries, and successful response payloads are unchanged.

## Public error contract

- workflow or execution not found: 404;
- invalid execution-related owner input: 400;
- workflow state conflict: 409;
- database/storage failure: 503;
- step, serialization, or unexpected owner failures: 500 fail-closed.

All public messages are static. Raw owner details remain in structured logs only.

## Validation

- branch is directly ahead of current `main` by one commit;
- source review confirmed exhaustive matching of all ten current `WorkflowError` variants and exactly two mapper callsites;
- full branch scope is two files (`+226/-8`);
- tests, Cargo commands, formatting commands, and verifier execution were not run, per request.