### PR TITLE
Harden fulfillment checkout lifecycle errors

### DIFF
--- a/crates/rustok-fulfillment/src/checkout_execution_typed.rs
+++ b/crates/rustok-fulfillment/src/checkout_execution_typed.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rustok_api::{PortContext, PortError, PortErrorKind};
+use rustok_api::{PortContext, PortError};
 use sea_orm::DatabaseConnection;
 
 use crate::checkout_execution::{
@@ -10,6 +10,11 @@ use crate::checkout_execution::{
 };
 use crate::dto::FulfillmentResponse;
 use crate::status::FulfillmentStatusKind;
+
+const MANUAL_RECONCILIATION_CODE: &str =
+    "fulfillment.checkout_execution_manual_reconciliation";
+const MANUAL_RECONCILIATION_MESSAGE: &str =
+    "checkout fulfillment requires manual reconciliation";
 
 /// Mounted in-process fulfillment boundary with fail-closed lifecycle validation.
 ///
@@ -35,11 +40,16 @@ impl CheckoutFulfillmentExecutionPort for TypedCheckoutFulfillmentExecutionPort 
         context: PortContext,
         request: EnsureCheckoutFulfillmentsRequest,
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
+        let lifecycle_context = context.clone();
         let fulfillments = self
             .delegate
             .ensure_checkout_fulfillments(context, request)
             .await?;
-        validate_checkout_fulfillment_lifecycle(&fulfillments)?;
+        validate_checkout_fulfillment_lifecycle(
+            &lifecycle_context,
+            "ensure_checkout_fulfillments",
+            &fulfillments,
+        )?;
         Ok(fulfillments)
     }
 
@@ -48,11 +58,16 @@ impl CheckoutFulfillmentExecutionPort for TypedCheckoutFulfillmentExecutionPort 
         context: PortContext,
         request: ReadCheckoutFulfillmentsRequest,
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
+        let lifecycle_context = context.clone();
         let fulfillments = self
             .delegate
             .read_checkout_fulfillments(context, request)
             .await?;
-        validate_checkout_fulfillment_lifecycle(&fulfillments)?;
+        validate_checkout_fulfillment_lifecycle(
+            &lifecycle_context,
+            "read_checkout_fulfillments",
+            &fulfillments,
+        )?;
         Ok(fulfillments)
     }
 }
