### PR TITLE
fix(index): harden evidence validator lifecycle

### DIFF
--- a/.github/workflows/index-storage-scale-evidence.yml
+++ b/.github/workflows/index-storage-scale-evidence.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/verify/check-index-storage-read-ordering.test.mjs"
       - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
       - "scripts/verify/validate-index-storage-evidence.mjs"
+      - "scripts/verify/validate-index-storage-runner-resources.mjs"
+      - "scripts/verify/run-index-storage-validator-core.mjs"
+      - "scripts/verify/index-storage-validator-arguments.test.mjs"
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
@@ -46,6 +49,9 @@ on:
       - "scripts/verify/check-index-storage-read-ordering.test.mjs"
       - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
       - "scripts/verify/validate-index-storage-evidence.mjs"
+      - "scripts/verify/validate-index-storage-runner-resources.mjs"
+      - "scripts/verify/run-index-storage-validator-core.mjs"
+      - "scripts/verify/index-storage-validator-arguments.test.mjs"
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
@@ -111,7 +117,12 @@ jobs:
       - name: Verify scale evidence validator syntax
         run: |
           node --check scripts/verify/validate-index-storage-evidence.mjs
+          node --check scripts/verify/validate-index-storage-runner-resources.mjs
+          node --check scripts/verify/run-index-storage-validator-core.mjs
+          node --check scripts/verify/index-storage-validator-arguments.test.mjs
           node --check scripts/verify/validate-index-storage-evidence-core.mjs
+      - name: Test scale evidence validator arguments
+        run: node --test scripts/verify/index-storage-validator-arguments.test.mjs
       - name: Verify cross-scale comparator syntax
         run: |
           node --check scripts/verify/index-storage-database-settings-contract.mjs

--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/verify/check-index-storage-read-ordering.test.mjs"
       - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
       - "scripts/verify/validate-index-storage-evidence.mjs"
+      - "scripts/verify/validate-index-storage-runner-resources.mjs"
+      - "scripts/verify/run-index-storage-validator-core.mjs"
+      - "scripts/verify/index-storage-validator-arguments.test.mjs"
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
@@ -43,6 +46,9 @@ on:
       - "scripts/verify/check-index-storage-read-ordering.test.mjs"
       - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
       - "scripts/verify/validate-index-storage-evidence.mjs"
+      - "scripts/verify/validate-index-storage-runner-resources.mjs"
+      - "scripts/verify/run-index-storage-validator-core.mjs"
+      - "scripts/verify/index-storage-validator-arguments.test.mjs"
       - "scripts/verify/validate-index-storage-evidence-core.mjs"
       - "scripts/verify/compare-index-storage-evidence.mjs"
       - "scripts/verify/compare-index-storage-evidence-core.mjs"
@@ -101,6 +107,9 @@ jobs:
             node --check scripts/verify/check-index-storage-read-ordering.test.mjs
             node --check scripts/verify/verify-index-storage-read-ordering-contract.mjs
             node --check scripts/verify/validate-index-storage-evidence.mjs
+            node --check scripts/verify/validate-index-storage-runner-resources.mjs
+            node --check scripts/verify/run-index-storage-validator-core.mjs
+            node --check scripts/verify/index-storage-validator-arguments.test.mjs
             node --check scripts/verify/validate-index-storage-evidence-core.mjs
             node --check scripts/verify/index-storage-database-settings-contract.mjs
             node --check scripts/verify/compare-index-storage-evidence.mjs
@@ -115,6 +124,7 @@ jobs:
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
             node --test scripts/verify/check-index-storage-read-ordering.test.mjs
+            node --test scripts/verify/index-storage-validator-arguments.test.mjs
             node --test scripts/verify/index-storage-standalone-tools.test.mjs
             node --test scripts/verify/index-storage-decision-tooling.test.mjs
           } 2>&1 | tee evidence/index-storage/contract/verify.log

