### PR TITLE
feat(forum): apply richer visibility to notifications

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,29 +1,33 @@
 {
-  "schema_version": 3,
-  "task": "FORUM-20I",
-  "scope": "Forum notification source composition through the current public topic visibility owner",
+  "schema_version": 4,
+  "task": "FORUM-20K",
+  "supersedes_task": "FORUM-20I",
+  "scope": "Forum notification source composition through the exact richer public topic visibility owner",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
-  "visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
-  "richer_visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
-  "visibility_contract": "crates/rustok-forum/contracts/forum-topic-visibility-scope.json",
-  "test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
+  "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
+  "base_visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
+  "visibility_contract": "crates/rustok-forum/contracts/forum-topic-audience-visibility.json",
+  "baseline_test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
+  "test_file": "crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20I",
+    "required_ledger_through": "FORUM-20K",
     "required_delivered_sections": [
       "FORUM-20H",
-      "FORUM-20I"
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
-    "viewer_profile": "public unauthenticated without channel context",
-    "topic_status": "open",
-    "category_floor": "inherited public categories only",
-    "channel_restrictions": "unavailable until recipient-specific membership authorization exists",
+    "viewer_profile": "public unauthenticated without route-channel context",
+    "evaluation_order": "exact open route-channel and category floor owner then normalized root-to-category audience layers then optional topic layer",
+    "facts_provider": "intentionally absent because public evaluation never calls authenticated owner facts capabilities",
+    "non_public_richer_layers": "unavailable before notification descriptor or audience materialization until recipient-specific authorization exists",
     "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",
     "reply_state": "pending deferred; approved eligible; all other states unavailable",
     "owner_failures": "preserve Forum retryability classification"
@@ -34,13 +38,17 @@
     "authorize_target_open": true,
     "topic_created": true,
     "topic_and_reply_mentions": true,
-    "duplicate_notification_open_predicate_removed": true,
-    "duplicate_notification_channel_predicate_removed": true
+    "exact_richer_public_owner": true,
+    "normalized_category_layers": true,
+    "normalized_topic_layer": true,
+    "dynamic_policy_recheck": true,
+    "duplicate_notification_visibility_predicate_removed": true
   },
   "not_delivered": [
     "recipient-specific authenticated role trust channel group and explicit-user evaluation",
+    "recipient-specific target-open authorization for non-public audiences",
     "profile privacy and blocking policy",
-    "notification source migration to the exact richer topic audience owner",
+    "host trust channel and group facts adapters for authenticated consumers",
     "search index SEO and deep-link migration",
     "final notification creation and delivery authorization",
     "PostgreSQL and cross-consumer runtime evidence"
@@ -48,6 +56,7 @@
   "verification": {
     "commands": [
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
       "cargo xtask module validate forum"
     ],

--- a/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
@@ -1,6 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20J",
+  "downstream_notification_task": "FORUM-20K",
   "scope": "Exact topic visibility composition through current open/channel/category-floor policy and normalized category/topic audience layers",
   "owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner": "crates/rustok-forum/src/services/topic_visibility.rs",
@@ -9,16 +10,19 @@
   "audience_evaluator": "crates/rustok-forum/src/audience.rs",
   "services_file": "crates/rustok-forum/src/services/mod.rs",
   "crate_file": "crates/rustok-forum/src/lib.rs",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "notification_visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
   "test_file": "crates/rustok-forum/tests/topic_audience_visibility_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-topic-audience-visibility.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20J",
+    "required_ledger_through": "FORUM-20K",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
-      "FORUM-20J"
+      "FORUM-20J",
+      "FORUM-20K"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -44,10 +48,11 @@
     "normalized_topic_layer": true,
     "role_and_explicit_user": true,
     "trust_channel_group_owner_facts": true,
+    "public_notification_source": true,
     "topic_and_reply_pages": false,
     "category_and_reply_exact_reads": false,
     "write_audiences": false,
-    "notifications_search_seo_deep_links": false
+    "search_index_seo_deep_links": false
   },
   "not_delivered": [
     "topic and reply page filtering before count and pagination",
@@ -55,12 +60,14 @@
     "create reply and moderate audience write policy",
     "host trust channel and group provider adapters",
     "visibility-scoped category and all-read mutations",
-    "notification search index SEO and deep-link migration to the richer exact owner",
+    "recipient-specific notification authorization for non-public audiences",
+    "search index SEO and deep-link migration to the richer exact owner",
     "PostgreSQL concurrency and cross-consumer runtime evidence"
   ],
   "verification": {
     "commands": [
       "cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-topic-audience-visibility.mjs",
       "cargo xtask module validate forum"
     ],

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -23,7 +23,7 @@ use crate::entities::{
     forum_category_subscription, forum_domain_event, forum_reply, forum_topic, forum_user_mention,
 };
 use crate::error::ForumError;
-use crate::services::topic_visibility::{ForumTopicVisibilityScope, ForumTopicVisibilityService};
+use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};
 use crate::state_machine::ReplyStatus;
 use crate::subscription::ForumSubscriptionLevel;
 
@@ -137,9 +137,9 @@ impl ForumNotificationSourceProvider {
         tenant_id: Uuid,
         topic_id: Uuid,
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
-        let scope = ForumTopicVisibilityScope::storefront(None).map_err(forum_owner_error)?;
-        if !ForumTopicVisibilityService::new(self.db.clone())
-            .is_topic_visible(tenant_id, topic_id, &scope)
+        let viewer = ForumTopicAudienceViewer::public();
+        if !ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())
+            .is_topic_visible(tenant_id, topic_id, None, &viewer)
             .await
             .map_err(forum_owner_error)?
         {

--- a/crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs
@@ -1,0 +1,288 @@
+use std::sync::Arc;
+
+use rustok_api::HostRuntimeContext;
+use rustok_core::{MemoryTransport, MigrationSource, ModuleRegistry, SecurityContext, UserRole};
+use rustok_forum::entities::forum_domain_event;
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateTopicInput, ForumAudienceConstraints,
+    ForumCategoryAudiencePolicyService, ForumModule, ForumTopicAudiencePolicyService,
+    SetForumCategoryAudiencePolicyInput, SetForumTopicAudiencePolicyInput, SubscriptionService,
+    TopicService,
+};
+use rustok_notifications::NotificationsModule;
+use rustok_notifications_api::{
+    AuthorizeNotificationTargetRequest, DescribeNotificationRequest, NotificationOpenAuthorization,
+    NotificationSourceEventRef, ResolveNotificationAudienceRequest,
+    materialize_notification_source_registry,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn notification_source_rechecks_category_and_topic_richer_visibility() {
+    let (db, event_bus) = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let author_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(author_id));
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Richer notifications".into(),
+                slug: "richer-notifications".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created");
+
+    SubscriptionService::new(db.clone())
+        .set_category_subscription(
+            tenant_id,
+            category.id,
+            SecurityContext::new(UserRole::Customer, Some(recipient_id)),
+        )
+        .await
+        .expect("category watcher should be stored");
+
+    let topic_service = TopicService::new(db.clone(), event_bus);
+    let topic_narrowed = topic_service
+        .create(
+            tenant_id,
+            admin.clone(),
+            topic_input(category.id, "Topic narrowing", "topic-narrowing"),
+        )
+        .await
+        .expect("topic-narrowing fixture should be created");
+    let category_narrowed = topic_service
+        .create(
+            tenant_id,
+            admin.clone(),
+            topic_input(category.id, "Category narrowing", "category-narrowing"),
+        )
+        .await
+        .expect("category-narrowing fixture should be created");
+
+    let topic_event = topic_created_event(&db, tenant_id, topic_narrowed.id).await;
+    let category_event = topic_created_event(&db, tenant_id, category_narrowed.id).await;
+    let topic_source_event = source_event_ref(&topic_event);
+    let category_source_event = source_event_ref(&category_event);
+
+    let registry = ModuleRegistry::new()
+        .register(NotificationsModule)
+        .register(ForumModule);
+    let mut extensions = registry
+        .build_runtime_extensions()
+        .expect("Notifications and Forum runtime extensions should initialize");
+    let host = extensions.apply_to_host_runtime(HostRuntimeContext::new(db.clone()));
+    let providers = materialize_notification_source_registry(&mut extensions, &host)
+        .expect("Forum source factory should materialize");
+    let provider = providers
+        .get_by_str("forum")
+        .expect("Forum source should be discoverable");
+
+    let topic_descriptor = provider
+        .describe_event(DescribeNotificationRequest {
+            event: topic_source_event.clone(),
+        })
+        .await
+        .expect("public topic event should be described")
+        .expect("public topic should initially be notifiable");
+    let category_descriptor = provider
+        .describe_event(DescribeNotificationRequest {
+            event: category_source_event.clone(),
+        })
+        .await
+        .expect("public category topic event should be described")
+        .expect("public category topic should initially be notifiable");
+
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            topic_narrowed.id,
+            admin.clone(),
+            SetForumTopicAudiencePolicyInput {
+                constraints: customer_only(),
+            },
+        )
+        .await
+        .expect("topic audience should narrow to authenticated customers");
+
+    assert!(
+        provider
+            .describe_event(DescribeNotificationRequest {
+                event: topic_source_event.clone(),
+            })
+            .await
+            .expect("topic-level richer visibility should fail closed")
+            .is_none()
+    );
+    let topic_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: topic_source_event,
+            descriptor: topic_descriptor.clone(),
+            cursor: None,
+            limit: 10,
+        })
+        .await
+        .expect("stale public descriptor should be rechecked");
+    assert!(topic_page.recipients().is_empty());
+    assert!(topic_page.is_complete());
+    let topic_open = provider
+        .authorize_target_open(AuthorizeNotificationTargetRequest {
+            tenant_id,
+            recipient_id,
+            target: topic_descriptor.target,
+        })
+        .await
+        .expect("topic open authorization should fail closed");
+    assert_eq!(topic_open, NotificationOpenAuthorization::Unavailable);
+
+    let category_open_before_narrowing = provider
+        .authorize_target_open(AuthorizeNotificationTargetRequest {
+            tenant_id,
+            recipient_id,
+            target: category_descriptor.target.clone(),
+        })
+        .await
+        .expect("public category topic should still authorize");
+    assert!(matches!(
+        category_open_before_narrowing,
+        NotificationOpenAuthorization::Allowed { .. }
+    ));
+
+    ForumCategoryAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            category.id,
+            admin,
+            SetForumCategoryAudiencePolicyInput {
+                constraints: customer_only(),
+            },
+        )
+        .await
+        .expect("category audience should narrow to authenticated customers");
+
+    assert!(
+        provider
+            .describe_event(DescribeNotificationRequest {
+                event: category_source_event.clone(),
+            })
+            .await
+            .expect("category-level richer visibility should fail closed")
+            .is_none()
+    );
+    let category_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: category_source_event,
+            descriptor: category_descriptor.clone(),
+            cursor: None,
+            limit: 10,
+        })
+        .await
+        .expect("category policy change should invalidate the old public descriptor");
+    assert!(category_page.recipients().is_empty());
+    assert!(category_page.is_complete());
+    let category_open = provider
+        .authorize_target_open(AuthorizeNotificationTargetRequest {
+            tenant_id,
+            recipient_id,
+            target: category_descriptor.target,
+        })
+        .await
+        .expect("category-narrowed target authorization should fail closed");
+    assert_eq!(category_open, NotificationOpenAuthorization::Unavailable);
+}
+
+fn topic_input(category_id: Uuid, title: &str, slug: &str) -> CreateTopicInput {
+    CreateTopicInput {
+        locale: "en".into(),
+        category_id,
+        title: title.into(),
+        slug: Some(slug.into()),
+        body: "Notification visibility must follow the current exact Forum owner.".into(),
+        body_format: "markdown".into(),
+        content_json: None,
+        metadata: serde_json::json!({}),
+        tags: Vec::new(),
+        channel_slugs: None,
+    }
+}
+
+fn customer_only() -> ForumAudienceConstraints {
+    ForumAudienceConstraints {
+        roles_any: vec![UserRole::Customer],
+        ..ForumAudienceConstraints::default()
+    }
+}
+
+async fn topic_created_event(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+) -> forum_domain_event::Model {
+    forum_domain_event::Entity::find()
+        .filter(forum_domain_event::Column::TenantId.eq(tenant_id))
+        .filter(forum_domain_event::Column::AggregateType.eq("topic"))
+        .filter(forum_domain_event::Column::AggregateId.eq(topic_id))
+        .filter(forum_domain_event::Column::EventType.eq("forum.topic.created"))
+        .one(db)
+        .await
+        .expect("topic-created event query should succeed")
+        .expect("topic-created event should be journaled")
+}
+
+fn source_event_ref(event: &forum_domain_event::Model) -> NotificationSourceEventRef {
+    NotificationSourceEventRef::new(
+        event.tenant_id,
+        event.event_id,
+        "forum".try_into().expect("source slug"),
+        event.event_type.clone().try_into().expect("event type"),
+        u64::try_from(event.sequence_no).expect("event sequence should be positive"),
+    )
+    .expect("source event reference")
+}
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus) {
+    let url = format!(
+        "sqlite:file:forum_notification_richer_visibility_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("notification richer visibility sqlite database should connect");
+    let manager = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus)
+}

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -32,23 +32,25 @@ const contractPath =
 const contract = JSON.parse(read(contractPath) || "{}");
 const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
