### PR TITLE
Harden order checkout recovery error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -54,6 +54,12 @@ available only for actionable domain errors.
   transition, validation, and core causes retain the settlement owner, correlation id,
   tenant, channel, operation, stable code, and reconciliation evidence. Public
   validation, not-found, conflict, unavailable, and invariant envelopes remain static.
+- `rustok-order` checkout recovery: read identity absence, immutable identity mismatch,
+  cancelled/unknown lifecycle states, owner-context validation, request/hash encoding,
+  missing resources, storage, transition, validation, and core causes retain the
+  recovery owner, correlation id, tenant, channel, operation, stable code, and
+  reconciliation evidence. Raw hash values remain private and public validation,
+  not-found, conflict, unavailable, and invariant envelopes remain static.
 - `rustok-tax` calculation port: request-validation details, provider-result contract
   violations, and owner validation causes remain internal. Every mapper records owner,
   correlation id, tenant, channel, operation, and stable code while public validation
@@ -78,6 +84,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
+- `node scripts/verify/verify-order-checkout-recovery-error-context.mjs`
 - `node scripts/verify/verify-tax-calculation-error-context.mjs`
 - `cargo test -p rustok-api ports::tests`
 - `cargo check -p rustok-cart --all-features`
@@ -86,8 +93,8 @@ available only for actionable domain errors.
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, order payment settlement, pricing, payment collection,
-  fulfillment checkout execution, and tax calculation validation, provider-contract,
-  reconciliation, correlation, and transport round-trip tests.
+- Targeted cart promotion, order payment settlement, order checkout recovery, pricing,
+  payment collection, fulfillment checkout execution, and tax calculation validation,
+  provider-contract, reconciliation, correlation, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-order/src/checkout_order_recovery.rs
+++ b/crates/rustok-order/src/checkout_order_recovery.rs
@@ -13,6 +13,7 @@ use crate::{
     ReadCheckoutOrderIdentityByOperationRequest,
 };
 
+const CHECKOUT_ORDER_RECOVERY_OWNER: &str = "rustok_order.checkout_order_recovery";
 const RECOVER_OPERATION: &str = "recover_existing_checkout";
 const READ_OPERATION: &str = "read_checkout_order";
 
