### PR TITLE
feat(forum): add notification recipient context capability

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-recipient-context.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-context.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20L",
+  "upstream_task": "FORUM-20K",
+  "scope": "Forum-owned exact recipient principal context capability for deferred notification authorization",
+  "owner_file": "crates/rustok-forum/src/notification_recipient.rs",
+  "crate_file": "crates/rustok-forum/src/lib.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "source_verifier": "scripts/verify/verify-forum-notification-recipient-context.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20L",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "caller": "tenant-matching system or service PortContext with read deadline semantics",
+    "request": "non-nil exact tenant_id and recipient_id",
+    "provider": "host-owned optional capability returning one exact user PortContext",
+    "returned_context": "tenant and actor must match the request and retain read deadline semantics",
+    "authority": "SecurityContext is reconstructed only from validated role and permission claims",
+    "topic_viewer": "validated authority converts through ForumTopicAudienceViewer::authenticated",
+    "provider_absence": "typed capability unavailable error",
+    "provider_failure": "stable source code and retryability preserved without leaking internals",
+    "storage_access": "none; Forum does not read auth, profile, channel or group owner tables directly"
+  },
+  "composition": {
+    "bounded_request": true,
+    "caller_read_semantics": true,
+    "caller_tenant_validation": true,
+    "system_or_service_caller": true,
+    "recipient_read_semantics": true,
+    "recipient_tenant_validation": true,
+    "exact_user_actor_validation": true,
+    "role_and_permission_snapshot_validation": true,
+    "authenticated_topic_viewer_conversion": true,
+    "typed_missing_capability": true,
+    "retryable_failure_mapping": true,
+    "inline_contract_tests": true
+  },
+  "not_delivered": [
+    "host recipient context adapter implementation",
+    "host runtime publication of the recipient context capability",
+    "notification source factory consumption of the recipient context capability",
+    "recipient-specific audience filtering for non-public topics",
+    "recipient-specific target-open authorization for non-public topics and replies",
+    "profile privacy and blocking policy",
+    "trust channel and group facts host adapters",
+    "final notification creation and delivery authorization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum notification_recipient -- --nocapture",
+      "node scripts/verify/verify-forum-notification-recipient-context.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -18,6 +18,7 @@ pub mod locale;
 #[allow(clippy::collapsible_if, clippy::redundant_closure)]
 pub mod mentions;
 pub mod migrations;
+pub mod notification_recipient;
 mod notification_source;
 pub mod openapi;
 mod seo_targets;
@@ -40,6 +41,13 @@ pub use entities::*;
 pub use error::{ForumError, ForumResult};
 pub use graphql::{ForumMutation, ForumQuery};
 pub use mentions::*;
+pub use notification_recipient::{
+    FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY,
+    FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE,
+    ForumNotificationRecipientContext, ForumNotificationRecipientContextPort,
+    ForumNotificationRecipientContextRequest, ForumNotificationRecipientContextResolver,
+    SharedForumNotificationRecipientContextPort,
+};
 pub use services::{
     CategoryService, ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
     ForumCategoryAudiencePolicyService, ForumCategoryVisibilityPolicy,

--- a/crates/rustok-forum/src/notification_recipient.rs
+++ b/crates/rustok-forum/src/notification_recipient.rs
@@ -1,0 +1,300 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_core::SecurityContext;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+use crate::services::ForumTopicAudienceViewer;
+
+pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY: &str =
+    "forum_notification_recipient_context";
+pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE: &str =
+    "FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE";
+
+/// Exact tenant-bound recipient identity requested by an asynchronous Forum
+/// notification consumer.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ForumNotificationRecipientContextRequest {
+    pub tenant_id: Uuid,
+    pub recipient_id: Uuid,
+}
+
+impl ForumNotificationRecipientContextRequest {
+    pub fn new(tenant_id: Uuid, recipient_id: Uuid) -> ForumResult<Self> {
+        if tenant_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum notification recipient tenant must not be nil".to_string(),
+            ));
+        }
+        if recipient_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum notification recipient user must not be nil".to_string(),
+            ));
+        }
+        Ok(Self {
+            tenant_id,
+            recipient_id,
+        })
+    }
+}
+
+/// Host-owned lookup for the exact recipient principal snapshot used by a
+/// deferred notification operation.
+///
+/// The host returns a normal `PortContext`; Forum validates its tenant, actor,
+/// deadline, role and permission claims before using it. Implementations must
+/// not return a broader system or service principal for a user recipient.
+#[async_trait]
+pub trait ForumNotificationRecipientContextPort: Send + Sync {
+    async fn resolve_forum_notification_recipient_context(
+        &self,
+        context: PortContext,
+        request: ForumNotificationRecipientContextRequest,
+    ) -> Result<PortContext, PortError>;
+}
+
+pub type SharedForumNotificationRecipientContextPort =
+    Arc<dyn ForumNotificationRecipientContextPort>;
+
+/// Validated recipient authority plus the same bounded context that may be
+/// forwarded to trust, channel or group facts owners.
+#[derive(Clone, Debug)]
+pub struct ForumNotificationRecipientContext {
+    pub security: SecurityContext,
+    pub port_context: PortContext,
+}
+
+impl ForumNotificationRecipientContext {
+    pub fn into_topic_viewer(self) -> ForumResult<ForumTopicAudienceViewer> {
+        ForumTopicAudienceViewer::authenticated(self.security, self.port_context)
+    }
+}
+
+/// Fail-closed recipient context composition for asynchronous notification
+/// consumers. Provider absence is a typed capability gap; provider failures
+/// preserve retryability through `ForumError::CapabilityFailure`.
+#[derive(Clone, Default)]
+pub struct ForumNotificationRecipientContextResolver {
+    port: Option<SharedForumNotificationRecipientContextPort>,
+}
+
+impl ForumNotificationRecipientContextResolver {
+    pub fn new(port: Option<SharedForumNotificationRecipientContextPort>) -> Self {
+        Self { port }
+    }
+
+    pub async fn resolve(
+        &self,
+        caller_context: PortContext,
+        tenant_id: Uuid,
+        recipient_id: Uuid,
+    ) -> ForumResult<ForumNotificationRecipientContext> {
+        let request = ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)?;
+        validate_caller_context(&caller_context, tenant_id)?;
+
+        let Some(port) = &self.port else {
+            return Err(ForumError::capability_unavailable(
+                FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY,
+                FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE,
+            ));
+        };
+
+        let recipient_context = port
+            .resolve_forum_notification_recipient_context(caller_context, request)
+            .await
+            .map_err(map_recipient_context_port_error)?;
+        validate_recipient_context(&recipient_context, tenant_id, recipient_id)?;
+
+        let security = SecurityContext::try_from_port_context(&recipient_context)
+            .map_err(map_recipient_context_port_error)?;
+        if security.user_id != Some(recipient_id) {
+            return Err(ForumError::Validation(
+                "Forum notification recipient authority does not match the requested user"
+                    .to_string(),
+            ));
+        }
+
+        Ok(ForumNotificationRecipientContext {
+            security,
+            port_context: recipient_context,
+        })
+    }
+}
+
+fn validate_caller_context(context: &PortContext, tenant_id: Uuid) -> ForumResult<()> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(map_recipient_context_port_error)?;
+    validate_context_tenant(context, tenant_id, "caller")?;
+    if !matches!(
+        context.actor.kind,
+        PortActorKind::System | PortActorKind::Service
+    ) {
+        return Err(ForumError::Validation(
+            "Forum notification recipient lookup requires a system or service caller".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_recipient_context(
+    context: &PortContext,
+    tenant_id: Uuid,
+    recipient_id: Uuid,
+) -> ForumResult<()> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(map_recipient_context_port_error)?;
+    validate_context_tenant(context, tenant_id, "recipient")?;
+    if context.actor.kind != PortActorKind::User {
+        return Err(ForumError::Validation(
+            "Forum notification recipient context requires a user actor".to_string(),
+        ));
+    }
+    let actor_id = Uuid::parse_str(&context.actor.id).map_err(|_| {
+        ForumError::Validation(
+            "Forum notification recipient context actor is invalid".to_string(),
+        )
+    })?;
+    if actor_id != recipient_id {
+        return Err(ForumError::Validation(
+            "Forum notification recipient context actor does not match the requested user"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_context_tenant(
+    context: &PortContext,
+    tenant_id: Uuid,
+    label: &str,
+) -> ForumResult<()> {
+    let context_tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        ForumError::Validation(format!(
+            "Forum notification recipient {label} context tenant is invalid"
+        ))
+    })?;
+    if context_tenant_id != tenant_id {
+        return Err(ForumError::Validation(format!(
+            "Forum notification recipient {label} context tenant does not match the request"
+        )));
+    }
+    Ok(())
+}
+
+fn map_recipient_context_port_error(error: PortError) -> ForumError {
+    ForumError::capability_failure(
+        FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY,
+        error.code,
+        error.message,
+        error.retryable,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rustok_api::{Permission, PortActor};
+    use rustok_core::UserRole;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct StaticRecipientContextPort {
+        context: PortContext,
+    }
+
+    #[async_trait]
+    impl ForumNotificationRecipientContextPort for StaticRecipientContextPort {
+        async fn resolve_forum_notification_recipient_context(
+            &self,
+            _context: PortContext,
+            _request: ForumNotificationRecipientContextRequest,
+        ) -> Result<PortContext, PortError> {
+            Ok(self.context.clone())
+        }
+    }
+
+    fn caller_context(tenant_id: Uuid) -> PortContext {
+        PortContext::new(
+            tenant_id.to_string(),
+            PortActor::system(),
+            "en",
+            "forum-notification-recipient-test",
+        )
+        .with_deadline(Duration::from_secs(5))
+    }
+
+    fn recipient_context(tenant_id: Uuid, recipient_id: Uuid) -> PortContext {
+        PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(recipient_id.to_string()),
+            "en",
+            "forum-notification-recipient-result",
+        )
+        .with_claim(Permission::FORUM_TOPICS_READ.to_string())
+        .with_role("customer")
+        .with_deadline(Duration::from_secs(5))
+    }
+
+    #[tokio::test]
+    async fn recipient_context_resolver_builds_exact_topic_viewer() {
+        let tenant_id = Uuid::new_v4();
+        let recipient_id = Uuid::new_v4();
+        let resolver = ForumNotificationRecipientContextResolver::new(Some(Arc::new(
+            StaticRecipientContextPort {
+                context: recipient_context(tenant_id, recipient_id),
+            },
+        )));
+
+        let resolved = resolver
+            .resolve(caller_context(tenant_id), tenant_id, recipient_id)
+            .await
+            .expect("exact recipient context should resolve");
+        assert_eq!(resolved.security.user_id, Some(recipient_id));
+        assert_eq!(resolved.security.role, UserRole::Customer);
+        assert!(
+            resolved
+                .into_topic_viewer()
+                .expect("recipient authority should build an authenticated topic viewer")
+                .is_authenticated()
+        );
+    }
+
+    #[tokio::test]
+    async fn recipient_context_resolver_rejects_foreign_actor() {
+        let tenant_id = Uuid::new_v4();
+        let recipient_id = Uuid::new_v4();
+        let resolver = ForumNotificationRecipientContextResolver::new(Some(Arc::new(
+            StaticRecipientContextPort {
+                context: recipient_context(tenant_id, Uuid::new_v4()),
+            },
+        )));
+
+        let error = resolver
+            .resolve(caller_context(tenant_id), tenant_id, recipient_id)
+            .await
+            .expect_err("foreign recipient context must fail closed");
+        assert_eq!(error.stable_code(), "FORUM_VALIDATION_FAILED");
+    }
+
+    #[tokio::test]
+    async fn recipient_context_resolver_reports_missing_capability() {
+        let tenant_id = Uuid::new_v4();
+        let recipient_id = Uuid::new_v4();
+        let error = ForumNotificationRecipientContextResolver::default()
+            .resolve(caller_context(tenant_id), tenant_id, recipient_id)
+            .await
+            .expect_err("missing recipient context provider must be explicit");
+        assert_eq!(
+            error.stable_code(),
+            FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE
+        );
+    }
+}

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-context.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const owner = read(contract.owner_file ?? "");
+const crate = read(contract.crate_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification recipient context contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20L" || contract.upstream_task !== "FORUM-20K") {
+  failures.push("forum notification recipient context contract must belong to FORUM-20L after FORUM-20K");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient context source publication must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "bounded_request",
+  "caller_read_semantics",
+  "caller_tenant_validation",
+  "system_or_service_caller",
+  "recipient_read_semantics",
+  "recipient_tenant_validation",
+  "exact_user_actor_validation",
+  "role_and_permission_snapshot_validation",
+  "authenticated_topic_viewer_conversion",
+  "typed_missing_capability",
+  "retryable_failure_mapping",
+  "inline_contract_tests",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
+  }
+}
+
+for (const residual of [
+  "host recipient context adapter implementation",
+  "host runtime publication of the recipient context capability",
+  "notification source factory consumption of the recipient context capability",
+  "recipient-specific audience filtering for non-public topics",
+  "recipient-specific target-open authorization for non-public topics and replies",
+  "profile privacy and blocking policy",
+  "trust channel and group facts host adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient context contract must keep ${residual} explicitly open`);
+  }
+}
+
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20L") {
+  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20L");
+}
+if (
+  JSON.stringify(planSync.required_delivered_sections) !==
+  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"])
+) {
+  failures.push("forum recipient context contract must require FORUM-20H/I/J/K/L delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"]) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-L provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through L",
+  );
+  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"]) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
+  "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE",
+  "pub struct ForumNotificationRecipientContextRequest",
+  "pub trait ForumNotificationRecipientContextPort: Send + Sync",
+  "pub type SharedForumNotificationRecipientContextPort",
+  "pub struct ForumNotificationRecipientContext",
+  "pub struct ForumNotificationRecipientContextResolver",
+  "ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)",
+  "context.require_policy(PortCallPolicy::read())",
+  "PortActorKind::System | PortActorKind::Service",
+  "context.actor.kind != PortActorKind::User",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "ForumTopicAudienceViewer::authenticated(self.security, self.port_context)",
+  "ForumError::capability_unavailable(",
+  "ForumError::capability_failure(",
+  "recipient_context_resolver_builds_exact_topic_viewer",
+  "recipient_context_resolver_rejects_foreign_actor",
+  "recipient_context_resolver_reports_missing_capability",
+]) {
+  requireText(owner, marker, `forum notification recipient context owner is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "crate::entities",
+  "forum_user",
+  "forum_profile",
+  "forum_channel",
+  "forum_group",
+  "HostRuntimeContext",
+]) {
+  rejectText(
+    owner,
+    forbidden,
+    `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`,
+  );
+}
+
+for (const marker of [
+  "pub mod notification_recipient;",
+  "FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
+  "ForumNotificationRecipientContextPort",
+  "ForumNotificationRecipientContextResolver",
+  "SharedForumNotificationRecipientContextPort",
+]) {
+  requireText(crate, marker, `forum crate surface is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 4 ||
+  upstream.task !== "FORUM-20K" ||
+  upstream.composition?.exact_richer_public_owner !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain grounded in delivered FORUM-20K public visibility composition");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification recipient context verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification recipient context contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -133,7 +133,7 @@ for (const marker of [
   "pub struct ForumNotificationRecipientContext",
   "pub struct ForumNotificationRecipientContextResolver",
   "ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)",
-  "context.require_policy(PortCallPolicy::read())",
+  ".require_policy(PortCallPolicy::read())",
   "PortActorKind::System | PortActorKind::Service",
   "context.actor.kind != PortActorKind::User",
   "SecurityContext::try_from_port_context(&recipient_context)",


### PR DESCRIPTION
## Summary

- deliver the next Forum visibility slice as `FORUM-20L`
- add a Forum-owned optional port for resolving one exact notification recipient `PortContext`
- validate non-nil tenant/user identifiers, caller tenant and read-deadline semantics, system/service caller authority, returned tenant/user identity, role claims and permission claims
- reconstruct `SecurityContext` only from the validated recipient snapshot and convert it through `ForumTopicAudienceViewer::authenticated`
- preserve typed capability absence and provider retryability without reading auth, profile, channel or group owner tables directly
- publish the crate surface, machine-readable contract and source verifier with inline contract tests

## Compatibility and degraded mode

This PR does not change current notification source behavior. The recipient-context provider remains optional and is not yet consumed by the notification factory. Missing provider state is represented as `FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE`, so later recipient-specific authorization can remain fail-closed.

The canonical Forum plan still physically ends at `FORUM-20G`; the new contract records synchronization as pending through `FORUM-20L` rather than claiming the plan is current.

## Remaining scope

- host adapter and runtime publication for recipient contexts
- notification source factory consumption
- recipient-specific filtering and target-open authorization for non-public topics/replies
- profile privacy/blocking and trust/channel/group facts adapters
- final notification creation/delivery authorization
- search/index, SEO, deep links and PostgreSQL/cross-consumer evidence

## Validation

Tests, Cargo commands and source verifiers were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-forum notification_recipient -- --nocapture
node scripts/verify/verify-forum-notification-recipient-context.mjs
cargo xtask module validate forum
```
