### PR TITLE
fix(index): harden comparator output lifecycle

### DIFF
--- a/scripts/verify/compare-index-storage-evidence.mjs
+++ b/scripts/verify/compare-index-storage-evidence.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs';
 import {
@@ -10,17 +20,25 @@ import {
 } from './index-storage-database-settings-contract.mjs';
 
 const prefix = '[compare-index-storage-evidence]';
+const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
 
 const preflightArgs = (args) => {
   const inputs = [];
   let output = 'evidence/index-storage/comparison';
+  let outputProvided = false;
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
-    if (argument === '--help' || argument === '-h') return null;
+    if (argument === '--help' || argument === '-h') {
+      if (args.length !== 1) throw new Error('help must be the only argument');
+      return null;
+    }
     if (argument === '--input' && args[index + 1] && !args[index + 1].startsWith('--')) {
       inputs.push(args[++index]);
     } else if (argument === '--output' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (outputProvided) throw new Error('--output was provided more than once');
       output = args[++index];
+      outputProvided = true;
     } else {
       return null;
     }
@@ -90,18 +108,83 @@ const finalizeDatabaseSettingsContract = ({ inputs, output }) => {
   writeFileSync(markdownPath, lines.join('\n'));
 };
 
-const main = async () => {
-  const parsed = preflightArgs(process.argv.slice(2));
-  if (parsed !== null) {
-    for (const input of parsed.inputs) validatePacketReadOrdering(input);
-  }
-  await import('./compare-index-storage-evidence-core.mjs');
-  if (parsed !== null) finalizeDatabaseSettingsContract(parsed);
+const forwardOutput = (stream, value) => {
+  if (typeof value === 'string' && value.length !== 0) stream.write(value);
 };
 
-try {
-  await main();
-} catch (error) {
-  console.error(`${prefix} ${error.message}`);
-  process.exitCode = 1;
+const runCore = ({ args, spawn = spawnSync, stdout = process.stdout, stderr = process.stderr }) => {
+  const result = spawn(process.execPath, [corePath, ...args], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  forwardOutput(stdout, result.stdout);
+  forwardOutput(stderr, result.stderr);
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`comparator core terminated by signal ${result.signal}`);
+  return result.status ?? 1;
+};
+
+export const runComparatorCoreWithAtomicComparison = ({
+  inputs,
+  output,
+  spawn = spawnSync,
+  finalizeComparison = finalizeDatabaseSettingsContract,
+  stdout = process.stdout,
+  stderr = process.stderr,
+}) => {
+  const outputJson = path.join(output, 'comparison.json');
+  const outputMarkdown = path.join(output, 'comparison.md');
+  rmSync(outputJson, { force: true });
+  mkdirSync(output, { recursive: true });
+  const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'));
+  let published = false;
+  try {
+    const args = inputs.flatMap((input) => ['--input', input]);
+    args.push('--output', stagingRoot);
+    const status = runCore({ args, spawn, stdout, stderr });
+    if (status !== 0) return status;
+
+    finalizeComparison({ inputs, output: stagingRoot });
+    const stagedJson = path.join(stagingRoot, 'comparison.json');
+    const stagedMarkdown = path.join(stagingRoot, 'comparison.md');
+    if (!existsSync(stagedJson) || !existsSync(stagedMarkdown)) {
+      throw new Error('comparator core exited successfully without complete comparison outputs');
+    }
+
+    renameSync(stagedMarkdown, outputMarkdown);
+    renameSync(stagedJson, outputJson);
+    published = true;
+    return 0;
+  } finally {
+    try {
+      rmSync(stagingRoot, { recursive: true, force: true });
+    } catch (error) {
+      if (!published) throw error;
+      forwardOutput(stderr, `${prefix} unable to remove staging directory: ${error.message}\n`);
+    }
+  }
+};
+
+const main = () => {
+  const args = process.argv.slice(2);
+  const parsed = preflightArgs(args);
+  if (parsed === null) {
+    const status = runCore({ args });
+    if (status !== 0) process.exitCode = status;
+    return;
+  }
+
+  rmSync(path.join(parsed.output, 'comparison.json'), { force: true });
+  for (const input of parsed.inputs) validatePacketReadOrdering(input);
+  const status = runComparatorCoreWithAtomicComparison(parsed);
+  if (status !== 0) process.exitCode = status;
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptPath)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`${prefix} ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/verify/index-storage-standalone-tools.test.mjs
+++ b/scripts/verify/index-storage-standalone-tools.test.mjs
@@ -2,10 +2,20 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
+
+import { runComparatorCoreWithAtomicComparison } from './compare-index-storage-evidence.mjs';
 
 const validator = path.resolve('scripts/verify/validate-index-storage-evidence.mjs');
 const comparator = path.resolve('scripts/verify/compare-index-storage-evidence.mjs');
@@ -85,6 +95,14 @@ const runValidator = (root) => spawnSync(process.execPath, [validator], {
 const runComparator = (...args) => spawnSync(process.execPath, [comparator, ...args], {
   encoding: 'utf8',
 });
+const quietStream = { write: () => true };
+const stagingEntries = (output) => readdirSync(output)
+  .filter((entry) => entry.startsWith('.comparison-staging-'));
+const stagedOutputFrom = (args) => {
+  const outputIndex = args.lastIndexOf('--output');
+  assert.notEqual(outputIndex, -1);
+  return args[outputIndex + 1];
+};
 
 const missingMutation = /missing evidence file: .*mutation-report\.json/u;
 
@@ -103,7 +121,7 @@ test('direct validator rejects non-executable terminal ordering before its core'
   });
 });
 
-test('direct comparator rejects nested-only terminal ordering before its core', () => {
+test('direct comparator revokes stale comparison before ordering preflight', () => {
   withPacket((value) => {
     value.prototypes[0].workloads[4].sql = [
       'SELECT entity_id, price_minor FROM (',
@@ -112,11 +130,16 @@ test('direct comparator rejects nested-only terminal ordering before its core', 
       ') nested_page LIMIT 100',
     ].join('\n');
   }, (root) => {
-    const result = runComparator('--input', root, '--output', path.join(root, 'comparison'));
+    const output = path.join(root, 'comparison');
+    mkdirSync(output);
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+
+    const result = runComparator('--input', root, '--output', output);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /\[compare-index-storage-evidence\]/u);
     assert.match(result.stderr, /must end with canonical ordering marker/u);
     assert.doesNotMatch(result.stderr, missingMutation);
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
   });
 });
 
@@ -133,4 +156,120 @@ test('direct comparator forwards help to the byte-preserved core', () => {
   const result = runComparator('--help');
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /compare-index-storage-evidence\.mjs --input <dir>/u);
+});
+
+test('direct comparator rejects help combined with other arguments', () => {
+  const result = runComparator('--help', '--output', 'comparison');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /help must be the only argument/u);
+  assert.equal(result.stdout, '');
+});
+
+test('direct comparator rejects duplicate output before its core', () => {
+  const result = runComparator(
+    '--input', 'missing-evidence',
+    '--output', 'first-comparison',
+    '--output', 'second-comparison',
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--output was provided more than once/u);
+  assert.doesNotMatch(result.stderr, /missing evidence file/u);
+});
+
+test('comparator publishes finalized JSON last and removes staging', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-comparator-publish-'));
+  const output = path.join(root, 'comparison');
+  try {
+    mkdirSync(output);
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    writeFileSync(path.join(output, 'comparison.md'), 'stale markdown\n', 'utf8');
+
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"core":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'core markdown\n', 'utf8');
+      return { status: 0, stdout: '', stderr: '' };
+    };
+    const finalizeComparison = ({ output: staged }) => {
+      writeFileSync(path.join(staged, 'comparison.json'), '{"finalized":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'finalized markdown\n', 'utf8');
+    };
+
+    const status = runComparatorCoreWithAtomicComparison({
+      inputs: ['packet-100k', 'packet-1m'],
+      output,
+      spawn,
+      finalizeComparison,
+      stdout: quietStream,
+      stderr: quietStream,
+    });
+
+    assert.equal(status, 0);
+    assert.equal(readFileSync(path.join(output, 'comparison.json'), 'utf8'), '{"finalized":true}\n');
+    assert.equal(readFileSync(path.join(output, 'comparison.md'), 'utf8'), 'finalized markdown\n');
+    assert.deepEqual(stagingEntries(output), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('comparator core failure cannot publish a partial decision input', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-comparator-core-failure-'));
+  const output = path.join(root, 'comparison');
+  try {
+    mkdirSync(output);
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"partial":', 'utf8');
+      return { status: 1, stdout: '', stderr: 'core failed\n' };
+    };
+
+    const status = runComparatorCoreWithAtomicComparison({
+      inputs: ['packet-100k', 'packet-1m'],
+      output,
+      spawn,
+      stdout: quietStream,
+      stderr: quietStream,
+    });
+
+    assert.equal(status, 1);
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
+    assert.deepEqual(stagingEntries(output), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('comparison post-processing failure leaves no decision input', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-comparator-finalize-failure-'));
+  const output = path.join(root, 'comparison');
+  try {
+    mkdirSync(output);
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"core":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'core markdown\n', 'utf8');
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    assert.throws(
+      () => runComparatorCoreWithAtomicComparison({
+        inputs: ['packet-100k', 'packet-1m'],
+        output,
+        spawn,
+        finalizeComparison: () => {
+          throw new Error('methodology finalization failed');
+        },
+        stdout: quietStream,
+        stderr: quietStream,
+      }),
+      /methodology finalization failed/u,
+    );
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
+    assert.deepEqual(stagingEntries(output), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/verify/verify-index-storage-standalone-tools.mjs
+++ b/scripts/verify/verify-index-storage-standalone-tools.mjs
@@ -25,6 +25,7 @@ const validator = readText(validatorPath);
 const validatorCoreBytes = readBytes(validatorCorePath);
 const comparator = readText(comparatorPath);
 const comparatorCoreBytes = readBytes(comparatorCorePath);
+const standaloneFixture = readText('scripts/verify/index-storage-standalone-tools.test.mjs');
 const sourceOracleGuard = readText('scripts/verify/verify-index-storage-source-oracle.mjs');
 
 for (const [label, actual, expected] of [
@@ -59,17 +60,64 @@ if (validatorPreflight < 0 || validatorCore < 0 || validatorPreflight > validato
 
 requireMarkers(comparator, 'comparator wrapper', [
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-  "if (argument === '--help' || argument === '-h') return null",
+  "import { spawnSync } from 'node:child_process'",
+  "const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url))",
+  "if (argument === '--help' || argument === '-h')",
+  "if (args.length !== 1) throw new Error('help must be the only argument')",
+  'let outputProvided = false;',
+  "if (outputProvided) throw new Error('--output was provided more than once')",
   "argument === '--input'",
   "argument === '--output'",
-  'for (const input of inputs) validatePacketReadOrdering(input);',
-  "await import('./compare-index-storage-evidence-core.mjs')",
+  "rmSync(path.join(parsed.output, 'comparison.json'), { force: true });",
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
+  'export const runComparatorCoreWithAtomicComparison = ({',
+  "const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'));",
+  'spawn(process.execPath, [corePath, ...args]',
+  'finalizeComparison({ inputs, output: stagingRoot });',
+  'renameSync(stagedMarkdown, outputMarkdown);',
+  'renameSync(stagedJson, outputJson);',
+  'rmSync(stagingRoot, { recursive: true, force: true });',
+  'const status = runComparatorCoreWithAtomicComparison(parsed);',
 ]);
-const comparatorPreflight = comparator.indexOf('for (const input of inputs) validatePacketReadOrdering(input);');
-const comparatorCore = comparator.indexOf("await import('./compare-index-storage-evidence-core.mjs')");
-if (comparatorPreflight < 0 || comparatorCore < 0 || comparatorPreflight > comparatorCore) {
-  fail('comparator wrapper must preflight every input before importing its core');
+const comparatorHelpGate = comparator.indexOf(
+  "if (args.length !== 1) throw new Error('help must be the only argument')",
+);
+const comparatorOutputGate = comparator.indexOf(
+  "if (outputProvided) throw new Error('--output was provided more than once')",
+);
+const comparatorRevoke = comparator.indexOf(
+  "rmSync(path.join(parsed.output, 'comparison.json'), { force: true });",
+);
+const comparatorPreflight = comparator.indexOf(
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
+);
+const comparatorAtomicRun = comparator.indexOf('const status = runComparatorCoreWithAtomicComparison(parsed);');
+if (comparatorRevoke < 0
+    || comparatorPreflight < 0
+    || comparatorAtomicRun < 0
+    || comparatorRevoke > comparatorPreflight
+    || comparatorPreflight > comparatorAtomicRun) {
+  fail('comparator wrapper must revoke stale comparison before preflight and stage core output afterward');
 }
+if (comparatorHelpGate < 0
+    || comparatorOutputGate < 0
+    || comparatorHelpGate > comparatorRevoke
+    || comparatorOutputGate > comparatorRevoke) {
+  fail('comparator wrapper must reject ambiguous control arguments before changing output state');
+}
+const markdownPublish = comparator.indexOf('renameSync(stagedMarkdown, outputMarkdown);');
+const jsonPublish = comparator.indexOf('renameSync(stagedJson, outputJson);');
+if (markdownPublish < 0 || jsonPublish < 0 || markdownPublish > jsonPublish) {
+  fail('comparator wrapper must publish comparison.json last as the decision-input success marker');
+}
+
+requireMarkers(standaloneFixture, 'standalone evidence fixture', [
+  "test('direct comparator revokes stale comparison before ordering preflight'",
+  "test('comparator publishes finalized JSON last and removes staging'",
+  "test('comparator core failure cannot publish a partial decision input'",
+  "test('comparison post-processing failure leaves no decision input'",
+  'assert.deepEqual(stagingEntries(output), [])',
+]);
 
 requireMarkers(sourceOracleGuard, 'source-oracle guard', [
   "read('scripts/verify/validate-index-storage-evidence-core.mjs')",
@@ -91,7 +139,7 @@ forbidMarkers(comparator, 'comparator wrapper', [
   'const resultDigestContract =',
   'shell: true',
   'execSync(',
-  'spawnSync(',
+  "await import('./compare-index-storage-evidence-core.mjs')",
 ]);
 
-console.log('[verify-index-storage-standalone-tools] direct validator and comparator enforce executable SQL ordering before byte-preserved core execution');
+console.log('[verify-index-storage-standalone-tools] validator ordering and comparator argument, staging, cleanup, and JSON-last publication contracts are cross-guarded');


### PR DESCRIPTION
## What changed

- retain strict comparator help-only and duplicate-output argument gates;
- revoke an existing `comparison.json` before a real comparison preflight starts;
- run the byte-preserved comparator core in a child process against a private staging directory;
- apply the observed PostgreSQL methodology post-processing only inside staging;
- publish `comparison.md` first and `comparison.json` last, making JSON the decision-input success marker;
- remove staging after success, core failure, signal termination, spawn failure, missing output, or methodology finalization failure;
- add focused regressions for stale-marker revocation, successful JSON-last publication, partial core output, and post-processing failure;
- cross-guard child-process isolation, cleanup, revocation ordering, and JSON-last publication.

## Root cause

The comparator core wrote `comparison.json` and `comparison.md` directly into the published output directory. The wrapper then reopened and rewrote both files to add the observed PostgreSQL settings methodology. A core interruption or wrapper failure between those writes could therefore expose a partial, stale, or not-yet-finalized `comparison.json` to decision preparation.

The core intentionally uses `process.exit(...)` for fail-fast validation, so same-process cleanup cannot reliably contain partial output. The wrapper now isolates the core in a child process and gives it a private output directory on the same filesystem as the final comparison.

## Impact

Argument failures do not change comparison state. A real comparison attempt first removes the old decision-input marker, performs packet ordering preflight, and generates all core and methodology output in staging. `comparison.json` becomes visible only after the finalized Markdown is published and every decision contract check has succeeded. Core or post-processing failure leaves no decision-input JSON and no staging residue.

The byte-preserved comparator core remains unchanged. This does not create replacement benchmark evidence, choose a PostgreSQL model, or advance M2 beyond same-commit 100k/1m evidence, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch was reduced to one commit on the current `main`; static review covered child-process status handling, output revocation, staging cleanup, methodology-before-publication ordering, JSON-last semantics, and preservation of the comparator core bytes.