### PR TITLE
refactor(forum): reuse visibility owner in notifications

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20I",
+  "scope": "Forum notification source composition through the current public topic visibility owner",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
+  "visibility_contract": "crates/rustok-forum/contracts/forum-topic-visibility-scope.json",
+  "test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
+  "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "policy": {
+    "viewer_profile": "public unauthenticated without channel context",
+    "topic_status": "open",
+    "category_floor": "inherited public categories only",
+    "channel_restrictions": "unavailable until recipient-specific membership authorization exists",
+    "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",
+    "reply_state": "pending deferred; approved eligible; all other states unavailable",
+    "owner_failures": "preserve Forum retryability classification"
+  },
+  "composition": {
+    "describe_event": true,
+    "resolve_audience": true,
+    "authorize_target_open": true,
+    "topic_created": true,
+    "topic_and_reply_mentions": true,
+    "duplicate_notification_open_predicate_removed": true,
+    "duplicate_notification_channel_predicate_removed": true
+  },
+  "not_delivered": [
+    "recipient-specific authenticated role trust channel group and explicit-user evaluation",
+    "profile privacy and blocking policy",
+    "normalized category and topic audience layer read composition",
+    "search index SEO and deep-link migration",
+    "final notification creation and delivery authorization",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -13,17 +13,18 @@ use rustok_notifications_api::{
     NotificationTemplateKey, NotificationTypeKey, ResolveNotificationAudienceRequest,
 };
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
-    QueryOrder, QuerySelect, Statement,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Statement,
 };
 use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::entities::{
-    forum_category_subscription, forum_domain_event, forum_reply, forum_topic,
-    forum_topic_channel_access, forum_user_mention,
+    forum_category_subscription, forum_domain_event, forum_reply, forum_topic, forum_user_mention,
 };
-use crate::state_machine::{ReplyStatus, TopicStatus};
+use crate::error::ForumError;
+use crate::services::topic_visibility::{ForumTopicVisibilityScope, ForumTopicVisibilityService};
+use crate::state_machine::ReplyStatus;
 use crate::subscription::ForumSubscriptionLevel;
 
 const FORUM_SOURCE: &str = "forum";
@@ -131,15 +132,23 @@ impl ForumNotificationSourceProvider {
         Ok(persisted)
     }
 