@@ -96,6 +97,7 @@ impl CheckoutOrderRecoveryAdapter {
         };
 
         validate_identity(
+            &context,
             &identity,
             tenant_id,
             &request,
@@ -134,6 +136,16 @@ impl CheckoutOrderRecoveryAdapter {
             )
             .await?
             .ok_or_else(|| {
+                tracing::warn!(
+                    owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    channel = ?context.channel,
+                    operation = READ_OPERATION,
+                    code = "order.checkout_order_not_found",
+                    checkout_operation_id = %request.checkout_operation_id,
+                    "checkout order identity was not found for the requested operation"
+                );
                 PortError::not_found(
                     "order.checkout_order_not_found",
                     "checkout order was not found for the requested operation",
@@ -198,14 +210,40 @@ impl CheckoutOrderRecoveryAdapter {
             | OrderStatusKind::Paid
             | OrderStatusKind::Shipped
             | OrderStatusKind::Delivered => Ok(order),
-            OrderStatusKind::Cancelled => Err(PortError::conflict(
-                "order.checkout_order_cancelled",
-                "checkout order is already cancelled",
-            )),
-            OrderStatusKind::Unknown => Err(PortError::invariant_violation(
-                "order.checkout_order_status_invalid",
-                "checkout order has an unsupported lifecycle state",
-            )),
+            OrderStatusKind::Cancelled => {
+                tracing::warn!(
+                    owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    channel = ?context.channel,
+                    operation = RECOVER_OPERATION,
+                    code = "order.checkout_order_cancelled",
+                    order_id = %order.id,
+                    order_state = ?OrderStatusKind::Cancelled,
+                    "checkout recovery found an already-cancelled order"
+                );
+                Err(PortError::conflict(
+                    "order.checkout_order_cancelled",
+                    "checkout order is already cancelled",
+                ))
+            }
+            OrderStatusKind::Unknown => {
+                tracing::error!(
+                    owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    channel = ?context.channel,
+                    operation = RECOVER_OPERATION,
+                    code = "order.checkout_order_status_invalid",
+                    order_id = %order.id,
+                    order_state = ?OrderStatusKind::Unknown,
+                    "checkout recovery found an unsupported order lifecycle state"
+                );
+                Err(PortError::invariant_violation(
+                    "order.checkout_order_status_invalid",
+                    "checkout order has an unsupported lifecycle state",
+                ))
+            }
         }
     }
 
@@ -252,6 +290,7 @@ pub struct ReadCheckoutOrderProjectionRequest {
 }
 
 fn validate_identity(
+    context: &PortContext,
     identity: &CheckoutOrderIdentitySnapshot,
     tenant_id: Uuid,
     request: &RecoverExistingCheckoutOrderRequest,
@@ -275,6 +314,28 @@ fn validate_identity(
     let legacy_hashes_match = identity.snapshot_hash.as_deref() == Some(legacy_snapshot_hash)
         && identity.request_hash.as_deref() == Some(legacy_request_hash);
     if !base_matches || !(owner_hashes_match || legacy_hashes_match) {
+        tracing::error!(
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
+            operation = RECOVER_OPERATION,
+            code = "order.checkout_request_conflict",
+            request_checkout_operation_id = %request.checkout_operation_id,
+            request_cart_id = %request.completion.cart_id,
+            request_payment_collection_id = ?request.completion.payment_collection_id,
+            request_shipping_option_id = ?request.completion.shipping_option_id,
+            identity_tenant_id = %identity.tenant_id,
+            identity_checkout_operation_id = %identity.checkout_operation_id,
+            identity_order_id = %identity.order_id,
+            identity_source_cart_id = ?identity.source_cart_id,
+            identity_payment_collection_id = ?identity.payment_collection_id,
+            identity_shipping_option_id = ?identity.shipping_option_id,
+            base_matches,
+            owner_hashes_match,
+            legacy_hashes_match,
+            "checkout recovery identity conflicts with the completion request"
+        );
         return Err(PortError::conflict(
             "order.checkout_request_conflict",
             "checkout operation is already bound to a different completion request",
@@ -294,11 +355,14 @@ fn require_operation_context(
         .and_then(|value| Uuid::parse_str(value).ok());
     if context_operation != Some(checkout_operation_id) {
         tracing::warn!(
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             code = "order.checkout_operation_id_invalid",
             expected_checkout_operation_id = %checkout_operation_id,
+            actual_causation_id = ?context.causation_id,
             "checkout recovery received invalid causation identity"
         );
         return Err(PortError::validation(
@@ -310,9 +374,13 @@ fn require_operation_context(
 }
 
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "tenant_id",
             value_length = context.tenant_id.len(),
@@ -327,10 +395,13 @@ fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uui
 }
 
 fn parse_actor_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.actor.id).map_err(|_| {
+    Uuid::parse_str(&context.actor.id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "actor_id",
             value_length = context.actor.id.len(),
@@ -360,8 +431,10 @@ fn checkout_request_hashes(
     let full_request = serde_json::to_value(request).map_err(|error| {
         tracing::error!(
             error = ?error,
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation = RECOVER_OPERATION,
             code = "order.checkout_request_encoding_failed",
             "failed to encode checkout recovery request"
@@ -386,8 +459,10 @@ fn hash_json(
     let bytes = serde_json::to_vec(&canonical).map_err(|error| {
         tracing::error!(
             error = ?error,
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             code = "order.checkout_request_encoding_failed",
             "failed to encode canonical checkout recovery request"
@@ -429,8 +504,10 @@ fn normalize_hash(
         || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
     {
         tracing::warn!(
+            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field,
             value_length = value.len(),
@@ -456,8 +533,10 @@ fn order_error_to_port_error(
         OrderError::Database(error) => {
             tracing::error!(
                 error = ?error,
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.database_unavailable",
                 "order checkout recovery storage failed"
@@ -467,14 +546,26 @@ fn order_error_to_port_error(
                 "order storage is temporarily unavailable",
             )
         }
-        OrderError::OrderNotFound(_) => {
+        OrderError::OrderNotFound(order_id) => {
+            tracing::warn!(
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.order_not_found",
+                order_id = %order_id,
+                "checkout recovery order was not found"
+            );
             PortError::not_found("order.order_not_found", "order was not found")
         }
         OrderError::Validation(cause) => {
             tracing::warn!(
                 cause = %cause,
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_recovery_validation",
                 "order owner rejected checkout recovery"
@@ -484,12 +575,16 @@ fn order_error_to_port_error(
                 "checkout order recovery request is invalid",
             )
         }
-        OrderError::InvalidTransition { .. } => {
+        OrderError::InvalidTransition { from, to } => {
             tracing::warn!(
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_recovery_state_conflict",
+                from = %from,
+                to = %to,
                 "order lifecycle conflicts with checkout recovery"
             );
             PortError::conflict(
@@ -497,7 +592,35 @@ fn order_error_to_port_error(
                 "order lifecycle transition conflicts with checkout recovery",
             )
         }
-        OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_) => {
+        OrderError::OrderReturnNotFound(return_id) => {
+            tracing::warn!(
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_return",
+                resource_id = %return_id,
+                "checkout recovery related order resource was not found"
+            );
+            PortError::not_found(
+                "order.related_resource_not_found",
+                "related order resource was not found",
+            )
+        }
+        OrderError::OrderChangeNotFound(change_id) => {
+            tracing::warn!(
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_change",
+                resource_id = %change_id,
+                "checkout recovery related order resource was not found"
+            );
             PortError::not_found(
                 "order.related_resource_not_found",
                 "related order resource was not found",
@@ -506,8 +629,10 @@ fn order_error_to_port_error(
         OrderError::Core(error) => {
             tracing::error!(
                 error = ?error,
+                owner = CHECKOUT_ORDER_RECOVERY_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.invariant_violation",
                 "order checkout recovery invariant failed"

--- a/scripts/verify/verify-order-checkout-recovery-error-context.mjs
+++ b/scripts/verify/verify-order-checkout-recovery-error-context.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-order/src/checkout_order_recovery.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const readCheckout = between(
+  source,
+  'pub async fn read_checkout_order(',
+  'async fn resume_order(',
+  'checkout order read',
+);
+const resumeOrder = between(
+  source,
+  'async fn resume_order(',
+  'async fn load_order(',
+  'checkout order lifecycle recovery',
+);
+const identityValidation = between(
+  source,
+  'fn validate_identity(',
+  'fn require_operation_context(',
+  'checkout recovery identity validation',
+);
+const operationContext = between(
+  source,
+  'fn require_operation_context(',
+  'fn parse_tenant_id(',
+  'checkout recovery causation validation',
+);
+const tenantParser = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn parse_actor_id(',
+  'checkout recovery tenant parser',
+);
+const actorParser = between(
+  source,
+  'fn parse_actor_id(',
+  'fn checkout_request_hashes(',
+  'checkout recovery actor parser',
+);
+const requestEncoding = between(
+  source,
+  'fn checkout_request_hashes(',
+  'fn hash_json(',
+  'checkout recovery request encoding',
+);
+const canonicalEncoding = between(
+  source,
+  'fn hash_json(',
+  'fn canonicalize_json(',
+  'checkout recovery canonical encoding',
+);
+const hashValidation = between(
+  source,
+  'fn normalize_hash(',
+  'fn order_error_to_port_error(',
+  'checkout recovery hash validation',
+);
+const ownerMapper = source.slice(source.indexOf('fn order_error_to_port_error('));
+
+for (const [value, label] of [
+  [
+    'const CHECKOUT_ORDER_RECOVERY_OWNER: &str = "rustok_order.checkout_order_recovery";',
+    'checkout recovery owner constant',
+  ],
+  ['const RECOVER_OPERATION: &str = "recover_existing_checkout";', 'recovery operation'],
+  ['const READ_OPERATION: &str = "read_checkout_order";', 'read operation'],
+  ['validate_identity(\n            &context,', 'context-aware identity validation'],
+  [
+    'order_error_to_port_error(\n                            context,\n                            "confirm_recovered_checkout_order"',
+    'context-aware recovery confirmation mapping',
+  ],
+  [
+    'order_error_to_port_error(context, "load_checkout_order", error)',
+    'context-aware order load mapping',
+  ],
+]) requireText(source, value, label);
+
+for (const [block, label] of [
+  [readCheckout, 'checkout order read'],
+  [resumeOrder, 'checkout order lifecycle recovery'],
+  [identityValidation, 'checkout recovery identity validation'],
+  [operationContext, 'checkout recovery causation validation'],
+  [tenantParser, 'checkout recovery tenant parser'],
+  [actorParser, 'checkout recovery actor parser'],
+  [requestEncoding, 'checkout recovery request encoding'],
+  [canonicalEncoding, 'checkout recovery canonical encoding'],
+  [hashValidation, 'checkout recovery hash validation'],
+]) {
+  for (const [value, detail] of [
+    ['owner = CHECKOUT_ORDER_RECOVERY_OWNER', `${label} owner log`],
+    ['correlation_id = %context.correlation_id', `${label} correlation log`],
+    ['tenant_id = %context.tenant_id', `${label} tenant log`],
+    ['channel = ?context.channel', `${label} channel log`],
+  ]) requireText(block, value, detail);
+}
+
+for (const [block, value, label] of [
+  [readCheckout, 'code = "order.checkout_order_not_found"', 'read missing-identity stable code'],
+  [readCheckout, 'checkout_operation_id = %request.checkout_operation_id', 'read missing operation identity'],
+  [resumeOrder, 'code = "order.checkout_order_cancelled"', 'cancelled lifecycle stable code'],
+  [resumeOrder, 'order_state = ?OrderStatusKind::Cancelled', 'cancelled lifecycle state'],
+  [resumeOrder, 'code = "order.checkout_order_status_invalid"', 'unknown lifecycle stable code'],
+  [resumeOrder, 'order_state = ?OrderStatusKind::Unknown', 'unknown lifecycle state'],
+  [identityValidation, 'base_matches,', 'identity base-match evidence'],
+  [identityValidation, 'owner_hashes_match,', 'identity owner-hash evidence'],
+  [identityValidation, 'legacy_hashes_match,', 'identity legacy-hash evidence'],
+  [identityValidation, 'identity_order_id = %identity.order_id', 'identity durable order evidence'],
+  [operationContext, 'actual_causation_id = ?context.causation_id', 'actual causation evidence'],
+  [tenantParser, 'error = ?error', 'tenant parse cause'],
+  [actorParser, 'error = ?error', 'actor parse cause'],
+  [requestEncoding, 'error = ?error', 'request encoding cause'],
+  [canonicalEncoding, 'error = ?error', 'canonical encoding cause'],
+  [hashValidation, 'value_length = value.len()', 'hash validation length evidence'],
+]) requireText(block, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Database(error)', 'database cause capture'],
+  ['OrderError::OrderNotFound(order_id)', 'order identity capture'],
+  ['order_id = %order_id', 'order identity log'],
+  ['OrderError::Validation(cause)', 'validation cause capture'],
+  ['cause = %cause', 'validation cause log'],
+  ['OrderError::InvalidTransition { from, to }', 'transition cause capture'],
+  ['from = %from', 'transition source log'],
+  ['to = %to', 'transition target log'],
+  ['OrderError::OrderReturnNotFound(return_id)', 'return identity capture'],
+  ['resource_id = %return_id', 'return identity log'],
+  ['OrderError::OrderChangeNotFound(change_id)', 'change identity capture'],
+  ['resource_id = %change_id', 'change identity log'],
+  ['OrderError::Core(error)', 'core cause capture'],
+]) requireText(ownerMapper, value, label);
+
+for (const value of [
+  'owner = CHECKOUT_ORDER_RECOVERY_OWNER',
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'channel = ?context.channel',
+  'operation,',
+]) requireText(ownerMapper, value, `owner mapper ${value}`);
+
+for (const [value, label] of [
+  [
+    '"checkout order was not found for the requested operation"',
+    'static checkout-order not-found envelope',
+  ],
+  ['"checkout order is already cancelled"', 'static cancelled envelope'],
+  [
+    '"checkout order has an unsupported lifecycle state"',
+    'static unsupported-state envelope',
+  ],
+  [
+    '"checkout operation is already bound to a different completion request"',
+    'static identity-conflict envelope',
+  ],
+  ['"checkout operation context is invalid"', 'static causation envelope'],
+  ['"order request context is invalid"', 'static owner-context envelope'],
+  ['"checkout completion request could not be encoded"', 'static encoding envelope'],
+  ['"checkout hash evidence is invalid"', 'static hash-validation envelope'],
+  ['"order storage is temporarily unavailable"', 'static storage envelope'],
+  ['"order was not found"', 'static order not-found envelope'],
+  ['"checkout order recovery request is invalid"', 'static owner-validation envelope'],
+  [
+    '"order lifecycle transition conflicts with checkout recovery"',
+    'static transition envelope',
+  ],
+  ['"related order resource was not found"', 'static related-resource envelope'],
+  ['"order operation failed an internal invariant"', 'static invariant envelope'],
+]) requireText(source, value, label);
+
+for (const value of [
+  'OrderError::OrderNotFound(_)',
+  'OrderError::InvalidTransition { .. }',
+  'OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_)',
+  '.map_err(order_error_to_port_error)',
+  'PortError::validation("order.checkout_recovery_validation", cause)',
+  'snapshot_hash =',
+  'request_hash =',
+]) forbidText(source, value, 'unsafe checkout recovery mapping');
+
+for (const [value, label] of [
+  ['pub struct PortContext {', 'shared port context'],
+  ['pub correlation_id: String', 'shared correlation field'],
+  ['pub channel: Option<String>', 'shared channel field'],
+  ['pub struct PortError {', 'shared port error'],
+  ['pub fn validation(', 'typed validation constructor'],
+  ['pub fn conflict(', 'typed conflict constructor'],
+  ['pub fn invariant_violation(', 'typed invariant constructor'],
+]) requireText(portContract, value, label);
+
+if (failures.length > 0) {
+  console.error('Order checkout recovery error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Order checkout recovery retains owner, channel, correlation, reconciliation evidence, and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- add the explicit `rustok_order.checkout_order_recovery` owner and request channel to checkout recovery diagnostics;
- record missing checkout identities, immutable identity mismatches, cancelled/unknown lifecycle states, invalid owner context, request/hash encoding failures, missing resources, transitions, storage failures, and core causes before returning stable `PortError` envelopes;
- retain reconciliation evidence without logging raw snapshot/request hash values;
- preserve recovery/adoption behavior, order confirmation, locale reloads, hash validation, public error codes, and public messages;
- add a focused static verifier and update the ecommerce error-safety plan while leaving remaining order adapters open.

## Scope

Three files only:

- `crates/rustok-order/src/checkout_order_recovery.rs`
- `scripts/verify/verify-order-checkout-recovery-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files (`+374/-16`);
- changed files were re-read statically to confirm owner/channel/correlation fields, reconciliation evidence, captured `OrderError` details, unchanged public envelopes, and absence of raw hash-value logs;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-order-checkout-recovery-error-context.mjs
cargo check -p rustok-order --all-features
```