### PR TITLE
Align admin return orchestration error verification

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -64,6 +64,12 @@ available only for actionable domain errors.
   order and return identities, stable public code, status, and HTTP boundary. Validation,
   not-found, conflict, storage, and fail-closed outcomes preserve the existing static
   status, code, and message policy without a second generic error event.
+- `rustok-commerce` admin order-return orchestration routes: decision and complete paths
+  retain the top-level typed post-order cause with orchestration and source owner, tenant,
+  actor, route operation, truthful optional order, return, and reserved refund identities,
+  stable public code, status, and HTTP boundary. Nested order, payment, provider, and
+  reserved-refund outcomes preserve the existing static status, code, and message policy
+  without delegating through a second generic error event.
 - `rustok-commerce` admin order detail payment lookup: the complete typed payment cause
   remains internal while owner, tenant, order, operation, error kind, stable public code,
   status, and HTTP boundary are logged. Validation, missing-resource, transition,
@@ -116,6 +122,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-fulfillment-error-safety.mjs`
 - `node scripts/verify/verify-order-payment-settlement-error-context.mjs`
@@ -132,8 +139,8 @@ available only for actionable domain errors.
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
   admin fulfillment reconciliation, admin fulfillment routes, admin order-return owner
-  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
-  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and
-  transport round-trip tests.
+  and orchestration mapping, admin order-detail payment and fulfillment mapping, and tax
+  calculation validation, provider-contract, reconciliation, correlation, HTTP-envelope,
+  and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -148,18 +148,25 @@ for (const [value, label] of [
   ['pub async fn list_order_returns(', 'admin return list'],
   ['pub async fn show_order_return(', 'admin return detail'],
   ['pub async fn create_order_return(', 'admin return create'],
+  ['pub async fn create_order_return_decision(', 'admin return decision'],
+  ['pub async fn complete_order_return(', 'admin return complete'],
   ['pub async fn cancel_order_return(', 'admin return cancel'],
   ['struct AdminOrderReturnErrorContext {', 'return owner context'],
   ['fn map_admin_order_return_error(', 'context-aware return owner mapper'],
-  ['.map_err(super::map_post_order_orchestration_error)?;', 'typed return orchestration mapping'],
+  ['struct AdminOrderReturnOrchestrationErrorContext {', 'return orchestration context'],
+  [
+    'fn map_admin_order_return_orchestration_error(',
+    'context-aware return orchestration mapper',
+  ],
   ['ListOrderReturnsInput {', 'return list input'],
   ['page: pagination.page', 'return page forwarding'],
   ['per_page: pagination.limit()', 'return page-size forwarding'],
 ]) requireText(returns, value, label);
 
-for (const value of ['.map_err(super::map_order_error)?;']) {
-  forbidText(returns, value, 'stale admin return shared owner mapper callsite');
-}
+for (const value of [
+  '.map_err(super::map_order_error)?;',
+  '.map_err(super::map_post_order_orchestration_error)?;',
+]) forbidText(returns, value, 'stale admin return shared mapper callsite');
 
 for (const [value, label] of [
   ['pub async fn list_fulfillments(', 'admin fulfillment list'],
@@ -214,6 +221,16 @@ if (returnOwnerMapperUses.length !== 4) {
   );
 }
 
+const returnOrchestrationMapperUses =
+  returns.match(
+    /map_admin_order_return_orchestration_error\(\s+AdminOrderReturnOrchestrationErrorContext::new\(/g,
+  ) ?? [];
+if (returnOrchestrationMapperUses.length !== 2) {
+  failures.push(
+    `expected two context-aware return orchestration mapper callsites, found ${returnOrchestrationMapperUses.length}`,
+  );
+}
+
 const fulfillmentMapperUses =
   fulfillments.match(
     /map_admin_fulfillment_error\(\s+AdminFulfillmentErrorContext::new\(/g,
@@ -232,12 +249,6 @@ if (fulfillmentOrchestrationUses.length !== 4) {
   failures.push(
     `expected four context-aware fulfillment orchestration mapper callsites, found ${fulfillmentOrchestrationUses.length}`,
   );
-}
-
-const postOrderUses =
-  returns.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
-if (postOrderUses.length !== 2) {
-  failures.push(`expected two post-order orchestration mapper callsites, found ${postOrderUses.length}`);
 }
 
 const remainingAdminDynamicStrings = admin.match(/other\.to_string\(\)/g) ?? [];


### PR DESCRIPTION
## Summary

- update the broad admin order/return/fulfillment verifier to require four local return owner mapper callsites and two local return orchestration mapper callsites;
- forbid the removed shared order and post-order mapper callsites in admin return routes;
- preserve the existing shared order, fulfillment owner, fulfillment orchestration, unsafe-conversion, and source-enum assertions;
- document the completed admin return orchestration boundary and its focused verifier in the ecommerce public-error safety plan.

## Scope

Two files only:

- `scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- based directly on the merged implementation PR;
- branch is directly ahead of current `main` by one commit and is not behind;
- final diff is limited to the two intended integration files;
- broad verifier source was re-read to confirm six remaining shared order callsites, four local return owner callsites, two local return orchestration callsites, and unchanged fulfillment counts;
- tests, Cargo commands, formatting commands, verifier execution, and CI were not run, per repository-owner instruction.

Intended focused check:

```bash
node scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
```