--- a/scripts/verify/index-storage-validator-arguments.test.mjs
+++ b/scripts/verify/index-storage-validator-arguments.test.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { runValidatorCoreWithAtomicProvenance } from './run-index-storage-validator-core.mjs';
+import { validateRunnerResourceSnapshots } from './validate-index-storage-runner-resources.mjs';
+
+const validator = path.resolve('scripts/verify/validate-index-storage-evidence.mjs');
+const validatorSource = readFileSync(validator, 'utf8');
+const reportFilenames = [
+  'read-report.json',
+  'mutation-report.json',
+  'maintenance-report.json',
+];
+
+const runValidator = (args = [], env = {}) => spawnSync(process.execPath, [validator, ...args], {
+  encoding: 'utf8',
+  env: {
+    ...process.env,
+    INDEX_BENCH_SCALE: '100k',
+    INDEX_BENCH_EVIDENCE_ROOT: 'missing-evidence',
+    ...env,
+  },
+});
+
+const expectArgumentFailure = (...args) => {
+  const result = runValidator(args);
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /validate-index-storage-evidence\.mjs does not accept arguments/u,
+  );
+  assert.doesNotMatch(result.stderr, /missing evidence file/u);
+  assert.equal(result.stdout, '');
+};
+
+const createCoreFixture = (root, name, source) => {
+  for (const filename of reportFilenames) {
+    writeFileSync(path.join(root, filename), '{}\n', 'utf8');
+  }
+  const corePath = path.join(root, name);
+  writeFileSync(corePath, source, 'utf8');
+  return corePath;
+};
+
+const assertNoStagingDirectories = (root) => {
+  assert.equal(
+    readdirSync(root).some((entry) => entry.startsWith('.provenance-validation-')),
+    false,
+  );
+};
+
+const snapshotText = ({
+  capturedAt,
+  phase,
+  runnerLabel = 'ubuntu-latest',
+  nproc = 4,
+  kernel = 'Linux runner 6.8.0 #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux',
+}) => [
+  `captured_at=${capturedAt}`,
+  `phase=${phase}`,
+  `runner_label=${runnerLabel}`,
+  kernel,
+  `nproc=${nproc}`,
+  '               total        used        free      shared  buff/cache   available',
+  'Mem:      8000000000  2000000000  3000000000   100000000  3000000000  5000000000',
+  'Swap:              0           0           0',
+  'Filesystem 1B-blocks Used Available Use% Mounted on',
+  '/dev/root 100000000000 10000000000 90000000000 10% /',
+  '',
+].join('\n');
+
+const writeSnapshotPair = (root, overrides = {}) => {
+  const before = {
+    capturedAt: '2026-07-25T10:00:00Z',
+    phase: 'before',
+    ...overrides.before,
+  };
+  const after = {
+    capturedAt: '2026-07-25T10:30:00Z',
+    phase: 'after',
+    ...overrides.after,
+  };
+  writeFileSync(
+    path.join(root, 'runner-resources-before.txt'),
+    snapshotText(before),
+    'utf8',
+  );
+  writeFileSync(
+    path.join(root, 'runner-resources-after.txt'),
+    snapshotText(after),
+    'utf8',
+  );
+};
+
+const requiredRunnerResources = { INDEX_BENCH_REQUIRE_RUNNER_RESOURCES: '1' };
+
+test('direct validator rejects help as an unsupported argument', () => {
+  expectArgumentFailure('--help');
+});
+
+test('direct validator rejects output arguments before evidence access', () => {
+  expectArgumentFailure('--output', 'ignored');
+});
+
+test('validator wires runner resource preflight before atomic core execution', () => {
+  const orderingGate = validatorSource.indexOf('validatePacketReadOrdering(evidenceRoot);');
+  const resourceGate = validatorSource.indexOf('validateRunnerResourceSnapshots(evidenceRoot);');
+  const coreGate = validatorSource.indexOf(
+    'const status = runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath });',
+  );
+  assert.notEqual(orderingGate, -1);
+  assert.notEqual(resourceGate, -1);
+  assert.notEqual(coreGate, -1);
+  assert.ok(orderingGate < resourceGate);
+  assert.ok(resourceGate < coreGate);
+});
+
+test('runner resource preflight is optional unless explicitly required', () => {
+  assert.doesNotThrow(() => validateRunnerResourceSnapshots('missing-evidence', {}));
+});
+
+test('runner resource preflight accepts one consistent before and after pair', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-runner-resources-valid-'));
+  try {
+    writeSnapshotPair(root);
+    assert.doesNotThrow(() => validateRunnerResourceSnapshots(root, requiredRunnerResources));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runner resource preflight rejects an empty snapshot', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-runner-resources-empty-'));
+  try {
+    writeSnapshotPair(root);
+    writeFileSync(path.join(root, 'runner-resources-before.txt'), '', 'utf8');
+    assert.throws(
+      () => validateRunnerResourceSnapshots(root, requiredRunnerResources),
+      /runner-resources-before\.txt must not be empty/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runner resource preflight rejects runner identity drift', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-runner-resources-drift-'));
+  try {
+    writeSnapshotPair(root, { after: { runnerLabel: 'different-runner' } });
+    assert.throws(
+      () => validateRunnerResourceSnapshots(root, requiredRunnerResources),
+      /must use the same runner_label/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('runner resource preflight rejects reversed capture timestamps', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-runner-resources-order-'));
+  try {
+    writeSnapshotPair(root, {
+      before: { capturedAt: '2026-07-25T11:00:00Z' },
+      after: { capturedAt: '2026-07-25T10:30:00Z' },
+    });
+    assert.throws(
+      () => validateRunnerResourceSnapshots(root, requiredRunnerResources),
+      /must be ordered before then after/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('validator revokes stale packet provenance only when validation starts', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-validator-lifecycle-'));
+  const provenancePath = path.join(root, 'provenance.json');
+  try {
+    writeFileSync(provenancePath, '{"packet_contract_version":2}\n', 'utf8');
+
+    const argumentFailure = runValidator(['--help'], {
+      INDEX_BENCH_EVIDENCE_ROOT: root,
+    });
+    assert.notEqual(argumentFailure.status, 0);
+    assert.equal(existsSync(provenancePath), true);
+
+    const validationFailure = runValidator([], {
+      INDEX_BENCH_EVIDENCE_ROOT: root,
+    });
+    assert.notEqual(validationFailure.status, 0);
+    assert.match(validationFailure.stderr, /missing evidence file: .*read-report\.json/u);
+    assert.equal(existsSync(provenancePath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('successful validator core publishes provenance from staging', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-validator-atomic-success-'));
+  try {
+    const corePath = createCoreFixture(root, 'success-core.mjs', `
+      import { writeFileSync } from 'node:fs';
+      import path from 'node:path';
+      writeFileSync(path.join(process.env.INDEX_BENCH_EVIDENCE_ROOT, 'provenance.json'), '{"ok":true}\\n', 'utf8');
+    `);
+    const status = runValidatorCoreWithAtomicProvenance({ evidenceRoot: root, corePath });
+    assert.equal(status, 0);
+    assert.equal(readFileSync(path.join(root, 'provenance.json'), 'utf8'), '{"ok":true}\n');
+    assertNoStagingDirectories(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('failed validator core cannot publish partial provenance', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-validator-atomic-failure-'));
+  try {
+    const corePath = createCoreFixture(root, 'failure-core.mjs', `
+      import { writeFileSync } from 'node:fs';
+      import path from 'node:path';
+      writeFileSync(path.join(process.env.INDEX_BENCH_EVIDENCE_ROOT, 'provenance.json'), '{"partial":true}', 'utf8');
+      process.exit(7);
+    `);
+    const status = runValidatorCoreWithAtomicProvenance({ evidenceRoot: root, corePath });
+    assert.equal(status, 7);
+    assert.equal(existsSync(path.join(root, 'provenance.json')), false);
+    assertNoStagingDirectories(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify/run-index-storage-validator-core.mjs
+++ b/scripts/verify/run-index-storage-validator-core.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const reportFilenames = Object.freeze([
+  'read-report.json',
+  'mutation-report.json',
+  'maintenance-report.json',
+]);
+const optionalResourceFilenames = Object.freeze([
+  'runner-resources-before.txt',
+  'runner-resources-after.txt',
+]);
+
+const forwardOutput = (stream, value) => {
+  if (typeof value === 'string' && value.length !== 0) stream.write(value);
+};
+
+export const runValidatorCoreWithAtomicProvenance = ({
+  evidenceRoot,
+  corePath,
+  environment = process.env,
+  spawn = spawnSync,
+  stdout = process.stdout,
+  stderr = process.stderr,
+}) => {
+  const stagingRoot = mkdtempSync(path.join(evidenceRoot, '.provenance-validation-'));
+  try {
+    for (const filename of reportFilenames) {
+      linkSync(path.join(evidenceRoot, filename), path.join(stagingRoot, filename));
+    }
+    for (const filename of optionalResourceFilenames) {
+      const source = path.join(evidenceRoot, filename);
+      if (existsSync(source)) linkSync(source, path.join(stagingRoot, filename));
+    }
+
+    const result = spawn(process.execPath, [corePath], {
+      encoding: 'utf8',
+      env: {
+        ...environment,
+        INDEX_BENCH_EVIDENCE_ROOT: stagingRoot,
+      },
+    });
+    forwardOutput(stdout, result.stdout);
+    forwardOutput(stderr, result.stderr);
+    if (result.error) throw result.error;
+    if (result.signal) {
+      throw new Error(`validator core terminated by signal ${result.signal}`);
+    }
+
+    const status = result.status ?? 1;
+    if (status !== 0) return status;
+
+    const stagedProvenance = path.join(stagingRoot, 'provenance.json');
+    if (!existsSync(stagedProvenance)) {
+      throw new Error('validator core exited successfully without provenance.json');
+    }
+    renameSync(stagedProvenance, path.join(evidenceRoot, 'provenance.json'));
+    return 0;
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true });
+  }
+};

--- a/scripts/verify/validate-index-storage-evidence.mjs
+++ b/scripts/verify/validate-index-storage-evidence.mjs
@@ -1,23 +1,43 @@
 #!/usr/bin/env node
 
+import { rmSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs';
+import { runValidatorCoreWithAtomicProvenance } from './run-index-storage-validator-core.mjs';
+import { validateRunnerResourceSnapshots } from './validate-index-storage-runner-resources.mjs';
 
 const prefix = '[validate-index-storage-evidence]';
 const supportedScales = new Set(['smoke', '100k', '1m']);
 const scale = process.env.INDEX_BENCH_SCALE;
+const corePath = fileURLToPath(new URL('./validate-index-storage-evidence-core.mjs', import.meta.url));
 
-const main = async () => {
-  if (supportedScales.has(scale)) {
-    const evidenceRoot = process.env.INDEX_BENCH_EVIDENCE_ROOT
-      ?? path.join('evidence/index-storage', scale);
-    validatePacketReadOrdering(evidenceRoot);
+const invalidatePacketProvenance = (evidenceRoot) => {
+  rmSync(path.join(evidenceRoot, 'provenance.json'), { force: true });
+};
+
+const main = () => {
+  const args = process.argv.slice(2);
+  if (args.length !== 0) {
+    throw new Error(
+      'validate-index-storage-evidence.mjs does not accept arguments; use INDEX_BENCH_SCALE and INDEX_BENCH_EVIDENCE_ROOT',
+    );
   }
-  await import('./validate-index-storage-evidence-core.mjs');
+  if (!supportedScales.has(scale)) {
+    throw new Error(`INDEX_BENCH_SCALE must be smoke, 100k, or 1m; got ${scale}`);
+  }
+
+  const evidenceRoot = process.env.INDEX_BENCH_EVIDENCE_ROOT
+    ?? path.join('evidence/index-storage', scale);
+  invalidatePacketProvenance(evidenceRoot);
+  validatePacketReadOrdering(evidenceRoot);
+  validateRunnerResourceSnapshots(evidenceRoot);
+  const status = runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath });
+  if (status !== 0) process.exitCode = status;
 };
 
 try {
-  await main();
+  main();
 } catch (error) {
   console.error(`${prefix} ${error.message}`);
   process.exitCode = 1;

--- a/scripts/verify/validate-index-storage-runner-resources.mjs
+++ b/scripts/verify/validate-index-storage-runner-resources.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const snapshotLimitBytes = 1024 * 1024;
+const snapshotFilenames = Object.freeze({
+  before: 'runner-resources-before.txt',
+  after: 'runner-resources-after.txt',
+});
+
+const requireSingletonValue = (lines, key, label) => {
+  const prefix = `${key}=`;
+  const matches = lines.filter((line) => line.startsWith(prefix));
+  if (matches.length !== 1) {
+    throw new Error(`${label} must contain exactly one ${key} entry`);
+  }
+  const value = matches[0].slice(prefix.length);
+  if (value.length === 0 || value !== value.trim()) {
+    throw new Error(`${label} ${key} must be a non-empty trimmed value`);
+  }
+  return value;
+};
+
+const requireUtcTimestamp = (value, label) => {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u.test(value)) {
+    throw new Error(`${label} must be a real UTC timestamp`);
+  }
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.valueOf())
+      || parsed.toISOString().replace('.000Z', 'Z') !== value) {
+    throw new Error(`${label} must be a real UTC timestamp`);
+  }
+  return parsed.valueOf();
+};
+
+const readSnapshot = (evidenceRoot, phase) => {
+  const filename = snapshotFilenames[phase];
+  const pathname = path.join(evidenceRoot, filename);
+  let stats;
+  try {
+    stats = statSync(pathname);
+  } catch (error) {
+    throw new Error(`missing runner resource snapshot ${filename}: ${error.message}`);
+  }
+  if (!stats.isFile()) throw new Error(`${filename} must be a regular file`);
+  if (stats.size === 0) throw new Error(`${filename} must not be empty`);
+  if (stats.size > snapshotLimitBytes) {
+    throw new Error(`${filename} exceeds ${snapshotLimitBytes} bytes`);
+  }
+
+  const bytes = readFileSync(pathname);
+  let text;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw new Error(`${filename} must contain valid UTF-8: ${error.message}`);
+  }
+  if (text.includes('\0')) throw new Error(`${filename} must not contain NUL bytes`);
+  const lines = text.replace(/\r\n/gu, '\n').split('\n');
+  while (lines.at(-1) === '') lines.pop();
+
+  const capturedAt = requireSingletonValue(lines, 'captured_at', filename);
+  const actualPhase = requireSingletonValue(lines, 'phase', filename);
+  const runnerLabel = requireSingletonValue(lines, 'runner_label', filename);
+  const nprocValue = requireSingletonValue(lines, 'nproc', filename);
+  if (actualPhase !== phase) throw new Error(`${filename} phase must be ${phase}`);
+  if (!/^\d+$/u.test(nprocValue) || Number.parseInt(nprocValue, 10) <= 0) {
+    throw new Error(`${filename} nproc must be a positive integer`);
+  }
+
+  const kernelLines = lines.filter((line) => line.startsWith('Linux '));
+  if (kernelLines.length !== 1) throw new Error(`${filename} must contain one Linux uname line`);
+  if (!lines.some((line) => /^\s*Mem:\s+\d+/u.test(line))) {
+    throw new Error(`${filename} must contain a free -b Mem row`);
+  }
+  if (!lines.some((line) => /^Filesystem\s+/u.test(line))) {
+    throw new Error(`${filename} must contain a df -B1 header`);
+  }
+  if (!lines.some((line) => /^\S+\s+\d+\s+\d+\s+\d+\s+\d+%\s+\/$/u.test(line.trim()))) {
+    throw new Error(`${filename} must contain the root filesystem df row`);
+  }
+
+  return {
+    capturedAt,
+    capturedAtMs: requireUtcTimestamp(capturedAt, `${filename} captured_at`),
+    runnerLabel,
+    nproc: Number.parseInt(nprocValue, 10),
+    kernel: kernelLines[0],
+  };
+};
+
+export const validateRunnerResourceSnapshots = (
+  evidenceRoot,
+  environment = process.env,
+) => {
+  if (environment.INDEX_BENCH_REQUIRE_RUNNER_RESOURCES !== '1') return;
+
+  const before = readSnapshot(evidenceRoot, 'before');
+  const after = readSnapshot(evidenceRoot, 'after');
+  if (before.runnerLabel !== after.runnerLabel) {
+    throw new Error('runner resource snapshots must use the same runner_label');
+  }
+  if (before.nproc !== after.nproc) {
+    throw new Error('runner resource snapshots must use the same nproc value');
+  }
+  if (before.kernel !== after.kernel) {
+    throw new Error('runner resource snapshots must use the same Linux uname identity');
+  }
+  if (before.capturedAtMs > after.capturedAtMs) {
+    throw new Error('runner resource snapshots must be ordered before then after');
+  }
+};


### PR DESCRIPTION
## What changed

- make the direct evidence validator an explicit env-only entrypoint;
- reject every CLI argument before reading evidence or changing packet state;
- revoke an existing `provenance.json` immediately before a real validation attempt;
- validate required runner-resource snapshots before the byte-preserved core starts;
- require regular, bounded, non-empty UTF-8 snapshots with one real UTC timestamp, exact before/after phase, nonblank runner label, positive `nproc`, Linux uname identity, `free -b` memory data, and a root-filesystem `df -B1` row;
- require before/after snapshots to agree on runner label, processor count, and uname identity and to be chronologically ordered;
- keep the snapshot gate opt-in through `INDEX_BENCH_REQUIRE_RUNNER_RESOURCES=1`, preserving smoke/local paths that do not request it;
- run the byte-preserved validator core in a child process over a hard-linked staging packet;
- publish a successful staged `provenance.json` into the real evidence directory with one rename;
- clean staging after success, core failure, signal termination, spawn failure, or missing output;
- add focused regressions for arguments, stale-marker revocation, snapshot shape/identity/order, preflight ordering, successful atomic publication, and partial-output rejection;
- protect the new helper through smoke and scale-evidence path triggers and syntax gates.

## Root cause

A reused evidence directory could retain an old success marker when a later validation attempt failed, and the byte-preserved core wrote its replacement marker directly into the published packet. The wrapper now revokes stale state, isolates the core in staging, and publishes only a complete result.

Scale evidence also declared `runner-resources-before.txt` and `runner-resources-after.txt`, but the core checked only whether those paths existed. Empty files, swapped phases, malformed timestamps, or snapshots from different runner identities could therefore be archived as resource evidence.

## Impact

Unsupported arguments do not touch evidence. A real validation attempt removes the old marker, validates SQL ordering, validates the requested resource snapshots, executes the unchanged core against staging, and atomically publishes the new marker only after core success.

Required scale snapshots now fail closed on missing, empty, oversized, non-UTF-8, structurally incomplete, identity-drifting, or time-reversed content. The validation checks the workflow's stable structural contract without fixing RAM, disk size, or hosted-runner-specific values.

This does not create replacement benchmark evidence, select a PostgreSQL storage model, or advance M2 beyond same-commit 100k/1m execution, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. Static review covered workflow output shape, UTF-8 and size boundaries, calendar timestamp round-tripping, before/after identity consistency, opt-in behavior, preflight ordering, hard-link scope, child-process exit behavior, same-filesystem rename, cleanup paths, marker absence after failure, and preservation of the validator core bytes.