### PR TITLE
fix(index): reject ambiguous router arguments

### DIFF
--- a/scripts/verify/index-storage-tooling-arguments.test.mjs
+++ b/scripts/verify/index-storage-tooling-arguments.test.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const script = path.resolve('scripts/verify/index-storage-tooling.mjs');
+const run = (...args) => spawnSync(process.execPath, [script, ...args], {
+  encoding: 'utf8',
+});
+
+test('rejects global help combined with other arguments', () => {
+  const result = run('--help', 'packet');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /help must be the only argument/u);
+  assert.equal(result.stdout, '');
+});
+
+test('rejects duplicate packet scale before invoking evidence tooling', () => {
+  const result = run('packet', '--scale', 'smoke', '--scale', '1m');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--scale was provided more than once/u);
+  assert.doesNotMatch(result.stderr, /check-index-storage-read-ordering/u);
+});
+
+test('rejects duplicate packet root before invoking evidence tooling', () => {
+  const result = run(
+    'packet',
+    '--scale', 'smoke',
+    '--root', 'first-evidence-root',
+    '--root', 'second-evidence-root',
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--root was provided more than once/u);
+  assert.doesNotMatch(result.stderr, /check-index-storage-read-ordering/u);
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -67,6 +67,7 @@ const runFixtures = (args) => {
   if (args.length !== 0) fail('fixtures does not accept arguments');
   runNode([
     '--test',
+    scriptPath('index-storage-tooling-arguments.test.mjs'),
     scriptPath('check-index-storage-read-ordering.test.mjs'),
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
@@ -81,8 +82,10 @@ const parsePacketArgs = (args) => {
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--scale' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (scale !== null) fail('--scale was provided more than once');
       scale = args[++index];
     } else if (argument === '--root' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (root !== null) fail('--root was provided more than once');
       root = args[++index];
     } else {
       fail(`unknown or incomplete packet argument: ${argument}`);
@@ -133,7 +136,12 @@ const runCompare = (args) => {
 };
 
 const [command, ...args] = process.argv.slice(2);
-if (!command || command === '--help' || command === '-h') {
+if (!command) {
+  usage();
+  process.exit(0);
+}
+if (command === '--help' || command === '-h') {
+  if (args.length !== 0) fail('help must be the only argument');
   usage();
   process.exit(0);
 }


### PR DESCRIPTION
## What changed

- require top-level `--help`/`-h` to be the sole router argument;
- reject repeated `packet --scale` and `packet --root` options instead of silently using the last value;
- run a dedicated argument-focused fixture suite through the canonical `fixtures` command;
- keep the existing router fixture untouched to avoid overlap with other open Index PRs.

## Root cause

The top-level router treated help as an unconditional successful exit, so malformed invocations such as `--help packet` appeared valid. The packet parser also assigned repeated value options without checking whether they had already been supplied, allowing the effective evidence scale or root to differ from the first scripted value.

## Impact

Index storage tooling now fails closed before invoking ordering checks or evidence validation when the router command line is ambiguous. This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was reduced to one commit directly on current `main`; GitHub comparison reports two changed files with the new fixture and the focused router parser changes only.