### PR TITLE
Harden storefront line-item pricing error context

### DIFF
--- a/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
+++ b/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
@@ -1,3 +1,4 @@
+use rustok_api::{PortContext, PortError};
 use rustok_inventory::{
     PublicChannelInventoryVariantProjectionInput, check_variant_availability_for_public_channel,
 };
@@ -5,7 +6,7 @@ use rustok_pricing::ResolveProductPriceRequest;
 use rustok_product::entities::{
     product, product_translation, product_variant, variant_translation,
 };
-use rustok_web::{HttpError, HttpResult};
+use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
 use uuid::Uuid;
 
@@ -40,6 +41,32 @@ fn map_storefront_line_item_database_error(
         "storefront line item catalog read failed"
     );
     HttpError::new(status, code, "Store catalog is temporarily unavailable")
+}
+
+fn map_storefront_line_item_pricing_error(
+    error: PortError,
+    context: &PortContext,
+    variant_id: Uuid,
+    product_id: Uuid,
+) -> HttpError {
+    let public = port_error_to_http_error(error.clone());
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_pricing",
+        operation = "resolve_product_price",
+        tenant_id = %context.tenant_id,
+        correlation_id = %context.correlation_id,
+        channel = ?context.channel,
+        variant_id = %variant_id,
+        product_id = %product_id,
+        error_kind = ?error.kind,
+        retryable = error.retryable,
+        public_code = %public.code,
+        status = %public.status,
+        boundary = "commerce_storefront_line_item_http",
+        "storefront line item pricing resolution failed"
+    );
+    public
 }
 
 fn map_storefront_line_item_inventory_error(
@@ -191,14 +218,15 @@ pub(super) async fn resolve_store_line_item_input(
             )
         })?;
 
