### PR TITLE
Correct admin error-safety verifier baseline

### DIFF
--- a/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
@@ -251,16 +251,11 @@ if (fulfillmentOrchestrationUses.length !== 4) {
   );
 }
 
-const remainingAdminDynamicStrings = admin.match(/other\.to_string\(\)/g) ?? [];
-if (remainingAdminDynamicStrings.length !== 1) {
-  failures.push(
-    `expected only the separately scoped shipping-profile mapper to retain other.to_string(), found ${remainingAdminDynamicStrings.length}`,
-  );
-}
+forbidText(admin, 'other.to_string()', 'unsafe shared admin dynamic string conversion');
 requireText(
   admin,
   'pub(crate) fn map_shipping_profile_error(error: crate::CommerceError)',
-  'separately scoped shipping-profile mapper',
+  'shared static shipping-profile mapper',
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary

- remove the stale expectation that one `other.to_string()` remains in the shared admin mapper file;
- forbid any shared admin `other.to_string()` conversion instead;
- keep the existing static shipping-profile mapper assertion and all order, return, fulfillment, source-enum, and callsite-count checks unchanged.

## Scope

One file only:

- `scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs`

## Validation

- based directly on merged PR #2191;
- branch is directly ahead of current `main` by one commit and is not behind;
- final diff is limited to a nine-line baseline correction in one verifier;
- no production code, routes, permissions, public envelopes, or documentation are changed;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused check:

```bash
node scripts/verify/verify-commerce-admin-order-fulfillment-http-error-safety.mjs
```