### PR TITLE
Harden admin shipping option error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -59,6 +59,11 @@ available only for actionable domain errors.
   route operation, truthful optional fulfillment and order identities, stable public code,
   status, and HTTP boundary. Persisted reconciliation errors adopt the fulfillment id from
   the typed orchestration error while validation and technical details stay internal.
+- `rustok-commerce` admin shipping-option routes: list, create, detail, update, deactivate,
+  and reactivate paths map the typed `FulfillmentError` locally with owner, tenant, route
+  operation, truthful optional shipping-option identity, stable public code, status, and
+  HTTP boundary. Validation details remain internal while the existing not-found,
+  transition, and storage status/code policy stays unchanged.
 - `rustok-commerce` admin order-return owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and return identities, stable public code, status, and HTTP boundary. Validation,
@@ -121,6 +126,8 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
+- `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
@@ -138,9 +145,9 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin order-return owner
-  and orchestration mapping, admin order-detail payment and fulfillment mapping, and tax
-  calculation validation, provider-contract, reconciliation, correlation, HTTP-envelope,
-  and transport round-trip tests.
+  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option
+  mapping, admin order-return owner and orchestration mapping, admin order-detail payment
+  and fulfillment mapping, and tax calculation validation, provider-contract,
+  reconciliation, correlation, HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/shipping.rs
+++ b/crates/rustok-commerce/src/controllers/admin/shipping.rs
@@ -6,6 +6,7 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_fulfillment::FulfillmentService;
+use rustok_fulfillment::error::FulfillmentError;
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -22,6 +23,29 @@ use crate::{
         UpdateShippingProfileInput,
     },
 };
+
+const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";
+const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";
+
+struct AdminShippingOptionErrorContext {
+    tenant_id: Uuid,
+    shipping_option_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminShippingOptionErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        shipping_option_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            shipping_option_id,
+            operation,
+        }
+    }
+}
 
 fn map_shipping_profile_error(error: CommerceError) -> HttpError {
     let (status, code, message, error_kind) = match &error {
@@ -72,8 +96,53 @@ fn map_shipping_profile_error(error: CommerceError) -> HttpError {
         error_kind,
         public_code = code,
         status = %status,
-        boundary = "commerce_admin_shipping_http",
+        boundary = ADMIN_SHIPPING_BOUNDARY,
         "commerce admin shipping profile operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_shipping_option_error(
+    context: AdminShippingOptionErrorContext,
+    error: FulfillmentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_) | FulfillmentError::FulfillmentNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        FulfillmentError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_SHIPPING_OPTION_OWNER,
+        tenant_id = %context.tenant_id,
+        shipping_option_id = ?context.shipping_option_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_SHIPPING_BOUNDARY,
+        "commerce admin shipping option operation failed"
     );
     HttpError::new(status, code, message)
 }
@@ -341,7 +410,12 @@ pub async fn list_shipping_options(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(tenant.id, None, "list_shipping_options"),
+                error,
+            )
+        })?;
     if let Some(active) = params.active {
         items.retain(|option| option.active == active);
     }
@@ -403,7 +477,12 @@ pub async fn create_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .create_shipping_option(tenant.id, input)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(tenant.id, None, "create_shipping_option"),
+                error,
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(option)))
 }
@@ -441,7 +520,16 @@ pub async fn show_shipping_option(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    "get_shipping_option",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(option))
 }
@@ -482,7 +570,16 @@ pub async fn update_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .update_shipping_option(tenant.id, id, input)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    "update_shipping_option",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(option))
 }
@@ -514,7 +611,16 @@ pub async fn deactivate_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .deactivate_shipping_option(tenant.id, id)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    "deactivate_shipping_option",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(option))
 }
@@ -546,7 +652,16 @@ pub async fn reactivate_shipping_option(
     let option = FulfillmentService::new(runtime.db_clone())
         .reactivate_shipping_option(tenant.id, id)
         .await
-        .map_err(super::map_fulfillment_error)?;
+        .map_err(|error| {
+            map_admin_shipping_option_error(
+                AdminShippingOptionErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    "reactivate_shipping_option",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(option))
 }

--- a/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
@@ -11,7 +11,6 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
-const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
 const shippingService = read('crates/rustok-commerce/src/services/shipping_profile.rs');
@@ -23,41 +22,70 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const profileMapper = between(
+  shipping,
+  'fn map_shipping_profile_error(',
+  'fn map_admin_shipping_option_error(',
+  'shipping-profile mapper',
+);
+const optionMapper = between(
+  shipping,
+  'fn map_admin_shipping_option_error(',
+  'async fn validate_shipping_option_profile_inputs(',
+  'shipping-option mapper',
+);
 
 for (const [value, label] of [
   ['CommerceError, ShippingProfileService', 'typed commerce error import'],
+  ['use rustok_fulfillment::error::FulfillmentError;', 'typed fulfillment error import'],
   ['fn map_shipping_profile_error(error: CommerceError)', 'local shipping profile mapper'],
+  ['fn map_admin_shipping_option_error(', 'local shipping option mapper'],
   ['async fn validate_shipping_option_profile_inputs(', 'local profile validation helper'],
-  ['error = ?error', 'raw internal error logging'],
-  ['owner = "rustok_commerce.shipping_profile"', 'owner logging'],
-  ['error_kind,', 'error-kind logging'],
-  ['public_code = code', 'public-code logging'],
-  ['status = %status', 'status logging'],
-  ['boundary = "commerce_admin_shipping_http"', 'shipping HTTP boundary logging'],
-  ['HttpError::new(status, code, message)', 'static public envelope construction'],
-]) {
-  requireText(shipping, value, label);
-}
+  [
+    'const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";',
+    'shipping-option owner constant',
+  ],
+  [
+    'const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";',
+    'shipping HTTP boundary constant',
+  ],
+  ['struct AdminShippingOptionErrorContext {', 'shipping-option context'],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['shipping_option_id: Option<Uuid>,', 'truthful option identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(shipping, value, label);
 
 for (const [value, label] of [
   ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
   ['CommerceError::DuplicateShippingProfileSlug(_)', 'duplicate profile slug mapping'],
   ['CommerceError::Validation(_)', 'profile validation mapping'],
   ['CommerceError::Database(_)', 'profile database mapping'],
-  ['StatusCode::NOT_FOUND', 'not-found status'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-  ['StatusCode::BAD_REQUEST', 'bad-request status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['StatusCode::NOT_FOUND', 'profile not-found status'],
+  ['StatusCode::CONFLICT', 'profile conflict status'],
+  ['StatusCode::BAD_REQUEST', 'profile bad-request status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'profile unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'profile fail-closed status'],
   ['"commerce_admin_not_found"', 'shared not-found code'],
   ['"commerce_admin_shipping_profile_conflict"', 'profile conflict code'],
   ['"commerce_admin_shipping_profile_invalid"', 'profile invalid code'],
   ['"commerce_admin_shipping_profile_storage_unavailable"', 'profile storage code'],
   ['"commerce_admin_shipping_profile_failed"', 'profile fail-closed code'],
   ['"unexpected_commerce_error"', 'unexpected owner variant kind'],
-]) {
-  requireText(shipping, value, label);
-}
+  ['error = ?error', 'profile typed internal cause'],
+  ['owner = "rustok_commerce.shipping_profile"', 'profile owner logging'],
+  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'profile boundary logging'],
+  ['HttpError::new(status, code, message)', 'profile static envelope construction'],
+]) requireText(profileMapper, value, label);
 
 for (const value of [
   'CommerceError::ProductNotFound(_)',
@@ -71,9 +99,41 @@ for (const value of [
   'CommerceError::CannotDeletePublished',
   'CommerceError::Rich(_)',
   'CommerceError::Core(_)',
-]) {
-  requireText(shipping, value, 'fail-closed unrelated commerce variant');
-}
+]) requireText(profileMapper, value, 'fail-closed unrelated commerce variant');
+
+for (const [value, label] of [
+  ['error: FulfillmentError,', 'owned fulfillment cause'],
+  ['FulfillmentError::Validation(_)', 'option validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'option not-found mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'unexpected fulfillment not-found mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'option transition mapping'],
+  ['FulfillmentError::Database(_)', 'option database mapping'],
+  ['StatusCode::BAD_REQUEST', 'option bad-request status'],
+  ['StatusCode::NOT_FOUND', 'option not-found status'],
+  ['StatusCode::CONFLICT', 'option conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'option unavailable status'],
+  ['"commerce_admin_fulfillment_invalid"', 'option validation code'],
+  ['"commerce_admin_not_found"', 'option not-found code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'option conflict code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'option storage code'],
+  ['"Fulfillment request is invalid"', 'static option validation message'],
+  ['"Commerce resource not found"', 'static option not-found message'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static option conflict message',
+  ],
+  ['"Fulfillment storage is temporarily unavailable"', 'static option storage message'],
+  ['error = ?error', 'option typed internal cause'],
+  ['owner = ADMIN_SHIPPING_OPTION_OWNER', 'option owner logging'],
+  ['tenant_id = %context.tenant_id', 'option tenant logging'],
+  ['shipping_option_id = ?context.shipping_option_id', 'option identity logging'],
+  ['operation = %context.operation', 'option operation logging'],
+  ['error_kind,', 'option error-kind logging'],
+  ['public_code = code', 'option public-code logging'],
+  ['status = %status', 'option status logging'],
+  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'option boundary logging'],
+  ['HttpError::new(status, code, message)', 'option static envelope construction'],
+]) requireText(optionMapper, value, label);
 
 for (const [value, label] of [
   ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
@@ -91,9 +151,7 @@ for (const [value, label] of [
   ['CannotDeletePublished', 'owner published-delete variant'],
   ['Rich(#[source] Box<RichError>)', 'owner rich variant'],
   ['Core(#[from] CoreError)', 'owner core variant'],
-]) {
-  requireText(commerceErrors, value, label);
-}
+]) requireText(commerceErrors, value, label);
 
 for (const [value, label] of [
   ['Validation(String)', 'fulfillment validation variant'],
@@ -101,18 +159,17 @@ for (const [value, label] of [
   ['FulfillmentNotFound(Uuid)', 'fulfillment resource variant'],
   ['InvalidTransition { from: String, to: String }', 'fulfillment transition variant'],
   ['Database(#[from] DbErr)', 'fulfillment database variant'],
-]) {
-  requireText(fulfillmentErrors, value, label);
-}
+]) requireText(fulfillmentErrors, value, label);
 
 for (const [value, label] of [
   ['CommerceError::Validation(error.to_string())', 'shipping service validation construction'],
-  ['CommerceError::ShippingProfileNotFound(shipping_profile_id)', 'shipping service not-found construction'],
+  [
+    'CommerceError::ShippingProfileNotFound(shipping_profile_id)',
+    'shipping service not-found construction',
+  ],
   ['CommerceError::DuplicateShippingProfileSlug(', 'shipping service conflict construction'],
   ['active_profile.insert(&self.db).await?;', 'shipping service database propagation'],
-]) {
-  requireText(shippingService, value, label);
-}
+]) requireText(shippingService, value, label);
 
 for (const [value, label] of [
   ['pub async fn list_shipping_profiles(', 'profile list handler'],
@@ -145,9 +202,7 @@ for (const [value, label] of [
   ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
   ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
   ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
-]) {
-  requireText(shipping, value, label);
-}
+]) requireText(shipping, value, label);
 
 for (const value of [
   'err.to_string()',
@@ -155,31 +210,27 @@ for (const value of [
   'HttpError::bad_request("commerce_operation_failed"',
   'super::map_shipping_profile_error',
   'super::validate_shipping_option_profile_inputs',
-]) {
-  forbidText(shipping, value, 'unsafe admin shipping public conversion');
-}
+  '.map_err(super::map_fulfillment_error)?;',
+  'format!("Fulfillment request is invalid:',
+]) forbidText(shipping, value, 'unsafe admin shipping public conversion');
 
 const profileMapperUses = shipping.match(/map_shipping_profile_error\(/g) ?? [];
 if (profileMapperUses.length !== 8) {
   failures.push(`expected profile mapper definition plus seven uses, found ${profileMapperUses.length}`);
 }
 
-const fulfillmentMapperUses =
-  shipping.match(/\.map_err\(super::map_fulfillment_error\)\?;/g) ?? [];
-if (fulfillmentMapperUses.length !== 6) {
-  failures.push(`expected six shipping-option fulfillment mapper callsites, found ${fulfillmentMapperUses.length}`);
+const optionMapperUses =
+  shipping.match(
+    /map_admin_shipping_option_error\(\s+AdminShippingOptionErrorContext::new\(/g,
+  ) ?? [];
+if (optionMapperUses.length !== 6) {
+  failures.push(`expected six context-aware shipping-option mapper callsites, found ${optionMapperUses.length}`);
 }
 
 const localValidationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
 if (localValidationUses.length !== 3) {
   failures.push(`expected local validation helper definition plus two uses, found ${localValidationUses.length}`);
 }
-
-requireText(
-  admin,
-  'pub(crate) fn map_fulfillment_error(error: FulfillmentError)',
-  'shared fulfillment mapper used by shipping options',
-);
 
 if (failures.length > 0) {
   console.error('Commerce admin shipping HTTP error-safety verification failed:');
@@ -188,5 +239,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping profile and option errors use stable typed public envelopes',
+  '✔ Commerce admin shipping profile and option errors use stable context-aware public envelopes',
 );

--- a/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  shipping,
+  'fn map_admin_shipping_option_error(',
+  'async fn validate_shipping_option_profile_inputs(',
+  'admin shipping-option mapper',
+);
+const listRoute = between(
+  shipping,
+  'pub async fn list_shipping_options(',
+  '/// Create admin shipping option',
+  'list shipping options route',
+);
+const createRoute = between(
+  shipping,
+  'pub async fn create_shipping_option(',
+  '/// Show admin shipping option',
+  'create shipping option route',
+);
+const showRoute = between(
+  shipping,
+  'pub async fn show_shipping_option(',
+  '/// Update admin shipping option',
+  'show shipping option route',
+);
+const updateRoute = between(
+  shipping,
+  'pub async fn update_shipping_option(',
+  '/// Deactivate admin shipping option',
+  'update shipping option route',
+);
+const deactivateRoute = between(
+  shipping,
+  'pub async fn deactivate_shipping_option(',
+  '/// Reactivate admin shipping option',
+  'deactivate shipping option route',
+);
+const reactivateStart = shipping.indexOf('pub async fn reactivate_shipping_option(');
+const reactivateRoute = reactivateStart < 0 ? '' : shipping.slice(reactivateStart);
+if (reactivateStart < 0) failures.push('reactivate shipping option route: unable to isolate source block');
+
+for (const [value, label] of [
+  ['use rustok_fulfillment::error::FulfillmentError;', 'typed fulfillment error import'],
+  [
+    'const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";',
+    'owner constant',
+  ],
+  [
+    'const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";',
+    'boundary constant',
+  ],
+  ['struct AdminShippingOptionErrorContext {', 'error context'],
+  ['tenant_id: Uuid,', 'tenant field'],
+  ['shipping_option_id: Option<Uuid>,', 'option identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(shipping, value, label);
+
+for (const [value, label] of [
+  ['error: FulfillmentError,', 'owned typed cause'],
+  ['FulfillmentError::Validation(_)', 'validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
+  ['FulfillmentError::Database(_)', 'database variant'],
+  ['StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['"commerce_admin_fulfillment_invalid"', 'validation code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'conflict code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'storage code'],
+  ['"Fulfillment request is invalid"', 'static validation message'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static conflict message',
+  ],
+  ['"Fulfillment storage is temporarily unavailable"', 'static storage message'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_SHIPPING_OPTION_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['shipping_option_id = ?context.shipping_option_id', 'option identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [block, operation, identity, serviceCall, label] of [
+  [
+    listRoute,
+    '"list_shipping_options"',
+    'tenant.id, None,',
+    '.list_all_shipping_options(',
+    'list route',
+  ],
+  [
+    createRoute,
+    '"create_shipping_option"',
+    'tenant.id, None,',
+    '.create_shipping_option(tenant.id, input)',
+    'create route',
+  ],
+  [
+    showRoute,
+    '"get_shipping_option"',
+    'tenant.id,\n                    Some(id),',
+    '.get_shipping_option(',
+    'show route',
+  ],
+  [
+    updateRoute,
+    '"update_shipping_option"',
+    'tenant.id,\n                    Some(id),',
+    '.update_shipping_option(tenant.id, id, input)',
+    'update route',
+  ],
+  [
+    deactivateRoute,
+    '"deactivate_shipping_option"',
+    'tenant.id,\n                    Some(id),',
+    '.deactivate_shipping_option(tenant.id, id)',
+    'deactivate route',
+  ],
+  [
+    reactivateRoute,
+    '"reactivate_shipping_option"',
+    'tenant.id,\n                    Some(id),',
+    '.reactivate_shipping_option(tenant.id, id)',
+    'reactivate route',
+  ],
+]) {
+  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
+  requireText(block, 'map_admin_shipping_option_error(', `${label} mapper handoff`);
+  requireText(block, 'AdminShippingOptionErrorContext::new(', `${label} context construction`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, identity, `${label} truthful identity`);
+  requireText(block, serviceCall, `${label} service contract`);
+}
+
+for (const [value, label] of [
+  ['[Permission::FULFILLMENTS_READ]', 'read permission'],
+  ['[Permission::FULFILLMENTS_CREATE]', 'create permission'],
+  ['[Permission::FULFILLMENTS_UPDATE]', 'update permission'],
+  ['page: pagination.page', 'pagination page forwarding'],
+  ['per_page: pagination.limit()', 'pagination size forwarding'],
+  ['items.retain(|option| option.active == active)', 'active filter'],
+  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
+  ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
+  ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
+  ['validate_shipping_option_profile_inputs(', 'profile validation helper'],
+]) requireText(shipping, value, label);
+
+const mapperUses =
+  shipping.match(
+    /map_admin_shipping_option_error\(\s+AdminShippingOptionErrorContext::new\(/g,
+  ) ?? [];
+if (mapperUses.length !== 6) {
+  failures.push(`expected six context-aware shipping-option mapper callsites, found ${mapperUses.length}`);
+}
+
+for (const [value, label] of [
+  ['Validation(String)', 'owner validation variant'],
+  ['ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+  ['FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
+  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  ['Database(#[from] DbErr)', 'owner database variant'],
+]) requireText(fulfillmentErrors, value, label);
+
+for (const value of [
+  '.map_err(super::map_fulfillment_error)?;',
+  'format!("Fulfillment request is invalid:',
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(shipping, value, 'unsafe admin shipping-option public conversion');
+
+if (failures.length > 0) {
+  console.error('Commerce admin shipping-option error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin shipping-option errors retain route context and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace all six shared fulfillment mapper callsites in admin shipping-option routes with one local context-aware typed mapper;
- keep validation details internal while preserving existing fulfillment status/code policy for validation, not-found, state conflict, and storage failures;
- retain owner, tenant, route operation, truthful optional shipping-option identity, stable public code, status, HTTP boundary, and the original typed cause in one structured error event;
- preserve shipping-profile routes, option filters, permission gates, service calls, pagination, and success responses;
- add a focused shipping-option verifier, align the existing shipping verifier, and update the ecommerce error-safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/shipping.rs`
- `scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
- `scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the four intended files;
- source was re-read to confirm six local mapper callsites with list/create using no option identity and detail/update/deactivate/reactivate using the route option ID;
- all current `FulfillmentError` variants are handled exhaustively with static envelopes;
- shipping-profile routes, shipping-option permission gates, filters, pagination, service calls, and success contracts remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```