@@ -64,6 +79,8 @@ pub fn in_process_checkout_fulfillment_execution_port(
 }
 
 fn validate_checkout_fulfillment_lifecycle(
+    context: &PortContext,
+    operation: &'static str,
     fulfillments: &[FulfillmentResponse],
 ) -> Result<(), PortError> {
     for fulfillment in fulfillments {
@@ -73,12 +90,18 @@ fn validate_checkout_fulfillment_lifecycle(
             | FulfillmentStatusKind::Delivered => {}
             FulfillmentStatusKind::Cancelled => {
                 return Err(manual_reconciliation(
-                    "checkout fulfillment is cancelled after payment capture",
+                    context,
+                    operation,
+                    fulfillment,
+                    "cancelled_after_payment_capture",
                 ));
             }
             FulfillmentStatusKind::Unknown => {
                 return Err(manual_reconciliation(
-                    "checkout fulfillment lifecycle is unknown",
+                    context,
+                    operation,
+                    fulfillment,
+                    "unknown_owner_status",
                 ));
             }
         }
@@ -86,12 +109,28 @@ fn validate_checkout_fulfillment_lifecycle(
     Ok(())
 }
 
-fn manual_reconciliation(message: &'static str) -> PortError {
-    PortError::new(
-        PortErrorKind::Conflict,
-        "fulfillment.checkout_execution_manual_reconciliation",
-        message,
-        false,
+fn manual_reconciliation(
+    context: &PortContext,
+    operation: &'static str,
+    fulfillment: &FulfillmentResponse,
+    cause: &'static str,
+) -> PortError {
+    tracing::error!(
+        owner = "rustok_fulfillment.checkout_execution",
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        channel = ?context.channel,
+        operation,
+        fulfillment_id = %fulfillment.id,
+        order_id = %fulfillment.order_id,
+        owner_status = %fulfillment.status,
+        cause,
+        code = MANUAL_RECONCILIATION_CODE,
+        "checkout fulfillment lifecycle requires manual reconciliation"
+    );
+    PortError::conflict(
+        MANUAL_RECONCILIATION_CODE,
+        MANUAL_RECONCILIATION_MESSAGE,
     )
 }
 
@@ -100,7 +139,18 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use serde_json::json;
+    use std::time::Duration;
     use uuid::Uuid;
+
+    fn context() -> PortContext {
+        PortContext::new(
+            Uuid::new_v4().to_string(),
+            rustok_api::PortActor::service("fulfillment-checkout-lifecycle-test"),
+            "en",
+            "fulfillment-checkout-lifecycle-test-correlation",
+        )
+        .with_deadline(Duration::from_secs(2))
+    }
 
     fn fulfillment(status: &str) -> FulfillmentResponse {
         FulfillmentResponse {
@@ -126,20 +176,31 @@ mod tests {
 
     #[test]
     fn checkout_replay_accepts_active_and_completed_fulfillments() {
+        let context = context();
         for status in ["pending", "shipped", "delivered"] {
-            assert!(validate_checkout_fulfillment_lifecycle(&[fulfillment(status)]).is_ok());
+            assert!(
+                validate_checkout_fulfillment_lifecycle(
+                    &context,
+                    "test_checkout_fulfillment_lifecycle",
+                    &[fulfillment(status)],
+                )
+                .is_ok()
+            );
         }
     }
 
     #[test]
     fn checkout_replay_reconciles_cancelled_and_unknown_fulfillments() {
+        let context = context();
         for status in ["cancelled", "carrier_custom"] {
-            let error = validate_checkout_fulfillment_lifecycle(&[fulfillment(status)])
-                .expect_err("unsafe fulfillment lifecycle must fail closed");
-            assert_eq!(
-                error.code,
-                "fulfillment.checkout_execution_manual_reconciliation"
-            );
+            let error = validate_checkout_fulfillment_lifecycle(
+                &context,
+                "test_checkout_fulfillment_lifecycle",
+                &[fulfillment(status)],
+            )
+            .expect_err("unsafe fulfillment lifecycle must fail closed");
+            assert_eq!(error.code, MANUAL_RECONCILIATION_CODE);
+            assert_eq!(error.message, MANUAL_RECONCILIATION_MESSAGE);
         }
     }
 }

--- a/scripts/verify/verify-fulfillment-checkout-lifecycle-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-checkout-lifecycle-error-safety.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-fulfillment/src/checkout_execution_typed.rs');
+const statusContract = read('crates/rustok-fulfillment/src/status.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const ensureMethod = between(
+  source,
+  'async fn ensure_checkout_fulfillments(',
+  'async fn read_checkout_fulfillments(',
+  'typed fulfillment ensure method',
+);
+const readMethod = between(
+  source,
+  'async fn read_checkout_fulfillments(',
+  'pub fn in_process_checkout_fulfillment_execution_port(',
+  'typed fulfillment read method',
+);
+const lifecycleValidator = between(
+  source,
+  'fn validate_checkout_fulfillment_lifecycle(',
+  'fn manual_reconciliation(',
+  'fulfillment lifecycle validator',
+);
+const reconciliationMapper = between(
+  source,
+  'fn manual_reconciliation(',
+  '#[cfg(test)]',
+  'fulfillment reconciliation mapper',
+);
+const tests = from(source, '#[cfg(test)]', 'fulfillment lifecycle tests');
+
+for (const [value, label] of [
+  ['use rustok_api::{PortContext, PortError};', 'typed port imports'],
+  ['const MANUAL_RECONCILIATION_CODE: &str =', 'stable reconciliation code'],
+  ['"fulfillment.checkout_execution_manual_reconciliation"', 'reconciliation code value'],
+  ['const MANUAL_RECONCILIATION_MESSAGE: &str =', 'stable reconciliation message'],
+  ['"checkout fulfillment requires manual reconciliation"', 'reconciliation message value'],
+]) requireText(source, value, label);
+
+for (const [content, operation, label] of [
+  [ensureMethod, '"ensure_checkout_fulfillments"', 'ensure operation'],
+  [readMethod, '"read_checkout_fulfillments"', 'read operation'],
+]) {
+  for (const [value, detail] of [
+    ['let lifecycle_context = context.clone();', `${label} context retention`],
+    ['&lifecycle_context,', `${label} validation context`],
+    [operation, `${label} label`],
+    ['&fulfillments,', `${label} fulfillment validation`],
+  ]) requireText(content, value, detail);
+}
+
+for (const [value, label] of [
+  ['context: &PortContext', 'validator context input'],
+  ["operation: &'static str", 'validator operation input'],
+  ['FulfillmentStatusKind::Pending', 'pending lifecycle'],
+  ['FulfillmentStatusKind::Shipped', 'shipped lifecycle'],
+  ['FulfillmentStatusKind::Delivered', 'delivered lifecycle'],
+  ['FulfillmentStatusKind::Cancelled', 'cancelled lifecycle'],
+  ['FulfillmentStatusKind::Unknown', 'unknown lifecycle'],
+  ['"cancelled_after_payment_capture"', 'cancelled internal cause'],
+  ['"unknown_owner_status"', 'unknown internal cause'],
+  ['manual_reconciliation(', 'typed reconciliation mapper use'],
+]) requireText(lifecycleValidator, value, label);
+
+for (const [value, label] of [
+  ['context: &PortContext', 'mapper context input'],
+  ["operation: &'static str", 'mapper operation input'],
+  ['fulfillment: &FulfillmentResponse', 'mapper fulfillment input'],
+  ["cause: &'static str", 'mapper internal cause input'],
+  ['owner = "rustok_fulfillment.checkout_execution"', 'owner log'],
+  ['correlation_id = %context.correlation_id', 'correlation log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['channel = ?context.channel', 'channel log'],
+  ['operation,', 'operation log'],
+  ['fulfillment_id = %fulfillment.id', 'fulfillment log'],
+  ['order_id = %fulfillment.order_id', 'order log'],
+  ['owner_status = %fulfillment.status', 'raw owner status internal log'],
+  ['cause,', 'internal cause log'],
+  ['code = MANUAL_RECONCILIATION_CODE', 'stable code log'],
+  ['PortError::conflict(', 'typed conflict envelope'],
+  ['MANUAL_RECONCILIATION_CODE,', 'public code use'],
+  ['MANUAL_RECONCILIATION_MESSAGE,', 'static public message use'],
+]) requireText(reconciliationMapper, value, label);
+
+for (const value of [
+  'PortError::new(',
+  'checkout fulfillment is cancelled after payment capture',
+  'checkout fulfillment lifecycle is unknown',
+]) forbidText(source, value, 'unsafe lifecycle public envelope');
+
+const reconciliationUses = source.match(/manual_reconciliation\(/g) ?? [];
+if (reconciliationUses.length !== 3) {
+  failures.push(
+    `expected reconciliation mapper definition plus cancelled/unknown uses, found ${reconciliationUses.length}`,
+  );
+}
+
+for (const [value, label] of [
+  ['fn context() -> PortContext', 'test context fixture'],
+  ['validate_checkout_fulfillment_lifecycle(', 'validator test use'],
+  ['error.code, MANUAL_RECONCILIATION_CODE', 'stable code assertion'],
+  ['error.message, MANUAL_RECONCILIATION_MESSAGE', 'static message assertion'],
+  ['["pending", "shipped", "delivered"]', 'accepted lifecycle fixture'],
+  ['["cancelled", "carrier_custom"]', 'reconciliation lifecycle fixture'],
+]) requireText(tests, value, label);
+
+for (const [content, value, label] of [
+  [statusContract, 'pub enum FulfillmentStatusKind {', 'typed fulfillment status enum'],
+  [statusContract, 'Pending,', 'pending status kind'],
+  [statusContract, 'Shipped,', 'shipped status kind'],
+  [statusContract, 'Delivered,', 'delivered status kind'],
+  [statusContract, 'Cancelled,', 'cancelled status kind'],
+  [statusContract, 'Unknown,', 'unknown status kind'],
+  [statusContract, '_ => Self::Unknown', 'unknown status fail-close'],
+  [portContract, 'pub correlation_id: String', 'port correlation field'],
+  [portContract, 'pub channel: Option<String>', 'port channel field'],
+  [portContract, 'pub struct PortError {', 'typed port error'],
+  [portContract, 'pub fn conflict(', 'typed conflict constructor'],
+]) requireText(content, value, label);
+
+if (failures.length > 0) {
+  console.error('Fulfillment checkout lifecycle error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Fulfillment checkout lifecycle failures keep owner causes internal and correlation-aware');


### PR DESCRIPTION
## Summary

- retain the mounted fulfillment `PortContext` across delegated ensure/read execution so lifecycle failures can be diagnosed with the original correlation identity;
- replace cancelled/unknown checkout-fulfillment public cause text with one stable manual-reconciliation conflict envelope;
- keep owner status and the concrete reconciliation cause internal in structured logs with owner, correlation id, tenant, channel, operation, fulfillment, order, and stable code;
- extend source tests to require the same public code/message for cancelled and unknown lifecycle states;
- add a focused static verifier for context retention, typed lifecycle coverage, internal diagnostics, and the absence of the previous cause-specific public messages.

## Plan alignment

This advances the still-open ecommerce audit items for fulfillment mapper cleanup and correlation-aware owner-side logging. It does not claim the broad ecommerce error-safety audit is complete and does not promote FBA/FFA status.

## Scope

Two files only:

- `crates/rustok-fulfillment/src/checkout_execution_typed.rs`
- `scripts/verify/verify-fulfillment-checkout-lifecycle-error-safety.mjs`

Fulfillment persistence, idempotent adoption, request validation, active lifecycle acceptance, checkout orchestration, transport shape, and status classification remain unchanged.

## Validation

- branch is directly ahead of current `main` by two commits and is not behind;
- diff is limited to the two intended files (`+242/-18`);
- both files were re-read after writing to confirm context propagation, fail-closed lifecycle matching, static public messaging, internal cause logging, and verifier coverage;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-fulfillment-checkout-lifecycle-error-safety.mjs
cargo test -p rustok-fulfillment checkout_execution_typed -- --nocapture
```