### PR TITLE
fix(index): reject ambiguous ADR verifier arguments

### DIFF
--- a/scripts/verify/index-storage-tooling.test.mjs
+++ b/scripts/verify/index-storage-tooling.test.mjs
@@ -121,6 +121,26 @@ test('forwards ADR verification help without rewriting its arguments', () => {
   assert.match(result.stdout, /--adr <adr\.md>/u);
 });
 
+test('rejects unknown ADR verification options before reading inputs', () => {
+  const result = run(
+    'verify-adr',
+    '--comparison', 'comparison.json',
+    '--decision', 'decision.json',
+    '--adr', 'adr.md',
+    '--format', 'markdown',
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unknown or incomplete argument: --format/u);
+  assert.equal(result.stdout, '');
+});
+
+test('rejects ADR verification help combined with other arguments', () => {
+  const result = run('verify-adr', '--help', '--adr', 'adr.md');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /help must be the only argument/u);
+  assert.equal(result.stdout, '');
+});
+
 test('rejects unsupported packet scales before invoking the validator', () => {
   const result = run('packet', '--scale', '10m');
   assert.notEqual(result.status, 0);

--- a/scripts/verify/verify-index-storage-adr.mjs
+++ b/scripts/verify/verify-index-storage-adr.mjs
@@ -29,14 +29,18 @@ const usage = () => {
 
 const parseArgs = () => {
   const values = new Map();
+  const allowedArguments = new Set(['--comparison', '--decision', '--adr']);
   const args = process.argv.slice(2);
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') {
+      if (args.length !== 1) fail('help must be the only argument');
       usage();
       return null;
     }
-    if (!argument.startsWith('--') || !args[index + 1] || args[index + 1].startsWith('--')) {
+    if (!allowedArguments.has(argument)
+        || !args[index + 1]
+        || args[index + 1].startsWith('--')) {
       fail(`unknown or incomplete argument: ${argument}`);
     }
     if (values.has(argument)) fail(`${argument} was provided more than once`);


### PR DESCRIPTION
## What changed

- restrict the saved ADR verifier to the documented `--comparison`, `--decision`, and `--adr` options;
- reject unknown key/value options before reading any evidence or ADR files;
- allow `--help`/`-h` only as the sole argument;
- add router-level regression coverage for unknown options and mixed help invocations.

## Root cause

The verifier parser accepted any `--name value` pair and only checked afterward that the required options existed. Unknown options were therefore silently ignored. Help also returned successfully as soon as it appeared, masking otherwise malformed scripted invocations.

## Impact

The exact-byte ADR verification path now fails closed on ambiguous CLI input before touching supplied files. This does not select a storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was manually inspected and contains one commit with two changed files.