### PR TITLE
feat(forum): authorize notification targets for recipients

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-recipient-context.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-context.json
@@ -1,25 +1,28 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "task": "FORUM-20L",
   "upstream_task": "FORUM-20K",
   "downstream_task": "FORUM-20M",
+  "consumer_task": "FORUM-20N",
   "scope": "Forum-owned exact recipient principal context capability for deferred notification authorization",
   "owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
+  "consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-context.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20M",
+    "required_ledger_through": "FORUM-20N",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
       "FORUM-20J",
       "FORUM-20K",
       "FORUM-20L",
-      "FORUM-20M"
+      "FORUM-20M",
+      "FORUM-20N"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -31,7 +34,7 @@
     "returned_context": "tenant and actor must match the request and retain read deadline semantics",
     "authority": "SecurityContext is reconstructed only from validated role and permission claims",
     "topic_viewer": "validated authority converts through ForumTopicAudienceViewer::authenticated",
-    "provider_absence": "typed capability unavailable error",
+    "provider_absence": "typed capability unavailable error at the resolver boundary; notification target-open keeps a public-only fail-closed fallback when the host capability is absent",
     "provider_failure": "stable source code and retryability preserved without leaking internals",
     "storage_access": "none; Forum does not read auth, profile, channel or group owner tables directly"
   },
@@ -49,12 +52,12 @@
     "retryable_failure_mapping": true,
     "inline_contract_tests": true,
     "host_adapter_implementation": true,
