### PR TITLE
Harden order checkout compensation error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -60,6 +60,12 @@ available only for actionable domain errors.
   recovery owner, correlation id, tenant, channel, operation, stable code, and
   reconciliation evidence. Raw hash values remain private and public validation,
   not-found, conflict, unavailable, and invariant envelopes remain static.
+- `rustok-order` checkout compensation: invalid request and causation context, durable
+  identity conflicts, cancellation races, effectful or unknown lifecycle states,
+  owner-context validation, missing resources, storage, transitions, validation, and
+  core causes retain the compensation owner, correlation id, tenant, channel, operation,
+  stable code, typed lifecycle state, and truthful optional order identity. Public
+  validation, not-found, conflict, unavailable, and invariant envelopes remain static.
 - `rustok-tax` calculation port: request-validation details, provider-result contract
   violations, and owner validation causes remain internal. Every mapper records owner,
   correlation id, tenant, channel, operation, and stable code while public validation
@@ -85,6 +91,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
 - `node scripts/verify/verify-order-checkout-recovery-error-context.mjs`
+- `node scripts/verify/verify-order-checkout-compensation-error-context.mjs`
 - `node scripts/verify/verify-tax-calculation-error-context.mjs`
 - `cargo test -p rustok-api ports::tests`
 - `cargo check -p rustok-cart --all-features`
@@ -93,8 +100,9 @@ available only for actionable domain errors.
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, order payment settlement, order checkout recovery, pricing,
-  payment collection, fulfillment checkout execution, and tax calculation validation,
-  provider-contract, reconciliation, correlation, and transport round-trip tests.
+- Targeted cart promotion, order payment settlement, order checkout recovery, order
+  checkout compensation, pricing, payment collection, fulfillment checkout execution,
+  and tax calculation validation, provider-contract, reconciliation, correlation, and
+  transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-order/src/checkout_compensation.rs
+++ b/crates/rustok-order/src/checkout_compensation.rs
@@ -13,6 +13,7 @@ use crate::{
     OrderService, OrderStatusKind, ReadCheckoutOrderIdentityByOperationRequest,
 };
 
+const ORDER_COMPENSATION_OWNER: &str = "rustok_order.checkout_compensation";
 const COMPENSATE_OPERATION: &str = "compensate_checkout_order";
 
 #[async_trait]
