### PR TITLE
Harden fulfillment checkout execution errors

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -40,12 +40,17 @@ available only for actionable domain errors.
   context and owner operation into the mapper. Database, validation, transition, and
   provider causes are logged with correlation identity; raw provider ids, lifecycle
   strings, and storage causes do not appear in the public message.
+- `rustok-fulfillment` checkout execution: ensure/read storage calls and idempotent
+  adoption lookups pass the original `PortContext` and owner operation into the mapper.
+  Validation, missing-resource, transition, and database causes are logged with
+  correlation identity and stable codes while the existing public envelopes remain
+  static.
 
 ## Still open
 
-- Audit order, fulfillment, inventory, customer, tax, promotion, payment execution/
-  compensation, and remaining ecommerce adapters for technical text mislabeled as
-  validation/conflict errors.
+- Audit order, remaining fulfillment adapters, inventory, customer, tax, promotion,
+  payment execution/compensation, and remaining ecommerce adapters for technical text
+  mislabeled as validation/conflict errors.
 - Add structured owner-side logging with `correlation_id`, owner operation, stable error
   code, and the original cause before every remaining technical `PortError` mapping.
 - Remove raw technical text from non-`PortError` public REST, GraphQL, native, and
@@ -56,10 +61,12 @@ available only for actionable domain errors.
 
 - `node scripts/verify/verify-port-error-public-safety.mjs`
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
+- `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `cargo test -p rustok-api ports::tests`
 - `cargo check -p rustok-pricing --all-features`
 - `cargo check -p rustok-payment --all-features`
-- Targeted pricing and payment collection database, validation, transition,
-  provider/invariant, correlation, and transport round-trip tests.
+- `cargo check -p rustok-fulfillment --all-features`
+- Targeted pricing, payment collection, and fulfillment checkout execution database,
+  validation, transition, correlation, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-fulfillment/src/checkout_execution.rs
+++ b/crates/rustok-fulfillment/src/checkout_execution.rs
@@ -13,6 +13,9 @@ use crate::{
     FulfillmentService,
 };
 
+const ENSURE_OPERATION: &str = "ensure_checkout_fulfillments";
+const READ_OPERATION: &str = "read_checkout_fulfillments";
+
 #[async_trait]
 pub trait CheckoutFulfillmentExecutionPort: Send + Sync {
     async fn ensure_checkout_fulfillments(
@@ -77,6 +80,7 @@ impl InProcessCheckoutFulfillmentExecutionPort {
 
     async fn ensure(
         &self,
+        context: &PortContext,
         tenant_id: Uuid,
         request: EnsureCheckoutFulfillmentsRequest,
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
@@ -91,7 +95,13 @@ impl InProcessCheckoutFulfillmentExecutionPort {
             let key = fulfillment_key(request.checkout_operation_id, plan.index);
             let input = build_input(&request, plan, key.as_str());
             let existing = self
-                .find_by_key(tenant_id, request.order_id, key.as_str())
+                .find_by_key(
+                    context,
+                    "find_checkout_fulfillment_before_create",
+                    tenant_id,
+                    request.order_id,
+                    key.as_str(),
+                )
                 .await?;
             let fulfillment = match existing {
                 Some(existing) => existing,
@@ -99,11 +109,23 @@ impl InProcessCheckoutFulfillmentExecutionPort {
                     Ok(created) => created,
                     Err(error) => {
                         let adopted = self
-                            .find_by_key(tenant_id, request.order_id, key.as_str())
+                            .find_by_key(
+                                context,
+                                "adopt_checkout_fulfillment_after_create_error",
+                                tenant_id,
+                                request.order_id,
+                                key.as_str(),
+                            )
                             .await?;
                         match adopted {
                             Some(adopted) => adopted,
-                            None => return Err(fulfillment_error_to_port_error(error)),
+                            None => {
+                                return Err(fulfillment_error_to_port_error(
+                                    context,
+                                    "create_checkout_fulfillment",
+                                    error,
+                                ));
+                            }
                         }
                     }
                 },
@@ -126,6 +148,7 @@ impl InProcessCheckoutFulfillmentExecutionPort {
 
     async fn read(
         &self,
+        context: &PortContext,
         tenant_id: Uuid,
         request: ReadCheckoutFulfillmentsRequest,
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
@@ -139,7 +162,13 @@ impl InProcessCheckoutFulfillmentExecutionPort {
             .service
             .list_by_order(tenant_id, request.order_id)
             .await
-            .map_err(fulfillment_error_to_port_error)?;
+            .map_err(|error| {
+                fulfillment_error_to_port_error(
+                    context,
+                    "list_checkout_fulfillments_for_read",
+                    error,
+                )
+            })?;
         let operation_id = request.checkout_operation_id.to_string();
         let mut by_index = BTreeMap::new();
         for row in rows.into_iter().filter(|row| {
@@ -189,6 +218,8 @@ impl InProcessCheckoutFulfillmentExecutionPort {
 
     async fn find_by_key(
         &self,
+        context: &PortContext,
+        owner_operation: &'static str,
         tenant_id: Uuid,
         order_id: Uuid,
         key: &str,
@@ -197,7 +228,9 @@ impl InProcessCheckoutFulfillmentExecutionPort {
             .service
             .list_by_order(tenant_id, order_id)
             .await
-            .map_err(fulfillment_error_to_port_error)?;
+            .map_err(|error| {
+                fulfillment_error_to_port_error(context, owner_operation, error)
+            })?;
         let mut matches = rows.into_iter().filter(|fulfillment| {
             fulfillment
                 .metadata
@@ -232,9 +265,9 @@ impl CheckoutFulfillmentExecutionPort for InProcessCheckoutFulfillmentExecutionP
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
         context.require_policy(PortCallPolicy::write())?;
         context.require_write_semantics()?;
-        let tenant_id = parse_tenant_id(&context)?;
-        require_operation_context(&context, request.checkout_operation_id)?;
-        self.ensure(tenant_id, request).await
+        let tenant_id = parse_tenant_id(&context, ENSURE_OPERATION)?;
+        require_operation_context(&context, ENSURE_OPERATION, request.checkout_operation_id)?;
+        self.ensure(&context, tenant_id, request).await
     }
 
     async fn read_checkout_fulfillments(
@@ -243,9 +276,9 @@ impl CheckoutFulfillmentExecutionPort for InProcessCheckoutFulfillmentExecutionP
         request: ReadCheckoutFulfillmentsRequest,
     ) -> Result<Vec<FulfillmentResponse>, PortError> {
         context.require_policy(PortCallPolicy::read())?;
-        let tenant_id = parse_tenant_id(&context)?;
-        require_operation_context(&context, request.checkout_operation_id)?;
-        self.read(tenant_id, request).await
+        let tenant_id = parse_tenant_id(&context, READ_OPERATION)?;
+        require_operation_context(&context, READ_OPERATION, request.checkout_operation_id)?;
+        self.read(&context, tenant_id, request).await
     }
 }
 
@@ -476,6 +509,7 @@ fn object_or_empty(value: Value) -> serde_json::Map<String, Value> {
 
 fn require_operation_context(
     context: &PortContext,
+    owner_operation: &'static str,
     checkout_operation_id: Uuid,
 ) -> Result<(), PortError> {
     let context_operation = context
@@ -483,6 +517,15 @@ fn require_operation_context(
         .as_deref()
         .and_then(|value| Uuid::parse_str(value).ok());
     if context_operation != Some(checkout_operation_id) {
+        tracing::warn!(
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
+            operation = owner_operation,
+            expected_checkout_operation_id = %checkout_operation_id,
+            code = "fulfillment.checkout_operation_id_invalid",
+            "checkout fulfillment execution received invalid causation identity"
+        );
         return Err(PortError::validation(
             "fulfillment.checkout_operation_id_invalid",
             "checkout fulfillment causation_id must match the checkout operation",
@@ -491,8 +534,20 @@ fn require_operation_context(
     Ok(())
 }
 
-fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+fn parse_tenant_id(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+        tracing::warn!(
+            error = ?error,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
+            operation = owner_operation,
+            code = "fulfillment.tenant_id_invalid",
+            "checkout fulfillment execution received invalid tenant context"
+        );
         PortError::validation(
             "fulfillment.tenant_id_invalid",
             "PortContext.tenant_id must be a UUID for fulfillment ports",
@@ -500,30 +555,87 @@ fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
     })
 }
 
-fn fulfillment_error_to_port_error(error: FulfillmentError) -> PortError {
+fn fulfillment_error_to_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: FulfillmentError,
+) -> PortError {
     match error {
-        FulfillmentError::Validation(_) => PortError::validation(
-            "fulfillment.checkout_execution_validation",
-            "checkout fulfillment request is invalid",
-        ),
-        FulfillmentError::ShippingOptionNotFound(_) => PortError::new(
-            PortErrorKind::NotFound,
-            "fulfillment.shipping_option_not_found",
-            "shipping option was not found",
-            false,
-        ),
-        FulfillmentError::FulfillmentNotFound(_) => PortError::new(
-            PortErrorKind::NotFound,
-            "fulfillment.fulfillment_not_found",
-            "fulfillment was not found",
-            false,
-        ),
-        FulfillmentError::InvalidTransition { .. } => PortError::conflict(
-            "fulfillment.checkout_execution_state_conflict",
-            "fulfillment lifecycle conflicts with checkout execution",
-        ),
+        FulfillmentError::Validation(cause) => {
+            tracing::warn!(
+                cause = %cause,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = owner_operation,
+                code = "fulfillment.checkout_execution_validation",
+                "fulfillment owner rejected checkout execution request"
+            );
+            PortError::validation(
+                "fulfillment.checkout_execution_validation",
+                "checkout fulfillment request is invalid",
+            )
+        }
+        FulfillmentError::ShippingOptionNotFound(id) => {
+            tracing::warn!(
+                shipping_option_id = %id,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = owner_operation,
+                code = "fulfillment.shipping_option_not_found",
+                "checkout fulfillment shipping option was not found"
+            );
+            PortError::new(
+                PortErrorKind::NotFound,
+                "fulfillment.shipping_option_not_found",
+                "shipping option was not found",
+                false,
+            )
+        }
+        FulfillmentError::FulfillmentNotFound(id) => {
+            tracing::warn!(
+                fulfillment_id = %id,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = owner_operation,
+                code = "fulfillment.fulfillment_not_found",
+                "checkout fulfillment resource was not found"
+            );
+            PortError::new(
+                PortErrorKind::NotFound,
+                "fulfillment.fulfillment_not_found",
+                "fulfillment was not found",
+                false,
+            )
+        }
+        FulfillmentError::InvalidTransition { from, to } => {
+            tracing::warn!(
+                from = %from,
+                to = %to,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = owner_operation,
+                code = "fulfillment.checkout_execution_state_conflict",
+                "fulfillment lifecycle conflicts with checkout execution"
+            );
+            PortError::conflict(
+                "fulfillment.checkout_execution_state_conflict",
+                "fulfillment lifecycle conflicts with checkout execution",
+            )
+        }
         FulfillmentError::Database(error) => {
-            tracing::error!(error = ?error, "checkout fulfillment storage failed");
+            tracing::error!(
+                error = ?error,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = owner_operation,
+                code = "fulfillment.database_unavailable",
+                "checkout fulfillment storage operation failed"
+            );
             PortError::unavailable(
                 "fulfillment.database_unavailable",
                 "fulfillment storage is temporarily unavailable",

--- a/scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-fulfillment/src/checkout_execution.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const ensure = between(
+  source,
+  'async fn ensure(',
+  'async fn read(',
+  'checkout fulfillment ensure helper',
+);
+const readHelper = between(
+  source,
+  'async fn read(',
+  'async fn find_by_key(',
+  'checkout fulfillment read helper',
+);
+const findHelper = between(
+  source,
+  'async fn find_by_key(',
+  'pub fn in_process_checkout_fulfillment_execution_port(',
+  'checkout fulfillment lookup helper',
+);
+const portImpl = between(
+  source,
+  'impl CheckoutFulfillmentExecutionPort for InProcessCheckoutFulfillmentExecutionPort {',
+  'fn validate_request(',
+  'checkout fulfillment port implementation',
+);
+const operationContext = between(
+  source,
+  'fn require_operation_context(',
+  'fn parse_tenant_id(',
+  'checkout operation context validator',
+);
+const tenantParser = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn fulfillment_error_to_port_error(',
+  'checkout tenant context parser',
+);
+const mapper = from(
+  source,
+  'fn fulfillment_error_to_port_error(',
+  'checkout fulfillment owner mapper',
+);
+
+for (const [value, label] of [
+  ['const ENSURE_OPERATION: &str = "ensure_checkout_fulfillments";', 'ensure operation constant'],
+  ['const READ_OPERATION: &str = "read_checkout_fulfillments";', 'read operation constant'],
+  ['use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};', 'typed port imports'],
+]) requireText(source, value, label);
+
+for (const [content, value, label] of [
+  [ensure, 'context: &PortContext', 'ensure context input'],
+  [ensure, '"find_checkout_fulfillment_before_create"', 'pre-create lookup operation'],
+  [ensure, '"adopt_checkout_fulfillment_after_create_error"', 'post-error adoption operation'],
+  [ensure, '"create_checkout_fulfillment"', 'create operation'],
+  [ensure, 'fulfillment_error_to_port_error(', 'create mapper handoff'],
+  [readHelper, 'context: &PortContext', 'read context input'],
+  [readHelper, '"list_checkout_fulfillments_for_read"', 'read owner operation'],
+  [readHelper, 'fulfillment_error_to_port_error(', 'read mapper handoff'],
+  [findHelper, 'context: &PortContext', 'lookup context input'],
+  [findHelper, "owner_operation: &'static str", 'lookup operation input'],
+  [findHelper, 'fulfillment_error_to_port_error(context, owner_operation, error)', 'lookup mapper handoff'],
+  [portImpl, 'parse_tenant_id(&context, ENSURE_OPERATION)', 'ensure context validation'],
+  [portImpl, 'require_operation_context(&context, ENSURE_OPERATION', 'ensure causation validation'],
+  [portImpl, 'self.ensure(&context, tenant_id, request).await', 'ensure context propagation'],
+  [portImpl, 'parse_tenant_id(&context, READ_OPERATION)', 'read context validation'],
+  [portImpl, 'require_operation_context(&context, READ_OPERATION', 'read causation validation'],
+  [portImpl, 'self.read(&context, tenant_id, request).await', 'read context propagation'],
+]) requireText(content, value, label);
+
+for (const [content, value, label] of [
+  [operationContext, 'correlation_id = %context.correlation_id', 'causation correlation log'],
+  [operationContext, 'tenant_id = %context.tenant_id', 'causation tenant log'],
+  [operationContext, 'channel = ?context.channel', 'causation channel log'],
+  [operationContext, 'operation = owner_operation', 'causation operation log'],
+  [operationContext, 'code = "fulfillment.checkout_operation_id_invalid"', 'causation code log'],
+  [tenantParser, 'error = ?error', 'tenant parse cause log'],
+  [tenantParser, 'correlation_id = %context.correlation_id', 'tenant parse correlation log'],
+  [tenantParser, 'tenant_id = %context.tenant_id', 'tenant parse tenant log'],
+  [tenantParser, 'channel = ?context.channel', 'tenant parse channel log'],
+  [tenantParser, 'operation = owner_operation', 'tenant parse operation log'],
+  [tenantParser, 'code = "fulfillment.tenant_id_invalid"', 'tenant parse code log'],
+]) requireText(content, value, label);
+
+for (const [value, label] of [
+  ['context: &PortContext', 'mapper context input'],
+  ["owner_operation: &'static str", 'mapper operation input'],
+  ['FulfillmentError::Validation(cause)', 'validation cause capture'],
+  ['FulfillmentError::ShippingOptionNotFound(id)', 'shipping option identity capture'],
+  ['FulfillmentError::FulfillmentNotFound(id)', 'fulfillment identity capture'],
+  ['FulfillmentError::InvalidTransition { from, to }', 'transition cause capture'],
+  ['FulfillmentError::Database(error)', 'database cause capture'],
+  ['correlation_id = %context.correlation_id', 'mapper correlation log'],
+  ['tenant_id = %context.tenant_id', 'mapper tenant log'],
+  ['channel = ?context.channel', 'mapper channel log'],
+  ['operation = owner_operation', 'mapper operation log'],
+  ['code = "fulfillment.checkout_execution_validation"', 'validation stable code log'],
+  ['code = "fulfillment.shipping_option_not_found"', 'shipping stable code log'],
+  ['code = "fulfillment.fulfillment_not_found"', 'fulfillment stable code log'],
+  ['code = "fulfillment.checkout_execution_state_conflict"', 'transition stable code log'],
+  ['code = "fulfillment.database_unavailable"', 'database stable code log'],
+  ['"checkout fulfillment request is invalid"', 'static validation public message'],
+  ['"shipping option was not found"', 'static shipping public message'],
+  ['"fulfillment was not found"', 'static fulfillment public message'],
+  ['"fulfillment lifecycle conflicts with checkout execution"', 'static transition public message'],
+  ['"fulfillment storage is temporarily unavailable"', 'static database public message'],
+]) requireText(mapper, value, label);
+
+for (const value of [
+  '.map_err(fulfillment_error_to_port_error)',
+  'tracing::error!(error = ?error, "checkout fulfillment storage failed")',
+  'FulfillmentError::Validation(_) =>',
+]) forbidText(source, value, 'context-free checkout fulfillment mapping');
+
+const mapperUses = source.match(/fulfillment_error_to_port_error\(/g) ?? [];
+if (mapperUses.length !== 4) {
+  failures.push(`expected mapper definition plus three service mappings, found ${mapperUses.length}`);
+}
+
+for (const [value, label] of [
+  ['pub struct PortContext {', 'shared port context'],
+  ['pub correlation_id: String', 'shared correlation field'],
+  ['pub channel: Option<String>', 'shared channel field'],
+  ['pub struct PortError {', 'shared port error'],
+  ['pub fn validation(', 'typed validation constructor'],
+  ['pub fn unavailable(', 'typed unavailable constructor'],
+]) requireText(portContract, value, label);
+
+if (failures.length > 0) {
+  console.error('Fulfillment checkout execution error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Fulfillment checkout execution owner errors retain context and stable public envelopes');


### PR DESCRIPTION
## Summary

- pass the original fulfillment `PortContext` through ensure, read, and idempotent adoption lookups;
- route create/list service failures through a context-aware owner mapper;
- record correlation id, tenant, channel, owner operation, stable code, and the original validation/database/transition cause internally;
- preserve the existing public error codes and messages for validation, not-found, lifecycle conflict, and unavailable outcomes;
- add a focused static verifier that rejects context-free mapper calls and the previous generic storage log;
- update the ecommerce error-safety plan to record this completed fulfillment slice while leaving the broader audit open.

## Scope

Three files only:

- `crates/rustok-fulfillment/src/checkout_execution.rs`
- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

Fulfillment request validation rules, idempotency/adoption behavior, immutable plan checks, metadata shape, lifecycle decisions, and public transport contracts remain unchanged.

## Validation

- branch is directly ahead of current `main` by three commits and is not behind;
- diff is limited to the three intended files (`+332/-40`);
- changed files were re-read statically after writing to confirm context propagation, mapper coverage, structured diagnostics, stable public messages, verifier assertions, and plan alignment;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
cargo check -p rustok-fulfillment --all-features
```