### PR TITLE
fix(index): bind evidence reports to benchmark runs

### DIFF
--- a/ops/benches/src/bin/index_storage_benchmark.rs
+++ b/ops/benches/src/bin/index_storage_benchmark.rs
@@ -1,10 +1,12 @@
-use rustok_benchmarks::index_storage::{BenchmarkConfig, run, write_report};
+use rustok_benchmarks::index_storage::{
+    BenchmarkConfig, run, write_provenance_bound_report,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report(&config.output_path, &report)?;
+    write_provenance_bound_report(&config.output_path, &report, &config.run_provenance)?;
 
     println!(
         "index storage benchmark complete: scale={:?}, product_rows={}, output={}",

--- a/ops/benches/src/bin/index_storage_maintenance_benchmark.rs
+++ b/ops/benches/src/bin/index_storage_maintenance_benchmark.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf};
 
 use anyhow::{Context, Result, ensure};
 use rustok_benchmarks::index_storage::{
-    BenchmarkConfig, run_maintenance, write_maintenance_report,
+    BenchmarkConfig, run_maintenance, write_provenance_bound_report,
 };
 
 #[tokio::main]
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         });
 
     let report = run_maintenance(&config, cycles).await?;
-    write_maintenance_report(&output, &report)?;
+    write_provenance_bound_report(&output, &report, &config.run_provenance)?;
 
     println!(
         "index maintenance benchmark complete: scale={:?}, cycles={}, output={}",

--- a/ops/benches/src/bin/index_storage_mutation_benchmark.rs
+++ b/ops/benches/src/bin/index_storage_mutation_benchmark.rs
@@ -1,6 +1,8 @@
 use std::{env, path::PathBuf};
 
-use rustok_benchmarks::index_storage::{BenchmarkConfig, run_mutations, write_mutation_report};
+use rustok_benchmarks::index_storage::{
+    BenchmarkConfig, run_mutations, write_provenance_bound_report,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -9,7 +11,7 @@ async fn main() -> anyhow::Result<()> {
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("target/index-storage-benchmark/mutation-report.json"));
     let report = run_mutations(&config).await?;
-    write_mutation_report(&output, &report)?;
+    write_provenance_bound_report(&output, &report, &config.run_provenance)?;
 
     println!(
         "index mutation benchmark complete: scale={:?}, output={}",

--- a/ops/benches/src/index_storage/config.rs
+++ b/ops/benches/src/index_storage/config.rs
@@ -96,12 +96,42 @@ impl DatasetConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BenchmarkRunProvenance {
+    pub repository: Option<String>,
+    pub commit: Option<String>,
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    pub run_id: Option<String>,
+    pub run_attempt: Option<String>,
+    pub job: Option<String>,
+    pub runner_os: Option<String>,
+    pub runner_arch: Option<String>,
+}
+
+impl BenchmarkRunProvenance {
+    fn from_env() -> Self {
+        let value = |name| env::var(name).ok().filter(|value| !value.is_empty());
+        Self {
+            repository: value("GITHUB_REPOSITORY"),
+            commit: value("GITHUB_SHA"),
+            git_ref: value("GITHUB_REF"),
+            run_id: value("GITHUB_RUN_ID"),
+            run_attempt: value("GITHUB_RUN_ATTEMPT"),
+            job: value("GITHUB_JOB"),
+            runner_os: value("RUNNER_OS"),
+            runner_arch: value("RUNNER_ARCH"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BenchmarkConfig {
     pub database_url: String,
     pub dataset: DatasetConfig,
     pub repetitions: u32,
     pub output_path: PathBuf,
+    pub run_provenance: BenchmarkRunProvenance,
 }
 
 impl BenchmarkConfig {
@@ -130,6 +160,7 @@ impl BenchmarkConfig {
             dataset: DatasetConfig::for_scale(scale, locales)?,
             repetitions,
             output_path,
+            run_provenance: BenchmarkRunProvenance::from_env(),
         })
     }
 }

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -4,10 +4,11 @@ mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
+mod report_provenance;
 mod runner;
 mod sql;
 
-pub use config::{BenchmarkConfig, DatasetConfig, DatasetScale};
+pub use config::{BenchmarkConfig, BenchmarkRunProvenance, DatasetConfig, DatasetScale};
 pub(crate) use connection::connect as connect_benchmark_database;
 pub use database_metadata::DatabaseMetadata;
 pub(crate) use database_metadata::{ensure_database_metadata_stable, read_database_metadata};
@@ -15,6 +16,7 @@ pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
+pub use report_provenance::write_provenance_bound_report;
 pub use runner::{BenchmarkReport, run, write_report};
 pub(crate) use sql::read_workload_contract;
 pub use sql::{
@@ -26,6 +28,6 @@ pub use sql::{
 pub async fn run_from_env() -> anyhow::Result<BenchmarkReport> {
     let config = BenchmarkConfig::from_env()?;
     let report = run(&config).await?;
-    write_report(&config.output_path, &report)?;
+    write_provenance_bound_report(&config.output_path, &report, &config.run_provenance)?;
     Ok(report)
 }

--- a/ops/benches/src/index_storage/report_provenance.rs
+++ b/ops/benches/src/index_storage/report_provenance.rs
@@ -1,0 +1,44 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use super::BenchmarkRunProvenance;
+
+#[derive(Serialize)]
+struct ProvenanceBoundReport<'a, T> {
+    #[serde(flatten)]
+    report: &'a T,
+    provenance: &'a BenchmarkRunProvenance,
+}
+
+pub fn write_provenance_bound_report<T: Serialize>(
+    path: &Path,
+    report: &T,
+    provenance: &BenchmarkRunProvenance,
+) -> Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create provenance-bound report directory {parent:?}"))?;
+    }
+    let filename = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("benchmark report path must have a UTF-8 filename")?;
+    let staged = path.with_file_name(format!("{filename}.tmp-{}", std::process::id()));
+    let envelope = ProvenanceBoundReport { report, provenance };
+    let result: Result<()> = (|| {
+        fs::write(&staged, serde_json::to_vec_pretty(&envelope)?)
+            .with_context(|| format!("failed to stage provenance-bound benchmark report {staged:?}"))?;
+        fs::rename(&staged, path)
+            .with_context(|| format!("failed to publish provenance-bound benchmark report {path:?}"))?;
+        Ok(())
+    })();
+    if staged.exists() {
+        let _ = fs::remove_file(&staged);
+    }
+    result
+}

--- a/scripts/verify/check-index-storage-read-ordering.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.mjs
@@ -35,6 +35,27 @@ const canonicalDatabaseMetadataFields = Object.freeze([
   ...comparableDatabaseFields,
 ]);
 const canonicalDatabaseMetadataFieldSet = [...canonicalDatabaseMetadataFields].sort();
+const canonicalRunProvenanceFields = Object.freeze([
+  'repository',
+  'commit',
+  'ref',
+  'run_id',
+  'run_attempt',
+  'job',
+  'runner_os',
+  'runner_arch',
+]);
+const canonicalRunProvenanceFieldSet = [...canonicalRunProvenanceFields].sort();
+const githubProvenanceEnvironment = new Map([
+  ['repository', 'GITHUB_REPOSITORY'],
+  ['commit', 'GITHUB_SHA'],
+  ['ref', 'GITHUB_REF'],
+  ['run_id', 'GITHUB_RUN_ID'],
+  ['run_attempt', 'GITHUB_RUN_ATTEMPT'],
+  ['job', 'GITHUB_JOB'],
+  ['runner_os', 'RUNNER_OS'],
+  ['runner_arch', 'RUNNER_ARCH'],
+]);
 
 const fail = (message) => {
   throw new Error(message);
@@ -88,6 +109,56 @@ const requireSameDatabaseMetadata = (expected, actual, label) => {
         `${label}.database.${field} must match read-report.json database metadata; expected ${expected[field]}, got ${actual[field]}`,
       );
     }
+  }
+};
+
+const readRunProvenance = (report, label) => {
+  if (!Object.hasOwn(report, 'provenance')) {
+    if (!Object.hasOwn(report, 'generated_at')) return null;
+    fail(`${label}.provenance must be an object`);
+  }
+  const provenance = requireObject(report.provenance, `${label}.provenance`);
+  const actualFields = Object.keys(provenance).sort();
+  if (!sameJson(actualFields, canonicalRunProvenanceFieldSet)) {
+    fail(
+      `${label}.provenance fields mismatch: expected ${canonicalRunProvenanceFields.join(', ')}, got ${actualFields.join(', ')}`,
+    );
+  }
+  for (const field of canonicalRunProvenanceFields) {
+    const value = provenance[field];
+    if (value !== null && (typeof value !== 'string' || value.length === 0)) {
+      fail(`${label}.provenance.${field} must be a non-empty string or null`);
+    }
+  }
+  return provenance;
+};
+
+const requireSameRunProvenance = (expected, actual, label) => {
+  for (const field of canonicalRunProvenanceFields) {
+    if (actual[field] !== expected[field]) {
+      fail(
+        `${label}.provenance.${field} must match read-report.json run provenance; expected ${expected[field]}, got ${actual[field]}`,
+      );
+    }
+  }
+};
+
+const requireCurrentGitHubProvenance = (provenance, label) => {
+  if (process.env.INDEX_BENCH_REQUIRE_GITHUB_PROVENANCE !== '1') return;
+  for (const [field, environmentName] of githubProvenanceEnvironment) {
+    const expected = process.env[environmentName];
+    if (typeof expected !== 'string' || expected.length === 0) {
+      fail(`${environmentName} is required when GitHub provenance is enforced`);
+    }
+    if (provenance[field] !== expected) {
+      fail(`${label}.provenance.${field} must match current ${environmentName}`);
+    }
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(provenance.commit)) {
+    fail(`${label}.provenance.commit must be a full Git SHA`);
+  }
+  if (!/^\d+$/u.test(provenance.run_id) || !/^\d+$/u.test(provenance.run_attempt)) {
+    fail(`${label}.provenance run_id and run_attempt must be numeric strings`);
   }
 };
 
@@ -209,9 +280,22 @@ const readReport = (directory, filename = 'read-report.json') => {
   }
 };
 
+const requireExistingPacketProvenance = (directory, expected) => {
+  if (expected === null) return;
+  const filename = 'provenance.json';
+  if (!existsSync(path.join(directory, filename))) return;
+  const packet = requireObject(readReport(directory, filename), `${directory} ${filename}`);
+  const actual = Object.fromEntries(
+    canonicalRunProvenanceFields.map((field) => [field, packet[field] ?? null]),
+  );
+  requireSameRunProvenance(expected, actual, `${directory} ${filename}`);
+};
+
 export const validatePacketReadOrdering = (directory) => {
   const read = requireObject(readReport(directory), `${directory} read report`);
   const readDatabase = requireSessionMetadata(read, directory);
+  const readProvenance = readRunProvenance(read, `${directory} read`);
+  if (readProvenance !== null) requireCurrentGitHubProvenance(readProvenance, `${directory} read`);
   requireExactNames(read.source_workloads, canonicalReadWorkloads, `${directory} source workload order`);
   for (const workload of read.source_workloads) {
     requireObject(workload, `${directory} source/${workload?.name ?? 'unknown'}`);
@@ -240,7 +324,16 @@ export const validatePacketReadOrdering = (directory) => {
     const report = requireObject(readReport(directory, filename), `${directory} ${filename}`);
     const database = requireDatabaseMetadata(report, `${directory} ${filename}`);
     requireSameDatabaseMetadata(readDatabase, database, `${directory} ${filename}`);
+    const provenance = readRunProvenance(report, `${directory} ${filename}`);
+    if ((readProvenance === null) !== (provenance === null)) {
+      fail(`${directory} reports must either all contain run provenance or all be incomplete core fixtures`);
+    }
+    if (readProvenance !== null && provenance !== null) {
+      requireSameRunProvenance(readProvenance, provenance, `${directory} ${filename}`);
+      requireCurrentGitHubProvenance(provenance, `${directory} ${filename}`);
+    }
   }
+  requireExistingPacketProvenance(directory, readProvenance);
 };
 
 const usage = () => {
@@ -253,6 +346,7 @@ const parseArgs = () => {
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') {
+      if (args.length !== 1) fail('help must be the only argument');
       usage();
       return null;
     }
@@ -269,7 +363,7 @@ const main = () => {
   const inputs = parseArgs();
   if (inputs === null) return;
   for (const input of inputs) validatePacketReadOrdering(input);
-  console.log(`${prefix} deterministic session metadata and executable terminal ordering verified across read, mutation, and maintenance reports for ${inputs.length} evidence packet(s)`);
+  console.log(`${prefix} benchmark run provenance, deterministic session metadata, and executable terminal ordering verified across read, mutation, and maintenance reports for ${inputs.length} evidence packet(s)`);
 };
 
 const isMain = process.argv[1]

--- a/scripts/verify/check-index-storage-read-ordering.test.mjs
+++ b/scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -34,6 +34,16 @@ const databaseMetadata = () => ({
   date_style: 'ISO, YMD',
   extra_float_digits: '3',
 });
+const runProvenance = () => ({
+  repository: process.env.GITHUB_REPOSITORY ?? 'RusTokRs/RusTok',
+  commit: process.env.GITHUB_SHA ?? 'a'.repeat(40),
+  ref: process.env.GITHUB_REF ?? 'refs/heads/agent/index-evidence',
+  run_id: process.env.GITHUB_RUN_ID ?? '123456',
+  run_attempt: process.env.GITHUB_RUN_ATTEMPT ?? '1',
+  job: process.env.GITHUB_JOB ?? 'evidence',
+  runner_os: process.env.RUNNER_OS ?? 'Linux',
+  runner_arch: process.env.RUNNER_ARCH ?? 'X64',
+});
 
 const sql = (relation, workload) => {
   if (workload === 'exact_count') {
@@ -46,7 +56,9 @@ const sql = (relation, workload) => {
 };
 
 const report = () => ({
+  generated_at: '2026-07-25T00:00:00Z',
   database: databaseMetadata(),
+  provenance: runProvenance(),
   source_workloads: workloads.map((name) => ({
     name,
     sql: `${sql('idx_bench_source.product', name)}   \n`,
@@ -64,8 +76,16 @@ const withPacket = (mutate, callback) => {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-read-ordering-'));
   try {
     const read = report();
-    const mutation = { database: databaseMetadata() };
-    const maintenance = { database: databaseMetadata() };
+    const mutation = {
+      generated_at: '2026-07-25T00:01:00Z',
+      database: databaseMetadata(),
+      provenance: runProvenance(),
+    };
+    const maintenance = {
+      generated_at: '2026-07-25T00:02:00Z',
+      database: databaseMetadata(),
+      provenance: runProvenance(),
+    };
     mutate?.(read, mutation, maintenance);
     mkdirSync(root, { recursive: true });
     writeFileSync(path.join(root, 'read-report.json'), `${JSON.stringify(read, null, 2)}\n`, 'utf8');
@@ -77,7 +97,11 @@ const withPacket = (mutate, callback) => {
   }
 };
 
-const run = (root) => spawnSync(process.execPath, [script, '--input', root], { encoding: 'utf8' });
+const run = (root, env = process.env) => spawnSync(
+  process.execPath,
+  [script, '--input', root],
+  { encoding: 'utf8', env },
+);
 
 const expectFailure = (mutate, pattern) => {
   withPacket(mutate, (root) => {
@@ -122,6 +146,56 @@ test('rejects a mutation report without observed database metadata', () => {
   expectFailure((_read, mutation) => {
     delete mutation.database;
   }, /mutation-report\.json\.database must be an object/u);
+});
+
+test('rejects missing report provenance fields', () => {
+  expectFailure((_read, mutation) => {
+    delete mutation.provenance.run_attempt;
+  }, /mutation-report\.json\.provenance fields mismatch/u);
+});
+
+test('rejects cross-report run provenance drift', () => {
+  expectFailure((_read, mutation) => {
+    mutation.provenance.commit = 'b'.repeat(40);
+  }, /mutation-report\.json\.provenance\.commit must match read-report\.json run provenance/u);
+});
+
+test('rejects report provenance from a different current GitHub job', () => {
+  withPacket(null, (root) => {
+    const differentCommit = runProvenance().commit === 'b'.repeat(40)
+      ? 'c'.repeat(40)
+      : 'b'.repeat(40);
+    const result = run(root, {
+      ...process.env,
+      INDEX_BENCH_REQUIRE_GITHUB_PROVENANCE: '1',
+      GITHUB_REPOSITORY: runProvenance().repository,
+      GITHUB_SHA: differentCommit,
+      GITHUB_REF: runProvenance().ref,
+      GITHUB_RUN_ID: runProvenance().run_id,
+      GITHUB_RUN_ATTEMPT: runProvenance().run_attempt,
+      GITHUB_JOB: runProvenance().job,
+      RUNNER_OS: runProvenance().runner_os,
+      RUNNER_ARCH: runProvenance().runner_arch,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /read\.provenance\.commit must match current GITHUB_SHA/u);
+  });
+});
+
+test('rejects stale packet provenance from another report run', () => {
+  withPacket(null, (root) => {
+    const staleCommit = runProvenance().commit === 'b'.repeat(40)
+      ? 'c'.repeat(40)
+      : 'b'.repeat(40);
+    writeFileSync(path.join(root, 'provenance.json'), `${JSON.stringify({
+      ...runProvenance(),
+      commit: staleCommit,
+      packet_contract_version: 2,
+    }, null, 2)}\n`, 'utf8');
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /provenance\.json\.provenance\.commit must match read-report\.json run provenance/u);
+  });
 });
 
 test('accepts comment tokens inside strings and comments after executable ordering', () => {
@@ -200,4 +274,15 @@ test('rejects workload order drift before checking SQL text', () => {
       value.source_workloads[0],
     ];
   }, /source workload order mismatch/u);
+});
+
+test('rejects help combined with evidence arguments', () => {
+  const result = spawnSync(
+    process.execPath,
+    [script, '--help', '--input', 'missing-evidence'],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /help must be the only argument/u);
+  assert.equal(result.stdout, '');
 });

--- a/scripts/verify/compare-index-storage-evidence.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence.test.mjs
@@ -138,6 +138,21 @@ function writePacket(root, scale, overrides = {}) {
   const sourceNames = overrides.sourceWorkloads ?? readWorkloads;
   const readRepetitions = overrides.readRepetitions ?? 3;
   const mutationRepetitions = overrides.mutationRepetitions ?? 3;
+  const reportProvenance = {
+    repository: process.env.GITHUB_REPOSITORY ?? 'RusTokRs/RusTok',
+    commit: process.env.GITHUB_SHA ?? '0123456789abcdef0123456789abcdef01234567',
+    ref: process.env.GITHUB_REF ?? 'refs/heads/main',
+    run_id: process.env.GITHUB_RUN_ID ?? (scale === '100k' ? '100' : '101'),
+    run_attempt: process.env.GITHUB_RUN_ATTEMPT ?? '1',
+    job: process.env.GITHUB_JOB ?? 'index-storage-scale',
+    runner_os: process.env.RUNNER_OS ?? 'Linux',
+    runner_arch: process.env.RUNNER_ARCH ?? 'X64',
+  };
+  for (const field of Object.keys(reportProvenance)) {
+    if (Object.hasOwn(overrides.provenance ?? {}, field)) {
+      reportProvenance[field] = overrides.provenance[field];
+    }
+  }
 
   const source_workloads = sourceNames.map((name) => {
     const index = readWorkloads.indexOf(name);
@@ -150,6 +165,7 @@ function writePacket(root, scale, overrides = {}) {
   });
   const read = {
     generated_at: generatedAt,
+    provenance: { ...reportProvenance },
     result_digest_contract: overrides.readDigestContract ?? resultDigestContract,
     database: databaseMetadata(overrides.database),
     dataset: {
@@ -192,6 +208,7 @@ function writePacket(root, scale, overrides = {}) {
 
   const mutation = {
     generated_at: generatedAt,
+    provenance: { ...reportProvenance },
     database: databaseMetadata({ ...overrides.database, ...overrides.mutationDatabase }),
     dataset_scale: values.debug,
     repetitions: 3,
@@ -214,6 +231,7 @@ function writePacket(root, scale, overrides = {}) {
 
   const maintenance = {
     generated_at: generatedAt,
+    provenance: { ...reportProvenance },
     database: databaseMetadata({ ...overrides.database, ...overrides.maintenanceDatabase }),
     dataset_scale: values.serialized,
     cycles: overrides.maintenanceCycles ?? 5,
@@ -235,15 +253,8 @@ function writePacket(root, scale, overrides = {}) {
   const provenance = {
     packet_contract_version: 2,
     generated_at: generatedAt,
-    repository: 'RusTokRs/RusTok',
-    commit: '0123456789abcdef0123456789abcdef01234567',
-    ref: 'refs/heads/main',
-    run_id: scale === '100k' ? '100' : '101',
-    run_attempt: '1',
-    job: 'index-storage-scale',
+    ...reportProvenance,
     postgres_image: 'postgres:16',
-    runner_os: 'Linux',
-    runner_arch: 'X64',
     scale,
     repetitions: 3,
     churn_cycles: 5,
@@ -269,7 +280,13 @@ const runComparator = (inputs, output) => {
   const args = [scriptPath];
   for (const input of inputs) args.push('--input', input);
   args.push('--output', output);
-  return spawnSync('node', args, { encoding: 'utf8' });
+  return spawnSync('node', args, {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      INDEX_BENCH_REQUIRE_GITHUB_PROVENANCE: '0',
+    },
+  });
 };
 const withFixture = (callback) => {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-comparison-'));
@@ -301,7 +318,7 @@ test('same-commit complete 100k and 1m evidence is decision-ready', () => {
     assert.deepEqual(report.methodology.comparable_database_fields, comparableDatabaseFields);
     assert.match(report.methodology.database_settings_source, /observed from the active PostgreSQL benchmark session/u);
     const markdown = readFileSync(path.join(output, 'comparison.md'), 'utf8');
-    for (const field of comparableDatabaseFields) assert.match(markdown, new RegExp(`\\\`${field}\\\``, 'u'));
+    for (const field of comparableDatabaseFields) assert.match(markdown, new RegExp(`\`${field}\``, 'u'));
     assert.equal(report.cross_scale_ratios.source_workloads[0].result_rows_ratio_1m_to_100k, 10);
   });
 });


### PR DESCRIPTION
## What changed

- capture repository, commit, ref, run id/attempt, job, and runner identity when each benchmark executable starts;
- serialize each read, mutation, and maintenance report together with that run envelope into one staged JSON file and publish it atomically;
- require complete reports to expose the exact canonical provenance field set;
- reject cross-report provenance drift before the validator or comparator core is imported;
- when workflow provenance is required, require every report to match the current GitHub job environment;
- reject an existing `provenance.json` whose run identity differs from the report envelopes;
- preserve intentionally incomplete standalone core fixtures, which still fail inside the byte-preserved core because they omit required report fields;
- update canonical comparison fixtures to carry report provenance while keeping archive-oriented comparison independent from the current workflow job;
- retain the direct ordering CLI rule that `--help`/`-h` must be the sole argument.

## Root cause

The validator generated `provenance.json` only after all three benchmark executables had finished. The individual report files did not contain commit or workflow-run identity. A stale or mixed set of otherwise valid reports could therefore be labeled with the validator's current `GITHUB_SHA` and run metadata rather than the run that actually generated those reports.

## Impact

Official smoke, 100k, and 1m reports now carry their generation-run identity before packet validation. The shared preflight used by both standalone validation and comparison rejects reports from different commits, workflow attempts, jobs, or runners and prevents a stale packet provenance file from being paired with newly generated reports. Immediate packet validation additionally rejects reports that do not match the current strict workflow job; archived comparison still validates report-to-report and report-to-packet provenance without requiring the archive to originate from the comparison job. Report publication remains staged and atomic without reparsing an already serialized evidence file. This does not create replacement benchmark evidence, select a PostgreSQL model, or advance M2 beyond same-commit 100k/1m execution, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch is one commit on the current `main`; static review covered generic Serde flattening, Rust ownership, staged report publication, exact provenance field names, incomplete-core-fixture behavior, strict packet-job environment matching, archived comparison behavior, cross-report equality, stale packet provenance rejection, canonical comparator-fixture compatibility, and the existing help-only CLI gate.