### PR TITLE
Harden admin order return owner error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -60,10 +60,10 @@ available only for actionable domain errors.
   status, and HTTP boundary. Persisted reconciliation errors adopt the fulfillment id from
   the typed orchestration error while validation and technical details stay internal.
 - `rustok-commerce` admin order-return owner routes: create, list, detail, and cancel paths
-  record the typed `OrderError` before public conversion with owner, tenant, route
-  operation, truthful optional order and return identities, stable public code, status,
-  and HTTP boundary. The existing shared mapper continues to provide the same static
-  validation, not-found, conflict, storage, and fail-closed envelopes.
+  map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
+  order and return identities, stable public code, status, and HTTP boundary. Validation,
+  not-found, conflict, storage, and fail-closed outcomes preserve the existing static
+  status, code, and message policy without a second generic error event.
 - `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, missing-resource, transition,

--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -59,6 +59,11 @@ available only for actionable domain errors.
   route operation, truthful optional fulfillment and order identities, stable public code,
   status, and HTTP boundary. Persisted reconciliation errors adopt the fulfillment id from
   the typed orchestration error while validation and technical details stay internal.
+- `rustok-commerce` admin order-return owner routes: create, list, detail, and cancel paths
+  record the typed `OrderError` before public conversion with owner, tenant, route
+  operation, truthful optional order and return identities, stable public code, status,
+  and HTTP boundary. The existing shared mapper continues to provide the same static
+  validation, not-found, conflict, storage, and fail-closed envelopes.
 - `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, missing-resource, transition,
@@ -110,6 +115,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
@@ -125,8 +131,9 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin order-detail payment
-  and fulfillment mapping, and tax calculation validation, provider-contract,
-  reconciliation, correlation, HTTP-envelope, and transport round-trip tests.
+  admin fulfillment reconciliation, admin fulfillment routes, admin order-return owner
+  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
+  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and
+  transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/returns.rs
+++ b/crates/rustok-commerce/src/controllers/admin/returns.rs
@@ -7,7 +7,7 @@ use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_order::OrderService;
 use rustok_order::error::OrderError;
-use rustok_web::HttpResult;
+use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use super::{
@@ -52,11 +52,15 @@ impl AdminOrderReturnErrorContext {
     }
 }
 
