### PR TITLE
fix(index): harden ADR finalization lifecycle

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -59,6 +59,8 @@ node scripts/verify/index-storage-tooling.mjs prepare \
 
 `prepare` requires an explicit prototype choice. It does not rank candidates or select a winner. It validates the decision-ready comparison and its exact observed database-settings methodology, copies the evidence commit, computes the SHA-256 of the exact comparison-file bytes, creates rejection entries for exactly the two unselected prototypes, and refuses to overwrite an existing decision unless `--force` is provided. The draft is written to a staged file and renamed only after the complete JSON is on disk.
 
+The generated draft has `status: proposed`. Change it to `accepted` only after the evidence and rationales have been reviewed. The finalizer rejects both `proposed` decisions and impossible calendar dates.
+
 The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects any remaining preparation marker.
 
 [`storage-decision.example.json`](storage-decision.example.json) shows the same decision fields and references [`storage-decision.schema.json`](storage-decision.schema.json). Its relative `$schema` is valid because the two files are colocated in the documentation directory. A generated decision under `evidence/index-storage/...` intentionally omits `$schema` rather than recording a false relative path; `$schema` remains an optional finalizer field when it correctly points to a colocated schema file.
@@ -93,6 +95,8 @@ Finalization snapshots the exact comparison and decision bytes before rendering.
 
 The finalizer fails closed unless:
 
+- the decision status is `accepted`;
+- `decision_date` is a real ISO calendar date;
 - the comparison contains the exact ten-field observed PostgreSQL database-settings methodology;
 - the comparison is decision-ready;
 - every decision-contract flag is true;

