### PR TITLE
feat(forum): resolve mention audiences for recipients

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-recipient-context.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-context.json
@@ -1,20 +1,22 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "task": "FORUM-20L",
   "upstream_task": "FORUM-20K",
   "downstream_task": "FORUM-20M",
   "consumer_task": "FORUM-20N",
-  "scope": "Forum-owned exact recipient principal context capability for deferred notification authorization",
+  "downstream_consumer_task": "FORUM-20O",
+  "scope": "Forum-owned exact recipient principal context capability for deferred notification target-open and user-mention authorization",
   "owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
   "consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
+  "downstream_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-context.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20N",
+    "required_ledger_through": "FORUM-20O",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -22,7 +24,8 @@
       "FORUM-20K",
       "FORUM-20L",
       "FORUM-20M",
-      "FORUM-20N"
+      "FORUM-20N",
+      "FORUM-20O"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -34,7 +37,7 @@
     "returned_context": "tenant and actor must match the request and retain read deadline semantics",
     "authority": "SecurityContext is reconstructed only from validated role and permission claims",
     "topic_viewer": "validated authority converts through ForumTopicAudienceViewer::authenticated",
-    "provider_absence": "typed capability unavailable error at the resolver boundary; notification target-open keeps a public-only fail-closed fallback when the host capability is absent",
+    "provider_absence": "typed capability unavailable error at the resolver boundary; notification consumers keep public-only fail-closed fallbacks when the host capability is absent",
     "provider_failure": "stable source code and retryability preserved without leaking internals",
     "storage_access": "none; Forum does not read auth, profile, channel or group owner tables directly"
   },
@@ -54,10 +57,14 @@
     "host_adapter_implementation": true,
     "host_runtime_publication": true,
     "notification_source_factory_consumption": true,