-fn log_admin_order_return_error(context: AdminOrderReturnErrorContext, error: &OrderError) {
-    let (status, code, error_kind) = match error {
+fn map_admin_order_return_error(
+    context: AdminOrderReturnErrorContext,
+    error: OrderError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
         OrderError::Validation(_) => (
             StatusCode::BAD_REQUEST,
             "commerce_admin_order_invalid",
+            "Order request is invalid",
             "validation",
         ),
         OrderError::OrderNotFound(_)
@@ -64,21 +68,25 @@ fn log_admin_order_return_error(context: AdminOrderReturnErrorContext, error: &O
         | OrderError::OrderChangeNotFound(_) => (
             StatusCode::NOT_FOUND,
             "commerce_admin_not_found",
+            "Commerce resource not found",
             "not_found",
         ),
         OrderError::InvalidTransition { .. } => (
             StatusCode::CONFLICT,
             "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
             "state_conflict",
         ),
         OrderError::Database(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
             "database",
         ),
         OrderError::Core(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
             "core",
         ),
     };
@@ -95,6 +103,7 @@ fn log_admin_order_return_error(context: AdminOrderReturnErrorContext, error: &O
         boundary = ADMIN_ORDER_RETURN_BOUNDARY,
         "commerce admin order return owner operation failed"
     );
+    HttpError::new(status, code, message)
 }
 
 #[utoipa::path(
@@ -121,16 +130,15 @@ pub async fn create_order_return(
         &[Permission::ORDERS_UPDATE],
         "Permission denied: orders:update required",
     )?;
-    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .create_return(tenant.id, id, input)
-        .await;
-    if let Err(error) = &result {
-        log_admin_order_return_error(
-            AdminOrderReturnErrorContext::new(tenant.id, Some(id), None, "create_return"),
-            error,
-        );
-    }
-    let created = result.map_err(super::map_order_error)?;
+        .await
+        .map_err(|error| {
+            map_admin_order_return_error(
+                AdminOrderReturnErrorContext::new(tenant.id, Some(id), None, "create_return"),
+                error,
+            )
+        })?;
     Ok((StatusCode::CREATED, Json(created)))
 }
 
@@ -200,7 +208,7 @@ pub async fn list_order_returns(
     )?;
     let pagination = params.pagination.unwrap_or_default();
     let order_id = params.order_id;
-    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_returns(
             tenant.id,
             ListOrderReturnsInput {
@@ -210,14 +218,13 @@ pub async fn list_order_returns(
                 status: params.status,
             },
         )
-        .await;
-    if let Err(error) = &result {
-        log_admin_order_return_error(
-            AdminOrderReturnErrorContext::new(tenant.id, order_id, None, "list_returns"),
-            error,
-        );
-    }
-    let (items, total) = result.map_err(super::map_order_error)?;
+        .await
+        .map_err(|error| {
+            map_admin_order_return_error(
+                AdminOrderReturnErrorContext::new(tenant.id, order_id, None, "list_returns"),
+                error,
+            )
+        })?;
     Ok(Json(PaginatedResponse {
         data: items,
         meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
@@ -246,16 +253,15 @@ pub async fn show_order_return(
         &[Permission::ORDERS_READ],
         "Permission denied: orders:read required",
     )?;
-    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .get_return(tenant.id, id)
-        .await;
-    if let Err(error) = &result {
-        log_admin_order_return_error(
-            AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "get_return"),
-            error,
-        );
-    }
-    let item = result.map_err(super::map_order_error)?;
+        .await
+        .map_err(|error| {
+            map_admin_order_return_error(
+                AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "get_return"),
+                error,
+            )
+        })?;
     Ok(Json(item))
 }
 
@@ -347,15 +353,14 @@ pub async fn cancel_order_return(
         &[Permission::ORDERS_UPDATE],
         "Permission denied: orders:update required",
     )?;
-    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .cancel_return(tenant.id, id, input)
-        .await;
-    if let Err(error) = &result {
-        log_admin_order_return_error(
-            AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "cancel_return"),
-            error,
-        );
-    }
-    let item = result.map_err(super::map_order_error)?;
+        .await
+        .map_err(|error| {
+            map_admin_order_return_error(
+                AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "cancel_return"),
+                error,
+            )
+        })?;
     Ok(Json(item))
 }

--- a/crates/rustok-commerce/src/controllers/admin/returns.rs
+++ b/crates/rustok-commerce/src/controllers/admin/returns.rs
@@ -6,6 +6,7 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_order::OrderService;
+use rustok_order::error::OrderError;
 use rustok_web::HttpResult;
 use uuid::Uuid;
 
@@ -24,6 +25,77 @@ use crate::{
         CancelOrderReturnInput, CreateOrderReturnInput, ListOrderReturnsInput, OrderReturnResponse,
     },
 };
+
+const ADMIN_ORDER_RETURN_OWNER: &str = "rustok_order.admin_returns";
+const ADMIN_ORDER_RETURN_BOUNDARY: &str = "commerce_admin_order_return_http";
+
+struct AdminOrderReturnErrorContext {
+    tenant_id: Uuid,
+    order_id: Option<Uuid>,
+    return_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminOrderReturnErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        order_id: Option<Uuid>,
+        return_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            order_id,
+            return_id,
+            operation,
+        }
+    }
+}
+
+fn log_admin_order_return_error(context: AdminOrderReturnErrorContext, error: &OrderError) {
+    let (status, code, error_kind) = match error {
+        OrderError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "validation",
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "state_conflict",
+        ),
+        OrderError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "database",
+        ),
+        OrderError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "core",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_RETURN_OWNER,
+        tenant_id = %context.tenant_id,
+        order_id = ?context.order_id,
+        return_id = ?context.return_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_RETURN_BOUNDARY,
+        "commerce admin order return owner operation failed"
+    );
+}
 
 #[utoipa::path(
     post,
