### PR TITLE
Harden cart promotion error context

### DIFF
--- a/crates/rustok-cart/src/promotion_guard.rs
+++ b/crates/rustok-cart/src/promotion_guard.rs
@@ -10,6 +10,7 @@ use crate::ports::{
 };
 use crate::{CartError, CartPromotionPreview, CartResponse, CartService};
 
+const CART_PROMOTION_OWNER: &str = "rustok_cart.promotion";
 const READ_CART_PROMOTION_PREVIEW_OPERATION: &str = "read_cart_promotion_preview";
 const APPLY_CART_PROMOTION_OPERATION: &str = "apply_cart_promotion";
 
@@ -167,8 +168,10 @@ fn validate_cart_promotion_request(
         tracing::warn!(
             scope = ?request.scope,
             line_item_present = request.line_item_id.is_some(),
+            owner = CART_PROMOTION_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation = owner_operation,
             code,
             "cart promotion target validation failed"
@@ -190,8 +193,10 @@ fn parse_cart_promotion_tenant_id(
         tracing::warn!(
             error = ?error,
             internal_tenant_id = %context.tenant_id,
+            owner = CART_PROMOTION_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation = owner_operation,
             code = "cart.tenant_id_invalid",
             "cart promotion tenant context is invalid"
@@ -213,8 +218,10 @@ fn cart_promotion_context_error(
         internal_message = %error.message,
         kind = ?error.kind,
         retryable = error.retryable,
+        owner = CART_PROMOTION_OWNER,
         correlation_id = %context.correlation_id,
         tenant_id = %context.tenant_id,
+        channel = ?context.channel,
         operation = owner_operation,
         code = "cart.promotion_context_invalid",
         "cart promotion call context was rejected"
@@ -244,8 +251,10 @@ fn cart_promotion_error(
     let code = cart_promotion_error_code(&error);
     tracing::error!(
         error = ?error,
+        owner = CART_PROMOTION_OWNER,
         correlation_id = %context.correlation_id,
         tenant_id = %context.tenant_id,
+        channel = ?context.channel,
         operation = owner_operation,
         code,
         "cart promotion owner operation failed"

--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -32,6 +32,10 @@ available only for actionable domain errors.
   message.
 - `rustok-cart` checkout snapshot: validator and serialization causes are logged
   internally; request/projection and encoding failures use stable public messages.
+- `rustok-cart` promotion guard: target validation, tenant parsing, rejected call
+  contexts, and owner service failures retain the cart-promotion owner, correlation id,
+  tenant, channel, operation, stable code, and original internal cause. Existing public
+  validation, not-found, conflict, tax-boundary, and unavailable messages remain static.
 - `rustok-pricing`: every read/write owner-port mapper receives the `PortContext` and
   operation name. Database, rich, and core causes are logged with `correlation_id`,
   tenant, operation, and stable code; public messages are stable. Pricing validation
@@ -52,9 +56,10 @@ available only for actionable domain errors.
 
 ## Still open
 
-- Audit order, remaining fulfillment adapters, inventory, customer, promotion, payment
-  execution/compensation, remaining tax adapters/transports, and remaining ecommerce
-  adapters for technical text mislabeled as validation/conflict errors.
+- Audit order, remaining fulfillment adapters, inventory, customer, remaining promotion
+  adapters/transports, payment execution/compensation, remaining tax adapters/transports,
+  and remaining ecommerce adapters for technical text mislabeled as validation/conflict
+  errors.
 - Add structured owner-side logging with `correlation_id`, owner operation, stable error
   code, and the original cause before every remaining technical `PortError` mapping.
 - Remove raw technical text from non-`PortError` public REST, GraphQL, native, and
@@ -65,14 +70,17 @@ available only for actionable domain errors.
 
 - `node scripts/verify/verify-port-error-public-safety.mjs`
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
+- `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-tax-calculation-error-context.mjs`
 - `cargo test -p rustok-api ports::tests`
+- `cargo check -p rustok-cart --all-features`
 - `cargo check -p rustok-pricing --all-features`
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted pricing, payment collection, fulfillment checkout execution, and tax
-  calculation validation, provider-contract, correlation, and transport round-trip tests.
+- Targeted cart promotion, pricing, payment collection, fulfillment checkout execution,
+  and tax calculation validation, provider-contract, correlation, and transport
+  round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/scripts/verify/verify-cart-promotion-port-error-safety.mjs
+++ b/scripts/verify/verify-cart-promotion-port-error-safety.mjs
@@ -14,12 +14,22 @@ const failures = [];
 const lib = read('crates/rustok-cart/src/lib.rs');
 const guard = read('crates/rustok-cart/src/promotion_guard.rs');
 const ports = read('crates/rustok-cart/src/ports.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
 
 const requireText = (source, value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
 };
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
 };
 
 requireText(lib, 'mod promotion_guard;', 'promotion guard module');
@@ -36,7 +46,33 @@ forbidText(
   'legacy constructor top-level export',
 );
 
+const targetValidation = between(
+  guard,
+  'fn validate_cart_promotion_request(',
+  'fn parse_cart_promotion_tenant_id(',
+  'promotion target validation',
+);
+const tenantParser = between(
+  guard,
+  'fn parse_cart_promotion_tenant_id(',
+  'fn cart_promotion_context_error(',
+  'promotion tenant parser',
+);
+const contextMapper = between(
+  guard,
+  'fn cart_promotion_context_error(',
+  'fn cart_promotion_error(',
+  'promotion context mapper',
+);
+const ownerMapper = between(
+  guard,
+  'fn cart_promotion_error(',
+  'fn cart_promotion_error_code(',
+  'promotion owner mapper',
+);
+
 for (const [value, label] of [
+  ['const CART_PROMOTION_OWNER: &str = "rustok_cart.promotion";', 'promotion owner constant'],
   ['const READ_CART_PROMOTION_PREVIEW_OPERATION', 'preview owner operation'],
   ['const APPLY_CART_PROMOTION_OPERATION', 'apply owner operation'],
   ['service: CartService::new(db)', 'direct owner service construction'],
@@ -56,13 +92,45 @@ for (const [value, label] of [
     'parse_cart_promotion_tenant_id(&context, owner_operation)',
     'context-aware tenant parsing',
   ],
-  ['correlation_id = %context.correlation_id', 'correlation logging'],
-  ['tenant_id = %context.tenant_id', 'tenant logging'],
-  ['operation = owner_operation', 'owner operation logging'],
-  ['error = ?error', 'raw owner error logging'],
-  ['internal_code = %error.code', 'context error code logging'],
-  ['internal_message = %error.message', 'context error message logging'],
+]) {
+  requireText(guard, value, label);
+}
+
+for (const [source, label] of [
+  [targetValidation, 'promotion target validation'],
+  [tenantParser, 'promotion tenant parser'],
+  [contextMapper, 'promotion context mapper'],
+  [ownerMapper, 'promotion owner mapper'],
+]) {
+  for (const [value, detail] of [
+    ['owner = CART_PROMOTION_OWNER', `${label} owner log`],
+    ['correlation_id = %context.correlation_id', `${label} correlation log`],
+    ['tenant_id = %context.tenant_id', `${label} tenant log`],
+    ['channel = ?context.channel', `${label} channel log`],
+    ['operation = owner_operation', `${label} operation log`],
+  ]) {
+    requireText(source, value, detail);
+  }
+}
+
+for (const [source, value, label] of [
+  [targetValidation, 'scope = ?request.scope', 'promotion target scope detail'],
+  [targetValidation, 'line_item_present = request.line_item_id.is_some()', 'promotion target line detail'],
+  [tenantParser, 'error = ?error', 'promotion tenant parse cause'],
+  [tenantParser, 'internal_tenant_id = %context.tenant_id', 'promotion tenant internal identity'],
+  [contextMapper, 'internal_code = %error.code', 'promotion context internal code'],
+  [contextMapper, 'internal_message = %error.message', 'promotion context internal message'],
+  [contextMapper, 'kind = ?error.kind', 'promotion context kind'],
+  [contextMapper, 'retryable = error.retryable', 'promotion context retryability'],
+  [ownerMapper, 'error = ?error', 'promotion raw owner cause'],
+  [ownerMapper, 'let code = cart_promotion_error_code(&error);', 'promotion stable code selection'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const [value, label] of [
   ['code = "cart.tenant_id_invalid"', 'tenant stable code'],
+  ['code = "cart.promotion_context_invalid"', 'context stable code'],
   ['"cart promotion request context is invalid"', 'stable context message'],
   ['"cart promotion request is invalid"', 'stable validation message'],
   ['"cart was not found"', 'stable cart not-found message'],
@@ -88,6 +156,15 @@ for (const value of [
   forbidText(guard, value, 'promotion public error mapping');
 }
 
+for (const [value, label] of [
+  ['pub struct PortContext {', 'shared port context'],
+  ['pub correlation_id: String', 'shared correlation field'],
+  ['pub channel: Option<String>', 'shared channel field'],
+  ['pub struct PortError {', 'shared port error'],
+]) {
+  requireText(portContract, value, label);
+}
+
 requireText(
   ports,
   'impl CartPromotionPort for crate::CartService',
@@ -101,5 +178,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Cart promotion preview/apply use the correlation-aware owner provider and keep internal CartError details out of the public contract',
+  '✔ Cart promotion preview/apply retain owner, channel, correlation, and stable public error envelopes',
 );


### PR DESCRIPTION
## Summary

- attach the explicit `rustok_cart.promotion` owner and request channel to target-validation, tenant-parse, context-rejection, and owner-service error logs;
- keep correlation id, tenant, owner operation, stable code, and original internal cause together at every cart promotion boundary;
- preserve all existing public validation, not-found, conflict, tax-boundary, timeout, and unavailable messages;
- strengthen the existing cart promotion verifier so each individual mapper block must contain owner/channel/correlation fields and stable public envelopes;
- update the ecommerce error-safety plan while leaving remaining promotion adapters/transports and the broader audit open.

## Scope

Three files only:

- `crates/rustok-cart/src/promotion_guard.rs`
- `scripts/verify/verify-cart-promotion-port-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

Promotion calculation, targeting rules, preview/apply service calls, tax-boundary propagation, and public error codes/messages remain unchanged.

## Validation

- final diff against current `main` is limited to the three intended files (`+106/-12`);
- concurrent unrelated `main` commits were rechecked and do not touch these files;
- changed files were re-read statically to confirm all four log paths retain owner, channel, correlation identity, operation, stable code, and internal cause;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-cart-promotion-port-error-safety.mjs
cargo check -p rustok-cart --all-features
```