### PR TITLE
fix(index): validate scale workflow inputs

### DIFF
--- a/.github/workflows/index-storage-scale-run-contract.yml
+++ b/.github/workflows/index-storage-scale-run-contract.yml
@@ -1,0 +1,35 @@
+name: Index Storage Scale Run Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-run-contract.yml"
+      - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+  push:
+    branches:
+      - main
+      - "agent/**"
+    paths:
+      - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-run-contract.yml"
+      - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Reusable scale workflow contract
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify contract script syntax
+        run: node --check scripts/verify/verify-index-storage-scale-run-contract.mjs
+      - name: Verify fail-closed scale workflow inputs
+        run: node scripts/verify/verify-index-storage-scale-run-contract.mjs

--- a/.github/workflows/index-storage-scale-run.yml
+++ b/.github/workflows/index-storage-scale-run.yml
@@ -39,7 +39,45 @@ env:
   INDEX_BENCH_REQUIRE_GITHUB_PROVENANCE: "1"
 
 jobs:
+  validate-inputs:
+    name: Validate scale evidence inputs
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Require canonical reusable workflow inputs
+        shell: bash
+        env:
+          REQUESTED_SCALE: ${{ inputs.scale }}
+          REQUESTED_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          REQUESTED_RUNNER_LABEL: ${{ inputs.runner_label }}
+          REQUESTED_MINIMUM_FREE_BYTES: ${{ inputs.minimum_free_bytes }}
+        run: |
+          case "$REQUESTED_SCALE" in
+            100k|1m) ;;
+            *)
+              echo "::error::scale must be 100k or 1m; got ${REQUESTED_SCALE}"
+              exit 1
+              ;;
+          esac
+          if ! [[ "$REQUESTED_TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::timeout_minutes must be a positive integer; got ${REQUESTED_TIMEOUT_MINUTES}"
+            exit 1
+          fi
+          if (( REQUESTED_TIMEOUT_MINUTES > 360 )); then
+            echo "::error::timeout_minutes must not exceed 360; got ${REQUESTED_TIMEOUT_MINUTES}"
+            exit 1
+          fi
+          if [[ -z "${REQUESTED_RUNNER_LABEL//[[:space:]]/}" ]]; then
+            echo "::error::runner_label must be non-empty"
+            exit 1
+          fi
+          if ! [[ "$REQUESTED_MINIMUM_FREE_BYTES" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::minimum_free_bytes must be a positive integer; got ${REQUESTED_MINIMUM_FREE_BYTES}"
+            exit 1
+          fi
+
   evidence:
+    needs: validate-inputs
     name: PostgreSQL ${{ inputs.scale }} evidence
     runs-on: ${{ inputs.runner_label }}
     timeout-minutes: ${{ inputs.timeout_minutes }}

--- a/scripts/verify/verify-index-storage-scale-run-contract.mjs
+++ b/scripts/verify/verify-index-storage-scale-run-contract.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync(
+  new URL('../../.github/workflows/index-storage-scale-run.yml', import.meta.url),
+  'utf8',
+);
+const prefix = '[verify-index-storage-scale-run-contract]';
+const fail = (message) => {
+  console.error(`${prefix} ${message}`);
+  process.exit(1);
+};
+
+const validateStart = workflow.indexOf('  validate-inputs:\n');
+const evidenceStart = workflow.indexOf('  evidence:\n');
+if (validateStart < 0) fail('reusable scale workflow is missing validate-inputs job');
+if (evidenceStart < 0) fail('reusable scale workflow is missing evidence job');
+if (validateStart > evidenceStart) {
+  fail('validate-inputs job must appear before the evidence job');
+}
+
+const validateBlock = workflow.slice(validateStart, evidenceStart);
+for (const marker of [
+  '    runs-on: ubuntu-slim',
+  '    timeout-minutes: 5',
+  '          REQUESTED_SCALE: ${{ inputs.scale }}',
+  '          REQUESTED_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}',
+  '          REQUESTED_RUNNER_LABEL: ${{ inputs.runner_label }}',
+  '          REQUESTED_MINIMUM_FREE_BYTES: ${{ inputs.minimum_free_bytes }}',
+  '          case "$REQUESTED_SCALE" in',
+  '            100k|1m) ;;',
+  '          if ! [[ "$REQUESTED_TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]]; then',
+  '          if (( REQUESTED_TIMEOUT_MINUTES > 360 )); then',
+  '          if [[ -z "${REQUESTED_RUNNER_LABEL//[[:space:]]/}" ]]; then',
+  '          if ! [[ "$REQUESTED_MINIMUM_FREE_BYTES" =~ ^[1-9][0-9]*$ ]]; then',
+]) {
+  if (!validateBlock.includes(marker)) fail(`validate-inputs job is missing ${marker}`);
+}
+for (const forbidden of [
+  'actions/checkout',
+  'dtolnay/rust-toolchain',
+  'services:',
+  'postgres:',
+  'cargo build',
+]) {
+  if (validateBlock.includes(forbidden)) {
+    fail(`validate-inputs job must remain lightweight; found ${forbidden}`);
+  }
+}
+
+const evidenceBlock = workflow.slice(evidenceStart);
+const needsIndex = evidenceBlock.indexOf('    needs: validate-inputs\n');
+const runnerIndex = evidenceBlock.indexOf('    runs-on: ${{ inputs.runner_label }}\n');
+const servicesIndex = evidenceBlock.indexOf('    services:\n');
+if (needsIndex < 0) fail('evidence job must depend on validate-inputs');
+if (runnerIndex < 0 || servicesIndex < 0) {
+  fail('evidence job is missing runner or service allocation markers');
+}
+if (needsIndex > runnerIndex || needsIndex > servicesIndex) {
+  fail('evidence dependency must be declared before runner and service allocation');
+}
+if (!evidenceBlock.includes('          if (( available_bytes < MINIMUM_FREE_BYTES )); then')) {
+  fail('evidence job must retain the runner disk-capacity gate');
+}
+
+console.log(`${prefix} reusable scale workflow input validation is fail closed`);


### PR DESCRIPTION
## What changed

- add a fixed-runner `validate-inputs` job to the reusable Index scale workflow;
- allow only the canonical `100k` and `1m` scales;
- require a positive integer timeout capped at GitHub Actions' 360-minute job limit;
- reject blank runner labels and non-positive `minimum_free_bytes` values;
- make the PostgreSQL evidence job depend on successful input validation;
- add a static verifier that protects the validation markers, lightweight-job boundary, and job ordering;
- add a self-triggering contract workflow for changes to the reusable workflow or its verifier.

## Root cause

The reusable workflow accepted arbitrary string scales and numeric resource thresholds. Scale validation happened only at the final storage-tooling step, after checkout, toolchain setup, compilation, and all three benchmark runs. A zero or negative `minimum_free_bytes` value also made the arithmetic disk-capacity guard pass regardless of available space.

The scale-evidence workflow intentionally skips its heavy contract job for pull-request events and restricts push execution to two M2 branches. A change to the reusable workflow on an ordinary agent branch therefore needed its own lightweight contract trigger instead of relying on the evidence workflow to validate itself.

## Impact

Malformed reusable-workflow calls now fail on a small fixed runner before PostgreSQL services, custom/large runner allocation, Rust setup, compilation, evidence generation, or artifact publication. The contract verifier rejects removal or reordering of this gate and prevents expensive setup from drifting into the validation job. Canonical calls from `index-storage-scale-evidence.yml` remain unchanged. This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and an accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per repository owner request. The branch contains one commit and three changed files.