### PR TITLE
Harden admin fulfillment reconciliation error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -49,6 +49,11 @@ available only for actionable domain errors.
   Validation, missing-resource, transition, and database causes are logged with
   correlation identity and stable codes while the existing public envelopes remain
   static.
+- `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
+  and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
+  truthful optional provider-operation identity, operation, stable code, status, and HTTP
+  boundary. Provider-result encoding failures are internal invariant failures with a
+  static fail-closed `500` envelope instead of dynamic serialization text in a `400`.
 - `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, missing-resource, transition,
@@ -98,6 +103,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
+- `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
@@ -113,8 +119,8 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin order-detail payment and fulfillment mapping, and tax calculation validation,
-  provider-contract, reconciliation, correlation, HTTP-envelope, and transport
-  round-trip tests.
+  admin fulfillment reconciliation, admin order-detail payment and fulfillment mapping,
+  and tax calculation validation, provider-contract, reconciliation, correlation,
+  HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/reconciliation.rs
+++ b/crates/rustok-commerce/src/controllers/reconciliation.rs
@@ -6,13 +6,24 @@ use axum::{
 use chrono::{Duration, Utc};
 use rustok_api::{AuthContext, Permission, TenantContext};
 use rustok_fulfillment::providers::FulfillmentProviderOperationResult;
-use rustok_fulfillment::{FulfillmentProviderOperationRecovery, entities::provider_operation};
+use rustok_fulfillment::{
+    FulfillmentError, FulfillmentProviderOperationRecovery, entities::provider_operation,
+};
 use rustok_web::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::{CommerceHttpRuntime, admin::map_fulfillment_orchestration_error};
-use crate::{FulfillmentCreateLabelRecoveryService, FulfillmentReconciliationService};
+use super::CommerceHttpRuntime;
+use crate::{
+    FulfillmentCreateLabelRecoveryService, FulfillmentOrchestrationError,
+    FulfillmentReconciliationService,
+};
+
+const ADMIN_RECONCILIATION_FULFILLMENT_OWNER: &str =
+    "rustok_fulfillment.admin_reconciliation";
+const ADMIN_RECONCILIATION_ORCHESTRATION_OWNER: &str =
+    "rustok_commerce.fulfillment_reconciliation";
+const ADMIN_RECONCILIATION_BOUNDARY: &str = "commerce_admin_reconciliation_http";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListReconciliationParams {
@@ -63,7 +74,14 @@ async fn list_reconciliation_required(
     let operations = FulfillmentProviderOperationRecovery::new(runtime.db_clone())
         .list_reconciliation_required(tenant.id, params.limit.unwrap_or(100))
         .await
-        .map_err(super::admin::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_reconciliation_fulfillment_error(
+                tenant.id,
+                None,
+                "list_reconciliation_required",
+                error,
+            )
+        })?;
     Ok(Json(operations))
 }
 
@@ -79,7 +97,14 @@ async fn quarantine_stale_executing(
     let quarantined = FulfillmentProviderOperationRecovery::new(runtime.db_clone())
         .quarantine_stale_executing(tenant.id, stale_before, input.limit.unwrap_or(100))
         .await
-        .map_err(super::admin::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_reconciliation_fulfillment_error(
+                tenant.id,
+                None,
+                "quarantine_stale_executing",
+                error,
+            )
+        })?;
     Ok(Json(QuarantineStaleResponse { quarantined }))
 }
 
@@ -94,7 +119,14 @@ async fn resolve_unknown_as_failed(
     let operation = FulfillmentProviderOperationRecovery::new(runtime.db_clone())
         .resolve_unknown_as_failed(tenant.id, operation_id, input.reason)
         .await
-        .map_err(super::admin::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_reconciliation_fulfillment_error(
+                tenant.id,
+                Some(operation_id),
+                "resolve_unknown_as_failed",
+                error,
+            )
+        })?;
     Ok(Json(operation))
 }
 
@@ -108,15 +140,19 @@ async fn resolve_unknown_as_succeeded(
     require_manage_permission(&auth)?;
     let provider_reference = input.provider_result.external_reference.clone();
     let provider_result = serde_json::to_value(input.provider_result).map_err(|error| {
-        HttpError::bad_request(
-            "commerce_admin_invalid",
-            format!("failed to serialize provider result: {error}"),
-        )
+        map_provider_result_encoding_error(tenant.id, operation_id, error)
     })?;
     let operation = FulfillmentProviderOperationRecovery::new(runtime.db_clone())
         .resolve_unknown_as_succeeded(tenant.id, operation_id, provider_reference, provider_result)
         .await
-        .map_err(super::admin::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_reconciliation_fulfillment_error(
+                tenant.id,
+                Some(operation_id),
+                "resolve_unknown_as_succeeded",
+                error,
+            )
+        })?;
     Ok(Json(operation))
 }
 
@@ -130,7 +166,14 @@ async fn retry_local_persistence(
     let fulfillment = FulfillmentReconciliationService::new(runtime.db_clone())
         .retry_local_persistence(tenant.id, operation_id)
         .await
-        .map_err(map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_reconciliation_orchestration_error(
+                tenant.id,
+                Some(operation_id),
+                "retry_local_persistence",
+                error,
+            )
+        })?;
     Ok(Json(fulfillment))
 }
 
@@ -145,8 +188,150 @@ async fn retry_create_label(
         .with_provider_registry(runtime.fulfillment_provider_registry())
         .retry(tenant.id, operation_id)
         .await
-        .map_err(map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_reconciliation_orchestration_error(
+                tenant.id,
+                Some(operation_id),
+                "retry_create_label",
+                error,
+            )
+        })?;
     Ok(Json(fulfillment))
+}
+
+fn map_reconciliation_fulfillment_error(
+    tenant_id: Uuid,
+    provider_operation_id: Option<Uuid>,
+    operation: &'static str,
+    error: FulfillmentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_)
+        | FulfillmentError::FulfillmentNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        FulfillmentError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_RECONCILIATION_FULFILLMENT_OWNER,
+        tenant_id = %tenant_id,
+        provider_operation_id = ?provider_operation_id,
+        operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_RECONCILIATION_BOUNDARY,
+        "commerce admin fulfillment reconciliation owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_reconciliation_orchestration_error(
+    tenant_id: Uuid,
+    provider_operation_id: Option<Uuid>,
+    operation: &'static str,
+    error: FulfillmentOrchestrationError,
+) -> HttpError {
+    match error {
+        FulfillmentOrchestrationError::Fulfillment(error) => map_reconciliation_fulfillment_error(
+            tenant_id,
+            provider_operation_id,
+            operation,
+            error,
+        ),
+        error => {
+            let (status, code, message, error_kind) = match &error {
+                FulfillmentOrchestrationError::OrderNotFound(_) => (
+                    axum::http::StatusCode::NOT_FOUND,
+                    "commerce_admin_not_found",
+                    "Commerce resource not found",
+                    "order_not_found",
+                ),
+                FulfillmentOrchestrationError::Database(_) => (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "commerce_admin_fulfillment_storage_unavailable",
+                    "Fulfillment storage is temporarily unavailable",
+                    "database",
+                ),
+                FulfillmentOrchestrationError::Validation(_) => (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "commerce_admin_fulfillment_invalid",
+                    "Fulfillment request is invalid",
+                    "validation",
+                ),
+                FulfillmentOrchestrationError::ProviderAfterPersistence { .. }
+                | FulfillmentOrchestrationError::PersistenceAfterProvider { .. } => (
+                    axum::http::StatusCode::CONFLICT,
+                    "commerce_admin_fulfillment_reconciliation_required",
+                    "Fulfillment operation requires reconciliation",
+                    "reconciliation_required",
+                ),
+                FulfillmentOrchestrationError::Fulfillment(_) => unreachable!(
+                    "nested fulfillment errors are handled before orchestration mapping"
+                ),
+            };
+            tracing::error!(
+                error = ?error,
+                owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER,
+                tenant_id = %tenant_id,
+                provider_operation_id = ?provider_operation_id,
+                operation,
+                error_kind,
+                public_code = code,
+                status = %status,
+                boundary = ADMIN_RECONCILIATION_BOUNDARY,
+                "commerce admin fulfillment reconciliation orchestration failed"
+            );
+            HttpError::new(status, code, message)
+        }
+    }
+}
+
+fn map_provider_result_encoding_error(
+    tenant_id: Uuid,
+    provider_operation_id: Uuid,
+    error: serde_json::Error,
+) -> HttpError {
+    let status = axum::http::StatusCode::INTERNAL_SERVER_ERROR;
+    let code = "commerce_admin_fulfillment_reconciliation_encoding_failed";
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER,
+        tenant_id = %tenant_id,
+        provider_operation_id = %provider_operation_id,
+        operation = "resolve_unknown_as_succeeded",
+        error_kind = "encoding",
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_RECONCILIATION_BOUNDARY,
+        "commerce admin fulfillment reconciliation provider result encoding failed"
+    );
+    HttpError::new(
+        status,
+        code,
+        "Fulfillment reconciliation result could not be processed safely",
+    )
 }
 
 fn require_manage_permission(auth: &AuthContext) -> HttpResult<()> {

--- a/scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-commerce/src/controllers/reconciliation.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const orchestrationErrors = read(
+  'crates/rustok-commerce/src/services/fulfillment_orchestration.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const ownerMapper = between(
+  source,
+  'fn map_reconciliation_fulfillment_error(',
+  'fn map_reconciliation_orchestration_error(',
+  'reconciliation fulfillment mapper',
+);
+const orchestrationMapper = between(
+  source,
+  'fn map_reconciliation_orchestration_error(',
+  'fn map_provider_result_encoding_error(',
+  'reconciliation orchestration mapper',
+);
+const encodingMapper = between(
+  source,
+  'fn map_provider_result_encoding_error(',
+  'fn require_manage_permission(',
+  'provider result encoding mapper',
+);
+
+for (const [value, label] of [
+  ['FulfillmentError, FulfillmentProviderOperationRecovery', 'typed fulfillment error import'],
+  ['FulfillmentOrchestrationError,', 'typed orchestration error import'],
+  [
+    'const ADMIN_RECONCILIATION_FULFILLMENT_OWNER: &str =',
+    'fulfillment owner constant',
+  ],
+  [
+    'const ADMIN_RECONCILIATION_ORCHESTRATION_OWNER: &str =',
+    'orchestration owner constant',
+  ],
+  [
+    'const ADMIN_RECONCILIATION_BOUNDARY: &str = "commerce_admin_reconciliation_http";',
+    'HTTP boundary constant',
+  ],
+  ['[Permission::FULFILLMENTS_MANAGE]', 'manage permission'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['"list_reconciliation_required"', 'list operation context'],
+  ['"quarantine_stale_executing"', 'quarantine operation context'],
+  ['"resolve_unknown_as_failed"', 'resolve-failed operation context'],
+  ['"resolve_unknown_as_succeeded"', 'resolve-succeeded operation context'],
+  ['"retry_local_persistence"', 'retry-local operation context'],
+  ['"retry_create_label"', 'retry-label operation context'],
+  ['Some(operation_id)', 'truthful provider operation identity'],
+  ['map_reconciliation_fulfillment_error(', 'owner mapper handoff'],
+  ['map_reconciliation_orchestration_error(', 'orchestration mapper handoff'],
+  ['map_provider_result_encoding_error(tenant.id, operation_id, error)', 'encoding mapper handoff'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
+  ['FulfillmentError::Database(_)', 'database variant'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_RECONCILIATION_FULFILLMENT_OWNER', 'owner log'],
+  ['tenant_id = %tenant_id', 'tenant log'],
+  ['provider_operation_id = ?provider_operation_id', 'optional operation identity log'],
+  ['operation,', 'owner operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_RECONCILIATION_BOUNDARY', 'boundary log'],
+  ['"Fulfillment request is invalid"', 'static validation envelope'],
+  ['"Commerce resource not found"', 'static not-found envelope'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static conflict envelope',
+  ],
+  ['"Fulfillment storage is temporarily unavailable"', 'static storage envelope'],
+  ['HttpError::new(status, code, message)', 'single owner envelope constructor'],
+]) requireText(ownerMapper, value, label);
+
+for (const [value, label] of [
+  ['FulfillmentOrchestrationError::Fulfillment(error)', 'nested owner delegation'],
+  ['FulfillmentOrchestrationError::OrderNotFound(_)', 'order-not-found variant'],
+  ['FulfillmentOrchestrationError::Database(_)', 'database variant'],
+  ['FulfillmentOrchestrationError::Validation(_)', 'validation variant'],
+  [
+    'FulfillmentOrchestrationError::ProviderAfterPersistence { .. }',
+    'provider-after-persistence variant',
+  ],
+  [
+    'FulfillmentOrchestrationError::PersistenceAfterProvider { .. }',
+    'persistence-after-provider variant',
+  ],
+  ['owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER', 'orchestration owner log'],
+  ['provider_operation_id = ?provider_operation_id', 'orchestration operation identity log'],
+  ['"Fulfillment operation requires reconciliation"', 'static reconciliation envelope'],
+  ['HttpError::new(status, code, message)', 'single orchestration envelope constructor'],
+]) requireText(orchestrationMapper, value, label);
+
+for (const [value, label] of [
+  ['axum::http::StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed encoding status'],
+  [
+    '"commerce_admin_fulfillment_reconciliation_encoding_failed"',
+    'stable encoding code',
+  ],
+  ['error = ?error', 'encoding cause log'],
+  ['tenant_id = %tenant_id', 'encoding tenant log'],
+  ['provider_operation_id = %provider_operation_id', 'encoding operation identity log'],
+  ['operation = "resolve_unknown_as_succeeded"', 'encoding operation log'],
+  ['error_kind = "encoding"', 'encoding kind log'],
+  [
+    '"Fulfillment reconciliation result could not be processed safely"',
+    'static fail-closed encoding envelope',
+  ],
+]) requireText(encodingMapper, value, label);
+
+for (const [ownerSource, value, label] of [
+  [fulfillmentErrors, 'Validation(String)', 'owner validation variant'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
+  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  [fulfillmentErrors, 'Database(#[from] DbErr)', 'owner database variant'],
+  [orchestrationErrors, 'OrderNotFound(Uuid)', 'orchestration order-not-found variant'],
+  [orchestrationErrors, 'Database(#[from] sea_orm::DbErr)', 'orchestration database variant'],
+  [orchestrationErrors, 'Fulfillment(#[from] rustok_fulfillment::error::FulfillmentError)', 'orchestration fulfillment variant'],
+  [orchestrationErrors, 'Validation(String)', 'orchestration validation variant'],
+  [orchestrationErrors, 'ProviderAfterPersistence {', 'provider-after-persistence variant'],
+  [orchestrationErrors, 'PersistenceAfterProvider {', 'persistence-after-provider variant'],
+]) requireText(ownerSource, value, label);
+
+for (const value of [
+  'super::admin::map_fulfillment_error',
+  'map_fulfillment_orchestration_error',
+  'format!("failed to serialize provider result:',
+  'HttpError::bad_request(',
+  'error.to_string()',
+]) forbidText(source, value, 'unsafe reconciliation public mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce admin fulfillment reconciliation error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin fulfillment reconciliation retains typed causes and returns static public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace shared admin fulfillment error mappers in the fulfillment reconciliation controller with local context-aware typed mappers;
- retain owner/orchestration causes internally with tenant, truthful optional provider-operation identity, operation, error kind, public code, status, and HTTP boundary;
- keep validation, not-found, transition, storage, and reconciliation responses static;
- change provider-result serialization failure from a dynamic `400` response to a fail-closed static `500` invariant envelope with a dedicated code;
- preserve all routes, permissions, service calls, and successful response contracts;
- add a focused static verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/reconciliation.rs`
- `scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` by 3 commits and is not behind;
- final diff is limited to the three intended files (`+384/-16`);
- the controller was re-read in full to confirm all six existing routes, the `fulfillments:manage` permission, unchanged service calls and success envelopes, truthful optional provider-operation identity, exhaustive typed error handling, and static public messages;
- repository search found no existing verifier that requires the removed shared reconciliation mapper callsites;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs
cargo check -p rustok-commerce --lib
```