-    "recipient_target_open_authorization": true
+    "recipient_target_open_authorization": true,
+    "recipient_mention_description_authorization": true,
+    "recipient_mention_audience_authorization": true,
+    "shared_consumer_resolution_helper": true
   },
   "not_delivered": [
-    "recipient-specific audience filtering for non-public topics before pagination",
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
     "final notification creation and delivery authorization",
@@ -69,9 +76,11 @@
       "cargo test -p rustok-forum notification_recipient -- --nocapture",
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
@@ -1,20 +1,22 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "task": "FORUM-20M",
   "upstream_task": "FORUM-20L",
   "downstream_task": "FORUM-20N",
-  "scope": "Server-owned exact notification recipient principal adapter, host runtime publication and notification target-open consumption",
+  "consumer_task": "FORUM-20O",
+  "scope": "Server-owned exact notification recipient principal adapter, host runtime publication and notification target-open plus user-mention consumption",
   "adapter_file": "apps/server/src/services/forum_notification_recipient_context.rs",
   "services_file": "apps/server/src/services/mod.rs",
   "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-context.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
+  "consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20N",
+    "required_ledger_through": "FORUM-20O",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -22,7 +24,8 @@
       "FORUM-20K",
       "FORUM-20L",
       "FORUM-20M",
-      "FORUM-20N"
+      "FORUM-20N",
+      "FORUM-20O"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -36,7 +39,7 @@
     "permission_bound": 512,
     "dependency_failure": "typed retryable unavailable PortError without internal database details",
     "storage_access": "server identity and RBAC owners only; no Forum profile channel group or audience relation tables",
-    "consumer": "Forum notification source factory reads the exact shared port before recipient-specific target-open authorization"
+    "consumer": "Forum notification source factory reads the exact shared port before recipient-specific target-open, mention description and mention audience authorization"
   },
   "composition": {
     "server_adapter": true,
@@ -52,10 +55,13 @@
     "feature_guarded_server_module": true,
     "inline_contract_tests": true,
     "notification_source_factory_consumption": true,
-    "recipient_target_open_authorization": true
+    "recipient_target_open_authorization": true,
+    "recipient_mention_description_authorization": true,
+    "recipient_mention_audience_authorization": true
   },
   "not_delivered": [
-    "recipient-specific audience filtering for non-public topics before pagination",
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
     "final notification creation and delivery authorization",
@@ -66,9 +72,11 @@
     "commands": [
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20O",
+  "upstream_task": "FORUM-20N",
+  "scope": "Exact recipient-specific Forum user-mention description and audience composition for topic and reply targets",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
+  "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
+  "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
+  "source_verifier": "scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20O",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "mention_recipient": "the exact mentioned user from the persisted relation event",
+    "description": "when recipient context is published, describe a topic or reply mention only if the exact mentioned recipient can view the current target",
+    "audience": "re-resolve the exact mentioned recipient and current target before returning the single-recipient audience",
+    "capability_absence": "preserve the existing public-only fail-closed mention path when the host recipient-context capability is absent",
+    "recipient_unavailable": "non-retryable recipient capability failure returns no descriptor or an empty audience without an existence oracle",
+    "authenticated_visibility": "compose exact base topic visibility and normalized inherited category/topic audience layers for the validated mentioned recipient",
+    "local_selectors": "role and explicit-user allow or deny constraints resolve without host facts adapters",
+    "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
+    "reply_target": "reply must be active and approved and its topic must be visible to the same mentioned recipient",
+    "topic_created_boundary": "topic-created description and subscription audience remain public-only in this slice",
+    "stale_descriptor": "audience resolution rechecks the current target policy for the exact mentioned recipient"
+  },
+  "composition": {
+    "shared_recipient_resolution_helper": true,
+    "bounded_mention_description_context": true,
+    "bounded_mention_audience_context": true,
+    "exact_mention_recipient_resolution": true,
+    "authenticated_topic_viewer": true,
+    "recipient_specific_mention_description": true,
+    "recipient_specific_mention_audience": true,
+    "topic_mention_target": true,
+    "reply_mention_target": true,
+    "public_only_fallback": true,
+    "unavailable_recipient_fail_closed": true,
+    "retryability_preserved": true,
+    "stale_descriptor_recheck": true,
+    "topic_created_paths_unchanged": true,
+    "sqlite_contract_test": true
+  },
+  "not_delivered": [
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
+    "profile privacy and blocking policy",
+    "host trust channel and group facts adapters",
+    "final notification creation and delivery authorization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
@@ -1,19 +1,22 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20N",
   "upstream_task": "FORUM-20M",
-  "scope": "Forum notification source factory consumption of exact recipient context for topic and reply target-open authorization",
+  "downstream_task": "FORUM-20O",
+  "scope": "Forum notification source factory consumption of exact recipient context for target-open and user-mention notification authorization",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
   "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
   "test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
+  "downstream_test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-target-open.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20N",
+    "required_ledger_through": "FORUM-20O",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -21,22 +24,24 @@
       "FORUM-20K",
       "FORUM-20L",
       "FORUM-20M",
-      "FORUM-20N"
+      "FORUM-20N",
+      "FORUM-20O"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
     "factory": "consume optional SharedForumNotificationRecipientContextPort and SharedForumAudienceFactsPort from HostRuntimeContext",
-    "capability_absence": "preserve the existing public-only fail-closed target-open path",
+    "capability_absence": "preserve the existing public-only fail-closed target-open and mention paths",
     "recipient_lookup": "bounded service PortContext for the exact tenant and notification recipient",
-    "recipient_unavailable": "non-retryable recipient capability failure resolves to target unavailable without an existence oracle",
+    "recipient_unavailable": "non-retryable recipient capability failure resolves to no descriptor, an empty audience or an unavailable target without an existence oracle",
     "authenticated_visibility": "compose exact base topic visibility and normalized inherited category/topic audience layers for the validated recipient",
-    "local_selectors": "role and explicit-user allow/deny constraints resolve without host facts adapters",
+    "local_selectors": "role and explicit-user allow or deny constraints resolve without host facts adapters",
     "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
     "reply_target": "reply must be active and approved and its owner topic must be visible to the same recipient",
-    "public_surfaces": "describe_event and resolve_audience remain public-only and unchanged",
-    "channel_context": "target-open has no route channel slug and therefore retains the existing channel-deny semantics"
+    "topic_created_surfaces": "topic-created description and subscription audience remain public-only",
+    "mention_surfaces": "FORUM-20O reuses exact recipient resolution for topic and reply mention description and audience",
+    "channel_context": "notification operations have no route channel slug and therefore retain the existing channel-deny semantics"
   },
   "composition": {
     "factory_recipient_capability_lookup": true,
@@ -49,12 +54,17 @@
     "public_only_fallback": true,
     "inactive_or_missing_recipient_fail_closed": true,
     "retryability_preserved": true,
-    "public_description_unchanged": true,
-    "public_audience_unchanged": true,
-    "sqlite_contract_test": true
+    "topic_created_public_description_unchanged": true,
+    "topic_created_public_audience_unchanged": true,
+    "recipient_specific_mention_description": true,
+    "recipient_specific_mention_audience": true,
+    "shared_recipient_resolution_helper": true,
+    "sqlite_contract_test": true,
+    "downstream_sqlite_contract_test": true
   },
   "not_delivered": [
-    "recipient-specific audience filtering for non-public topics before pagination",
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters",
     "final notification creation and delivery authorization",
@@ -64,12 +74,12 @@
   "verification": {
     "commands": [
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
-      "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
-      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,22 +1,24 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "task": "FORUM-20K",
   "supersedes_task": "FORUM-20I",
-  "downstream_task": "FORUM-20N",
-  "scope": "Forum notification source composition through exact richer public and recipient-specific target-open visibility owners",
+  "downstream_task": "FORUM-20O",
+  "scope": "Forum notification source composition through exact richer public, recipient target-open and recipient mention visibility owners",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
   "visibility_contract": "crates/rustok-forum/contracts/forum-topic-audience-visibility.json",
   "recipient_target_open_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
+  "recipient_mention_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
   "baseline_test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
   "test_file": "crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs",
   "recipient_test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
+  "recipient_mention_test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20N",
+    "required_ledger_through": "FORUM-20O",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -24,18 +26,20 @@
       "FORUM-20K",
       "FORUM-20L",
       "FORUM-20M",
-      "FORUM-20N"
+      "FORUM-20N",
+      "FORUM-20O"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
-    "description_and_audience_viewer": "public unauthenticated without route-channel context",
+    "topic_created_description_and_audience_viewer": "public unauthenticated without route-channel context",
+    "mention_description_and_audience_viewer": "exact mentioned recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "target_open_viewer": "exact validated recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "evaluation_order": "exact open route-channel and category floor owner then normalized root-to-category audience layers then optional topic layer",
     "public_facts_provider": "never consulted because public evaluation does not call authenticated owner facts capabilities",
     "authenticated_facts_provider": "optional host capability; local role and explicit user selectors resolve without it while fact-dependent selectors preserve capability retryability",
-    "non_public_richer_layers": "unavailable before notification descriptor or audience materialization; target-open authorization re-evaluates them for the exact recipient",
+    "non_public_richer_layers": "exact user mentions and target-open authorization re-evaluate them for one recipient; topic-created descriptor and subscription pagination remain public-only",
     "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",
     "reply_state": "pending deferred; approved eligible; all other states unavailable",
     "owner_failures": "preserve Forum retryability classification"
@@ -53,10 +57,14 @@
     "duplicate_notification_visibility_predicate_removed": true,
     "recipient_context_factory_consumption": true,
     "recipient_specific_target_open": true,
-    "public_only_description_and_audience": true
+    "topic_created_public_description_and_audience": true,
+    "recipient_specific_mention_description": true,
+    "recipient_specific_mention_audience": true,
+    "shared_recipient_resolution_helper": true
   },
   "not_delivered": [
-    "recipient-specific authenticated audience filtering before notification pagination",
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters for authenticated consumers",
     "search index SEO and deep-link migration",
@@ -68,8 +76,10 @@
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
@@ -1,8 +1,9 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "task": "FORUM-20J",
   "downstream_notification_task": "FORUM-20K",
-  "scope": "Exact topic visibility composition through current open/channel/category-floor policy and normalized category/topic audience layers",
+  "notification_consumer_task": "FORUM-20O",
+  "scope": "Exact topic visibility composition through current open, channel, category-floor and normalized category/topic audience layers",
   "owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner": "crates/rustok-forum/src/services/topic_visibility.rs",
   "category_policy_owner": "crates/rustok-forum/src/services/category_audience.rs",
@@ -12,17 +13,22 @@
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "notification_visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "notification_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
   "test_file": "crates/rustok-forum/tests/topic_audience_visibility_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-topic-audience-visibility.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20K",
+    "required_ledger_through": "FORUM-20O",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
       "FORUM-20J",
-      "FORUM-20K"
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -48,7 +54,10 @@
     "normalized_topic_layer": true,
     "role_and_explicit_user": true,
     "trust_channel_group_owner_facts": true,
-    "public_notification_source": true,
+    "public_topic_created_notification": true,
+    "recipient_target_open_notification": true,
+    "recipient_mention_description_notification": true,
+    "recipient_mention_audience_notification": true,
     "topic_and_reply_pages": false,
     "category_and_reply_exact_reads": false,
     "write_audiences": false,
@@ -60,7 +69,8 @@
     "create reply and moderate audience write policy",
     "host trust channel and group provider adapters",
     "visibility-scoped category and all-read mutations",
-    "recipient-specific notification authorization for non-public audiences",
+    "recipient-specific topic-created subscription filtering before pagination",
+    "initially non-public topic-created descriptor materialization",
     "search index SEO and deep-link migration to the richer exact owner",
     "PostgreSQL concurrency and cross-consumer runtime evidence"
   ],
@@ -68,7 +78,11 @@
     "commands": [
       "cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-topic-audience-visibility.mjs",
+      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -37,8 +37,10 @@ const TOPIC_CREATED_TYPE: &str = "forum.topic.created";
 const USER_MENTION_ADDED_TYPE: &str = "forum.mention.user_added";
 const FORUM_TOPIC_TARGET: &str = "forum.topic";
 const FORUM_REPLY_TARGET: &str = "forum.reply";
+const MENTION_DESCRIBE_ACTOR: &str = "forum-notification-mention-describe";
+const MENTION_AUDIENCE_ACTOR: &str = "forum-notification-mention-audience";
 const TARGET_OPEN_ACTOR: &str = "forum-notification-target-open";
-const TARGET_OPEN_DEADLINE: Duration = Duration::from_secs(2);
+const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Default)]
 pub(crate) struct ForumNotificationSourceProviderFactory;
@@ -268,6 +270,68 @@ impl ForumNotificationSourceProvider {
         .await
     }
 
+    async fn load_mention_target_for_recipient(
+        &self,
+        event: &forum_domain_event::Model,
+        payload: &ForumUserMentionPayload,
+        actor: &'static str,
+    ) -> NotificationProviderResult<ForumTargetAvailability> {
+        if self.recipient_context_port.is_none() {
+            return self
+                .load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)
+                .await;
+        }
+
+        let Some(viewer) = self
+            .resolve_recipient_viewer(
+                recipient_operation_context(
+                    event.tenant_id,
+                    payload.mentioned_user_id,
+                    payload.source_id,
+                    actor,
+                ),
+                event.tenant_id,
+                payload.mentioned_user_id,
+            )
+            .await?
+        else {
+            return Ok(ForumTargetAvailability::Unavailable);
+        };
+        self.load_target_for_viewer(
+            event.tenant_id,
+            &payload.source_kind,
+            payload.source_id,
+            &viewer,
+        )
+        .await
+    }
+
+    async fn resolve_recipient_viewer(
+        &self,
+        caller_context: PortContext,
+        tenant_id: Uuid,
+        recipient_id: Uuid,
+    ) -> NotificationProviderResult<Option<ForumTopicAudienceViewer>> {
+        let Some(port) = self.recipient_context_port.clone() else {
+            return Ok(None);
+        };
+        let resolver = ForumNotificationRecipientContextResolver::new(Some(port));
+        let recipient = match resolver
+            .resolve(caller_context, tenant_id, recipient_id)
+            .await
+        {
+            Ok(recipient) => recipient,
+            Err(ForumError::CapabilityFailure {
+                retryable: false, ..
+            }) => return Ok(None),
+            Err(error) => return Err(forum_owner_error(error)),
+        };
+        recipient
+            .into_topic_viewer()
+            .map(Some)
+            .map_err(forum_owner_error)
+    }
+
     async fn row_is_active(
         &self,
         table: &'static str,
@@ -469,7 +533,7 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
                     return Err(NotificationProviderError::InvalidEvent);
                 }
                 match self
-                    .load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)
+                    .load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)
                     .await?
                 {
                     ForumTargetAvailability::Visible(target) => {
@@ -568,7 +632,7 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
                     return Err(NotificationProviderError::InvalidEvent);
                 }
                 match self
-                    .load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)
+                    .load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)
                     .await?
                 {
                     ForumTargetAvailability::Visible(_) => {}
@@ -609,23 +673,17 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
             return Ok(NotificationOpenAuthorization::Unavailable);
         };
 
