### PR TITLE
chore(forum): record canonical plan drift

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20I",
   "scope": "Forum notification source composition through the current public topic visibility owner",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
@@ -8,6 +8,16 @@
   "test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20I",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
   "policy": {
     "viewer_profile": "public unauthenticated without channel context",
     "topic_status": "open",

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -35,8 +35,8 @@ const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum notification visibility contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification visibility contract must use schema_version=2");
 }
 if (contract.task !== "FORUM-20I") {
   failures.push("forum notification visibility contract must belong to FORUM-20I");
@@ -55,6 +55,52 @@ for (const residual of [
   if (!contract.not_delivered?.includes(residual)) {
     failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
   }
+}
+
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20I") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20I");
+}
+if (
+  JSON.stringify(planSync.required_delivered_sections) !==
+  JSON.stringify(["FORUM-20H", "FORUM-20I"])
+) {
+  failures.push("forum notification visibility contract must require FORUM-20H/I delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  rejectText(
+    plan,
+    "### Delivered in `FORUM-20H`",
+    "canonical plan now contains FORUM-20H; update canonical_plan_sync to synchronized",
+  );
+  rejectText(
+    plan,
+    "### Delivered in `FORUM-20I`",
+    "canonical plan now contains FORUM-20I; update canonical_plan_sync to synchronized",
+  );
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-I provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through I",
+  );
+  for (const slice of ["FORUM-20H", "FORUM-20I"]) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
 }
 
 for (const marker of [
@@ -128,7 +174,6 @@ for (const marker of [
 for (const marker of [
   "## `FORUM-20` — ACL and visibility inheritance",
   "notifications, search, SEO and deep links must call the same",
-  "migrate notifications,",
 ]) {
   requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
 }


### PR DESCRIPTION
## Summary

- version the FORUM-20I notification visibility contract to schema v2
- record that the canonical Forum plan currently stops at FORUM-20G while merged implementation exists through FORUM-20I
- make the required H/I ledger and delivered-section synchronization explicit instead of silently treating stale prose as current
- update the source verifier to validate either the current pending state or a future synchronized state
- remove the obsolete verifier requirement for the phrase `migrate notifications,`, which became false after the notification owner composition merged

## Recheck

The current `main` was re-read after new overlapping Forum commits landed. The notification visibility contract and verifier blobs were unchanged, and this branch was rebuilt directly on the latest `main`. The resulting diff is one commit and exactly two Forum files.

A full replacement of the 100-KB canonical plan was intentionally not performed through the GitHub Contents connector: that interface requires whole-file replacement and concurrent repository activity makes a blind replacement unsafe. This PR records the exact drift and makes it executable so the follow-up synchronization cannot be forgotten or falsely reported as complete.

## Compatibility

- no runtime behavior, migration, endpoint, transport, UI, or CI change
- existing FORUM-20I notification composition remains unchanged
- canonical plan synchronization remains explicitly pending

## Validation

Not run at the maintainer's request. Intended commands:

```bash
node scripts/verify/verify-forum-notification-visibility-composition.mjs
cargo xtask module validate forum
```
