### PR TITLE
fix(index): reject ambiguous hash help

### DIFF
--- a/scripts/verify/hash-index-storage-comparison.mjs
+++ b/scripts/verify/hash-index-storage-comparison.mjs
@@ -10,7 +10,7 @@ const fail = (message) => {
 };
 
 const args = process.argv.slice(2);
-if (args.includes('--help') || args.includes('-h')) {
+if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
   console.log('Usage: node scripts/verify/hash-index-storage-comparison.mjs <comparison.json>');
   process.exit(0);
 }

--- a/scripts/verify/index-storage-tooling.test.mjs
+++ b/scripts/verify/index-storage-tooling.test.mjs
@@ -94,6 +94,13 @@ test('forwards hash help to the exact-byte comparison helper', () => {
   assert.match(result.stdout, /hash-index-storage-comparison\.mjs <comparison\.json>/u);
 });
 
+test('rejects hash help combined with a comparison path', () => {
+  const result = run('hash', 'comparison.json', '--help');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /exactly one comparison\.json path is required/u);
+  assert.equal(result.stdout, '');
+});
+
 test('forwards comparator help without rewriting its arguments', () => {
   const result = run('compare', '--help');
   assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## What changed

- accept `--help`/`-h` in the comparison hash helper only when it is the sole argument;
- reject mixed invocations such as `hash comparison.json --help` instead of silently printing usage and exiting successfully;
- add router-level fixture coverage for the ambiguous invocation.

## Root cause

The hash helper used `args.includes('--help')`, so help took precedence over argument-count validation. A malformed scripted invocation could therefore appear successful without hashing the requested comparison file.

## Impact

The exact-byte comparison digest path now fails closed on ambiguous CLI input while preserving the documented one-argument help behavior. This does not select a storage model or advance M2 beyond replacement same-commit 100k/1m evidence and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was manually checked and contains two files with eight additions and one deletion.