-    "host_runtime_publication": true
+    "host_runtime_publication": true,
+    "notification_source_factory_consumption": true,
+    "recipient_target_open_authorization": true
   },
   "not_delivered": [
-    "notification source factory consumption of the recipient context capability",
-    "recipient-specific audience filtering for non-public topics",
-    "recipient-specific target-open authorization for non-public topics and replies",
+    "recipient-specific audience filtering for non-public topics before pagination",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
     "final notification creation and delivery authorization",
@@ -65,8 +68,10 @@
     "commands": [
       "cargo test -p rustok-forum notification_recipient -- --nocapture",
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
@@ -1,24 +1,28 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20M",
   "upstream_task": "FORUM-20L",
-  "scope": "Server-owned exact notification recipient principal adapter and host runtime publication",
+  "downstream_task": "FORUM-20N",
+  "scope": "Server-owned exact notification recipient principal adapter, host runtime publication and notification target-open consumption",
   "adapter_file": "apps/server/src/services/forum_notification_recipient_context.rs",
   "services_file": "apps/server/src/services/mod.rs",
   "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-context.json",
+  "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20M",
+    "required_ledger_through": "FORUM-20N",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
       "FORUM-20J",
       "FORUM-20K",
       "FORUM-20L",
-      "FORUM-20M"
+      "FORUM-20M",
+      "FORUM-20N"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -31,7 +35,8 @@
     "empty_authority": "forbidden without synthesizing default role permissions",
     "permission_bound": 512,
     "dependency_failure": "typed retryable unavailable PortError without internal database details",
-    "storage_access": "server identity and RBAC owners only; no Forum profile channel group or audience relation tables"
+    "storage_access": "server identity and RBAC owners only; no Forum profile channel group or audience relation tables",
+    "consumer": "Forum notification source factory reads the exact shared port before recipient-specific target-open authorization"
   },
   "composition": {
     "server_adapter": true,
@@ -45,12 +50,12 @@
     "runtime_extension_publication": true,
     "publication_before_notification_source_materialization": true,
     "feature_guarded_server_module": true,
-    "inline_contract_tests": true
+    "inline_contract_tests": true,
+    "notification_source_factory_consumption": true,
+    "recipient_target_open_authorization": true
   },
   "not_delivered": [
-    "notification source factory consumption of the recipient context capability",
-    "recipient-specific audience filtering for non-public topics",
-    "recipient-specific target-open authorization for non-public topics and replies",
+    "recipient-specific audience filtering for non-public topics before pagination",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
     "final notification creation and delivery authorization",
@@ -60,8 +65,10 @@
   "verification": {
     "commands": [
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20N",
+  "upstream_task": "FORUM-20M",
+  "scope": "Forum notification source factory consumption of exact recipient context for topic and reply target-open authorization",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
+  "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
+  "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
+  "source_verifier": "scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20N",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "factory": "consume optional SharedForumNotificationRecipientContextPort and SharedForumAudienceFactsPort from HostRuntimeContext",
+    "capability_absence": "preserve the existing public-only fail-closed target-open path",
+    "recipient_lookup": "bounded service PortContext for the exact tenant and notification recipient",
+    "recipient_unavailable": "non-retryable recipient capability failure resolves to target unavailable without an existence oracle",
+    "authenticated_visibility": "compose exact base topic visibility and normalized inherited category/topic audience layers for the validated recipient",
+    "local_selectors": "role and explicit-user allow/deny constraints resolve without host facts adapters",
+    "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
+    "reply_target": "reply must be active and approved and its owner topic must be visible to the same recipient",
+    "public_surfaces": "describe_event and resolve_audience remain public-only and unchanged",
+    "channel_context": "target-open has no route channel slug and therefore retains the existing channel-deny semantics"
+  },
+  "composition": {
+    "factory_recipient_capability_lookup": true,
+    "factory_facts_capability_lookup": true,
+    "bounded_target_open_context": true,
+    "exact_recipient_resolution": true,
+    "authenticated_topic_viewer": true,
+    "recipient_specific_topic_open": true,
+    "recipient_specific_reply_open": true,
+    "public_only_fallback": true,
+    "inactive_or_missing_recipient_fail_closed": true,
+    "retryability_preserved": true,
+    "public_description_unchanged": true,
+    "public_audience_unchanged": true,
+    "sqlite_contract_test": true
+  },
+  "not_delivered": [
+    "recipient-specific audience filtering for non-public topics before pagination",
+    "profile privacy and blocking policy",
+    "host trust channel and group facts adapters",
+    "final notification creation and delivery authorization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-context.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -33,7 +33,7 @@
     "description_and_audience_viewer": "public unauthenticated without route-channel context",
     "target_open_viewer": "exact validated recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "evaluation_order": "exact open route-channel and category floor owner then normalized root-to-category audience layers then optional topic layer",
-    "public_facts_provider": "intentionally absent because public evaluation never calls authenticated owner facts capabilities",
+    "public_facts_provider": "never consulted because public evaluation does not call authenticated owner facts capabilities",
     "authenticated_facts_provider": "optional host capability; local role and explicit user selectors resolve without it while fact-dependent selectors preserve capability retryability",
     "non_public_richer_layers": "unavailable before notification descriptor or audience materialization; target-open authorization re-evaluates them for the exact recipient",
     "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",

--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,33 +1,41 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "task": "FORUM-20K",
   "supersedes_task": "FORUM-20I",
-  "scope": "Forum notification source composition through the exact richer public topic visibility owner",
+  "downstream_task": "FORUM-20N",
+  "scope": "Forum notification source composition through exact richer public and recipient-specific target-open visibility owners",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
   "visibility_contract": "crates/rustok-forum/contracts/forum-topic-audience-visibility.json",
+  "recipient_target_open_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
   "baseline_test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
   "test_file": "crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs",
+  "recipient_test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20K",
+    "required_ledger_through": "FORUM-20N",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
       "FORUM-20J",
-      "FORUM-20K"
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
-    "viewer_profile": "public unauthenticated without route-channel context",
+    "description_and_audience_viewer": "public unauthenticated without route-channel context",
+    "target_open_viewer": "exact validated recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "evaluation_order": "exact open route-channel and category floor owner then normalized root-to-category audience layers then optional topic layer",
-    "facts_provider": "intentionally absent because public evaluation never calls authenticated owner facts capabilities",
-    "non_public_richer_layers": "unavailable before notification descriptor or audience materialization until recipient-specific authorization exists",
+    "public_facts_provider": "intentionally absent because public evaluation never calls authenticated owner facts capabilities",
+    "authenticated_facts_provider": "optional host capability; local role and explicit user selectors resolve without it while fact-dependent selectors preserve capability retryability",
+    "non_public_richer_layers": "unavailable before notification descriptor or audience materialization; target-open authorization re-evaluates them for the exact recipient",
     "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",
     "reply_state": "pending deferred; approved eligible; all other states unavailable",
     "owner_failures": "preserve Forum retryability classification"
@@ -42,11 +50,13 @@
     "normalized_category_layers": true,
     "normalized_topic_layer": true,
     "dynamic_policy_recheck": true,
-    "duplicate_notification_visibility_predicate_removed": true
+    "duplicate_notification_visibility_predicate_removed": true,
+    "recipient_context_factory_consumption": true,
+    "recipient_specific_target_open": true,
+    "public_only_description_and_audience": true
   },
   "not_delivered": [
-    "recipient-specific authenticated role trust channel group and explicit-user evaluation",
-    "recipient-specific target-open authorization for non-public audiences",
+    "recipient-specific authenticated audience filtering before notification pagination",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters for authenticated consumers",
     "search index SEO and deep-link migration",
@@ -57,7 +67,9 @@
     "commands": [
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use rustok_api::HostRuntimeContext;
+use rustok_api::{HostRuntimeContext, PortActor, PortContext};
 use rustok_notifications_api::{
     AuthorizeNotificationTargetRequest, DescribeNotificationRequest, NotificationAudienceCandidate,
     NotificationAudienceCursor, NotificationAudiencePage, NotificationOpenAuthorization,
@@ -19,10 +20,14 @@ use sea_orm::{
 use serde::Deserialize;
 use uuid::Uuid;
 
+use crate::audience::SharedForumAudienceFactsPort;
 use crate::entities::{
     forum_category_subscription, forum_domain_event, forum_reply, forum_topic, forum_user_mention,
 };
 use crate::error::ForumError;
+use crate::notification_recipient::{
+    ForumNotificationRecipientContextResolver, SharedForumNotificationRecipientContextPort,
+};
 use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};
 use crate::state_machine::ReplyStatus;
 use crate::subscription::ForumSubscriptionLevel;
@@ -32,6 +37,8 @@ const TOPIC_CREATED_TYPE: &str = "forum.topic.created";
 const USER_MENTION_ADDED_TYPE: &str = "forum.mention.user_added";
 const FORUM_TOPIC_TARGET: &str = "forum.topic";
 const FORUM_REPLY_TARGET: &str = "forum.reply";
+const TARGET_OPEN_ACTOR: &str = "forum-notification-target-open";
+const TARGET_OPEN_DEADLINE: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Default)]
 pub(crate) struct ForumNotificationSourceProviderFactory;
@@ -47,6 +54,8 @@ impl NotificationSourceProviderFactory for ForumNotificationSourceProviderFactor
     ) -> NotificationProviderResult<Arc<dyn NotificationSourceProvider>> {
         Ok(Arc::new(ForumNotificationSourceProvider::new(
             host.db_clone(),
+            host.shared_get::<SharedForumNotificationRecipientContextPort>(),
+            host.shared_get::<SharedForumAudienceFactsPort>(),
         )))
     }
 }
@@ -54,6 +63,8 @@ impl NotificationSourceProviderFactory for ForumNotificationSourceProviderFactor
 #[derive(Clone)]
 struct ForumNotificationSourceProvider {
     db: DatabaseConnection,
+    recipient_context_port: Option<SharedForumNotificationRecipientContextPort>,
+    facts_port: Option<SharedForumAudienceFactsPort>,
 }
 
 #[derive(Clone, Debug)]
@@ -81,8 +92,16 @@ struct ForumUserMentionPayload {
 }
 
 impl ForumNotificationSourceProvider {
-    fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+    fn new(
+        db: DatabaseConnection,
+        recipient_context_port: Option<SharedForumNotificationRecipientContextPort>,
+        facts_port: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self {
+            db,
+            recipient_context_port,
+            facts_port,
+        }
     }
 
     async fn load_event(
@@ -132,14 +151,14 @@ impl ForumNotificationSourceProvider {
         Ok(persisted)
     }
 
-    async fn load_public_topic(
+    async fn load_topic_for_viewer(
         &self,
         tenant_id: Uuid,
         topic_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
-        let viewer = ForumTopicAudienceViewer::public();
-        if !ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())
-            .is_topic_visible(tenant_id, topic_id, None, &viewer)
+        if !ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())
+            .is_topic_visible(tenant_id, topic_id, None, viewer)
             .await
             .map_err(forum_owner_error)?
         {
@@ -164,15 +183,28 @@ impl ForumNotificationSourceProvider {
         Ok(Some(topic))
     }
 
-    async fn load_public_target(
+    async fn load_public_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+    ) -> NotificationProviderResult<Option<forum_topic::Model>> {
+        self.load_topic_for_viewer(tenant_id, topic_id, &ForumTopicAudienceViewer::public())
+            .await
+    }
+
+    async fn load_target_for_viewer(
         &self,
         tenant_id: Uuid,
         source_kind: &str,
         source_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
     ) -> NotificationProviderResult<ForumTargetAvailability> {
         match source_kind {
             "topic" => {
-                let Some(topic) = self.load_public_topic(tenant_id, source_id).await? else {
+                let Some(topic) = self
+                    .load_topic_for_viewer(tenant_id, source_id, viewer)
+                    .await?
+                else {
                     return Ok(ForumTargetAvailability::Unavailable);
                 };
                 Ok(ForumTargetAvailability::Visible(ForumTargetContext {
@@ -204,7 +236,10 @@ impl ForumNotificationSourceProvider {
                 if reply.status != ReplyStatus::Approved {
                     return Ok(ForumTargetAvailability::Unavailable);
                 }
-                let Some(topic) = self.load_public_topic(tenant_id, reply.topic_id).await? else {
+                let Some(topic) = self
+                    .load_topic_for_viewer(tenant_id, reply.topic_id, viewer)
+                    .await?
+                else {
                     return Ok(ForumTargetAvailability::Unavailable);
                 };
                 Ok(ForumTargetAvailability::Visible(ForumTargetContext {
@@ -216,6 +251,21 @@ impl ForumNotificationSourceProvider {
             }
             _ => Err(NotificationProviderError::InvalidEvent),
         }
+    }
+
+    async fn load_public_target(
+        &self,
+        tenant_id: Uuid,
+        source_kind: &str,
+        source_id: Uuid,
+    ) -> NotificationProviderResult<ForumTargetAvailability> {
+        self.load_target_for_viewer(
+            tenant_id,
+            source_kind,
+            source_id,
+            &ForumTopicAudienceViewer::public(),
+        )
+        .await
     }
 
     async fn row_is_active(
@@ -558,10 +608,37 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
         } else {
             return Ok(NotificationOpenAuthorization::Unavailable);
         };
-        match self
-            .load_public_target(request.tenant_id, source_kind, request.target.id)
+
+        let availability = if let Some(port) = self.recipient_context_port.clone() {
+            let resolver = ForumNotificationRecipientContextResolver::new(Some(port));
+            let recipient = match resolver
+                .resolve(
+                    target_open_context(&request),
+                    request.tenant_id,
+                    request.recipient_id,
+                )
+                .await
+            {
+                Ok(recipient) => recipient,
+                Err(ForumError::CapabilityFailure {
+                    retryable: false, ..
+                }) => return Ok(NotificationOpenAuthorization::Unavailable),
+                Err(error) => return Err(forum_owner_error(error)),
+            };
+            let viewer = recipient.into_topic_viewer().map_err(forum_owner_error)?;
+            self.load_target_for_viewer(
+                request.tenant_id,
+                source_kind,
+                request.target.id,
+                &viewer,
+            )
             .await?
-        {
+        } else {
+            self.load_public_target(request.tenant_id, source_kind, request.target.id)
+                .await?
+        };
+
+        match availability {
             ForumTargetAvailability::Visible(target) => {
                 Ok(NotificationOpenAuthorization::Allowed {
                     route: self.target_route(&target)?,
@@ -574,13 +651,34 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
     }
 }
 
+fn target_open_context(request: &AuthorizeNotificationTargetRequest) -> PortContext {
+    PortContext::new(
+        request.tenant_id.to_string(),
+        PortActor::service(TARGET_OPEN_ACTOR),
+        "und",
+        format!(
+            "forum-target-open:{}:{}",
+            request.recipient_id, request.target.id
+        ),
+    )
+    .with_deadline(TARGET_OPEN_DEADLINE)
+}
+
 fn retryable_database_error(_error: sea_orm::DbErr) -> NotificationProviderError {
     NotificationProviderError::Internal { retryable: true }
 }
 
 fn forum_owner_error(error: ForumError) -> NotificationProviderError {
-    NotificationProviderError::Internal {
-        retryable: error.is_retryable(),
+    match error {
+        ForumError::CapabilityUnavailable { .. } => {
+            NotificationProviderError::CapabilityUnavailable { retryable: true }
+        }
+        ForumError::CapabilityFailure { retryable, .. } => {
+            NotificationProviderError::Internal { retryable }
+        }
+        error => NotificationProviderError::Internal {
+            retryable: error.is_retryable(),
+        },
     }
 }
 

--- a/crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs
@@ -1,0 +1,238 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{Permission, PortActor, PortCallPolicy, PortContext, PortError};
+use rustok_core::{MemoryTransport, MigrationSource, ModuleRegistry, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput,
+    ForumAudienceConstraints, ForumModule, ForumNotificationRecipientContextPort,
+    ForumNotificationRecipientContextRequest, ForumTopicAudiencePolicyService, ReplyService,
+    SetForumTopicAudiencePolicyInput, SharedForumNotificationRecipientContextPort, TopicService,
+};
+use rustok_notifications::NotificationsModule;
+use rustok_notifications_api::{
+    AuthorizeNotificationTargetRequest, NotificationOpenAuthorization, NotificationSourceSlug,
+    NotificationTargetKind, NotificationTargetRef, materialize_notification_source_registry,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct StaticRecipientContextPort {
+    customer_id: Uuid,
+    manager_id: Uuid,
+}
+
+#[async_trait]
+impl ForumNotificationRecipientContextPort for StaticRecipientContextPort {
+    async fn resolve_forum_notification_recipient_context(
+        &self,
+        context: PortContext,
+        request: ForumNotificationRecipientContextRequest,
+    ) -> Result<PortContext, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let role = if request.recipient_id == self.customer_id {
+            "customer"
+        } else if request.recipient_id == self.manager_id {
+            "manager"
+        } else {
+            return Err(PortError::not_found(
+                "forum.notification_recipient_context.test_recipient_unavailable",
+                "Forum notification recipient is unavailable",
+            ));
+        };
+
+        let mut recipient = PortContext::new(
+            request.tenant_id.to_string(),
+            PortActor::user(request.recipient_id.to_string()),
+            context.locale.clone(),
+            context.correlation_id.clone(),
+        )
+        .with_role(role)
+        .with_claim(Permission::FORUM_TOPICS_READ.to_string())
+        .with_claim(Permission::FORUM_REPLIES_READ.to_string());
+        recipient.causation_id = context.causation_id;
+        recipient.traceparent = context.traceparent;
+        recipient.deadline_ms = context.deadline_ms;
+        Ok(recipient)
+    }
+}
+
+#[tokio::test]
+async fn notification_target_open_uses_exact_recipient_role_for_topics_and_replies() {
+    let (db, event_bus) = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let author_id = Uuid::new_v4();
+    let customer_id = Uuid::new_v4();
+    let manager_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(author_id));
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Recipient target open".into(),
+                slug: "recipient-target-open".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created");
+    let topic = TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id: category.id,
+                title: "Recipient-specific target".into(),
+                slug: Some("recipient-specific-target".into()),
+                body: "Notification target-open authorization must use the exact recipient.".into(),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created");
+    let reply = ReplyService::new(db.clone(), event_bus)
+        .create(
+            tenant_id,
+            admin.clone(),
+            topic.id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Recipient-specific reply target".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("reply should be created");
+
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            topic.id,
+            admin,
+            SetForumTopicAudiencePolicyInput {
+                constraints: ForumAudienceConstraints {
+                    roles_any: vec![UserRole::Customer],
+                    ..ForumAudienceConstraints::default()
+                },
+            },
+        )
+        .await
+        .expect("topic audience should narrow to customers");
+
+    let registry = ModuleRegistry::new()
+        .register(NotificationsModule)
+        .register(ForumModule);
+    let mut extensions = registry
+        .build_runtime_extensions()
+        .expect("Notifications and Forum runtime extensions should initialize");
+    let recipient_port: SharedForumNotificationRecipientContextPort =
+        Arc::new(StaticRecipientContextPort {
+            customer_id,
+            manager_id,
+        });
+    extensions.insert(recipient_port);
+    let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+    let providers = materialize_notification_source_registry(&mut extensions, &host)
+        .expect("Forum source factory should consume the recipient capability");
+    let provider = providers
+        .get_by_str("forum")
+        .expect("Forum source should be discoverable");
+
+    let topic_target = NotificationTargetRef {
+        owner: NotificationSourceSlug::new("forum").expect("source slug"),
+        kind: NotificationTargetKind::new("forum.topic").expect("topic target kind"),
+        id: topic.id,
+    };
+    let reply_target = NotificationTargetRef {
+        owner: NotificationSourceSlug::new("forum").expect("source slug"),
+        kind: NotificationTargetKind::new("forum.reply").expect("reply target kind"),
+        id: reply.id,
+    };
+
+    for target in [topic_target.clone(), reply_target.clone()] {
+        let allowed = provider
+            .authorize_target_open(AuthorizeNotificationTargetRequest {
+                tenant_id,
+                recipient_id: customer_id,
+                target,
+            })
+            .await
+            .expect("customer target-open authorization should complete");
+        assert!(matches!(allowed, NotificationOpenAuthorization::Allowed { .. }));
+    }
+
+    for target in [topic_target, reply_target] {
+        let denied = provider
+            .authorize_target_open(AuthorizeNotificationTargetRequest {
+                tenant_id,
+                recipient_id: manager_id,
+                target,
+            })
+            .await
+            .expect("manager target-open authorization should fail closed");
+        assert_eq!(denied, NotificationOpenAuthorization::Unavailable);
+    }
+
+    let unavailable = provider
+        .authorize_target_open(AuthorizeNotificationTargetRequest {
+            tenant_id,
+            recipient_id: Uuid::new_v4(),
+            target: NotificationTargetRef {
+                owner: NotificationSourceSlug::new("forum").expect("source slug"),
+                kind: NotificationTargetKind::new("forum.topic").expect("topic target kind"),
+                id: topic.id,
+            },
+        })
+        .await
+        .expect("unavailable recipient should fail closed without an existence oracle");
+    assert_eq!(unavailable, NotificationOpenAuthorization::Unavailable);
+}
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus) {
+    let url = format!(
+        "sqlite:file:forum_notification_recipient_target_open_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("notification recipient target-open database should connect");
+    let manager = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus)
+}

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -34,17 +34,19 @@ const owner = read(contract.owner_file ?? "");
 const crate = read(contract.crate_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const consumer = JSON.parse(read(contract.consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum notification recipient context contract must use schema_version=2");
+if (contract.schema_version !== 3) {
+  failures.push("forum notification recipient context contract must use schema_version=3");
 }
 if (
   contract.task !== "FORUM-20L" ||
   contract.upstream_task !== "FORUM-20K" ||
-  contract.downstream_task !== "FORUM-20M"
+  contract.downstream_task !== "FORUM-20M" ||
+  contract.consumer_task !== "FORUM-20N"
 ) {
-  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M");
+  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M/N");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("recipient context source publication must not claim unexecuted evidence");
@@ -65,16 +67,15 @@ for (const delivered of [
   "inline_contract_tests",
   "host_adapter_implementation",
   "host_runtime_publication",
+  "notification_source_factory_consumption",
+  "recipient_target_open_authorization",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
   }
 }
-
 for (const residual of [
-  "notification source factory consumption of the recipient context capability",
-  "recipient-specific audience filtering for non-public topics",
-  "recipient-specific target-open authorization for non-public topics and replies",
+  "recipient-specific audience filtering for non-public topics before pagination",
   "profile privacy and blocking policy",
   "trust channel and group facts host adapters",
   "final notification creation and delivery authorization",
@@ -88,13 +89,14 @@ for (const residual of [
 for (const staleResidual of [
   "host recipient context adapter implementation",
   "host runtime publication of the recipient context capability",
+  "notification source factory consumption of the recipient context capability",
+  "recipient-specific target-open authorization for non-public topics and replies",
 ]) {
   if (contract.not_delivered?.includes(staleResidual)) {
     failures.push(`forum notification recipient context contract must remove delivered residual ${staleResidual}`);
   }
 }
 
-const planSync = contract.canonical_plan_sync ?? {};
 const deliveredSlices = [
   "FORUM-20H",
   "FORUM-20I",
@@ -102,12 +104,14 @@ const deliveredSlices = [
   "FORUM-20K",
   "FORUM-20L",
   "FORUM-20M",
+  "FORUM-20N",
 ];
-if (planSync.required_ledger_through !== "FORUM-20M") {
-  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20M");
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20N") {
+  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20N");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20M delivered sections");
+  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20N delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -128,8 +132,8 @@ if (planSync.status === "pending") {
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-M provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through M",
+    "FORUM-20A-N provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through N",
   );
   for (const slice of deliveredSlices) {
     requireText(
@@ -164,7 +168,6 @@ for (const marker of [
 ]) {
   requireText(owner, marker, `forum notification recipient context owner is missing ${marker}`);
 }
-
 for (const forbidden of [
   "sea_orm",
   "DatabaseConnection",
@@ -181,7 +184,6 @@ for (const forbidden of [
     `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`,
   );
 }
-
 for (const marker of [
   "pub mod notification_recipient;",
   "FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
@@ -193,20 +195,34 @@ for (const marker of [
 }
 
 if (
-  upstream.schema_version !== 4 ||
+  upstream.schema_version !== 5 ||
   upstream.task !== "FORUM-20K" ||
-  upstream.composition?.exact_richer_public_owner !== true
+  upstream.downstream_task !== "FORUM-20N" ||
+  upstream.composition?.exact_richer_public_owner !== true ||
+  upstream.composition?.recipient_specific_target_open !== true
 ) {
-  failures.push("FORUM-20L recipient context capability must remain grounded in delivered FORUM-20K public visibility composition");
+  failures.push("FORUM-20L recipient context capability must remain grounded in FORUM-20K visibility composition through FORUM-20N");
 }
 if (
-  downstream.schema_version !== 1 ||
+  downstream.schema_version !== 2 ||
   downstream.task !== "FORUM-20M" ||
   downstream.upstream_task !== "FORUM-20L" ||
+  downstream.downstream_task !== "FORUM-20N" ||
   downstream.composition?.server_adapter !== true ||
-  downstream.composition?.runtime_extension_publication !== true
+  downstream.composition?.runtime_extension_publication !== true ||
+  downstream.composition?.notification_source_factory_consumption !== true
 ) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with delivered FORUM-20M host composition");
+  failures.push("FORUM-20L recipient context capability must remain synchronized with FORUM-20M host composition through FORUM-20N");
+}
+if (
+  consumer.schema_version !== 1 ||
+  consumer.task !== "FORUM-20N" ||
+  consumer.upstream_task !== "FORUM-20M" ||
+  consumer.composition?.exact_recipient_resolution !== true ||
+  consumer.composition?.recipient_specific_topic_open !== true ||
+  consumer.composition?.recipient_specific_reply_open !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the delivered FORUM-20N consumer");
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
@@ -33,14 +33,20 @@ const contract = JSON.parse(read(contractPath) || "{}");
 const adapter = read(contract.adapter_file ?? "");
 const services = read(contract.services_file ?? "");
 const runtime = read(contract.runtime_composition_file ?? "");
+const notificationSource = read(contract.notification_source_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum notification recipient host runtime contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification recipient host runtime contract must use schema_version=2");
 }
-if (contract.task !== "FORUM-20M" || contract.upstream_task !== "FORUM-20L") {
-  failures.push("forum notification recipient host runtime contract must belong to FORUM-20M after FORUM-20L");
+if (
+  contract.task !== "FORUM-20M" ||
+  contract.upstream_task !== "FORUM-20L" ||
+  contract.downstream_task !== "FORUM-20N"
+) {
+  failures.push("forum notification recipient host runtime contract must connect FORUM-20L/M/N");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("recipient host runtime publication must not claim unexecuted evidence");
@@ -62,16 +68,15 @@ for (const delivered of [
   "publication_before_notification_source_materialization",
   "feature_guarded_server_module",
   "inline_contract_tests",
+  "notification_source_factory_consumption",
+  "recipient_target_open_authorization",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification recipient host runtime contract must record ${delivered} as delivered`);
   }
 }
-
 for (const residual of [
-  "notification source factory consumption of the recipient context capability",
-  "recipient-specific audience filtering for non-public topics",
-  "recipient-specific target-open authorization for non-public topics and replies",
+  "recipient-specific audience filtering for non-public topics before pagination",
   "profile privacy and blocking policy",
   "trust channel and group facts host adapters",
   "final notification creation and delivery authorization",
@@ -82,8 +87,15 @@ for (const residual of [
     failures.push(`forum notification recipient host runtime contract must keep ${residual} explicitly open`);
   }
 }
+for (const staleResidual of [
+  "notification source factory consumption of the recipient context capability",
+  "recipient-specific target-open authorization for non-public topics and replies",
+]) {
+  if (contract.not_delivered?.includes(staleResidual)) {
+    failures.push(`forum notification recipient host runtime contract must remove delivered residual ${staleResidual}`);
+  }
+}
 
-const planSync = contract.canonical_plan_sync ?? {};
 const deliveredSlices = [
   "FORUM-20H",
   "FORUM-20I",
@@ -91,12 +103,14 @@ const deliveredSlices = [
   "FORUM-20K",
   "FORUM-20L",
   "FORUM-20M",
+  "FORUM-20N",
 ];
-if (planSync.required_ledger_through !== "FORUM-20M") {
-  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20M");
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20N") {
+  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20N");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20M delivered sections");
+  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20N delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -117,8 +131,8 @@ if (planSync.status === "pending") {
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-M provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through M",
+    "FORUM-20A-N provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through N",
   );
   for (const slice of deliveredSlices) {
     requireText(
@@ -154,7 +168,6 @@ for (const marker of [
 ]) {
   requireText(adapter, marker, `forum notification recipient host adapter is missing ${marker}`);
 }
-
 for (const forbidden of [
   "rustok_forum::entities",
   "forum_category_audience_",
@@ -172,14 +185,12 @@ for (const forbidden of [
     `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`,
   );
 }
-
 for (const marker of [
   "#[cfg(feature = \"mod-forum\")]",
   "pub mod forum_notification_recipient_context;",
 ]) {
   requireText(services, marker, `server services surface is missing ${marker}`);
 }
-
 for (const marker of [
   "ServerForumNotificationRecipientContextPort::shared(",
   "extensions.insert(recipient_context)",
@@ -199,14 +210,36 @@ if (
   failures.push("recipient context capability must be published before notification source materialization");
 }
 
+for (const marker of [
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "target_open_context(&request)",
+  "recipient.into_topic_viewer()",
+]) {
+  requireText(notificationSource, marker, `notification source consumer is missing ${marker}`);
+}
+
 if (
-  upstream.schema_version !== 2 ||
+  upstream.schema_version !== 3 ||
   upstream.task !== "FORUM-20L" ||
   upstream.downstream_task !== "FORUM-20M" ||
+  upstream.consumer_task !== "FORUM-20N" ||
   upstream.composition?.host_adapter_implementation !== true ||
-  upstream.composition?.host_runtime_publication !== true
+  upstream.composition?.host_runtime_publication !== true ||
+  upstream.composition?.notification_source_factory_consumption !== true
 ) {
-  failures.push("FORUM-20M host runtime must remain synchronized with the delivered FORUM-20L capability contract");
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20L capability contract through FORUM-20N");
+}
+if (
+  downstream.schema_version !== 1 ||
+  downstream.task !== "FORUM-20N" ||
+  downstream.upstream_task !== "FORUM-20M" ||
+  downstream.composition?.factory_recipient_capability_lookup !== true ||
+  downstream.composition?.recipient_specific_topic_open !== true ||
+  downstream.composition?.recipient_specific_reply_open !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with delivered FORUM-20N target-open consumption");
 }
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const source = read(contract.notification_source_file ?? "");
+const visibilityOwner = read(contract.visibility_owner_file ?? "");
+const recipientOwner = read(contract.recipient_context_owner_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification recipient target-open contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M") {
+  failures.push("forum notification recipient target-open contract must belong to FORUM-20N after FORUM-20M");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient target-open publication must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "factory_recipient_capability_lookup",
+  "factory_facts_capability_lookup",
+  "bounded_target_open_context",
+  "exact_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_topic_open",
+  "recipient_specific_reply_open",
+  "public_only_fallback",
+  "inactive_or_missing_recipient_fail_closed",
+  "retryability_preserved",
+  "public_description_unchanged",
+  "public_audience_unchanged",
+  "sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient target-open contract must record ${delivered} as delivered`);
+  }
+}
+for (const residual of [
+  "recipient-specific audience filtering for non-public topics before pagination",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient target-open contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20N") {
+  failures.push("forum notification recipient target-open contract must require the canonical ledger through FORUM-20N");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient target-open contract must require FORUM-20H through FORUM-20N delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-N provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through N",
+  );
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "facts_port: Option<SharedForumAudienceFactsPort>",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_target_for_viewer(",
+  "reply.status == ReplyStatus::Pending",
+  "reply.status != ReplyStatus::Approved",
+  "const TARGET_OPEN_DEADLINE: Duration = Duration::from_secs(2)",
+  "PortActor::service(TARGET_OPEN_ACTOR)",
+  ".with_deadline(TARGET_OPEN_DEADLINE)",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "target_open_context(&request)",
+  "recipient.into_topic_viewer()",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
+  "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
+  "ForumError::CapabilityUnavailable { .. }",
+  "NotificationProviderError::CapabilityUnavailable { retryable: true }",
+]) {
+  requireText(source, marker, `forum notification recipient target-open source is missing ${marker}`);
+}
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(
+    source,
+    forbidden,
+    `forum notification target-open must reuse owners instead of ${forbidden}`,
+  );
+}
+
+const describeIndex = source.indexOf("async fn describe_event(");
+const audienceIndex = source.indexOf("async fn resolve_audience(");
+const targetOpenIndex = source.indexOf("async fn authorize_target_open(");
+const recipientResolutionIndex = source.indexOf("ForumNotificationRecipientContextResolver::new(Some(port))");
+if (
+  describeIndex < 0 ||
+  audienceIndex < 0 ||
+  targetOpenIndex < 0 ||
+  recipientResolutionIndex < targetOpenIndex ||
+  recipientResolutionIndex < audienceIndex
+) {
+  failures.push("exact recipient resolution must remain scoped to authorize_target_open after public description and audience methods");
+}
+
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "SharedForumNotificationRecipientContextPort",
+  "Forum source factory should consume the recipient capability",
+  "customer target-open authorization should complete",
+  "manager target-open authorization should fail closed",
+  "unavailable recipient should fail closed without an existence oracle",
+  "NotificationOpenAuthorization::Allowed",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(testSource, marker, `recipient target-open SQLite contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 2 ||
+  upstream.task !== "FORUM-20M" ||
+  upstream.downstream_task !== "FORUM-20N" ||
+  upstream.composition?.notification_source_factory_consumption !== true ||
+  upstream.composition?.recipient_target_open_authorization !== true
+) {
+  failures.push("FORUM-20N target-open must remain synchronized with the FORUM-20M host runtime contract");
+}
+if (
+  visibilityContract.schema_version !== 5 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20N" ||
+  visibilityContract.composition?.recipient_specific_target_open !== true ||
+  visibilityContract.composition?.public_only_description_and_audience !== true
+) {
+  failures.push("FORUM-20N target-open must remain synchronized with the FORUM-20K visibility composition contract");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification recipient target-open verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification recipient target-open contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -34,21 +34,27 @@ const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
 const baselineTestSource = read(contract.baseline_test_file ?? "");
-const testSource = read(contract.test_file ?? "");
+const richerTestSource = read(contract.test_file ?? "");
+const recipientTestSource = read(contract.recipient_test_file ?? "");
+const recipientContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) {
-  failures.push("forum notification visibility contract must use schema_version=4");
+if (contract.schema_version !== 5) {
+  failures.push("forum notification visibility contract must use schema_version=5");
 }
-if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I") {
-  failures.push("forum notification richer visibility contract must belong to FORUM-20K and supersede FORUM-20I");
+if (
+  contract.task !== "FORUM-20K" ||
+  contract.supersedes_task !== "FORUM-20I" ||
+  contract.downstream_task !== "FORUM-20N"
+) {
+  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20N");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted notification evidence");
 }
+
 for (const residual of [
-  "recipient-specific authenticated role trust channel group and explicit-user evaluation",
-  "recipient-specific target-open authorization for non-public audiences",
+  "recipient-specific authenticated audience filtering before notification pagination",
   "profile privacy and blocking policy",
   "host trust channel and group facts adapters for authenticated consumers",
   "search index SEO and deep-link migration",
@@ -59,27 +65,35 @@ for (const residual of [
     failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
   }
 }
-
 for (const delivered of [
   "exact_richer_public_owner",
   "normalized_category_layers",
   "normalized_topic_layer",
   "dynamic_policy_recheck",
+  "recipient_context_factory_consumption",
+  "recipient_specific_target_open",
+  "public_only_description_and_audience",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
   }
 }
 
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20K") {
-  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20K");
+if (planSync.required_ledger_through !== "FORUM-20N") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20N");
 }
-if (
-  JSON.stringify(planSync.required_delivered_sections) !==
-  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"])
-) {
-  failures.push("forum notification visibility contract must require FORUM-20H/I/J/K delivered sections");
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20N delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -90,7 +104,7 @@ if (planSync.status === "pending") {
     "FORUM-20A-G provide",
     "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
+  for (const slice of deliveredSlices) {
     rejectText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -100,10 +114,10 @@ if (planSync.status === "pending") {
 } else if (planSync.status === "synchronized") {
   requireText(
     plan,
-    "FORUM-20A-K provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through K",
+    "FORUM-20A-N provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through N",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
+  for (const slice of deliveredSlices) {
     requireText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -117,8 +131,8 @@ if (planSync.status === "pending") {
 for (const marker of [
   "pub struct ForumTopicAudienceViewer",
   "pub fn public() -> Self",
+  "pub fn authenticated(",
   "pub struct ForumTopicAudienceVisibilityService",
-  "pub fn without_facts_provider",
   "pub async fn is_topic_visible(",
   "ForumTopicVisibilityScope::storefront_for_viewer(",
   "ForumTopicVisibilityService::new(self.db.clone())",
@@ -138,18 +152,19 @@ for (const marker of [
 }
 
 for (const marker of [
-  "use crate::error::ForumError;",
-  "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
   "async fn load_public_topic(",
-  "let viewer = ForumTopicAudienceViewer::public();",
-  "ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
-  ".map_err(forum_owner_error)?",
-  ".load_public_topic(tenant_id, source_id)",
-  ".load_public_topic(tenant_id, reply.topic_id)",
-  ".load_public_topic(event.tenant_id, event.aggregate_id)",
+  "ForumTopicAudienceViewer::public()",
+  "async fn load_target_for_viewer(",
+  "async fn load_public_target(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "target_open_context(&request)",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
-  "retryable: error.is_retryable()",
 ]) {
   requireText(
     notificationSource,
@@ -173,7 +188,6 @@ for (const forbidden of [
   "forum_topic_audience_channel",
   "forum_topic_audience_group",
   "forum_topic_audience_user",
-  "ForumAudienceFactsPort",
 ]) {
   rejectText(
     notificationSource,
@@ -182,40 +196,55 @@ for (const forbidden of [
   );
 }
 
-const visibilityIndex = notificationSource.indexOf(
-  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
-);
-const materializeIndex = notificationSource.indexOf(
-  "let topic = forum_topic::Entity::find()",
-);
-if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
-  failures.push("notification target richer visibility must be evaluated before target materialization");
+const describeIndex = notificationSource.indexOf("async fn describe_event(");
+const audienceIndex = notificationSource.indexOf("async fn resolve_audience(");
+const targetOpenIndex = notificationSource.indexOf("async fn authorize_target_open(");
+const resolverIndex = notificationSource.indexOf("ForumNotificationRecipientContextResolver::new(Some(port))");
+if (
+  describeIndex < 0 ||
+  audienceIndex < 0 ||
+  targetOpenIndex < 0 ||
+  resolverIndex < targetOpenIndex ||
+  resolverIndex < audienceIndex
+) {
+  failures.push("recipient context resolution must remain scoped to target-open authorization after public description and audience paths");
 }
 
 for (const marker of [
   "forum_topic_and_user_mention_sources_support_notifications_profiles",
   "restricted topic description should fail closed",
   "restricted topic authorization should fail closed",
-  "restricted mention description should fail closed",
   "cross-tenant authorization should fail closed",
   "closed target authorization should fail closed",
-  "database failure should be classified",
   "NotificationProviderError::Internal { retryable: true }",
 ]) {
   requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
 }
-
 for (const marker of [
   "notification_source_rechecks_category_and_topic_richer_visibility",
-  "ForumTopicAudiencePolicyService::new(db.clone())",
-  "ForumCategoryAudiencePolicyService::new(db.clone())",
   "topic-level richer visibility should fail closed",
   "stale public descriptor should be rechecked",
-  "category-level richer visibility should fail closed",
   "category policy change should invalidate the old public descriptor",
+]) {
+  requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "SharedForumNotificationRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "NotificationOpenAuthorization::Allowed",
   "NotificationOpenAuthorization::Unavailable",
 ]) {
-  requireText(testSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
+  requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
+}
+
+if (
+  recipientContract.schema_version !== 1 ||
+  recipientContract.task !== "FORUM-20N" ||
+  recipientContract.composition?.recipient_specific_topic_open !== true ||
+  recipientContract.composition?.recipient_specific_reply_open !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient target-open contract");
 }
 
 for (const marker of [


### PR DESCRIPTION
## Summary

- consume the optional exact Forum notification-recipient context capability while materializing the Forum notification source provider
- construct a bounded service `PortContext` for each target-open authorization and resolve the exact tenant recipient through the Forum-owned resolver
- authorize topic and reply targets through `ForumTopicAudienceVisibilityService` using the validated authenticated recipient viewer
- preserve reply lifecycle checks: pending remains deferred, approved may open, and every other state remains unavailable
- keep `describe_event` and `resolve_audience` on the existing public-only fail-closed path
- retain the previous public-only target-open fallback when the host recipient-context capability is absent
- consume an optional audience-facts capability for authenticated selectors while local role and explicit-user selectors continue without host adapters
- add the FORUM-20N machine contract, SQLite source contract and synchronized K/L/M/N static verifiers

## Safety and degraded behavior

- missing, inactive or otherwise unavailable recipients do not receive an existence oracle and resolve to an unavailable target
- retryable recipient-context and audience-facts failures remain retryable provider failures
- recipient authority is never synthesized in the notification source; it is accepted only through the validated Forum recipient resolver
- the notification source does not read normalized category/topic audience relation tables directly
- target-open evaluation has no route channel slug and therefore keeps the existing channel-deny behavior

## Remaining scope

- recipient-specific audience filtering for non-public topics before pagination
- profile privacy and blocking policy
- host trust, channel and group facts adapters
- final notification creation and delivery authorization
- search/index, SEO and deep-link migration
- PostgreSQL and cross-consumer runtime evidence

The canonical implementation plan still physically ends at FORUM-20G. Machine contracts keep synchronization explicitly pending through FORUM-20N.

## Validation

Tests, Cargo commands, formatting commands, verifiers and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture
node scripts/verify/verify-forum-notification-visibility-composition.mjs
node scripts/verify/verify-forum-notification-recipient-context.mjs
node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
node scripts/verify/verify-forum-notification-recipient-target-open.mjs
cargo xtask module validate forum
```