### PR TITLE
chore(forum): correct notification visibility residual

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,9 +1,10 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "task": "FORUM-20I",
   "scope": "Forum notification source composition through the current public topic visibility owner",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
+  "richer_visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "visibility_contract": "crates/rustok-forum/contracts/forum-topic-visibility-scope.json",
   "test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
@@ -39,7 +40,7 @@
   "not_delivered": [
     "recipient-specific authenticated role trust channel group and explicit-user evaluation",
     "profile privacy and blocking policy",
-    "normalized category and topic audience layer read composition",
+    "notification source migration to the exact richer topic audience owner",
     "search index SEO and deep-link migration",
     "final notification creation and delivery authorization",
     "PostgreSQL and cross-consumer runtime evidence"

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -32,11 +32,12 @@ const contractPath =
 const contract = JSON.parse(read(contractPath) || "{}");
 const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
+const richerVisibilityOwner = read(contract.richer_visibility_owner_file ?? "");
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum notification visibility contract must use schema_version=2");
+if (contract.schema_version !== 3) {
+  failures.push("forum notification visibility contract must use schema_version=3");
 }
 if (contract.task !== "FORUM-20I") {
   failures.push("forum notification visibility contract must belong to FORUM-20I");
@@ -47,7 +48,7 @@ if (contract.verification?.execution_status !== "not_run_by_implementation_agent
 for (const residual of [
   "recipient-specific authenticated role trust channel group and explicit-user evaluation",
   "profile privacy and blocking policy",
-  "normalized category and topic audience layer read composition",
+  "notification source migration to the exact richer topic audience owner",
   "search index SEO and deep-link migration",
   "final notification creation and delivery authorization",
   "PostgreSQL and cross-consumer runtime evidence",
@@ -116,6 +117,20 @@ for (const marker of [
 }
 
 for (const marker of [
+  "pub struct ForumTopicAudienceViewer",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+]) {
+  requireText(
+    richerVisibilityOwner,
+    marker,
+    `exact richer topic visibility owner is missing ${marker}`,
+  );
+}
+
+for (const marker of [
   "use crate::error::ForumError;",
   "ForumTopicVisibilityScope, ForumTopicVisibilityService",
   "async fn load_public_topic(",
@@ -139,11 +154,12 @@ for (const forbidden of [
   "async fn is_channel_restricted(",
   "forum_topic_channel_access",
   "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "ForumTopicAudienceVisibilityService",
 ]) {
   rejectText(
     notificationSource,
     forbidden,
-    `forum notification source must not retain duplicate visibility policy ${forbidden}`,
+    `forum notification source must not retain or prematurely claim visibility policy ${forbidden}`,
   );
 }
 


### PR DESCRIPTION
## Summary

- advance the Forum notification visibility composition contract to schema v3
- record the already-merged `ForumTopicAudienceVisibilityService` as the exact richer owner available for future notification composition
- replace the stale claim that normalized category/topic read composition is wholly undelivered with the precise remaining migration of the notification source to that richer owner
- keep recipient-specific role, trust, channel, group, explicit-user, profile privacy, final notification, delivery and runtime evidence explicitly open
- update the source verifier to require the richer owner while rejecting any premature claim that the current public notification source already uses it

## Scope

Machine-readable contract and verifier only. No Forum runtime, persistence, transport, UI, notification behavior or canonical-plan status changes.

## Validation

Not run at the maintainer's request. Intended command:

```bash
node scripts/verify/verify-forum-notification-visibility-composition.mjs
```
