### PR TITLE
Harden admin order change owner error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -64,6 +64,11 @@ available only for actionable domain errors.
   operation, truthful optional shipping-option identity, stable public code, status, and
   HTTP boundary. Validation details remain internal while the existing not-found,
   transition, and storage status/code policy stays unchanged.
+- `rustok-commerce` admin order-change owner routes: create, list, detail, and cancel paths
+  map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
+  order and order-change identities, stable public code, status, and HTTP boundary. Typed
+  missing-resource identities are adopted from the error while validation, conflict,
+  storage, and fail-closed responses preserve the existing static policy.
 - `rustok-commerce` admin order-return owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and return identities, stable public code, status, and HTTP boundary. Validation,
@@ -128,6 +133,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
@@ -145,9 +151,10 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option
-  mapping, admin order-return owner and orchestration mapping, admin order-detail payment
-  and fulfillment mapping, and tax calculation validation, provider-contract,
-  reconciliation, correlation, HTTP-envelope, and transport round-trip tests.
+  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option and
+  order-change owner mapping, admin order-return owner and orchestration mapping, admin
+  order-detail payment and fulfillment mapping, and tax calculation validation,
+  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
+  tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/changes.rs
+++ b/crates/rustok-commerce/src/controllers/admin/changes.rs
@@ -6,7 +6,8 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_order::OrderService;
-use rustok_web::HttpResult;
+use rustok_order::error::OrderError;
+use rustok_web::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -23,6 +24,102 @@ use crate::{
         CancelOrderChangeInput, CreateOrderChangeInput, ListOrderChangesInput, OrderChangeResponse,
     },
 };
+
+const ADMIN_ORDER_CHANGE_OWNER: &str = "rustok_order.admin_changes";
+const ADMIN_ORDER_CHANGE_BOUNDARY: &str = "commerce_admin_order_change_http";
+
+struct AdminOrderChangeErrorContext {
+    tenant_id: Uuid,
+    order_id: Option<Uuid>,
+    order_change_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminOrderChangeErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        order_id: Option<Uuid>,
+        order_change_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            order_id,
+            order_change_id,
+            operation,
+        }
+    }
+}
+
+fn map_admin_order_change_error(
+    mut context: AdminOrderChangeErrorContext,
+    error: OrderError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error {
+        OrderError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        OrderError::OrderNotFound(id) => {
+            context.order_id = Some(*id);
+            (
+                StatusCode::NOT_FOUND,
+                "commerce_admin_not_found",
+                "Commerce resource not found",
+                "not_found",
+            )
+        }
+        OrderError::OrderChangeNotFound(id) => {
+            context.order_change_id = Some(*id);
+            (
+                StatusCode::NOT_FOUND,
+                "commerce_admin_not_found",
+                "Commerce resource not found",
+                "not_found",
+            )
+        }
+        OrderError::OrderReturnNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        OrderError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "database",
+        ),
+        OrderError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "core",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_CHANGE_OWNER,
+        tenant_id = %context.tenant_id,
+        order_id = ?context.order_id,
+        order_change_id = ?context.order_change_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_CHANGE_BOUNDARY,
+        "commerce admin order change owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
 
 /// Create admin order change preview
 #[utoipa::path(
@@ -54,7 +151,17 @@ pub async fn create_order_change(
     let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .create_order_change(tenant.id, actor_id, id, input)
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_change_error(
+                AdminOrderChangeErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    None,
+                    "create_order_change",
+                ),
+                error,
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(created)))
 }
@@ -83,19 +190,30 @@ pub async fn list_order_changes(
     )?;
 
     let pagination = params.pagination.unwrap_or_default();