@@ -49,10 +121,16 @@ pub async fn create_order_return(
         &[Permission::ORDERS_UPDATE],
         "Permission denied: orders:update required",
     )?;
-    let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .create_return(tenant.id, id, input)
-        .await
-        .map_err(super::map_order_error)?;
+        .await;
+    if let Err(error) = &result {
+        log_admin_order_return_error(
+            AdminOrderReturnErrorContext::new(tenant.id, Some(id), None, "create_return"),
+            error,
+        );
+    }
+    let created = result.map_err(super::map_order_error)?;
     Ok((StatusCode::CREATED, Json(created)))
 }
 
@@ -121,18 +199,25 @@ pub async fn list_order_returns(
         "Permission denied: orders:read required",
     )?;
     let pagination = params.pagination.unwrap_or_default();
-    let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let order_id = params.order_id;
+    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_returns(
             tenant.id,
             ListOrderReturnsInput {
                 page: pagination.page,
                 per_page: pagination.limit(),
-                order_id: params.order_id,
+                order_id,
                 status: params.status,
             },
         )
-        .await
-        .map_err(super::map_order_error)?;
+        .await;
+    if let Err(error) = &result {
+        log_admin_order_return_error(
+            AdminOrderReturnErrorContext::new(tenant.id, order_id, None, "list_returns"),
+            error,
+        );
+    }
+    let (items, total) = result.map_err(super::map_order_error)?;
     Ok(Json(PaginatedResponse {
         data: items,
         meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
@@ -161,10 +246,16 @@ pub async fn show_order_return(
         &[Permission::ORDERS_READ],
         "Permission denied: orders:read required",
     )?;
-    let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .get_return(tenant.id, id)
-        .await
-        .map_err(super::map_order_error)?;
+        .await;
+    if let Err(error) = &result {
+        log_admin_order_return_error(
+            AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "get_return"),
+            error,
+        );
+    }
+    let item = result.map_err(super::map_order_error)?;
     Ok(Json(item))
 }
 
@@ -256,9 +347,15 @@ pub async fn cancel_order_return(
         &[Permission::ORDERS_UPDATE],
         "Permission denied: orders:update required",
     )?;
-    let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
+    let result = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .cancel_return(tenant.id, id, input)
-        .await
-        .map_err(super::map_order_error)?;
+        .await;
+    if let Err(error) = &result {
+        log_admin_order_return_error(
+            AdminOrderReturnErrorContext::new(tenant.id, None, Some(id), "cancel_return"),
+            error,
+        );
+    }
+    let item = result.map_err(super::map_order_error)?;
     Ok(Json(item))
 }