@@ -113,7 +114,7 @@ impl InProcessCheckoutOrderCompensationPort {
                 .await
             {
                 Ok(cancelled) => Ok(cancelled),
-                Err(OrderError::InvalidTransition { .. }) => {
+                Err(OrderError::InvalidTransition { from, to }) => {
                     let current = self
                         .order_service
                         .get_order(tenant_id, order.id)
@@ -128,6 +129,19 @@ impl InProcessCheckoutOrderCompensationPort {
                     if current.status_kind() == OrderStatusKind::Cancelled {
                         Ok(current)
                     } else {
+                        tracing::warn!(
+                            owner = ORDER_COMPENSATION_OWNER,
+                            correlation_id = %context.correlation_id,
+                            tenant_id = %context.tenant_id,
+                            channel = ?context.channel,
+                            operation = "cancel_checkout_order",
+                            code = "order.checkout_compensation_state_conflict",
+                            order_id = %current.id,
+                            current_state = ?current.status_kind(),
+                            from = %from,
+                            to = %to,
+                            "order lifecycle changed while checkout compensation was being applied"
+                        );
                         Err(PortError::conflict(
                             "order.checkout_compensation_state_conflict",
                             "checkout order changed while compensation was being applied",
@@ -141,16 +155,20 @@ impl InProcessCheckoutOrderCompensationPort {
                 )),
             },
             OrderStatusKind::Cancelled => Ok(order),
-            OrderStatusKind::Paid | OrderStatusKind::Shipped | OrderStatusKind::Delivered => {
-                Err(manual_reconciliation(
-                    context,
-                    "cancel_checkout_order",
-                    "checkout order has financial or fulfillment effects and cannot be cancelled automatically",
-                ))
-            }
+            state @ (OrderStatusKind::Paid
+            | OrderStatusKind::Shipped
+            | OrderStatusKind::Delivered) => Err(manual_reconciliation(
+                context,
+                "cancel_checkout_order",
+                Some(order.id),
+                state,
+                "checkout order has financial or fulfillment effects and cannot be cancelled automatically",
+            )),
             OrderStatusKind::Unknown => Err(manual_reconciliation(
                 context,
                 "cancel_checkout_order",
+                Some(order.id),
+                OrderStatusKind::Unknown,
                 "checkout order lifecycle is unknown",
             )),
         }
@@ -182,10 +200,15 @@ impl CheckoutOrderCompensationPort for InProcessCheckoutOrderCompensationPort {
         )?;
         if request.checkout_operation_id.is_nil() || request.cart_id.is_nil() {
             tracing::warn!(
+                owner = ORDER_COMPENSATION_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation = COMPENSATE_OPERATION,
                 code = "order.checkout_compensation_identity_invalid",
+                checkout_operation_id = %request.checkout_operation_id,
+                cart_id = %request.cart_id,
+                expected_order_id = ?request.expected_order_id,
                 "checkout compensation rejected invalid owner identity"
             );
             return Err(PortError::validation(
@@ -201,11 +224,13 @@ impl CheckoutOrderCompensationPort for InProcessCheckoutOrderCompensationPort {
                 Err(manual_reconciliation(
                     &context,
                     COMPENSATE_OPERATION,
+                    request.expected_order_id,
+                    OrderStatusKind::Unknown,
                     "checkout operation records an order but the order owner has no durable checkout identity",
                 ))
             };
         };
-        validate_identity(tenant_id, &request, &identity)?;
+        validate_identity(&context, tenant_id, &request, &identity)?;
 
         let order = self
             .order_service
@@ -225,6 +250,7 @@ impl CheckoutOrderCompensationPort for InProcessCheckoutOrderCompensationPort {
 }
 
 fn validate_identity(
+    context: &PortContext,
     tenant_id: Uuid,
     request: &CheckoutOrderCompensationRequest,
     identity: &CheckoutOrderIdentitySnapshot,
@@ -238,6 +264,22 @@ fn validate_identity(
             .expected_order_id
             .is_none_or(|order_id| order_id == identity.order_id);
     if !valid {
+        tracing::error!(
+            owner = ORDER_COMPENSATION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
+            operation = COMPENSATE_OPERATION,
+            code = "order.checkout_compensation_identity_conflict",
+            request_checkout_operation_id = %request.checkout_operation_id,
+            request_cart_id = %request.cart_id,
+            request_expected_order_id = ?request.expected_order_id,
+            identity_tenant_id = %identity.tenant_id,
+            identity_checkout_operation_id = %identity.checkout_operation_id,
+            identity_order_id = %identity.order_id,
+            identity_source_cart_id = ?identity.source_cart_id,
+            "checkout order identity conflicts with compensation"
+        );
         return Err(PortError::conflict(
             "order.checkout_compensation_identity_conflict",
             "checkout order identity conflicts with the compensation request",
@@ -257,11 +299,14 @@ fn require_operation_context(
         .and_then(|value| Uuid::parse_str(value).ok());
     if context_operation != Some(checkout_operation_id) {
         tracing::warn!(
+            owner = ORDER_COMPENSATION_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             code = "order.checkout_compensation_causation_invalid",
             expected_checkout_operation_id = %checkout_operation_id,
+            actual_causation_id = ?context.causation_id,
             "checkout compensation received invalid causation identity"
         );
         return Err(PortError::validation(
@@ -273,9 +318,13 @@ fn require_operation_context(
 }
 
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = ORDER_COMPENSATION_OWNER,
             correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "tenant_id",
             value_length = context.tenant_id.len(),
@@ -290,10 +339,13 @@ fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uui
 }
 
 fn parse_actor_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.actor.id).map_err(|_| {
+    Uuid::parse_str(&context.actor.id).map_err(|error| {
         tracing::warn!(
+            error = ?error,
+            owner = ORDER_COMPENSATION_OWNER,
             correlation_id = %context.correlation_id,
             tenant_id = %context.tenant_id,
+            channel = ?context.channel,
             operation,
             field = "actor_id",
             value_length = context.actor.id.len(),
@@ -307,13 +359,19 @@ fn parse_actor_id(context: &PortContext, operation: &'static str) -> Result<Uuid
 fn manual_reconciliation(
     context: &PortContext,
     operation: &'static str,
+    order_id: Option<Uuid>,
+    order_state: OrderStatusKind,
     reason: &'static str,
 ) -> PortError {
     tracing::error!(
+        owner = ORDER_COMPENSATION_OWNER,
         correlation_id = %context.correlation_id,
         tenant_id = %context.tenant_id,
+        channel = ?context.channel,
         operation,
         code = "order.checkout_compensation_manual_reconciliation",
+        order_id = ?order_id,
+        order_state = ?order_state,
         reason = %reason,
         "checkout order compensation requires manual reconciliation"
     );
@@ -332,8 +390,10 @@ fn order_error_to_port_error(
         OrderError::Database(error) => {
             tracing::error!(
                 error = ?error,
+                owner = ORDER_COMPENSATION_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.database_unavailable",
                 "order checkout compensation storage failed"
@@ -343,14 +403,26 @@ fn order_error_to_port_error(
                 "order storage is temporarily unavailable",
             )
         }
-        OrderError::OrderNotFound(_) => {
+        OrderError::OrderNotFound(order_id) => {
+            tracing::warn!(
+                owner = ORDER_COMPENSATION_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.order_not_found",
+                order_id = %order_id,
+                "checkout compensation order was not found"
+            );
             PortError::not_found("order.order_not_found", "order was not found")
         }
         OrderError::Validation(cause) => {
             tracing::warn!(
                 cause = %cause,
+                owner = ORDER_COMPENSATION_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_compensation_validation",
                 "order owner rejected checkout compensation"
@@ -360,12 +432,16 @@ fn order_error_to_port_error(
                 "checkout order compensation request is invalid",
             )
         }
-        OrderError::InvalidTransition { .. } => {
+        OrderError::InvalidTransition { from, to } => {
             tracing::warn!(
+                owner = ORDER_COMPENSATION_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.checkout_compensation_state_conflict",
+                from = %from,
+                to = %to,
                 "order lifecycle conflicts with checkout compensation"
             );
             PortError::conflict(
@@ -373,7 +449,35 @@ fn order_error_to_port_error(
                 "checkout order lifecycle conflicts with compensation",
             )
         }
-        OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_) => {
+        OrderError::OrderReturnNotFound(return_id) => {
+            tracing::warn!(
+                owner = ORDER_COMPENSATION_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_return",
+                resource_id = %return_id,
+                "checkout compensation related order resource was not found"
+            );
+            PortError::not_found(
+                "order.related_resource_not_found",
+                "related order resource was not found",
+            )
+        }
+        OrderError::OrderChangeNotFound(change_id) => {
+            tracing::warn!(
+                owner = ORDER_COMPENSATION_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                operation,
+                code = "order.related_resource_not_found",
+                resource = "order_change",
+                resource_id = %change_id,
+                "checkout compensation related order resource was not found"
+            );
             PortError::not_found(
                 "order.related_resource_not_found",
                 "related order resource was not found",
@@ -382,8 +486,10 @@ fn order_error_to_port_error(
         OrderError::Core(error) => {
             tracing::error!(
                 error = ?error,
+                owner = ORDER_COMPENSATION_OWNER,
                 correlation_id = %context.correlation_id,
                 tenant_id = %context.tenant_id,
+                channel = ?context.channel,
                 operation,
                 code = "order.invariant_violation",
                 "order checkout compensation invariant failed"

--- a/scripts/verify/verify-order-checkout-compensation-error-context.mjs
+++ b/scripts/verify/verify-order-checkout-compensation-error-context.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-order/src/checkout_compensation.rs');
+const portContract = read('crates/rustok-api/src/ports.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const cancellation = between(
+  source,
+  'async fn cancel_or_adopt_cancelled(',
+  'pub fn in_process_checkout_order_compensation_port(',
+  'checkout cancellation/adoption implementation',
+);
+const compensation = between(
+  source,
+  'impl CheckoutOrderCompensationPort for InProcessCheckoutOrderCompensationPort {',
+  'fn validate_identity(',
+  'checkout compensation implementation',
+);
+const invalidRequest = between(
+  compensation,
+  'if request.checkout_operation_id.is_nil() || request.cart_id.is_nil() {',
+  'let Some(identity) = self.resolve_identity',
+  'checkout compensation request validation',
+);
+const missingIdentity = between(
+  compensation,
+  'let Some(identity) = self.resolve_identity',
+  'validate_identity(&context, tenant_id, &request, &identity)?;',
+  'missing durable checkout identity',
+);
+const identityValidation = between(
+  source,
+  'fn validate_identity(',
+  'fn require_operation_context(',
+  'checkout compensation identity validation',
+);
+const operationContext = between(
+  source,
+  'fn require_operation_context(',
+  'fn parse_tenant_id(',
+  'checkout compensation causation validation',
+);
+const tenantParser = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn parse_actor_id(',
+  'checkout compensation tenant parser',
+);
+const actorParser = between(
+  source,
+  'fn parse_actor_id(',
+  'fn manual_reconciliation(',
+  'checkout compensation actor parser',
+);
+const reconciliation = between(
+  source,
+  'fn manual_reconciliation(',
+  'fn order_error_to_port_error(',
+  'checkout compensation reconciliation mapper',
+);
+const ownerMapper = source.slice(source.indexOf('fn order_error_to_port_error('));
+
+for (const [value, label] of [
+  [
+    'const ORDER_COMPENSATION_OWNER: &str = "rustok_order.checkout_compensation";',
+    'compensation owner constant',
+  ],
+  ['const COMPENSATE_OPERATION: &str = "compensate_checkout_order";', 'compensation operation'],
+  ['parse_tenant_id(&context, COMPENSATE_OPERATION)', 'context-aware tenant parsing'],
+  ['parse_actor_id(&context, COMPENSATE_OPERATION)', 'context-aware actor parsing'],
+  [
+    'validate_identity(&context, tenant_id, &request, &identity)?;',
+    'context-aware identity validation',
+  ],
+  [
+    'order_error_to_port_error(&context, "read_checkout_order_for_compensation", error)',
+    'context-aware order read mapping',
+  ],
+]) requireText(source, value, label);
+
+for (const [block, label] of [
+  [invalidRequest, 'checkout compensation request validation'],
+  [identityValidation, 'checkout compensation identity validation'],
+  [operationContext, 'checkout compensation causation validation'],
+  [tenantParser, 'checkout compensation tenant parser'],
+  [actorParser, 'checkout compensation actor parser'],
+  [reconciliation, 'checkout compensation reconciliation mapper'],
+]) {
+  for (const [value, detail] of [
+    ['owner = ORDER_COMPENSATION_OWNER', `${label} owner log`],
+    ['correlation_id = %context.correlation_id', `${label} correlation log`],
+    ['tenant_id = %context.tenant_id', `${label} tenant log`],
+    ['channel = ?context.channel', `${label} channel log`],
+  ]) requireText(block, value, detail);
+}
+
+for (const [value, label] of [
+  ['Err(OrderError::InvalidTransition { from, to })', 'transition race cause capture'],
+  ['current_state = ?current.status_kind()', 'transition race current state'],
+  ['from = %from', 'transition race source state'],
+  ['to = %to', 'transition race target state'],
+  ['state @ (OrderStatusKind::Paid', 'financial-effect typed lifecycle reconciliation'],
+  ['Some(order.id)', 'known order identity reconciliation'],
+  ['request.expected_order_id', 'missing identity reconciliation evidence'],
+]) requireText(cancellation + missingIdentity, value, label);
+
+for (const [block, value, label] of [
+  [invalidRequest, 'expected_order_id = ?request.expected_order_id', 'request expected order evidence'],
+  [identityValidation, 'code = "order.checkout_compensation_identity_conflict"', 'identity conflict stable code'],
+  [identityValidation, 'identity_order_id = %identity.order_id', 'durable order identity evidence'],
+  [identityValidation, 'identity_source_cart_id = ?identity.source_cart_id', 'durable cart identity evidence'],
+  [operationContext, 'actual_causation_id = ?context.causation_id', 'actual causation evidence'],
+  [tenantParser, 'error = ?error', 'tenant parse cause'],
+  [actorParser, 'error = ?error', 'actor parse cause'],
+  [reconciliation, 'order_id: Option<Uuid>', 'truthful optional order identity'],
+  [reconciliation, 'order_state = ?order_state', 'typed reconciliation state'],
+  [reconciliation, 'reason = %reason', 'internal reconciliation cause'],
+]) requireText(block, value, label);
+
+for (const [value, label] of [
+  ['OrderError::OrderNotFound(order_id)', 'order not-found identity capture'],
+  ['order_id = %order_id', 'order not-found identity log'],
+  ['OrderError::Validation(cause)', 'validation cause capture'],
+  ['cause = %cause', 'validation cause log'],
+  ['OrderError::InvalidTransition { from, to }', 'owner transition cause capture'],
+  ['from = %from', 'owner transition source log'],
+  ['to = %to', 'owner transition target log'],
+  ['OrderError::OrderReturnNotFound(return_id)', 'return identity capture'],
+  ['resource_id = %return_id', 'return identity log'],
+  ['OrderError::OrderChangeNotFound(change_id)', 'change identity capture'],
+  ['resource_id = %change_id', 'change identity log'],
+  ['OrderError::Database(error)', 'database cause capture'],
+  ['OrderError::Core(error)', 'core cause capture'],
+]) requireText(ownerMapper, value, label);
+
+for (const value of [
+  'owner = ORDER_COMPENSATION_OWNER',
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'channel = ?context.channel',
+  'operation,',
+]) requireText(ownerMapper, value, `owner mapper ${value}`);
+
+for (const [value, label] of [
+  ['"checkout compensation request is invalid"', 'static request-validation envelope'],
+  [
+    '"checkout order identity conflicts with the compensation request"',
+    'static identity-conflict envelope',
+  ],
+  ['"checkout operation context is invalid"', 'static causation envelope'],
+  ['"order request context is invalid"', 'static owner-context envelope'],
+  ['"checkout requires manual reconciliation"', 'static reconciliation envelope'],
+  ['"order storage is temporarily unavailable"', 'static storage envelope'],
+  ['"order was not found"', 'static order not-found envelope'],
+  ['"checkout order compensation request is invalid"', 'static owner-validation envelope'],
+  ['"checkout order lifecycle conflicts with compensation"', 'static owner-transition envelope'],
+  ['"related order resource was not found"', 'static related-resource envelope'],
+  ['"order compensation failed an internal invariant"', 'static invariant envelope'],
+]) requireText(source, value, label);
+
+for (const value of [
+  'validate_identity(tenant_id, &request, &identity)',
+  'OrderError::OrderNotFound(_)',
+  'OrderError::InvalidTransition { .. }',
+  'OrderError::OrderReturnNotFound(_) | OrderError::OrderChangeNotFound(_)',
+  '.map_err(order_error_to_port_error)',
+  'PortError::validation("order.checkout_compensation_validation", cause)',
+  'unwrap_or_default()',
+]) forbidText(source, value, 'unsafe checkout compensation mapping');
+
+for (const [value, label] of [
+  ['pub struct PortContext {', 'shared port context'],
+  ['pub correlation_id: String', 'shared correlation field'],
+  ['pub channel: Option<String>', 'shared channel field'],
+  ['pub struct PortError {', 'shared port error'],
+  ['pub fn validation(', 'typed validation constructor'],
+  ['pub fn conflict(', 'typed conflict constructor'],
+  ['pub fn invariant_violation(', 'typed invariant constructor'],
+]) requireText(portContract, value, label);
+
+if (failures.length > 0) {
+  console.error('Order checkout compensation error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Order checkout compensation retains owner, channel, correlation, reconciliation evidence, and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- add the explicit `rustok_order.checkout_compensation` owner and request channel to checkout compensation diagnostics;
- retain durable identity mismatches, invalid causation/context, cancellation races, effectful or unknown lifecycle states, missing resources, transitions, storage failures, validation causes, and core causes before returning stable `PortError` envelopes;
- preserve truthful unknown identity by logging `Option<Uuid>` rather than inventing a nil/sentinel order id;
- preserve compensation behavior, idempotent cancelled adoption, typed lifecycle routing, public error codes, and public messages;
- add a focused static verifier and update the ecommerce error-safety plan while leaving remaining order and ecommerce adapters open.

## Scope

Three files only:

- `crates/rustok-order/src/checkout_compensation.rs`
- `scripts/verify/verify-order-checkout-compensation-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` by 3 commits and is not behind;
- final diff is limited to the three intended files (`+346/-17`);
- changed files were re-read statically to confirm owner/channel/correlation fields, captured transition and resource identities, truthful optional order identity, unchanged public envelopes, and absence of nil/sentinel identity invention;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-order-checkout-compensation-error-context.mjs
cargo check -p rustok-order --all-features
```