### PR TITLE
Harden admin order detail payment error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -49,6 +49,11 @@ available only for actionable domain errors.
   Validation, missing-resource, transition, and database causes are logged with
   correlation identity and stable codes while the existing public envelopes remain
   static.
+- `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
+  remains internal while owner, tenant, order, operation, error kind, stable public code,
+  status, and HTTP boundary are logged. Validation, missing-resource, transition,
+  provider, reconciliation, configuration, and storage outcomes preserve the existing
+  static public messages and status policy.
 - `rustok-commerce` admin order detail fulfillment lookup: the typed fulfillment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, not-found, transition, and storage
@@ -93,6 +98,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
+- `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
 - `node scripts/verify/verify-order-checkout-recovery-error-context.mjs`
@@ -107,7 +113,7 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin order-detail fulfillment mapping, and tax calculation validation,
+  admin order-detail payment and fulfillment mapping, and tax calculation validation,
   provider-contract, reconciliation, correlation, HTTP-envelope, and transport
   round-trip tests.
 

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -6,7 +6,7 @@ use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_fulfillment::{FulfillmentError, FulfillmentService};
 use rustok_order::OrderService;
-use rustok_payment::PaymentService;
+use rustok_payment::{PaymentError, PaymentService};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -19,6 +19,8 @@ use crate::dto::{
     CancelOrderInput, DeliverOrderInput, MarkPaidOrderInput, OrderResponse, ShipOrderInput,
 };
 
+const ADMIN_ORDER_DETAIL_PAYMENT_OWNER: &str = "rustok_payment.admin_order_detail";
+const ADMIN_ORDER_DETAIL_PAYMENT_OPERATION: &str = "find_latest_payment_collection_by_order";
 const ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_order_detail";
 const ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION: &str = "find_fulfillment_by_order";
 
@@ -104,7 +106,7 @@ pub async fn show_order(
     let payment_collection = PaymentService::new(runtime.db_clone())
         .find_latest_collection_by_order(tenant.id, id)
         .await
-        .map_err(super::map_payment_error)?;
+        .map_err(|error| map_order_detail_payment_error(tenant.id, id, error))?;
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .find_by_order(tenant.id, id)
         .await
@@ -115,6 +117,78 @@ pub async fn show_order(
         payment_collection,
         fulfillment,
     }))
