### PR TITLE
fix(index): require exact comparison methodology envelope

### DIFF
--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -14,12 +14,28 @@ export const comparableDatabaseFields = Object.freeze([
 export const databaseSettingsSource =
   'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata';
 
+export const comparisonMethodologyKeys = Object.freeze([
+  'source_oracle',
+  'result_digest',
+  'evidence_validation',
+  'first_run',
+  'warm_run',
+  'automatic_winner_selection',
+  'comparable_database_fields',
+  'database_settings_source',
+]);
+
 const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
 export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) => {
   const methodology = comparison?.methodology;
   if (!methodology || typeof methodology !== 'object' || Array.isArray(methodology)) {
     fail('comparison.methodology must be an object');
+  }
+  const actualKeys = Object.keys(methodology).sort();
+  const expectedKeys = [...comparisonMethodologyKeys].sort();
+  if (!sameJson(actualKeys, expectedKeys)) {
+    fail('comparison methodology must contain exactly the canonical methodology fields');
   }
   if (!sameJson(methodology.comparable_database_fields, comparableDatabaseFields)) {
     fail(
@@ -28,7 +44,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata; database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
     );
   }
   return methodology;

--- a/scripts/verify/verify-index-storage-adr-tooling.mjs
+++ b/scripts/verify/verify-index-storage-adr-tooling.mjs
@@ -87,10 +87,10 @@ for (const marker of [
   "'date_style'",
   "'extra_float_digits'",
   'export const databaseSettingsSource =',
-  'read-report.json database metadata observed from the active PostgreSQL benchmark session',
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata',
   'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
   'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
-  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+  'database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
 ]) {
   if (!databaseSettingsContract.includes(marker)) {
     fail(`database settings contract is missing marker: ${marker}`);

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -209,10 +209,10 @@ requireMarkers(databaseSettingsContract, 'shared database settings contract', [
   'export const comparableDatabaseFields = Object.freeze([',
   ...comparableDatabaseFieldMarkers,
   'export const databaseSettingsSource =',
-  'read-report.json database metadata observed from the active PostgreSQL benchmark session',
+  'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata',
   'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
   'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
-  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+  'database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
 ]);
 requireMarkers(prepareDecision, 'decision preparation database settings gate', [
   "from './index-storage-database-settings-contract.mjs'",


### PR DESCRIPTION
## What changed

- retain the full canonical PostgreSQL database-settings provenance string across the shared runtime contract and both static integrity guards;
- define the exact eight-field comparison methodology envelope emitted by the official comparator;
- reject missing, renamed, or additional methodology fields before decision preparation, ADR rendering, or finalization;
- continue requiring the exact ordered `comparable_database_fields` list and canonical `database_settings_source` value.

## Root cause

The shared gate validated only `comparable_database_fields` and `database_settings_source`. A comparison could therefore carry arbitrary additional methodology metadata, or omit another canonical methodology field, while still passing the database-settings gate used by the decision path.

## Impact

The official decision and ADR paths now accept only the methodology envelope produced by the canonical comparator: `source_oracle`, `result_digest`, `evidence_validation`, `first_run`, `warm_run`, `automatic_winner_selection`, `comparable_database_fields`, and `database_settings_source`. Extension or omission drift fails closed before a comparison can become decision input.

This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was reduced to one commit on the current `main`; static review covered the comparator-emitted field set, order-insensitive exact-key comparison, existing exact database-field ordering, provenance-string preservation, and unchanged unrelated repository files.