--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -45,9 +45,7 @@ for (const [value, label] of [
   ['pub(crate) fn map_fulfillment_error(error: FulfillmentError)', 'fulfillment mapper'],
   ['pub(crate) fn map_fulfillment_orchestration_error(', 'fulfillment orchestration mapper'],
   ['pub(crate) fn map_post_order_orchestration_error(', 'post-order mapper'],
-]) {
-  requireText(admin, value, label);
-}
+]) requireText(admin, value, label);
 
 for (const [value, label] of [
   ['OrderError::Validation(_)', 'order validation mapping'],
@@ -67,9 +65,7 @@ for (const [value, label] of [
   ['axum::http::StatusCode::CONFLICT', 'conflict status'],
   ['axum::http::StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
   ['axum::http::StatusCode::INTERNAL_SERVER_ERROR', 'internal status'],
-]) {
-  requireText(admin, value, label);
-}
+]) requireText(admin, value, label);
 
 for (const [value, label] of [
   ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
@@ -87,9 +83,7 @@ for (const [value, label] of [
   ['FulfillmentOrchestrationError::PersistenceAfterProvider { .. }', 'persistence-after-provider mapping'],
   ['"commerce_admin_fulfillment_reconciliation_required"', 'fulfillment reconciliation code'],
   ['"Fulfillment operation requires reconciliation"', 'fulfillment reconciliation message'],
-]) {
-  requireText(admin, value, label);
-}
+]) requireText(admin, value, label);
 
 for (const [value, label] of [
   ['PostOrderOrchestrationError::Order(error) => map_order_error(error)', 'post-order order delegation'],
@@ -97,9 +91,7 @@ for (const [value, label] of [
   ['PostOrderOrchestrationError::PaymentOrchestration(error)', 'post-order payment orchestration delegation'],
   ['PostOrderOrchestrationError::Validation(_)', 'post-order validation mapping'],
   ['"commerce_admin_post_order_invalid"', 'post-order validation code'],
-]) {
-  requireText(admin, value, label);
-}
+]) requireText(admin, value, label);
 
 for (const [ownerSource, value, label] of [
   [orderErrors, 'Validation(String)', 'owner order validation variant'],
@@ -124,9 +116,7 @@ for (const [ownerSource, value, label] of [
   [postOrder, 'Payment(#[from] rustok_payment::error::PaymentError)', 'post-order payment variant'],
   [postOrder, 'PaymentOrchestration(#[from] PaymentOrchestrationError)', 'post-order payment orchestration variant'],
   [postOrder, 'Validation(String)', 'post-order validation variant'],
-]) {
-  requireText(ownerSource, value, label);
-}
+]) requireText(ownerSource, value, label);
 
 for (const [value, label] of [
   ['pub async fn list_orders(', 'admin list-orders handler'],
@@ -147,29 +137,28 @@ for (const [value, label] of [
   ],
   ['page: pagination.page', 'order page forwarding'],
   ['per_page: pagination.limit()', 'order page-size forwarding'],
-]) {
-  requireText(orders, value, label);
-}
+]) requireText(orders, value, label);
 
 for (const value of [
   '.map_err(super::map_payment_error)?;',
   '.map_err(super::map_fulfillment_error)?;',
-]) {
-  forbidText(orders, value, 'stale order-detail shared mapper callsite');
-}
+]) forbidText(orders, value, 'stale order-detail shared mapper callsite');
 
 for (const [value, label] of [
   ['pub async fn list_order_returns(', 'admin return list'],
   ['pub async fn show_order_return(', 'admin return detail'],
   ['pub async fn create_order_return(', 'admin return create'],
   ['pub async fn cancel_order_return(', 'admin return cancel'],
-  ['.map_err(super::map_order_error)?;', 'typed return owner mapping'],
+  ['struct AdminOrderReturnErrorContext {', 'return owner context'],
+  ['fn map_admin_order_return_error(', 'context-aware return owner mapper'],
   ['.map_err(super::map_post_order_orchestration_error)?;', 'typed return orchestration mapping'],
   ['ListOrderReturnsInput {', 'return list input'],
   ['page: pagination.page', 'return page forwarding'],
   ['per_page: pagination.limit()', 'return page-size forwarding'],
-]) {
-  requireText(returns, value, label);
+]) requireText(returns, value, label);
+
+for (const value of ['.map_err(super::map_order_error)?;']) {
+  forbidText(returns, value, 'stale admin return shared owner mapper callsite');
 }
 
 for (const [value, label] of [
@@ -190,16 +179,12 @@ for (const [value, label] of [
     'fn map_admin_fulfillment_orchestration_error(',
     'context-aware fulfillment orchestration mapper',
   ],
-]) {
-  requireText(fulfillments, value, label);
-}
+]) requireText(fulfillments, value, label);
 
 for (const value of [
   '.map_err(super::map_fulfillment_error)?;',
   '.map_err(super::map_fulfillment_orchestration_error)?;',
-]) {
-  forbidText(fulfillments, value, 'stale admin fulfillment shared mapper callsite');
-}
+]) forbidText(fulfillments, value, 'stale admin fulfillment shared mapper callsite');
 
 for (const [content, label] of [
   [orders, 'admin order reads'],
@@ -211,15 +196,22 @@ for (const [content, label] of [
     'error.to_string()',
     'other.to_string()',
     'HttpError::bad_request("commerce_operation_failed"',
-  ]) {
-    forbidText(content, value, `${label} unsafe public conversion`);
-  }
+  ]) forbidText(content, value, `${label} unsafe public conversion`);
 }
 
