### PR TITLE
fix(index): reject disguised decision placeholders

### DIFF
--- a/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+test('finalizer rejects a preparation placeholder hidden behind reviewed text', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-decision-placeholder-'));
+  try {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const outputPath = path.join(root, 'adr.md');
+    writeJson(comparisonPath, {
+      methodology: {
+        automatic_winner_selection: false,
+        comparable_database_fields: [...comparableDatabaseFields],
+        database_settings_source: databaseSettingsSource,
+      },
+    });
+    writeJson(decisionPath, {
+      status: 'proposed',
+      decision_date: '2026-07-25',
+      owner: 'Index maintainers',
+      comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+      comparison_sha256: '0'.repeat(64),
+      selected_prototype: 'typed_eav',
+      selection_rationale: 'Reviewed: TODO(index-storage-decision): explain the selected prototype.',
+      rejection_rationales: {
+        jsonb: 'JSONB was not selected.',
+        hot_projection: 'Hot projection was not selected.',
+      },
+      operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+      migration_strategy: 'Backfill and verify parity before cutover.',
+      rollback_strategy: 'Retain the previous path until cutover verification completes.',
+    });
+
+    const result = spawnSync(process.execPath, [
+      finalizer,
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ], { encoding: 'utf8' });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /decision\.selection_rationale still contains a preparation placeholder/u);
+    assert.equal(existsSync(outputPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -103,7 +103,7 @@ const requireDecisionEnvelope = (decision) => {
 
 const requireDecisionText = (value, label) => {
   if (typeof value !== 'string' || value.trim().length === 0) return;
-  if (value.trim().startsWith(placeholderPrefix)) {
+  if (value.includes(placeholderPrefix)) {
     fail(`${label} still contains a preparation placeholder`);
   }
 };

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -67,6 +67,7 @@ const runFixtures = (args) => {
   if (args.length !== 0) fail('fixtures does not accept arguments');
   runNode([
     '--test',
+    scriptPath('finalize-index-storage-adr-placeholder.test.mjs'),
     scriptPath('check-index-storage-read-ordering.test.mjs'),
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),


### PR DESCRIPTION
## What changed

- reject `TODO(index-storage-decision):` anywhere inside required decision rationale text, not only at the start of the string;
- add a focused regression fixture for a placeholder hidden behind reviewed text;
- include the fixture in the canonical Index storage `fixtures` command.

## Root cause

The ADR finalizer used `startsWith(placeholderPrefix)`, while the documented contract requires that no preparation placeholder remain. Prefixing the placeholder with ordinary text such as `Reviewed:` therefore bypassed the finalization gate.

## Impact

The M2 manual decision path now fails closed when preparation text remains anywhere in selection, rejection, operational, migration, or rollback rationale fields. This does not select a storage model or advance M2 beyond replacement same-commit 100k/1m evidence and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was manually checked and contains one finalizer condition change, one focused fixture, and one fixture-router entry.