+    let pricing_port_context = crate::controllers::store::store_line_item_pricing_port_context(
+        tenant_id,
+        variant.id,
+        locale,
+        pricing_context,
+    );
     let resolved_price: rustok_pricing::ResolvedPrice = pricing_read_port
         .resolve_product_price(
-            crate::controllers::store::store_line_item_pricing_port_context(
-                tenant_id,
-                variant.id,
-                locale,
-                pricing_context,
-            ),
+            pricing_port_context.clone(),
             ResolveProductPriceRequest {
                 product_id: Some(product_model.id),
                 variant_id: variant.id,
@@ -211,7 +239,14 @@ pub(super) async fn resolve_store_line_item_input(
             },
         )
         .await
-        .map_err(rustok_web::port_error_to_http_error)?
+        .map_err(|error| {
+            map_storefront_line_item_pricing_error(
+                error,
+                &pricing_port_context,
+                variant.id,
+                product_model.id,
+            )
+        })?
         .into();
     let (base_unit_price, pricing_adjustment) =
         crate::controllers::store::storefront_cart_pricing_snapshot(

--- a/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
@@ -14,6 +14,7 @@ const carts = read('crates/rustok-commerce/src/controllers/store/carts.rs');
 const boundary = read(
   'crates/rustok-commerce/src/controllers/store/line_item_resolution.rs',
 );
+const portContract = read('crates/rustok-api/src/ports.rs');
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const inventoryOwner = read('crates/rustok-inventory/src/services/public_channel.rs');
 const productTests = read('crates/rustok-commerce/src/controllers/store/tests/products.rs');
@@ -47,8 +48,14 @@ const from = (content, start, label) => {
 const databaseMapper = between(
   boundary,
   'fn map_storefront_line_item_database_error(',
-  'fn map_storefront_line_item_inventory_error(',
+  'fn map_storefront_line_item_pricing_error(',
   'line-item database mapper',
+);
+const pricingMapper = between(
+  boundary,
+  'fn map_storefront_line_item_pricing_error(',
+  'fn map_storefront_line_item_inventory_error(',
+  'line-item pricing mapper',
 );
 const inventoryMapper = between(
   boundary,
@@ -86,8 +93,10 @@ for (const value of [
 ]) forbidText(carts, value, 'legacy unsafe production helper call');
 
 for (const [value, label] of [
+  ['use rustok_api::{PortContext, PortError};', 'typed pricing port imports'],
   ['DbErr', 'typed database error import'],
   ['CommerceError', 'typed inventory error import'],
+  ['port_error_to_http_error', 'shared safe port mapper import'],
   ['boundary = "commerce_storefront_line_item_http"', 'line-item boundary name'],
 ]) requireText(boundary, value, label);
 
@@ -139,6 +148,25 @@ for (const [value, label] of [
 ]) requireText(databaseMapper, value, label);
 
 for (const [value, label] of [
+  ['error: PortError', 'typed pricing port error'],
+  ['context: &PortContext', 'pricing port context'],
+  ['let public = port_error_to_http_error(error.clone());', 'shared safe pricing envelope'],
+  ['owner = "rustok_pricing"', 'pricing owner logging'],
+  ['operation = "resolve_product_price"', 'pricing operation logging'],
+  ['tenant_id = %context.tenant_id', 'pricing tenant logging'],
+  ['correlation_id = %context.correlation_id', 'pricing correlation logging'],
+  ['channel = ?context.channel', 'pricing channel logging'],
+  ['variant_id = %variant_id', 'pricing variant logging'],
+  ['product_id = %product_id', 'pricing product logging'],
+  ['error_kind = ?error.kind', 'pricing error-kind logging'],
+  ['retryable = error.retryable', 'pricing retryability logging'],
+  ['public_code = %public.code', 'pricing public-code logging'],
+  ['status = %public.status', 'pricing status logging'],
+  ['boundary = "commerce_storefront_line_item_http"', 'pricing boundary logging'],
+  ['public\n}', 'pricing safe envelope return'],
+]) requireText(pricingMapper, value, label);
+
+for (const [value, label] of [
   ['CommerceError::Validation(_)', 'inventory validation variant'],
   ['CommerceError::ProductNotFound(_)', 'inventory product-not-found variant'],
   ['CommerceError::VariantNotFound(_)', 'inventory variant-not-found variant'],
@@ -183,8 +211,11 @@ for (const [value, label] of [
   ['product_model.status != product::ProductStatus::Active', 'active product guard'],
   ['product_model.published_at.is_none()', 'published product guard'],
   ['is_metadata_visible_for_public_channel', 'channel visibility guard'],
+  ['let pricing_port_context =', 'pricing context retention'],
+  ['store_line_item_pricing_port_context(', 'pricing context construction'],
   ['.resolve_product_price(', 'pricing resolution'],
-  ['.map_err(rustok_web::port_error_to_http_error)?', 'pricing shared mapper'],
+  ['pricing_port_context.clone()', 'pricing context propagation'],
+  ['map_storefront_line_item_pricing_error(', 'correlation-safe pricing mapper'],
   ['storefront_cart_pricing_snapshot', 'pricing snapshot'],
   ['validate_store_variant_inventory(', 'inventory validation'],
   ['pick_product_translation(', 'product title fallback'],
@@ -193,6 +224,11 @@ for (const [value, label] of [
   ['seller_snapshot_metadata(', 'seller snapshot'],
   ['merge_metadata(', 'metadata merge'],
 ]) requireText(resolver, value, label);
+forbidText(
+  resolver,
+  '.map_err(rustok_web::port_error_to_http_error)?',
+  'unlogged pricing mapper call',
+);
 
 for (const [value, label] of [
   ['product_variant::Entity::find_by_id(variant_id)', 'quantity variant lookup'],
@@ -222,6 +258,12 @@ for (const value of [
 ]) forbidText(boundary, value, 'unsafe line-item public conversion');
 
 for (const [content, value, label] of [
+  [portContract, 'pub struct PortContext {', 'shared port context'],
+  [portContract, 'pub correlation_id: String', 'shared correlation field'],
+  [portContract, 'pub channel: Option<String>', 'shared channel field'],
+  [portContract, 'pub struct PortError {', 'shared port error'],
+  [portContract, 'pub kind: PortErrorKind', 'shared port error kind'],
+  [portContract, 'pub retryable: bool', 'shared port retryability'],
   [commerceErrors, 'pub enum CommerceError {', 'commerce owner enum'],
   [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'commerce database variant'],
   [commerceErrors, 'ProductNotFound(Uuid)', 'commerce product variant'],
@@ -241,6 +283,10 @@ const databaseMapperUses = boundary.match(/map_storefront_line_item_database_err
 if (databaseMapperUses.length !== 6) {
   failures.push(`expected database mapper definition plus five uses, found ${databaseMapperUses.length}`);
 }
+const pricingMapperUses = boundary.match(/map_storefront_line_item_pricing_error\(/g) ?? [];
+if (pricingMapperUses.length !== 2) {
+  failures.push(`expected pricing mapper definition plus one use, found ${pricingMapperUses.length}`);
+}
 const inventoryMapperUses = boundary.match(/map_storefront_line_item_inventory_error\(/g) ?? [];
 if (inventoryMapperUses.length !== 2) {
   failures.push(`expected inventory mapper definition plus one use, found ${inventoryMapperUses.length}`);
@@ -252,4 +298,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Storefront line-item catalog and inventory errors use typed safe envelopes');
+console.log('✔ Storefront line-item catalog, pricing, and inventory errors use typed safe envelopes');


### PR DESCRIPTION
## Summary

- retain the canonical pricing `PortContext` before resolving a storefront line-item price;
- route pricing failures through a dedicated line-item boundary mapper while preserving the shared safe public `PortError` envelope;
- record tenant, correlation id, channel, variant, product, error kind, retryability, public code, and status in structured internal diagnostics;
- extend the existing storefront line-item verifier to lock the pricing context, mapper handoff, diagnostics, shared port contract fields, and removal of the unlogged direct mapper call.

## Plan alignment

This advances the still-open ecommerce audit item for correlation-safe mapper cleanup across remaining ecommerce adapters. It does not claim that the broad item is complete and does not promote FBA/FFA status.

## Scope

Two files only:

- `crates/rustok-commerce/src/controllers/store/line_item_resolution.rs`
- `scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs`

Catalog reads, product/channel visibility, pricing request fields, pricing result conversion, inventory checks, title fallback, shipping-profile selection, seller metadata, cart mutation behavior, and public error semantics remain unchanged.

## Validation

- branch is directly ahead of current `main` by two commits and is not behind;
- diff is limited to the two intended files (`+92/-11`);
- source was re-read statically after writing to confirm context propagation, safe public mapping, structured diagnostics, and verifier coverage;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.