-    async fn load_open_topic(
+    async fn load_public_topic(
         &self,
         tenant_id: Uuid,
         topic_id: Uuid,
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
+        let scope = ForumTopicVisibilityScope::storefront(None).map_err(forum_owner_error)?;
+        if !ForumTopicVisibilityService::new(self.db.clone())
+            .is_topic_visible(tenant_id, topic_id, &scope)
+            .await
+            .map_err(forum_owner_error)?
+        {
+            return Ok(None);
+        }
+
         let topic = forum_topic::Entity::find()
             .filter(forum_topic::Column::TenantId.eq(tenant_id))
             .filter(forum_topic::Column::Id.eq(topic_id))
-            .filter(forum_topic::Column::Status.eq(TopicStatus::Open))
             .one(&self.db)
             .await
             .map_err(retryable_database_error)?;
@@ -163,12 +172,9 @@ impl ForumNotificationSourceProvider {
     ) -> NotificationProviderResult<ForumTargetAvailability> {
         match source_kind {
             "topic" => {
-                let Some(topic) = self.load_open_topic(tenant_id, source_id).await? else {
+                let Some(topic) = self.load_public_topic(tenant_id, source_id).await? else {
                     return Ok(ForumTargetAvailability::Unavailable);
                 };
-                if self.is_channel_restricted(tenant_id, topic.id).await? {
-                    return Ok(ForumTargetAvailability::Unavailable);
-                }
                 Ok(ForumTargetAvailability::Visible(ForumTargetContext {
                     source_kind: "topic".to_string(),
                     source_id: topic.id,
@@ -198,12 +204,9 @@ impl ForumNotificationSourceProvider {
                 if reply.status != ReplyStatus::Approved {
                     return Ok(ForumTargetAvailability::Unavailable);
                 }
-                let Some(topic) = self.load_open_topic(tenant_id, reply.topic_id).await? else {
+                let Some(topic) = self.load_public_topic(tenant_id, reply.topic_id).await? else {
                     return Ok(ForumTargetAvailability::Unavailable);
                 };
-                if self.is_channel_restricted(tenant_id, topic.id).await? {
-                    return Ok(ForumTargetAvailability::Unavailable);
-                }
                 Ok(ForumTargetAvailability::Visible(ForumTargetContext {
                     source_kind: "reply".to_string(),
                     source_id: reply.id,
@@ -231,20 +234,6 @@ impl ForumNotificationSourceProvider {
             ))
             .await
             .map(|row| row.is_some())
-            .map_err(retryable_database_error)
-    }
-
-    async fn is_channel_restricted(
-        &self,
-        tenant_id: Uuid,
-        topic_id: Uuid,
-    ) -> NotificationProviderResult<bool> {
-        forum_topic_channel_access::Entity::find()
-            .filter(forum_topic_channel_access::Column::TenantId.eq(tenant_id))
-            .filter(forum_topic_channel_access::Column::TopicId.eq(topic_id))
-            .count(&self.db)
-            .await
-            .map(|count| count > 0)
             .map_err(retryable_database_error)
     }
 
@@ -397,17 +386,11 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
                     return Err(NotificationProviderError::InvalidEvent);
                 }
                 let Some(topic) = self
-                    .load_open_topic(event.tenant_id, event.aggregate_id)
+                    .load_public_topic(event.tenant_id, event.aggregate_id)
                     .await?
                 else {
                     return Ok(None);
                 };
-                if self
-                    .is_channel_restricted(event.tenant_id, event.aggregate_id)
-                    .await?
-                {
-                    return Ok(None);
-                }
                 let template_data = NotificationTemplateData::try_new(BTreeMap::from([
                     ("topic_id".to_string(), topic.id.to_string()),
                     ("category_id".to_string(), topic.category_id.to_string()),
@@ -461,17 +444,11 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
             TOPIC_CREATED_TYPE => {
                 self.validate_topic_descriptor(&event, &request.descriptor)?;
                 let Some(topic) = self
-                    .load_open_topic(event.tenant_id, event.aggregate_id)
+                    .load_public_topic(event.tenant_id, event.aggregate_id)
                     .await?
                 else {
                     return Ok(NotificationAudiencePage::empty());
                 };
-                if self
-                    .is_channel_restricted(event.tenant_id, event.aggregate_id)
-                    .await?
-                {
-                    return Ok(NotificationAudiencePage::empty());
-                }
 
                 let limit = request.bounded_limit();
                 if limit == 0 {
@@ -599,6 +576,12 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
 
 fn retryable_database_error(_error: sea_orm::DbErr) -> NotificationProviderError {
     NotificationProviderError::Internal { retryable: true }
+}
+
+fn forum_owner_error(error: ForumError) -> NotificationProviderError {
+    NotificationProviderError::Internal {
+        retryable: error.is_retryable(),
+    }
 }
 
 fn is_supported_event_type(event_type: &NotificationTypeKey) -> bool {

--- a/crates/rustok-forum/tests/notification_source_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_source_sqlite.rs
@@ -13,8 +13,9 @@ use rustok_notifications::NotificationsModule;
 use rustok_notifications_api::{
     AuthorizeNotificationTargetRequest, DescribeNotificationRequest, NotificationOpenAuthorization,
     NotificationProviderError, NotificationSourceEventRef, NotificationSourceSlug,
-    NotificationTypeKey, ResolveNotificationAudienceRequest,
-    materialize_notification_source_registry, notification_source_factory_registry_from_extensions,
+    NotificationTargetKind, NotificationTargetRef, NotificationTypeKey,
+    ResolveNotificationAudienceRequest, materialize_notification_source_registry,
+    notification_source_factory_registry_from_extensions,
     notification_source_registry_from_extensions,
 };
 use rustok_outbox::TransactionalEventBus;
@@ -203,6 +204,77 @@ async fn forum_topic_and_user_mention_sources_support_notifications_profiles() {
         ),
         NotificationOpenAuthorization::Unavailable => panic!("open topic should be available"),
     }
+
+    let restricted_topic = TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id: category.id,
+                title: "Mobile provider proof".into(),
+                slug: Some("mobile-provider-proof".into()),
+                body: "This topic is visible only in the mobile channel.".into(),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: Some(vec!["mobile".into()]),
+            },
+        )
+        .await
+        .expect("channel-restricted topic should be created");
+    let restricted_event = forum_domain_event::Entity::find()
+        .filter(forum_domain_event::Column::TenantId.eq(tenant_id))
+        .filter(forum_domain_event::Column::AggregateType.eq("topic"))
+        .filter(forum_domain_event::Column::AggregateId.eq(restricted_topic.id))
+        .filter(forum_domain_event::Column::EventType.eq("forum.topic.created"))
+        .one(&db)
+        .await
+        .expect("restricted topic event query should succeed")
+        .expect("restricted topic-created event should be journaled");
+    assert!(
+        provider
+            .describe_event(DescribeNotificationRequest {
+                event: source_event_ref(&restricted_event),
+            })
+            .await
+            .expect("restricted topic description should fail closed")
+            .is_none()
+    );
+    let restricted_open = provider
+        .authorize_target_open(AuthorizeNotificationTargetRequest {
+            tenant_id,
+            recipient_id: first_recipient,
+            target: NotificationTargetRef {
+                owner: NotificationSourceSlug::new("forum").expect("source slug"),
+                kind: NotificationTargetKind::new("forum.topic").expect("topic target kind"),
+                id: restricted_topic.id,
+            },
+        })
+        .await
+        .expect("restricted topic authorization should fail closed");
+    assert_eq!(
+        restricted_open,
+        NotificationOpenAuthorization::Unavailable
+    );
+    let restricted_mention_event = seed_user_mention_event(
+        &db,
+        tenant_id,
+        author_id,
+        restricted_topic.id,
+        first_recipient,
+    )
+    .await;
+    assert!(
+        provider
+            .describe_event(DescribeNotificationRequest {
+                event: source_event_ref(&restricted_mention_event),
+            })
+            .await
+            .expect("restricted mention description should fail closed")
+            .is_none()
+    );
 
     let mention_event =
         seed_user_mention_event(&db, tenant_id, author_id, topic.id, first_recipient).await;

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const notificationSource = read(contract.notification_source_file ?? "");
+const visibilityOwner = read(contract.visibility_owner_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification visibility contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20I") {
+  failures.push("forum notification visibility contract must belong to FORUM-20I");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted notification evidence");
+}
+for (const residual of [
+  "recipient-specific authenticated role trust channel group and explicit-user evaluation",
+  "profile privacy and blocking policy",
+  "normalized category and topic audience layer read composition",
+  "search index SEO and deep-link migration",
+  "final notification creation and delivery authorization",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
+  }
+}
+
+for (const marker of [
+  "pub struct ForumTopicVisibilityScope",
+  "pub fn storefront(channel_slug: Option<&str>) -> ForumResult<Self>",
+  "pub struct ForumTopicVisibilityService",
+  "pub async fn is_topic_visible",
+  "self.hidden_category_ids_for_scope(tenant_id, scope)",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "all_topic_channel_access_subquery(tenant_id)",
+]) {
+  requireText(visibilityOwner, marker, `topic visibility owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "use crate::error::ForumError;",
+  "ForumTopicVisibilityScope, ForumTopicVisibilityService",
+  "async fn load_public_topic(",
+  "ForumTopicVisibilityScope::storefront(None)",
+  ".is_topic_visible(tenant_id, topic_id, &scope)",
+  ".map_err(forum_owner_error)?",
+  ".load_public_topic(tenant_id, source_id)",
+  ".load_public_topic(tenant_id, reply.topic_id)",
+  ".load_public_topic(event.tenant_id, event.aggregate_id)",
+  "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
+  "retryable: error.is_retryable()",
+]) {
+  requireText(
+    notificationSource,
+    marker,
+    `forum notification source is missing owner visibility composition ${marker}`,
+  );
+}
+for (const forbidden of [
+  "async fn load_open_topic(",
+  "async fn is_channel_restricted(",
+  "forum_topic_channel_access",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+]) {
+  rejectText(
+    notificationSource,
+    forbidden,
+    `forum notification source must not retain duplicate visibility policy ${forbidden}`,
+  );
+}
+
+const visibilityIndex = notificationSource.indexOf(
+  ".is_topic_visible(tenant_id, topic_id, &scope)",
+);
+const materializeIndex = notificationSource.indexOf(
+  "let topic = forum_topic::Entity::find()",
+);
+if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
+  failures.push("notification target visibility must be evaluated before target materialization");
+}
+
+for (const marker of [
+  "forum_topic_and_user_mention_sources_support_notifications_profiles",
+  "channel-restricted topic should be created",
+  "restricted topic description should fail closed",
+  "restricted topic authorization should fail closed",
+  "restricted mention description should fail closed",
+  "cross-tenant authorization should fail closed",
+  "closed target authorization should fail closed",
+  "database failure should be classified",
+  "NotificationProviderError::Internal { retryable: true }",
+]) {
+  requireText(testSource, marker, `notification SQLite scenario is missing ${marker}`);
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+  "migrate notifications,",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification visibility composition verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification visibility composition contract is source-ready.");


### PR DESCRIPTION
## Summary

- deliver the notification-consumer portion of the Forum visibility migration as `FORUM-20I`
- route topic-created and topic/reply mention description, audience resolution, and target-open authorization through `ForumTopicVisibilityService`
- preserve topic/reply soft-delete checks, pending/approved reply semantics, and Forum retryability classification
- remove notification-local open-topic and channel-restriction predicates
- add channel-restricted topic/mention, cross-tenant, closed-target, and database-failure SQLite coverage
- add a dedicated machine contract and source verifier for the notification visibility composition

## Recheck

The abandoned `forum20b-clean` branch was not merged wholesale. Its two implementation files were first compared with their original base and current `main`; neither had changed on `main`, so only those clean file deltas were reused. The old contract and canonical-plan blobs were rejected because they predated `FORUM-20C–H` and would have reverted newer roadmap and policy work.

The current owner now composes the open/exact-channel rule with the inherited public/authenticated category floor. This PR deliberately uses the public, unauthenticated, no-channel scope; channel-restricted targets remain unavailable until recipient-specific membership and richer audience authorization are composed.

## Compatibility

- no migration, backfill, endpoint, transport field, UI, or CI change
- Notifications remains optional and Forum commands remain independent from it
- normalized category/topic audience layers, profile privacy/blocking, final delivery authorization, search/index, SEO, deep links, and PostgreSQL runtime evidence remain open

## Validation

Not run at the maintainer's request. Intended commands:

```bash
cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
node scripts/verify/verify-forum-notification-visibility-composition.mjs
cargo xtask module validate forum
```

Closes #2101