-const richerVisibilityOwner = read(contract.richer_visibility_owner_file ?? "");
+const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
+const baselineTestSource = read(contract.baseline_test_file ?? "");
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) {
-  failures.push("forum notification visibility contract must use schema_version=3");
+if (contract.schema_version !== 4) {
+  failures.push("forum notification visibility contract must use schema_version=4");
 }
-if (contract.task !== "FORUM-20I") {
-  failures.push("forum notification visibility contract must belong to FORUM-20I");
+if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I") {
+  failures.push("forum notification richer visibility contract must belong to FORUM-20K and supersede FORUM-20I");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted notification evidence");
 }
 for (const residual of [
   "recipient-specific authenticated role trust channel group and explicit-user evaluation",
+  "recipient-specific target-open authorization for non-public audiences",
   "profile privacy and blocking policy",
-  "notification source migration to the exact richer topic audience owner",
+  "host trust channel and group facts adapters for authenticated consumers",
   "search index SEO and deep-link migration",
   "final notification creation and delivery authorization",
   "PostgreSQL and cross-consumer runtime evidence",
@@ -58,15 +60,26 @@ for (const residual of [
   }
 }
 
+for (const delivered of [
+  "exact_richer_public_owner",
+  "normalized_category_layers",
+  "normalized_topic_layer",
+  "dynamic_policy_recheck",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
+  }
+}
+
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20I") {
-  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20I");
+if (planSync.required_ledger_through !== "FORUM-20K") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20K");
 }
 if (
   JSON.stringify(planSync.required_delivered_sections) !==
-  JSON.stringify(["FORUM-20H", "FORUM-20I"])
+  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"])
 ) {
-  failures.push("forum notification visibility contract must require FORUM-20H/I delivered sections");
+  failures.push("forum notification visibility contract must require FORUM-20H/I/J/K delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -77,23 +90,20 @@ if (planSync.status === "pending") {
     "FORUM-20A-G provide",
     "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
   );
-  rejectText(
-    plan,
-    "### Delivered in `FORUM-20H`",
-    "canonical plan now contains FORUM-20H; update canonical_plan_sync to synchronized",
-  );
-  rejectText(
-    plan,
-    "### Delivered in `FORUM-20I`",
-    "canonical plan now contains FORUM-20I; update canonical_plan_sync to synchronized",
-  );
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-I provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through I",
+    "FORUM-20A-K provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through K",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I"]) {
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
     requireText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -105,37 +115,35 @@ if (planSync.status === "pending") {
 }
 
 for (const marker of [
+  "pub struct ForumTopicAudienceViewer",
+  "pub fn public() -> Self",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub fn without_facts_provider",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers",
+  "policy.configured_constraints",
+]) {
+  requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
+}
+for (const marker of [
   "pub struct ForumTopicVisibilityScope",
-  "pub fn storefront(channel_slug: Option<&str>) -> ForumResult<Self>",
   "pub struct ForumTopicVisibilityService",
-  "pub async fn is_topic_visible",
-  "self.hidden_category_ids_for_scope(tenant_id, scope)",
   "forum_topic::Column::Status.eq(TopicStatus::Open)",
   "all_topic_channel_access_subquery(tenant_id)",
 ]) {
-  requireText(visibilityOwner, marker, `topic visibility owner is missing ${marker}`);
-}
-
-for (const marker of [
-  "pub struct ForumTopicAudienceViewer",
-  "pub struct ForumTopicAudienceVisibilityService",
-  "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityService::new(self.db.clone())",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-]) {
-  requireText(
-    richerVisibilityOwner,
-    marker,
-    `exact richer topic visibility owner is missing ${marker}`,
-  );
+  requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
 }
 
 for (const marker of [
   "use crate::error::ForumError;",
-  "ForumTopicVisibilityScope, ForumTopicVisibilityService",
+  "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
   "async fn load_public_topic(",
-  "ForumTopicVisibilityScope::storefront(None)",
-  ".is_topic_visible(tenant_id, topic_id, &scope)",
+  "let viewer = ForumTopicAudienceViewer::public();",
+  "ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
   ".map_err(forum_owner_error)?",
   ".load_public_topic(tenant_id, source_id)",
   ".load_public_topic(tenant_id, reply.topic_id)",
@@ -146,36 +154,46 @@ for (const marker of [
   requireText(
     notificationSource,
     marker,
-    `forum notification source is missing owner visibility composition ${marker}`,
+    `forum notification source is missing exact richer visibility composition ${marker}`,
   );
 }
 for (const forbidden of [
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
   "async fn load_open_topic(",
   "async fn is_channel_restricted(",
   "forum_topic_channel_access",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
-  "ForumTopicAudienceVisibilityService",
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "ForumAudienceFactsPort",
 ]) {
   rejectText(
     notificationSource,
     forbidden,
-    `forum notification source must not retain or prematurely claim visibility policy ${forbidden}`,
+    `forum notification source must reuse the richer owner instead of ${forbidden}`,
   );
 }
 
 const visibilityIndex = notificationSource.indexOf(
-  ".is_topic_visible(tenant_id, topic_id, &scope)",
+  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
 );
 const materializeIndex = notificationSource.indexOf(
   "let topic = forum_topic::Entity::find()",
 );
 if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
-  failures.push("notification target visibility must be evaluated before target materialization");
+  failures.push("notification target richer visibility must be evaluated before target materialization");
 }
 
 for (const marker of [
   "forum_topic_and_user_mention_sources_support_notifications_profiles",
-  "channel-restricted topic should be created",
   "restricted topic description should fail closed",
   "restricted topic authorization should fail closed",
   "restricted mention description should fail closed",
@@ -184,7 +202,20 @@ for (const marker of [
   "database failure should be classified",
   "NotificationProviderError::Internal { retryable: true }",
 ]) {
-  requireText(testSource, marker, `notification SQLite scenario is missing ${marker}`);
+  requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
+}
+
+for (const marker of [
+  "notification_source_rechecks_category_and_topic_richer_visibility",
+  "ForumTopicAudiencePolicyService::new(db.clone())",
+  "ForumCategoryAudiencePolicyService::new(db.clone())",
+  "topic-level richer visibility should fail closed",
+  "stale public descriptor should be rechecked",
+  "category-level richer visibility should fail closed",
+  "category policy change should invalidate the old public descriptor",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(testSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
 }
 
 for (const marker of [
@@ -200,4 +231,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Forum notification visibility composition contract is source-ready.");
+console.log("Forum notification richer visibility composition contract is source-ready.");

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -37,17 +37,24 @@ const topicOwner = read(contract.topic_policy_owner ?? "");
 const evaluator = read(contract.audience_evaluator ?? "");
 const services = read(contract.services_file ?? "");
 const crate = read(contract.crate_file ?? "");
+const notificationSource = read(contract.notification_source_file ?? "");
+const notificationContract = JSON.parse(
+  read(contract.notification_visibility_contract ?? "") || "{}",
+);
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum topic audience visibility contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("forum topic audience visibility contract must use schema_version=2");
 }
-if (contract.task !== "FORUM-20J") {
-  failures.push("forum topic audience visibility contract must belong to FORUM-20J");
+if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K") {
+  failures.push("forum topic audience visibility contract must belong to FORUM-20J and record FORUM-20K notification composition");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted richer visibility evidence");
+}
+if (contract.composition?.public_notification_source !== true) {
+  failures.push("forum topic audience visibility contract must record the public notification source consumer");
 }
 for (const residual of [
   "topic and reply page filtering before count and pagination",
@@ -55,7 +62,8 @@ for (const residual of [
   "create reply and moderate audience write policy",
   "host trust channel and group provider adapters",
   "visibility-scoped category and all-read mutations",
-  "notification search index SEO and deep-link migration to the richer exact owner",
+  "recipient-specific notification authorization for non-public audiences",
+  "search index SEO and deep-link migration to the richer exact owner",
   "PostgreSQL concurrency and cross-consumer runtime evidence",
 ]) {
   if (!contract.not_delivered?.includes(residual)) {
@@ -64,14 +72,14 @@ for (const residual of [
 }
 
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20J") {
-  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20J");
+if (planSync.required_ledger_through !== "FORUM-20K") {
+  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20K");
 }
 if (
   JSON.stringify(planSync.required_delivered_sections) !==
-  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J"])
+  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"])
 ) {
-  failures.push("forum topic audience visibility contract must require FORUM-20H/I/J delivered sections");
+  failures.push("forum topic audience visibility contract must require FORUM-20H/I/J/K delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -82,7 +90,7 @@ if (planSync.status === "pending") {
     "FORUM-20A-G provide",
     "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J"]) {
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
     rejectText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -92,10 +100,10 @@ if (planSync.status === "pending") {
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-J provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through J",
+    "FORUM-20A-K provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through K",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J"]) {
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
     requireText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -206,6 +214,38 @@ for (const marker of [
   "ForumTopicAudienceVisibilityService",
 ]) {
   requireText(crate, marker, `forum crate surface is missing ${marker}`);
+}
+
+for (const marker of [
+  "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
+  "let viewer = ForumTopicAudienceViewer::public();",
+  "ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
+]) {
+  requireText(
+    notificationSource,
+    marker,
+    `public notification source is missing richer topic visibility composition ${marker}`,
+  );
+}
+for (const forbidden of [
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
+  "forum_category_audience_policy",
+  "forum_topic_audience_policy",
+]) {
+  rejectText(
+    notificationSource,
+    forbidden,
+    `public notification source must not bypass the richer owner with ${forbidden}`,
+  );
+}
+if (
+  notificationContract.schema_version !== 4 ||
+  notificationContract.task !== "FORUM-20K" ||
+  notificationContract.composition?.exact_richer_public_owner !== true
+) {
+  failures.push("FORUM-20K notification visibility contract must record exact richer public composition");
 }
 
 for (const marker of [


### PR DESCRIPTION
## Summary

- migrate the Forum notification source from the base public topic visibility owner to `ForumTopicAudienceVisibilityService`
- use a public viewer without an owner-facts provider, so normalized category/topic role, trust, channel, group and explicit-user narrowing fails closed without authenticated capability calls
- recheck the exact richer policy during event description, audience resolution and target-open authorization before topic materialization
- add a SQLite regression scenario for dynamic topic- and category-level role narrowing after a descriptor was already materialized
- advance the notification visibility contract to FORUM-20K and align the FORUM-20J owner contract with the delivered public notification consumer

## Compatibility and degraded mode

Public topics without richer layers retain the existing notification behavior. A non-public richer layer suppresses source description, audience materialization and target opening until recipient-specific authenticated authorization is delivered. Forum owner commands remain independent from the optional Notifications module.

The canonical implementation plan still physically ends at FORUM-20G. Both machine contracts keep synchronization explicitly pending through FORUM-20K; this PR does not claim the plan is synchronized.

## Remaining scope

- recipient-specific role, trust, channel, group and explicit-user evaluation
- recipient-specific target-open authorization for non-public audiences
- profile privacy and blocking
- host facts adapters for authenticated consumers
- final notification creation and delivery policy
- search/index, SEO and deep-link migration
- PostgreSQL and cross-consumer runtime evidence

## Validation

Tests, Cargo, verifiers and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture
node scripts/verify/verify-forum-notification-visibility-composition.mjs
node scripts/verify/verify-forum-topic-audience-visibility.mjs
cargo xtask module validate forum
```
