### PR TITLE
fix(index): reject whitespace decision text

### DIFF
--- a/crates/rustok-index/docs/storage-decision.schema.json
+++ b/crates/rustok-index/docs/storage-decision.schema.json
@@ -32,7 +32,8 @@
     },
     "owner": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "comparison_commit": {
       "type": "string",
@@ -48,22 +49,26 @@
     },
     "selection_rationale": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "rejection_rationales": {
       "type": "object"
     },
     "operational_tradeoffs": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "migration_strategy": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "rollback_strategy": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     }
   },
   "allOf": [
@@ -81,8 +86,8 @@
             "additionalProperties": false,
             "required": ["typed_eav", "hot_projection"],
             "properties": {
-              "typed_eav": { "type": "string", "minLength": 1 },
-              "hot_projection": { "type": "string", "minLength": 1 }
+              "typed_eav": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "hot_projection": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }
@@ -102,8 +107,8 @@
             "additionalProperties": false,
             "required": ["jsonb", "hot_projection"],
             "properties": {
-              "jsonb": { "type": "string", "minLength": 1 },
-              "hot_projection": { "type": "string", "minLength": 1 }
+              "jsonb": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "hot_projection": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }
@@ -123,8 +128,8 @@
             "additionalProperties": false,
             "required": ["jsonb", "typed_eav"],
             "properties": {
-              "jsonb": { "type": "string", "minLength": 1 },
-              "typed_eav": { "type": "string", "minLength": 1 }
+              "jsonb": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "typed_eav": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }


### PR DESCRIPTION
## What changed

- require at least one non-whitespace character in the decision owner and every required rationale field;
- apply the same rule to all conditional rejection-rationale properties for JSONB, typed EAV, and hot projection decisions;
- keep the existing `minLength` checks while aligning the JSON Schema with the renderer's trimmed non-empty-string contract.

## Root cause

The decision Schema used only `minLength: 1`, so values containing spaces or line breaks could pass Schema validation. The ADR renderer trims required text and rejects the same values as empty, which meant a Schema-valid decision could still fail the canonical runtime path.

## Impact

Schema validation and runtime rendering now agree on basic required-text semantics. This does not select a storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The replacement JSON was parsed locally, and its calculated Git blob SHA matched the blob stored by GitHub. The branch contains one commit and one changed file.