### PR TITLE
fix(index): bind methodology source to all report sessions

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -42,7 +42,7 @@ The accepted methodology contains the exact ordered `comparable_database_fields`
 - `date_style`;
 - `extra_float_digits`.
 
-Its `database_settings_source` must state that these values came from `read-report.json` database metadata observed from the active PostgreSQL benchmark session. The comparator rejects cross-scale drift in any field, and decision preparation, the direct renderer, and finalization all reject a comparison whose field list, order, or source string differs from the canonical contract.
+Its `database_settings_source` must state that the comparison uses `read-report.json` database metadata observed from its active PostgreSQL benchmark session only after exact equality was verified against the active-session metadata archived in `mutation-report.json` and `maintenance-report.json`. The comparator rejects intra-packet or cross-scale drift in any field, and decision preparation, the direct renderer, and finalization all reject a comparison whose field list, order, or source string differs from the canonical contract. The former read-only source string is no longer valid decision methodology.
 
 ## Prepare the decision
 

--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -28,7 +28,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
+      'comparison methodology database_settings_source must identify metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
     );
   }
   return methodology;

--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -28,7 +28,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
+      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata; database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
     );
   }
   return methodology;

--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -12,7 +12,7 @@ export const comparableDatabaseFields = Object.freeze([
 ]);
 
 export const databaseSettingsSource =
-  'read-report.json database metadata observed from the active PostgreSQL benchmark session';
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata';
 
 const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
@@ -28,7 +28,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
     );
   }
   return methodology;

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -29,7 +29,7 @@ const comparableDatabaseFields = [
   'extra_float_digits',
 ];
 const databaseSettingsSource =
-  'read-report.json database metadata observed from the active PostgreSQL benchmark session';
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata';
 const decisionFlags = {
   required_scales_present: true,
   same_packet_contract_version: true,
@@ -251,12 +251,13 @@ test('rejects an unedited prepared decision', () => {
   });
 });
 
-test('finalizer rejects database-settings provenance drift with a matching comparison digest', () => {
+test('finalizer rejects legacy read-only database-settings provenance with a matching comparison digest', () => {
   withFixture((root) => {
     const fixture = prepare(root);
     assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
     const comparisonValue = JSON.parse(readFileSync(fixture.comparisonPath, 'utf8'));
-    comparisonValue.methodology.database_settings_source = 'declared benchmark constants';
+    comparisonValue.methodology.database_settings_source =
+      'read-report.json database metadata observed from the active PostgreSQL benchmark session';
     const comparisonBytes = writeJson(fixture.comparisonPath, comparisonValue);
     const decision = completeDecision(JSON.parse(readFileSync(fixture.decisionPath, 'utf8')));
     decision.comparison_sha256 = sha256(comparisonBytes);
@@ -268,7 +269,10 @@ test('finalizer rejects database-settings provenance drift with a matching compa
       '--output', outputPath,
     ]);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /database_settings_source must identify metadata observed from the active PostgreSQL benchmark session/u);
+    assert.match(
+      result.stderr,
+      /database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata/u,
+    );
     assert.equal(existsSync(outputPath), false);
   });
 });

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -251,7 +251,7 @@ test('rejects an unedited prepared decision', () => {
   });
 });
 
-test('finalizer rejects legacy read-only database-settings provenance with a matching comparison digest', () => {
+test('finalizer rejects database-settings provenance drift with a matching comparison digest', () => {
   withFixture((root) => {
     const fixture = prepare(root);
     assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);


### PR DESCRIPTION
## Summary

- extend the canonical `database_settings_source` so `read-report.json` is only representative after exact equality with mutation and maintenance active-session metadata;
- keep the official comparator/ADR methodology fail-closed on the exact source string;
- turn the former read-only source string into a negative decision-tooling fixture even when the comparison digest is recalculated;
- document the representative-read plus cross-report-equality semantics for ADR reviewers.

## Why

The packet preflight already requires exact PostgreSQL metadata equality across `read-report.json`, `mutation-report.json`, and `maintenance-report.json`, but the generated methodology source still described only the read session. That wording understated the evidence boundary and could make a legacy read-only comparison appear current. The new canonical string records both the representative source and the prerequisite equality gate.

## Scope

Three files. No benchmark runner, SQL workload, evidence packet schema, packet contract version, comparable field list, byte-preserved validator/comparator core, workflow, production Index API, migration, evidence result, or storage selection is changed.

## Validation

Tests, Node/Cargo commands, formatting, verifier execution, workflow runs, and benchmarks were not run, per repository-owner instruction. The diff was reviewed statically against the comparator wrapper assignment, shared methodology validator, decision preparation/finalization gates, existing static guard markers, and the cross-report packet preflight.