### PR TITLE
Harden admin order return orchestration error context

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/returns.rs
+++ b/crates/rustok-commerce/src/controllers/admin/returns.rs
@@ -7,6 +7,7 @@ use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_order::OrderService;
 use rustok_order::error::OrderError;
+use rustok_payment::error::PaymentError;
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -19,7 +20,8 @@ use super::{
 };
 use crate::{
     CompleteReturnClaimInput, CompleteReturnExchangeInput, CompleteReturnRefundInput,
-    CompleteReturnResolutionInput, CreateReturnDecisionInput, PostOrderOrchestrationService,
+    CompleteReturnResolutionInput, CreateReturnDecisionInput, PaymentOrchestrationError,
+    PostOrderOrchestrationError, PostOrderOrchestrationService,
     ReturnCompletionOrchestrationService, ReturnDecisionResponse,
     dto::{
         CancelOrderReturnInput, CreateOrderReturnInput, ListOrderReturnsInput, OrderReturnResponse,
@@ -27,7 +29,16 @@ use crate::{
 };
 
 const ADMIN_ORDER_RETURN_OWNER: &str = "rustok_order.admin_returns";
+const ADMIN_ORDER_RETURN_ORCHESTRATION_OWNER: &str =
+    "rustok_commerce.admin_order_return_orchestration";
 const ADMIN_ORDER_RETURN_BOUNDARY: &str = "commerce_admin_order_return_http";
+
+type AdminOrderReturnHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
 
 struct AdminOrderReturnErrorContext {
     tenant_id: Uuid,
@@ -52,11 +63,36 @@ impl AdminOrderReturnErrorContext {
     }
 }
 
-fn map_admin_order_return_error(
-    context: AdminOrderReturnErrorContext,
-    error: OrderError,
-) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
+struct AdminOrderReturnOrchestrationErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Option<Uuid>,
+    return_id: Option<Uuid>,
+    refund_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminOrderReturnOrchestrationErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        order_id: Option<Uuid>,
+        return_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            order_id,
+            return_id,
+            refund_id: None,
+            operation,
+        }
+    }
+}
+
+fn admin_order_error_policy(error: &OrderError) -> AdminOrderReturnHttpPolicy {
+    match error {
         OrderError::Validation(_) => (
             StatusCode::BAD_REQUEST,
             "commerce_admin_order_invalid",
@@ -89,7 +125,88 @@ fn map_admin_order_return_error(
             "Order operation could not be completed safely",
             "core",
         ),
-    };
+    }
+}
+
+fn admin_payment_error_policy(error: &PaymentError) -> AdminOrderReturnHttpPolicy {
+    match error {
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PaymentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::BAD_GATEWAY,
+            "commerce_admin_payment_provider_invalid_response",
+            "Payment provider returned an invalid response; reconciliation may be required",
+            "provider_invalid_response",
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment provider outcome is unknown and requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        PaymentError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "database",
+        ),
+    }
+}
+
+fn admin_reserved_refund_error_policy(error: &PaymentError) -> AdminOrderReturnHttpPolicy {
+    match error {
+        PaymentError::ProviderOutcomeUnknown { .. }
+        | PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_refund_reconciliation_required",
+            "Refund remains reserved while the provider outcome is reconciled",
+            "refund_reconciliation_required",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_refund_provider_unavailable",
+            "Refund remains reserved and the provider operation may be retried safely",
+            "refund_provider_unavailable",
+        ),
+        error => admin_payment_error_policy(error),
+    }
+}
+
+fn map_admin_order_return_error(
+    context: AdminOrderReturnErrorContext,
+    error: OrderError,
+) -> HttpError {
+    let (status, code, message, error_kind) = admin_order_error_policy(&error);
     tracing::error!(
         error = ?error,
         owner = ADMIN_ORDER_RETURN_OWNER,
@@ -102,6 +219,73 @@ fn map_admin_order_return_error(
         status = %status,
         boundary = ADMIN_ORDER_RETURN_BOUNDARY,
         "commerce admin order return owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_order_return_orchestration_error(
+    mut context: AdminOrderReturnOrchestrationErrorContext,
+    error: PostOrderOrchestrationError,
+) -> HttpError {
+    let (status, code, message, error_kind, source_owner) = match &error {
+        PostOrderOrchestrationError::Order(source) => {
+            match source {
+                OrderError::OrderNotFound(id) => context.order_id = Some(*id),
+                OrderError::OrderReturnNotFound(id) => context.return_id = Some(*id),
+                _ => {}
+            }
+            let (status, code, message, error_kind) = admin_order_error_policy(source);
+            (status, code, message, error_kind, "rustok_order")
+        }
+        PostOrderOrchestrationError::Payment(source) => {
+            if let PaymentError::RefundNotFound(id) = source {
+                context.refund_id = Some(*id);
+            }
+            let (status, code, message, error_kind) = admin_payment_error_policy(source);
+            (status, code, message, error_kind, "rustok_payment")
+        }
+        PostOrderOrchestrationError::PaymentOrchestration(source) => match source {
+            PaymentOrchestrationError::Provider(source)
+            | PaymentOrchestrationError::Payment(source) => {
+                if let PaymentError::RefundNotFound(id) = source {
+                    context.refund_id = Some(*id);
+                }
+                let (status, code, message, error_kind) = admin_payment_error_policy(source);
+                (status, code, message, error_kind, "rustok_payment")
+            }
+            PaymentOrchestrationError::ProviderAfterRefundReservation {
+                refund_id,
+                source,
+            } => {
+                context.refund_id = Some(*refund_id);
+                let (status, code, message, error_kind) =
+                    admin_reserved_refund_error_policy(source);
+                (status, code, message, error_kind, "rustok_payment")
+            }
+        },
+        PostOrderOrchestrationError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_post_order_invalid",
+            "Post-order request is invalid",
+            "validation",
+            "rustok_commerce",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_RETURN_ORCHESTRATION_OWNER,
+        source_owner,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        order_id = ?context.order_id,
+        return_id = ?context.return_id,
+        refund_id = ?context.refund_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_RETURN_BOUNDARY,
+        "commerce admin order return orchestration failed"
     );
     HttpError::new(status, code, message)
 }
@@ -181,7 +365,18 @@ pub async fn create_order_return_decision(
     let decision = service
         .create_return_decision(tenant.id, auth.user_id, id, input)
         .await
-        .map_err(super::map_post_order_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_order_return_orchestration_error(
+                AdminOrderReturnOrchestrationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "create_return_decision",
+                ),
+                error,
+            )
+        })?;
     Ok((StatusCode::CREATED, Json(decision)))
 }
 
