### PR TITLE
feat(forum): publish recipient context host capability

### DIFF
--- a/apps/server/src/services/forum_notification_recipient_context.rs
+++ b/apps/server/src/services/forum_notification_recipient_context.rs
@@ -1,0 +1,237 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{Permission, PortActor, PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_core::{UserRole, UserStatus};
+use rustok_forum::{
+    ForumNotificationRecipientContextPort, ForumNotificationRecipientContextRequest,
+    SharedForumNotificationRecipientContextPort,
+};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+
+use crate::models::_entities::users;
+use crate::services::rbac_service::RbacService;
+
+const MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512;
+const RECIPIENT_UNAVAILABLE_CODE: &str = "forum.notification_recipient_context.unavailable";
+const RECIPIENT_DEPENDENCY_CODE: &str = "forum.notification_recipient_context.dependency_unavailable";
+
+/// Server-owned adapter for the exact Forum notification-recipient principal
+/// capability. Identity and RBAC state remain owned by the host; Forum receives
+/// only one validated, tenant-bound `PortContext` snapshot.
+#[derive(Clone)]
+pub(crate) struct ServerForumNotificationRecipientContextPort {
+    db: DatabaseConnection,
+}
+
+impl ServerForumNotificationRecipientContextPort {
+    pub(crate) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub(crate) fn shared(db: DatabaseConnection) -> SharedForumNotificationRecipientContextPort {
+        Arc::new(Self::new(db))
+    }
+}
+
+#[async_trait]
+impl ForumNotificationRecipientContextPort for ServerForumNotificationRecipientContextPort {
+    async fn resolve_forum_notification_recipient_context(
+        &self,
+        caller_context: PortContext,
+        request: ForumNotificationRecipientContextRequest,
+    ) -> Result<PortContext, PortError> {
+        validate_request(&caller_context, &request)?;
+
+        let active_recipient = users::Entity::find()
+            .filter(users::Column::TenantId.eq(request.tenant_id))
+            .filter(users::Column::Id.eq(request.recipient_id))
+            .filter(users::Column::Status.eq(UserStatus::Active))
+            .one(&self.db)
+            .await
+            .map_err(|_| dependency_unavailable())?;
+        if active_recipient.is_none() {
+            return Err(recipient_unavailable());
+        }
+
+        let permissions = RbacService::get_user_permissions(
+            &self.db,
+            &request.tenant_id,
+            &request.recipient_id,
+        )
+        .await
+        .map_err(|_| dependency_unavailable())?;
+        let role = RbacService::get_user_role(
+            &self.db,
+            &request.tenant_id,
+            &request.recipient_id,
+        )
+        .await
+        .map_err(|_| dependency_unavailable())?;
+
+        build_recipient_context(&caller_context, &request, role, permissions)
+    }
+}
+
+fn validate_request(
+    caller_context: &PortContext,
+    request: &ForumNotificationRecipientContextRequest,
+) -> Result<(), PortError> {
+    caller_context.require_policy(PortCallPolicy::read())?;
+    if request.tenant_id.is_nil() || request.recipient_id.is_nil() {
+        return Err(PortError::validation(
+            "forum.notification_recipient_context.invalid_request",
+            "Forum notification recipient identity must not be nil",
+        ));
+    }
+    if caller_context.tenant_id != request.tenant_id.to_string() {
+        return Err(PortError::validation(
+            "forum.notification_recipient_context.tenant_mismatch",
+            "Forum notification recipient tenant does not match the caller context",
+        ));
+    }
+    if !matches!(
+        caller_context.actor.kind,
+        PortActorKind::System | PortActorKind::Service
+    ) {
+        return Err(PortError::forbidden(
+            "forum.notification_recipient_context.caller_forbidden",
+            "Forum notification recipient lookup requires a system or service caller",
+        ));
+    }
+    Ok(())
+}
+
+fn build_recipient_context(
+    caller_context: &PortContext,
+    request: &ForumNotificationRecipientContextRequest,
+    role: UserRole,
+    permissions: Vec<Permission>,
+) -> Result<PortContext, PortError> {
+    if permissions.is_empty() {
+        return Err(PortError::forbidden(
+            RECIPIENT_UNAVAILABLE_CODE,
+            "Forum notification recipient has no active permission snapshot",
+        ));
+    }
+    if permissions.len() > MAX_RECIPIENT_PERMISSION_CLAIMS {
+        return Err(PortError::invariant_violation(
+            "forum.notification_recipient_context.permission_bound_exceeded",
+            "Forum notification recipient permission snapshot exceeded its bound",
+        ));
+    }
+
+    let mut recipient_context = PortContext::new(
+        request.tenant_id.to_string(),
+        PortActor::user(request.recipient_id.to_string()),
+        caller_context.locale.clone(),
+        caller_context.correlation_id.clone(),
+    )
+    .with_role(role.to_string());
+    for permission in permissions {
+        recipient_context = recipient_context.with_claim(permission.to_string());
+    }
+
+    recipient_context.causation_id = caller_context.causation_id.clone();
+    recipient_context.traceparent = caller_context.traceparent.clone();
+    recipient_context.deadline_ms = caller_context.deadline_ms;
+    Ok(recipient_context)
+}
+
+fn recipient_unavailable() -> PortError {
+    PortError::not_found(
+        RECIPIENT_UNAVAILABLE_CODE,
+        "Forum notification recipient is unavailable",
+    )
+}
+
+fn dependency_unavailable() -> PortError {
+    PortError::unavailable(
+        RECIPIENT_DEPENDENCY_CODE,
+        "Forum notification recipient authority is temporarily unavailable",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rustok_api::{PortErrorKind, Resource};
+
+    use super::*;
+
+    fn caller_context(tenant_id: uuid::Uuid) -> PortContext {
+        PortContext::new(
+            tenant_id.to_string(),
+            PortActor::service("notifications"),
+            "en",
+            "recipient-context-test",
+        )
+        .with_causation_id("source-event")
+        .with_traceparent("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+        .with_deadline(Duration::from_secs(3))
+    }
+
+    #[test]
+    fn recipient_context_preserves_bounded_read_metadata() {
+        let tenant_id = uuid::Uuid::new_v4();
+        let recipient_id = uuid::Uuid::new_v4();
+        let caller = caller_context(tenant_id);
+        let request = ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)
+            .expect("request should be valid");
+
+        let result = build_recipient_context(
+            &caller,
+            &request,
+            UserRole::Customer,
+            vec![Permission::new(Resource::ForumTopics, rustok_api::Action::Read)],
+        )
+        .expect("recipient context should be built");
+
+        assert_eq!(result.tenant_id, tenant_id.to_string());
+        assert_eq!(result.actor, PortActor::user(recipient_id.to_string()));
+        assert_eq!(result.roles, vec!["customer"]);
+        assert_eq!(result.claims, vec!["forum_topics:read"]);
+        assert_eq!(result.locale, caller.locale);
+        assert_eq!(result.correlation_id, caller.correlation_id);
+        assert_eq!(result.causation_id, caller.causation_id);
+        assert_eq!(result.traceparent, caller.traceparent);
+        assert_eq!(result.deadline_ms, caller.deadline_ms);
+        assert!(result.idempotency_key.is_none());
+    }
+
+    #[test]
+    fn recipient_context_rejects_empty_authority() {
+        let tenant_id = uuid::Uuid::new_v4();
+        let request = ForumNotificationRecipientContextRequest::new(tenant_id, uuid::Uuid::new_v4())
+            .expect("request should be valid");
+        let error = build_recipient_context(
+            &caller_context(tenant_id),
+            &request,
+            UserRole::Customer,
+            Vec::new(),
+        )
+        .expect_err("empty authority must fail closed");
+
+        assert_eq!(error.kind, PortErrorKind::Forbidden);
+    }
+
+    #[test]
+    fn recipient_context_rejects_user_caller() {
+        let tenant_id = uuid::Uuid::new_v4();
+        let recipient_id = uuid::Uuid::new_v4();
+        let caller = PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(uuid::Uuid::new_v4().to_string()),
+            "en",
+            "recipient-context-user-test",
+        )
+        .with_deadline(Duration::from_secs(3));
+        let request = ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)
+            .expect("request should be valid");
+
+        let error = validate_request(&caller, &request)
+            .expect_err("user caller must not resolve another recipient authority");
+        assert_eq!(error.kind, PortErrorKind::Forbidden);
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -41,6 +41,8 @@ pub mod mcp_runtime;
 pub mod mcp_scaffold_workspace;
 pub mod module_event_dispatcher;
 pub mod module_lifecycle;
+#[cfg(feature = "mod-forum")]
+pub mod forum_notification_recipient_context;
 #[cfg(feature = "mod-notifications")]
 pub mod notification_candidate_worker;
 #[cfg(feature = "mod-notifications")]

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -292,6 +292,14 @@ pub fn build_shared_runtime_extensions_with_host_providers(
         extensions.insert(policy);
     }
 
+    #[cfg(feature = "mod-forum")]
+    {
+        let recipient_context = crate::services::forum_notification_recipient_context::ServerForumNotificationRecipientContextPort::shared(
+            db.clone(),
+        );
+        extensions.insert(recipient_context);
+    }
+
     #[cfg(feature = "mod-notifications")]
     {
         let host =
@@ -390,6 +398,8 @@ mod tests {
         assert!(extensions.contains::<rustok_auth::OAuthAdminRuntime>());
         assert!(extensions.contains::<rustok_auth::UserAdminMutationRuntime>());
         assert!(extensions.contains::<rustok_mcp::McpManagementRuntime>());
+        #[cfg(feature = "mod-forum")]
+        assert!(extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>());
         #[cfg(feature = "mod-notifications")]
         assert!(
             rustok_notifications::api::notification_source_registry_from_extensions(

--- a/crates/rustok-forum/contracts/forum-notification-recipient-context.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-context.json
@@ -1,22 +1,25 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20L",
   "upstream_task": "FORUM-20K",
+  "downstream_task": "FORUM-20M",
   "scope": "Forum-owned exact recipient principal context capability for deferred notification authorization",
   "owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-context.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20L",
+    "required_ledger_through": "FORUM-20M",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
       "FORUM-20J",
       "FORUM-20K",
-      "FORUM-20L"
+      "FORUM-20L",
+      "FORUM-20M"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -44,11 +47,11 @@
     "authenticated_topic_viewer_conversion": true,
     "typed_missing_capability": true,
     "retryable_failure_mapping": true,
-    "inline_contract_tests": true
+    "inline_contract_tests": true,
+    "host_adapter_implementation": true,
+    "host_runtime_publication": true
   },
   "not_delivered": [
-    "host recipient context adapter implementation",
-    "host runtime publication of the recipient context capability",
     "notification source factory consumption of the recipient context capability",
     "recipient-specific audience filtering for non-public topics",
     "recipient-specific target-open authorization for non-public topics and replies",
@@ -61,7 +64,9 @@
   "verification": {
     "commands": [
       "cargo test -p rustok-forum notification_recipient -- --nocapture",
+      "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20M",
+  "upstream_task": "FORUM-20L",
+  "scope": "Server-owned exact notification recipient principal adapter and host runtime publication",
+  "adapter_file": "apps/server/src/services/forum_notification_recipient_context.rs",
+  "services_file": "apps/server/src/services/mod.rs",
+  "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-context.json",
+  "source_verifier": "scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20M",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "caller": "tenant-matching system or service PortContext with read deadline semantics",
+    "recipient": "exact active tenant-owned user row",
+    "authority": "tenant-scoped role and permission snapshot from the server RBAC resolver",
+    "returned_context": "exact user actor with one role, bounded permission claims and inherited deadline correlation causation trace and locale metadata",
+    "empty_authority": "forbidden without synthesizing default role permissions",
+    "permission_bound": 512,
+    "dependency_failure": "typed retryable unavailable PortError without internal database details",
+    "storage_access": "server identity and RBAC owners only; no Forum profile channel group or audience relation tables"
+  },
+  "composition": {
+    "server_adapter": true,
+    "active_user_lookup": true,
+    "tenant_user_predicates": true,
+    "rbac_role_snapshot": true,
+    "rbac_permission_snapshot": true,
+    "exact_user_port_actor": true,
+    "bounded_permission_claims": true,
+    "read_metadata_preserved": true,
+    "runtime_extension_publication": true,
+    "publication_before_notification_source_materialization": true,
+    "feature_guarded_server_module": true,
+    "inline_contract_tests": true
+  },
+  "not_delivered": [
+    "notification source factory consumption of the recipient context capability",
+    "recipient-specific audience filtering for non-public topics",
+    "recipient-specific target-open authorization for non-public topics and replies",
+    "profile privacy and blocking policy",
+    "trust channel and group facts host adapters",
+    "final notification creation and delivery authorization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
+      "node scripts/verify/verify-forum-notification-recipient-context.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -33,13 +33,18 @@ const contract = JSON.parse(read(contractPath) || "{}");
 const owner = read(contract.owner_file ?? "");
 const crate = read(contract.crate_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum notification recipient context contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification recipient context contract must use schema_version=2");
 }
-if (contract.task !== "FORUM-20L" || contract.upstream_task !== "FORUM-20K") {
-  failures.push("forum notification recipient context contract must belong to FORUM-20L after FORUM-20K");
+if (
+  contract.task !== "FORUM-20L" ||
+  contract.upstream_task !== "FORUM-20K" ||
+  contract.downstream_task !== "FORUM-20M"
+) {
+  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("recipient context source publication must not claim unexecuted evidence");
@@ -58,6 +63,8 @@ for (const delivered of [
   "typed_missing_capability",
   "retryable_failure_mapping",
   "inline_contract_tests",
+  "host_adapter_implementation",
+  "host_runtime_publication",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
@@ -65,8 +72,6 @@ for (const delivered of [
 }
 
 for (const residual of [
-  "host recipient context adapter implementation",
-  "host runtime publication of the recipient context capability",
   "notification source factory consumption of the recipient context capability",
   "recipient-specific audience filtering for non-public topics",
   "recipient-specific target-open authorization for non-public topics and replies",
@@ -80,16 +85,29 @@ for (const residual of [
     failures.push(`forum notification recipient context contract must keep ${residual} explicitly open`);
   }
 }
+for (const staleResidual of [
+  "host recipient context adapter implementation",
+  "host runtime publication of the recipient context capability",
+]) {
+  if (contract.not_delivered?.includes(staleResidual)) {
+    failures.push(`forum notification recipient context contract must remove delivered residual ${staleResidual}`);
+  }
+}
 
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20L") {
-  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20L");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+];
+if (planSync.required_ledger_through !== "FORUM-20M") {
+  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20M");
 }
-if (
-  JSON.stringify(planSync.required_delivered_sections) !==
-  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"])
-) {
-  failures.push("forum recipient context contract must require FORUM-20H/I/J/K/L delivered sections");
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20M delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -100,7 +118,7 @@ if (planSync.status === "pending") {
     "FORUM-20A-G provide",
     "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"]) {
+  for (const slice of deliveredSlices) {
     rejectText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -110,10 +128,10 @@ if (planSync.status === "pending") {
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-L provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through L",
+    "FORUM-20A-M provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through M",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L"]) {
+  for (const slice of deliveredSlices) {
     requireText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -180,6 +198,15 @@ if (
   upstream.composition?.exact_richer_public_owner !== true
 ) {
   failures.push("FORUM-20L recipient context capability must remain grounded in delivered FORUM-20K public visibility composition");
+}
+if (
+  downstream.schema_version !== 1 ||
+  downstream.task !== "FORUM-20M" ||
+  downstream.upstream_task !== "FORUM-20L" ||
+  downstream.composition?.server_adapter !== true ||
+  downstream.composition?.runtime_extension_publication !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with delivered FORUM-20M host composition");
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const adapter = read(contract.adapter_file ?? "");
+const services = read(contract.services_file ?? "");
+const runtime = read(contract.runtime_composition_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification recipient host runtime contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20M" || contract.upstream_task !== "FORUM-20L") {
+  failures.push("forum notification recipient host runtime contract must belong to FORUM-20M after FORUM-20L");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient host runtime publication must not claim unexecuted evidence");
+}
+if (contract.policy?.permission_bound !== 512) {
+  failures.push("forum notification recipient permission claims must remain bounded at 512");
+}
+
+for (const delivered of [
+  "server_adapter",
+  "active_user_lookup",
+  "tenant_user_predicates",
+  "rbac_role_snapshot",
+  "rbac_permission_snapshot",
+  "exact_user_port_actor",
+  "bounded_permission_claims",
+  "read_metadata_preserved",
+  "runtime_extension_publication",
+  "publication_before_notification_source_materialization",
+  "feature_guarded_server_module",
+  "inline_contract_tests",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient host runtime contract must record ${delivered} as delivered`);
+  }
+}
+
+for (const residual of [
+  "notification source factory consumption of the recipient context capability",
+  "recipient-specific audience filtering for non-public topics",
+  "recipient-specific target-open authorization for non-public topics and replies",
+  "profile privacy and blocking policy",
+  "trust channel and group facts host adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient host runtime contract must keep ${residual} explicitly open`);
+  }
+}
+
+const planSync = contract.canonical_plan_sync ?? {};
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+];
+if (planSync.required_ledger_through !== "FORUM-20M") {
+  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20M");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20M delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-M provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through M",
+  );
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "pub(crate) struct ServerForumNotificationRecipientContextPort",
+  "impl ForumNotificationRecipientContextPort for ServerForumNotificationRecipientContextPort",
+  "caller_context.require_policy(PortCallPolicy::read())",
+  "PortActorKind::System | PortActorKind::Service",
+  "users::Column::TenantId.eq(request.tenant_id)",
+  "users::Column::Id.eq(request.recipient_id)",
+  "users::Column::Status.eq(UserStatus::Active)",
+  "RbacService::get_user_permissions(",
+  "RbacService::get_user_role(",
+  "PortActor::user(request.recipient_id.to_string())",
+  "MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512",
+  "permissions.is_empty()",
+  "permissions.len() > MAX_RECIPIENT_PERMISSION_CLAIMS",
+  "recipient_context.causation_id = caller_context.causation_id.clone()",
+  "recipient_context.traceparent = caller_context.traceparent.clone()",
+  "recipient_context.deadline_ms = caller_context.deadline_ms",
+  "recipient_context_preserves_bounded_read_metadata",
+  "recipient_context_rejects_empty_authority",
+  "recipient_context_rejects_user_caller",
+]) {
+  requireText(adapter, marker, `forum notification recipient host adapter is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "rustok_forum::entities",
+  "forum_category_audience_",
+  "forum_topic_audience_",
+  "forum_user_",
+  "forum_profile",
+  "forum_channel",
+  "forum_group",
+  "SecurityContext::new(",
+  "Rbac::permissions_for_role",
+]) {
+  rejectText(
+    adapter,
+    forbidden,
+    `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`,
+  );
+}
+
+for (const marker of [
+  "#[cfg(feature = \"mod-forum\")]",
+  "pub mod forum_notification_recipient_context;",
+]) {
+  requireText(services, marker, `server services surface is missing ${marker}`);
+}
+
+for (const marker of [
+  "ServerForumNotificationRecipientContextPort::shared(",
+  "extensions.insert(recipient_context)",
+  "extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>()",
+]) {
+  requireText(runtime, marker, `server runtime composition is missing ${marker}`);
+}
+const publicationIndex = runtime.indexOf("extensions.insert(recipient_context)");
+const materializationIndex = runtime.indexOf(
+  "materialize_notification_source_registry(&mut extensions, &host)",
+);
+if (
+  publicationIndex < 0 ||
+  materializationIndex < 0 ||
+  publicationIndex > materializationIndex
+) {
+  failures.push("recipient context capability must be published before notification source materialization");
+}
+
+if (
+  upstream.schema_version !== 2 ||
+  upstream.task !== "FORUM-20L" ||
+  upstream.downstream_task !== "FORUM-20M" ||
+  upstream.composition?.host_adapter_implementation !== true ||
+  upstream.composition?.host_runtime_publication !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the delivered FORUM-20L capability contract");
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification recipient host runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification recipient host runtime contract is source-ready.");


### PR DESCRIPTION
## Summary

- implement a server-owned `ForumNotificationRecipientContextPort` adapter over the authoritative users and RBAC owners
- require an exact active tenant-owned user and resolve the current role plus bounded permission snapshot without reading Forum-owned relation tables
- return an exact user `PortContext` while preserving the caller deadline, correlation, causation, trace and locale metadata
- publish `SharedForumNotificationRecipientContextPort` into host runtime extensions before notification source provider materialization
- advance the FORUM-20L capability contract and add the FORUM-20M host-runtime contract plus static verifier

## Safety and degraded behavior

- nil, foreign-tenant and user-principal callers fail before owner reads
- inactive, missing or permissionless recipients fail closed without a usable authority snapshot
- database and RBAC dependency failures return a stable retryable unavailable port error without internal details
- permission claims are bounded at 512 and no default permissions are synthesized
- the current notification source does not consume this capability yet, so notification behavior is unchanged in this slice

## Remaining scope

- notification source factory consumption of the recipient context capability
- recipient-specific audience filtering and target-open authorization for non-public topics/replies
- profile privacy and blocking
- trust/channel/group facts host adapters
- final notification creation and delivery authorization
- search/index, SEO and deep-link migration
- PostgreSQL and cross-consumer runtime evidence

The canonical implementation plan still physically ends at FORUM-20G. Machine contracts keep synchronization explicitly pending through FORUM-20M.

## Validation

Tests, Cargo, verifiers and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-forum notification_recipient -- --nocapture
cargo test -p rustok-server forum_notification_recipient_context -- --nocapture
node scripts/verify/verify-forum-notification-recipient-context.mjs
node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
cargo xtask module validate forum
```
