### PR TITLE
Harden admin order detail fulfillment errors

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -49,6 +49,10 @@ available only for actionable domain errors.
   Validation, missing-resource, transition, and database causes are logged with
   correlation identity and stable codes while the existing public envelopes remain
   static.
+- `rustok-commerce` admin order detail fulfillment lookup: the typed fulfillment cause
+  remains internal while owner, tenant, order, operation, error kind, stable public code,
+  status, and HTTP boundary are logged. Validation, not-found, transition, and storage
+  outcomes use static public messages instead of the shared dynamic validation envelope.
 - `rustok-order` checkout payment settlement: identity absence/mismatch, lifecycle and
   payment-reference conflicts, owner-context validation, missing resources, storage,
   transition, validation, and core causes retain the settlement owner, correlation id,
@@ -89,6 +93,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
+- `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
 - `node scripts/verify/verify-order-checkout-recovery-error-context.mjs`
 - `node scripts/verify/verify-order-checkout-compensation-error-context.mjs`
@@ -102,7 +107,8 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  and tax calculation validation, provider-contract, reconciliation, correlation, and
-  transport round-trip tests.
+  admin order-detail fulfillment mapping, and tax calculation validation,
+  provider-contract, reconciliation, correlation, HTTP-envelope, and transport
+  round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -84,7 +84,13 @@ pub async fn show_order(
     tenant: TenantContext,
     auth: AuthContext,
     request_context: rustok_api::RequestContext,
-    Path(id):?;
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<AdminOrderDetailResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
 
     let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .get_order_with_locale_fallback(

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -4,10 +4,10 @@ use axum::{
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
-use rustok_fulfillment::FulfillmentService;
+use rustok_fulfillment::{FulfillmentError, FulfillmentService};
 use rustok_order::OrderService;
 use rustok_payment::PaymentService;
-use rustok_web::HttpResult;
+use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use super::{
@@ -18,6 +18,9 @@ use super::{
 use crate::dto::{
     CancelOrderInput, DeliverOrderInput, MarkPaidOrderInput, OrderResponse, ShipOrderInput,
 };
+
+const ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_order_detail";
+const ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION: &str = "find_fulfillment_by_order";
 
 /// Show admin ecommerce order
 #[utoipa::path(
@@ -81,13 +84,7 @@ pub async fn show_order(
     tenant: TenantContext,
     auth: AuthContext,
     request_context: rustok_api::RequestContext,
-    Path(id): Path<Uuid>,
-) -> HttpResult<Json<AdminOrderDetailResponse>> {
-    ensure_permissions(
-        &auth,
-        &[Permission::ORDERS_READ],
-        "Permission denied: orders:read required",
-    )?;
+    Path(id):?;
 
     let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .get_order_with_locale_fallback(
@@ -105,13 +102,60 @@ pub async fn show_order(
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .find_by_order(tenant.id, id)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| map_order_detail_fulfillment_error(tenant.id, id, error))?;
 
     Ok(Json(AdminOrderDetailResponse {
         order,
         payment_collection,
         fulfillment,
     }))
+}
+
+fn map_order_detail_fulfillment_error(
+    tenant_id: Uuid,
+    order_id: Uuid,
+    error: FulfillmentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_)
+        | FulfillmentError::FulfillmentNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        FulfillmentError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER,
+        tenant_id = %tenant_id,
+        order_id = %order_id,
+        operation = ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_admin_order_detail_http",
+        "commerce admin order detail fulfillment lookup failed"
+    );
+    HttpError::new(status, code, message)
 }
 
 /// Mark admin ecommerce order as paid

--- a/scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const showOrder = between(
+  source,
+  'pub async fn show_order(',
+  'fn map_order_detail_fulfillment_error(',
+  'admin order detail handler',
+);
+const mapper = between(
+  source,
+  'fn map_order_detail_fulfillment_error(',
+  '/// Mark admin ecommerce order as paid',
+  'admin order detail fulfillment mapper',
+);
+
+for (const [value, label] of [
+  [
+    'const ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_order_detail";',
+    'fulfillment owner constant',
+  ],
+  [
+    'const ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION: &str = "find_fulfillment_by_order";',
+    'fulfillment operation constant',
+  ],
+  ['use rustok_fulfillment::{FulfillmentError, FulfillmentService};', 'typed fulfillment error import'],
+  ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  [
+    '.map_err(|error| map_order_detail_fulfillment_error(tenant.id, id, error))?',
+    'order-detail mapper handoff',
+  ],
+  ['[Permission::ORDERS_READ]', 'order read permission'],
+  ['Path(id): Path<Uuid>', 'typed order path'],
+  ['HttpResult<Json<AdminOrderDetailResponse>>', 'order detail result contract'],
+]) requireText(showOrder, value, label);
+
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
+  ['FulfillmentError::Database(_)', 'database variant'],
+  ['error = ?error', 'internal typed cause'],
+  ['owner = ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER', 'owner log'],
+  ['tenant_id = %tenant_id', 'tenant log'],
+  ['order_id = %order_id', 'order identity log'],
+  ['operation = ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION', 'operation log'],
+  ['error_kind,', 'error kind log'],
+  ['public_code = code', 'stable code log'],
+  ['status = %status', 'status log'],
+  ['boundary = "commerce_admin_order_detail_http"', 'HTTP boundary log'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['"Fulfillment request is invalid"', 'static validation envelope'],
+  ['"Commerce resource not found"', 'static not-found envelope'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static transition envelope',
+  ],
+  [
+    '"Fulfillment storage is temporarily unavailable"',
+    'static storage envelope',
+  ],
+  ['HttpError::new(status, code, message)', 'single public envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const value of [
+  '.map_err(super::map_fulfillment_error)',
+  'format!("Fulfillment request is invalid: {msg}")',
+  'HttpError::bad_request("commerce_admin_fulfillment_invalid", msg)',
+  'error.to_string()',
+]) forbidText(showOrder + mapper, value, 'unsafe admin order detail fulfillment mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-detail fulfillment error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order detail keeps fulfillment causes internal and returns static public envelopes',
+);


### PR DESCRIPTION
## Summary

- route the admin order-detail fulfillment lookup through a dedicated typed `FulfillmentError` mapper;
- keep validation, missing-resource, transition, and database causes internal while returning stable public HTTP envelopes;
- record the fulfillment owner, tenant, order, operation, error kind, public code, status, and HTTP boundary for failed lookups;
- preserve the order-detail permission check, order/payment lookups, successful response shape, and all other admin routes;
- add a focused static verifier and update the ecommerce public-error safety plan while leaving remaining fulfillment and non-`PortError` transports open.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/admin/orders.rs`
- `scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` by 4 commits and is not behind;
- final diff is limited to the three intended files (`+175/-5`);
- the corrected handler was re-read in full to confirm the typed path signature, `orders:read` permission, unchanged success response, dedicated mapper handoff, exhaustive `FulfillmentError` coverage, structured internal diagnostics, and static public messages;
- an intermediate handler-signature mistake was corrected on the branch before opening this PR; the final diff contains the valid signature and permission block;
- tests, Cargo commands, formatting commands, and verifier execution were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs
cargo check -p rustok-commerce --lib
```