@@ -324,7 +519,18 @@ pub async fn complete_order_return(
         .with_payment_provider_registry(runtime.payment_provider_registry())
         .complete_return(tenant.id, auth.user_id, id, command)
         .await
-        .map_err(super::map_post_order_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_order_return_orchestration_error(
+                AdminOrderReturnOrchestrationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    Some(id),
+                    "complete_return",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(item))
 }

--- a/scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const paymentOrchestration = read(
+  'crates/rustok-commerce/src/services/payment_orchestration.rs',
+);
+const postOrder = read('crates/rustok-commerce/src/services/post_order.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const orderPolicy = between(
+  returns,
+  'fn admin_order_error_policy(',
+  'fn admin_payment_error_policy(',
+  'admin order policy',
+);
+const paymentPolicy = between(
+  returns,
+  'fn admin_payment_error_policy(',
+  'fn admin_reserved_refund_error_policy(',
+  'admin payment policy',
+);
+const reservedRefundPolicy = between(
+  returns,
+  'fn admin_reserved_refund_error_policy(',
+  'fn map_admin_order_return_error(',
+  'reserved refund policy',
+);
+const orchestrationMapper = between(
+  returns,
+  'fn map_admin_order_return_orchestration_error(',
+  '#[utoipa::path(',
+  'admin order-return orchestration mapper',
+);
+const decisionRoute = between(
+  returns,
+  'pub async fn create_order_return_decision(',
+  '#[utoipa::path(\n    get,\n    path = "/admin/returns"',
+  'return decision route',
+);
+const completeRoute = between(
+  returns,
+  'pub async fn complete_order_return(',
+  '#[utoipa::path(\n    post,\n    path = "/admin/returns/{id}/cancel"',
+  'return completion route',
+);
+
+for (const [value, label] of [
+  ['use rustok_payment::error::PaymentError;', 'typed payment error import'],
+  ['PaymentOrchestrationError,', 'typed payment orchestration import'],
+  ['PostOrderOrchestrationError,', 'typed post-order import'],
+  [
+    'const ADMIN_ORDER_RETURN_ORCHESTRATION_OWNER: &str =',
+    'orchestration owner constant',
+  ],
+  [
+    '"rustok_commerce.admin_order_return_orchestration";',
+    'orchestration owner value',
+  ],
+  [
+    'const ADMIN_ORDER_RETURN_BOUNDARY: &str = "commerce_admin_order_return_http";',
+    'HTTP boundary constant',
+  ],
+  ['struct AdminOrderReturnOrchestrationErrorContext {', 'orchestration error context'],
+  ['tenant_id: Uuid,', 'tenant field'],
+  ['actor_id: Uuid,', 'actor field'],
+  ['order_id: Option<Uuid>,', 'order identity field'],
+  ['return_id: Option<Uuid>,', 'return identity field'],
+  ['refund_id: Option<Uuid>,', 'refund identity field'],
+  ["operation: &'static str,", 'operation field'],
+  ['refund_id: None,', 'truthful absent refund default'],
+]) requireText(returns, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'order validation variant'],
+  ['OrderError::OrderNotFound(_)', 'order not-found variant'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found variant'],
+  ['OrderError::InvalidTransition { .. }', 'order transition variant'],
+  ['OrderError::Database(_)', 'order database variant'],
+  ['OrderError::Core(_)', 'order core variant'],
+  ['"commerce_admin_order_invalid"', 'order validation code'],
+  ['"commerce_admin_order_state_conflict"', 'order conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'order storage code'],
+  ['"commerce_admin_order_failed"', 'order fail-closed code'],
+]) requireText(orderPolicy, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found variant'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found variant'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found variant'],
+  ['PaymentError::Validation(_)', 'payment validation variant'],
+  ['PaymentError::InvalidTransition { .. }', 'payment transition variant'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'provider invalid-response variant'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'provider unknown-outcome variant'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration variant'],
+  ['PaymentError::Database(_)', 'payment database variant'],
+  ['"commerce_admin_payment_invalid"', 'payment validation code'],
+  ['"commerce_admin_payment_state_conflict"', 'payment conflict code'],
+  ['"commerce_admin_payment_provider_unavailable"', 'provider unavailable code'],
+  ['"commerce_admin_payment_provider_invalid_response"', 'provider invalid-response code'],
+  ['"commerce_admin_payment_reconciliation_required"', 'payment reconciliation code'],
+  ['"commerce_admin_payment_provider_not_configured"', 'provider configuration code'],
+  ['"commerce_admin_payment_storage_unavailable"', 'payment storage code'],
+  ['StatusCode::BAD_GATEWAY', 'provider invalid-response status'],
+]) requireText(paymentPolicy, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'reserved unknown-outcome variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'reserved invalid-response variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'reserved unavailable variant'],
+  ['"commerce_admin_refund_reconciliation_required"', 'reserved reconciliation code'],
+  ['"Refund remains reserved while the provider outcome is reconciled"', 'reserved reconciliation message'],
+  ['"commerce_admin_refund_provider_unavailable"', 'reserved unavailable code'],
+  [
+    '"Refund remains reserved and the provider operation may be retried safely"',
+    'reserved retry message',
+  ],
+  ['error => admin_payment_error_policy(error)', 'reserved fallback policy'],
+]) requireText(reservedRefundPolicy, value, label);
+
+for (const [value, label] of [
+  ['error: PostOrderOrchestrationError,', 'owned post-order cause'],
+  ['PostOrderOrchestrationError::Order(source)', 'order source branch'],
+  ['PostOrderOrchestrationError::Payment(source)', 'payment source branch'],
+  ['PostOrderOrchestrationError::PaymentOrchestration(source)', 'payment orchestration branch'],
+  ['PostOrderOrchestrationError::Validation(_)', 'post-order validation branch'],
+  ['PaymentOrchestrationError::Provider(source)', 'provider branch'],
+  ['PaymentOrchestrationError::Payment(source)', 'payment branch'],
+  [
+    'PaymentOrchestrationError::ProviderAfterRefundReservation {',
+    'reserved refund branch',
+  ],
+  ['context.order_id = Some(*id)', 'typed order identity adoption'],
+  ['context.return_id = Some(*id)', 'typed return identity adoption'],
+  ['context.refund_id = Some(*id)', 'typed missing-refund identity adoption'],
+  ['context.refund_id = Some(*refund_id)', 'reserved refund identity adoption'],
+  ['"commerce_admin_post_order_invalid"', 'post-order validation code'],
+  ['"Post-order request is invalid"', 'static post-order validation message'],
+  ['error = ?error', 'typed top-level error log'],
+  ['owner = ADMIN_ORDER_RETURN_ORCHESTRATION_OWNER', 'orchestration owner log'],
+  ['source_owner,', 'source owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['return_id = ?context.return_id', 'return identity log'],
+  ['refund_id = ?context.refund_id', 'refund identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_RETURN_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(orchestrationMapper, value, label);
+
+for (const [block, operation, identity, label] of [
+  [
+    decisionRoute,
+    '"create_return_decision"',
+    'auth.user_id,\n                    Some(id),\n                    None,',
+    'decision context',
+  ],
+  [
+    completeRoute,
+    '"complete_return"',
+    'auth.user_id,\n                    None,\n                    Some(id),',
+    'completion context',
+  ],
+]) {
+  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
+  requireText(block, 'map_admin_order_return_orchestration_error(', `${label} mapper handoff`);
+  requireText(block, 'AdminOrderReturnOrchestrationErrorContext::new(', `${label} context construction`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, identity, `${label} truthful route identity`);
+}
+
+for (const [value, label] of [
+  ['.create_return_decision(tenant.id, auth.user_id, id, input)', 'decision service contract'],
+  ['.complete_return(tenant.id, auth.user_id, id, command)', 'completion service contract'],
+  ['[Permission::ORDERS_UPDATE]', 'order update permission'],
+  ['[Permission::PAYMENTS_UPDATE]', 'payment update permission'],
+  ['super::decision_requires_payments_update(', 'decision payment permission gate'],
+  ['if input.refund.is_some() {', 'completion payment permission gate'],
+]) requireText(returns, value, label);
+
+const orchestrationMapperUses =
+  returns.match(
+    /map_admin_order_return_orchestration_error\(\s+AdminOrderReturnOrchestrationErrorContext::new\(/g,
+  ) ?? [];
+if (orchestrationMapperUses.length !== 2) {
+  failures.push(
+    `expected two context-aware return orchestration mapper callsites, found ${orchestrationMapperUses.length}`,
+  );
+}
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
+  [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
+  [paymentErrors, 'RefundNotFound(Uuid)', 'owner refund variant'],
+  [paymentErrors, 'ProviderUnavailable {', 'owner unavailable variant'],
+  [paymentErrors, 'ProviderRejected {', 'owner rejected variant'],
+  [paymentErrors, 'ProviderInvalidResponse {', 'owner invalid-response variant'],
+  [paymentErrors, 'ProviderOutcomeUnknown {', 'owner unknown-outcome variant'],
+  [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner configuration variant'],
+  [paymentErrors, 'Database(#[from] DbErr)', 'owner payment database variant'],
+  [paymentOrchestration, 'Provider(#[source] PaymentError)', 'payment orchestration provider variant'],
+  [paymentOrchestration, 'ProviderAfterRefundReservation {', 'reserved refund variant'],
+  [paymentOrchestration, 'Payment(#[from] PaymentError)', 'payment orchestration payment variant'],
+  [postOrder, 'Order(#[from] rustok_order::error::OrderError)', 'post-order order variant'],
+  [postOrder, 'Payment(#[from] rustok_payment::error::PaymentError)', 'post-order payment variant'],
+  [postOrder, 'PaymentOrchestration(#[from] PaymentOrchestrationError)', 'post-order orchestration variant'],
+  [postOrder, 'Validation(String)', 'post-order validation variant'],
+]) requireText(ownerSource, value, label);
+
+for (const value of [
+  '.map_err(super::map_post_order_orchestration_error)?;',
+  'format!("Post-order request is invalid:',
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(returns, value, 'unsafe admin return orchestration mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-return orchestration error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order-return orchestration errors retain route context and static public envelopes',
+);

--- a/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
@@ -30,10 +30,16 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
+const orderPolicy = between(
+  returns,
+  'fn admin_order_error_policy(',
+  'fn admin_payment_error_policy(',
+  'admin order policy',
+);
 const mapper = between(
   returns,
   'fn map_admin_order_return_error(',
-  '#[utoipa::path(',
+  'fn map_admin_order_return_orchestration_error(',
   'admin order-return owner mapper',
 );
 const createRoute = between(
@@ -74,8 +80,6 @@ for (const [value, label] of [
 ]) requireText(returns, value, label);
 
 for (const [value, label] of [
-  ['error: OrderError,', 'owned typed cause'],
-  [') -> HttpError {', 'typed HTTP mapper result'],
   ['OrderError::Validation(_)', 'validation variant'],
   ['OrderError::OrderNotFound(_)', 'order-not-found variant'],
   ['OrderError::OrderReturnNotFound(_)', 'return-not-found variant'],
@@ -83,20 +87,6 @@ for (const [value, label] of [
   ['OrderError::InvalidTransition { .. }', 'transition variant'],
   ['OrderError::Database(_)', 'database variant'],
   ['OrderError::Core(_)', 'core variant'],
-  ['error = ?error', 'typed internal cause'],
-  ['owner = ADMIN_ORDER_RETURN_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['order_id = ?context.order_id', 'order identity log'],
-  ['return_id = ?context.return_id', 'return identity log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public-code log'],
-  ['status = %status', 'status log'],
-  ['boundary = ADMIN_ORDER_RETURN_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
-]) requireText(mapper, value, label);
-
-for (const [value, label] of [
   ['"commerce_admin_order_invalid"', 'validation code'],
   ['"commerce_admin_not_found"', 'not-found code'],
   ['"commerce_admin_order_state_conflict"', 'conflict code'],
@@ -112,6 +102,23 @@ for (const [value, label] of [
   ['StatusCode::CONFLICT', 'conflict status'],
   ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
   ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+]) requireText(orderPolicy, value, label);
+
+for (const [value, label] of [
+  ['error: OrderError,', 'owned typed cause'],
+  [') -> HttpError {', 'typed HTTP mapper result'],
+  ['admin_order_error_policy(&error)', 'shared typed order policy'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_ORDER_RETURN_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['return_id = ?context.return_id', 'return identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_RETURN_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
 ]) requireText(mapper, value, label);
 
 for (const [block, operation, identity, label] of [
@@ -143,10 +150,7 @@ for (const [value, label] of [
   ['.list_returns(', 'list service contract'],
   ['.get_return(tenant.id, id)', 'detail service contract'],
   ['.cancel_return(tenant.id, id, input)', 'cancel service contract'],
-  [
-    '.map_err(super::map_post_order_orchestration_error)?;',
-    'unchanged orchestration public mapping',
-  ],
+  ['fn map_admin_order_return_orchestration_error(', 'local orchestration mapper'],
 ]) requireText(returns, value, label);
 
 const mapperUses = returns.match(/map_admin_order_return_error\(/g) ?? [];
@@ -154,9 +158,13 @@ if (mapperUses.length !== 5) {
   failures.push(`expected mapper definition plus four uses, found ${mapperUses.length}`);
 }
 const orchestrationMapperUses =
-  returns.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
+  returns.match(
+    /map_admin_order_return_orchestration_error\(\s+AdminOrderReturnOrchestrationErrorContext::new\(/g,
+  ) ?? [];
 if (orchestrationMapperUses.length !== 2) {
-  failures.push(`expected two unchanged orchestration mapper callsites, found ${orchestrationMapperUses.length}`);
+  failures.push(
+    `expected two context-aware orchestration mapper callsites, found ${orchestrationMapperUses.length}`,
+  );
 }
 
 for (const [value, label] of [
@@ -171,6 +179,7 @@ for (const [value, label] of [
 
 for (const value of [
   '.map_err(super::map_order_error)?;',
+  '.map_err(super::map_post_order_orchestration_error)?;',
   'error.to_string()',
   'err.to_string()',
   'other.to_string()',


### PR DESCRIPTION
## Summary

- replace the two shared post-order mapper callsites in admin return decision and completion routes with one local context-aware typed mapper;
- preserve existing order, payment, provider, post-order validation, and reserved-refund HTTP status/code/message policies;
- retain orchestration owner, source owner, tenant, actor, route operation, truthful optional order, return, and refund identities, and the original top-level typed cause in one error event;
- reuse one exhaustive typed order policy for existing owner routes without changing their public behavior;
- add a focused orchestration verifier and align the existing owner verifier.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/admin/returns.rs`
- `scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs`
- `scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`

## Validation

- rebased onto current `main` after an unrelated Notifications commit landed;
- branch is directly ahead of current `main` by one commit and is not behind;
- final diff is limited to the three intended files;
- source was re-read to confirm all six routes, unchanged permission gates, service calls and success envelopes, four owner mapper callsites, and two orchestration mapper callsites;
- all current `PostOrderOrchestrationError`, `PaymentOrchestrationError`, `OrderError`, and `PaymentError` variants are handled by typed policies;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs
node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs
cargo check -p rustok-commerce --lib
```