### PR TITLE
Harden order payment settlement error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -49,6 +49,11 @@ available only for actionable domain errors.
   Validation, missing-resource, transition, and database causes are logged with
   correlation identity and stable codes while the existing public envelopes remain
   static.
+- `rustok-order` checkout payment settlement: identity absence/mismatch, lifecycle and
+  payment-reference conflicts, owner-context validation, missing resources, storage,
+  transition, validation, and core causes retain the settlement owner, correlation id,
+  tenant, channel, operation, stable code, and reconciliation evidence. Public
+  validation, not-found, conflict, unavailable, and invariant envelopes remain static.
 - `rustok-tax` calculation port: request-validation details, provider-result contract
   violations, and owner validation causes remain internal. Every mapper records owner,
   correlation id, tenant, channel, operation, and stable code while public validation
@@ -56,10 +61,10 @@ available only for actionable domain errors.
 
 ## Still open
 
-- Audit order, remaining fulfillment adapters, inventory, customer, remaining promotion
-  adapters/transports, payment execution/compensation, remaining tax adapters/transports,
-  and remaining ecommerce adapters for technical text mislabeled as validation/conflict
-  errors.
+- Audit remaining order adapters, remaining fulfillment adapters, inventory, customer,
+  remaining promotion adapters/transports, payment execution/compensation, remaining tax
+  adapters/transports, and remaining ecommerce adapters for technical text mislabeled as
+  validation/conflict errors.
 - Add structured owner-side logging with `correlation_id`, owner operation, stable error
   code, and the original cause before every remaining technical `PortError` mapping.
 - Remove raw technical text from non-`PortError` public REST, GraphQL, native, and