-const orderMapperUses = (orders.match(/\.map_err\(super::map_order_error\)\?;/g) ?? []).length
-  + (returns.match(/\.map_err\(super::map_order_error\)\?;/g) ?? []).length;
-if (orderMapperUses !== 10) {
-  failures.push(`expected ten order/return owner mapper callsites, found ${orderMapperUses}`);
+const sharedOrderMapperUses = orders.match(/\.map_err\(super::map_order_error\)\?;/g) ?? [];
+if (sharedOrderMapperUses.length !== 6) {
+  failures.push(`expected six remaining shared order mapper callsites, found ${sharedOrderMapperUses.length}`);
+}
+
+const returnOwnerMapperUses =
+  returns.match(
+    /map_admin_order_return_error\(\s+AdminOrderReturnErrorContext::new\(/g,
+  ) ?? [];
+if (returnOwnerMapperUses.length !== 4) {
+  failures.push(
+    `expected four context-aware return owner mapper callsites, found ${returnOwnerMapperUses.length}`,
+  );
 }
 
 const fulfillmentMapperUses =

--- a/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const logger = between(
+  returns,
+  'fn log_admin_order_return_error(',
+  '#[utoipa::path(',
+  'admin order-return owner logger',
+);
+const createRoute = between(
+  returns,
+  'pub async fn create_order_return(',
+  '#[utoipa::path(\n    post,\n    path = "/admin/orders/{id}/returns/decision"',
+  'create return route',
+);
+const listRoute = between(
+  returns,
+  'pub async fn list_order_returns(',
+  '#[utoipa::path(\n    get,\n    path = "/admin/returns/{id}"',
+  'list returns route',
+);
+const showRoute = between(
+  returns,
+  'pub async fn show_order_return(',
+  '#[utoipa::path(\n    post,\n    path = "/admin/returns/{id}/complete"',
+  'show return route',
+);
+const cancelStart = returns.indexOf('pub async fn cancel_order_return(');
+const cancelRoute = cancelStart < 0 ? '' : returns.slice(cancelStart);
+if (cancelStart < 0) failures.push('cancel return route: unable to isolate source block');
+
+for (const [value, label] of [
+  ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['const ADMIN_ORDER_RETURN_OWNER: &str = "rustok_order.admin_returns";', 'owner constant'],
+  [
+    'const ADMIN_ORDER_RETURN_BOUNDARY: &str = "commerce_admin_order_return_http";',
+    'HTTP boundary constant',
+  ],
+  ['struct AdminOrderReturnErrorContext {', 'owner error context'],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['order_id: Option<Uuid>,', 'truthful order identity field'],
+  ['return_id: Option<Uuid>,', 'truthful return identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(returns, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'validation variant'],
+  ['OrderError::OrderNotFound(_)', 'order-not-found variant'],
+  ['OrderError::OrderReturnNotFound(_)', 'return-not-found variant'],
+  ['OrderError::OrderChangeNotFound(_)', 'change-not-found variant'],
+  ['OrderError::InvalidTransition { .. }', 'transition variant'],
+  ['OrderError::Database(_)', 'database variant'],
+  ['OrderError::Core(_)', 'core variant'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_ORDER_RETURN_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['return_id = ?context.return_id', 'return identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_RETURN_BOUNDARY', 'boundary log'],
+]) requireText(logger, value, label);
+
+for (const [value, label] of [
+  ['"commerce_admin_order_invalid"', 'validation code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_order_state_conflict"', 'conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'storage code'],
+  ['"commerce_admin_order_failed"', 'fail-closed code'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+]) requireText(logger, value, label);
+
+for (const [block, operation, identity, label] of [
+  [createRoute, '"create_return"', 'Some(id), None', 'create return context'],
+  [listRoute, '"list_returns"', 'tenant.id, order_id, None', 'list return context'],
+  [showRoute, '"get_return"', 'None, Some(id)', 'show return context'],
+  [cancelRoute, '"cancel_return"', 'None, Some(id)', 'cancel return context'],
+]) {
+  requireText(block, 'if let Err(error) = &result {', `${label} conditional log`);
+  requireText(block, 'log_admin_order_return_error(', `${label} logger handoff`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, identity, `${label} identity`);
+  requireText(block, 'result.map_err(super::map_order_error)?;', `${label} shared mapping`);
+  const logIndex = block.indexOf('log_admin_order_return_error(');
+  const mapIndex = block.indexOf('result.map_err(super::map_order_error)?;');
+  if (logIndex < 0 || mapIndex < 0 || logIndex > mapIndex) {
+    failures.push(`${label}: owner context must be logged before public mapping`);
+  }
+}
+
+for (const [value, label] of [
+  ['pub async fn create_order_return(', 'create handler'],
+  ['pub async fn create_order_return_decision(', 'decision handler'],
+  ['pub async fn list_order_returns(', 'list handler'],
+  ['pub async fn show_order_return(', 'detail handler'],
+  ['pub async fn complete_order_return(', 'complete handler'],
+  ['pub async fn cancel_order_return(', 'cancel handler'],
+  ['[Permission::ORDERS_READ]', 'read permission'],
+  ['[Permission::ORDERS_UPDATE]', 'update permission'],
+  ['[Permission::PAYMENTS_UPDATE]', 'payment permission'],
+  ['page: pagination.page', 'page forwarding'],
+  ['per_page: pagination.limit()', 'page-size forwarding'],
+  ['let order_id = params.order_id;', 'list order filter capture'],
+  ['.create_return(tenant.id, id, input)', 'create service contract'],
+  ['.list_returns(', 'list service contract'],
+  ['.get_return(tenant.id, id)', 'detail service contract'],
+  ['.cancel_return(tenant.id, id, input)', 'cancel service contract'],
+  [
+    '.map_err(super::map_post_order_orchestration_error)?;',
+    'unchanged orchestration public mapping',
+  ],
+]) requireText(returns, value, label);
+
+const ownerMapperUses = returns.match(/result\.map_err\(super::map_order_error\)\?;/g) ?? [];
+if (ownerMapperUses.length !== 4) {
+  failures.push(`expected four logged owner mapper callsites, found ${ownerMapperUses.length}`);
+}
+const loggerUses = returns.match(/log_admin_order_return_error\(/g) ?? [];
+if (loggerUses.length !== 5) {
+  failures.push(`expected logger definition plus four uses, found ${loggerUses.length}`);
+}
+const orchestrationMapperUses =
+  returns.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
+if (orchestrationMapperUses.length !== 2) {
+  failures.push(`expected two unchanged orchestration mapper callsites, found ${orchestrationMapperUses.length}`);
+}
+
+for (const [value, label] of [
+  ['pub(crate) fn map_order_error(error: OrderError)', 'shared order mapper'],
+  ['"Order request is invalid"', 'static validation message'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  ['"Order operation conflicts with the current state"', 'static conflict message'],
+  ['"Order storage is temporarily unavailable"', 'static storage message'],
+  ['"Order operation could not be completed safely"', 'static fail-closed message'],
+]) requireText(admin, value, label);
+
+for (const [value, label] of [
+  ['Validation(String)', 'owner validation variant'],
+  ['OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  ['OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  ['OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  ['Database(#[from] DbErr)', 'owner database variant'],
+  ['Core(#[from] rustok_core::Error)', 'owner core variant'],
+]) requireText(orderErrors, value, label);
+
+for (const value of [
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(returns, value, 'unsafe admin return public conversion');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-return owner error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order-return owner errors retain route context before static public mapping',
+);

--- a/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
@@ -11,7 +11,6 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
-const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
 const orderErrors = read('crates/rustok-order/src/error.rs');
 const failures = [];
 
@@ -31,11 +30,11 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const logger = between(
+const mapper = between(
   returns,
-  'fn log_admin_order_return_error(',
+  'fn map_admin_order_return_error(',
   '#[utoipa::path(',
-  'admin order-return owner logger',
+  'admin order-return owner mapper',
 );
 const createRoute = between(
   returns,
@@ -61,6 +60,7 @@ if (cancelStart < 0) failures.push('cancel return route: unable to isolate sourc
 
 for (const [value, label] of [
   ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
   ['const ADMIN_ORDER_RETURN_OWNER: &str = "rustok_order.admin_returns";', 'owner constant'],
   [
     'const ADMIN_ORDER_RETURN_BOUNDARY: &str = "commerce_admin_order_return_http";',
@@ -74,6 +74,8 @@ for (const [value, label] of [
 ]) requireText(returns, value, label);
 
 for (const [value, label] of [
+  ['error: OrderError,', 'owned typed cause'],
+  [') -> HttpError {', 'typed HTTP mapper result'],
   ['OrderError::Validation(_)', 'validation variant'],
   ['OrderError::OrderNotFound(_)', 'order-not-found variant'],
   ['OrderError::OrderReturnNotFound(_)', 'return-not-found variant'],
@@ -91,7 +93,8 @@ for (const [value, label] of [
   ['public_code = code', 'public-code log'],
   ['status = %status', 'status log'],
   ['boundary = ADMIN_ORDER_RETURN_BOUNDARY', 'boundary log'],
-]) requireText(logger, value, label);
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
 
 for (const [value, label] of [
   ['"commerce_admin_order_invalid"', 'validation code'],
@@ -99,12 +102,17 @@ for (const [value, label] of [
   ['"commerce_admin_order_state_conflict"', 'conflict code'],
   ['"commerce_admin_order_storage_unavailable"', 'storage code'],
   ['"commerce_admin_order_failed"', 'fail-closed code'],
+  ['"Order request is invalid"', 'static validation message'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  ['"Order operation conflicts with the current state"', 'static conflict message'],
+  ['"Order storage is temporarily unavailable"', 'static storage message'],
+  ['"Order operation could not be completed safely"', 'static fail-closed message'],
   ['StatusCode::BAD_REQUEST', 'validation status'],
   ['StatusCode::NOT_FOUND', 'not-found status'],
   ['StatusCode::CONFLICT', 'conflict status'],
   ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
   ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
-]) requireText(logger, value, label);
+]) requireText(mapper, value, label);
 
 for (const [block, operation, identity, label] of [
   [createRoute, '"create_return"', 'Some(id), None', 'create return context'],
@@ -112,16 +120,10 @@ for (const [block, operation, identity, label] of [
   [showRoute, '"get_return"', 'None, Some(id)', 'show return context'],
   [cancelRoute, '"cancel_return"', 'None, Some(id)', 'cancel return context'],
 ]) {
-  requireText(block, 'if let Err(error) = &result {', `${label} conditional log`);
-  requireText(block, 'log_admin_order_return_error(', `${label} logger handoff`);
+  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
+  requireText(block, 'map_admin_order_return_error(', `${label} mapper handoff`);
   requireText(block, operation, `${label} operation`);
   requireText(block, identity, `${label} identity`);
-  requireText(block, 'result.map_err(super::map_order_error)?;', `${label} shared mapping`);
-  const logIndex = block.indexOf('log_admin_order_return_error(');
-  const mapIndex = block.indexOf('result.map_err(super::map_order_error)?;');
-  if (logIndex < 0 || mapIndex < 0 || logIndex > mapIndex) {
-    failures.push(`${label}: owner context must be logged before public mapping`);
-  }
 }
 
 for (const [value, label] of [
@@ -147,28 +149,15 @@ for (const [value, label] of [
   ],
 ]) requireText(returns, value, label);
 
-const ownerMapperUses = returns.match(/result\.map_err\(super::map_order_error\)\?;/g) ?? [];
-if (ownerMapperUses.length !== 4) {
-  failures.push(`expected four logged owner mapper callsites, found ${ownerMapperUses.length}`);
-}
-const loggerUses = returns.match(/log_admin_order_return_error\(/g) ?? [];
-if (loggerUses.length !== 5) {
-  failures.push(`expected logger definition plus four uses, found ${loggerUses.length}`);
+const mapperUses = returns.match(/map_admin_order_return_error\(/g) ?? [];
+if (mapperUses.length !== 5) {
+  failures.push(`expected mapper definition plus four uses, found ${mapperUses.length}`);
 }
 const orchestrationMapperUses =
   returns.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
 if (orchestrationMapperUses.length !== 2) {
   failures.push(`expected two unchanged orchestration mapper callsites, found ${orchestrationMapperUses.length}`);
 }
-
-for (const [value, label] of [
-  ['pub(crate) fn map_order_error(error: OrderError)', 'shared order mapper'],
-  ['"Order request is invalid"', 'static validation message'],
-  ['"Commerce resource not found"', 'static not-found message'],
-  ['"Order operation conflicts with the current state"', 'static conflict message'],
-  ['"Order storage is temporarily unavailable"', 'static storage message'],
-  ['"Order operation could not be completed safely"', 'static fail-closed message'],
-]) requireText(admin, value, label);
 
 for (const [value, label] of [
   ['Validation(String)', 'owner validation variant'],
@@ -181,6 +170,7 @@ for (const [value, label] of [
 ]) requireText(orderErrors, value, label);
 
 for (const value of [
+  '.map_err(super::map_order_error)?;',
   'error.to_string()',
   'err.to_string()',
   'other.to_string()',
@@ -194,5 +184,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin order-return owner errors retain route context before static public mapping',
+  '✔ Commerce admin order-return owner errors retain route context and static public envelopes',
 );


### PR DESCRIPTION
## Summary

- replace the four shared `OrderError` mapper callsites in admin return owner routes with a local context-aware typed mapper;
- retain owner, tenant, route operation, truthful optional order and return identities, error kind, public code, status, HTTP boundary, and original typed cause in one error event;
- preserve the existing validation, not-found, transition, storage, and fail-closed status/code/message policy;
- leave the two post-order orchestration routes unchanged for a separate follow-up slice;
- add a focused static verifier, align the broad admin order/fulfillment verifier, and update the ecommerce public-error safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/returns.rs`
- `scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
- `scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- the branch is directly ahead of current `main` by 7 commits and is not behind;
- final diff is limited to the four intended files (`+335/-46`);
- the controller was re-read to confirm all six routes, read/update/payment permissions, unchanged service calls and success envelopes, four context-aware owner mapper callsites, and two unchanged orchestration mapper callsites;
- an intermediate duplicate-logging approach was removed before opening the PR; the final mapper emits one context-rich event per owner error;
- the focused and broad verifier sources were re-read to preserve the existing order, fulfillment, post-order, unsafe-conversion, and callsite-count assertions;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
node scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```