-        let availability = if let Some(port) = self.recipient_context_port.clone() {
-            let resolver = ForumNotificationRecipientContextResolver::new(Some(port));
-            let recipient = match resolver
-                .resolve(
+        let availability = if self.recipient_context_port.is_some() {
+            let Some(viewer) = self
+                .resolve_recipient_viewer(
                     target_open_context(&request),
                     request.tenant_id,
                     request.recipient_id,
                 )
-                .await
-            {
-                Ok(recipient) => recipient,
-                Err(ForumError::CapabilityFailure {
-                    retryable: false, ..
-                }) => return Ok(NotificationOpenAuthorization::Unavailable),
-                Err(error) => return Err(forum_owner_error(error)),
+                .await?
+            else {
+                return Ok(NotificationOpenAuthorization::Unavailable);
             };
-            let viewer = recipient.into_topic_viewer().map_err(forum_owner_error)?;
             self.load_target_for_viewer(
                 request.tenant_id,
                 source_kind,
@@ -651,17 +709,28 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
     }
 }
 
-fn target_open_context(request: &AuthorizeNotificationTargetRequest) -> PortContext {
+fn recipient_operation_context(
+    tenant_id: Uuid,
+    recipient_id: Uuid,
+    target_id: Uuid,
+    actor: &'static str,
+) -> PortContext {
     PortContext::new(
-        request.tenant_id.to_string(),
-        PortActor::service(TARGET_OPEN_ACTOR),
+        tenant_id.to_string(),
+        PortActor::service(actor),
         "und",
-        format!(
-            "forum-target-open:{}:{}",
-            request.recipient_id, request.target.id
-        ),
+        format!("{actor}:{recipient_id}:{target_id}"),
     )
-    .with_deadline(TARGET_OPEN_DEADLINE)
+    .with_deadline(RECIPIENT_CONTEXT_DEADLINE)
+}
+
+fn target_open_context(request: &AuthorizeNotificationTargetRequest) -> PortContext {
+    recipient_operation_context(
+        request.tenant_id,
+        request.recipient_id,
+        request.target.id,
+        TARGET_OPEN_ACTOR,
+    )
 }
 
 fn retryable_database_error(_error: sea_orm::DbErr) -> NotificationProviderError {

--- a/crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs
@@ -1,0 +1,401 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{Permission, PortActor, PortCallPolicy, PortContext, PortError};
+use rustok_core::{MemoryTransport, MigrationSource, ModuleRegistry, SecurityContext, UserRole};
+use rustok_forum::entities::{forum_domain_event, forum_relation_revision, forum_user_mention};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput,
+    ForumAudienceConstraints, ForumModule, ForumNotificationRecipientContextPort,
+    ForumNotificationRecipientContextRequest, ForumTopicAudiencePolicyService, ReplyService,
+    SetForumTopicAudiencePolicyInput, SharedForumNotificationRecipientContextPort, TopicService,
+};
+use rustok_notifications::NotificationsModule;
+use rustok_notifications_api::{
+    DescribeNotificationRequest, NotificationSourceEventRef, ResolveNotificationAudienceRequest,
+    materialize_notification_source_registry,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ActiveModelTrait,
+    ActiveValue::{NotSet, Set},
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct StaticRecipientContextPort {
+    customer_id: Uuid,
+    manager_id: Uuid,
+}
+
+#[async_trait]
+impl ForumNotificationRecipientContextPort for StaticRecipientContextPort {
+    async fn resolve_forum_notification_recipient_context(
+        &self,
+        context: PortContext,
+        request: ForumNotificationRecipientContextRequest,
+    ) -> Result<PortContext, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        if context.tenant_id != request.tenant_id.to_string() {
+            return Err(PortError::validation(
+                "forum.notification_recipient_context.test_tenant_mismatch",
+                "Forum notification recipient tenant does not match",
+            ));
+        }
+        let role = if request.recipient_id == self.customer_id {
+            "customer"
+        } else if request.recipient_id == self.manager_id {
+            "manager"
+        } else {
+            return Err(PortError::not_found(
+                "forum.notification_recipient_context.test_recipient_unavailable",
+                "Forum notification recipient is unavailable",
+            ));
+        };
+
+        let mut recipient = PortContext::new(
+            request.tenant_id.to_string(),
+            PortActor::user(request.recipient_id.to_string()),
+            context.locale.clone(),
+            context.correlation_id.clone(),
+        )
+        .with_role(role)
+        .with_claim(Permission::FORUM_TOPICS_READ.to_string())
+        .with_claim(Permission::FORUM_REPLIES_READ.to_string());
+        recipient.causation_id = context.causation_id;
+        recipient.traceparent = context.traceparent;
+        recipient.deadline_ms = context.deadline_ms;
+        Ok(recipient)
+    }
+}
+
+#[tokio::test]
+async fn mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies() {
+    let (db, event_bus) = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let author_id = Uuid::new_v4();
+    let customer_id = Uuid::new_v4();
+    let manager_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(author_id));
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Exact mention audience".into(),
+                slug: "exact-mention-audience".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created");
+    let topic = TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id: category.id,
+                title: "Recipient-specific mention".into(),
+                slug: Some("recipient-specific-mention".into()),
+                body: "Mention notification visibility must follow the exact recipient.".into(),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created");
+    let reply = ReplyService::new(db.clone(), event_bus)
+        .create(
+            tenant_id,
+            admin.clone(),
+            topic.id,
+            CreateReplyInput {
+                locale: "en".into(),
+                content: "Reply mention target".into(),
+                content_format: "markdown".into(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await
+        .expect("reply should be created");
+
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            topic.id,
+            admin.clone(),
+            SetForumTopicAudiencePolicyInput {
+                constraints: role_only(UserRole::Customer),
+            },
+        )
+        .await
+        .expect("topic audience should narrow to customers");
+
+    let topic_customer_event = seed_user_mention_event(
+        &db,
+        tenant_id,
+        author_id,
+        "topic",
+        topic.id,
+        customer_id,
+    )
+    .await;
+    let reply_customer_event = seed_user_mention_event(
+        &db,
+        tenant_id,
+        author_id,
+        "reply",
+        reply.id,
+        customer_id,
+    )
+    .await;
+    let topic_manager_event = seed_user_mention_event(
+        &db,
+        tenant_id,
+        author_id,
+        "topic",
+        topic.id,
+        manager_id,
+    )
+    .await;
+
+    let registry = ModuleRegistry::new()
+        .register(NotificationsModule)
+        .register(ForumModule);
+    let mut extensions = registry
+        .build_runtime_extensions()
+        .expect("Notifications and Forum runtime extensions should initialize");
+    let recipient_port: SharedForumNotificationRecipientContextPort =
+        Arc::new(StaticRecipientContextPort {
+            customer_id,
+            manager_id,
+        });
+    extensions.insert(recipient_port);
+    let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db.clone()));
+    let providers = materialize_notification_source_registry(&mut extensions, &host)
+        .expect("Forum source factory should consume the recipient capability");
+    let provider = providers
+        .get_by_str("forum")
+        .expect("Forum source should be discoverable");
+
+    let topic_customer_ref = source_event_ref(&topic_customer_event);
+    let topic_descriptor = provider
+        .describe_event(DescribeNotificationRequest {
+            event: topic_customer_ref.clone(),
+        })
+        .await
+        .expect("customer topic mention description should complete")
+        .expect("customer topic mention should be describable");
+    assert_eq!(topic_descriptor.target.kind.as_str(), "forum.topic");
+    let topic_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: topic_customer_ref.clone(),
+            descriptor: topic_descriptor.clone(),
+            cursor: None,
+            limit: 1,
+        })
+        .await
+        .expect("customer topic mention audience should resolve");
+    assert_eq!(topic_page.recipients().len(), 1);
+    assert_eq!(topic_page.recipients()[0].recipient_id, customer_id);
+    assert!(topic_page.is_complete());
+
+    let reply_customer_ref = source_event_ref(&reply_customer_event);
+    let reply_descriptor = provider
+        .describe_event(DescribeNotificationRequest {
+            event: reply_customer_ref.clone(),
+        })
+        .await
+        .expect("customer reply mention description should complete")
+        .expect("customer reply mention should be describable");
+    assert_eq!(reply_descriptor.target.kind.as_str(), "forum.reply");
+    let reply_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: reply_customer_ref,
+            descriptor: reply_descriptor,
+            cursor: None,
+            limit: 1,
+        })
+        .await
+        .expect("customer reply mention audience should resolve");
+    assert_eq!(reply_page.recipients().len(), 1);
+    assert_eq!(reply_page.recipients()[0].recipient_id, customer_id);
+    assert!(reply_page.is_complete());
+
+    assert!(
+        provider
+            .describe_event(DescribeNotificationRequest {
+                event: source_event_ref(&topic_manager_event),
+            })
+            .await
+            .expect("manager topic mention description should fail closed")
+            .is_none()
+    );
+
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            topic.id,
+            admin,
+            SetForumTopicAudiencePolicyInput {
+                constraints: role_only(UserRole::Manager),
+            },
+        )
+        .await
+        .expect("topic audience should narrow away from the customer");
+    let stale_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: topic_customer_ref,
+            descriptor: topic_descriptor,
+            cursor: None,
+            limit: 1,
+        })
+        .await
+        .expect("stale customer mention descriptor should be rechecked");
+    assert!(stale_page.recipients().is_empty());
+    assert!(stale_page.is_complete());
+}
+
+fn role_only(role: UserRole) -> ForumAudienceConstraints {
+    ForumAudienceConstraints {
+        roles_any: vec![role],
+        ..ForumAudienceConstraints::default()
+    }
+}
+
+fn source_event_ref(event: &forum_domain_event::Model) -> NotificationSourceEventRef {
+    NotificationSourceEventRef::new(
+        event.tenant_id,
+        event.event_id,
+        "forum".try_into().expect("source slug"),
+        event.event_type.clone().try_into().expect("event type"),
+        u64::try_from(event.sequence_no).expect("event sequence should be positive"),
+    )
+    .expect("source event reference")
+}
+
+async fn seed_user_mention_event(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    source_kind: &str,
+    source_id: Uuid,
+    mentioned_user_id: Uuid,
+) -> forum_domain_event::Model {
+    let revision = ensure_relation_revision(db, tenant_id, source_kind, source_id).await;
+    forum_user_mention::ActiveModel {
+        tenant_id: Set(tenant_id),
+        source_kind: Set(source_kind.to_string()),
+        source_id: Set(source_id),
+        source_locale: Set("en".to_string()),
+        source_revision_id: Set(revision.revision_id),
+        mentioned_user_id: Set(mentioned_user_id),
+        handle_snapshot: Set(format!("member-{mentioned_user_id}")),
+        created_at: Set(Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .expect("user mention relation should persist");
+
+    forum_domain_event::ActiveModel {
+        sequence_no: NotSet,
+        event_id: Set(Uuid::new_v4()),
+        tenant_id: Set(tenant_id),
+        aggregate_type: Set(source_kind.to_string()),
+        aggregate_id: Set(source_id),
+        event_type: Set("forum.mention.user_added".to_string()),
+        schema_version: Set(1),
+        actor_id: Set(Some(actor_id)),
+        payload: Set(serde_json::json!({
+            "source_kind": source_kind,
+            "source_id": source_id,
+            "source_revision_id": revision.revision_id,
+            "source_locale": "en",
+            "mentioned_user_id": mentioned_user_id,
+        })),
+        created_at: Set(Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .expect("user mention event should persist")
+}
+
+async fn ensure_relation_revision(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    source_kind: &str,
+    source_id: Uuid,
+) -> forum_relation_revision::Model {
+    if let Some(revision) = forum_relation_revision::Entity::find()
+        .filter(forum_relation_revision::Column::TenantId.eq(tenant_id))
+        .filter(forum_relation_revision::Column::TargetKind.eq(source_kind))
+        .filter(forum_relation_revision::Column::TargetId.eq(source_id))
+        .filter(forum_relation_revision::Column::Locale.eq("en"))
+        .order_by_desc(forum_relation_revision::Column::RevisionId)
+        .one(db)
+        .await
+        .expect("relation revision query should succeed")
+    {
+        return revision;
+    }
+
+    forum_relation_revision::ActiveModel {
+        revision_id: NotSet,
+        tenant_id: Set(tenant_id),
+        target_kind: Set(source_kind.to_string()),
+        target_id: Set(source_id),
+        locale: Set("en".to_string()),
+        projection_fingerprint: Set("notification-recipient-mention-test".to_string()),
+        created_at: Set(Utc::now().into()),
+    }
+    .insert(db)
+    .await
+    .expect("relation revision fixture should persist")
+}
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus) {
+    let url = format!(
+        "sqlite:file:forum_notification_recipient_mention_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("notification recipient mention database should connect");
+    let manager = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus)
+}

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -35,18 +35,20 @@ const crate = read(contract.crate_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
 const consumer = JSON.parse(read(contract.consumer_contract ?? "") || "{}");
+const downstreamConsumer = JSON.parse(read(contract.downstream_consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) {
-  failures.push("forum notification recipient context contract must use schema_version=3");
+if (contract.schema_version !== 4) {
+  failures.push("forum notification recipient context contract must use schema_version=4");
 }
 if (
   contract.task !== "FORUM-20L" ||
   contract.upstream_task !== "FORUM-20K" ||
   contract.downstream_task !== "FORUM-20M" ||
-  contract.consumer_task !== "FORUM-20N"
+  contract.consumer_task !== "FORUM-20N" ||
+  contract.downstream_consumer_task !== "FORUM-20O"
 ) {
-  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M/N");
+  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M/N/O");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("recipient context source publication must not claim unexecuted evidence");
@@ -69,13 +71,17 @@ for (const delivered of [
   "host_runtime_publication",
   "notification_source_factory_consumption",
   "recipient_target_open_authorization",
+  "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization",
+  "shared_consumer_resolution_helper",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
   }
 }
 for (const residual of [
-  "recipient-specific audience filtering for non-public topics before pagination",
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
   "profile privacy and blocking policy",
   "trust channel and group facts host adapters",
   "final notification creation and delivery authorization",
@@ -105,13 +111,14 @@ const deliveredSlices = [
   "FORUM-20L",
   "FORUM-20M",
   "FORUM-20N",
+  "FORUM-20O",
 ];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20N") {
-  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20N");
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20O");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20N delivered sections");
+  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20O delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -130,11 +137,7 @@ if (planSync.status === "pending") {
     );
   }
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-N provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through N",
-  );
+  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
   for (const slice of deliveredSlices) {
     requireText(
       plan,
@@ -178,11 +181,7 @@ for (const forbidden of [
   "forum_group",
   "HostRuntimeContext",
 ]) {
-  rejectText(
-    owner,
-    forbidden,
-    `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`,
-  );
+  rejectText(owner, forbidden, `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`);
 }
 for (const marker of [
   "pub mod notification_recipient;",
@@ -195,34 +194,52 @@ for (const marker of [
 }
 
 if (
-  upstream.schema_version !== 5 ||
+  upstream.schema_version !== 6 ||
   upstream.task !== "FORUM-20K" ||
-  upstream.downstream_task !== "FORUM-20N" ||
+  upstream.downstream_task !== "FORUM-20O" ||
   upstream.composition?.exact_richer_public_owner !== true ||
-  upstream.composition?.recipient_specific_target_open !== true
+  upstream.composition?.recipient_specific_target_open !== true ||
+  upstream.composition?.recipient_specific_mention_description !== true ||
+  upstream.composition?.recipient_specific_mention_audience !== true
 ) {
-  failures.push("FORUM-20L recipient context capability must remain grounded in FORUM-20K visibility composition through FORUM-20N");
+  failures.push("FORUM-20L recipient context capability must remain grounded in FORUM-20K visibility composition through FORUM-20O");
 }
 if (
-  downstream.schema_version !== 2 ||
+  downstream.schema_version !== 3 ||
   downstream.task !== "FORUM-20M" ||
   downstream.upstream_task !== "FORUM-20L" ||
   downstream.downstream_task !== "FORUM-20N" ||
+  downstream.consumer_task !== "FORUM-20O" ||
   downstream.composition?.server_adapter !== true ||
   downstream.composition?.runtime_extension_publication !== true ||
-  downstream.composition?.notification_source_factory_consumption !== true
+  downstream.composition?.notification_source_factory_consumption !== true ||
+  downstream.composition?.recipient_mention_description_authorization !== true ||
+  downstream.composition?.recipient_mention_audience_authorization !== true
 ) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with FORUM-20M host composition through FORUM-20N");
+  failures.push("FORUM-20L recipient context capability must remain synchronized with FORUM-20M host composition through FORUM-20O");
 }
 if (
-  consumer.schema_version !== 1 ||
+  consumer.schema_version !== 2 ||
   consumer.task !== "FORUM-20N" ||
   consumer.upstream_task !== "FORUM-20M" ||
+  consumer.downstream_task !== "FORUM-20O" ||
   consumer.composition?.exact_recipient_resolution !== true ||
   consumer.composition?.recipient_specific_topic_open !== true ||
-  consumer.composition?.recipient_specific_reply_open !== true
+  consumer.composition?.recipient_specific_reply_open !== true ||
+  consumer.composition?.recipient_specific_mention_description !== true ||
+  consumer.composition?.recipient_specific_mention_audience !== true
 ) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with the delivered FORUM-20N consumer");
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20N recipient consumer");
+}
+if (
+  downstreamConsumer.schema_version !== 1 ||
+  downstreamConsumer.task !== "FORUM-20O" ||
+  downstreamConsumer.upstream_task !== "FORUM-20N" ||
+  downstreamConsumer.composition?.exact_mention_recipient_resolution !== true ||
+  downstreamConsumer.composition?.recipient_specific_mention_description !== true ||
+  downstreamConsumer.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20O mention consumer");
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
@@ -36,17 +36,19 @@ const runtime = read(contract.runtime_composition_file ?? "");
 const notificationSource = read(contract.notification_source_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const consumer = JSON.parse(read(contract.consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum notification recipient host runtime contract must use schema_version=2");
+if (contract.schema_version !== 3) {
+  failures.push("forum notification recipient host runtime contract must use schema_version=3");
 }
 if (
   contract.task !== "FORUM-20M" ||
   contract.upstream_task !== "FORUM-20L" ||
-  contract.downstream_task !== "FORUM-20N"
+  contract.downstream_task !== "FORUM-20N" ||
+  contract.consumer_task !== "FORUM-20O"
 ) {
-  failures.push("forum notification recipient host runtime contract must connect FORUM-20L/M/N");
+  failures.push("forum notification recipient host runtime contract must connect FORUM-20L/M/N/O");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("recipient host runtime publication must not claim unexecuted evidence");
@@ -70,13 +72,16 @@ for (const delivered of [
   "inline_contract_tests",
   "notification_source_factory_consumption",
   "recipient_target_open_authorization",
+  "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification recipient host runtime contract must record ${delivered} as delivered`);
   }
 }
 for (const residual of [
-  "recipient-specific audience filtering for non-public topics before pagination",
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
   "profile privacy and blocking policy",
   "trust channel and group facts host adapters",
   "final notification creation and delivery authorization",
@@ -85,14 +90,6 @@ for (const residual of [
 ]) {
   if (!contract.not_delivered?.includes(residual)) {
     failures.push(`forum notification recipient host runtime contract must keep ${residual} explicitly open`);
-  }
-}
-for (const staleResidual of [
-  "notification source factory consumption of the recipient context capability",
-  "recipient-specific target-open authorization for non-public topics and replies",
-]) {
-  if (contract.not_delivered?.includes(staleResidual)) {
-    failures.push(`forum notification recipient host runtime contract must remove delivered residual ${staleResidual}`);
   }
 }
 
@@ -104,13 +101,14 @@ const deliveredSlices = [
   "FORUM-20L",
   "FORUM-20M",
   "FORUM-20N",
+  "FORUM-20O",
 ];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20N") {
-  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20N");
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20O");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20N delivered sections");
+  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20O delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -129,11 +127,7 @@ if (planSync.status === "pending") {
     );
   }
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-N provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through N",
-  );
+  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
   for (const slice of deliveredSlices) {
     requireText(
       plan,
@@ -179,11 +173,7 @@ for (const forbidden of [
   "SecurityContext::new(",
   "Rbac::permissions_for_role",
 ]) {
-  rejectText(
-    adapter,
-    forbidden,
-    `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`,
-  );
+  rejectText(adapter, forbidden, `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`);
 }
 for (const marker of [
   "#[cfg(feature = \"mod-forum\")]",
@@ -199,47 +189,59 @@ for (const marker of [
   requireText(runtime, marker, `server runtime composition is missing ${marker}`);
 }
 const publicationIndex = runtime.indexOf("extensions.insert(recipient_context)");
-const materializationIndex = runtime.indexOf(
-  "materialize_notification_source_registry(&mut extensions, &host)",
-);
-if (
-  publicationIndex < 0 ||
-  materializationIndex < 0 ||
-  publicationIndex > materializationIndex
-) {
+const materializationIndex = runtime.indexOf("materialize_notification_source_registry(&mut extensions, &host)");
+if (publicationIndex < 0 || materializationIndex < 0 || publicationIndex > materializationIndex) {
   failures.push("recipient context capability must be published before notification source materialization");
 }
 
 for (const marker of [
   "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
   "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "async fn resolve_recipient_viewer(",
   "ForumNotificationRecipientContextResolver::new(Some(port))",
   "target_open_context(&request)",
+  "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)",
+  "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)",
   "recipient.into_topic_viewer()",
 ]) {
   requireText(notificationSource, marker, `notification source consumer is missing ${marker}`);
 }
 
 if (
-  upstream.schema_version !== 3 ||
+  upstream.schema_version !== 4 ||
   upstream.task !== "FORUM-20L" ||
   upstream.downstream_task !== "FORUM-20M" ||
   upstream.consumer_task !== "FORUM-20N" ||
+  upstream.downstream_consumer_task !== "FORUM-20O" ||
   upstream.composition?.host_adapter_implementation !== true ||
   upstream.composition?.host_runtime_publication !== true ||
-  upstream.composition?.notification_source_factory_consumption !== true
+  upstream.composition?.notification_source_factory_consumption !== true ||
+  upstream.composition?.recipient_mention_description_authorization !== true ||
+  upstream.composition?.recipient_mention_audience_authorization !== true
 ) {
-  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20L capability contract through FORUM-20N");
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20L capability contract through FORUM-20O");
 }
 if (
-  downstream.schema_version !== 1 ||
+  downstream.schema_version !== 2 ||
   downstream.task !== "FORUM-20N" ||
   downstream.upstream_task !== "FORUM-20M" ||
+  downstream.downstream_task !== "FORUM-20O" ||
   downstream.composition?.factory_recipient_capability_lookup !== true ||
   downstream.composition?.recipient_specific_topic_open !== true ||
-  downstream.composition?.recipient_specific_reply_open !== true
+  downstream.composition?.recipient_specific_reply_open !== true ||
+  downstream.composition?.recipient_specific_mention_description !== true ||
+  downstream.composition?.recipient_specific_mention_audience !== true
 ) {
-  failures.push("FORUM-20M host runtime must remain synchronized with delivered FORUM-20N target-open consumption");
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20N recipient consumer");
+}
+if (
+  consumer.schema_version !== 1 ||
+  consumer.task !== "FORUM-20O" ||
+  consumer.upstream_task !== "FORUM-20N" ||
+  consumer.composition?.recipient_specific_mention_description !== true ||
+  consumer.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20O mention consumer");
 }
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const source = read(contract.notification_source_file ?? "");
+const visibilityOwner = read(contract.visibility_owner_file ?? "");
+const recipientOwner = read(contract.recipient_context_owner_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification recipient mention audience contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N") {
+  failures.push("forum notification recipient mention audience contract must belong to FORUM-20O after FORUM-20N");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient mention audience publication must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "shared_recipient_resolution_helper",
+  "bounded_mention_description_context",
+  "bounded_mention_audience_context",
+  "exact_mention_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "topic_mention_target",
+  "reply_mention_target",
+  "public_only_fallback",
+  "unavailable_recipient_fail_closed",
+  "retryability_preserved",
+  "stale_descriptor_recheck",
+  "topic_created_paths_unchanged",
+  "sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
+  }
+}
+for (const residual of [
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum notification recipient mention audience contract must require the canonical ledger through FORUM-20O");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20O delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-O provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through O",
+  );
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "const MENTION_DESCRIBE_ACTOR: &str = \"forum-notification-mention-describe\"",
+  "const MENTION_AUDIENCE_ACTOR: &str = \"forum-notification-mention-audience\"",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
+  "async fn load_mention_target_for_recipient(",
+  "async fn resolve_recipient_viewer(",
+  "recipient_operation_context(",
+  "if self.recipient_context_port.is_none()",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)",
+]) {
+  requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(
+    source,
+    forbidden,
+    `forum notification recipient mention paths must reuse owners instead of ${forbidden}`,
+  );
+}
+
+const describeBlock = between(
+  source,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  source,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  source,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
+for (const [block, marker, label] of [
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "shared target-open recipient resolution"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![role]",
+  "Forum source factory should consume the recipient capability",
+  "customer topic mention should be describable",
+  "customer topic mention audience should resolve",
+  "customer reply mention should be describable",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 2 ||
+  upstream.task !== "FORUM-20N" ||
+  upstream.downstream_task !== "FORUM-20O" ||
+  upstream.composition?.recipient_specific_mention_description !== true ||
+  upstream.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20N recipient contract");
+}
+if (
+  visibilityContract.schema_version !== 6 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20O" ||
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20K visibility composition contract");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification recipient mention audience verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification recipient mention audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -27,6 +27,16 @@ function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
 
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
 const contractPath =
   "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
 const contract = JSON.parse(read(contractPath) || "{}");
@@ -35,17 +45,23 @@ const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
-const testSource = read(contract.test_file ?? "");
+const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const targetOpenTest = read(contract.test_file ?? "");
+const mentionTest = read(contract.downstream_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum notification recipient target-open contract must use schema_version=1");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification recipient contract must use schema_version=2");
 }
-if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M") {
-  failures.push("forum notification recipient target-open contract must belong to FORUM-20N after FORUM-20M");
+if (
+  contract.task !== "FORUM-20N" ||
+  contract.upstream_task !== "FORUM-20M" ||
+  contract.downstream_task !== "FORUM-20O"
+) {
+  failures.push("forum notification recipient contract must connect FORUM-20M/N/O");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient target-open publication must not claim unexecuted evidence");
+  failures.push("recipient authorization publication must not claim unexecuted evidence");
 }
 
 for (const delivered of [
@@ -59,16 +75,21 @@ for (const delivered of [
   "public_only_fallback",
   "inactive_or_missing_recipient_fail_closed",
   "retryability_preserved",
-  "public_description_unchanged",
-  "public_audience_unchanged",
+  "topic_created_public_description_unchanged",
+  "topic_created_public_audience_unchanged",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
   "sqlite_contract_test",
+  "downstream_sqlite_contract_test",
 ]) {
   if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient target-open contract must record ${delivered} as delivered`);
+    failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
   }
 }
 for (const residual of [
-  "recipient-specific audience filtering for non-public topics before pagination",
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
   "profile privacy and blocking policy",
   "host trust channel and group facts adapters",
   "final notification creation and delivery authorization",
@@ -76,7 +97,7 @@ for (const residual of [
   "PostgreSQL and cross-consumer runtime evidence",
 ]) {
   if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient target-open contract must keep ${residual} explicitly open`);
+    failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
   }
 }
 
@@ -88,13 +109,14 @@ const deliveredSlices = [
   "FORUM-20L",
   "FORUM-20M",
   "FORUM-20N",
+  "FORUM-20O",
 ];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20N") {
-  failures.push("forum notification recipient target-open contract must require the canonical ledger through FORUM-20N");
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum notification recipient contract must require the canonical ledger through FORUM-20O");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification recipient target-open contract must require FORUM-20H through FORUM-20N delivered sections");
+  failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20O delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -113,11 +135,7 @@ if (planSync.status === "pending") {
     );
   }
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-N provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through N",
-  );
+  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
   for (const slice of deliveredSlices) {
     requireText(
       plan,
@@ -140,19 +158,22 @@ for (const marker of [
   "async fn load_target_for_viewer(",
   "reply.status == ReplyStatus::Pending",
   "reply.status != ReplyStatus::Approved",
-  "const TARGET_OPEN_DEADLINE: Duration = Duration::from_secs(2)",
-  "PortActor::service(TARGET_OPEN_ACTOR)",
-  ".with_deadline(TARGET_OPEN_DEADLINE)",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
+  "async fn resolve_recipient_viewer(",
   "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "target_open_context(&request)",
   "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "target_open_context(&request)",
   "Err(ForumError::CapabilityFailure {",
   "retryable: false, ..",
   "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
   "ForumError::CapabilityUnavailable { .. }",
   "NotificationProviderError::CapabilityUnavailable { retryable: true }",
+  "async fn load_mention_target_for_recipient(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
 ]) {
-  requireText(source, marker, `forum notification recipient target-open source is missing ${marker}`);
+  requireText(source, marker, `forum notification recipient source is missing ${marker}`);
 }
 for (const forbidden of [
   "forum_category_audience_policy",
@@ -168,25 +189,20 @@ for (const forbidden of [
   "Rbac::permissions_for_role",
   "SecurityContext::new(",
 ]) {
-  rejectText(
-    source,
-    forbidden,
-    `forum notification target-open must reuse owners instead of ${forbidden}`,
-  );
+  rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
 }
 
-const describeIndex = source.indexOf("async fn describe_event(");
-const audienceIndex = source.indexOf("async fn resolve_audience(");
-const targetOpenIndex = source.indexOf("async fn authorize_target_open(");
-const recipientResolutionIndex = source.indexOf("ForumNotificationRecipientContextResolver::new(Some(port))");
-if (
-  describeIndex < 0 ||
-  audienceIndex < 0 ||
-  targetOpenIndex < 0 ||
-  recipientResolutionIndex < targetOpenIndex ||
-  recipientResolutionIndex < audienceIndex
-) {
-  failures.push("exact recipient resolution must remain scoped to authorize_target_open after public description and audience methods");
+const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
+const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
+const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
+for (const [block, marker, label] of [
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "exact target-open authorization"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
 }
 
 for (const marker of [
@@ -212,15 +228,22 @@ for (const marker of [
   "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
   "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
   "roles_any: vec![UserRole::Customer]",
-  "SharedForumNotificationRecipientContextPort",
-  "Forum source factory should consume the recipient capability",
   "customer target-open authorization should complete",
   "manager target-open authorization should fail closed",
   "unavailable recipient should fail closed without an existence oracle",
   "NotificationOpenAuthorization::Allowed",
   "NotificationOpenAuthorization::Unavailable",
 ]) {
-  requireText(testSource, marker, `recipient target-open SQLite contract is missing ${marker}`);
+  requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
 }
 
 if (
@@ -230,16 +253,26 @@ if (
   upstream.composition?.notification_source_factory_consumption !== true ||
   upstream.composition?.recipient_target_open_authorization !== true
 ) {
-  failures.push("FORUM-20N target-open must remain synchronized with the FORUM-20M host runtime contract");
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20M host runtime contract");
 }
 if (
-  visibilityContract.schema_version !== 5 ||
+  visibilityContract.schema_version !== 6 ||
   visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20N" ||
+  visibilityContract.downstream_task !== "FORUM-20O" ||
   visibilityContract.composition?.recipient_specific_target_open !== true ||
-  visibilityContract.composition?.public_only_description_and_audience !== true
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true
 ) {
-  failures.push("FORUM-20N target-open must remain synchronized with the FORUM-20K visibility composition contract");
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20K visibility composition contract");
+}
+if (
+  downstream.schema_version !== 1 ||
+  downstream.task !== "FORUM-20O" ||
+  downstream.upstream_task !== "FORUM-20N" ||
+  downstream.composition?.recipient_specific_mention_description !== true ||
+  downstream.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20O mention audience contract");
 }
 
 for (const marker of [
@@ -250,9 +283,9 @@ for (const marker of [
 }
 
 if (failures.length > 0) {
-  console.error("Forum notification recipient target-open verification failed:");
+  console.error("Forum notification recipient authorization verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
 
-console.log("Forum notification recipient target-open contract is source-ready.");
+console.log("Forum notification recipient authorization contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -290,7 +290,6 @@ if (
   recipientContract.schema_version !== 2 ||
   recipientContract.task !== "FORUM-20N" ||
   recipientContract.downstream_task !== "FORUM-20O" ||
-  recipientContract.composition?.recipient_specific_target_open !== undefined ||
   recipientContract.composition?.recipient_specific_topic_open !== true ||
   recipientContract.composition?.recipient_specific_reply_open !== true ||
   recipientContract.composition?.recipient_specific_mention_description !== true ||

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -27,6 +27,16 @@ function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
 
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
 const contractPath =
   "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
 const contract = JSON.parse(read(contractPath) || "{}");
@@ -36,25 +46,28 @@ const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
 const baselineTestSource = read(contract.baseline_test_file ?? "");
 const richerTestSource = read(contract.test_file ?? "");
 const recipientTestSource = read(contract.recipient_test_file ?? "");
+const mentionTestSource = read(contract.recipient_mention_test_file ?? "");
 const recipientContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
+const mentionContract = JSON.parse(read(contract.recipient_mention_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 5) {
-  failures.push("forum notification visibility contract must use schema_version=5");
+if (contract.schema_version !== 6) {
+  failures.push("forum notification visibility contract must use schema_version=6");
 }
 if (
   contract.task !== "FORUM-20K" ||
   contract.supersedes_task !== "FORUM-20I" ||
-  contract.downstream_task !== "FORUM-20N"
+  contract.downstream_task !== "FORUM-20O"
 ) {
-  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20N");
+  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20O");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted notification evidence");
 }
 
 for (const residual of [
-  "recipient-specific authenticated audience filtering before notification pagination",
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
   "profile privacy and blocking policy",
   "host trust channel and group facts adapters for authenticated consumers",
   "search index SEO and deep-link migration",
@@ -72,7 +85,10 @@ for (const delivered of [
   "dynamic_policy_recheck",
   "recipient_context_factory_consumption",
   "recipient_specific_target_open",
-  "public_only_description_and_audience",
+  "topic_created_public_description_and_audience",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
 ]) {
   if (contract.composition?.[delivered] !== true) {
     failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
@@ -87,13 +103,14 @@ const deliveredSlices = [
   "FORUM-20L",
   "FORUM-20M",
   "FORUM-20N",
+  "FORUM-20O",
 ];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20N") {
-  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20N");
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20O");
 }
 if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20N delivered sections");
+  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20O delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -112,11 +129,7 @@ if (planSync.status === "pending") {
     );
   }
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-N provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through N",
-  );
+  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
   for (const slice of deliveredSlices) {
     requireText(
       plan,
@@ -161,8 +174,13 @@ for (const marker of [
   "ForumTopicAudienceViewer::public()",
   "async fn load_target_for_viewer(",
   "async fn load_public_target(",
+  "async fn load_mention_target_for_recipient(",
+  "async fn resolve_recipient_viewer(",
   "ForumNotificationRecipientContextResolver::new(Some(port))",
   "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
   "target_open_context(&request)",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
 ]) {
@@ -196,24 +214,45 @@ for (const forbidden of [
   );
 }
 
-const describeIndex = notificationSource.indexOf("async fn describe_event(");
-const audienceIndex = notificationSource.indexOf("async fn resolve_audience(");
-const targetOpenIndex = notificationSource.indexOf("async fn authorize_target_open(");
-const resolverIndex = notificationSource.indexOf("ForumNotificationRecipientContextResolver::new(Some(port))");
-if (
-  describeIndex < 0 ||
-  audienceIndex < 0 ||
-  targetOpenIndex < 0 ||
-  resolverIndex < targetOpenIndex ||
-  resolverIndex < audienceIndex
-) {
-  failures.push("recipient context resolution must remain scoped to target-open authorization after public description and audience paths");
+const visibilityIndex = notificationSource.indexOf(".is_topic_visible(tenant_id, topic_id, None, viewer)");
+const materializeIndex = notificationSource.indexOf("let topic = forum_topic::Entity::find()");
+if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
+  failures.push("notification richer visibility must be evaluated before topic materialization");
+}
+
+const describeBlock = between(
+  notificationSource,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  notificationSource,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  notificationSource,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
+for (const [block, marker, label] of [
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "recipient target-open authorization"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
 }
 
 for (const marker of [
   "forum_topic_and_user_mention_sources_support_notifications_profiles",
   "restricted topic description should fail closed",
   "restricted topic authorization should fail closed",
+  "restricted mention description should fail closed",
   "cross-tenant authorization should fail closed",
   "closed target authorization should fail closed",
   "NotificationProviderError::Internal { retryable: true }",
@@ -237,14 +276,36 @@ for (const marker of [
 ]) {
   requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
 }
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
+}
 
 if (
-  recipientContract.schema_version !== 1 ||
+  recipientContract.schema_version !== 2 ||
   recipientContract.task !== "FORUM-20N" ||
+  recipientContract.downstream_task !== "FORUM-20O" ||
+  recipientContract.composition?.recipient_specific_target_open !== undefined ||
   recipientContract.composition?.recipient_specific_topic_open !== true ||
-  recipientContract.composition?.recipient_specific_reply_open !== true
+  recipientContract.composition?.recipient_specific_reply_open !== true ||
+  recipientContract.composition?.recipient_specific_mention_description !== true ||
+  recipientContract.composition?.recipient_specific_mention_audience !== true
 ) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient target-open contract");
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient contract");
+}
+if (
+  mentionContract.schema_version !== 1 ||
+  mentionContract.task !== "FORUM-20O" ||
+  mentionContract.upstream_task !== "FORUM-20N" ||
+  mentionContract.composition?.recipient_specific_mention_description !== true ||
+  mentionContract.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20O mention audience contract");
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -38,23 +38,33 @@ const evaluator = read(contract.audience_evaluator ?? "");
 const services = read(contract.services_file ?? "");
 const crate = read(contract.crate_file ?? "");
 const notificationSource = read(contract.notification_source_file ?? "");
-const notificationContract = JSON.parse(
-  read(contract.notification_visibility_contract ?? "") || "{}",
-);
+const notificationContract = JSON.parse(read(contract.notification_visibility_contract ?? "") || "{}");
+const notificationConsumer = JSON.parse(read(contract.notification_consumer_contract ?? "") || "{}");
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum topic audience visibility contract must use schema_version=2");
+if (contract.schema_version !== 3) {
+  failures.push("forum topic audience visibility contract must use schema_version=3");
 }
-if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K") {
-  failures.push("forum topic audience visibility contract must belong to FORUM-20J and record FORUM-20K notification composition");
+if (
+  contract.task !== "FORUM-20J" ||
+  contract.downstream_notification_task !== "FORUM-20K" ||
+  contract.notification_consumer_task !== "FORUM-20O"
+) {
+  failures.push("forum topic audience visibility contract must connect FORUM-20J/K/O notification composition");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("source publication must not claim unexecuted richer visibility evidence");
 }
-if (contract.composition?.public_notification_source !== true) {
-  failures.push("forum topic audience visibility contract must record the public notification source consumer");
+for (const delivered of [
+  "public_topic_created_notification",
+  "recipient_target_open_notification",
+  "recipient_mention_description_notification",
+  "recipient_mention_audience_notification",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
+  }
 }
 for (const residual of [
   "topic and reply page filtering before count and pagination",
@@ -62,7 +72,8 @@ for (const residual of [
   "create reply and moderate audience write policy",
   "host trust channel and group provider adapters",
   "visibility-scoped category and all-read mutations",
-  "recipient-specific notification authorization for non-public audiences",
+  "recipient-specific topic-created subscription filtering before pagination",
+  "initially non-public topic-created descriptor materialization",
   "search index SEO and deep-link migration to the richer exact owner",
   "PostgreSQL concurrency and cross-consumer runtime evidence",
 ]) {
@@ -71,15 +82,22 @@ for (const residual of [
   }
 }
 
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20K") {
-  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20K");
+if (planSync.required_ledger_through !== "FORUM-20O") {
+  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20O");
 }
-if (
-  JSON.stringify(planSync.required_delivered_sections) !==
-  JSON.stringify(["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"])
-) {
-  failures.push("forum topic audience visibility contract must require FORUM-20H/I/J/K delivered sections");
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20O delivered sections");
 }
 if (planSync.status === "pending") {
   if (planSync.current_plan_through !== "FORUM-20G") {
@@ -90,7 +108,7 @@ if (planSync.status === "pending") {
     "FORUM-20A-G provide",
     "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
   );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
+  for (const slice of deliveredSlices) {
     rejectText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -98,12 +116,8 @@ if (planSync.status === "pending") {
     );
   }
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-K provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through K",
-  );
-  for (const slice of ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K"]) {
+  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
+  for (const slice of deliveredSlices) {
     requireText(
       plan,
       `### Delivered in \`${slice}\``,
@@ -151,19 +165,11 @@ for (const forbidden of [
   "forum_topic_audience_group::",
   "forum_topic_audience_user::",
 ]) {
-  rejectText(
-    owner,
-    forbidden,
-    `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`,
-  );
+  rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`);
 }
 
-const baseIndex = owner.indexOf(
-  ".is_topic_visible(tenant_id, topic_id, &scope)",
-);
-const policyIndex = owner.indexOf(
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-);
+const baseIndex = owner.indexOf(".is_topic_visible(tenant_id, topic_id, &scope)");
+const policyIndex = owner.indexOf("load_policy_for_topic(&self.db, tenant_id, &topic)");
 const providerIndex = owner.indexOf(".resolve_for_constraints(");
 if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) {
   failures.push("current exact storefront visibility must run before richer policy materialization");
@@ -181,17 +187,10 @@ for (const marker of [
 ]) {
   requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
 }
-for (const marker of [
-  "pub(crate) async fn load_category_audience_policy",
-  "effective_layers",
-]) {
+for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) {
   requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
 }
-for (const marker of [
-  "async fn load_policy_for_topic",
-  "inherited_category_layers",
-  "configured_constraints",
-]) {
+for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) {
   requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
 }
 for (const marker of [
@@ -201,7 +200,6 @@ for (const marker of [
 ]) {
   requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
 }
-
 for (const marker of [
   "include!(\"topic_audience_visibility.rs\")",
   "ForumTopicAudienceViewer",
@@ -209,24 +207,21 @@ for (const marker of [
 ]) {
   requireText(services, marker, `forum services surface is missing ${marker}`);
 }
-for (const marker of [
-  "ForumTopicAudienceViewer",
-  "ForumTopicAudienceVisibilityService",
-]) {
+for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) {
   requireText(crate, marker, `forum crate surface is missing ${marker}`);
 }
 
 for (const marker of [
   "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
-  "let viewer = ForumTopicAudienceViewer::public();",
-  "ForumTopicAudienceVisibilityService::without_facts_provider(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, &viewer)",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_public_topic(",
+  "ForumTopicAudienceViewer::public()",
+  "async fn resolve_recipient_viewer(",
+  "async fn load_mention_target_for_recipient(",
 ]) {
-  requireText(
-    notificationSource,
-    marker,
-    `public notification source is missing richer topic visibility composition ${marker}`,
-  );
+  requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
 }
 for (const forbidden of [
   "ForumTopicVisibilityScope::storefront(None)",
@@ -234,18 +229,27 @@ for (const forbidden of [
   "forum_category_audience_policy",
   "forum_topic_audience_policy",
 ]) {
-  rejectText(
-    notificationSource,
-    forbidden,
-    `public notification source must not bypass the richer owner with ${forbidden}`,
-  );
+  rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
+}
+
+if (
+  notificationContract.schema_version !== 6 ||
+  notificationContract.task !== "FORUM-20K" ||
+  notificationContract.downstream_task !== "FORUM-20O" ||
+  notificationContract.composition?.exact_richer_public_owner !== true ||
+  notificationContract.composition?.recipient_specific_target_open !== true ||
+  notificationContract.composition?.recipient_specific_mention_description !== true ||
+  notificationContract.composition?.recipient_specific_mention_audience !== true
+) {
+  failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20O");
 }
 if (
-  notificationContract.schema_version !== 4 ||
-  notificationContract.task !== "FORUM-20K" ||
-  notificationContract.composition?.exact_richer_public_owner !== true
+  notificationConsumer.schema_version !== 1 ||
+  notificationConsumer.task !== "FORUM-20O" ||
+  notificationConsumer.upstream_task !== "FORUM-20N" ||
+  notificationConsumer.composition?.exact_mention_recipient_resolution !== true
 ) {
-  failures.push("FORUM-20K notification visibility contract must record exact richer public composition");
+  failures.push("FORUM-20J topic visibility must remain synchronized with the FORUM-20O notification consumer");
 }
 
 for (const marker of [


### PR DESCRIPTION
## Summary

- reuse the published Forum notification-recipient context capability for user-mention description and audience resolution
- resolve the exact mentioned user through the shared Forum recipient resolver before describing topic or reply mention targets
- re-resolve the exact mentioned recipient and current richer visibility policy before returning the single-recipient mention audience
- share recipient resolution across mention description, mention audience and target-open authorization
- preserve the public-only fail-closed mention fallback when the host recipient capability is absent
- keep topic-created description and subscription audience behavior public-only and unchanged
- preserve reply lifecycle checks and exact owner-topic visibility for reply mention targets
- add the FORUM-20O contract, SQLite scenario and synchronized J/K/L/M/N/O source verifiers

## Safety and degraded behavior

- unavailable or inactive mentioned recipients produce no descriptor or an empty audience without an existence oracle
- retryable recipient-context and audience-facts failures remain retryable provider failures
- local role and explicit-user constraints continue to resolve without host facts adapters
- the notification source does not read normalized category/topic audience relation tables directly
- stale mention descriptors are rechecked against the current exact recipient policy before fanout

## Remaining scope

- recipient-specific topic-created subscription filtering before pagination
- initially non-public topic-created descriptor materialization
- profile privacy and blocking policy
- host trust, channel and group facts adapters
- final notification creation and delivery authorization
- search/index, SEO and deep-link migration
- PostgreSQL and cross-consumer runtime evidence

The canonical implementation plan still physically ends at FORUM-20G. Machine contracts keep synchronization explicitly pending through FORUM-20O.

## Validation

Tests, Cargo commands, formatting commands, verifiers and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture
node scripts/verify/verify-forum-topic-audience-visibility.mjs
node scripts/verify/verify-forum-notification-visibility-composition.mjs
node scripts/verify/verify-forum-notification-recipient-context.mjs
node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
node scripts/verify/verify-forum-notification-recipient-target-open.mjs
node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
cargo xtask module validate forum
```