@@ -72,15 +77,17 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
+- `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
 - `node scripts/verify/verify-tax-calculation-error-context.mjs`
 - `cargo test -p rustok-api ports::tests`
 - `cargo check -p rustok-cart --all-features`
+- `cargo check -p rustok-order --all-features`
 - `cargo check -p rustok-pricing --all-features`
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, pricing, payment collection, fulfillment checkout execution,
-  and tax calculation validation, provider-contract, correlation, and transport
-  round-trip tests.
+- Targeted cart promotion, order payment settlement, pricing, payment collection,
+  fulfillment checkout execution, and tax calculation validation, provider-contract,
+  reconciliation, correlation, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-order/src/checkout_payment_settlement.rs
+++ b/crates/rustok-order/src/checkout_payment_settlement.rs
@@ -13,6 +13,7 @@ use crate::{
     ReadCheckoutOrderIdentityByOperationRequest,
 };
 
+const ORDER_PAYMENT_SETTLEMENT_OWNER: &str = "rustok_order.checkout_payment_settlement";
 const SETTLE_PAYMENT_OPERATION: &str = "settle_checkout_payment";
 
 #[async_trait]
@@ -134,11 +135,16 @@ impl CheckoutOrderPaymentSettlementPort for InProcessCheckoutOrderPaymentSettlem
         }
         let identity = identity.ok_or_else(|| {
             tracing::error!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation = SETTLE_PAYMENT_OPERATION,
                 code = "order.checkout_payment_identity_missing",
                 checkout_operation_id = %request.checkout_operation_id,
+                cart_id = %request.cart_id,
+                order_id = %request.order_id,
+                payment_collection_id = %request.payment_collection_id,
                 "checkout payment settlement has no durable order identity"
             );
             PortError::conflict(
@@ -156,6 +162,24 @@ impl CheckoutOrderPaymentSettlementPort for InProcessCheckoutOrderPaymentSettlem
                 .payment_collection_id
                 .is_some_and(|collection_id| collection_id != request.payment_collection_id)
         {
+            tracing::error!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = SETTLE_PAYMENT_OPERATION,
+                code = "order.checkout_payment_identity_conflict",
+                checkout_operation_id = %request.checkout_operation_id,
+                request_cart_id = %request.cart_id,
+                request_order_id = %request.order_id,
+                request_payment_collection_id = %request.payment_collection_id,
+                identity_tenant_id = %identity.tenant_id,
+                identity_checkout_operation_id = %identity.checkout_operation_id,
+                identity_order_id = %identity.order_id,
+                identity_source_cart_id = ?identity.source_cart_id,
+                identity_payment_collection_id = ?identity.payment_collection_id,
+                "checkout order identity conflicts with payment settlement"
+            );
             return Err(PortError::conflict(
                 "order.checkout_payment_identity_conflict",
                 "checkout order identity conflicts with the payment settlement request",
@@ -180,7 +204,20 @@ impl CheckoutOrderPaymentSettlementPort for InProcessCheckoutOrderPaymentSettlem
             OrderStatusKind::Paid | OrderStatusKind::Shipped | OrderStatusKind::Delivered => {
                 current
             }
-            OrderStatusKind::Pending | OrderStatusKind::Cancelled | OrderStatusKind::Unknown => {
+            state @ (OrderStatusKind::Pending
+            | OrderStatusKind::Cancelled
+            | OrderStatusKind::Unknown) => {
+                tracing::warn!(
+                    owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    channel = ?context.channel,
+                    operation = SETTLE_PAYMENT_OPERATION,
+                    code = "order.checkout_payment_state_conflict",
+                    order_id = %current.id,
+                    order_state = ?state,
+                    "checkout order lifecycle does not allow payment settlement"
+                );
                 return Err(PortError::conflict(
                     "order.checkout_payment_state_conflict",
                     "checkout order lifecycle does not allow payment settlement",
@@ -190,6 +227,20 @@ impl CheckoutOrderPaymentSettlementPort for InProcessCheckoutOrderPaymentSettlem
         if settled.payment_id.as_deref() != Some(request.payment_reference.as_str())
             || settled.payment_method.as_deref() != Some(request.payment_method.as_str())
         {
+            tracing::error!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation = SETTLE_PAYMENT_OPERATION,
+                code = "order.checkout_payment_reference_conflict",
+                order_id = %settled.id,
+                requested_payment_reference = %request.payment_reference,
+                requested_payment_method = %request.payment_method,
+                settled_payment_reference = ?settled.payment_id,
+                settled_payment_method = ?settled.payment_method,
+                "checkout order is settled by another payment identity"
+            );
             return Err(PortError::conflict(
                 "order.checkout_payment_reference_conflict",
                 "checkout order is settled by another payment identity",
@@ -211,10 +262,18 @@ fn validate_request(
         || request.payment_method.trim().is_empty()
     {
         tracing::warn!(
+            owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation = SETTLE_PAYMENT_OPERATION,
             code = "order.checkout_payment_request_invalid",
+            checkout_operation_id = %request.checkout_operation_id,
+            cart_id = %request.cart_id,
+            order_id = %request.order_id,
+            payment_collection_id = %request.payment_collection_id,
+            payment_reference_present = !request.payment_reference.trim().is_empty(),
+            payment_method_present = !request.payment_method.trim().is_empty(),
             "checkout payment settlement rejected invalid owner identities"
         );
         return Err(PortError::validation(
@@ -236,11 +295,14 @@ fn require_operation_context(
         .and_then(|value| Uuid::parse_str(value).ok());
     if context_operation != Some(checkout_operation_id) {
         tracing::warn!(
+            owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             code = "order.checkout_payment_causation_invalid",
             expected_checkout_operation_id = %checkout_operation_id,
+            actual_causation_id = ?context.causation_id,
             "checkout payment settlement received invalid causation identity"
         );
         return Err(PortError::validation(
@@ -252,9 +314,13 @@ fn require_operation_context(
 }
 
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
             correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "tenant_id",
             value_length = context.tenant_id.len(),
@@ -269,10 +335,13 @@ fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uui
 }
 
 fn parse_actor_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.actor.id).map_err(|_| {
+    Uuid::parse_str(&context.actor.id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "actor_id",
             value_length = context.actor.id.len(),
@@ -292,8 +361,10 @@ fn order_error_to_port_error(
         OrderError::Database(error) => {
             tracing::error!(
                 error = ?error,
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.database_unavailable",
                 "checkout order payment settlement storage failed"
@@ -303,14 +374,26 @@ fn order_error_to_port_error(
                 "order storage is temporarily unavailable",
             )
         }
-        OrderError::OrderNotFound(_) => {
+        OrderError::OrderNotFound(order_id) => {
+            tracing::warn!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.order_not_found",
+                order_id = %order_id,
+                "checkout payment settlement order was not found"
+            );
             PortError::not_found("order.order_not_found", "order was not found")
         }
         OrderError::Validation(cause) => {
             tracing::warn!(
                 cause = %cause,
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_payment_validation",
                 "order owner rejected checkout payment settlement"
@@ -320,12 +403,16 @@ fn order_error_to_port_error(
                 "checkout order payment settlement request is invalid",
             )
         }
-        OrderError::InvalidTransition { .. } => {
+        OrderError::InvalidTransition { from, to } => {
             tracing::warn!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_payment_state_conflict",
+                from = %from,
+                to = %to,
                 "order lifecycle conflicts with checkout payment settlement"
             );
             PortError::conflict(
@@ -333,7 +420,35 @@ fn order_error_to_port_error(
                 "order lifecycle conflicts with payment settlement",
             )
         }
-        OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_) => {
+        OrderError::OrderReturnNotFound(return_id) => {
+            tracing::warn!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_return",
+                resource_id = %return_id,
+                "checkout payment settlement related order resource was not found"
+            );
+            PortError::not_found(
+                "order.related_resource_not_found",
+                "related order resource was not found",
+            )
+        }
+        OrderError::OrderChangeNotFound(change_id) => {
+            tracing::warn!(
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_change",
+                resource_id = %change_id,
+                "checkout payment settlement related order resource was not found"
+            );
             PortError::not_found(
                 "order.related_resource_not_found",
                 "related order resource was not found",
@@ -342,8 +457,10 @@ fn order_error_to_port_error(
         OrderError::Core(error) => {
             tracing::error!(
                 error = ?error,
+                owner = ORDER_PAYMENT_SETTLEMENT_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.invariant_violation",
                 "checkout order payment settlement invariant failed"

--- a/scripts/verify/verify-order-payment-settlement-error-context.mjs
+++ b/scripts/verify/verify-order-payment-settlement-error-context.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-order/src/checkout_payment_settlement.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const settlement = between(
+  source,
+  'impl CheckoutOrderPaymentSettlementPort for InProcessCheckoutOrderPaymentSettlementPort {',
+  'fn validate_request(',
+  'checkout payment settlement implementation',
+);
+const identityMissing = between(
+  settlement,
+  'let identity = identity.ok_or_else(|| {',
+  'if identity.tenant_id != tenant_id',
+  'missing checkout order identity',
+);
+const identityConflict = between(
+  settlement,
+  'if identity.tenant_id != tenant_id',
+  'let current = self.load_order',
+  'checkout order identity conflict',
+);
+const lifecycleConflict = between(
+  settlement,
+  'state @ (OrderStatusKind::Pending',
+  'if settled.payment_id.as_deref()',
+  'checkout payment lifecycle conflict',
+);
+const paymentReferenceConflict = between(
+  settlement,
+  'if settled.payment_id.as_deref()',
+  'Ok(settled)',
+  'checkout payment reference conflict',
+);
+const requestValidation = between(
+  source,
+  'fn validate_request(',
+  'fn require_operation_context(',
+  'checkout payment request validation',
+);
+const operationContext = between(
+  source,
+  'fn require_operation_context(',
+  'fn parse_tenant_id(',
+  'checkout payment causation validation',
+);
+const tenantParser = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn parse_actor_id(',
+  'checkout payment tenant parser',
+);
+const actorParser = between(
+  source,
+  'fn parse_actor_id(',
+  'fn order_error_to_port_error(',
+  'checkout payment actor parser',
+);
+const ownerMapper = source.slice(source.indexOf('fn order_error_to_port_error('));
+
+for (const [value, label] of [
+  [
+    'const ORDER_PAYMENT_SETTLEMENT_OWNER: &str = "rustok_order.checkout_payment_settlement";',
+    'settlement owner constant',
+  ],
+  ['const SETTLE_PAYMENT_OPERATION: &str = "settle_checkout_payment";', 'settlement operation'],
+  ['parse_tenant_id(&context, SETTLE_PAYMENT_OPERATION)', 'context-aware tenant parsing'],
+  ['parse_actor_id(&context, SETTLE_PAYMENT_OPERATION)', 'context-aware actor parsing'],
+  ['validate_request(&context, &request)', 'context-aware request validation'],
+  [
+    'order_error_to_port_error(&context, "mark_checkout_order_paid", error)',
+    'context-aware mark-paid mapping',
+  ],
+]) requireText(source, value, label);
+
+for (const [block, label] of [
+  [identityMissing, 'missing checkout order identity'],
+  [identityConflict, 'checkout order identity conflict'],
+  [lifecycleConflict, 'checkout payment lifecycle conflict'],
+  [paymentReferenceConflict, 'checkout payment reference conflict'],
+  [requestValidation, 'checkout payment request validation'],
+  [operationContext, 'checkout payment causation validation'],
+  [tenantParser, 'checkout payment tenant parser'],
+  [actorParser, 'checkout payment actor parser'],
+]) {
+  for (const [value, detail] of [
+    ['owner = ORDER_PAYMENT_SETTLEMENT_OWNER', `${label} owner log`],
+    ['correlation_id = %context.correlation_id', `${label} correlation log`],
+    ['tenant_id = %context.tenant_id', `${label} tenant log`],
+    ['channel = ?context.channel', `${label} channel log`],
+  ]) requireText(block, value, detail);
+}
+
+for (const [block, value, label] of [
+  [identityMissing, 'code = "order.checkout_payment_identity_missing"', 'identity-missing stable code'],
+  [identityMissing, 'checkout_operation_id = %request.checkout_operation_id', 'identity-missing operation identity'],
+  [identityConflict, 'code = "order.checkout_payment_identity_conflict"', 'identity-conflict stable code'],
+  [identityConflict, 'identity_order_id = %identity.order_id', 'identity-conflict durable order identity'],
+  [identityConflict, 'identity_payment_collection_id = ?identity.payment_collection_id', 'identity-conflict payment identity'],
+  [lifecycleConflict, 'code = "order.checkout_payment_state_conflict"', 'lifecycle stable code'],
+  [lifecycleConflict, 'order_state = ?state', 'lifecycle internal state'],
+  [paymentReferenceConflict, 'code = "order.checkout_payment_reference_conflict"', 'payment-reference stable code'],
+  [paymentReferenceConflict, 'settled_payment_reference = ?settled.payment_id', 'settled payment reference'],
+  [requestValidation, 'payment_reference_present = !request.payment_reference.trim().is_empty()', 'request reference presence'],
+  [operationContext, 'actual_causation_id = ?context.causation_id', 'actual causation evidence'],
+  [tenantParser, 'error = ?error', 'tenant parse cause'],
+  [actorParser, 'error = ?error', 'actor parse cause'],
+]) requireText(block, value, label);
+
+for (const [value, label] of [
+  ['OrderError::OrderNotFound(order_id)', 'order not-found identity capture'],
+  ['order_id = %order_id', 'order not-found identity log'],
+  ['OrderError::Validation(cause)', 'validation cause capture'],
+  ['cause = %cause', 'validation cause log'],
+  ['OrderError::InvalidTransition { from, to }', 'transition cause capture'],
+  ['from = %from', 'transition source log'],
+  ['to = %to', 'transition target log'],
+  ['OrderError::OrderReturnNotFound(return_id)', 'return identity capture'],
+  ['resource_id = %return_id', 'return identity log'],
+  ['OrderError::OrderChangeNotFound(change_id)', 'change identity capture'],
+  ['resource_id = %change_id', 'change identity log'],
+  ['OrderError::Database(error)', 'database cause capture'],
+  ['OrderError::Core(error)', 'core cause capture'],
+]) requireText(ownerMapper, value, label);
+
+for (const value of [
+  'owner = ORDER_PAYMENT_SETTLEMENT_OWNER',
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'channel = ?context.channel',
+  'operation,',
+]) requireText(ownerMapper, value, `owner mapper ${value}`);
+
+for (const [value, label] of [
+  ['"checkout requires manual reconciliation"', 'static identity-missing envelope'],
+  [
+    '"checkout order identity conflicts with the payment settlement request"',
+    'static identity-conflict envelope',
+  ],
+  [
+    '"checkout order lifecycle does not allow payment settlement"',
+    'static lifecycle-conflict envelope',
+  ],
+  [
+    '"checkout order is settled by another payment identity"',
+    'static payment-reference envelope',
+  ],
+  ['"checkout payment settlement request is invalid"', 'static request-validation envelope'],
+  ['"checkout operation context is invalid"', 'static causation envelope'],
+  ['"order request context is invalid"', 'static owner-context envelope'],
+  ['"order storage is temporarily unavailable"', 'static storage envelope'],
+  ['"order was not found"', 'static order not-found envelope'],
+  [
+    '"checkout order payment settlement request is invalid"',
+    'static owner-validation envelope',
+  ],
+  ['"order lifecycle conflicts with payment settlement"', 'static owner-transition envelope'],
+  ['"related order resource was not found"', 'static related-resource envelope'],
+  [
+    '"order payment settlement failed an internal invariant"',
+    'static invariant envelope',
+  ],
+]) requireText(source, value, label);
+
+for (const value of [
+  'OrderError::OrderNotFound(_)',
+  'OrderError::InvalidTransition { .. }',
+  'OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_)',
+  '.map_err(order_error_to_port_error)',
+  'PortError::validation("order.checkout_payment_validation", cause)',
+]) forbidText(source, value, 'unsafe checkout payment settlement mapping');
+
+for (const [value, label] of [
+  ['pub struct PortContext {', 'shared port context'],
+  ['pub correlation_id: String', 'shared correlation field'],
+  ['pub channel: Option<String>', 'shared channel field'],
+  ['pub struct PortError {', 'shared port error'],
+  ['pub fn validation(', 'typed validation constructor'],
+  ['pub fn conflict(', 'typed conflict constructor'],
+  ['pub fn invariant_violation(', 'typed invariant constructor'],
+]) requireText(portContract, value, label);
+
+if (failures.length > 0) {
+  console.error('Order payment settlement error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Order payment settlement retains owner, channel, correlation, reconciliation evidence, and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- add the explicit `rustok_order.checkout_payment_settlement` owner and request channel to checkout payment settlement diagnostics;
- record durable identity mismatches, lifecycle conflicts, payment-reference conflicts, invalid owner context, missing resources, transitions, storage failures, and core causes before returning stable `PortError` envelopes;
- preserve settlement behavior, idempotency, order transitions, payment identity matching, public error codes, and public messages;
- add a focused static verifier for reconciliation evidence, context-aware logging, cause capture, and static public envelopes;
- update the ecommerce error-safety plan while leaving remaining order adapters and the broader audit open.

## Scope

Three files only:

- `crates/rustok-order/src/checkout_payment_settlement.rs`
- `scripts/verify/verify-order-payment-settlement-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the final diff is limited to the three intended files (`+356/-13`);
- the concurrent `main` commit only changes forum contract/verifier files and does not overlap this slice;
- changed files were re-read statically to confirm owner/channel/correlation fields, original reconciliation evidence, captured `OrderError` details, and unchanged public envelopes;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-order-payment-settlement-error-context.mjs
cargo check -p rustok-order --all-features
```