+}
+
+fn map_order_detail_payment_error(
+    tenant_id: Uuid,
+    order_id: Uuid,
+    error: PaymentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PaymentError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            axum::http::StatusCode::BAD_GATEWAY,
+            "commerce_admin_payment_provider_invalid_response",
+            "Payment provider returned an invalid response; reconciliation may be required",
+            "provider_invalid_response",
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment provider outcome is unknown and requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        PaymentError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_DETAIL_PAYMENT_OWNER,
+        tenant_id = %tenant_id,
+        order_id = %order_id,
+        operation = ADMIN_ORDER_DETAIL_PAYMENT_OPERATION,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_admin_order_detail_http",
+        "commerce admin order detail payment lookup failed"
+    );
+    HttpError::new(status, code, message)
 }
 
 fn map_order_detail_fulfillment_error(

--- a/scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const showOrder = between(
+  source,
+  'pub async fn show_order(',
+  'fn map_order_detail_payment_error(',
+  'admin order detail handler',
+);
+const mapper = between(
+  source,
+  'fn map_order_detail_payment_error(',
+  'fn map_order_detail_fulfillment_error(',
+  'admin order detail payment mapper',
+);
+
+for (const [value, label] of [
+  ['use rustok_payment::{PaymentError, PaymentService};', 'typed payment error import'],
+  [
+    'const ADMIN_ORDER_DETAIL_PAYMENT_OWNER: &str = "rustok_payment.admin_order_detail";',
+    'payment owner constant',
+  ],
+  [
+    'const ADMIN_ORDER_DETAIL_PAYMENT_OPERATION: &str = "find_latest_payment_collection_by_order";',
+    'payment operation constant',
+  ],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  [
+    '.map_err(|error| map_order_detail_payment_error(tenant.id, id, error))?',
+    'order-detail payment mapper handoff',
+  ],
+  ['[Permission::ORDERS_READ]', 'order read permission'],
+  ['Path(id): Path<Uuid>', 'typed order path'],
+  ['HttpResult<Json<AdminOrderDetailResponse>>', 'order detail result contract'],
+  ['find_latest_collection_by_order(tenant.id, id)', 'payment lookup contract'],
+]) requireText(showOrder, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::Validation(_)', 'validation variant'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found variant'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found variant'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found variant'],
+  ['PaymentError::InvalidTransition { .. }', 'transition variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'provider invalid-response variant'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'provider unknown-outcome variant'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration variant'],
+  ['PaymentError::Database(_)', 'database variant'],
+  ['error = ?error', 'internal typed cause'],
+  ['owner = ADMIN_ORDER_DETAIL_PAYMENT_OWNER', 'owner log'],
+  ['tenant_id = %tenant_id', 'tenant log'],
+  ['order_id = %order_id', 'order identity log'],
+  ['operation = ADMIN_ORDER_DETAIL_PAYMENT_OPERATION', 'operation log'],
+  ['error_kind,', 'error kind log'],
+  ['public_code = code', 'stable code log'],
+  ['status = %status', 'status log'],
+  ['boundary = "commerce_admin_order_detail_http"', 'HTTP boundary log'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['"Commerce resource not found"', 'static not-found envelope'],
+  ['"Payment request is invalid"', 'static validation envelope'],
+  ['"Payment operation conflicts with the current state"', 'static conflict envelope'],
+  ['"Payment provider is temporarily unavailable"', 'static provider-unavailable envelope'],
+  [
+    '"Payment provider returned an invalid response; reconciliation may be required"',
+    'static provider-invalid-response envelope',
+  ],
+  [
+    '"Payment provider outcome is unknown and requires reconciliation"',
+    'static reconciliation envelope',
+  ],
+  [
+    '"Payment provider is not configured for this tenant"',
+    'static provider-configuration envelope',
+  ],
+  ['"Payment storage is temporarily unavailable"', 'static storage envelope'],
+  ['HttpError::new(status, code, message)', 'single public envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['Validation(String)', 'owner validation variant'],
+  ['PaymentCollectionNotFound(Uuid)', 'owner collection not-found variant'],
+  ['PaymentNotFound(Uuid)', 'owner payment not-found variant'],
+  ['RefundNotFound(Uuid)', 'owner refund not-found variant'],
+  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  ['ProviderUnavailable {', 'owner provider unavailable variant'],
+  ['ProviderRejected {', 'owner provider rejected variant'],
+  ['ProviderInvalidResponse {', 'owner provider invalid-response variant'],
+  ['ProviderOutcomeUnknown {', 'owner provider unknown-outcome variant'],
+  ['ProviderConfiguration { provider_id: String }', 'owner provider configuration variant'],
+  ['Database(#[from] DbErr)', 'owner database variant'],
+]) requireText(paymentErrors, value, label);
+
+for (const value of [
+  '.map_err(super::map_payment_error)',
+  'error.to_string()',
+  'format!("Payment request is invalid:',
+  'HttpError::bad_request("commerce_admin_payment_invalid", error',
+]) forbidText(showOrder + mapper, value, 'unsafe admin order detail payment mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-detail payment error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order detail retains payment causes internally and returns static public envelopes',
+);

--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -135,12 +135,27 @@ for (const [value, label] of [
   ['get_order_with_locale_fallback(', 'localized order detail'],
   ['find_latest_collection_by_order(tenant.id, id)', 'payment collection detail read'],
   ['find_by_order(tenant.id, id)', 'fulfillment detail read'],
-  ['.map_err(super::map_payment_error)?;', 'typed payment detail mapping'],
-  ['.map_err(super::map_fulfillment_error)?;', 'typed fulfillment detail mapping'],
+  ['fn map_order_detail_payment_error(', 'order-detail payment mapper'],
+  ['fn map_order_detail_fulfillment_error(', 'order-detail fulfillment mapper'],
+  [
+    '.map_err(|error| map_order_detail_payment_error(tenant.id, id, error))?;',
+    'context-aware payment detail mapping',
+  ],
+  [
+    '.map_err(|error| map_order_detail_fulfillment_error(tenant.id, id, error))?;',
+    'context-aware fulfillment detail mapping',
+  ],
   ['page: pagination.page', 'order page forwarding'],
   ['per_page: pagination.limit()', 'order page-size forwarding'],
 ]) {
   requireText(orders, value, label);
+}
+
+for (const value of [
+  '.map_err(super::map_payment_error)?;',
+  '.map_err(super::map_fulfillment_error)?;',
+]) {
+  forbidText(orders, value, 'stale order-detail shared mapper callsite');
 }
 
 for (const [value, label] of [


### PR DESCRIPTION
## Summary

- route the admin order-detail payment collection lookup through a dedicated typed `PaymentError` mapper;
- retain validation, missing-resource, transition, provider, reconciliation, configuration, and database causes internally with owner, tenant, order, operation, error kind, public code, status, and HTTP boundary;
- preserve the existing public status/code/message policy for every `PaymentError` variant and keep the order-detail success response unchanged;
- add a focused payment error-context verifier;
- repair the broad order/fulfillment HTTP verifier so it recognizes the context-aware payment and fulfillment order-detail mappers already present on `main`;
- update the ecommerce public-error safety plan without claiming runtime verification or FBA/FFA promotion.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/orders.rs`
- `scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
- `scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` by 4 commits and is not behind;
- final diff is limited to the four intended files (`+242/-5`);
- the changed handler was re-read to confirm the `orders:read` permission, typed path/result contract, unchanged order and fulfillment paths, exhaustive `PaymentError` mapping, static public envelopes, and structured internal diagnostics;
- the broad verifier was re-read to confirm it no longer expects the stale shared order-detail mapper callsites and still counts the dedicated fulfillment-route mappers separately;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs
node scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```