--- a/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const comparison = () => ({
+  methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
+});
+
+const decision = (overrides = {}) => ({
+  status: 'accepted',
+  decision_date: '2026-07-25',
+  owner: 'Index maintainers',
+  comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+  comparison_sha256: '0'.repeat(64),
+  selected_prototype: 'typed_eav',
+  selection_rationale: 'Measured evidence supports the selected prototype.',
+  rejection_rationales: {
+    jsonb: 'JSONB was not selected.',
+    hot_projection: 'Hot projection was not selected.',
+  },
+  operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+  migration_strategy: 'Backfill and verify parity before cutover.',
+  rollback_strategy: 'Retain the previous path until cutover verification completes.',
+  ...overrides,
+});
+
+const runFinalizerArgs = (args) => spawnSync(process.execPath, [finalizer, ...args], {
+  encoding: 'utf8',
+});
+
+const stagingEntries = (root) => readdirSync(root)
+  .filter((entry) => entry.startsWith('adr.md.tmp-'));
+
+const runFinalizer = (root, decisionValue, staleOutput = null) => {
+  const comparisonPath = path.join(root, 'comparison.json');
+  const decisionPath = path.join(root, 'decision.json');
+  const outputPath = path.join(root, 'adr.md');
+  writeJson(comparisonPath, comparison());
+  writeJson(decisionPath, decisionValue);
+  if (staleOutput !== null) writeFileSync(outputPath, staleOutput, 'utf8');
+  return {
+    comparisonPath,
+    decisionPath,
+    outputPath,
+    result: runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]),
+  };
+};
+
+const withFixture = (prefix, callback) => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('finalizer accepts help only as the sole argument', () => {
+  const result = runFinalizerArgs(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^Usage: node scripts\/verify\/finalize-index-storage-adr\.mjs /u);
+  assert.equal(result.stderr, '');
+});
+
+test('finalizer rejects mixed help without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-help-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs(['--help', '--output', outputPath]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--help\/-h must be the only argument/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer rejects unknown options without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-unknown-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs([
+      '--comparison', 'missing-comparison.json',
+      '--decision', 'missing-decision.json',
+      '--output', outputPath,
+      '--format', 'markdown',
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown argument: --format/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer input collision preserves the comparison bytes', () => {
+  withFixture('rustok-index-finalizer-collision-', (root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    writeJson(comparisonPath, comparison());
+    writeJson(decisionPath, decision());
+    const original = readFileSync(comparisonPath);
+    const result = runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', comparisonPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--output must not overwrite the comparison input/u);
+    assert.deepEqual(readFileSync(comparisonPath), original);
+  });
+});
+
+test('real finalization attempts revoke stale ADR before evidence access', () => {
+  withFixture('rustok-index-finalizer-missing-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    writeFileSync(outputPath, 'stale ADR\n', 'utf8');
+    const result = runFinalizerArgs([
+      '--comparison', path.join(root, 'missing-comparison.json'),
+      '--decision', path.join(root, 'missing-decision.json'),
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing comparison/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects an impossible decision date without leaving stale output', () => {
+  withFixture('rustok-index-decision-date-', (root) => {
+    const { outputPath, result } = runFinalizer(root, decision({
+      decision_date: '2026-02-31',
+    }), 'stale ADR\n');
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /decision\.decision_date must be a real ISO calendar date/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects a proposed decision without leaving stale output', () => {
+  withFixture('rustok-index-decision-status-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision({ status: 'proposed' }),
+      'stale ADR\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /decision\.status must be accepted before ADR finalization/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('renderer failure leaves neither stale ADR nor staged output', () => {
+  withFixture('rustok-index-finalizer-render-', (root) => {
+    const { outputPath, result } = runFinalizer(root, decision(), 'stale ADR\n');
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /strict ADR renderer failed/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -20,6 +20,7 @@ import { requireComparisonDatabaseSettingsMethodology } from './index-storage-da
 const prefix = '[finalize-index-storage-adr]';
 const placeholderPrefix = 'TODO(index-storage-decision):';
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const allowedArguments = new Set(['--comparison', '--decision', '--output']);
 const requiredDecisionKeys = [
   'status',
   'decision_date',
@@ -49,19 +50,23 @@ const usage = () => {
 const parseArgs = () => {
   const values = new Map();
   const args = process.argv.slice(2);
+  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+    usage();
+    return null;
+  }
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') {
-      usage();
-      return null;
+      fail('--help/-h must be the only argument');
     }
-    if (!argument.startsWith('--') || !args[index + 1] || args[index + 1].startsWith('--')) {
-      fail(`unknown or incomplete argument: ${argument}`);
+    if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`);
+    if (!args[index + 1] || args[index + 1].startsWith('--')) {
+      fail(`incomplete argument: ${argument}`);
     }
     if (values.has(argument)) fail(`${argument} was provided more than once`);
     values.set(argument, args[++index]);
   }
-  for (const argument of ['--comparison', '--decision', '--output']) {
+  for (const argument of allowedArguments) {
     if (!values.has(argument)) fail(`${argument} is required`);
   }
   return {
@@ -98,6 +103,22 @@ const requireDecisionEnvelope = (decision) => {
   if (Object.hasOwn(decision, '$schema')
       && decision.$schema !== './storage-decision.schema.json') {
     fail('decision.$schema must reference ./storage-decision.schema.json when present');
+  }
+};
+
+const requireAcceptedDecision = (decision) => {
+  if (decision.status !== 'accepted') {
+    fail('decision.status must be accepted before ADR finalization');
+  }
+};
+
+const requireIsoCalendarDate = (value, label) => {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    fail(`${label} must be a real ISO calendar date`);
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== value) {
+    fail(`${label} must be a real ISO calendar date`);
   }
 };
 
@@ -146,11 +167,14 @@ const main = () => {
   for (const [label, filename] of [['comparison', args.comparison], ['decision', args.decision]]) {
     if (resolvedOutput === path.resolve(filename)) fail(`--output must not overwrite the ${label} input`);
   }
+  rmSync(args.output, { force: true });
 
   const comparison = readJsonBytes(args.comparison, 'comparison');
   const decision = readJsonBytes(args.decision, 'decision');
   requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
   requireDecisionEnvelope(decision.value);
+  requireAcceptedDecision(decision.value);
+  requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');
   rejectPlaceholders(decision.value);
 
   const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rustok-index-storage-adr-'));

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -71,6 +71,7 @@ const runFixtures = (args) => {
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
+    scriptPath('finalize-index-storage-adr-decision-contract.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
   ], 'Index storage fixture suites');
 };

--- a/scripts/verify/verify-index-storage-adr-integrity.mjs
+++ b/scripts/verify/verify-index-storage-adr-integrity.mjs
@@ -23,6 +23,7 @@ const preparer = read('scripts/verify/prepare-index-storage-decision.mjs');
 const finalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
 const verifier = read('scripts/verify/verify-index-storage-adr.mjs');
 const fixture = read('scripts/verify/index-storage-decision-tooling.test.mjs');
+const finalizerContractFixture = read('scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs');
 const guide = read('crates/rustok-index/docs/storage-decision.md');
 const smokeWorkflow = read('.github/workflows/index-storage-smoke.yml');
 const scaleWorkflow = read('.github/workflows/index-storage-scale-evidence.yml');
@@ -44,6 +45,7 @@ requireMarkers(router, 'storage tooling router', [
   "'verify-index-storage-adr-integrity.mjs'",
   "scriptPath('check-index-storage-read-ordering.test.mjs')",
   "scriptPath('index-storage-standalone-tools.test.mjs')",
+  "scriptPath('finalize-index-storage-adr-decision-contract.test.mjs')",
   "runScript('check-index-storage-read-ordering.mjs', ['--input', packetRoot])",
   "runScript('check-index-storage-read-ordering.mjs', orderingArgs)",
   "case 'prepare':",
@@ -176,12 +178,21 @@ forbidMarkers(preparer, 'decision preparer', [
 ]);
 
 requireMarkers(finalizer, 'ADR finalizer', [
+  "const allowedArguments = new Set(['--comparison', '--decision', '--output'])",
+  "if (args.length === 1 && (args[0] === '--help' || args[0] === '-h'))",
+  "fail('--help/-h must be the only argument')",
+  'if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`)',
   'const requiredDecisionKeys = [',
   "const allowedDecisionKeys = new Set(['$schema', ...requiredDecisionKeys])",
   'decision is missing required field ${key}',
   'decision contains unsupported field ${key}',
   'decision.$schema must reference ./storage-decision.schema.json when present',
+  'const requireAcceptedDecision = (decision) =>',
+  'decision.status must be accepted before ADR finalization',
+  'decision.decision_date must be a real ISO calendar date',
+  'requireAcceptedDecision(decision.value);',
   'still contains a preparation placeholder',
+  'rmSync(args.output, { force: true });',
   'writeFileSync(comparisonPath, comparison.bytes)',
   'writeFileSync(decisionPath, decision.bytes)',
   "path.join(scriptDirectory, 'render-index-storage-adr.mjs')",
@@ -189,7 +200,40 @@ requireMarkers(finalizer, 'ADR finalizer', [
   'const stagedOutput = `${args.output}.tmp-${process.pid}`',
   'rmSync(temporaryRoot, { recursive: true, force: true })',
 ]);
+const finalizerCollisionGate = finalizer.indexOf(
+  'if (resolvedOutput === path.resolve(filename)) fail(`--output must not overwrite the ${label} input`);',
+);
+const finalizerOutputRevocation = finalizer.indexOf('rmSync(args.output, { force: true });');
+const finalizerEvidenceRead = finalizer.indexOf("const comparison = readJsonBytes(args.comparison, 'comparison');");
+if (finalizerCollisionGate < 0
+    || finalizerOutputRevocation < 0
+    || finalizerEvidenceRead < 0
+    || finalizerCollisionGate > finalizerOutputRevocation
+    || finalizerOutputRevocation > finalizerEvidenceRead) {
+  fail('ADR finalizer must check input collisions, revoke stale output, then read evidence');
+}
 forbidMarkers(finalizer, 'ADR finalizer', ['shell: true', 'execSync(', 'process.exit(']);
+
+requireMarkers(finalizerContractFixture, 'ADR finalizer decision-contract fixture', [
+  "test('finalizer accepts help only as the sole argument'",
+  "test('finalizer rejects mixed help without changing an existing ADR'",
+  "test('finalizer rejects unknown options without changing an existing ADR'",
+  "test('finalizer input collision preserves the comparison bytes'",
+  "test('real finalization attempts revoke stale ADR before evidence access'",
+  "test('finalizer rejects an impossible decision date without leaving stale output'",
+  "test('finalizer rejects a proposed decision without leaving stale output'",
+  "test('renderer failure leaves neither stale ADR nor staged output'",
+  '--help/-h must be the only argument',
+  'unknown argument: --format',
+  "source_oracle: 'normalized idx_bench_source workload result digests'",
+  "result_digest: 'ordered_length_prefixed_json_v1'",
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  'database_settings_source: databaseSettingsSource',
+  'decision.status must be accepted before ADR finalization',
+  'decision.decision_date must be a real ISO calendar date',
+  'assert.equal(existsSync(outputPath), false)',
+  'assert.deepEqual(stagingEntries(root), [])',
+]);
 
 requireMarkers(verifier, 'saved ADR verifier', [
   "const prefix = '[verify-index-storage-adr]'",
@@ -225,6 +269,9 @@ requireMarkers(guide, 'storage decision guide', [
   'Direct output from `compare-index-storage-evidence-core.mjs` is intentionally incomplete',
   'exact ordered `comparable_database_fields` contract',
   'The comparator rejects cross-scale drift in any field',
+  'The generated draft has `status: proposed`.',
+  'Change it to `accepted` only after the evidence and rationales have been reviewed.',
+  'The finalizer rejects both `proposed` decisions and impossible calendar dates.',
   'The standalone renderer enforces the same methodology contract even when invoked directly.',
   'Recomputing `comparison_sha256` after removing or changing the methodology does not make the input acceptable.',
   'Comparison SHA-256',
@@ -262,4 +309,4 @@ for (const [label, workflow] of [
   ]);
 }
 
-console.log('[verify-index-storage-adr-integrity] executable SQL ordering, observed database-settings methodology, standalone evidence entrypoints, atomic decision preparation, byte-bound finalization, saved ADR verification, fixtures, docs, and workflows are cross-guarded');
+console.log('[verify-index-storage-adr-integrity] executable SQL ordering, observed database-settings methodology, standalone evidence entrypoints, atomic decision preparation, strict finalizer CLI and lifecycle, accepted byte-bound finalization, saved ADR verification, fixtures, docs, and workflows are cross-guarded');


### PR DESCRIPTION
## What changed

- keep the strict ADR finalizer CLI contract: only `--comparison`, `--decision`, and `--output`, with help allowed only as the sole argument;
- require an explicitly accepted decision and a real ISO calendar date before rendering;
- preserve comparison/decision input collision guards before any output mutation;
- treat a syntactically valid finalization invocation as a replacement attempt by revoking an existing ADR before comparison and decision access;
- preserve malformed invocations and input-collision failures as non-destructive;
- retain staged final publication and cleanup;
- update the focused fixture to the canonical eight-field comparison methodology envelope;
- add regressions for parser non-destruction, stale ADR revocation before evidence access, invalid accepted-decision failures, and staging cleanup;
- cross-guard the ordering `collision checks -> stale output revocation -> evidence reads`.

## Root cause

The finalizer already wrote a completed ADR through a staged file, but a failed rerun left the previous `adr.md` in place. A scripted finalization attempt could therefore fail against replacement comparison or decision evidence while an older accepted ADR remained available and appeared current.

The branch fixture also modeled only the database-settings subset of comparison methodology. The exact methodology envelope in #2154 would make the lifecycle tests fail before reaching the finalizer behavior owned here.

## Impact

Malformed command lines and attempts to overwrite comparison or decision inputs do not change files. Once the command line and paths are valid, the old ADR is withdrawn before evidence access. Any missing, malformed, proposed, impossible-date, placeholder-bearing, renderer-failing, or otherwise invalid replacement attempt leaves no stale final ADR. Successful finalization still publishes the completed Markdown through one staged rename.

The fixture remains compatible with #2154 regardless of merge order. This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. Static review covers parser-before-mutation ordering, collision-before-revocation ordering, revocation-before-evidence-access ordering, accepted-status and calendar-date gates, staged publication cleanup, exact methodology fixture shape, and preservation of unrelated repository changes.