+    let order_id = params.order_id;
     let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_order_changes(
             tenant.id,
             ListOrderChangesInput {
                 page: pagination.page,
                 per_page: pagination.limit(),
-                order_id: params.order_id,
+                order_id,
                 status: params.status,
                 change_type: params.change_type,
             },
         )
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_change_error(
+                AdminOrderChangeErrorContext::new(
+                    tenant.id,
+                    order_id,
+                    None,
+                    "list_order_changes",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: items,
@@ -130,7 +248,17 @@ pub async fn show_order_change(
     let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .get_order_change(tenant.id, id)
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_change_error(
+                AdminOrderChangeErrorContext::new(
+                    tenant.id,
+                    None,
+                    Some(id),
+                    "get_order_change",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(item))
 }
@@ -206,7 +334,17 @@ pub async fn cancel_order_change(
     let item = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .cancel_order_change(tenant.id, id, input)
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_change_error(
+                AdminOrderChangeErrorContext::new(
+                    tenant.id,
+                    None,
+                    Some(id),
+                    "cancel_order_change",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(item))
 }

--- a/scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const changes = read('crates/rustok-commerce/src/controllers/admin/changes.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  changes,
+  'fn map_admin_order_change_error(',
+  '/// Create admin order change preview',
+  'admin order-change owner mapper',
+);
+const createRoute = between(
+  changes,
+  'pub async fn create_order_change(',
+  '/// List admin order changes',
+  'create order change route',
+);
+const listRoute = between(
+  changes,
+  'pub async fn list_order_changes(',
+  '/// Show admin order change',
+  'list order changes route',
+);
+const showRoute = between(
+  changes,
+  'pub async fn show_order_change(',
+  '#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]',
+  'show order change route',
+);
+const applyRoute = between(
+  changes,
+  'pub async fn apply_order_change(',
+  '/// Cancel admin order change',
+  'apply order change route',
+);
+const cancelStart = changes.indexOf('pub async fn cancel_order_change(');
+const cancelRoute = cancelStart < 0 ? '' : changes.slice(cancelStart);
+if (cancelStart < 0) failures.push('cancel order change route: unable to isolate source block');
+
+for (const [value, label] of [
+  ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
+  ['const ADMIN_ORDER_CHANGE_OWNER: &str = "rustok_order.admin_changes";', 'owner constant'],
+  [
+    'const ADMIN_ORDER_CHANGE_BOUNDARY: &str = "commerce_admin_order_change_http";',
+    'HTTP boundary constant',
+  ],
+  ['struct AdminOrderChangeErrorContext {', 'owner error context'],
+  ['tenant_id: Uuid,', 'tenant field'],
+  ['order_id: Option<Uuid>,', 'order identity field'],
+  ['order_change_id: Option<Uuid>,', 'change identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(changes, value, label);
+
+for (const [value, label] of [
+  ['mut context: AdminOrderChangeErrorContext,', 'mutable typed context'],
+  ['error: OrderError,', 'owned typed cause'],
+  ['OrderError::Validation(_)', 'validation variant'],
+  ['OrderError::OrderNotFound(id)', 'order not-found variant'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
+  ['OrderError::OrderChangeNotFound(id)', 'change not-found variant'],
+  ['OrderError::InvalidTransition { .. }', 'transition variant'],
+  ['OrderError::Database(_)', 'database variant'],
+  ['OrderError::Core(_)', 'core variant'],
+  ['context.order_id = Some(*id);', 'typed order identity adoption'],
+  ['context.order_change_id = Some(*id);', 'typed change identity adoption'],
+  ['StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"commerce_admin_order_invalid"', 'validation code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_order_state_conflict"', 'conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'storage code'],
+  ['"commerce_admin_order_failed"', 'fail-closed code'],
+  ['"Order request is invalid"', 'static validation message'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  ['"Order operation conflicts with the current state"', 'static conflict message'],
+  ['"Order storage is temporarily unavailable"', 'static storage message'],
+  ['"Order operation could not be completed safely"', 'static fail-closed message'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_ORDER_CHANGE_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['order_change_id = ?context.order_change_id', 'change identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_CHANGE_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [block, operation, identity, serviceCall, label] of [
+  [
+    createRoute,
+    '"create_order_change"',
+    'tenant.id,\n                    Some(id),\n                    None,',
+    '.create_order_change(tenant.id, actor_id, id, input)',
+    'create route',
+  ],
+  [
+    listRoute,
+    '"list_order_changes"',
+    'tenant.id,\n                    order_id,\n                    None,',
+    '.list_order_changes(',
+    'list route',
+  ],
+  [
+    showRoute,
+    '"get_order_change"',
+    'tenant.id,\n                    None,\n                    Some(id),',
+    '.get_order_change(tenant.id, id)',
+    'show route',
+  ],
+  [
+    cancelRoute,
+    '"cancel_order_change"',
+    'tenant.id,\n                    None,\n                    Some(id),',
+    '.cancel_order_change(tenant.id, id, input)',
+    'cancel route',
+  ],
+]) {
+  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
+  requireText(block, 'map_admin_order_change_error(', `${label} mapper handoff`);
+  requireText(block, 'AdminOrderChangeErrorContext::new(', `${label} context construction`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, identity, `${label} truthful route identity`);
+  requireText(block, serviceCall, `${label} service contract`);
+}
+
+for (const [value, label] of [
+  ['[Permission::ORDERS_READ]', 'read permission'],
+  ['[Permission::ORDERS_UPDATE]', 'update permission'],
+  ['let actor_id = auth.user_id;', 'create actor capture'],
+  ['let order_id = params.order_id;', 'list order filter capture'],
+  ['page: pagination.page', 'pagination page forwarding'],
+  ['per_page: pagination.limit()', 'pagination size forwarding'],
+  ['order_id,', 'list order filter forwarding'],
+  ['status: params.status', 'list status forwarding'],
+  ['change_type: params.change_type', 'list type forwarding'],
+]) requireText(changes, value, label);
+
+requireText(
+  applyRoute,
+  '.map_err(super::map_post_order_orchestration_error)?;',
+  'unchanged apply orchestration mapping',
+);
+requireText(
+  applyRoute,
+  '.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)',
+  'apply service contract',
+);
+
+const ownerMapperUses =
+  changes.match(
+    /map_admin_order_change_error\(\s+AdminOrderChangeErrorContext::new\(/g,
+  ) ?? [];
+if (ownerMapperUses.length !== 4) {
+  failures.push(`expected four context-aware order-change owner mapper callsites, found ${ownerMapperUses.length}`);
+}
+const orchestrationMapperUses =
+  changes.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
+if (orchestrationMapperUses.length !== 1) {
+  failures.push(`expected one unchanged order-change orchestration mapper callsite, found ${orchestrationMapperUses.length}`);
+}
+
+for (const [value, label] of [
+  ['Validation(String)', 'owner validation variant'],
+  ['OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  ['OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  ['OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  ['Database(#[from] DbErr)', 'owner database variant'],
+  ['Core(#[from] rustok_core::Error)', 'owner core variant'],
+]) requireText(orderErrors, value, label);
+
+for (const value of [
+  '.map_err(super::map_order_error)?;',
+  'format!("Order request is invalid:',
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(changes, value, 'unsafe admin order-change owner public conversion');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-change owner error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order-change owner errors retain route context and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace the four shared `OrderError` mapper callsites in admin order-change create, list, detail, and cancel routes with one local context-aware typed mapper;
- preserve existing validation, not-found, state-conflict, storage, and fail-closed HTTP status/code/message policies;
- retain owner, tenant, route operation, truthful optional order and order-change identities, stable public code, status, HTTP boundary, and the original typed cause in one structured error event;
- adopt typed order and order-change identities from not-found errors;
- keep the apply-order-change orchestration route, permission gates, service calls, pagination, filters, and success responses unchanged;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/admin/changes.rs`
- `scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files;
- source was re-read to confirm four local owner mapper callsites and one unchanged apply orchestration mapper callsite;
- all current `OrderError` variants are handled exhaustively with static public envelopes;
- permissions, pagination, list filters, service calls, apply orchestration behavior, and success contracts remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
cargo check -p rustok-commerce --lib
```