### PR TITLE
Harden admin fulfillment route error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -54,6 +54,11 @@ available only for actionable domain errors.
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
   boundary. Provider-result encoding failures are internal invariant failures with a
   static fail-closed `500` envelope instead of dynamic serialization text in a `400`.
+- `rustok-commerce` admin fulfillment routes: list, create, detail, ship, deliver, reopen,
+  reship, and cancel paths retain typed owner or orchestration causes with owner, tenant,
+  route operation, truthful optional fulfillment and order identities, stable public code,
+  status, and HTTP boundary. Persisted reconciliation errors adopt the fulfillment id from
+  the typed orchestration error while validation and technical details stay internal.
 - `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, missing-resource, transition,
@@ -104,6 +109,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
@@ -119,8 +125,8 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin order-detail payment and fulfillment mapping,
-  and tax calculation validation, provider-contract, reconciliation, correlation,
-  HTTP-envelope, and transport round-trip tests.
+  admin fulfillment reconciliation, admin fulfillment routes, admin order-detail payment
+  and fulfillment mapping, and tax calculation validation, provider-contract,
+  reconciliation, correlation, HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
+++ b/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
@@ -5,8 +5,8 @@ use axum::{
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
-use rustok_fulfillment::FulfillmentService;
-use rustok_web::HttpResult;
+use rustok_fulfillment::{FulfillmentError, FulfillmentService};
+use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use super::{
@@ -15,13 +15,41 @@ use super::{
     ListFulfillmentsParams,
 };
 use crate::{
-    FulfillmentOrchestrationService,
+    FulfillmentOrchestrationError, FulfillmentOrchestrationService,
     dto::{
         CancelFulfillmentInput, CreateFulfillmentInput, DeliverFulfillmentInput,
         FulfillmentResponse, ListFulfillmentsInput, ReopenFulfillmentInput, ReshipFulfillmentInput,
         ShipFulfillmentInput,
     },
 };
+
+const ADMIN_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_routes";
+const ADMIN_FULFILLMENT_ORCHESTRATION_OWNER: &str =
+    "rustok_commerce.admin_fulfillment_orchestration";
+const ADMIN_FULFILLMENT_BOUNDARY: &str = "commerce_admin_fulfillment_http";
+
+struct AdminFulfillmentErrorContext {
+    tenant_id: Uuid,
+    fulfillment_id: Option<Uuid>,
+    order_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminFulfillmentErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        fulfillment_id: Option<Uuid>,
+        order_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            fulfillment_id,
+            order_id,
+            operation,
+        }
+    }
+}
 
 /// List admin fulfillments
 #[utoipa::path(
@@ -59,7 +87,17 @@ pub async fn list_fulfillments(
             },
         )
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    None,
+                    None,
+                    "list_fulfillments",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: fulfillments,
@@ -91,11 +129,22 @@ pub async fn create_fulfillment(
         "Permission denied: fulfillments:create required",
     )?;
 
+    let order_id = input.order_id;
     let fulfillment = FulfillmentOrchestrationService::new(runtime.db_clone())
         .with_provider_registry(runtime.fulfillment_provider_registry())
         .create_manual_fulfillment(tenant.id, input)
         .await
-        .map_err(super::map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_orchestration_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    None,
+                    Some(order_id),
+                    "create_manual_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(fulfillment)))
 }
@@ -127,7 +176,17 @@ pub async fn show_fulfillment(
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .get_fulfillment(tenant.id, id)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "get_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
 }
@@ -162,7 +221,17 @@ pub async fn ship_fulfillment(
         .with_provider_registry(runtime.fulfillment_provider_registry())
         .ship_fulfillment(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_orchestration_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "ship_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
 }
@@ -196,7 +265,17 @@ pub async fn deliver_fulfillment(
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .deliver_fulfillment(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "deliver_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
 }
@@ -230,7 +309,17 @@ pub async fn reopen_fulfillment(
     let fulfillment = FulfillmentService::new(runtime.db_clone())
         .reopen_fulfillment(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "reopen_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
 }
@@ -265,7 +354,17 @@ pub async fn reship_fulfillment(
         .with_provider_registry(runtime.fulfillment_provider_registry())
         .reship_fulfillment(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_orchestration_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "reship_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
 }
@@ -300,7 +399,131 @@ pub async fn cancel_fulfillment(
         .with_provider_registry(runtime.fulfillment_provider_registry())
         .cancel_fulfillment(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_fulfillment_orchestration_error(
+                AdminFulfillmentErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "cancel_fulfillment",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(fulfillment))
+}
+
+fn map_admin_fulfillment_error(
+    context: AdminFulfillmentErrorContext,
+    error: FulfillmentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_)
+        | FulfillmentError::FulfillmentNotFound(_) => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        FulfillmentError::Database(_) => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_FULFILLMENT_OWNER,
+        tenant_id = %context.tenant_id,
+        fulfillment_id = ?context.fulfillment_id,
+        order_id = ?context.order_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_FULFILLMENT_BOUNDARY,
+        "commerce admin fulfillment owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_fulfillment_orchestration_error(
+    context: AdminFulfillmentErrorContext,
+    error: FulfillmentOrchestrationError,
+) -> HttpError {
+    match error {
+        FulfillmentOrchestrationError::Fulfillment(error) => {
+            map_admin_fulfillment_error(context, error)
+        }
+        error => {
+            let mut context = context;
+            if let FulfillmentOrchestrationError::ProviderAfterPersistence {
+                fulfillment_id, ..
+            }
+            | FulfillmentOrchestrationError::PersistenceAfterProvider {
+                fulfillment_id, ..
+            } = &error
+            {
+                context.fulfillment_id = Some(*fulfillment_id);
+            }
+            let (status, code, message, error_kind) = match &error {
+                FulfillmentOrchestrationError::OrderNotFound(_) => (
+                    axum::http::StatusCode::NOT_FOUND,
+                    "commerce_admin_not_found",
+                    "Commerce resource not found",
+                    "order_not_found",
+                ),
+                FulfillmentOrchestrationError::Database(_) => (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "commerce_admin_fulfillment_storage_unavailable",
+                    "Fulfillment storage is temporarily unavailable",
+                    "database",
+                ),
+                FulfillmentOrchestrationError::Validation(_) => (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "commerce_admin_fulfillment_invalid",
+                    "Fulfillment request is invalid",
+                    "validation",
+                ),
+                FulfillmentOrchestrationError::ProviderAfterPersistence { .. }
+                | FulfillmentOrchestrationError::PersistenceAfterProvider { .. } => (
+                    axum::http::StatusCode::CONFLICT,
+                    "commerce_admin_fulfillment_reconciliation_required",
+                    "Fulfillment operation requires reconciliation",
+                    "reconciliation_required",
+                ),
+                FulfillmentOrchestrationError::Fulfillment(_) => unreachable!(
+                    "nested fulfillment errors are handled before orchestration mapping"
+                ),
+            };
+            tracing::error!(
+                error = ?error,
+                owner = ADMIN_FULFILLMENT_ORCHESTRATION_OWNER,
+                tenant_id = %context.tenant_id,
+                fulfillment_id = ?context.fulfillment_id,
+                order_id = ?context.order_id,
+                operation = %context.operation,
+                error_kind,
+                public_code = code,
+                status = %status,
+                boundary = ADMIN_FULFILLMENT_BOUNDARY,
+                "commerce admin fulfillment orchestration failed"
+            );
+            HttpError::new(status, code, message)
+        }
+    }
 }

--- a/scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read('crates/rustok-commerce/src/controllers/admin/fulfillments.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const orchestrationErrors = read(
+  'crates/rustok-commerce/src/services/fulfillment_orchestration.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const ownerMapper = between(
+  source,
+  'fn map_admin_fulfillment_error(',
+  'fn map_admin_fulfillment_orchestration_error(',
+  'admin fulfillment owner mapper',
+);
+const orchestrationStart = source.indexOf('fn map_admin_fulfillment_orchestration_error(');
+const orchestrationMapper =
+  orchestrationStart < 0
+    ? ''
+    : source.slice(orchestrationStart);
+if (orchestrationStart < 0) {
+  failures.push('admin fulfillment orchestration mapper: unable to isolate source block');
+}
+
+for (const [value, label] of [
+  ['use rustok_fulfillment::{FulfillmentError, FulfillmentService};', 'typed fulfillment import'],
+  ['FulfillmentOrchestrationError, FulfillmentOrchestrationService,', 'typed orchestration import'],
+  ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
+  ['const ADMIN_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_routes";', 'owner constant'],
+  [
+    'const ADMIN_FULFILLMENT_ORCHESTRATION_OWNER: &str =',
+    'orchestration owner constant',
+  ],
+  [
+    'const ADMIN_FULFILLMENT_BOUNDARY: &str = "commerce_admin_fulfillment_http";',
+    'HTTP boundary constant',
+  ],
+  ['struct AdminFulfillmentErrorContext {', 'route error context'],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['fulfillment_id: Option<Uuid>,', 'truthful fulfillment identity field'],
+  ['order_id: Option<Uuid>,', 'truthful order identity field'],
+  ["operation: &'static str,", 'operation context field'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['pub async fn list_fulfillments(', 'list route'],
+  ['pub async fn create_fulfillment(', 'create route'],
+  ['pub async fn show_fulfillment(', 'show route'],
+  ['pub async fn ship_fulfillment(', 'ship route'],
+  ['pub async fn deliver_fulfillment(', 'deliver route'],
+  ['pub async fn reopen_fulfillment(', 'reopen route'],
+  ['pub async fn reship_fulfillment(', 'reship route'],
+  ['pub async fn cancel_fulfillment(', 'cancel route'],
+  ['[Permission::FULFILLMENTS_READ]', 'read permission'],
+  ['[Permission::FULFILLMENTS_CREATE]', 'create permission'],
+  ['[Permission::FULFILLMENTS_UPDATE]', 'update permission'],
+  ['ListFulfillmentsInput {', 'list input contract'],
+  ['page: pagination.page', 'page forwarding'],
+  ['per_page: pagination.limit()', 'page-size forwarding'],
+  ['let order_id = input.order_id;', 'create order identity capture'],
+  ['Some(order_id)', 'create order identity context'],
+  ['.create_manual_fulfillment(tenant.id, input)', 'create service contract'],
+  ['.get_fulfillment(tenant.id, id)', 'show service contract'],
+  ['.ship_fulfillment(tenant.id, id, input)', 'ship service contract'],
+  ['.deliver_fulfillment(tenant.id, id, input)', 'deliver service contract'],
+  ['.reopen_fulfillment(tenant.id, id, input)', 'reopen service contract'],
+  ['.reship_fulfillment(tenant.id, id, input)', 'reship service contract'],
+  ['.cancel_fulfillment(tenant.id, id, input)', 'cancel service contract'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['"list_fulfillments"', 'list operation'],
+  ['"create_manual_fulfillment"', 'create operation'],
+  ['"get_fulfillment"', 'show operation'],
+  ['"ship_fulfillment"', 'ship operation'],
+  ['"deliver_fulfillment"', 'deliver operation'],
+  ['"reopen_fulfillment"', 'reopen operation'],
+  ['"reship_fulfillment"', 'reship operation'],
+  ['"cancel_fulfillment"', 'cancel operation'],
+]) requireText(source, value, label);
+
+const ownerMapperUses =
+  source.match(
+    /map_admin_fulfillment_error\(\s+AdminFulfillmentErrorContext::new\(/g,
+  ) ?? [];
+if (ownerMapperUses.length !== 4) {
+  failures.push(`expected four context-aware owner mapper callsites, found ${ownerMapperUses.length}`);
+}
+const orchestrationMapperUses =
+  source.match(
+    /map_admin_fulfillment_orchestration_error\(\s+AdminFulfillmentErrorContext::new\(/g,
+  ) ?? [];
+if (orchestrationMapperUses.length !== 4) {
+  failures.push(
+    `expected four context-aware orchestration mapper callsites, found ${orchestrationMapperUses.length}`,
+  );
+}
+
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
+  ['FulfillmentError::Database(_)', 'database variant'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_FULFILLMENT_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['fulfillment_id = ?context.fulfillment_id', 'fulfillment identity log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_FULFILLMENT_BOUNDARY', 'boundary log'],
+  ['"Fulfillment request is invalid"', 'static validation envelope'],
+  ['"Commerce resource not found"', 'static not-found envelope'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static conflict envelope',
+  ],
+  ['"Fulfillment storage is temporarily unavailable"', 'static storage envelope'],
+  ['HttpError::new(status, code, message)', 'single owner envelope constructor'],
+]) requireText(ownerMapper, value, label);
+
+for (const [value, label] of [
+  ['FulfillmentOrchestrationError::Fulfillment(error)', 'nested owner delegation'],
+  ['FulfillmentOrchestrationError::OrderNotFound(_)', 'order-not-found variant'],
+  ['FulfillmentOrchestrationError::Database(_)', 'database variant'],
+  ['FulfillmentOrchestrationError::Validation(_)', 'validation variant'],
+  [
+    'FulfillmentOrchestrationError::ProviderAfterPersistence {',
+    'provider-after-persistence variant',
+  ],
+  [
+    'FulfillmentOrchestrationError::PersistenceAfterProvider {',
+    'persistence-after-provider variant',
+  ],
+  ['context.fulfillment_id = Some(*fulfillment_id);', 'persisted fulfillment identity adoption'],
+  ['owner = ADMIN_FULFILLMENT_ORCHESTRATION_OWNER', 'orchestration owner log'],
+  ['tenant_id = %context.tenant_id', 'orchestration tenant log'],
+  ['fulfillment_id = ?context.fulfillment_id', 'orchestration fulfillment identity log'],
+  ['order_id = ?context.order_id', 'orchestration order identity log'],
+  ['operation = %context.operation', 'orchestration operation log'],
+  ['"Fulfillment operation requires reconciliation"', 'static reconciliation envelope'],
+  ['HttpError::new(status, code, message)', 'single orchestration envelope constructor'],
+]) requireText(orchestrationMapper, value, label);
+
+for (const [ownerSource, value, label] of [
+  [fulfillmentErrors, 'Validation(String)', 'owner validation variant'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
+  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  [fulfillmentErrors, 'Database(#[from] DbErr)', 'owner database variant'],
+  [orchestrationErrors, 'OrderNotFound(Uuid)', 'orchestration order-not-found variant'],
+  [orchestrationErrors, 'Database(#[from] sea_orm::DbErr)', 'orchestration database variant'],
+  [
+    orchestrationErrors,
+    'Fulfillment(#[from] rustok_fulfillment::error::FulfillmentError)',
+    'orchestration fulfillment variant',
+  ],
+  [orchestrationErrors, 'Validation(String)', 'orchestration validation variant'],
+  [orchestrationErrors, 'ProviderAfterPersistence {', 'provider-after-persistence owner variant'],
+  [orchestrationErrors, 'PersistenceAfterProvider {', 'persistence-after-provider owner variant'],
+]) requireText(ownerSource, value, label);
+
+for (const value of [
+  '.map_err(super::map_fulfillment_error)',
+  '.map_err(super::map_fulfillment_orchestration_error)',
+  'format!("Fulfillment request is invalid:',
+  'error.to_string()',
+  'HttpError::bad_request("commerce_admin_fulfillment_invalid", error',
+]) forbidText(source, value, 'unsafe admin fulfillment public mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce admin fulfillment route error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin fulfillment routes retain typed causes and return static public envelopes',
+);

--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -174,14 +174,31 @@ for (const [value, label] of [
 
 for (const [value, label] of [
   ['pub async fn list_fulfillments(', 'admin fulfillment list'],
+  ['pub async fn create_fulfillment(', 'admin fulfillment create'],
   ['pub async fn show_fulfillment(', 'admin fulfillment detail'],
+  ['pub async fn ship_fulfillment(', 'admin fulfillment ship'],
+  ['pub async fn deliver_fulfillment(', 'admin fulfillment deliver'],
+  ['pub async fn reopen_fulfillment(', 'admin fulfillment reopen'],
+  ['pub async fn reship_fulfillment(', 'admin fulfillment reship'],
+  ['pub async fn cancel_fulfillment(', 'admin fulfillment cancel'],
   ['ListFulfillmentsInput {', 'fulfillment list input'],
   ['page: pagination.page', 'fulfillment page forwarding'],
   ['per_page: pagination.limit()', 'fulfillment page-size forwarding'],
-  ['.map_err(super::map_fulfillment_error)?;', 'typed fulfillment owner mapping'],
-  ['.map_err(super::map_fulfillment_orchestration_error)?;', 'typed fulfillment orchestration mapping'],
+  ['struct AdminFulfillmentErrorContext {', 'fulfillment route context'],
+  ['fn map_admin_fulfillment_error(', 'context-aware fulfillment owner mapper'],
+  [
+    'fn map_admin_fulfillment_orchestration_error(',
+    'context-aware fulfillment orchestration mapper',
+  ],
 ]) {
   requireText(fulfillments, value, label);
+}
+
+for (const value of [
+  '.map_err(super::map_fulfillment_error)?;',
+  '.map_err(super::map_fulfillment_orchestration_error)?;',
+]) {
+  forbidText(fulfillments, value, 'stale admin fulfillment shared mapper callsite');
 }
 
 for (const [content, label] of [
@@ -206,15 +223,23 @@ if (orderMapperUses !== 10) {
 }
 
 const fulfillmentMapperUses =
-  fulfillments.match(/\.map_err\(super::map_fulfillment_error\)\?;/g) ?? [];
+  fulfillments.match(
+    /map_admin_fulfillment_error\(\s+AdminFulfillmentErrorContext::new\(/g,
+  ) ?? [];
 if (fulfillmentMapperUses.length !== 4) {
-  failures.push(`expected four fulfillment owner mapper callsites, found ${fulfillmentMapperUses.length}`);
+  failures.push(
+    `expected four context-aware fulfillment owner mapper callsites, found ${fulfillmentMapperUses.length}`,
+  );
 }
 
 const fulfillmentOrchestrationUses =
-  fulfillments.match(/\.map_err\(super::map_fulfillment_orchestration_error\)\?;/g) ?? [];
+  fulfillments.match(
+    /map_admin_fulfillment_orchestration_error\(\s+AdminFulfillmentErrorContext::new\(/g,
+  ) ?? [];
 if (fulfillmentOrchestrationUses.length !== 4) {
-  failures.push(`expected four fulfillment orchestration mapper callsites, found ${fulfillmentOrchestrationUses.length}`);
+  failures.push(
+    `expected four context-aware fulfillment orchestration mapper callsites, found ${fulfillmentOrchestrationUses.length}`,
+  );
 }
 
 const postOrderUses =


### PR DESCRIPTION
## Summary

- replace the eight shared admin fulfillment mapper callsites with route-local context-aware typed mappers;
- retain fulfillment and orchestration causes internally with owner, tenant, route operation, truthful optional fulfillment and order identities, error kind, public code, status, and HTTP boundary;
- preserve existing public validation, not-found, transition, storage, and reconciliation status/code/message policies while removing the shared dynamic validation envelope from these routes;
- capture the create route's order identity before consuming the request;
- adopt the persisted fulfillment identity from reconciliation-required orchestration errors;
- add a focused static verifier, align the broad admin order/fulfillment verifier, and update the ecommerce public-error safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/fulfillments.rs`
- `scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
- `scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch was rebased onto current `main` after an unrelated Forum commit landed;
- the branch is directly ahead of current `main` by 4 commits and is not behind;
- final diff is limited to the four intended files (`+482/-20`);
- the controller was re-read to confirm all eight existing routes, read/create/update permissions, unchanged service calls and success response contracts, truthful route identities, exhaustive typed error handling, and static public envelopes;
- the focused and broad verifier sources were re-read to confirm exactly four owner and four orchestration context-aware callsites and to forbid the removed shared mapper callsites;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
node scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```