### PR TITLE
feat(forum): filter topic subscription audiences by recipient

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-recipient-context.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-context.json
@@ -1,22 +1,24 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "task": "FORUM-20L",
   "upstream_task": "FORUM-20K",
   "downstream_task": "FORUM-20M",
-  "consumer_task": "FORUM-20N",
-  "downstream_consumer_task": "FORUM-20O",
-  "scope": "Forum-owned exact recipient principal context capability for deferred notification target-open and user-mention authorization",
+  "target_open_consumer_task": "FORUM-20N",
+  "mention_consumer_task": "FORUM-20O",
+  "topic_subscription_consumer_task": "FORUM-20P",
+  "scope": "Forum-owned exact recipient principal context capability for notification target-open, user mentions and bounded topic subscription audiences",
   "owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
-  "consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
-  "downstream_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "target_open_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
+  "mention_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "topic_subscription_consumer_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-context.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -25,7 +27,8 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -60,10 +63,10 @@
     "recipient_target_open_authorization": true,
     "recipient_mention_description_authorization": true,
     "recipient_mention_audience_authorization": true,
+    "recipient_topic_subscription_audience_authorization": true,
     "shared_consumer_resolution_helper": true
   },
   "not_delivered": [
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
@@ -77,10 +80,12 @@
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json
@@ -1,22 +1,24 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "task": "FORUM-20M",
   "upstream_task": "FORUM-20L",
   "downstream_task": "FORUM-20N",
-  "consumer_task": "FORUM-20O",
-  "scope": "Server-owned exact notification recipient principal adapter, host runtime publication and notification target-open plus user-mention consumption",
+  "mention_consumer_task": "FORUM-20O",
+  "topic_subscription_consumer_task": "FORUM-20P",
+  "scope": "Server-owned exact notification recipient principal adapter, host runtime publication and target-open, mention plus topic subscription consumption",
   "adapter_file": "apps/server/src/services/forum_notification_recipient_context.rs",
   "services_file": "apps/server/src/services/mod.rs",
   "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-context.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
-  "consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "mention_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "topic_subscription_consumer_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -25,7 +27,8 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -39,7 +42,7 @@
     "permission_bound": 512,
     "dependency_failure": "typed retryable unavailable PortError without internal database details",
     "storage_access": "server identity and RBAC owners only; no Forum profile channel group or audience relation tables",
-    "consumer": "Forum notification source factory reads the exact shared port before recipient-specific target-open, mention description and mention audience authorization"
+    "consumer": "Forum notification source factory reads the exact shared port before recipient-specific target-open, mention stages and bounded topic subscription filtering"
   },
   "composition": {
     "server_adapter": true,
@@ -57,10 +60,10 @@
     "notification_source_factory_consumption": true,
     "recipient_target_open_authorization": true,
     "recipient_mention_description_authorization": true,
-    "recipient_mention_audience_authorization": true
+    "recipient_mention_audience_authorization": true,
+    "recipient_topic_subscription_audience_authorization": true
   },
   "not_delivered": [
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "trust channel and group facts host adapters",
@@ -73,10 +76,12 @@
       "cargo test -p rustok-server forum_notification_recipient_context -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json
@@ -1,19 +1,22 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task": "FORUM-20O",
   "upstream_task": "FORUM-20N",
-  "scope": "Exact recipient-specific Forum user-mention description and audience composition for topic and reply targets",
+  "downstream_task": "FORUM-20P",
+  "scope": "Exact recipient-specific Forum user-mention description and audience composition for topic and reply targets, followed by bounded topic-created subscription filtering",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
   "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "downstream_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
+  "downstream_test_file": "crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -22,7 +25,8 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -37,7 +41,7 @@
     "local_selectors": "role and explicit-user allow or deny constraints resolve without host facts adapters",
     "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
     "reply_target": "reply must be active and approved and its topic must be visible to the same mentioned recipient",
-    "topic_created_boundary": "topic-created description and subscription audience remain public-only in this slice",
+    "topic_created_boundary": "topic-created description remains public-only; FORUM-20P consumes the same recipient capability for bounded subscription audience filtering",
     "stale_descriptor": "audience resolution rechecks the current target policy for the exact mentioned recipient"
   },
   "composition": {
@@ -54,11 +58,12 @@
     "unavailable_recipient_fail_closed": true,
     "retryability_preserved": true,
     "stale_descriptor_recheck": true,
-    "topic_created_paths_unchanged": true,
-    "sqlite_contract_test": true
+    "topic_created_description_unchanged": true,
+    "topic_created_subscription_audience_downstream": true,
+    "sqlite_contract_test": true,
+    "downstream_sqlite_contract_test": true
   },
   "not_delivered": [
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters",
@@ -71,8 +76,10 @@
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
       "cargo xtask module validate forum"
     ],

--- a/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
+++ b/crates/rustok-forum/contracts/forum-notification-recipient-target-open.json
@@ -1,22 +1,25 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "task": "FORUM-20N",
   "upstream_task": "FORUM-20M",
   "downstream_task": "FORUM-20O",
-  "scope": "Forum notification source factory consumption of exact recipient context for target-open and user-mention notification authorization",
+  "downstream_chain_task": "FORUM-20P",
+  "scope": "Forum notification source factory consumption of exact recipient context for target-open, user mentions and bounded topic subscription audiences",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json",
   "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
   "downstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "downstream_chain_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
   "downstream_test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
+  "downstream_chain_test_file": "crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-recipient-target-open.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -25,21 +28,22 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
     "factory": "consume optional SharedForumNotificationRecipientContextPort and SharedForumAudienceFactsPort from HostRuntimeContext",
-    "capability_absence": "preserve the existing public-only fail-closed target-open and mention paths",
+    "capability_absence": "preserve the existing public-only fail-closed target-open, mention and topic subscription audience paths",
     "recipient_lookup": "bounded service PortContext for the exact tenant and notification recipient",
-    "recipient_unavailable": "non-retryable recipient capability failure resolves to no descriptor, an empty audience or an unavailable target without an existence oracle",
+    "recipient_unavailable": "non-retryable recipient capability failure resolves to no descriptor, an empty audience, a skipped subscription or an unavailable target without an existence oracle",
     "authenticated_visibility": "compose exact base topic visibility and normalized inherited category/topic audience layers for the validated recipient",
     "local_selectors": "role and explicit-user allow or deny constraints resolve without host facts adapters",
     "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
     "reply_target": "reply must be active and approved and its owner topic must be visible to the same recipient",
-    "topic_created_surfaces": "topic-created description and subscription audience remain public-only",
+    "topic_created_surfaces": "topic-created description remains public-only while FORUM-20P filters bounded subscription pages for exact recipients",
     "mention_surfaces": "FORUM-20O reuses exact recipient resolution for topic and reply mention description and audience",
     "channel_context": "notification operations have no route channel slug and therefore retain the existing channel-deny semantics"
   },
@@ -55,15 +59,15 @@
     "inactive_or_missing_recipient_fail_closed": true,
     "retryability_preserved": true,
     "topic_created_public_description_unchanged": true,
-    "topic_created_public_audience_unchanged": true,
+    "recipient_specific_topic_subscription_audience": true,
     "recipient_specific_mention_description": true,
     "recipient_specific_mention_audience": true,
     "shared_recipient_resolution_helper": true,
     "sqlite_contract_test": true,
-    "downstream_sqlite_contract_test": true
+    "downstream_sqlite_contract_test": true,
+    "downstream_chain_sqlite_contract_test": true
   },
   "not_delivered": [
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters",
@@ -76,10 +80,12 @@
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-recipient-context.mjs",
       "node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json
+++ b/crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20P",
+  "upstream_task": "FORUM-20O",
+  "fanout_prerequisite_task": "NOTIFY-03I",
+  "scope": "Bounded recipient-specific Forum topic-created subscription audience filtering with sparse keyset cursor progress",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
+  "recipient_context_owner_file": "crates/rustok-forum/src/notification_recipient.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
+  "fanout_contract": "crates/rustok-notifications/contracts/notifications-source-fanout.json",
+  "test_file": "crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs",
+  "source_verifier": "scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20P",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O",
+      "FORUM-20P"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "descriptor_boundary": "topic-created descriptor materialization remains public-only in this slice",
+    "raw_candidate_query": "tenant and category scoped notify-new-topics subscriptions excluding muted rows and the event actor, ordered by user_id",
+    "scan_bound": "read at most requested limit plus one lookahead row and evaluate only the first requested-limit raw subscriptions",
+    "cursor": "when more raw subscriptions exist, advance by the last scanned raw user_id rather than the last allowed recipient",
+    "sparse_page": "an all-denied or unavailable raw page returns zero recipients with an advancing cursor under NOTIFY-03I",
+    "recipient_resolution": "resolve one exact recipient context for each scanned subscription when the host capability is published",
+    "capability_absence": "preserve the previous public-only subscription audience fallback when recipient context is absent",
+    "recipient_unavailable": "non-retryable recipient capability failure skips that subscription without an existence oracle",
+    "authenticated_visibility": "re-evaluate exact base and normalized category/topic audience visibility for every resolved recipient",
+    "local_selectors": "role and explicit-user allow or deny constraints resolve without host facts adapters",
+    "fact_dependent_selectors": "missing or failing host facts capability preserves typed retryability",
+    "failure_atomicity": "a retryable recipient or facts failure returns a provider error before the page cursor is persisted"
+  },
+  "composition": {
+    "notification_sparse_page_prerequisite": true,
+    "bounded_raw_keyset_scan": true,
+    "limit_plus_one_lookahead": true,
+    "last_scanned_raw_cursor": true,
+    "actor_subscription_excluded": true,
+    "exact_recipient_context_per_scanned_subscription": true,
+    "authenticated_topic_viewer": true,
+    "recipient_specific_topic_visibility": true,
+    "sparse_all_denied_page": true,
+    "mixed_allowed_denied_page": true,
+    "terminal_allowed_page": true,
+    "public_only_fallback": true,
+    "unavailable_recipient_skipped": true,
+    "retryability_preserved": true,
+    "initial_descriptor_behavior_unchanged": true,
+    "sqlite_contract_test": true
+  },
+  "not_delivered": [
+    "initially non-public topic-created descriptor materialization",
+    "profile privacy and blocking policy",
+    "host trust channel and group facts adapters",
+    "final notification creation and delivery authorization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-notifications --test fanout_sparse_page_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
+      "node scripts/verify/verify-notifications-source-fanout.mjs",
+      "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json
+++ b/crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json
@@ -32,6 +32,7 @@
   },
   "policy": {
     "descriptor_boundary": "topic-created descriptor materialization remains public-only in this slice",
+    "source_recheck": "when recipient context is published, load the current active topic record without a public visibility short-circuit and delegate authorization to each exact recipient; preserve the public source recheck when the capability is absent",
     "raw_candidate_query": "tenant and category scoped notify-new-topics subscriptions excluding muted rows and the event actor, ordered by user_id",
     "scan_bound": "read at most requested limit plus one lookahead row and evaluate only the first requested-limit raw subscriptions",
     "cursor": "when more raw subscriptions exist, advance by the last scanned raw user_id rather than the last allowed recipient",
@@ -46,6 +47,8 @@
   },
   "composition": {
     "notification_sparse_page_prerequisite": true,
+    "active_topic_source_recheck": true,
+    "stale_public_descriptor_to_non_public_recipient_filtering": true,
     "bounded_raw_keyset_scan": true,
     "limit_plus_one_lookahead": true,
     "last_scanned_raw_cursor": true,

--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -1,24 +1,26 @@
 {
-  "schema_version": 6,
+  "schema_version": 7,
   "task": "FORUM-20K",
   "supersedes_task": "FORUM-20I",
-  "downstream_task": "FORUM-20O",
-  "scope": "Forum notification source composition through exact richer public, recipient target-open and recipient mention visibility owners",
+  "downstream_task": "FORUM-20P",
+  "scope": "Forum notification source composition through exact richer public, recipient target-open, recipient mention and bounded topic subscription visibility owners",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "visibility_owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner_file": "crates/rustok-forum/src/services/topic_visibility.rs",
   "visibility_contract": "crates/rustok-forum/contracts/forum-topic-audience-visibility.json",
   "recipient_target_open_contract": "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json",
   "recipient_mention_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "recipient_topic_subscription_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "baseline_test_file": "crates/rustok-forum/tests/notification_source_sqlite.rs",
   "test_file": "crates/rustok-forum/tests/notification_richer_visibility_sqlite.rs",
   "recipient_test_file": "crates/rustok-forum/tests/notification_recipient_target_open_sqlite.rs",
   "recipient_mention_test_file": "crates/rustok-forum/tests/notification_recipient_mention_audience_sqlite.rs",
+  "recipient_topic_subscription_test_file": "crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-notification-visibility-composition.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -27,19 +29,22 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
   },
   "policy": {
-    "topic_created_description_and_audience_viewer": "public unauthenticated without route-channel context",
+    "topic_created_description_viewer": "public unauthenticated without route-channel context",
+    "topic_created_subscription_viewer": "exact subscription recipient when host recipient context is published; public-only fallback when absent",
+    "topic_created_subscription_cursor": "bounded raw keyset page advances by the last scanned subscription rather than the last allowed recipient",
     "mention_description_and_audience_viewer": "exact mentioned recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "target_open_viewer": "exact validated recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
     "evaluation_order": "exact open route-channel and category floor owner then normalized root-to-category audience layers then optional topic layer",
     "public_facts_provider": "never consulted because public evaluation does not call authenticated owner facts capabilities",
     "authenticated_facts_provider": "optional host capability; local role and explicit user selectors resolve without it while fact-dependent selectors preserve capability retryability",
-    "non_public_richer_layers": "exact user mentions and target-open authorization re-evaluate them for one recipient; topic-created descriptor and subscription pagination remain public-only",
+    "non_public_richer_layers": "mentions, target-open and bounded topic subscription pages re-evaluate them for exact recipients; initially non-public topic-created descriptor materialization remains deferred",
     "missing_foreign_closed_deleted_or_denied": "absent without an existence oracle",
     "reply_state": "pending deferred; approved eligible; all other states unavailable",
     "owner_failures": "preserve Forum retryability classification"
@@ -57,13 +62,14 @@
     "duplicate_notification_visibility_predicate_removed": true,
     "recipient_context_factory_consumption": true,
     "recipient_specific_target_open": true,
-    "topic_created_public_description_and_audience": true,
+    "topic_created_public_description": true,
+    "recipient_specific_topic_subscription_audience": true,
+    "topic_subscription_sparse_cursor": true,
     "recipient_specific_mention_description": true,
     "recipient_specific_mention_audience": true,
     "shared_recipient_resolution_helper": true
   },
   "not_delivered": [
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "profile privacy and blocking policy",
     "host trust channel and group facts adapters for authenticated consumers",
@@ -73,13 +79,16 @@
   ],
   "verification": {
     "commands": [
+      "cargo test -p rustok-notifications --test fanout_sparse_page_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
       "node scripts/verify/verify-forum-notification-recipient-target-open.mjs",
       "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
+++ b/crates/rustok-forum/contracts/forum-notification-visibility-composition.json
@@ -37,6 +37,7 @@
   },
   "policy": {
     "topic_created_description_viewer": "public unauthenticated without route-channel context",
+    "topic_created_subscription_source_recheck": "active topic record when exact recipient context is published, public visibility when it is absent",
     "topic_created_subscription_viewer": "exact subscription recipient when host recipient context is published; public-only fallback when absent",
     "topic_created_subscription_cursor": "bounded raw keyset page advances by the last scanned subscription rather than the last allowed recipient",
     "mention_description_and_audience_viewer": "exact mentioned recipient when the host recipient-context capability is published; public-only fail-closed fallback when it is absent",
@@ -63,6 +64,7 @@
     "recipient_context_factory_consumption": true,
     "recipient_specific_target_open": true,
     "topic_created_public_description": true,
+    "topic_subscription_active_source_recheck": true,
     "recipient_specific_topic_subscription_audience": true,
     "topic_subscription_sparse_cursor": true,
     "recipient_specific_mention_description": true,

--- a/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-visibility.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "task": "FORUM-20J",
   "downstream_notification_task": "FORUM-20K",
-  "notification_consumer_task": "FORUM-20O",
+  "notification_consumer_task": "FORUM-20P",
   "scope": "Exact topic visibility composition through current open, channel, category-floor and normalized category/topic audience layers",
   "owner_file": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
   "base_visibility_owner": "crates/rustok-forum/src/services/topic_visibility.rs",
@@ -13,13 +13,14 @@
   "crate_file": "crates/rustok-forum/src/lib.rs",
   "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
   "notification_visibility_contract": "crates/rustok-forum/contracts/forum-notification-visibility-composition.json",
-  "notification_consumer_contract": "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json",
+  "notification_consumer_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
   "test_file": "crates/rustok-forum/tests/topic_audience_visibility_sqlite.rs",
+  "notification_consumer_test_file": "crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs",
   "source_verifier": "scripts/verify/verify-forum-topic-audience-visibility.mjs",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_plan_sync": {
     "status": "pending",
-    "required_ledger_through": "FORUM-20O",
+    "required_ledger_through": "FORUM-20P",
     "required_delivered_sections": [
       "FORUM-20H",
       "FORUM-20I",
@@ -28,7 +29,8 @@
       "FORUM-20L",
       "FORUM-20M",
       "FORUM-20N",
-      "FORUM-20O"
+      "FORUM-20O",
+      "FORUM-20P"
     ],
     "current_plan_through": "FORUM-20G",
     "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
@@ -58,6 +60,7 @@
     "recipient_target_open_notification": true,
     "recipient_mention_description_notification": true,
     "recipient_mention_audience_notification": true,
+    "recipient_topic_subscription_audience_notification": true,
     "topic_and_reply_pages": false,
     "category_and_reply_exact_reads": false,
     "write_audiences": false,
@@ -69,7 +72,6 @@
     "create reply and moderate audience write policy",
     "host trust channel and group provider adapters",
     "visibility-scoped category and all-read mutations",
-    "recipient-specific topic-created subscription filtering before pagination",
     "initially non-public topic-created descriptor materialization",
     "search index SEO and deep-link migration to the richer exact owner",
     "PostgreSQL concurrency and cross-consumer runtime evidence"
@@ -80,9 +82,10 @@
       "cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-topic-audience-visibility.mjs",
       "node scripts/verify/verify-forum-notification-visibility-composition.mjs",
-      "node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs",
+      "node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs",
       "cargo xtask module validate forum"
     ],
     "execution_status": "not_run_by_implementation_agent"

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -39,6 +39,7 @@ const FORUM_TOPIC_TARGET: &str = "forum.topic";
 const FORUM_REPLY_TARGET: &str = "forum.reply";
 const MENTION_DESCRIBE_ACTOR: &str = "forum-notification-mention-describe";
 const MENTION_AUDIENCE_ACTOR: &str = "forum-notification-mention-audience";
+const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = "forum-notification-topic-subscription-audience";
 const TARGET_OPEN_ACTOR: &str = "forum-notification-target-open";
 const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2);
 
@@ -304,6 +305,35 @@ impl ForumNotificationSourceProvider {
             &viewer,
         )
         .await
+    }
+
+    async fn topic_subscription_recipient_visible(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        recipient_id: Uuid,
+    ) -> NotificationProviderResult<bool> {
+        if self.recipient_context_port.is_none() {
+            return Ok(true);
+        }
+        let Some(viewer) = self
+            .resolve_recipient_viewer(
+                recipient_operation_context(
+                    tenant_id,
+                    recipient_id,
+                    topic_id,
+                    TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR,
+                ),
+                tenant_id,
+                recipient_id,
+            )
+            .await?
+        else {
+            return Ok(false);
+        };
+        self.load_topic_for_viewer(tenant_id, topic_id, &viewer)
+            .await
+            .map(|topic| topic.is_some())
     }
 
     async fn resolve_recipient_viewer(
@@ -607,12 +637,21 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
                 } else {
                     None
                 };
-                let recipients = subscriptions
-                    .into_iter()
-                    .map(|subscription| NotificationAudienceCandidate {
-                        recipient_id: subscription.user_id,
-                    })
-                    .collect();
+                let mut recipients = Vec::with_capacity(subscriptions.len());
+                for subscription in subscriptions {
+                    if self
+                        .topic_subscription_recipient_visible(
+                            event.tenant_id,
+                            topic.id,
+                            subscription.user_id,
+                        )
+                        .await?
+                    {
+                        recipients.push(NotificationAudienceCandidate {
+                            recipient_id: subscription.user_id,
+                        });
+                    }
+                }
                 NotificationAudiencePage::try_new(recipients, next_cursor)
                     .map_err(|_| NotificationProviderError::Internal { retryable: false })
             }

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -207,11 +207,7 @@ impl ForumNotificationSourceProvider {
         tenant_id: Uuid,
         topic_id: Uuid,
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
-        if self.recipient_context_port.is_none() {
-            self.load_public_topic(tenant_id, topic_id).await
-        } else {
-            self.load_active_topic(tenant_id, topic_id).await
-        }
+        self.load_active_topic(tenant_id, topic_id).await
     }
 
     async fn load_target_for_viewer(
@@ -606,10 +602,17 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
         match event.event_type.as_str() {
             TOPIC_CREATED_TYPE => {
                 self.validate_topic_descriptor(&event, &request.descriptor)?;
-                let Some(topic) = self
-                    .load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)
+                let topic = if self.recipient_context_port.is_none() {
+                    self.load_public_topic(event.tenant_id, event.aggregate_id)
+                        .await?
+                } else {
+                    self.load_topic_for_subscription_audience(
+                        event.tenant_id,
+                        event.aggregate_id,
+                    )
                     .await?
-                else {
+                };
+                let Some(topic) = topic else {
                     return Ok(NotificationAudiencePage::empty());
                 };
 

--- a/crates/rustok-forum/src/notification_source.rs
+++ b/crates/rustok-forum/src/notification_source.rs
@@ -154,20 +154,11 @@ impl ForumNotificationSourceProvider {
         Ok(persisted)
     }
 
-    async fn load_topic_for_viewer(
+    async fn load_active_topic(
         &self,
         tenant_id: Uuid,
         topic_id: Uuid,
-        viewer: &ForumTopicAudienceViewer,
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
-        if !ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())
-            .is_topic_visible(tenant_id, topic_id, None, viewer)
-            .await
-            .map_err(forum_owner_error)?
-        {
-            return Ok(None);
-        }
-
         let topic = forum_topic::Entity::find()
             .filter(forum_topic::Column::TenantId.eq(tenant_id))
             .filter(forum_topic::Column::Id.eq(topic_id))
@@ -186,6 +177,22 @@ impl ForumNotificationSourceProvider {
         Ok(Some(topic))
     }
 
+    async fn load_topic_for_viewer(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
+    ) -> NotificationProviderResult<Option<forum_topic::Model>> {
+        if !ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())
+            .is_topic_visible(tenant_id, topic_id, None, viewer)
+            .await
+            .map_err(forum_owner_error)?
+        {
+            return Ok(None);
+        }
+        self.load_active_topic(tenant_id, topic_id).await
+    }
+
     async fn load_public_topic(
         &self,
         tenant_id: Uuid,
@@ -193,6 +200,18 @@ impl ForumNotificationSourceProvider {
     ) -> NotificationProviderResult<Option<forum_topic::Model>> {
         self.load_topic_for_viewer(tenant_id, topic_id, &ForumTopicAudienceViewer::public())
             .await
+    }
+
+    async fn load_topic_for_subscription_audience(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+    ) -> NotificationProviderResult<Option<forum_topic::Model>> {
+        if self.recipient_context_port.is_none() {
+            self.load_public_topic(tenant_id, topic_id).await
+        } else {
+            self.load_active_topic(tenant_id, topic_id).await
+        }
     }
 
     async fn load_target_for_viewer(
@@ -588,7 +607,7 @@ impl NotificationSourceProvider for ForumNotificationSourceProvider {
             TOPIC_CREATED_TYPE => {
                 self.validate_topic_descriptor(&event, &request.descriptor)?;
                 let Some(topic) = self
-                    .load_public_topic(event.tenant_id, event.aggregate_id)
+                    .load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)
                     .await?
                 else {
                     return Ok(NotificationAudiencePage::empty());

--- a/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
@@ -193,13 +193,14 @@ async fn topic_subscription_audience_filters_exact_recipients_before_cursor_prog
             admin,
             SetForumTopicAudiencePolicyInput {
                 constraints: ForumAudienceConstraints {
+                    roles_any: vec![UserRole::Customer],
                     deny_user_ids: vec![denied_first, denied_fourth],
                     ..ForumAudienceConstraints::default()
                 },
             },
         )
         .await
-        .expect("topic audience should deny exact recipients while remaining public");
+        .expect("topic audience should become non-public and deny exact recipients");
 
     let first_page = provider
         .resolve_audience(ResolveNotificationAudienceRequest {

--- a/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
@@ -80,6 +80,8 @@ async fn topic_subscription_audience_filters_exact_recipients_before_cursor_prog
     let allowed_third = Uuid::from_u128(3);
     let denied_fourth = Uuid::from_u128(4);
     let allowed_fifth = Uuid::from_u128(5);
+    let unavailable_cursor = unavailable_second.to_string();
+    let denied_cursor = denied_fourth.to_string();
     let admin = SecurityContext::new(UserRole::Admin, Some(author_id));
 
     let category = CategoryService::new(db.clone())
@@ -212,7 +214,7 @@ async fn topic_subscription_audience_filters_exact_recipients_before_cursor_prog
     assert!(!first_page.is_complete());
     assert_eq!(
         first_page.next_cursor().map(NotificationAudienceCursor::as_str),
-        Some(unavailable_second.to_string().as_str())
+        Some(unavailable_cursor.as_str())
     );
     assert_eq!(recorded_calls(&calls), vec![denied_first, unavailable_second]);
 
@@ -230,7 +232,7 @@ async fn topic_subscription_audience_filters_exact_recipients_before_cursor_prog
     assert!(!second_page.is_complete());
     assert_eq!(
         second_page.next_cursor().map(NotificationAudienceCursor::as_str),
-        Some(denied_fourth.to_string().as_str())
+        Some(denied_cursor.as_str())
     );
     assert_eq!(
         recorded_calls(&calls),

--- a/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
+++ b/crates/rustok-forum/tests/notification_recipient_topic_subscription_audience_sqlite.rs
@@ -1,0 +1,318 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use rustok_api::{Permission, PortActor, PortCallPolicy, PortContext, PortError};
+use rustok_core::{MemoryTransport, MigrationSource, ModuleRegistry, SecurityContext, UserRole};
+use rustok_forum::entities::forum_domain_event;
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateTopicInput, ForumAudienceConstraints, ForumModule,
+    ForumNotificationRecipientContextPort, ForumNotificationRecipientContextRequest,
+    ForumTopicAudiencePolicyService, SetForumTopicAudiencePolicyInput,
+    SharedForumNotificationRecipientContextPort, SubscriptionService, TopicService,
+};
+use rustok_notifications::NotificationsModule;
+use rustok_notifications_api::{
+    DescribeNotificationRequest, NotificationAudienceCursor, NotificationSourceEventRef,
+    ResolveNotificationAudienceRequest, materialize_notification_source_registry,
+};
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct RecordingRecipientContextPort {
+    roles: BTreeMap<Uuid, &'static str>,
+    calls: Arc<Mutex<Vec<Uuid>>>,
+}
+
+#[async_trait]
+impl ForumNotificationRecipientContextPort for RecordingRecipientContextPort {
+    async fn resolve_forum_notification_recipient_context(
+        &self,
+        context: PortContext,
+        request: ForumNotificationRecipientContextRequest,
+    ) -> Result<PortContext, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        if context.tenant_id != request.tenant_id.to_string() {
+            return Err(PortError::validation(
+                "forum.notification_recipient_context.test_tenant_mismatch",
+                "Forum notification recipient tenant does not match",
+            ));
+        }
+        self.calls
+            .lock()
+            .expect("recipient call recorder should stay available")
+            .push(request.recipient_id);
+        let Some(role) = self.roles.get(&request.recipient_id) else {
+            return Err(PortError::not_found(
+                "forum.notification_recipient_context.test_recipient_unavailable",
+                "Forum notification recipient is unavailable",
+            ));
+        };
+
+        let mut recipient = PortContext::new(
+            request.tenant_id.to_string(),
+            PortActor::user(request.recipient_id.to_string()),
+            context.locale.clone(),
+            context.correlation_id.clone(),
+        )
+        .with_role(*role)
+        .with_claim(Permission::FORUM_TOPICS_READ.to_string());
+        recipient.causation_id = context.causation_id;
+        recipient.traceparent = context.traceparent;
+        recipient.deadline_ms = context.deadline_ms;
+        Ok(recipient)
+    }
+}
+
+#[tokio::test]
+async fn topic_subscription_audience_filters_exact_recipients_before_cursor_progress() {
+    let (db, event_bus) = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let author_id = Uuid::from_u128(100);
+    let denied_first = Uuid::from_u128(1);
+    let unavailable_second = Uuid::from_u128(2);
+    let allowed_third = Uuid::from_u128(3);
+    let denied_fourth = Uuid::from_u128(4);
+    let allowed_fifth = Uuid::from_u128(5);
+    let admin = SecurityContext::new(UserRole::Admin, Some(author_id));
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".into(),
+                name: "Recipient-filtered subscriptions".into(),
+                slug: "recipient-filtered-subscriptions".into(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await
+        .expect("category should be created");
+
+    let subscriptions = SubscriptionService::new(db.clone());
+    for recipient_id in [
+        denied_first,
+        unavailable_second,
+        allowed_third,
+        denied_fourth,
+        allowed_fifth,
+    ] {
+        subscriptions
+            .set_category_subscription(
+                tenant_id,
+                category.id,
+                SecurityContext::new(UserRole::Customer, Some(recipient_id)),
+            )
+            .await
+            .expect("category subscription should persist");
+    }
+
+    let topic = TopicService::new(db.clone(), event_bus)
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateTopicInput {
+                locale: "en".into(),
+                category_id: category.id,
+                title: "Bounded recipient filtering".into(),
+                slug: Some("bounded-recipient-filtering".into()),
+                body: "Topic-created fanout must scan raw subscriptions without skipping denied recipients."
+                    .into(),
+                body_format: "markdown".into(),
+                content_json: None,
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("topic should be created");
+    let event = forum_domain_event::Entity::find()
+        .filter(forum_domain_event::Column::TenantId.eq(tenant_id))
+        .filter(forum_domain_event::Column::AggregateType.eq("topic"))
+        .filter(forum_domain_event::Column::AggregateId.eq(topic.id))
+        .filter(forum_domain_event::Column::EventType.eq("forum.topic.created"))
+        .order_by_desc(forum_domain_event::Column::SequenceNo)
+        .one(&db)
+        .await
+        .expect("topic event query should succeed")
+        .expect("topic-created event should exist");
+    let event_ref = source_event_ref(&event);
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let recipient_port: SharedForumNotificationRecipientContextPort =
+        Arc::new(RecordingRecipientContextPort {
+            roles: BTreeMap::from([
+                (denied_first, "customer"),
+                (allowed_third, "customer"),
+                (denied_fourth, "customer"),
+                (allowed_fifth, "customer"),
+            ]),
+            calls: calls.clone(),
+        });
+    let registry = ModuleRegistry::new()
+        .register(NotificationsModule)
+        .register(ForumModule);
+    let mut extensions = registry
+        .build_runtime_extensions()
+        .expect("Notifications and Forum runtime extensions should initialize");
+    extensions.insert(recipient_port);
+    let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db.clone()));
+    let providers = materialize_notification_source_registry(&mut extensions, &host)
+        .expect("Forum source factory should consume the recipient capability");
+    let provider = providers
+        .get_by_str("forum")
+        .expect("Forum source should be discoverable");
+
+    let descriptor = provider
+        .describe_event(DescribeNotificationRequest {
+            event: event_ref.clone(),
+        })
+        .await
+        .expect("public topic description should complete")
+        .expect("public topic should materialize a descriptor");
+
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            tenant_id,
+            topic.id,
+            admin,
+            SetForumTopicAudiencePolicyInput {
+                constraints: ForumAudienceConstraints {
+                    deny_user_ids: vec![denied_first, denied_fourth],
+                    ..ForumAudienceConstraints::default()
+                },
+            },
+        )
+        .await
+        .expect("topic audience should deny exact recipients while remaining public");
+
+    let first_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: event_ref.clone(),
+            descriptor: descriptor.clone(),
+            cursor: None,
+            limit: 2,
+        })
+        .await
+        .expect("first exact subscription page should resolve");
+    assert!(first_page.recipients().is_empty());
+    assert!(!first_page.is_complete());
+    assert_eq!(
+        first_page.next_cursor().map(NotificationAudienceCursor::as_str),
+        Some(unavailable_second.to_string().as_str())
+    );
+    assert_eq!(recorded_calls(&calls), vec![denied_first, unavailable_second]);
+
+    let second_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: event_ref.clone(),
+            descriptor: descriptor.clone(),
+            cursor: first_page.next_cursor().cloned(),
+            limit: 2,
+        })
+        .await
+        .expect("second exact subscription page should resolve");
+    assert_eq!(second_page.recipients().len(), 1);
+    assert_eq!(second_page.recipients()[0].recipient_id, allowed_third);
+    assert!(!second_page.is_complete());
+    assert_eq!(
+        second_page.next_cursor().map(NotificationAudienceCursor::as_str),
+        Some(denied_fourth.to_string().as_str())
+    );
+    assert_eq!(
+        recorded_calls(&calls),
+        vec![denied_first, unavailable_second, allowed_third, denied_fourth]
+    );
+
+    let third_page = provider
+        .resolve_audience(ResolveNotificationAudienceRequest {
+            event: event_ref,
+            descriptor,
+            cursor: second_page.next_cursor().cloned(),
+            limit: 2,
+        })
+        .await
+        .expect("terminal exact subscription page should resolve");
+    assert_eq!(third_page.recipients().len(), 1);
+    assert_eq!(third_page.recipients()[0].recipient_id, allowed_fifth);
+    assert!(third_page.is_complete());
+    assert_eq!(
+        recorded_calls(&calls),
+        vec![
+            denied_first,
+            unavailable_second,
+            allowed_third,
+            denied_fourth,
+            allowed_fifth,
+        ]
+    );
+
+    let recipients = second_page
+        .recipients()
+        .iter()
+        .chain(third_page.recipients())
+        .map(|candidate| candidate.recipient_id)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(recipients, BTreeSet::from([allowed_third, allowed_fifth]));
+}
+
+fn recorded_calls(calls: &Arc<Mutex<Vec<Uuid>>>) -> Vec<Uuid> {
+    calls
+        .lock()
+        .expect("recipient call recorder should stay available")
+        .clone()
+}
+
+fn source_event_ref(event: &forum_domain_event::Model) -> NotificationSourceEventRef {
+    NotificationSourceEventRef::new(
+        event.tenant_id,
+        event.event_id,
+        "forum".try_into().expect("source slug"),
+        event.event_type.clone().try_into().expect("event type"),
+        u64::try_from(event.sequence_no).expect("event sequence should be positive"),
+    )
+    .expect("source event reference")
+}
+
+async fn setup() -> (DatabaseConnection, TransactionalEventBus) {
+    let url = format!(
+        "sqlite:file:forum_notification_topic_subscription_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("notification topic subscription database should connect");
+    let manager = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("forum migration should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(MemoryTransport::new()));
+    (db, event_bus)
+}

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -18,24 +18,30 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
+
 function requireText(source, marker, message) {
   if (!source.includes(marker)) failures.push(message);
 }
+
 function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-context.json") || "{}");
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-context.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const owner = read(contract.owner_file ?? "");
 const crate = read(contract.crate_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const targetOpen = JSON.parse(read(contract.target_open_consumer_contract ?? "") || "{}");
-const mention = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
-const subscriptions = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
+const targetOpenConsumer = JSON.parse(read(contract.target_open_consumer_contract ?? "") || "{}");
+const mentionConsumer = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
+const subscriptionConsumer = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 5) failures.push("forum notification recipient context contract must use schema_version=5");
+if (contract.schema_version !== 5) {
+  failures.push("forum notification recipient context contract must use schema_version=5");
+}
 if (
   contract.task !== "FORUM-20L" ||
   contract.upstream_task !== "FORUM-20K" ||
@@ -43,63 +49,228 @@ if (
   contract.target_open_consumer_task !== "FORUM-20N" ||
   contract.mention_consumer_task !== "FORUM-20O" ||
   contract.topic_subscription_consumer_task !== "FORUM-20P"
-) failures.push("forum recipient context contract must connect FORUM-20K/L/M/N/O/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient context contract must not claim unexecuted evidence");
+) {
+  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M/N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient context source publication must not claim unexecuted evidence");
+}
 
-for (const field of [
-  "bounded_request", "caller_read_semantics", "caller_tenant_validation", "system_or_service_caller",
-  "recipient_read_semantics", "recipient_tenant_validation", "exact_user_actor_validation",
-  "role_and_permission_snapshot_validation", "authenticated_topic_viewer_conversion",
-  "typed_missing_capability", "retryable_failure_mapping", "inline_contract_tests",
-  "host_adapter_implementation", "host_runtime_publication", "notification_source_factory_consumption",
-  "recipient_target_open_authorization", "recipient_mention_description_authorization",
-  "recipient_mention_audience_authorization", "recipient_topic_subscription_audience_authorization",
+for (const delivered of [
+  "bounded_request",
+  "caller_read_semantics",
+  "caller_tenant_validation",
+  "system_or_service_caller",
+  "recipient_read_semantics",
+  "recipient_tenant_validation",
+  "exact_user_actor_validation",
+  "role_and_permission_snapshot_validation",
+  "authenticated_topic_viewer_conversion",
+  "typed_missing_capability",
+  "retryable_failure_mapping",
+  "inline_contract_tests",
+  "host_adapter_implementation",
+  "host_runtime_publication",
+  "notification_source_factory_consumption",
+  "recipient_target_open_authorization",
+  "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization",
+  "recipient_topic_subscription_audience_authorization",
   "shared_consumer_resolution_helper",
-]) if (contract.composition?.[field] !== true) failures.push(`recipient context contract must record ${field}=true`);
-
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "trust channel and group facts host adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`recipient context contract must keep ${residual} open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "trust channel and group facts host adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient context contract must keep ${residual} explicitly open`);
+  }
+}
+for (const staleResidual of [
+  "host recipient context adapter implementation",
+  "host runtime publication of the recipient context capability",
+  "notification source factory consumption of the recipient context capability",
+  "recipient-specific target-open authorization for non-public topics and replies",
+  "recipient-specific topic-created subscription filtering before pagination",
+]) {
+  if (contract.not_delivered?.includes(staleResidual)) {
+    failures.push(`forum notification recipient context contract must remove delivered residual ${staleResidual}`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("recipient context contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized plan must advance through P");
-} else failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
   "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
+  "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE",
   "pub struct ForumNotificationRecipientContextRequest",
   "pub trait ForumNotificationRecipientContextPort: Send + Sync",
   "pub type SharedForumNotificationRecipientContextPort",
+  "pub struct ForumNotificationRecipientContext",
   "pub struct ForumNotificationRecipientContextResolver",
   "ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)",
   ".require_policy(PortCallPolicy::read())",
   "PortActorKind::System | PortActorKind::Service",
+  "context.actor.kind != PortActorKind::User",
   "SecurityContext::try_from_port_context(&recipient_context)",
   "ForumTopicAudienceViewer::authenticated(self.security, self.port_context)",
   "ForumError::capability_unavailable(",
   "ForumError::capability_failure(",
-]) requireText(owner, marker, `recipient context owner is missing ${marker}`);
-for (const forbidden of ["sea_orm", "DatabaseConnection", "crate::entities", "HostRuntimeContext"]) rejectText(owner, forbidden, `recipient context owner must remain neutral instead of ${forbidden}`);
-for (const marker of ["pub mod notification_recipient;", "ForumNotificationRecipientContextResolver", "SharedForumNotificationRecipientContextPort"]) requireText(crate, marker, `forum crate surface is missing ${marker}`);
+  "recipient_context_resolver_builds_exact_topic_viewer",
+  "recipient_context_resolver_rejects_foreign_actor",
+  "recipient_context_resolver_reports_missing_capability",
+]) {
+  requireText(owner, marker, `forum notification recipient context owner is missing ${marker}`);
+}
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "crate::entities",
+  "forum_user",
+  "forum_profile",
+  "forum_channel",
+  "forum_group",
+  "HostRuntimeContext",
+]) {
+  rejectText(owner, forbidden, `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`);
+}
+for (const marker of [
+  "pub mod notification_recipient;",
+  "FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
+  "ForumNotificationRecipientContextPort",
+  "ForumNotificationRecipientContextResolver",
+  "SharedForumNotificationRecipientContextPort",
+]) {
+  requireText(crate, marker, `forum crate surface is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 7 || upstream.task !== "FORUM-20K" || upstream.downstream_task !== "FORUM-20P" || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20L must remain grounded in FORUM-20K/P visibility composition");
-if (downstream.schema_version !== 4 || downstream.task !== "FORUM-20M" || downstream.topic_subscription_consumer_task !== "FORUM-20P" || downstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20M/P host composition");
-if (targetOpen.schema_version !== 3 || targetOpen.task !== "FORUM-20N" || targetOpen.downstream_chain_task !== "FORUM-20P" || targetOpen.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20N/P consumer chain");
-if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P" || mention.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20O/P consumer chain");
-if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.exact_recipient_context_per_scanned_subscription !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20P subscription consumer");
+if (
+  upstream.schema_version !== 7 ||
+  upstream.task !== "FORUM-20K" ||
+  upstream.downstream_task !== "FORUM-20P" ||
+  upstream.composition?.exact_richer_public_owner !== true ||
+  upstream.composition?.recipient_specific_target_open !== true ||
+  upstream.composition?.recipient_specific_mention_description !== true ||
+  upstream.composition?.recipient_specific_mention_audience !== true ||
+  upstream.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain grounded in FORUM-20K visibility composition through FORUM-20P");
+}
+if (
+  downstream.schema_version !== 4 ||
+  downstream.task !== "FORUM-20M" ||
+  downstream.upstream_task !== "FORUM-20L" ||
+  downstream.downstream_task !== "FORUM-20N" ||
+  downstream.mention_consumer_task !== "FORUM-20O" ||
+  downstream.topic_subscription_consumer_task !== "FORUM-20P" ||
+  downstream.composition?.server_adapter !== true ||
+  downstream.composition?.runtime_extension_publication !== true ||
+  downstream.composition?.notification_source_factory_consumption !== true ||
+  downstream.composition?.recipient_mention_description_authorization !== true ||
+  downstream.composition?.recipient_mention_audience_authorization !== true ||
+  downstream.composition?.recipient_topic_subscription_audience_authorization !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with FORUM-20M host composition through FORUM-20P");
+}
+if (
+  targetOpenConsumer.schema_version !== 3 ||
+  targetOpenConsumer.task !== "FORUM-20N" ||
+  targetOpenConsumer.upstream_task !== "FORUM-20M" ||
+  targetOpenConsumer.downstream_task !== "FORUM-20O" ||
+  targetOpenConsumer.downstream_chain_task !== "FORUM-20P" ||
+  targetOpenConsumer.composition?.exact_recipient_resolution !== true ||
+  targetOpenConsumer.composition?.recipient_specific_topic_open !== true ||
+  targetOpenConsumer.composition?.recipient_specific_reply_open !== true ||
+  targetOpenConsumer.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20N recipient consumer through P");
+}
+if (
+  mentionConsumer.schema_version !== 2 ||
+  mentionConsumer.task !== "FORUM-20O" ||
+  mentionConsumer.upstream_task !== "FORUM-20N" ||
+  mentionConsumer.downstream_task !== "FORUM-20P" ||
+  mentionConsumer.composition?.exact_mention_recipient_resolution !== true ||
+  mentionConsumer.composition?.recipient_specific_mention_description !== true ||
+  mentionConsumer.composition?.recipient_specific_mention_audience !== true ||
+  mentionConsumer.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20O mention consumer through P");
+}
+if (
+  subscriptionConsumer.schema_version !== 1 ||
+  subscriptionConsumer.task !== "FORUM-20P" ||
+  subscriptionConsumer.upstream_task !== "FORUM-20O" ||
+  subscriptionConsumer.composition?.exact_recipient_context_per_scanned_subscription !== true ||
+  subscriptionConsumer.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20P subscription consumer");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum notification recipient context verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient context contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-context.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-context.mjs
@@ -18,241 +18,88 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-
 function requireText(source, marker, message) {
   if (!source.includes(marker)) failures.push(message);
 }
-
 function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-context.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-context.json") || "{}");
 const owner = read(contract.owner_file ?? "");
 const crate = read(contract.crate_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const consumer = JSON.parse(read(contract.consumer_contract ?? "") || "{}");
-const downstreamConsumer = JSON.parse(read(contract.downstream_consumer_contract ?? "") || "{}");
+const targetOpen = JSON.parse(read(contract.target_open_consumer_contract ?? "") || "{}");
+const mention = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
+const subscriptions = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) {
-  failures.push("forum notification recipient context contract must use schema_version=4");
-}
+if (contract.schema_version !== 5) failures.push("forum notification recipient context contract must use schema_version=5");
 if (
   contract.task !== "FORUM-20L" ||
   contract.upstream_task !== "FORUM-20K" ||
   contract.downstream_task !== "FORUM-20M" ||
-  contract.consumer_task !== "FORUM-20N" ||
-  contract.downstream_consumer_task !== "FORUM-20O"
-) {
-  failures.push("forum notification recipient context contract must connect FORUM-20K/L/M/N/O");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient context source publication must not claim unexecuted evidence");
-}
+  contract.target_open_consumer_task !== "FORUM-20N" ||
+  contract.mention_consumer_task !== "FORUM-20O" ||
+  contract.topic_subscription_consumer_task !== "FORUM-20P"
+) failures.push("forum recipient context contract must connect FORUM-20K/L/M/N/O/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient context contract must not claim unexecuted evidence");
 
-for (const delivered of [
-  "bounded_request",
-  "caller_read_semantics",
-  "caller_tenant_validation",
-  "system_or_service_caller",
-  "recipient_read_semantics",
-  "recipient_tenant_validation",
-  "exact_user_actor_validation",
-  "role_and_permission_snapshot_validation",
-  "authenticated_topic_viewer_conversion",
-  "typed_missing_capability",
-  "retryable_failure_mapping",
-  "inline_contract_tests",
-  "host_adapter_implementation",
-  "host_runtime_publication",
-  "notification_source_factory_consumption",
-  "recipient_target_open_authorization",
-  "recipient_mention_description_authorization",
-  "recipient_mention_audience_authorization",
+for (const field of [
+  "bounded_request", "caller_read_semantics", "caller_tenant_validation", "system_or_service_caller",
+  "recipient_read_semantics", "recipient_tenant_validation", "exact_user_actor_validation",
+  "role_and_permission_snapshot_validation", "authenticated_topic_viewer_conversion",
+  "typed_missing_capability", "retryable_failure_mapping", "inline_contract_tests",
+  "host_adapter_implementation", "host_runtime_publication", "notification_source_factory_consumption",
+  "recipient_target_open_authorization", "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization", "recipient_topic_subscription_audience_authorization",
   "shared_consumer_resolution_helper",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient context contract must record ${delivered} as delivered`);
-  }
-}
-for (const residual of [
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "trust channel and group facts host adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient context contract must keep ${residual} explicitly open`);
-  }
-}
-for (const staleResidual of [
-  "host recipient context adapter implementation",
-  "host runtime publication of the recipient context capability",
-  "notification source factory consumption of the recipient context capability",
-  "recipient-specific target-open authorization for non-public topics and replies",
-]) {
-  if (contract.not_delivered?.includes(staleResidual)) {
-    failures.push(`forum notification recipient context contract must remove delivered residual ${staleResidual}`);
-  }
-}
+]) if (contract.composition?.[field] !== true) failures.push(`recipient context contract must record ${field}=true`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum recipient context contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient context contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+for (const residual of [
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "trust channel and group facts host adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`recipient context contract must keep ${residual} open`);
+
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("recipient context contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized plan must advance through P");
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
   "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
-  "pub const FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE",
   "pub struct ForumNotificationRecipientContextRequest",
   "pub trait ForumNotificationRecipientContextPort: Send + Sync",
   "pub type SharedForumNotificationRecipientContextPort",
-  "pub struct ForumNotificationRecipientContext",
   "pub struct ForumNotificationRecipientContextResolver",
   "ForumNotificationRecipientContextRequest::new(tenant_id, recipient_id)",
   ".require_policy(PortCallPolicy::read())",
   "PortActorKind::System | PortActorKind::Service",
-  "context.actor.kind != PortActorKind::User",
   "SecurityContext::try_from_port_context(&recipient_context)",
   "ForumTopicAudienceViewer::authenticated(self.security, self.port_context)",
   "ForumError::capability_unavailable(",
   "ForumError::capability_failure(",
-  "recipient_context_resolver_builds_exact_topic_viewer",
-  "recipient_context_resolver_rejects_foreign_actor",
-  "recipient_context_resolver_reports_missing_capability",
-]) {
-  requireText(owner, marker, `forum notification recipient context owner is missing ${marker}`);
-}
-for (const forbidden of [
-  "sea_orm",
-  "DatabaseConnection",
-  "crate::entities",
-  "forum_user",
-  "forum_profile",
-  "forum_channel",
-  "forum_group",
-  "HostRuntimeContext",
-]) {
-  rejectText(owner, forbidden, `forum notification recipient context owner must remain storage and host neutral instead of ${forbidden}`);
-}
-for (const marker of [
-  "pub mod notification_recipient;",
-  "FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY",
-  "ForumNotificationRecipientContextPort",
-  "ForumNotificationRecipientContextResolver",
-  "SharedForumNotificationRecipientContextPort",
-]) {
-  requireText(crate, marker, `forum crate surface is missing ${marker}`);
-}
+]) requireText(owner, marker, `recipient context owner is missing ${marker}`);
+for (const forbidden of ["sea_orm", "DatabaseConnection", "crate::entities", "HostRuntimeContext"]) rejectText(owner, forbidden, `recipient context owner must remain neutral instead of ${forbidden}`);
+for (const marker of ["pub mod notification_recipient;", "ForumNotificationRecipientContextResolver", "SharedForumNotificationRecipientContextPort"]) requireText(crate, marker, `forum crate surface is missing ${marker}`);
 
-if (
-  upstream.schema_version !== 6 ||
-  upstream.task !== "FORUM-20K" ||
-  upstream.downstream_task !== "FORUM-20O" ||
-  upstream.composition?.exact_richer_public_owner !== true ||
-  upstream.composition?.recipient_specific_target_open !== true ||
-  upstream.composition?.recipient_specific_mention_description !== true ||
-  upstream.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20L recipient context capability must remain grounded in FORUM-20K visibility composition through FORUM-20O");
-}
-if (
-  downstream.schema_version !== 3 ||
-  downstream.task !== "FORUM-20M" ||
-  downstream.upstream_task !== "FORUM-20L" ||
-  downstream.downstream_task !== "FORUM-20N" ||
-  downstream.consumer_task !== "FORUM-20O" ||
-  downstream.composition?.server_adapter !== true ||
-  downstream.composition?.runtime_extension_publication !== true ||
-  downstream.composition?.notification_source_factory_consumption !== true ||
-  downstream.composition?.recipient_mention_description_authorization !== true ||
-  downstream.composition?.recipient_mention_audience_authorization !== true
-) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with FORUM-20M host composition through FORUM-20O");
-}
-if (
-  consumer.schema_version !== 2 ||
-  consumer.task !== "FORUM-20N" ||
-  consumer.upstream_task !== "FORUM-20M" ||
-  consumer.downstream_task !== "FORUM-20O" ||
-  consumer.composition?.exact_recipient_resolution !== true ||
-  consumer.composition?.recipient_specific_topic_open !== true ||
-  consumer.composition?.recipient_specific_reply_open !== true ||
-  consumer.composition?.recipient_specific_mention_description !== true ||
-  consumer.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20N recipient consumer");
-}
-if (
-  downstreamConsumer.schema_version !== 1 ||
-  downstreamConsumer.task !== "FORUM-20O" ||
-  downstreamConsumer.upstream_task !== "FORUM-20N" ||
-  downstreamConsumer.composition?.exact_mention_recipient_resolution !== true ||
-  downstreamConsumer.composition?.recipient_specific_mention_description !== true ||
-  downstreamConsumer.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20L recipient context capability must remain synchronized with the FORUM-20O mention consumer");
-}
-
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
+if (upstream.schema_version !== 7 || upstream.task !== "FORUM-20K" || upstream.downstream_task !== "FORUM-20P" || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20L must remain grounded in FORUM-20K/P visibility composition");
+if (downstream.schema_version !== 4 || downstream.task !== "FORUM-20M" || downstream.topic_subscription_consumer_task !== "FORUM-20P" || downstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20M/P host composition");
+if (targetOpen.schema_version !== 3 || targetOpen.task !== "FORUM-20N" || targetOpen.downstream_chain_task !== "FORUM-20P" || targetOpen.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20N/P consumer chain");
+if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P" || mention.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20O/P consumer chain");
+if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.exact_recipient_context_per_scanned_subscription !== true) failures.push("FORUM-20L must remain synchronized with FORUM-20P subscription consumer");
 
 if (failures.length > 0) {
   console.error("Forum notification recipient context verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient context contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
@@ -5,139 +5,56 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
-  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
-  : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
 const failures = [];
-
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) {
-    failures.push(`${relativePath}: required file is missing`);
-    return "";
-  }
+  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
   return readFileSync(absolute, "utf8");
 }
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json") || "{}");
 const adapter = read(contract.adapter_file ?? "");
 const services = read(contract.services_file ?? "");
 const runtime = read(contract.runtime_composition_file ?? "");
-const notificationSource = read(contract.notification_source_file ?? "");
+const source = read(contract.notification_source_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const consumer = JSON.parse(read(contract.consumer_contract ?? "") || "{}");
+const mention = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
+const subscriptions = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) {
-  failures.push("forum notification recipient host runtime contract must use schema_version=3");
-}
-if (
-  contract.task !== "FORUM-20M" ||
-  contract.upstream_task !== "FORUM-20L" ||
-  contract.downstream_task !== "FORUM-20N" ||
-  contract.consumer_task !== "FORUM-20O"
-) {
-  failures.push("forum notification recipient host runtime contract must connect FORUM-20L/M/N/O");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient host runtime publication must not claim unexecuted evidence");
-}
-if (contract.policy?.permission_bound !== 512) {
-  failures.push("forum notification recipient permission claims must remain bounded at 512");
-}
+if (contract.schema_version !== 4) failures.push("forum notification recipient host runtime contract must use schema_version=4");
+if (contract.task !== "FORUM-20M" || contract.upstream_task !== "FORUM-20L" || contract.downstream_task !== "FORUM-20N" || contract.mention_consumer_task !== "FORUM-20O" || contract.topic_subscription_consumer_task !== "FORUM-20P") failures.push("host runtime contract must connect FORUM-20L/M/N/O/P");
+if (contract.policy?.permission_bound !== 512) failures.push("recipient permission claims must remain bounded at 512");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("host runtime contract must not claim unexecuted evidence");
 
-for (const delivered of [
-  "server_adapter",
-  "active_user_lookup",
-  "tenant_user_predicates",
-  "rbac_role_snapshot",
-  "rbac_permission_snapshot",
-  "exact_user_port_actor",
-  "bounded_permission_claims",
-  "read_metadata_preserved",
-  "runtime_extension_publication",
-  "publication_before_notification_source_materialization",
-  "feature_guarded_server_module",
-  "inline_contract_tests",
-  "notification_source_factory_consumption",
-  "recipient_target_open_authorization",
-  "recipient_mention_description_authorization",
-  "recipient_mention_audience_authorization",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient host runtime contract must record ${delivered} as delivered`);
-  }
-}
+for (const field of [
+  "server_adapter", "active_user_lookup", "tenant_user_predicates", "rbac_role_snapshot",
+  "rbac_permission_snapshot", "exact_user_port_actor", "bounded_permission_claims",
+  "read_metadata_preserved", "runtime_extension_publication",
+  "publication_before_notification_source_materialization", "feature_guarded_server_module",
+  "inline_contract_tests", "notification_source_factory_consumption",
+  "recipient_target_open_authorization", "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization", "recipient_topic_subscription_audience_authorization",
+]) if (contract.composition?.[field] !== true) failures.push(`host runtime contract must record ${field}=true`);
+
 for (const residual of [
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "trust channel and group facts host adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient host runtime contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "trust channel and group facts host adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`host runtime contract must keep ${residual} open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("host runtime contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
   "pub(crate) struct ServerForumNotificationRecipientContextPort",
@@ -147,107 +64,30 @@ for (const marker of [
   "users::Column::TenantId.eq(request.tenant_id)",
   "users::Column::Id.eq(request.recipient_id)",
   "users::Column::Status.eq(UserStatus::Active)",
-  "RbacService::get_user_permissions(",
-  "RbacService::get_user_role(",
-  "PortActor::user(request.recipient_id.to_string())",
-  "MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512",
-  "permissions.is_empty()",
-  "permissions.len() > MAX_RECIPIENT_PERMISSION_CLAIMS",
-  "recipient_context.causation_id = caller_context.causation_id.clone()",
-  "recipient_context.traceparent = caller_context.traceparent.clone()",
+  "RbacService::get_user_permissions(", "RbacService::get_user_role(",
+  "PortActor::user(request.recipient_id.to_string())", "MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512",
   "recipient_context.deadline_ms = caller_context.deadline_ms",
-  "recipient_context_preserves_bounded_read_metadata",
-  "recipient_context_rejects_empty_authority",
-  "recipient_context_rejects_user_caller",
-]) {
-  requireText(adapter, marker, `forum notification recipient host adapter is missing ${marker}`);
-}
-for (const forbidden of [
-  "rustok_forum::entities",
-  "forum_category_audience_",
-  "forum_topic_audience_",
-  "forum_user_",
-  "forum_profile",
-  "forum_channel",
-  "forum_group",
-  "SecurityContext::new(",
-  "Rbac::permissions_for_role",
-]) {
-  rejectText(adapter, forbidden, `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`);
-}
-for (const marker of [
-  "#[cfg(feature = \"mod-forum\")]",
-  "pub mod forum_notification_recipient_context;",
-]) {
-  requireText(services, marker, `server services surface is missing ${marker}`);
-}
-for (const marker of [
-  "ServerForumNotificationRecipientContextPort::shared(",
-  "extensions.insert(recipient_context)",
-  "extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>()",
-]) {
-  requireText(runtime, marker, `server runtime composition is missing ${marker}`);
-}
-const publicationIndex = runtime.indexOf("extensions.insert(recipient_context)");
-const materializationIndex = runtime.indexOf("materialize_notification_source_registry(&mut extensions, &host)");
-if (publicationIndex < 0 || materializationIndex < 0 || publicationIndex > materializationIndex) {
-  failures.push("recipient context capability must be published before notification source materialization");
-}
-
+]) requireText(adapter, marker, `host recipient adapter is missing ${marker}`);
+for (const forbidden of ["rustok_forum::entities", "forum_category_audience_", "forum_topic_audience_", "SecurityContext::new(", "Rbac::permissions_for_role"]) rejectText(adapter, forbidden, `host adapter must not bypass owner boundaries with ${forbidden}`);
+for (const marker of ["#[cfg(feature = \"mod-forum\")]", "pub mod forum_notification_recipient_context;"]) requireText(services, marker, `server services surface is missing ${marker}`);
+for (const marker of ["ServerForumNotificationRecipientContextPort::shared(", "extensions.insert(recipient_context)", "materialize_notification_source_registry(&mut extensions, &host)"]) requireText(runtime, marker, `server runtime composition is missing ${marker}`);
+if (runtime.indexOf("extensions.insert(recipient_context)") > runtime.indexOf("materialize_notification_source_registry(&mut extensions, &host)")) failures.push("recipient context must be published before source materialization");
 for (const marker of [
   "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
-  "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "target_open_context(&request)",
+  "async fn resolve_recipient_viewer(", "target_open_context(&request)",
   "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)",
   "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)",
-  "recipient.into_topic_viewer()",
-]) {
-  requireText(notificationSource, marker, `notification source consumer is missing ${marker}`);
-}
+  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) requireText(source, marker, `notification source consumer is missing ${marker}`);
 
-if (
-  upstream.schema_version !== 4 ||
-  upstream.task !== "FORUM-20L" ||
-  upstream.downstream_task !== "FORUM-20M" ||
-  upstream.consumer_task !== "FORUM-20N" ||
-  upstream.downstream_consumer_task !== "FORUM-20O" ||
-  upstream.composition?.host_adapter_implementation !== true ||
-  upstream.composition?.host_runtime_publication !== true ||
-  upstream.composition?.notification_source_factory_consumption !== true ||
-  upstream.composition?.recipient_mention_description_authorization !== true ||
-  upstream.composition?.recipient_mention_audience_authorization !== true
-) {
-  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20L capability contract through FORUM-20O");
-}
-if (
-  downstream.schema_version !== 2 ||
-  downstream.task !== "FORUM-20N" ||
-  downstream.upstream_task !== "FORUM-20M" ||
-  downstream.downstream_task !== "FORUM-20O" ||
-  downstream.composition?.factory_recipient_capability_lookup !== true ||
-  downstream.composition?.recipient_specific_topic_open !== true ||
-  downstream.composition?.recipient_specific_reply_open !== true ||
-  downstream.composition?.recipient_specific_mention_description !== true ||
-  downstream.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20N recipient consumer");
-}
-if (
-  consumer.schema_version !== 1 ||
-  consumer.task !== "FORUM-20O" ||
-  consumer.upstream_task !== "FORUM-20N" ||
-  consumer.composition?.recipient_specific_mention_description !== true ||
-  consumer.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20O mention consumer");
-}
+if (upstream.schema_version !== 5 || upstream.task !== "FORUM-20L" || upstream.topic_subscription_consumer_task !== "FORUM-20P" || upstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20L/P");
+if (downstream.schema_version !== 3 || downstream.task !== "FORUM-20N" || downstream.downstream_chain_task !== "FORUM-20P" || downstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20N/P");
+if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P") failures.push("FORUM-20M must remain synchronized with FORUM-20O/P");
+if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.exact_recipient_context_per_scanned_subscription !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20P");
 
 if (failures.length > 0) {
   console.error("Forum notification recipient host runtime verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient host runtime contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
@@ -5,56 +5,142 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
 const failures = [];
+
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json") || "{}");
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-host-runtime.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const adapter = read(contract.adapter_file ?? "");
 const services = read(contract.services_file ?? "");
 const runtime = read(contract.runtime_composition_file ?? "");
-const source = read(contract.notification_source_file ?? "");
+const notificationSource = read(contract.notification_source_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const mention = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
-const subscriptions = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
+const mentionConsumer = JSON.parse(read(contract.mention_consumer_contract ?? "") || "{}");
+const subscriptionConsumer = JSON.parse(read(contract.topic_subscription_consumer_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) failures.push("forum notification recipient host runtime contract must use schema_version=4");
-if (contract.task !== "FORUM-20M" || contract.upstream_task !== "FORUM-20L" || contract.downstream_task !== "FORUM-20N" || contract.mention_consumer_task !== "FORUM-20O" || contract.topic_subscription_consumer_task !== "FORUM-20P") failures.push("host runtime contract must connect FORUM-20L/M/N/O/P");
-if (contract.policy?.permission_bound !== 512) failures.push("recipient permission claims must remain bounded at 512");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("host runtime contract must not claim unexecuted evidence");
+if (contract.schema_version !== 4) {
+  failures.push("forum notification recipient host runtime contract must use schema_version=4");
+}
+if (
+  contract.task !== "FORUM-20M" ||
+  contract.upstream_task !== "FORUM-20L" ||
+  contract.downstream_task !== "FORUM-20N" ||
+  contract.mention_consumer_task !== "FORUM-20O" ||
+  contract.topic_subscription_consumer_task !== "FORUM-20P"
+) {
+  failures.push("forum notification recipient host runtime contract must connect FORUM-20L/M/N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient host runtime publication must not claim unexecuted evidence");
+}
+if (contract.policy?.permission_bound !== 512) {
+  failures.push("forum notification recipient permission claims must remain bounded at 512");
+}
 
-for (const field of [
-  "server_adapter", "active_user_lookup", "tenant_user_predicates", "rbac_role_snapshot",
-  "rbac_permission_snapshot", "exact_user_port_actor", "bounded_permission_claims",
-  "read_metadata_preserved", "runtime_extension_publication",
-  "publication_before_notification_source_materialization", "feature_guarded_server_module",
-  "inline_contract_tests", "notification_source_factory_consumption",
-  "recipient_target_open_authorization", "recipient_mention_description_authorization",
-  "recipient_mention_audience_authorization", "recipient_topic_subscription_audience_authorization",
-]) if (contract.composition?.[field] !== true) failures.push(`host runtime contract must record ${field}=true`);
-
+for (const delivered of [
+  "server_adapter",
+  "active_user_lookup",
+  "tenant_user_predicates",
+  "rbac_role_snapshot",
+  "rbac_permission_snapshot",
+  "exact_user_port_actor",
+  "bounded_permission_claims",
+  "read_metadata_preserved",
+  "runtime_extension_publication",
+  "publication_before_notification_source_materialization",
+  "feature_guarded_server_module",
+  "inline_contract_tests",
+  "notification_source_factory_consumption",
+  "recipient_target_open_authorization",
+  "recipient_mention_description_authorization",
+  "recipient_mention_audience_authorization",
+  "recipient_topic_subscription_audience_authorization",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient host runtime contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "trust channel and group facts host adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`host runtime contract must keep ${residual} open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "trust channel and group facts host adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient host runtime contract must keep ${residual} explicitly open`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("host runtime contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum recipient host runtime contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum recipient host runtime contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
   "pub(crate) struct ServerForumNotificationRecipientContextPort",
@@ -64,30 +150,123 @@ for (const marker of [
   "users::Column::TenantId.eq(request.tenant_id)",
   "users::Column::Id.eq(request.recipient_id)",
   "users::Column::Status.eq(UserStatus::Active)",
-  "RbacService::get_user_permissions(", "RbacService::get_user_role(",
-  "PortActor::user(request.recipient_id.to_string())", "MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512",
+  "RbacService::get_user_permissions(",
+  "RbacService::get_user_role(",
+  "PortActor::user(request.recipient_id.to_string())",
+  "MAX_RECIPIENT_PERMISSION_CLAIMS: usize = 512",
+  "permissions.is_empty()",
+  "permissions.len() > MAX_RECIPIENT_PERMISSION_CLAIMS",
+  "recipient_context.causation_id = caller_context.causation_id.clone()",
+  "recipient_context.traceparent = caller_context.traceparent.clone()",
   "recipient_context.deadline_ms = caller_context.deadline_ms",
-]) requireText(adapter, marker, `host recipient adapter is missing ${marker}`);
-for (const forbidden of ["rustok_forum::entities", "forum_category_audience_", "forum_topic_audience_", "SecurityContext::new(", "Rbac::permissions_for_role"]) rejectText(adapter, forbidden, `host adapter must not bypass owner boundaries with ${forbidden}`);
-for (const marker of ["#[cfg(feature = \"mod-forum\")]", "pub mod forum_notification_recipient_context;"]) requireText(services, marker, `server services surface is missing ${marker}`);
-for (const marker of ["ServerForumNotificationRecipientContextPort::shared(", "extensions.insert(recipient_context)", "materialize_notification_source_registry(&mut extensions, &host)"]) requireText(runtime, marker, `server runtime composition is missing ${marker}`);
-if (runtime.indexOf("extensions.insert(recipient_context)") > runtime.indexOf("materialize_notification_source_registry(&mut extensions, &host)")) failures.push("recipient context must be published before source materialization");
+  "recipient_context_preserves_bounded_read_metadata",
+  "recipient_context_rejects_empty_authority",
+  "recipient_context_rejects_user_caller",
+]) {
+  requireText(adapter, marker, `forum notification recipient host adapter is missing ${marker}`);
+}
+for (const forbidden of [
+  "rustok_forum::entities",
+  "forum_category_audience_",
+  "forum_topic_audience_",
+  "forum_user_",
+  "forum_profile",
+  "forum_channel",
+  "forum_group",
+  "SecurityContext::new(",
+  "Rbac::permissions_for_role",
+]) {
+  rejectText(adapter, forbidden, `forum notification recipient host adapter must not bypass owner boundaries with ${forbidden}`);
+}
+for (const marker of [
+  "#[cfg(feature = \"mod-forum\")]",
+  "pub mod forum_notification_recipient_context;",
+]) {
+  requireText(services, marker, `server services surface is missing ${marker}`);
+}
+for (const marker of [
+  "ServerForumNotificationRecipientContextPort::shared(",
+  "extensions.insert(recipient_context)",
+  "extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>()",
+]) {
+  requireText(runtime, marker, `server runtime composition is missing ${marker}`);
+}
+const publicationIndex = runtime.indexOf("extensions.insert(recipient_context)");
+const materializationIndex = runtime.indexOf("materialize_notification_source_registry(&mut extensions, &host)");
+if (publicationIndex < 0 || materializationIndex < 0 || publicationIndex > materializationIndex) {
+  failures.push("recipient context capability must be published before notification source materialization");
+}
+
 for (const marker of [
   "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "async fn resolve_recipient_viewer(", "target_open_context(&request)",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "target_open_context(&request)",
   "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)",
   "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)",
-  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) requireText(source, marker, `notification source consumer is missing ${marker}`);
+  "async fn topic_subscription_recipient_visible(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+  "recipient.into_topic_viewer()",
+]) {
+  requireText(notificationSource, marker, `notification source consumer is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 5 || upstream.task !== "FORUM-20L" || upstream.topic_subscription_consumer_task !== "FORUM-20P" || upstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20L/P");
-if (downstream.schema_version !== 3 || downstream.task !== "FORUM-20N" || downstream.downstream_chain_task !== "FORUM-20P" || downstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20N/P");
-if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P") failures.push("FORUM-20M must remain synchronized with FORUM-20O/P");
-if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.exact_recipient_context_per_scanned_subscription !== true) failures.push("FORUM-20M must remain synchronized with FORUM-20P");
+if (
+  upstream.schema_version !== 5 ||
+  upstream.task !== "FORUM-20L" ||
+  upstream.downstream_task !== "FORUM-20M" ||
+  upstream.target_open_consumer_task !== "FORUM-20N" ||
+  upstream.mention_consumer_task !== "FORUM-20O" ||
+  upstream.topic_subscription_consumer_task !== "FORUM-20P" ||
+  upstream.composition?.host_adapter_implementation !== true ||
+  upstream.composition?.host_runtime_publication !== true ||
+  upstream.composition?.notification_source_factory_consumption !== true ||
+  upstream.composition?.recipient_mention_description_authorization !== true ||
+  upstream.composition?.recipient_mention_audience_authorization !== true ||
+  upstream.composition?.recipient_topic_subscription_audience_authorization !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20L capability contract through FORUM-20P");
+}
+if (
+  downstream.schema_version !== 3 ||
+  downstream.task !== "FORUM-20N" ||
+  downstream.upstream_task !== "FORUM-20M" ||
+  downstream.downstream_task !== "FORUM-20O" ||
+  downstream.downstream_chain_task !== "FORUM-20P" ||
+  downstream.composition?.factory_recipient_capability_lookup !== true ||
+  downstream.composition?.recipient_specific_topic_open !== true ||
+  downstream.composition?.recipient_specific_reply_open !== true ||
+  downstream.composition?.recipient_specific_mention_description !== true ||
+  downstream.composition?.recipient_specific_mention_audience !== true ||
+  downstream.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20N recipient consumer through P");
+}
+if (
+  mentionConsumer.schema_version !== 2 ||
+  mentionConsumer.task !== "FORUM-20O" ||
+  mentionConsumer.upstream_task !== "FORUM-20N" ||
+  mentionConsumer.downstream_task !== "FORUM-20P" ||
+  mentionConsumer.composition?.recipient_specific_mention_description !== true ||
+  mentionConsumer.composition?.recipient_specific_mention_audience !== true ||
+  mentionConsumer.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20O mention consumer through P");
+}
+if (
+  subscriptionConsumer.schema_version !== 1 ||
+  subscriptionConsumer.task !== "FORUM-20P" ||
+  subscriptionConsumer.composition?.exact_recipient_context_per_scanned_subscription !== true ||
+  subscriptionConsumer.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20M host runtime must remain synchronized with the FORUM-20P subscription consumer");
+}
 
 if (failures.length > 0) {
   console.error("Forum notification recipient host runtime verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient host runtime contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
@@ -5,278 +5,91 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
-  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
-  : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
 const failures = [];
-
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) {
-    failures.push(`${relativePath}: required file is missing`);
-    return "";
-  }
+  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
-  const startIndex = source.indexOf(start);
-  const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
-  return source.slice(startIndex, endIndex);
+  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
+  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  return source.slice(a, b);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json") || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
-const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
-const testSource = read(contract.test_file ?? "");
+const visibility = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const mentionTest = read(contract.test_file ?? "");
+const subscriptionTest = read(contract.downstream_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum notification recipient mention audience contract must use schema_version=1");
-}
-if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N") {
-  failures.push("forum notification recipient mention audience contract must belong to FORUM-20O after FORUM-20N");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient mention audience publication must not claim unexecuted evidence");
-}
+if (contract.schema_version !== 2) failures.push("forum notification recipient mention contract must use schema_version=2");
+if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N" || contract.downstream_task !== "FORUM-20P") failures.push("mention contract must connect FORUM-20N/O/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("mention contract must not claim unexecuted evidence");
 
-for (const delivered of [
-  "shared_recipient_resolution_helper",
-  "bounded_mention_description_context",
-  "bounded_mention_audience_context",
-  "exact_mention_recipient_resolution",
-  "authenticated_topic_viewer",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "topic_mention_target",
-  "reply_mention_target",
-  "public_only_fallback",
-  "unavailable_recipient_fail_closed",
-  "retryability_preserved",
-  "stale_descriptor_recheck",
-  "topic_created_paths_unchanged",
-  "sqlite_contract_test",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
-  }
-}
+for (const field of [
+  "shared_recipient_resolution_helper", "bounded_mention_description_context", "bounded_mention_audience_context",
+  "exact_mention_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "topic_mention_target", "reply_mention_target", "public_only_fallback",
+  "unavailable_recipient_fail_closed", "retryability_preserved", "stale_descriptor_recheck",
+  "topic_created_description_unchanged", "topic_created_subscription_audience_downstream",
+  "sqlite_contract_test", "downstream_sqlite_contract_test",
+]) if (contract.composition?.[field] !== true) failures.push(`mention contract must record ${field}=true`);
 for (const residual of [
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`mention contract must keep ${residual} open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum notification recipient mention audience contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-O provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through O",
-  );
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("mention contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
   "const MENTION_DESCRIBE_ACTOR: &str = \"forum-notification-mention-describe\"",
   "const MENTION_AUDIENCE_ACTOR: &str = \"forum-notification-mention-audience\"",
-  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
-  "async fn load_mention_target_for_recipient(",
-  "async fn resolve_recipient_viewer(",
-  "recipient_operation_context(",
-  "if self.recipient_context_port.is_none()",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "Err(ForumError::CapabilityFailure {",
-  "retryable: false, ..",
+  "async fn load_mention_target_for_recipient(", "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)",
-]) {
-  requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
-}
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn topic_subscription_recipient_visible(",
+]) requireText(source, marker, `mention source is missing ${marker}`);
+for (const forbidden of ["forum_category_audience_policy", "forum_topic_audience_policy", "Rbac::permissions_for_role", "SecurityContext::new("]) rejectText(source, forbidden, `notification recipient paths must reuse owners instead of ${forbidden}`);
 
-for (const forbidden of [
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-  "Rbac::permissions_for_role",
-  "SecurityContext::new(",
-]) {
-  rejectText(
-    source,
-    forbidden,
-    `forum notification recipient mention paths must reuse owners instead of ${forbidden}`,
-  );
-}
-
-const describeBlock = between(
-  source,
-  "async fn describe_event(",
-  "async fn resolve_audience(",
-  "forum notification describe_event",
-);
-const audienceBlock = between(
-  source,
-  "async fn resolve_audience(",
-  "async fn authorize_target_open(",
-  "forum notification resolve_audience",
-);
-const targetOpenBlock = between(
-  source,
-  "async fn authorize_target_open(",
-  "fn recipient_operation_context(",
-  "forum notification authorize_target_open",
-);
+const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
+const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
 for (const [block, marker, label] of [
-  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
-  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
-  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
-  [targetOpenBlock, "resolve_recipient_viewer(", "shared target-open recipient resolution"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic descriptor"],
+  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [audience, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
-for (const marker of [
-  "pub fn authenticated(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "resolve_for_constraints(",
-  "Local allow/deny/role resolution intentionally skips owner-port calls",
-]) {
-  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumNotificationRecipientContextResolver",
-  "pub async fn resolve(",
-  "validate_caller_context(&caller_context, tenant_id)?",
-  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
-  "SecurityContext::try_from_port_context(&recipient_context)",
-  "pub fn into_topic_viewer(self)",
-]) {
-  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
-}
+for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints("]) requireText(visibilityOwner, marker, `visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient owner is missing ${marker}`);
+for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
+for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
 
-for (const marker of [
-  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
-  "roles_any: vec![role]",
-  "Forum source factory should consume the recipient capability",
-  "customer topic mention should be describable",
-  "customer topic mention audience should resolve",
-  "customer reply mention should be describable",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
-  "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
-}
-
-if (
-  upstream.schema_version !== 2 ||
-  upstream.task !== "FORUM-20N" ||
-  upstream.downstream_task !== "FORUM-20O" ||
-  upstream.composition?.recipient_specific_mention_description !== true ||
-  upstream.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20N recipient contract");
-}
-if (
-  visibilityContract.schema_version !== 6 ||
-  visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20O" ||
-  visibilityContract.composition?.recipient_specific_mention_description !== true ||
-  visibilityContract.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20K visibility composition contract");
-}
-
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
+if (upstream.schema_version !== 3 || upstream.task !== "FORUM-20N" || upstream.downstream_chain_task !== "FORUM-20P" || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20N/P");
+if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20K/P");
+if (downstream.schema_version !== 1 || downstream.task !== "FORUM-20P" || downstream.upstream_task !== "FORUM-20O" || downstream.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20P");
 
 if (failures.length > 0) {
   console.error("Forum notification recipient mention audience verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient mention audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
@@ -18,16 +18,28 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
   return source.slice(startIndex, endIndex);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json") || "{}");
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
@@ -38,96 +50,265 @@ const testSource = read(contract.test_file ?? "");
 const downstreamTestSource = read(contract.downstream_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) failures.push("forum notification recipient mention audience contract must use schema_version=2");
-if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N" || contract.downstream_task !== "FORUM-20P") failures.push("forum notification recipient mention audience contract must connect FORUM-20N/O/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient mention audience publication must not claim unexecuted evidence");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification recipient mention audience contract must use schema_version=2");
+}
+if (
+  contract.task !== "FORUM-20O" ||
+  contract.upstream_task !== "FORUM-20N" ||
+  contract.downstream_task !== "FORUM-20P"
+) {
+  failures.push("forum notification recipient mention audience contract must connect FORUM-20N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient mention audience publication must not claim unexecuted evidence");
+}
 
 for (const delivered of [
-  "shared_recipient_resolution_helper", "bounded_mention_description_context", "bounded_mention_audience_context",
-  "exact_mention_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "topic_mention_target", "reply_mention_target", "public_only_fallback",
-  "unavailable_recipient_fail_closed", "retryability_preserved", "stale_descriptor_recheck",
-  "topic_created_description_unchanged", "topic_created_subscription_audience_downstream",
-  "sqlite_contract_test", "downstream_sqlite_contract_test",
-]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
+  "shared_recipient_resolution_helper",
+  "bounded_mention_description_context",
+  "bounded_mention_audience_context",
+  "exact_mention_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "topic_mention_target",
+  "reply_mention_target",
+  "public_only_fallback",
+  "unavailable_recipient_fail_closed",
+  "retryability_preserved",
+  "stale_descriptor_recheck",
+  "topic_created_description_unchanged",
+  "topic_created_subscription_audience_downstream",
+  "sqlite_contract_test",
+  "downstream_sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
+  }
+}
 
-const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20P");
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification recipient mention audience contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20P delivered sections");
+}
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
-  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
-  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
-} else failures.push("canonical_plan_sync.status must be pending or synchronized");
+  requireText(
+    plan,
+    "FORUM-20A-P provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through P",
+  );
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
   "const MENTION_DESCRIBE_ACTOR: &str = \"forum-notification-mention-describe\"",
   "const MENTION_AUDIENCE_ACTOR: &str = \"forum-notification-mention-audience\"",
   "const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = \"forum-notification-topic-subscription-audience\"",
   "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
-  "async fn load_active_topic(", "async fn load_topic_for_subscription_audience(",
-  "async fn load_mention_target_for_recipient(", "async fn topic_subscription_recipient_visible(",
-  "async fn resolve_recipient_viewer(", "recipient_operation_context(",
-  "if self.recipient_context_port.is_none()", "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()", "Err(ForumError::CapabilityFailure {", "retryable: false, ..",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "async fn resolve_recipient_viewer(",
+  "recipient_operation_context(",
+  "if self.recipient_context_port.is_none()",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
   ".is_topic_visible(tenant_id, topic_id, None, viewer)",
   "load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)",
-]) requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
-for (const forbidden of [
-  "forum_category_audience_policy", "forum_category_audience_role", "forum_category_audience_channel",
-  "forum_category_audience_group", "forum_category_audience_user", "forum_topic_audience_policy",
-  "forum_topic_audience_role", "forum_topic_audience_channel", "forum_topic_audience_group",
-  "forum_topic_audience_user", "Rbac::permissions_for_role", "SecurityContext::new(",
-]) rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
+]) {
+  requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
+}
 
-const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "forum notification describe_event");
-const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "forum notification resolve_audience");
-const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "forum notification authorize_target_open");
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(
+    source,
+    forbidden,
+    `forum notification recipient paths must reuse owners instead of ${forbidden}`,
+  );
+}
+
+const describeBlock = between(
+  source,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  source,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  source,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "topic-created exact subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "shared target-open recipient resolution"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
-for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints(", "Local allow/deny/role resolution intentionally skips owner-port calls"]) requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "pub async fn resolve(", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "SecurityContext::try_from_port_context(&recipient_context)", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
 
 for (const marker of [
   "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort", "roles_any: vec![role]",
-  "Forum source factory should consume the recipient capability", "customer topic mention should be describable",
-  "customer topic mention audience should resolve", "customer reply mention should be describable",
-  "customer reply mention audience should resolve", "manager topic mention description should fail closed",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![role]",
+  "Forum source factory should consume the recipient capability",
+  "customer topic mention should be describable",
+  "customer topic mention audience should resolve",
+  "customer reply mention should be describable",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
   "stale customer mention descriptor should be rechecked",
-]) requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
+]) {
+  requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
+}
 for (const marker of [
   "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "roles_any: vec![UserRole::Customer]", "topic audience should become non-public and deny exact recipients",
-  "first_page.recipients().is_empty()", "recorded_calls(&calls), vec![denied_first, unavailable_second]",
-  "second_page.recipients()[0].recipient_id, allowed_third", "third_page.recipients()[0].recipient_id, allowed_fifth",
-]) requireText(downstreamTestSource, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth",
+]) {
+  requireText(downstreamTestSource, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 3 || upstream.task !== "FORUM-20N" || upstream.downstream_task !== "FORUM-20O" || upstream.downstream_chain_task !== "FORUM-20P" || upstream.composition?.recipient_specific_mention_description !== true || upstream.composition?.recipient_specific_mention_audience !== true || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20N/P");
-if (visibilityContract.schema_version !== 7 || visibilityContract.task !== "FORUM-20K" || visibilityContract.downstream_task !== "FORUM-20P" || visibilityContract.composition?.topic_subscription_active_source_recheck !== true || visibilityContract.composition?.recipient_specific_mention_description !== true || visibilityContract.composition?.recipient_specific_mention_audience !== true || visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20K/P");
-if (downstream.schema_version !== 1 || downstream.task !== "FORUM-20P" || downstream.upstream_task !== "FORUM-20O" || downstream.composition?.active_topic_source_recheck !== true || downstream.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || downstream.composition?.bounded_raw_keyset_scan !== true || downstream.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20P");
+if (
+  upstream.schema_version !== 3 ||
+  upstream.task !== "FORUM-20N" ||
+  upstream.downstream_task !== "FORUM-20O" ||
+  upstream.downstream_chain_task !== "FORUM-20P" ||
+  upstream.composition?.recipient_specific_mention_description !== true ||
+  upstream.composition?.recipient_specific_mention_audience !== true ||
+  upstream.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20N recipient contract through P");
+}
+if (
+  visibilityContract.schema_version !== 7 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20P" ||
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
+  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20K visibility composition contract through P");
+}
+if (
+  downstream.schema_version !== 1 ||
+  downstream.task !== "FORUM-20P" ||
+  downstream.upstream_task !== "FORUM-20O" ||
+  downstream.composition?.bounded_raw_keyset_scan !== true ||
+  downstream.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20P topic subscription consumer");
+}
 
-for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
 if (failures.length > 0) {
   console.error("Forum notification recipient mention audience verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient mention audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
@@ -18,28 +18,16 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
+  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
   return source.slice(startIndex, endIndex);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json") || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
@@ -50,265 +38,96 @@ const testSource = read(contract.test_file ?? "");
 const downstreamTestSource = read(contract.downstream_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum notification recipient mention audience contract must use schema_version=2");
-}
-if (
-  contract.task !== "FORUM-20O" ||
-  contract.upstream_task !== "FORUM-20N" ||
-  contract.downstream_task !== "FORUM-20P"
-) {
-  failures.push("forum notification recipient mention audience contract must connect FORUM-20N/O/P");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient mention audience publication must not claim unexecuted evidence");
-}
+if (contract.schema_version !== 2) failures.push("forum notification recipient mention audience contract must use schema_version=2");
+if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N" || contract.downstream_task !== "FORUM-20P") failures.push("forum notification recipient mention audience contract must connect FORUM-20N/O/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient mention audience publication must not claim unexecuted evidence");
 
 for (const delivered of [
-  "shared_recipient_resolution_helper",
-  "bounded_mention_description_context",
-  "bounded_mention_audience_context",
-  "exact_mention_recipient_resolution",
-  "authenticated_topic_viewer",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "topic_mention_target",
-  "reply_mention_target",
-  "public_only_fallback",
-  "unavailable_recipient_fail_closed",
-  "retryability_preserved",
-  "stale_descriptor_recheck",
-  "topic_created_description_unchanged",
-  "topic_created_subscription_audience_downstream",
-  "sqlite_contract_test",
-  "downstream_sqlite_contract_test",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
-  }
-}
+  "shared_recipient_resolution_helper", "bounded_mention_description_context", "bounded_mention_audience_context",
+  "exact_mention_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "topic_mention_target", "reply_mention_target", "public_only_fallback",
+  "unavailable_recipient_fail_closed", "retryability_preserved", "stale_descriptor_recheck",
+  "topic_created_description_unchanged", "topic_created_subscription_audience_downstream",
+  "sqlite_contract_test", "downstream_sqlite_contract_test",
+]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
 for (const residual of [
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-];
+const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P") {
-  failures.push("forum notification recipient mention audience contract must require the canonical ledger through FORUM-20P");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20P delivered sections");
-}
+if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20P");
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
+  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
+  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
 } else if (planSync.status === "synchronized") {
-  requireText(
-    plan,
-    "FORUM-20A-P provide",
-    "synchronized canonical plan must advance the FORUM-20 ledger through P",
-  );
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
   "const MENTION_DESCRIBE_ACTOR: &str = \"forum-notification-mention-describe\"",
   "const MENTION_AUDIENCE_ACTOR: &str = \"forum-notification-mention-audience\"",
   "const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = \"forum-notification-topic-subscription-audience\"",
   "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
-  "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(",
-  "async fn resolve_recipient_viewer(",
-  "recipient_operation_context(",
-  "if self.recipient_context_port.is_none()",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "Err(ForumError::CapabilityFailure {",
-  "retryable: false, ..",
+  "async fn load_active_topic(", "async fn load_topic_for_subscription_audience(",
+  "async fn load_mention_target_for_recipient(", "async fn topic_subscription_recipient_visible(",
+  "async fn resolve_recipient_viewer(", "recipient_operation_context(",
+  "if self.recipient_context_port.is_none()", "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()", "Err(ForumError::CapabilityFailure {", "retryable: false, ..",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
   ".is_topic_visible(tenant_id, topic_id, None, viewer)",
   "load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)",
-]) {
-  requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
-}
-
+]) requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
 for (const forbidden of [
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-  "Rbac::permissions_for_role",
-  "SecurityContext::new(",
-]) {
-  rejectText(
-    source,
-    forbidden,
-    `forum notification recipient paths must reuse owners instead of ${forbidden}`,
-  );
-}
+  "forum_category_audience_policy", "forum_category_audience_role", "forum_category_audience_channel",
+  "forum_category_audience_group", "forum_category_audience_user", "forum_topic_audience_policy",
+  "forum_topic_audience_role", "forum_topic_audience_channel", "forum_topic_audience_group",
+  "forum_topic_audience_user", "Rbac::permissions_for_role", "SecurityContext::new(",
+]) rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
 
-const describeBlock = between(
-  source,
-  "async fn describe_event(",
-  "async fn resolve_audience(",
-  "forum notification describe_event",
-);
-const audienceBlock = between(
-  source,
-  "async fn resolve_audience(",
-  "async fn authorize_target_open(",
-  "forum notification resolve_audience",
-);
-const targetOpenBlock = between(
-  source,
-  "async fn authorize_target_open(",
-  "fn recipient_operation_context(",
-  "forum notification authorize_target_open",
-);
+const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "forum notification describe_event");
+const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "forum notification resolve_audience");
+const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "forum notification authorize_target_open");
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "topic-created exact subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "shared target-open recipient resolution"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
-for (const marker of [
-  "pub fn authenticated(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "resolve_for_constraints(",
-  "Local allow/deny/role resolution intentionally skips owner-port calls",
-]) {
-  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumNotificationRecipientContextResolver",
-  "pub async fn resolve(",
-  "validate_caller_context(&caller_context, tenant_id)?",
-  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
-  "SecurityContext::try_from_port_context(&recipient_context)",
-  "pub fn into_topic_viewer(self)",
-]) {
-  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
-}
+for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints(", "Local allow/deny/role resolution intentionally skips owner-port calls"]) requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "pub async fn resolve(", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "SecurityContext::try_from_port_context(&recipient_context)", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
 
 for (const marker of [
   "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
-  "roles_any: vec![role]",
-  "Forum source factory should consume the recipient capability",
-  "customer topic mention should be describable",
-  "customer topic mention audience should resolve",
-  "customer reply mention should be describable",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort", "roles_any: vec![role]",
+  "Forum source factory should consume the recipient capability", "customer topic mention should be describable",
+  "customer topic mention audience should resolve", "customer reply mention should be describable",
+  "customer reply mention audience should resolve", "manager topic mention description should fail closed",
   "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
-}
+]) requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
 for (const marker of [
   "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "first_page.recipients().is_empty()",
-  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
-  "second_page.recipients()[0].recipient_id, allowed_third",
-  "third_page.recipients()[0].recipient_id, allowed_fifth",
-]) {
-  requireText(downstreamTestSource, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
-}
+  "roles_any: vec![UserRole::Customer]", "topic audience should become non-public and deny exact recipients",
+  "first_page.recipients().is_empty()", "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third", "third_page.recipients()[0].recipient_id, allowed_fifth",
+]) requireText(downstreamTestSource, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
 
-if (
-  upstream.schema_version !== 3 ||
-  upstream.task !== "FORUM-20N" ||
-  upstream.downstream_task !== "FORUM-20O" ||
-  upstream.downstream_chain_task !== "FORUM-20P" ||
-  upstream.composition?.recipient_specific_mention_description !== true ||
-  upstream.composition?.recipient_specific_mention_audience !== true ||
-  upstream.composition?.recipient_specific_topic_subscription_audience !== true
-) {
-  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20N recipient contract through P");
-}
-if (
-  visibilityContract.schema_version !== 7 ||
-  visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20P" ||
-  visibilityContract.composition?.recipient_specific_mention_description !== true ||
-  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
-  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
-) {
-  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20K visibility composition contract through P");
-}
-if (
-  downstream.schema_version !== 1 ||
-  downstream.task !== "FORUM-20P" ||
-  downstream.upstream_task !== "FORUM-20O" ||
-  downstream.composition?.bounded_raw_keyset_scan !== true ||
-  downstream.composition?.recipient_specific_topic_visibility !== true
-) {
-  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20P topic subscription consumer");
-}
+if (upstream.schema_version !== 3 || upstream.task !== "FORUM-20N" || upstream.downstream_task !== "FORUM-20O" || upstream.downstream_chain_task !== "FORUM-20P" || upstream.composition?.recipient_specific_mention_description !== true || upstream.composition?.recipient_specific_mention_audience !== true || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20N/P");
+if (visibilityContract.schema_version !== 7 || visibilityContract.task !== "FORUM-20K" || visibilityContract.downstream_task !== "FORUM-20P" || visibilityContract.composition?.topic_subscription_active_source_recheck !== true || visibilityContract.composition?.recipient_specific_mention_description !== true || visibilityContract.composition?.recipient_specific_mention_audience !== true || visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20K/P");
+if (downstream.schema_version !== 1 || downstream.task !== "FORUM-20P" || downstream.upstream_task !== "FORUM-20O" || downstream.composition?.active_topic_source_recheck !== true || downstream.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || downstream.composition?.bounded_raw_keyset_scan !== true || downstream.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20P");
 
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
-
+for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
 if (failures.length > 0) {
   console.error("Forum notification recipient mention audience verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient mention audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
@@ -5,91 +5,310 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
 const failures = [];
+
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
-function between(source, start, end, label) {
-  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
-  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
-  return source.slice(a, b);
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json") || "{}");
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-mention-audience.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
-const visibility = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
 const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const mentionTest = read(contract.test_file ?? "");
-const subscriptionTest = read(contract.downstream_test_file ?? "");
+const testSource = read(contract.test_file ?? "");
+const downstreamTestSource = read(contract.downstream_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) failures.push("forum notification recipient mention contract must use schema_version=2");
-if (contract.task !== "FORUM-20O" || contract.upstream_task !== "FORUM-20N" || contract.downstream_task !== "FORUM-20P") failures.push("mention contract must connect FORUM-20N/O/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("mention contract must not claim unexecuted evidence");
+if (contract.schema_version !== 2) {
+  failures.push("forum notification recipient mention audience contract must use schema_version=2");
+}
+if (
+  contract.task !== "FORUM-20O" ||
+  contract.upstream_task !== "FORUM-20N" ||
+  contract.downstream_task !== "FORUM-20P"
+) {
+  failures.push("forum notification recipient mention audience contract must connect FORUM-20N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient mention audience publication must not claim unexecuted evidence");
+}
 
-for (const field of [
-  "shared_recipient_resolution_helper", "bounded_mention_description_context", "bounded_mention_audience_context",
-  "exact_mention_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "topic_mention_target", "reply_mention_target", "public_only_fallback",
-  "unavailable_recipient_fail_closed", "retryability_preserved", "stale_descriptor_recheck",
-  "topic_created_description_unchanged", "topic_created_subscription_audience_downstream",
-  "sqlite_contract_test", "downstream_sqlite_contract_test",
-]) if (contract.composition?.[field] !== true) failures.push(`mention contract must record ${field}=true`);
+for (const delivered of [
+  "shared_recipient_resolution_helper",
+  "bounded_mention_description_context",
+  "bounded_mention_audience_context",
+  "exact_mention_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "topic_mention_target",
+  "reply_mention_target",
+  "public_only_fallback",
+  "unavailable_recipient_fail_closed",
+  "retryability_preserved",
+  "stale_descriptor_recheck",
+  "topic_created_description_unchanged",
+  "topic_created_subscription_audience_downstream",
+  "sqlite_contract_test",
+  "downstream_sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient mention audience contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`mention contract must keep ${residual} open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient mention audience contract must keep ${residual} explicitly open`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("mention contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification recipient mention audience contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient mention audience contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(
+    plan,
+    "FORUM-20A-P provide",
+    "synchronized canonical plan must advance the FORUM-20 ledger through P",
+  );
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
   "const MENTION_DESCRIBE_ACTOR: &str = \"forum-notification-mention-describe\"",
   "const MENTION_AUDIENCE_ACTOR: &str = \"forum-notification-mention-audience\"",
-  "async fn load_mention_target_for_recipient(", "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
+  "const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = \"forum-notification-topic-subscription-audience\"",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "async fn resolve_recipient_viewer(",
+  "recipient_operation_context(",
+  "if self.recipient_context_port.is_none()",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn topic_subscription_recipient_visible(",
-]) requireText(source, marker, `mention source is missing ${marker}`);
-for (const forbidden of ["forum_category_audience_policy", "forum_topic_audience_policy", "Rbac::permissions_for_role", "SecurityContext::new("]) rejectText(source, forbidden, `notification recipient paths must reuse owners instead of ${forbidden}`);
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "load_public_target(event.tenant_id, &payload.source_kind, payload.source_id)",
+]) {
+  requireText(source, marker, `forum notification recipient mention source is missing ${marker}`);
+}
 
-const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
-const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(
+    source,
+    forbidden,
+    `forum notification recipient paths must reuse owners instead of ${forbidden}`,
+  );
+}
+
+const describeBlock = between(
+  source,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  source,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  source,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
 for (const [block, marker, label] of [
-  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic descriptor"],
-  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
-  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
-  [audience, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "topic_subscription_recipient_visible(", "topic-created exact subscription audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "shared target-open recipient resolution"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
-for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints("]) requireText(visibilityOwner, marker, `visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient owner is missing ${marker}`);
-for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
-for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 3 || upstream.task !== "FORUM-20N" || upstream.downstream_chain_task !== "FORUM-20P" || upstream.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20N/P");
-if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20K/P");
-if (downstream.schema_version !== 1 || downstream.task !== "FORUM-20P" || downstream.upstream_task !== "FORUM-20O" || downstream.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20O must remain synchronized with FORUM-20P");
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![role]",
+  "Forum source factory should consume the recipient capability",
+  "customer topic mention should be describable",
+  "customer topic mention audience should resolve",
+  "customer reply mention should be describable",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(testSource, marker, `recipient mention SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth",
+]) {
+  requireText(downstreamTestSource, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 3 ||
+  upstream.task !== "FORUM-20N" ||
+  upstream.downstream_task !== "FORUM-20O" ||
+  upstream.downstream_chain_task !== "FORUM-20P" ||
+  upstream.composition?.recipient_specific_mention_description !== true ||
+  upstream.composition?.recipient_specific_mention_audience !== true ||
+  upstream.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20N recipient contract through P");
+}
+if (
+  visibilityContract.schema_version !== 7 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20P" ||
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
+  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20K visibility composition contract through P");
+}
+if (
+  downstream.schema_version !== 1 ||
+  downstream.task !== "FORUM-20P" ||
+  downstream.upstream_task !== "FORUM-20O" ||
+  downstream.composition?.bounded_raw_keyset_scan !== true ||
+  downstream.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20O mention audience must remain synchronized with the FORUM-20P topic subscription consumer");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum notification recipient mention audience verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient mention audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -18,28 +18,16 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
+  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
   return source.slice(startIndex, endIndex);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-target-open.json") || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
@@ -52,269 +40,86 @@ const mentionTest = read(contract.downstream_test_file ?? "");
 const subscriptionTest = read(contract.downstream_chain_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) {
-  failures.push("forum notification recipient contract must use schema_version=3");
-}
-if (
-  contract.task !== "FORUM-20N" ||
-  contract.upstream_task !== "FORUM-20M" ||
-  contract.downstream_task !== "FORUM-20O" ||
-  contract.downstream_chain_task !== "FORUM-20P"
-) {
-  failures.push("forum notification recipient contract must connect FORUM-20M/N/O/P");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient authorization publication must not claim unexecuted evidence");
-}
+if (contract.schema_version !== 3) failures.push("forum notification recipient contract must use schema_version=3");
+if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M" || contract.downstream_task !== "FORUM-20O" || contract.downstream_chain_task !== "FORUM-20P") failures.push("forum notification recipient contract must connect FORUM-20M/N/O/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient authorization publication must not claim unexecuted evidence");
 
 for (const delivered of [
-  "factory_recipient_capability_lookup",
-  "factory_facts_capability_lookup",
-  "bounded_target_open_context",
-  "exact_recipient_resolution",
-  "authenticated_topic_viewer",
-  "recipient_specific_topic_open",
-  "recipient_specific_reply_open",
-  "public_only_fallback",
-  "inactive_or_missing_recipient_fail_closed",
-  "retryability_preserved",
-  "topic_created_public_description_unchanged",
-  "recipient_specific_topic_subscription_audience",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "shared_recipient_resolution_helper",
-  "sqlite_contract_test",
-  "downstream_sqlite_contract_test",
-  "downstream_chain_sqlite_contract_test",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
-  }
-}
+  "factory_recipient_capability_lookup", "factory_facts_capability_lookup", "bounded_target_open_context",
+  "exact_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_topic_open",
+  "recipient_specific_reply_open", "public_only_fallback", "inactive_or_missing_recipient_fail_closed",
+  "retryability_preserved", "topic_created_public_description_unchanged",
+  "recipient_specific_topic_subscription_audience", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "shared_recipient_resolution_helper", "sqlite_contract_test",
+  "downstream_sqlite_contract_test", "downstream_chain_sqlite_contract_test",
+]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
 for (const residual of [
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-];
+const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P") {
-  failures.push("forum notification recipient contract must require the canonical ledger through FORUM-20P");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20P delivered sections");
-}
+if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20P");
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
+  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
+  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
+  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
-  "facts_port: Option<SharedForumAudienceFactsPort>",
-  "async fn load_topic_for_viewer(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_target_for_viewer(",
-  "reply.status == ReplyStatus::Pending",
-  "reply.status != ReplyStatus::Approved",
-  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
-  "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "recipient_operation_context(",
-  "target_open_context(&request)",
-  "Err(ForumError::CapabilityFailure {",
-  "retryable: false, ..",
-  "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
-  "ForumError::CapabilityUnavailable { .. }",
-  "NotificationProviderError::CapabilityUnavailable { retryable: true }",
-  "async fn load_mention_target_for_recipient(",
-  "MENTION_DESCRIBE_ACTOR",
-  "MENTION_AUDIENCE_ACTOR",
-  "async fn topic_subscription_recipient_visible(",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>", "facts_port: Option<SharedForumAudienceFactsPort>",
+  "async fn load_active_topic(", "async fn load_topic_for_viewer(", "async fn load_topic_for_subscription_audience(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())", ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_target_for_viewer(", "reply.status == ReplyStatus::Pending", "reply.status != ReplyStatus::Approved",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)", "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()", "recipient_operation_context(",
+  "target_open_context(&request)", "Err(ForumError::CapabilityFailure {", "retryable: false, ..",
+  "self.load_public_target(request.tenant_id, source_kind, request.target.id)", "ForumError::CapabilityUnavailable { .. }",
+  "NotificationProviderError::CapabilityUnavailable { retryable: true }", "async fn load_mention_target_for_recipient(",
+  "MENTION_DESCRIBE_ACTOR", "MENTION_AUDIENCE_ACTOR", "async fn topic_subscription_recipient_visible(",
   "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) {
-  requireText(source, marker, `forum notification recipient source is missing ${marker}`);
-}
+]) requireText(source, marker, `forum notification recipient source is missing ${marker}`);
 for (const forbidden of [
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-  "Rbac::permissions_for_role",
-  "SecurityContext::new(",
-]) {
-  rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
-}
+  "forum_category_audience_policy", "forum_category_audience_role", "forum_category_audience_channel",
+  "forum_category_audience_group", "forum_category_audience_user", "forum_topic_audience_policy",
+  "forum_topic_audience_role", "forum_topic_audience_channel", "forum_topic_audience_group",
+  "forum_topic_audience_user", "Rbac::permissions_for_role", "SecurityContext::new(",
+]) rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
 
 const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
 const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
 const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "exact target-open authorization"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
-for (const marker of [
-  "pub fn authenticated(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "resolve_for_constraints(",
-  "Local allow/deny/role resolution intentionally skips owner-port calls",
-]) {
-  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumNotificationRecipientContextResolver",
-  "pub async fn resolve(",
-  "validate_caller_context(&caller_context, tenant_id)?",
-  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
-  "SecurityContext::try_from_port_context(&recipient_context)",
-  "pub fn into_topic_viewer(self)",
-]) {
-  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
-}
+for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints(", "Local allow/deny/role resolution intentionally skips owner-port calls"]) requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "pub async fn resolve(", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "SecurityContext::try_from_port_context(&recipient_context)", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
 
-for (const marker of [
-  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
-  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
-  "roles_any: vec![UserRole::Customer]",
-  "customer target-open authorization should complete",
-  "manager target-open authorization should fail closed",
-  "unavailable recipient should fail closed without an existence oracle",
-  "NotificationOpenAuthorization::Allowed",
-  "NotificationOpenAuthorization::Unavailable",
-]) {
-  requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
-}
-for (const marker of [
-  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "customer topic mention audience should resolve",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
-  "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
-}
-for (const marker of [
-  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "first_page.recipients().is_empty()",
-  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
-  "BTreeSet::from([allowed_third, allowed_fifth])",
-]) {
-  requireText(subscriptionTest, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
-}
+for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort", "roles_any: vec![UserRole::Customer]", "customer target-open authorization should complete", "manager target-open authorization should fail closed", "unavailable recipient should fail closed without an existence oracle", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
+for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "manager topic mention description should fail closed", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
+for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "roles_any: vec![UserRole::Customer]", "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()", "recorded_calls(&calls), vec![denied_first, unavailable_second]", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
 
-if (
-  upstream.schema_version !== 4 ||
-  upstream.task !== "FORUM-20M" ||
-  upstream.downstream_task !== "FORUM-20N" ||
-  upstream.topic_subscription_consumer_task !== "FORUM-20P" ||
-  upstream.composition?.notification_source_factory_consumption !== true ||
-  upstream.composition?.recipient_target_open_authorization !== true ||
-  upstream.composition?.recipient_topic_subscription_audience_authorization !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20M host runtime contract through P");
-}
-if (
-  visibilityContract.schema_version !== 7 ||
-  visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20P" ||
-  visibilityContract.composition?.recipient_specific_target_open !== true ||
-  visibilityContract.composition?.recipient_specific_mention_description !== true ||
-  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
-  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20K visibility composition contract through P");
-}
-if (
-  downstream.schema_version !== 2 ||
-  downstream.task !== "FORUM-20O" ||
-  downstream.upstream_task !== "FORUM-20N" ||
-  downstream.downstream_task !== "FORUM-20P" ||
-  downstream.composition?.recipient_specific_mention_description !== true ||
-  downstream.composition?.recipient_specific_mention_audience !== true ||
-  downstream.composition?.topic_created_subscription_audience_downstream !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20O mention audience contract through P");
-}
-if (
-  downstreamChain.schema_version !== 1 ||
-  downstreamChain.task !== "FORUM-20P" ||
-  downstreamChain.upstream_task !== "FORUM-20O" ||
-  downstreamChain.composition?.bounded_raw_keyset_scan !== true ||
-  downstreamChain.composition?.recipient_specific_topic_visibility !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20P subscription audience contract");
-}
+if (upstream.schema_version !== 4 || upstream.task !== "FORUM-20M" || upstream.downstream_task !== "FORUM-20N" || upstream.topic_subscription_consumer_task !== "FORUM-20P" || upstream.composition?.notification_source_factory_consumption !== true || upstream.composition?.recipient_target_open_authorization !== true || upstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20M/P");
+if (visibilityContract.schema_version !== 7 || visibilityContract.task !== "FORUM-20K" || visibilityContract.downstream_task !== "FORUM-20P" || visibilityContract.composition?.topic_subscription_active_source_recheck !== true || visibilityContract.composition?.recipient_specific_target_open !== true || visibilityContract.composition?.recipient_specific_mention_description !== true || visibilityContract.composition?.recipient_specific_mention_audience !== true || visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20K/P");
+if (downstream.schema_version !== 2 || downstream.task !== "FORUM-20O" || downstream.upstream_task !== "FORUM-20N" || downstream.downstream_task !== "FORUM-20P" || downstream.composition?.recipient_specific_mention_description !== true || downstream.composition?.recipient_specific_mention_audience !== true || downstream.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20O/P");
+if (downstreamChain.schema_version !== 1 || downstreamChain.task !== "FORUM-20P" || downstreamChain.upstream_task !== "FORUM-20O" || downstreamChain.composition?.active_topic_source_recheck !== true || downstreamChain.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || downstreamChain.composition?.bounded_raw_keyset_scan !== true || downstreamChain.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20P");
 
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
-
+for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
 if (failures.length > 0) {
   console.error("Forum notification recipient authorization verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient authorization contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -18,16 +18,28 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
   return source.slice(startIndex, endIndex);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-target-open.json") || "{}");
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
@@ -40,86 +52,269 @@ const mentionTest = read(contract.downstream_test_file ?? "");
 const subscriptionTest = read(contract.downstream_chain_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) failures.push("forum notification recipient contract must use schema_version=3");
-if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M" || contract.downstream_task !== "FORUM-20O" || contract.downstream_chain_task !== "FORUM-20P") failures.push("forum notification recipient contract must connect FORUM-20M/N/O/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient authorization publication must not claim unexecuted evidence");
+if (contract.schema_version !== 3) {
+  failures.push("forum notification recipient contract must use schema_version=3");
+}
+if (
+  contract.task !== "FORUM-20N" ||
+  contract.upstream_task !== "FORUM-20M" ||
+  contract.downstream_task !== "FORUM-20O" ||
+  contract.downstream_chain_task !== "FORUM-20P"
+) {
+  failures.push("forum notification recipient contract must connect FORUM-20M/N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient authorization publication must not claim unexecuted evidence");
+}
 
 for (const delivered of [
-  "factory_recipient_capability_lookup", "factory_facts_capability_lookup", "bounded_target_open_context",
-  "exact_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_topic_open",
-  "recipient_specific_reply_open", "public_only_fallback", "inactive_or_missing_recipient_fail_closed",
-  "retryability_preserved", "topic_created_public_description_unchanged",
-  "recipient_specific_topic_subscription_audience", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "shared_recipient_resolution_helper", "sqlite_contract_test",
-  "downstream_sqlite_contract_test", "downstream_chain_sqlite_contract_test",
-]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
+  "factory_recipient_capability_lookup",
+  "factory_facts_capability_lookup",
+  "bounded_target_open_context",
+  "exact_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_topic_open",
+  "recipient_specific_reply_open",
+  "public_only_fallback",
+  "inactive_or_missing_recipient_fail_closed",
+  "retryability_preserved",
+  "topic_created_public_description_unchanged",
+  "recipient_specific_topic_subscription_audience",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
+  "sqlite_contract_test",
+  "downstream_sqlite_contract_test",
+  "downstream_chain_sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
+  }
+}
 
-const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20P");
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification recipient contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20P delivered sections");
+}
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
-  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
-  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
-} else failures.push("canonical_plan_sync.status must be pending or synchronized");
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>", "facts_port: Option<SharedForumAudienceFactsPort>",
-  "async fn load_active_topic(", "async fn load_topic_for_viewer(", "async fn load_topic_for_subscription_audience(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())", ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_target_for_viewer(", "reply.status == ReplyStatus::Pending", "reply.status != ReplyStatus::Approved",
-  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)", "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()", "recipient_operation_context(",
-  "target_open_context(&request)", "Err(ForumError::CapabilityFailure {", "retryable: false, ..",
-  "self.load_public_target(request.tenant_id, source_kind, request.target.id)", "ForumError::CapabilityUnavailable { .. }",
-  "NotificationProviderError::CapabilityUnavailable { retryable: true }", "async fn load_mention_target_for_recipient(",
-  "MENTION_DESCRIBE_ACTOR", "MENTION_AUDIENCE_ACTOR", "async fn topic_subscription_recipient_visible(",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "facts_port: Option<SharedForumAudienceFactsPort>",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_target_for_viewer(",
+  "reply.status == ReplyStatus::Pending",
+  "reply.status != ReplyStatus::Approved",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
+  "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "target_open_context(&request)",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
+  "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
+  "ForumError::CapabilityUnavailable { .. }",
+  "NotificationProviderError::CapabilityUnavailable { retryable: true }",
+  "async fn load_mention_target_for_recipient(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
+  "async fn topic_subscription_recipient_visible(",
   "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) requireText(source, marker, `forum notification recipient source is missing ${marker}`);
+]) {
+  requireText(source, marker, `forum notification recipient source is missing ${marker}`);
+}
 for (const forbidden of [
-  "forum_category_audience_policy", "forum_category_audience_role", "forum_category_audience_channel",
-  "forum_category_audience_group", "forum_category_audience_user", "forum_topic_audience_policy",
-  "forum_topic_audience_role", "forum_topic_audience_channel", "forum_topic_audience_group",
-  "forum_topic_audience_user", "Rbac::permissions_for_role", "SecurityContext::new(",
-]) rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
+}
 
 const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
 const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
 const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "exact target-open authorization"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
-for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints(", "Local allow/deny/role resolution intentionally skips owner-port calls"]) requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "pub async fn resolve(", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "SecurityContext::try_from_port_context(&recipient_context)", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
 
-for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort", "roles_any: vec![UserRole::Customer]", "customer target-open authorization should complete", "manager target-open authorization should fail closed", "unavailable recipient should fail closed without an existence oracle", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
-for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "manager topic mention description should fail closed", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
-for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "roles_any: vec![UserRole::Customer]", "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()", "recorded_calls(&calls), vec![denied_first, unavailable_second]", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "customer target-open authorization should complete",
+  "manager target-open authorization should fail closed",
+  "unavailable recipient should fail closed without an existence oracle",
+  "NotificationOpenAuthorization::Allowed",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(subscriptionTest, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 4 || upstream.task !== "FORUM-20M" || upstream.downstream_task !== "FORUM-20N" || upstream.topic_subscription_consumer_task !== "FORUM-20P" || upstream.composition?.notification_source_factory_consumption !== true || upstream.composition?.recipient_target_open_authorization !== true || upstream.composition?.recipient_topic_subscription_audience_authorization !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20M/P");
-if (visibilityContract.schema_version !== 7 || visibilityContract.task !== "FORUM-20K" || visibilityContract.downstream_task !== "FORUM-20P" || visibilityContract.composition?.topic_subscription_active_source_recheck !== true || visibilityContract.composition?.recipient_specific_target_open !== true || visibilityContract.composition?.recipient_specific_mention_description !== true || visibilityContract.composition?.recipient_specific_mention_audience !== true || visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20K/P");
-if (downstream.schema_version !== 2 || downstream.task !== "FORUM-20O" || downstream.upstream_task !== "FORUM-20N" || downstream.downstream_task !== "FORUM-20P" || downstream.composition?.recipient_specific_mention_description !== true || downstream.composition?.recipient_specific_mention_audience !== true || downstream.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20O/P");
-if (downstreamChain.schema_version !== 1 || downstreamChain.task !== "FORUM-20P" || downstreamChain.upstream_task !== "FORUM-20O" || downstreamChain.composition?.active_topic_source_recheck !== true || downstreamChain.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || downstreamChain.composition?.bounded_raw_keyset_scan !== true || downstreamChain.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20P");
+if (
+  upstream.schema_version !== 4 ||
+  upstream.task !== "FORUM-20M" ||
+  upstream.downstream_task !== "FORUM-20N" ||
+  upstream.topic_subscription_consumer_task !== "FORUM-20P" ||
+  upstream.composition?.notification_source_factory_consumption !== true ||
+  upstream.composition?.recipient_target_open_authorization !== true ||
+  upstream.composition?.recipient_topic_subscription_audience_authorization !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20M host runtime contract through P");
+}
+if (
+  visibilityContract.schema_version !== 7 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20P" ||
+  visibilityContract.composition?.recipient_specific_target_open !== true ||
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
+  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20K visibility composition contract through P");
+}
+if (
+  downstream.schema_version !== 2 ||
+  downstream.task !== "FORUM-20O" ||
+  downstream.upstream_task !== "FORUM-20N" ||
+  downstream.downstream_task !== "FORUM-20P" ||
+  downstream.composition?.recipient_specific_mention_description !== true ||
+  downstream.composition?.recipient_specific_mention_audience !== true ||
+  downstream.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20O mention audience contract through P");
+}
+if (
+  downstreamChain.schema_version !== 1 ||
+  downstreamChain.task !== "FORUM-20P" ||
+  downstreamChain.upstream_task !== "FORUM-20O" ||
+  downstreamChain.composition?.bounded_raw_keyset_scan !== true ||
+  downstreamChain.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20P subscription audience contract");
+}
 
-for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
 if (failures.length > 0) {
   console.error("Forum notification recipient authorization verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient authorization contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -5,100 +5,316 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
 const failures = [];
+
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
-function between(source, start, end, label) {
-  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
-  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
-  return source.slice(a, b);
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-target-open.json") || "{}");
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
-const visibility = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
-const mention = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const subscriptions = JSON.parse(read(contract.downstream_chain_contract ?? "") || "{}");
-const targetTest = read(contract.test_file ?? "");
+const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const downstreamChain = JSON.parse(read(contract.downstream_chain_contract ?? "") || "{}");
+const targetOpenTest = read(contract.test_file ?? "");
 const mentionTest = read(contract.downstream_test_file ?? "");
 const subscriptionTest = read(contract.downstream_chain_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) failures.push("forum notification recipient contract must use schema_version=3");
-if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M" || contract.downstream_task !== "FORUM-20O" || contract.downstream_chain_task !== "FORUM-20P") failures.push("recipient contract must connect FORUM-20M/N/O/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient contract must not claim unexecuted evidence");
+if (contract.schema_version !== 3) {
+  failures.push("forum notification recipient contract must use schema_version=3");
+}
+if (
+  contract.task !== "FORUM-20N" ||
+  contract.upstream_task !== "FORUM-20M" ||
+  contract.downstream_task !== "FORUM-20O" ||
+  contract.downstream_chain_task !== "FORUM-20P"
+) {
+  failures.push("forum notification recipient contract must connect FORUM-20M/N/O/P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("recipient authorization publication must not claim unexecuted evidence");
+}
 
-for (const field of [
-  "factory_recipient_capability_lookup", "factory_facts_capability_lookup", "bounded_target_open_context",
-  "exact_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_topic_open",
-  "recipient_specific_reply_open", "public_only_fallback", "inactive_or_missing_recipient_fail_closed",
-  "retryability_preserved", "topic_created_public_description_unchanged",
-  "recipient_specific_topic_subscription_audience", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "shared_recipient_resolution_helper", "sqlite_contract_test",
-  "downstream_sqlite_contract_test", "downstream_chain_sqlite_contract_test",
-]) if (contract.composition?.[field] !== true) failures.push(`recipient contract must record ${field}=true`);
+for (const delivered of [
+  "factory_recipient_capability_lookup",
+  "factory_facts_capability_lookup",
+  "bounded_target_open_context",
+  "exact_recipient_resolution",
+  "authenticated_topic_viewer",
+  "recipient_specific_topic_open",
+  "recipient_specific_reply_open",
+  "public_only_fallback",
+  "inactive_or_missing_recipient_fail_closed",
+  "retryability_preserved",
+  "topic_created_public_description_unchanged",
+  "recipient_specific_topic_subscription_audience",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
+  "sqlite_contract_test",
+  "downstream_sqlite_contract_test",
+  "downstream_chain_sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`recipient contract must keep ${residual} open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("recipient contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification recipient contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_target_for_viewer(",
-  "reply.status == ReplyStatus::Pending", "reply.status != ReplyStatus::Approved",
-  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)", "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
-  "target_open_context(&request)", "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-  "ForumError::CapabilityUnavailable { .. }", "NotificationProviderError::CapabilityUnavailable { retryable: true }",
-]) requireText(source, marker, `recipient source is missing ${marker}`);
-for (const forbidden of ["forum_category_audience_policy", "forum_topic_audience_policy", "Rbac::permissions_for_role", "SecurityContext::new("]) rejectText(source, forbidden, `recipient paths must reuse owners instead of ${forbidden}`);
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
+  "facts_port: Option<SharedForumAudienceFactsPort>",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_target_for_viewer(",
+  "reply.status == ReplyStatus::Pending",
+  "reply.status != ReplyStatus::Approved",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
+  "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "target_open_context(&request)",
+  "Err(ForumError::CapabilityFailure {",
+  "retryable: false, ..",
+  "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
+  "ForumError::CapabilityUnavailable { .. }",
+  "NotificationProviderError::CapabilityUnavailable { retryable: true }",
+  "async fn load_mention_target_for_recipient(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
+  "async fn topic_subscription_recipient_visible(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) {
+  requireText(source, marker, `forum notification recipient source is missing ${marker}`);
+}
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
+}
 
-const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
-const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
-const targetOpen = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
+const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
+const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
+const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
 for (const [block, marker, label] of [
-  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic descriptor"],
-  [audience, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
-  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
-  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
-  [targetOpen, "resolve_recipient_viewer(", "exact target-open"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "exact target-open authorization"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
-for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints("]) requireText(visibilityOwner, marker, `visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient owner is missing ${marker}`);
-for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetTest, marker, `target-open test is missing ${marker}`);
-for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
-for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
 
-if (upstream.schema_version !== 4 || upstream.task !== "FORUM-20M" || upstream.topic_subscription_consumer_task !== "FORUM-20P") failures.push("FORUM-20N must remain synchronized with FORUM-20M/P");
-if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20K/P");
-if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P") failures.push("FORUM-20N must remain synchronized with FORUM-20O/P");
-if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20P");
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "customer target-open authorization should complete",
+  "manager target-open authorization should fail closed",
+  "unavailable recipient should fail closed without an existence oracle",
+  "NotificationOpenAuthorization::Allowed",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(subscriptionTest, marker, `recipient topic subscription SQLite contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 4 ||
+  upstream.task !== "FORUM-20M" ||
+  upstream.downstream_task !== "FORUM-20N" ||
+  upstream.topic_subscription_consumer_task !== "FORUM-20P" ||
+  upstream.composition?.notification_source_factory_consumption !== true ||
+  upstream.composition?.recipient_target_open_authorization !== true ||
+  upstream.composition?.recipient_topic_subscription_audience_authorization !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20M host runtime contract through P");
+}
+if (
+  visibilityContract.schema_version !== 7 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20P" ||
+  visibilityContract.composition?.recipient_specific_target_open !== true ||
+  visibilityContract.composition?.recipient_specific_mention_description !== true ||
+  visibilityContract.composition?.recipient_specific_mention_audience !== true ||
+  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20K visibility composition contract through P");
+}
+if (
+  downstream.schema_version !== 2 ||
+  downstream.task !== "FORUM-20O" ||
+  downstream.upstream_task !== "FORUM-20N" ||
+  downstream.downstream_task !== "FORUM-20P" ||
+  downstream.composition?.recipient_specific_mention_description !== true ||
+  downstream.composition?.recipient_specific_mention_audience !== true ||
+  downstream.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20O mention audience contract through P");
+}
+if (
+  downstreamChain.schema_version !== 1 ||
+  downstreamChain.task !== "FORUM-20P" ||
+  downstreamChain.upstream_task !== "FORUM-20O" ||
+  downstreamChain.composition?.bounded_raw_keyset_scan !== true ||
+  downstreamChain.composition?.recipient_specific_topic_visibility !== true
+) {
+  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20P subscription audience contract");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum notification recipient authorization verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification recipient authorization contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-recipient-target-open.mjs
+++ b/scripts/verify/verify-forum-notification-recipient-target-open.mjs
@@ -5,287 +5,100 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
-  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
-  : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
 const failures = [];
-
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) {
-    failures.push(`${relativePath}: required file is missing`);
-    return "";
-  }
+  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
-  const startIndex = source.indexOf(start);
-  const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
-  return source.slice(startIndex, endIndex);
+  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
+  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  return source.slice(a, b);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-recipient-target-open.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-recipient-target-open.json") || "{}");
 const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const recipientOwner = read(contract.recipient_context_owner_file ?? "");
 const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
-const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
-const downstream = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
-const targetOpenTest = read(contract.test_file ?? "");
+const visibility = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const mention = JSON.parse(read(contract.downstream_contract ?? "") || "{}");
+const subscriptions = JSON.parse(read(contract.downstream_chain_contract ?? "") || "{}");
+const targetTest = read(contract.test_file ?? "");
 const mentionTest = read(contract.downstream_test_file ?? "");
+const subscriptionTest = read(contract.downstream_chain_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 2) {
-  failures.push("forum notification recipient contract must use schema_version=2");
-}
-if (
-  contract.task !== "FORUM-20N" ||
-  contract.upstream_task !== "FORUM-20M" ||
-  contract.downstream_task !== "FORUM-20O"
-) {
-  failures.push("forum notification recipient contract must connect FORUM-20M/N/O");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("recipient authorization publication must not claim unexecuted evidence");
-}
+if (contract.schema_version !== 3) failures.push("forum notification recipient contract must use schema_version=3");
+if (contract.task !== "FORUM-20N" || contract.upstream_task !== "FORUM-20M" || contract.downstream_task !== "FORUM-20O" || contract.downstream_chain_task !== "FORUM-20P") failures.push("recipient contract must connect FORUM-20M/N/O/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("recipient contract must not claim unexecuted evidence");
 
-for (const delivered of [
-  "factory_recipient_capability_lookup",
-  "factory_facts_capability_lookup",
-  "bounded_target_open_context",
-  "exact_recipient_resolution",
-  "authenticated_topic_viewer",
-  "recipient_specific_topic_open",
-  "recipient_specific_reply_open",
-  "public_only_fallback",
-  "inactive_or_missing_recipient_fail_closed",
-  "retryability_preserved",
-  "topic_created_public_description_unchanged",
-  "topic_created_public_audience_unchanged",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "shared_recipient_resolution_helper",
-  "sqlite_contract_test",
-  "downstream_sqlite_contract_test",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification recipient contract must record ${delivered} as delivered`);
-  }
-}
+for (const field of [
+  "factory_recipient_capability_lookup", "factory_facts_capability_lookup", "bounded_target_open_context",
+  "exact_recipient_resolution", "authenticated_topic_viewer", "recipient_specific_topic_open",
+  "recipient_specific_reply_open", "public_only_fallback", "inactive_or_missing_recipient_fail_closed",
+  "retryability_preserved", "topic_created_public_description_unchanged",
+  "recipient_specific_topic_subscription_audience", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "shared_recipient_resolution_helper", "sqlite_contract_test",
+  "downstream_sqlite_contract_test", "downstream_chain_sqlite_contract_test",
+]) if (contract.composition?.[field] !== true) failures.push(`recipient contract must record ${field}=true`);
 for (const residual of [
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters",
-  "final notification creation and delivery authorization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification recipient contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters", "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`recipient contract must keep ${residual} open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum notification recipient contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification recipient contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("recipient contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "recipient_context_port: Option<SharedForumNotificationRecipientContextPort>",
-  "facts_port: Option<SharedForumAudienceFactsPort>",
-  "async fn load_topic_for_viewer(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_target_for_viewer(",
-  "reply.status == ReplyStatus::Pending",
-  "reply.status != ReplyStatus::Approved",
-  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)",
-  "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "recipient_operation_context(",
-  "target_open_context(&request)",
-  "Err(ForumError::CapabilityFailure {",
-  "retryable: false, ..",
-  "self.load_public_target(request.tenant_id, source_kind, request.target.id)",
-  "ForumError::CapabilityUnavailable { .. }",
-  "NotificationProviderError::CapabilityUnavailable { retryable: true }",
-  "async fn load_mention_target_for_recipient(",
-  "MENTION_DESCRIBE_ACTOR",
-  "MENTION_AUDIENCE_ACTOR",
-]) {
-  requireText(source, marker, `forum notification recipient source is missing ${marker}`);
-}
-for (const forbidden of [
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-  "Rbac::permissions_for_role",
-  "SecurityContext::new(",
-]) {
-  rejectText(source, forbidden, `forum notification recipient paths must reuse owners instead of ${forbidden}`);
-}
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_target_for_viewer(",
+  "reply.status == ReplyStatus::Pending", "reply.status != ReplyStatus::Approved",
+  "const RECIPIENT_CONTEXT_DEADLINE: Duration = Duration::from_secs(2)", "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
+  "target_open_context(&request)", "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+  "ForumError::CapabilityUnavailable { .. }", "NotificationProviderError::CapabilityUnavailable { retryable: true }",
+]) requireText(source, marker, `recipient source is missing ${marker}`);
+for (const forbidden of ["forum_category_audience_policy", "forum_topic_audience_policy", "Rbac::permissions_for_role", "SecurityContext::new("]) rejectText(source, forbidden, `recipient paths must reuse owners instead of ${forbidden}`);
 
-const describeBlock = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
-const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
-const targetOpenBlock = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
+const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
+const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
+const targetOpen = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
 for (const [block, marker, label] of [
-  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
-  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
-  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
-  [targetOpenBlock, "resolve_recipient_viewer(", "exact target-open authorization"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic descriptor"],
+  [audience, "topic_subscription_recipient_visible(", "exact topic subscription audience"],
+  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "exact mention description"],
+  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "exact mention audience"],
+  [targetOpen, "resolve_recipient_viewer(", "exact target-open"],
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
-for (const marker of [
-  "pub fn authenticated(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "resolve_for_constraints(",
-  "Local allow/deny/role resolution intentionally skips owner-port calls",
-]) {
-  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumNotificationRecipientContextResolver",
-  "pub async fn resolve(",
-  "validate_caller_context(&caller_context, tenant_id)?",
-  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
-  "SecurityContext::try_from_port_context(&recipient_context)",
-  "pub fn into_topic_viewer(self)",
-]) {
-  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
-}
+for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints("]) requireText(visibilityOwner, marker, `visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient owner is missing ${marker}`);
+for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetTest, marker, `target-open test is missing ${marker}`);
+for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
+for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
 
-for (const marker of [
-  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
-  "impl ForumNotificationRecipientContextPort for StaticRecipientContextPort",
-  "roles_any: vec![UserRole::Customer]",
-  "customer target-open authorization should complete",
-  "manager target-open authorization should fail closed",
-  "unavailable recipient should fail closed without an existence oracle",
-  "NotificationOpenAuthorization::Allowed",
-  "NotificationOpenAuthorization::Unavailable",
-]) {
-  requireText(targetOpenTest, marker, `recipient target-open SQLite contract is missing ${marker}`);
-}
-for (const marker of [
-  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "customer topic mention audience should resolve",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
-  "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(mentionTest, marker, `recipient mention SQLite contract is missing ${marker}`);
-}
-
-if (
-  upstream.schema_version !== 2 ||
-  upstream.task !== "FORUM-20M" ||
-  upstream.downstream_task !== "FORUM-20N" ||
-  upstream.composition?.notification_source_factory_consumption !== true ||
-  upstream.composition?.recipient_target_open_authorization !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20M host runtime contract");
-}
-if (
-  visibilityContract.schema_version !== 6 ||
-  visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20O" ||
-  visibilityContract.composition?.recipient_specific_target_open !== true ||
-  visibilityContract.composition?.recipient_specific_mention_description !== true ||
-  visibilityContract.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20K visibility composition contract");
-}
-if (
-  downstream.schema_version !== 1 ||
-  downstream.task !== "FORUM-20O" ||
-  downstream.upstream_task !== "FORUM-20N" ||
-  downstream.composition?.recipient_specific_mention_description !== true ||
-  downstream.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20N recipient authorization must remain synchronized with the FORUM-20O mention audience contract");
-}
-
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
+if (upstream.schema_version !== 4 || upstream.task !== "FORUM-20M" || upstream.topic_subscription_consumer_task !== "FORUM-20P") failures.push("FORUM-20N must remain synchronized with FORUM-20M/P");
+if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20K/P");
+if (mention.schema_version !== 2 || mention.task !== "FORUM-20O" || mention.downstream_task !== "FORUM-20P") failures.push("FORUM-20N must remain synchronized with FORUM-20O/P");
+if (subscriptions.schema_version !== 1 || subscriptions.task !== "FORUM-20P" || subscriptions.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20N must remain synchronized with FORUM-20P");
 
 if (failures.length > 0) {
   console.error("Forum notification recipient authorization verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification recipient authorization contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
+++ b/scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function requireOrder(source, markers, message) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, previous + 1);
+    if (index < 0 || index <= previous) {
+      failures.push(`${message}: missing or out-of-order marker ${marker}`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const source = read(contract.notification_source_file ?? "");
+const visibilityOwner = read(contract.visibility_owner_file ?? "");
+const recipientOwner = read(contract.recipient_context_owner_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const visibilityContract = JSON.parse(read(contract.visibility_contract ?? "") || "{}");
+const fanoutContract = JSON.parse(read(contract.fanout_contract ?? "") || "{}");
+const testSource = read(contract.test_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum topic subscription audience contract must use schema_version=1");
+}
+if (
+  contract.task !== "FORUM-20P" ||
+  contract.upstream_task !== "FORUM-20O" ||
+  contract.fanout_prerequisite_task !== "NOTIFY-03I"
+) {
+  failures.push("forum topic subscription audience contract must connect FORUM-20O/P to NOTIFY-03I");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("topic subscription audience publication must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "notification_sparse_page_prerequisite",
+  "bounded_raw_keyset_scan",
+  "limit_plus_one_lookahead",
+  "last_scanned_raw_cursor",
+  "actor_subscription_excluded",
+  "exact_recipient_context_per_scanned_subscription",
+  "authenticated_topic_viewer",
+  "recipient_specific_topic_visibility",
+  "sparse_all_denied_page",
+  "mixed_allowed_denied_page",
+  "terminal_allowed_page",
+  "public_only_fallback",
+  "unavailable_recipient_skipped",
+  "retryability_preserved",
+  "initial_descriptor_behavior_unchanged",
+  "sqlite_contract_test",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum topic subscription audience contract must record ${delivered} as delivered`);
+  }
+}
+for (const residual of [
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters",
+  "final notification creation and delivery authorization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum topic subscription audience contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum topic subscription audience contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum topic subscription audience contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = \"forum-notification-topic-subscription-audience\"",
+  "async fn topic_subscription_recipient_visible(",
+  "if self.recipient_context_port.is_none()",
+  "return Ok(true);",
+  "resolve_recipient_viewer(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+  "load_topic_for_viewer(tenant_id, topic_id, &viewer)",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  ".limit((limit + 1) as u64)",
+  "let has_more = subscriptions.len() > limit;",
+  "subscriptions.truncate(limit);",
+  "NotificationAudienceCursor::new(subscription.user_id.to_string())",
+  "for subscription in subscriptions",
+  ".topic_subscription_recipient_visible(",
+]) {
+  requireText(source, marker, `forum topic subscription source is missing ${marker}`);
+}
+
+const audienceBlock = between(
+  source,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+requireOrder(
+  audienceBlock,
+  [
+    ".limit((limit + 1) as u64)",
+    "let has_more = subscriptions.len() > limit;",
+    "subscriptions.truncate(limit);",
+    "let next_cursor = if has_more",
+    "let mut recipients = Vec::with_capacity(subscriptions.len());",
+    "for subscription in subscriptions",
+    ".topic_subscription_recipient_visible(",
+    "NotificationAudiencePage::try_new(recipients, next_cursor)",
+  ],
+  "topic subscription audience must compute raw keyset progress before exact recipient filtering",
+);
+
+for (const forbidden of [
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+  "Rbac::permissions_for_role",
+  "SecurityContext::new(",
+]) {
+  rejectText(source, forbidden, `forum topic subscription audience must reuse owners instead of ${forbidden}`);
+}
+
+for (const marker of [
+  "pub fn authenticated(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "resolve_for_constraints(",
+  "Local allow/deny/role resolution intentionally skips owner-port calls",
+]) {
+  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumNotificationRecipientContextResolver",
+  "pub async fn resolve(",
+  "validate_caller_context(&caller_context, tenant_id)?",
+  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
+  "SecurityContext::try_from_port_context(&recipient_context)",
+  "pub fn into_topic_viewer(self)",
+]) {
+  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "impl ForumNotificationRecipientContextPort for RecordingRecipientContextPort",
+  "let denied_first = Uuid::from_u128(1)",
+  "let unavailable_second = Uuid::from_u128(2)",
+  "let allowed_third = Uuid::from_u128(3)",
+  "let denied_fourth = Uuid::from_u128(4)",
+  "let allowed_fifth = Uuid::from_u128(5)",
+  "deny_user_ids: vec![denied_first, denied_fourth]",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(testSource, marker, `topic subscription SQLite contract is missing ${marker}`);
+}
+
+if (
+  fanoutContract.schema_version !== 5 ||
+  !fanoutContract.promoted_by_slices?.includes("NOTIFY-03I") ||
+  fanoutContract.fanout_job?.sparse_page_may_continue !== true ||
+  fanoutContract.fanout_job?.sparse_page_creates_no_candidates !== true ||
+  fanoutContract.fanout_job?.cursor_must_advance !== true
+) {
+  failures.push("FORUM-20P requires the NOTIFY-03I sparse fanout contract");
+}
+if (
+  upstream.schema_version !== 2 ||
+  upstream.task !== "FORUM-20O" ||
+  upstream.downstream_task !== "FORUM-20P" ||
+  upstream.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20P must remain synchronized with the FORUM-20O recipient contract");
+}
+if (
+  visibilityContract.schema_version !== 7 ||
+  visibilityContract.task !== "FORUM-20K" ||
+  visibilityContract.downstream_task !== "FORUM-20P" ||
+  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true ||
+  visibilityContract.composition?.topic_subscription_sparse_cursor !== true
+) {
+  failures.push("FORUM-20P must remain synchronized with the FORUM-20K visibility contract");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification topic subscription audience verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification topic subscription audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
+++ b/scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
@@ -18,15 +18,12 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-
 function requireText(source, marker, message) {
   if (!source.includes(marker)) failures.push(message);
 }
-
 function rejectText(source, marker, message) {
   if (source.includes(marker)) failures.push(message);
 }
-
 function requireOrder(source, markers, message) {
   let previous = -1;
   for (const marker of markers) {
@@ -38,7 +35,6 @@ function requireOrder(source, markers, message) {
     previous = index;
   }
 }
-
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
@@ -61,22 +57,14 @@ const fanoutContract = JSON.parse(read(contract.fanout_contract ?? "") || "{}");
 const testSource = read(contract.test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 1) {
-  failures.push("forum topic subscription audience contract must use schema_version=1");
-}
-if (
-  contract.task !== "FORUM-20P" ||
-  contract.upstream_task !== "FORUM-20O" ||
-  contract.fanout_prerequisite_task !== "NOTIFY-03I"
-) {
-  failures.push("forum topic subscription audience contract must connect FORUM-20O/P to NOTIFY-03I");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("topic subscription audience publication must not claim unexecuted evidence");
-}
+if (contract.schema_version !== 1) failures.push("forum topic subscription audience contract must use schema_version=1");
+if (contract.task !== "FORUM-20P" || contract.upstream_task !== "FORUM-20O" || contract.fanout_prerequisite_task !== "NOTIFY-03I") failures.push("forum topic subscription audience contract must connect FORUM-20O/P to NOTIFY-03I");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("topic subscription audience publication must not claim unexecuted evidence");
 
 for (const delivered of [
   "notification_sparse_page_prerequisite",
+  "active_topic_source_recheck",
+  "stale_public_descriptor_to_non_public_recipient_filtering",
   "bounded_raw_keyset_scan",
   "limit_plus_one_lookahead",
   "last_scanned_raw_cursor",
@@ -93,9 +81,7 @@ for (const delivered of [
   "initial_descriptor_behavior_unchanged",
   "sqlite_contract_test",
 ]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum topic subscription audience contract must record ${delivered} as delivered`);
-  }
+  if (contract.composition?.[delivered] !== true) failures.push(`forum topic subscription audience contract must record ${delivered} as delivered`);
 }
 for (const residual of [
   "initially non-public topic-created descriptor materialization",
@@ -105,62 +91,30 @@ for (const residual of [
   "search index SEO and deep-link migration",
   "PostgreSQL and cross-consumer runtime evidence",
 ]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum topic subscription audience contract must keep ${residual} explicitly open`);
-  }
+  if (!contract.not_delivered?.includes(residual)) failures.push(`forum topic subscription audience contract must keep ${residual} explicitly open`);
 }
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-];
+const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P") {
-  failures.push("forum topic subscription audience contract must require the canonical ledger through FORUM-20P");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum topic subscription audience contract must require FORUM-20H through FORUM-20P delivered sections");
-}
+if (planSync.required_ledger_through !== "FORUM-20P") failures.push("forum topic subscription audience contract must require the canonical ledger through FORUM-20P");
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum topic subscription audience contract must require FORUM-20H through FORUM-20P delivered sections");
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
+  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
+  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
 } else if (planSync.status === "synchronized") {
   requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing the delivered ${slice} section`);
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
   "const TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR: &str = \"forum-notification-topic-subscription-audience\"",
-  "async fn topic_subscription_recipient_visible(",
+  "async fn load_active_topic(",
+  "async fn load_topic_for_subscription_audience(",
   "if self.recipient_context_port.is_none()",
+  "self.load_public_topic(tenant_id, topic_id).await",
+  "self.load_active_topic(tenant_id, topic_id).await",
+  "async fn topic_subscription_recipient_visible(",
   "return Ok(true);",
   "resolve_recipient_viewer(",
   "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
@@ -173,19 +127,13 @@ for (const marker of [
   "NotificationAudienceCursor::new(subscription.user_id.to_string())",
   "for subscription in subscriptions",
   ".topic_subscription_recipient_visible(",
-]) {
-  requireText(source, marker, `forum topic subscription source is missing ${marker}`);
-}
+]) requireText(source, marker, `forum topic subscription source is missing ${marker}`);
 
-const audienceBlock = between(
-  source,
-  "async fn resolve_audience(",
-  "async fn authorize_target_open(",
-  "forum notification resolve_audience",
-);
+const audienceBlock = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "forum notification resolve_audience");
 requireOrder(
   audienceBlock,
   [
+    "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)",
     ".limit((limit + 1) as u64)",
     "let has_more = subscriptions.len() > limit;",
     "subscriptions.truncate(limit);",
@@ -195,44 +143,17 @@ requireOrder(
     ".topic_subscription_recipient_visible(",
     "NotificationAudiencePage::try_new(recipients, next_cursor)",
   ],
-  "topic subscription audience must compute raw keyset progress before exact recipient filtering",
+  "topic subscription audience must load the active source and compute raw keyset progress before exact recipient filtering",
 );
-
 for (const forbidden of [
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-  "Rbac::permissions_for_role",
-  "SecurityContext::new(",
-]) {
-  rejectText(source, forbidden, `forum topic subscription audience must reuse owners instead of ${forbidden}`);
-}
+  "forum_category_audience_policy", "forum_category_audience_role", "forum_category_audience_channel",
+  "forum_category_audience_group", "forum_category_audience_user", "forum_topic_audience_policy",
+  "forum_topic_audience_role", "forum_topic_audience_channel", "forum_topic_audience_group",
+  "forum_topic_audience_user", "Rbac::permissions_for_role", "SecurityContext::new(",
+]) rejectText(source, forbidden, `forum topic subscription audience must reuse owners instead of ${forbidden}`);
 
-for (const marker of [
-  "pub fn authenticated(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "resolve_for_constraints(",
-  "Local allow/deny/role resolution intentionally skips owner-port calls",
-]) {
-  requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumNotificationRecipientContextResolver",
-  "pub async fn resolve(",
-  "validate_caller_context(&caller_context, tenant_id)?",
-  "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?",
-  "SecurityContext::try_from_port_context(&recipient_context)",
-  "pub fn into_topic_viewer(self)",
-]) {
-  requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
-}
+for (const marker of ["pub fn authenticated(", "ForumTopicVisibilityScope::storefront_for_viewer(", "resolve_for_constraints(", "Local allow/deny/role resolution intentionally skips owner-port calls"]) requireText(visibilityOwner, marker, `authenticated visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumNotificationRecipientContextResolver", "pub async fn resolve(", "validate_caller_context(&caller_context, tenant_id)?", "validate_recipient_context(&recipient_context, tenant_id, recipient_id)?", "SecurityContext::try_from_port_context(&recipient_context)", "pub fn into_topic_viewer(self)"]) requireText(recipientOwner, marker, `recipient context owner is missing ${marker}`);
 
 for (const marker of [
   "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
@@ -242,54 +163,25 @@ for (const marker of [
   "let allowed_third = Uuid::from_u128(3)",
   "let denied_fourth = Uuid::from_u128(4)",
   "let allowed_fifth = Uuid::from_u128(5)",
+  "roles_any: vec![UserRole::Customer]",
   "deny_user_ids: vec![denied_first, denied_fourth]",
+  "topic audience should become non-public and deny exact recipients",
   "first_page.recipients().is_empty()",
   "recorded_calls(&calls), vec![denied_first, unavailable_second]",
   "second_page.recipients()[0].recipient_id, allowed_third",
   "third_page.recipients()[0].recipient_id, allowed_fifth",
   "BTreeSet::from([allowed_third, allowed_fifth])",
-]) {
-  requireText(testSource, marker, `topic subscription SQLite contract is missing ${marker}`);
-}
+]) requireText(testSource, marker, `topic subscription SQLite contract is missing ${marker}`);
 
-if (
-  fanoutContract.schema_version !== 5 ||
-  !fanoutContract.promoted_by_slices?.includes("NOTIFY-03I") ||
-  fanoutContract.fanout_job?.sparse_page_may_continue !== true ||
-  fanoutContract.fanout_job?.sparse_page_creates_no_candidates !== true ||
-  fanoutContract.fanout_job?.cursor_must_advance !== true
-) {
-  failures.push("FORUM-20P requires the NOTIFY-03I sparse fanout contract");
-}
-if (
-  upstream.schema_version !== 2 ||
-  upstream.task !== "FORUM-20O" ||
-  upstream.downstream_task !== "FORUM-20P" ||
-  upstream.composition?.topic_created_subscription_audience_downstream !== true
-) {
-  failures.push("FORUM-20P must remain synchronized with the FORUM-20O recipient contract");
-}
-if (
-  visibilityContract.schema_version !== 7 ||
-  visibilityContract.task !== "FORUM-20K" ||
-  visibilityContract.downstream_task !== "FORUM-20P" ||
-  visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true ||
-  visibilityContract.composition?.topic_subscription_sparse_cursor !== true
-) {
-  failures.push("FORUM-20P must remain synchronized with the FORUM-20K visibility contract");
-}
+if (fanoutContract.schema_version !== 5 || !fanoutContract.promoted_by_slices?.includes("NOTIFY-03I") || fanoutContract.fanout_job?.sparse_page_may_continue !== true || fanoutContract.fanout_job?.sparse_page_creates_no_candidates !== true || fanoutContract.fanout_job?.cursor_must_advance !== true) failures.push("FORUM-20P requires the NOTIFY-03I sparse fanout contract");
+if (upstream.schema_version !== 2 || upstream.task !== "FORUM-20O" || upstream.downstream_task !== "FORUM-20P" || upstream.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20P must remain synchronized with the FORUM-20O recipient contract");
+if (visibilityContract.schema_version !== 7 || visibilityContract.task !== "FORUM-20K" || visibilityContract.downstream_task !== "FORUM-20P" || visibilityContract.composition?.topic_subscription_active_source_recheck !== true || visibilityContract.composition?.recipient_specific_topic_subscription_audience !== true || visibilityContract.composition?.topic_subscription_sparse_cursor !== true) failures.push("FORUM-20P must remain synchronized with the FORUM-20K visibility contract");
 
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
+for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
 
 if (failures.length > 0) {
   console.error("Forum notification topic subscription audience verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification topic subscription audience contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -5,102 +5,353 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
 const failures = [];
+
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
-function between(source, start, end, label) {
-  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
-  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
-  return source.slice(a, b);
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-visibility-composition.json") || "{}");
-const source = read(contract.notification_source_file ?? "");
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
-const baseOwner = read(contract.base_visibility_owner_file ?? "");
-const baselineTest = read(contract.baseline_test_file ?? "");
-const richerTest = read(contract.test_file ?? "");
-const targetTest = read(contract.recipient_test_file ?? "");
-const mentionTest = read(contract.recipient_mention_test_file ?? "");
-const subscriptionTest = read(contract.recipient_topic_subscription_test_file ?? "");
-const targetContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
+const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
+const baselineTestSource = read(contract.baseline_test_file ?? "");
+const richerTestSource = read(contract.test_file ?? "");
+const recipientTestSource = read(contract.recipient_test_file ?? "");
+const mentionTestSource = read(contract.recipient_mention_test_file ?? "");
+const subscriptionTestSource = read(contract.recipient_topic_subscription_test_file ?? "");
+const recipientContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
 const mentionContract = JSON.parse(read(contract.recipient_mention_contract ?? "") || "{}");
 const subscriptionContract = JSON.parse(read(contract.recipient_topic_subscription_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 7) failures.push("forum notification visibility contract must use schema_version=7");
-if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I" || contract.downstream_task !== "FORUM-20P") failures.push("visibility contract must remain FORUM-20K and advance through FORUM-20P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("visibility contract must not claim unexecuted evidence");
-for (const field of [
-  "exact_richer_public_owner", "normalized_category_layers", "normalized_topic_layer",
-  "dynamic_policy_recheck", "recipient_context_factory_consumption", "recipient_specific_target_open",
-  "topic_created_public_description", "recipient_specific_topic_subscription_audience",
-  "topic_subscription_sparse_cursor", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "shared_recipient_resolution_helper",
-]) if (contract.composition?.[field] !== true) failures.push(`visibility contract must record ${field}=true`);
+if (contract.schema_version !== 7) {
+  failures.push("forum notification visibility contract must use schema_version=7");
+}
+if (
+  contract.task !== "FORUM-20K" ||
+  contract.supersedes_task !== "FORUM-20I" ||
+  contract.downstream_task !== "FORUM-20P"
+) {
+  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted notification evidence");
+}
+
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters for authenticated consumers", "search index SEO and deep-link migration",
-  "final notification creation and delivery authorization", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`visibility contract must keep ${residual} open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters for authenticated consumers",
+  "search index SEO and deep-link migration",
+  "final notification creation and delivery authorization",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
+  }
+}
+for (const delivered of [
+  "exact_richer_public_owner",
+  "normalized_category_layers",
+  "normalized_topic_layer",
+  "dynamic_policy_recheck",
+  "recipient_context_factory_consumption",
+  "recipient_specific_target_open",
+  "topic_created_public_description",
+  "recipient_specific_topic_subscription_audience",
+  "topic_subscription_sparse_cursor",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("visibility contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
-  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(", "load_policy_for_topic(&self.db, tenant_id, &topic)",
-]) requireText(visibilityOwner, marker, `exact visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumTopicVisibilityScope", "pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base visibility owner is missing ${marker}`);
+  "pub struct ForumTopicAudienceViewer",
+  "pub fn public() -> Self",
+  "pub fn authenticated(",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers",
+  "policy.configured_constraints",
+]) {
+  requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
+}
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
-  "async fn load_target_for_viewer(", "async fn load_mention_target_for_recipient(",
-  "async fn resolve_recipient_viewer(", "async fn topic_subscription_recipient_visible(",
-  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR", ".limit((limit + 1) as u64)",
-  "subscriptions.truncate(limit);", "for subscription in subscriptions",
+  "pub struct ForumTopicVisibilityScope",
+  "pub struct ForumTopicVisibilityService",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "all_topic_channel_access_subquery(tenant_id)",
+]) {
+  requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_public_topic(",
+  "ForumTopicAudienceViewer::public()",
+  "async fn load_target_for_viewer(",
+  "async fn load_public_target(",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+  "target_open_context(&request)",
+  ".limit((limit + 1) as u64)",
+  "subscriptions.truncate(limit);",
+  "for subscription in subscriptions",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
-]) requireText(source, marker, `notification source is missing ${marker}`);
-for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(source, forbidden, `notification source must reuse exact owner instead of ${forbidden}`);
+]) {
+  requireText(
+    notificationSource,
+    marker,
+    `forum notification source is missing exact richer visibility composition ${marker}`,
+  );
+}
+for (const forbidden of [
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
+  "async fn load_open_topic(",
+  "async fn is_channel_restricted(",
+  "forum_topic_channel_access",
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+]) {
+  rejectText(
+    notificationSource,
+    forbidden,
+    `forum notification source must reuse the richer owner instead of ${forbidden}`,
+  );
+}
 
-const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
-const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
-const targetOpen = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
+const visibilityIndex = notificationSource.indexOf(".is_topic_visible(tenant_id, topic_id, None, viewer)");
+const materializeIndex = notificationSource.indexOf("let topic = forum_topic::Entity::find()");
+if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
+  failures.push("notification richer visibility must be evaluated before topic materialization");
+}
+
+const describeBlock = between(
+  notificationSource,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  notificationSource,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  notificationSource,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
 for (const [block, marker, label] of [
-  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic description"],
-  [audience, "topic_subscription_recipient_visible(", "recipient topic subscription audience"],
-  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
-  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
-  [targetOpen, "resolve_recipient_viewer(", "recipient target-open"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "topic_subscription_recipient_visible(", "recipient topic subscription audience"],
+  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
+  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
+  [targetOpenBlock, "resolve_recipient_viewer(", "recipient target-open authorization"],
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
-for (const marker of ["forum_topic_and_user_mention_sources_support_notifications_profiles", "restricted topic description should fail closed", "NotificationProviderError::Internal { retryable: true }"]) requireText(baselineTest, marker, `baseline test is missing ${marker}`);
-for (const marker of ["notification_source_rechecks_category_and_topic_richer_visibility", "stale public descriptor should be rechecked"]) requireText(richerTest, marker, `richer visibility test is missing ${marker}`);
-for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetTest, marker, `target-open test is missing ${marker}`);
-for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
-for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
+for (const marker of [
+  "forum_topic_and_user_mention_sources_support_notifications_profiles",
+  "restricted topic description should fail closed",
+  "restricted topic authorization should fail closed",
+  "restricted mention description should fail closed",
+  "cross-tenant authorization should fail closed",
+  "closed target authorization should fail closed",
+  "NotificationProviderError::Internal { retryable: true }",
+]) {
+  requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "notification_source_rechecks_category_and_topic_richer_visibility",
+  "topic-level richer visibility should fail closed",
+  "stale public descriptor should be rechecked",
+  "category policy change should invalidate the old public descriptor",
+]) {
+  requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "SharedForumNotificationRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "NotificationOpenAuthorization::Allowed",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(subscriptionTestSource, marker, `recipient topic subscription SQLite scenario is missing ${marker}`);
+}
 
-if (targetContract.schema_version !== 3 || targetContract.task !== "FORUM-20N" || targetContract.downstream_chain_task !== "FORUM-20P" || targetContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20N/P");
-if (mentionContract.schema_version !== 2 || mentionContract.task !== "FORUM-20O" || mentionContract.downstream_task !== "FORUM-20P") failures.push("FORUM-20K must remain synchronized with FORUM-20O/P");
-if (subscriptionContract.schema_version !== 1 || subscriptionContract.task !== "FORUM-20P" || subscriptionContract.composition?.bounded_raw_keyset_scan !== true || subscriptionContract.composition?.sparse_all_denied_page !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20P");
+if (
+  recipientContract.schema_version !== 3 ||
+  recipientContract.task !== "FORUM-20N" ||
+  recipientContract.downstream_task !== "FORUM-20O" ||
+  recipientContract.downstream_chain_task !== "FORUM-20P" ||
+  recipientContract.composition?.recipient_specific_topic_open !== true ||
+  recipientContract.composition?.recipient_specific_reply_open !== true ||
+  recipientContract.composition?.recipient_specific_mention_description !== true ||
+  recipientContract.composition?.recipient_specific_mention_audience !== true ||
+  recipientContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient contract through P");
+}
+if (
+  mentionContract.schema_version !== 2 ||
+  mentionContract.task !== "FORUM-20O" ||
+  mentionContract.upstream_task !== "FORUM-20N" ||
+  mentionContract.downstream_task !== "FORUM-20P" ||
+  mentionContract.composition?.recipient_specific_mention_description !== true ||
+  mentionContract.composition?.recipient_specific_mention_audience !== true ||
+  mentionContract.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20O mention audience contract through P");
+}
+if (
+  subscriptionContract.schema_version !== 1 ||
+  subscriptionContract.task !== "FORUM-20P" ||
+  subscriptionContract.upstream_task !== "FORUM-20O" ||
+  subscriptionContract.composition?.bounded_raw_keyset_scan !== true ||
+  subscriptionContract.composition?.recipient_specific_topic_visibility !== true ||
+  subscriptionContract.composition?.sparse_all_denied_page !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20P subscription audience contract");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum notification visibility composition verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification richer visibility composition contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -5,319 +5,102 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
-  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
-  : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
 const failures = [];
-
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) {
-    failures.push(`${relativePath}: required file is missing`);
-    return "";
-  }
+  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
-  const startIndex = source.indexOf(start);
-  const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
-  return source.slice(startIndex, endIndex);
+  const a = source.indexOf(start); const b = source.indexOf(end, a + start.length);
+  if (a < 0 || b < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  return source.slice(a, b);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
-const contract = JSON.parse(read(contractPath) || "{}");
-const notificationSource = read(contract.notification_source_file ?? "");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-visibility-composition.json") || "{}");
+const source = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
-const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
-const baselineTestSource = read(contract.baseline_test_file ?? "");
-const richerTestSource = read(contract.test_file ?? "");
-const recipientTestSource = read(contract.recipient_test_file ?? "");
-const mentionTestSource = read(contract.recipient_mention_test_file ?? "");
-const recipientContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
+const baseOwner = read(contract.base_visibility_owner_file ?? "");
+const baselineTest = read(contract.baseline_test_file ?? "");
+const richerTest = read(contract.test_file ?? "");
+const targetTest = read(contract.recipient_test_file ?? "");
+const mentionTest = read(contract.recipient_mention_test_file ?? "");
+const subscriptionTest = read(contract.recipient_topic_subscription_test_file ?? "");
+const targetContract = JSON.parse(read(contract.recipient_target_open_contract ?? "") || "{}");
 const mentionContract = JSON.parse(read(contract.recipient_mention_contract ?? "") || "{}");
+const subscriptionContract = JSON.parse(read(contract.recipient_topic_subscription_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 6) {
-  failures.push("forum notification visibility contract must use schema_version=6");
-}
-if (
-  contract.task !== "FORUM-20K" ||
-  contract.supersedes_task !== "FORUM-20I" ||
-  contract.downstream_task !== "FORUM-20O"
-) {
-  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20O");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("source publication must not claim unexecuted notification evidence");
-}
-
+if (contract.schema_version !== 7) failures.push("forum notification visibility contract must use schema_version=7");
+if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I" || contract.downstream_task !== "FORUM-20P") failures.push("visibility contract must remain FORUM-20K and advance through FORUM-20P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("visibility contract must not claim unexecuted evidence");
+for (const field of [
+  "exact_richer_public_owner", "normalized_category_layers", "normalized_topic_layer",
+  "dynamic_policy_recheck", "recipient_context_factory_consumption", "recipient_specific_target_open",
+  "topic_created_public_description", "recipient_specific_topic_subscription_audience",
+  "topic_subscription_sparse_cursor", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "shared_recipient_resolution_helper",
+]) if (contract.composition?.[field] !== true) failures.push(`visibility contract must record ${field}=true`);
 for (const residual of [
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters for authenticated consumers",
-  "search index SEO and deep-link migration",
-  "final notification creation and delivery authorization",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
-  }
-}
-for (const delivered of [
-  "exact_richer_public_owner",
-  "normalized_category_layers",
-  "normalized_topic_layer",
-  "dynamic_policy_recheck",
-  "recipient_context_factory_consumption",
-  "recipient_specific_target_open",
-  "topic_created_public_description_and_audience",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "shared_recipient_resolution_helper",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters for authenticated consumers", "search index SEO and deep-link migration",
+  "final notification creation and delivery authorization", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`visibility contract must keep ${residual} open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("visibility contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer",
-  "pub fn public() -> Self",
-  "pub fn authenticated(",
-  "pub struct ForumTopicAudienceVisibilityService",
-  "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "ForumTopicVisibilityService::new(self.db.clone())",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-  "for layer in &policy.inherited_category_layers",
-  "policy.configured_constraints",
-]) {
-  requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
-}
+  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
+  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(", "load_policy_for_topic(&self.db, tenant_id, &topic)",
+]) requireText(visibilityOwner, marker, `exact visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumTopicVisibilityScope", "pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base visibility owner is missing ${marker}`);
 for (const marker of [
-  "pub struct ForumTopicVisibilityScope",
-  "pub struct ForumTopicVisibilityService",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
-  "all_topic_channel_access_subquery(tenant_id)",
-]) {
-  requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
-}
-
-for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "async fn load_topic_for_viewer(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_public_topic(",
-  "ForumTopicAudienceViewer::public()",
-  "async fn load_target_for_viewer(",
-  "async fn load_public_target(",
-  "async fn load_mention_target_for_recipient(",
-  "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "recipient_operation_context(",
-  "MENTION_DESCRIBE_ACTOR",
-  "MENTION_AUDIENCE_ACTOR",
-  "target_open_context(&request)",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
+  "async fn load_target_for_viewer(", "async fn load_mention_target_for_recipient(",
+  "async fn resolve_recipient_viewer(", "async fn topic_subscription_recipient_visible(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR", ".limit((limit + 1) as u64)",
+  "subscriptions.truncate(limit);", "for subscription in subscriptions",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
-]) {
-  requireText(
-    notificationSource,
-    marker,
-    `forum notification source is missing exact richer visibility composition ${marker}`,
-  );
-}
-for (const forbidden of [
-  "ForumTopicVisibilityScope::storefront(None)",
-  "ForumTopicVisibilityService::new(",
-  "async fn load_open_topic(",
-  "async fn is_channel_restricted(",
-  "forum_topic_channel_access",
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-]) {
-  rejectText(
-    notificationSource,
-    forbidden,
-    `forum notification source must reuse the richer owner instead of ${forbidden}`,
-  );
-}
+]) requireText(source, marker, `notification source is missing ${marker}`);
+for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(source, forbidden, `notification source must reuse exact owner instead of ${forbidden}`);
 
-const visibilityIndex = notificationSource.indexOf(".is_topic_visible(tenant_id, topic_id, None, viewer)");
-const materializeIndex = notificationSource.indexOf("let topic = forum_topic::Entity::find()");
-if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
-  failures.push("notification richer visibility must be evaluated before topic materialization");
-}
-
-const describeBlock = between(
-  notificationSource,
-  "async fn describe_event(",
-  "async fn resolve_audience(",
-  "forum notification describe_event",
-);
-const audienceBlock = between(
-  notificationSource,
-  "async fn resolve_audience(",
-  "async fn authorize_target_open(",
-  "forum notification resolve_audience",
-);
-const targetOpenBlock = between(
-  notificationSource,
-  "async fn authorize_target_open(",
-  "fn recipient_operation_context(",
-  "forum notification authorize_target_open",
-);
+const describe = between(source, "async fn describe_event(", "async fn resolve_audience(", "describe_event");
+const audience = between(source, "async fn resolve_audience(", "async fn authorize_target_open(", "resolve_audience");
+const targetOpen = between(source, "async fn authorize_target_open(", "fn recipient_operation_context(", "authorize_target_open");
 for (const [block, marker, label] of [
-  [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public audience"],
-  [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
-  [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
-  [targetOpenBlock, "resolve_recipient_viewer(", "recipient target-open authorization"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+  [describe, "load_public_topic(event.tenant_id, event.aggregate_id)", "public topic description"],
+  [audience, "topic_subscription_recipient_visible(", "recipient topic subscription audience"],
+  [describe, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
+  [audience, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
+  [targetOpen, "resolve_recipient_viewer(", "recipient target-open"],
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
-for (const marker of [
-  "forum_topic_and_user_mention_sources_support_notifications_profiles",
-  "restricted topic description should fail closed",
-  "restricted topic authorization should fail closed",
-  "restricted mention description should fail closed",
-  "cross-tenant authorization should fail closed",
-  "closed target authorization should fail closed",
-  "NotificationProviderError::Internal { retryable: true }",
-]) {
-  requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "notification_source_rechecks_category_and_topic_richer_visibility",
-  "topic-level richer visibility should fail closed",
-  "stale public descriptor should be rechecked",
-  "category policy change should invalidate the old public descriptor",
-]) {
-  requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
-  "SharedForumNotificationRecipientContextPort",
-  "roles_any: vec![UserRole::Customer]",
-  "NotificationOpenAuthorization::Allowed",
-  "NotificationOpenAuthorization::Unavailable",
-]) {
-  requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "customer topic mention audience should resolve",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
-  "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
-}
+for (const marker of ["forum_topic_and_user_mention_sources_support_notifications_profiles", "restricted topic description should fail closed", "NotificationProviderError::Internal { retryable: true }"]) requireText(baselineTest, marker, `baseline test is missing ${marker}`);
+for (const marker of ["notification_source_rechecks_category_and_topic_richer_visibility", "stale public descriptor should be rechecked"]) requireText(richerTest, marker, `richer visibility test is missing ${marker}`);
+for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(targetTest, marker, `target-open test is missing ${marker}`);
+for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "stale customer mention descriptor should be rechecked"]) requireText(mentionTest, marker, `mention test is missing ${marker}`);
+for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "first_page.recipients().is_empty()", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(subscriptionTest, marker, `subscription test is missing ${marker}`);
 
-if (
-  recipientContract.schema_version !== 2 ||
-  recipientContract.task !== "FORUM-20N" ||
-  recipientContract.downstream_task !== "FORUM-20O" ||
-  recipientContract.composition?.recipient_specific_topic_open !== true ||
-  recipientContract.composition?.recipient_specific_reply_open !== true ||
-  recipientContract.composition?.recipient_specific_mention_description !== true ||
-  recipientContract.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient contract");
-}
-if (
-  mentionContract.schema_version !== 1 ||
-  mentionContract.task !== "FORUM-20O" ||
-  mentionContract.upstream_task !== "FORUM-20N" ||
-  mentionContract.composition?.recipient_specific_mention_description !== true ||
-  mentionContract.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20O mention audience contract");
-}
-
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
+if (targetContract.schema_version !== 3 || targetContract.task !== "FORUM-20N" || targetContract.downstream_chain_task !== "FORUM-20P" || targetContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20N/P");
+if (mentionContract.schema_version !== 2 || mentionContract.task !== "FORUM-20O" || mentionContract.downstream_task !== "FORUM-20P") failures.push("FORUM-20K must remain synchronized with FORUM-20O/P");
+if (subscriptionContract.schema_version !== 1 || subscriptionContract.task !== "FORUM-20P" || subscriptionContract.composition?.bounded_raw_keyset_scan !== true || subscriptionContract.composition?.sparse_all_denied_page !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20P");
 
 if (failures.length > 0) {
   console.error("Forum notification visibility composition verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification richer visibility composition contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -18,28 +18,16 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return "";
-  }
+  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
   return source.slice(startIndex, endIndex);
 }
 
-const contractPath =
-  "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-visibility-composition.json") || "{}");
 const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
@@ -53,305 +41,105 @@ const mentionContract = JSON.parse(read(contract.recipient_mention_contract ?? "
 const subscriptionContract = JSON.parse(read(contract.recipient_topic_subscription_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 7) {
-  failures.push("forum notification visibility contract must use schema_version=7");
-}
-if (
-  contract.task !== "FORUM-20K" ||
-  contract.supersedes_task !== "FORUM-20I" ||
-  contract.downstream_task !== "FORUM-20P"
-) {
-  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20P");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("source publication must not claim unexecuted notification evidence");
-}
+if (contract.schema_version !== 7) failures.push("forum notification visibility contract must use schema_version=7");
+if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I" || contract.downstream_task !== "FORUM-20P") failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("source publication must not claim unexecuted notification evidence");
 
 for (const residual of [
-  "initially non-public topic-created descriptor materialization",
-  "profile privacy and blocking policy",
-  "host trust channel and group facts adapters for authenticated consumers",
-  "search index SEO and deep-link migration",
-  "final notification creation and delivery authorization",
-  "PostgreSQL and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
-  }
-}
+  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
+  "host trust channel and group facts adapters for authenticated consumers", "search index SEO and deep-link migration",
+  "final notification creation and delivery authorization", "PostgreSQL and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
 for (const delivered of [
-  "exact_richer_public_owner",
-  "normalized_category_layers",
-  "normalized_topic_layer",
-  "dynamic_policy_recheck",
-  "recipient_context_factory_consumption",
-  "recipient_specific_target_open",
-  "topic_created_public_description",
-  "recipient_specific_topic_subscription_audience",
-  "topic_subscription_sparse_cursor",
-  "recipient_specific_mention_description",
-  "recipient_specific_mention_audience",
-  "shared_recipient_resolution_helper",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
-  }
-}
+  "exact_richer_public_owner", "normalized_category_layers", "normalized_topic_layer", "dynamic_policy_recheck",
+  "recipient_context_factory_consumption", "recipient_specific_target_open", "topic_created_public_description",
+  "topic_subscription_active_source_recheck", "recipient_specific_topic_subscription_audience",
+  "topic_subscription_sparse_cursor", "recipient_specific_mention_description",
+  "recipient_specific_mention_audience", "shared_recipient_resolution_helper",
+]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-];
+const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P") {
-  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20P");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20P delivered sections");
-}
+if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20P");
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
+  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
+  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
+  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer",
-  "pub fn public() -> Self",
-  "pub fn authenticated(",
-  "pub struct ForumTopicAudienceVisibilityService",
-  "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "ForumTopicVisibilityService::new(self.db.clone())",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-  "for layer in &policy.inherited_category_layers",
+  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
+  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)", "for layer in &policy.inherited_category_layers",
   "policy.configured_constraints",
-]) {
-  requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumTopicVisibilityScope",
-  "pub struct ForumTopicVisibilityService",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
-  "all_topic_channel_access_subquery(tenant_id)",
-]) {
-  requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
-}
+]) requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
+for (const marker of ["pub struct ForumTopicVisibilityScope", "pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
-  "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "async fn load_topic_for_viewer(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_public_topic(",
-  "ForumTopicAudienceViewer::public()",
-  "async fn load_target_for_viewer(",
-  "async fn load_public_target(",
-  "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(",
-  "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))",
-  "recipient.into_topic_viewer()",
-  "recipient_operation_context(",
-  "MENTION_DESCRIBE_ACTOR",
-  "MENTION_AUDIENCE_ACTOR",
-  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-  "target_open_context(&request)",
-  ".limit((limit + 1) as u64)",
-  "subscriptions.truncate(limit);",
-  "for subscription in subscriptions",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_active_topic(", "async fn load_topic_for_viewer(", "async fn load_public_topic(",
+  "async fn load_topic_for_subscription_audience(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "ForumTopicAudienceViewer::public()",
+  "async fn load_target_for_viewer(", "async fn load_public_target(", "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(", "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
+  "recipient_operation_context(", "MENTION_DESCRIBE_ACTOR", "MENTION_AUDIENCE_ACTOR",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR", "target_open_context(&request)",
+  ".limit((limit + 1) as u64)", "subscriptions.truncate(limit);", "for subscription in subscriptions",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
-]) {
-  requireText(
-    notificationSource,
-    marker,
-    `forum notification source is missing exact richer visibility composition ${marker}`,
-  );
-}
+]) requireText(notificationSource, marker, `forum notification source is missing exact richer visibility composition ${marker}`);
 for (const forbidden of [
-  "ForumTopicVisibilityScope::storefront(None)",
-  "ForumTopicVisibilityService::new(",
-  "async fn load_open_topic(",
-  "async fn is_channel_restricted(",
-  "forum_topic_channel_access",
-  "forum_category_audience_policy",
-  "forum_category_audience_role",
-  "forum_category_audience_channel",
-  "forum_category_audience_group",
-  "forum_category_audience_user",
-  "forum_topic_audience_policy",
-  "forum_topic_audience_role",
-  "forum_topic_audience_channel",
-  "forum_topic_audience_group",
-  "forum_topic_audience_user",
-]) {
-  rejectText(
-    notificationSource,
-    forbidden,
-    `forum notification source must reuse the richer owner instead of ${forbidden}`,
-  );
-}
+  "ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "async fn load_open_topic(",
+  "async fn is_channel_restricted(", "forum_topic_channel_access", "forum_category_audience_policy",
+  "forum_category_audience_role", "forum_category_audience_channel", "forum_category_audience_group",
+  "forum_category_audience_user", "forum_topic_audience_policy", "forum_topic_audience_role",
+  "forum_topic_audience_channel", "forum_topic_audience_group", "forum_topic_audience_user",
+]) rejectText(notificationSource, forbidden, `forum notification source must reuse the richer owner instead of ${forbidden}`);
 
 const visibilityIndex = notificationSource.indexOf(".is_topic_visible(tenant_id, topic_id, None, viewer)");
-const materializeIndex = notificationSource.indexOf("let topic = forum_topic::Entity::find()");
-if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
-  failures.push("notification richer visibility must be evaluated before topic materialization");
-}
+const activeTopicIndex = notificationSource.indexOf("async fn load_active_topic(");
+if (visibilityIndex < 0 || activeTopicIndex < 0) failures.push("notification source must retain exact visibility and active topic owners");
 
-const describeBlock = between(
-  notificationSource,
-  "async fn describe_event(",
-  "async fn resolve_audience(",
-  "forum notification describe_event",
-);
-const audienceBlock = between(
-  notificationSource,
-  "async fn resolve_audience(",
-  "async fn authorize_target_open(",
-  "forum notification resolve_audience",
-);
-const targetOpenBlock = between(
-  notificationSource,
-  "async fn authorize_target_open(",
-  "fn recipient_operation_context(",
-  "forum notification authorize_target_open",
-);
+const describeBlock = between(notificationSource, "async fn describe_event(", "async fn resolve_audience(", "forum notification describe_event");
+const audienceBlock = between(notificationSource, "async fn resolve_audience(", "async fn authorize_target_open(", "forum notification resolve_audience");
+const targetOpenBlock = between(notificationSource, "async fn authorize_target_open(", "fn recipient_operation_context(", "forum notification authorize_target_open");
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
+  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "recipient topic subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "recipient target-open authorization"],
-]) {
-  requireText(block, marker, `${label} is missing ${marker}`);
-}
+]) requireText(block, marker, `${label} is missing ${marker}`);
 
 for (const marker of [
-  "forum_topic_and_user_mention_sources_support_notifications_profiles",
-  "restricted topic description should fail closed",
-  "restricted topic authorization should fail closed",
-  "restricted mention description should fail closed",
-  "cross-tenant authorization should fail closed",
-  "closed target authorization should fail closed",
+  "forum_topic_and_user_mention_sources_support_notifications_profiles", "restricted topic description should fail closed",
+  "restricted topic authorization should fail closed", "restricted mention description should fail closed",
+  "cross-tenant authorization should fail closed", "closed target authorization should fail closed",
   "NotificationProviderError::Internal { retryable: true }",
-]) {
-  requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
-}
+]) requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
+for (const marker of ["notification_source_rechecks_category_and_topic_richer_visibility", "topic-level richer visibility should fail closed", "stale public descriptor should be rechecked", "category policy change should invalidate the old public descriptor"]) requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
+for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "SharedForumNotificationRecipientContextPort", "roles_any: vec![UserRole::Customer]", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
+for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "manager topic mention description should fail closed", "stale customer mention descriptor should be rechecked"]) requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
 for (const marker of [
-  "notification_source_rechecks_category_and_topic_richer_visibility",
-  "topic-level richer visibility should fail closed",
-  "stale public descriptor should be rechecked",
-  "category policy change should invalidate the old public descriptor",
-]) {
-  requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
-  "SharedForumNotificationRecipientContextPort",
-  "roles_any: vec![UserRole::Customer]",
-  "NotificationOpenAuthorization::Allowed",
-  "NotificationOpenAuthorization::Unavailable",
-]) {
-  requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
-  "customer topic mention audience should resolve",
-  "customer reply mention audience should resolve",
-  "manager topic mention description should fail closed",
-  "stale customer mention descriptor should be rechecked",
-]) {
-  requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
-}
-for (const marker of [
-  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "first_page.recipients().is_empty()",
-  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
-  "second_page.recipients()[0].recipient_id, allowed_third",
-  "third_page.recipients()[0].recipient_id, allowed_fifth",
-  "BTreeSet::from([allowed_third, allowed_fifth])",
-]) {
-  requireText(subscriptionTestSource, marker, `recipient topic subscription SQLite scenario is missing ${marker}`);
-}
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "roles_any: vec![UserRole::Customer]",
+  "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]", "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth", "BTreeSet::from([allowed_third, allowed_fifth])",
+]) requireText(subscriptionTestSource, marker, `recipient topic subscription SQLite scenario is missing ${marker}`);
 
-if (
-  recipientContract.schema_version !== 3 ||
-  recipientContract.task !== "FORUM-20N" ||
-  recipientContract.downstream_task !== "FORUM-20O" ||
-  recipientContract.downstream_chain_task !== "FORUM-20P" ||
-  recipientContract.composition?.recipient_specific_topic_open !== true ||
-  recipientContract.composition?.recipient_specific_reply_open !== true ||
-  recipientContract.composition?.recipient_specific_mention_description !== true ||
-  recipientContract.composition?.recipient_specific_mention_audience !== true ||
-  recipientContract.composition?.recipient_specific_topic_subscription_audience !== true
-) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient contract through P");
-}
-if (
-  mentionContract.schema_version !== 2 ||
-  mentionContract.task !== "FORUM-20O" ||
-  mentionContract.upstream_task !== "FORUM-20N" ||
-  mentionContract.downstream_task !== "FORUM-20P" ||
-  mentionContract.composition?.recipient_specific_mention_description !== true ||
-  mentionContract.composition?.recipient_specific_mention_audience !== true ||
-  mentionContract.composition?.topic_created_subscription_audience_downstream !== true
-) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20O mention audience contract through P");
-}
-if (
-  subscriptionContract.schema_version !== 1 ||
-  subscriptionContract.task !== "FORUM-20P" ||
-  subscriptionContract.upstream_task !== "FORUM-20O" ||
-  subscriptionContract.composition?.bounded_raw_keyset_scan !== true ||
-  subscriptionContract.composition?.recipient_specific_topic_visibility !== true ||
-  subscriptionContract.composition?.sparse_all_denied_page !== true
-) {
-  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20P subscription audience contract");
-}
+if (recipientContract.schema_version !== 3 || recipientContract.task !== "FORUM-20N" || recipientContract.downstream_task !== "FORUM-20O" || recipientContract.downstream_chain_task !== "FORUM-20P" || recipientContract.composition?.recipient_specific_topic_open !== true || recipientContract.composition?.recipient_specific_reply_open !== true || recipientContract.composition?.recipient_specific_mention_description !== true || recipientContract.composition?.recipient_specific_mention_audience !== true || recipientContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20N/P");
+if (mentionContract.schema_version !== 2 || mentionContract.task !== "FORUM-20O" || mentionContract.upstream_task !== "FORUM-20N" || mentionContract.downstream_task !== "FORUM-20P" || mentionContract.composition?.recipient_specific_mention_description !== true || mentionContract.composition?.recipient_specific_mention_audience !== true || mentionContract.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20O/P");
+if (subscriptionContract.schema_version !== 1 || subscriptionContract.task !== "FORUM-20P" || subscriptionContract.upstream_task !== "FORUM-20O" || subscriptionContract.composition?.active_topic_source_recheck !== true || subscriptionContract.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || subscriptionContract.composition?.bounded_raw_keyset_scan !== true || subscriptionContract.composition?.recipient_specific_topic_visibility !== true || subscriptionContract.composition?.sparse_all_denied_page !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20P");
 
-for (const marker of [
-  "## `FORUM-20` — ACL and visibility inheritance",
-  "notifications, search, SEO and deep links must call the same",
-]) {
-  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
-}
-
+for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
 if (failures.length > 0) {
   console.error("Forum notification visibility composition verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum notification richer visibility composition contract is source-ready.");

--- a/scripts/verify/verify-forum-notification-visibility-composition.mjs
+++ b/scripts/verify/verify-forum-notification-visibility-composition.mjs
@@ -18,16 +18,28 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
 function between(source, start, end, label) {
   const startIndex = source.indexOf(start);
   const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ""; }
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
   return source.slice(startIndex, endIndex);
 }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-notification-visibility-composition.json") || "{}");
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-visibility-composition.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const notificationSource = read(contract.notification_source_file ?? "");
 const visibilityOwner = read(contract.visibility_owner_file ?? "");
 const baseVisibilityOwner = read(contract.base_visibility_owner_file ?? "");
@@ -41,105 +53,305 @@ const mentionContract = JSON.parse(read(contract.recipient_mention_contract ?? "
 const subscriptionContract = JSON.parse(read(contract.recipient_topic_subscription_contract ?? "") || "{}");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 7) failures.push("forum notification visibility contract must use schema_version=7");
-if (contract.task !== "FORUM-20K" || contract.supersedes_task !== "FORUM-20I" || contract.downstream_task !== "FORUM-20P") failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("source publication must not claim unexecuted notification evidence");
+if (contract.schema_version !== 7) {
+  failures.push("forum notification visibility contract must use schema_version=7");
+}
+if (
+  contract.task !== "FORUM-20K" ||
+  contract.supersedes_task !== "FORUM-20I" ||
+  contract.downstream_task !== "FORUM-20P"
+) {
+  failures.push("forum notification visibility contract must remain FORUM-20K and advance through FORUM-20P");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted notification evidence");
+}
 
 for (const residual of [
-  "initially non-public topic-created descriptor materialization", "profile privacy and blocking policy",
-  "host trust channel and group facts adapters for authenticated consumers", "search index SEO and deep-link migration",
-  "final notification creation and delivery authorization", "PostgreSQL and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
+  "initially non-public topic-created descriptor materialization",
+  "profile privacy and blocking policy",
+  "host trust channel and group facts adapters for authenticated consumers",
+  "search index SEO and deep-link migration",
+  "final notification creation and delivery authorization",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification visibility contract must keep ${residual} explicitly open`);
+  }
+}
 for (const delivered of [
-  "exact_richer_public_owner", "normalized_category_layers", "normalized_topic_layer", "dynamic_policy_recheck",
-  "recipient_context_factory_consumption", "recipient_specific_target_open", "topic_created_public_description",
-  "topic_subscription_active_source_recheck", "recipient_specific_topic_subscription_audience",
-  "topic_subscription_sparse_cursor", "recipient_specific_mention_description",
-  "recipient_specific_mention_audience", "shared_recipient_resolution_helper",
-]) if (contract.composition?.[delivered] !== true) failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
+  "exact_richer_public_owner",
+  "normalized_category_layers",
+  "normalized_topic_layer",
+  "dynamic_policy_recheck",
+  "recipient_context_factory_consumption",
+  "recipient_specific_target_open",
+  "topic_created_public_description",
+  "recipient_specific_topic_subscription_audience",
+  "topic_subscription_sparse_cursor",
+  "recipient_specific_mention_description",
+  "recipient_specific_mention_audience",
+  "shared_recipient_resolution_helper",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification visibility contract must record ${delivered} as delivered`);
+  }
+}
 
-const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20P");
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum notification visibility contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum notification visibility contract must require FORUM-20H through FORUM-20P delivered sections");
+}
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
-  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
-  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
-} else failures.push("canonical_plan_sync.status must be pending or synchronized");
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
-  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)", "for layer in &policy.inherited_category_layers",
+  "pub struct ForumTopicAudienceViewer",
+  "pub fn public() -> Self",
+  "pub fn authenticated(",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers",
   "policy.configured_constraints",
-]) requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
-for (const marker of ["pub struct ForumTopicVisibilityScope", "pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
+]) {
+  requireText(visibilityOwner, marker, `exact richer topic visibility owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumTopicVisibilityScope",
+  "pub struct ForumTopicVisibilityService",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "all_topic_channel_access_subquery(tenant_id)",
+]) {
+  requireText(baseVisibilityOwner, marker, `base topic visibility owner is missing ${marker}`);
+}
 
 for (const marker of [
-  "host.shared_get::<SharedForumNotificationRecipientContextPort>()", "host.shared_get::<SharedForumAudienceFactsPort>()",
-  "async fn load_active_topic(", "async fn load_topic_for_viewer(", "async fn load_public_topic(",
-  "async fn load_topic_for_subscription_audience(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "ForumTopicAudienceViewer::public()",
-  "async fn load_target_for_viewer(", "async fn load_public_target(", "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(", "async fn resolve_recipient_viewer(",
-  "ForumNotificationRecipientContextResolver::new(Some(port))", "recipient.into_topic_viewer()",
-  "recipient_operation_context(", "MENTION_DESCRIBE_ACTOR", "MENTION_AUDIENCE_ACTOR",
-  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR", "target_open_context(&request)",
-  ".limit((limit + 1) as u64)", "subscriptions.truncate(limit);", "for subscription in subscriptions",
+  "host.shared_get::<SharedForumNotificationRecipientContextPort>()",
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_public_topic(",
+  "ForumTopicAudienceViewer::public()",
+  "async fn load_target_for_viewer(",
+  "async fn load_public_target(",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "async fn resolve_recipient_viewer(",
+  "ForumNotificationRecipientContextResolver::new(Some(port))",
+  "recipient.into_topic_viewer()",
+  "recipient_operation_context(",
+  "MENTION_DESCRIBE_ACTOR",
+  "MENTION_AUDIENCE_ACTOR",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+  "target_open_context(&request)",
+  ".limit((limit + 1) as u64)",
+  "subscriptions.truncate(limit);",
+  "for subscription in subscriptions",
   "fn forum_owner_error(error: ForumError) -> NotificationProviderError",
-]) requireText(notificationSource, marker, `forum notification source is missing exact richer visibility composition ${marker}`);
+]) {
+  requireText(
+    notificationSource,
+    marker,
+    `forum notification source is missing exact richer visibility composition ${marker}`,
+  );
+}
 for (const forbidden of [
-  "ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "async fn load_open_topic(",
-  "async fn is_channel_restricted(", "forum_topic_channel_access", "forum_category_audience_policy",
-  "forum_category_audience_role", "forum_category_audience_channel", "forum_category_audience_group",
-  "forum_category_audience_user", "forum_topic_audience_policy", "forum_topic_audience_role",
-  "forum_topic_audience_channel", "forum_topic_audience_group", "forum_topic_audience_user",
-]) rejectText(notificationSource, forbidden, `forum notification source must reuse the richer owner instead of ${forbidden}`);
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
+  "async fn load_open_topic(",
+  "async fn is_channel_restricted(",
+  "forum_topic_channel_access",
+  "forum_category_audience_policy",
+  "forum_category_audience_role",
+  "forum_category_audience_channel",
+  "forum_category_audience_group",
+  "forum_category_audience_user",
+  "forum_topic_audience_policy",
+  "forum_topic_audience_role",
+  "forum_topic_audience_channel",
+  "forum_topic_audience_group",
+  "forum_topic_audience_user",
+]) {
+  rejectText(
+    notificationSource,
+    forbidden,
+    `forum notification source must reuse the richer owner instead of ${forbidden}`,
+  );
+}
 
 const visibilityIndex = notificationSource.indexOf(".is_topic_visible(tenant_id, topic_id, None, viewer)");
-const activeTopicIndex = notificationSource.indexOf("async fn load_active_topic(");
-if (visibilityIndex < 0 || activeTopicIndex < 0) failures.push("notification source must retain exact visibility and active topic owners");
+const materializeIndex = notificationSource.indexOf("let topic = forum_topic::Entity::find()");
+if (visibilityIndex < 0 || materializeIndex < 0 || visibilityIndex > materializeIndex) {
+  failures.push("notification richer visibility must be evaluated before topic materialization");
+}
 
-const describeBlock = between(notificationSource, "async fn describe_event(", "async fn resolve_audience(", "forum notification describe_event");
-const audienceBlock = between(notificationSource, "async fn resolve_audience(", "async fn authorize_target_open(", "forum notification resolve_audience");
-const targetOpenBlock = between(notificationSource, "async fn authorize_target_open(", "fn recipient_operation_context(", "forum notification authorize_target_open");
+const describeBlock = between(
+  notificationSource,
+  "async fn describe_event(",
+  "async fn resolve_audience(",
+  "forum notification describe_event",
+);
+const audienceBlock = between(
+  notificationSource,
+  "async fn resolve_audience(",
+  "async fn authorize_target_open(",
+  "forum notification resolve_audience",
+);
+const targetOpenBlock = between(
+  notificationSource,
+  "async fn authorize_target_open(",
+  "fn recipient_operation_context(",
+  "forum notification authorize_target_open",
+);
 for (const [block, marker, label] of [
   [describeBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public description"],
-  [audienceBlock, "load_topic_for_subscription_audience(event.tenant_id, event.aggregate_id)", "active topic subscription source recheck"],
+  [audienceBlock, "load_public_topic(event.tenant_id, event.aggregate_id)", "topic-created public source recheck"],
   [audienceBlock, "topic_subscription_recipient_visible(", "recipient topic subscription audience"],
   [describeBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_DESCRIBE_ACTOR)", "recipient mention description"],
   [audienceBlock, "load_mention_target_for_recipient(&event, &payload, MENTION_AUDIENCE_ACTOR)", "recipient mention audience"],
   [targetOpenBlock, "resolve_recipient_viewer(", "recipient target-open authorization"],
-]) requireText(block, marker, `${label} is missing ${marker}`);
+]) {
+  requireText(block, marker, `${label} is missing ${marker}`);
+}
 
 for (const marker of [
-  "forum_topic_and_user_mention_sources_support_notifications_profiles", "restricted topic description should fail closed",
-  "restricted topic authorization should fail closed", "restricted mention description should fail closed",
-  "cross-tenant authorization should fail closed", "closed target authorization should fail closed",
+  "forum_topic_and_user_mention_sources_support_notifications_profiles",
+  "restricted topic description should fail closed",
+  "restricted topic authorization should fail closed",
+  "restricted mention description should fail closed",
+  "cross-tenant authorization should fail closed",
+  "closed target authorization should fail closed",
   "NotificationProviderError::Internal { retryable: true }",
-]) requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
-for (const marker of ["notification_source_rechecks_category_and_topic_richer_visibility", "topic-level richer visibility should fail closed", "stale public descriptor should be rechecked", "category policy change should invalidate the old public descriptor"]) requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
-for (const marker of ["notification_target_open_uses_exact_recipient_role_for_topics_and_replies", "SharedForumNotificationRecipientContextPort", "roles_any: vec![UserRole::Customer]", "NotificationOpenAuthorization::Allowed", "NotificationOpenAuthorization::Unavailable"]) requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
-for (const marker of ["mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies", "customer topic mention audience should resolve", "customer reply mention audience should resolve", "manager topic mention description should fail closed", "stale customer mention descriptor should be rechecked"]) requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
+]) {
+  requireText(baselineTestSource, marker, `notification baseline SQLite scenario is missing ${marker}`);
+}
 for (const marker of [
-  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "roles_any: vec![UserRole::Customer]",
-  "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()",
-  "recorded_calls(&calls), vec![denied_first, unavailable_second]", "second_page.recipients()[0].recipient_id, allowed_third",
-  "third_page.recipients()[0].recipient_id, allowed_fifth", "BTreeSet::from([allowed_third, allowed_fifth])",
-]) requireText(subscriptionTestSource, marker, `recipient topic subscription SQLite scenario is missing ${marker}`);
+  "notification_source_rechecks_category_and_topic_richer_visibility",
+  "topic-level richer visibility should fail closed",
+  "stale public descriptor should be rechecked",
+  "category policy change should invalidate the old public descriptor",
+]) {
+  requireText(richerTestSource, marker, `notification richer visibility SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "notification_target_open_uses_exact_recipient_role_for_topics_and_replies",
+  "SharedForumNotificationRecipientContextPort",
+  "roles_any: vec![UserRole::Customer]",
+  "NotificationOpenAuthorization::Allowed",
+  "NotificationOpenAuthorization::Unavailable",
+]) {
+  requireText(recipientTestSource, marker, `recipient target-open SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "mention_description_and_audience_use_the_exact_recipient_for_topics_and_replies",
+  "customer topic mention audience should resolve",
+  "customer reply mention audience should resolve",
+  "manager topic mention description should fail closed",
+  "stale customer mention descriptor should be rechecked",
+]) {
+  requireText(mentionTestSource, marker, `recipient mention SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "first_page.recipients().is_empty()",
+  "recorded_calls(&calls), vec![denied_first, unavailable_second]",
+  "second_page.recipients()[0].recipient_id, allowed_third",
+  "third_page.recipients()[0].recipient_id, allowed_fifth",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(subscriptionTestSource, marker, `recipient topic subscription SQLite scenario is missing ${marker}`);
+}
 
-if (recipientContract.schema_version !== 3 || recipientContract.task !== "FORUM-20N" || recipientContract.downstream_task !== "FORUM-20O" || recipientContract.downstream_chain_task !== "FORUM-20P" || recipientContract.composition?.recipient_specific_topic_open !== true || recipientContract.composition?.recipient_specific_reply_open !== true || recipientContract.composition?.recipient_specific_mention_description !== true || recipientContract.composition?.recipient_specific_mention_audience !== true || recipientContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20N/P");
-if (mentionContract.schema_version !== 2 || mentionContract.task !== "FORUM-20O" || mentionContract.upstream_task !== "FORUM-20N" || mentionContract.downstream_task !== "FORUM-20P" || mentionContract.composition?.recipient_specific_mention_description !== true || mentionContract.composition?.recipient_specific_mention_audience !== true || mentionContract.composition?.topic_created_subscription_audience_downstream !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20O/P");
-if (subscriptionContract.schema_version !== 1 || subscriptionContract.task !== "FORUM-20P" || subscriptionContract.upstream_task !== "FORUM-20O" || subscriptionContract.composition?.active_topic_source_recheck !== true || subscriptionContract.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || subscriptionContract.composition?.bounded_raw_keyset_scan !== true || subscriptionContract.composition?.recipient_specific_topic_visibility !== true || subscriptionContract.composition?.sparse_all_denied_page !== true) failures.push("FORUM-20K must remain synchronized with FORUM-20P");
+if (
+  recipientContract.schema_version !== 3 ||
+  recipientContract.task !== "FORUM-20N" ||
+  recipientContract.downstream_task !== "FORUM-20O" ||
+  recipientContract.downstream_chain_task !== "FORUM-20P" ||
+  recipientContract.composition?.recipient_specific_topic_open !== true ||
+  recipientContract.composition?.recipient_specific_reply_open !== true ||
+  recipientContract.composition?.recipient_specific_mention_description !== true ||
+  recipientContract.composition?.recipient_specific_mention_audience !== true ||
+  recipientContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20N recipient contract through P");
+}
+if (
+  mentionContract.schema_version !== 2 ||
+  mentionContract.task !== "FORUM-20O" ||
+  mentionContract.upstream_task !== "FORUM-20N" ||
+  mentionContract.downstream_task !== "FORUM-20P" ||
+  mentionContract.composition?.recipient_specific_mention_description !== true ||
+  mentionContract.composition?.recipient_specific_mention_audience !== true ||
+  mentionContract.composition?.topic_created_subscription_audience_downstream !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20O mention audience contract through P");
+}
+if (
+  subscriptionContract.schema_version !== 1 ||
+  subscriptionContract.task !== "FORUM-20P" ||
+  subscriptionContract.upstream_task !== "FORUM-20O" ||
+  subscriptionContract.composition?.bounded_raw_keyset_scan !== true ||
+  subscriptionContract.composition?.recipient_specific_topic_visibility !== true ||
+  subscriptionContract.composition?.sparse_all_denied_page !== true
+) {
+  failures.push("FORUM-20K visibility composition must remain synchronized with the FORUM-20P subscription audience contract");
+}
 
-for (const marker of ["## `FORUM-20` — ACL and visibility inheritance", "notifications, search, SEO and deep links must call the same"]) requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
 if (failures.length > 0) {
   console.error("Forum notification visibility composition verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum notification richer visibility composition contract is source-ready.");

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -5,31 +5,17 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
-  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
-  : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
 const failures = [];
-
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) {
-    failures.push(`${relativePath}: required file is missing`);
-    return "";
-  }
+  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
   return readFileSync(absolute, "utf8");
 }
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
-const contractPath =
-  "crates/rustok-forum/contracts/forum-topic-audience-visibility.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-topic-audience-visibility.json") || "{}");
 const owner = read(contract.owner_file ?? "");
 const baseOwner = read(contract.base_visibility_owner ?? "");
 const categoryOwner = read(contract.category_policy_owner ?? "");
@@ -37,240 +23,70 @@ const topicOwner = read(contract.topic_policy_owner ?? "");
 const evaluator = read(contract.audience_evaluator ?? "");
 const services = read(contract.services_file ?? "");
 const crate = read(contract.crate_file ?? "");
-const notificationSource = read(contract.notification_source_file ?? "");
-const notificationContract = JSON.parse(read(contract.notification_visibility_contract ?? "") || "{}");
-const notificationConsumer = JSON.parse(read(contract.notification_consumer_contract ?? "") || "{}");
-const testSource = read(contract.test_file ?? "");
+const source = read(contract.notification_source_file ?? "");
+const visibility = JSON.parse(read(contract.notification_visibility_contract ?? "") || "{}");
+const consumer = JSON.parse(read(contract.notification_consumer_contract ?? "") || "{}");
+const ownerTest = read(contract.test_file ?? "");
+const consumerTest = read(contract.notification_consumer_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 3) {
-  failures.push("forum topic audience visibility contract must use schema_version=3");
-}
-if (
-  contract.task !== "FORUM-20J" ||
-  contract.downstream_notification_task !== "FORUM-20K" ||
-  contract.notification_consumer_task !== "FORUM-20O"
-) {
-  failures.push("forum topic audience visibility contract must connect FORUM-20J/K/O notification composition");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("source publication must not claim unexecuted richer visibility evidence");
-}
-for (const delivered of [
-  "public_topic_created_notification",
-  "recipient_target_open_notification",
-  "recipient_mention_description_notification",
-  "recipient_mention_audience_notification",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
-  }
-}
+if (contract.schema_version !== 4) failures.push("forum topic audience visibility contract must use schema_version=4");
+if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K" || contract.notification_consumer_task !== "FORUM-20P") failures.push("topic visibility contract must connect FORUM-20J/K/P");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("topic visibility contract must not claim unexecuted evidence");
+for (const field of [
+  "exact_topic", "open_status", "route_channel", "public_authenticated_category_floor",
+  "normalized_category_layers", "normalized_topic_layer", "role_and_explicit_user",
+  "trust_channel_group_owner_facts", "public_topic_created_notification",
+  "recipient_target_open_notification", "recipient_mention_description_notification",
+  "recipient_mention_audience_notification", "recipient_topic_subscription_audience_notification",
+]) if (contract.composition?.[field] !== true) failures.push(`topic visibility contract must record ${field}=true`);
 for (const residual of [
-  "topic and reply page filtering before count and pagination",
-  "category and reply exact richer-audience composition",
-  "create reply and moderate audience write policy",
-  "host trust channel and group provider adapters",
-  "visibility-scoped category and all-read mutations",
-  "recipient-specific topic-created subscription filtering before pagination",
-  "initially non-public topic-created descriptor materialization",
-  "search index SEO and deep-link migration to the richer exact owner",
-  "PostgreSQL concurrency and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
-  }
-}
+  "topic and reply page filtering before count and pagination", "category and reply exact richer-audience composition",
+  "create reply and moderate audience write policy", "host trust channel and group provider adapters",
+  "visibility-scoped category and all-read mutations", "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration to the richer exact owner", "PostgreSQL concurrency and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`topic visibility contract must keep ${residual} open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20O") {
-  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20O");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20O delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-O provide", "synchronized canonical plan must advance the FORUM-20 ledger through O");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const sync = contract.canonical_plan_sync ?? {};
+if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("topic visibility contract must require FORUM-20H through FORUM-20P");
+if (sync.status === "pending") {
+  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
+  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
+  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
+} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer",
-  "pub fn public() -> Self",
-  "pub fn authenticated(",
-  "security.actor_kind != SecurityActorKind::User",
-  "port_context.actor.kind != PortActorKind::User",
-  "actor does not match the viewer",
-  "pub struct ForumTopicAudienceVisibilityService",
-  "pub fn without_facts_provider",
-  "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "ForumTopicVisibilityService::new(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, &scope)",
-  "find_topic(&self.db, tenant_id, topic_id)",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-  "for layer in &policy.inherited_category_layers",
-  "policy.configured_constraints",
-  ".resolve_for_constraints(",
-  "ForumAudienceEvaluator::decide(",
-  "facts.tenant_id = tenant_id",
-  "facts.user_id = viewer.security.user_id",
-]) {
-  requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
-}
-for (const forbidden of [
-  "crate::entities",
-  "forum_category_audience_policy::",
-  "forum_category_audience_role::",
-  "forum_category_audience_channel::",
-  "forum_category_audience_group::",
-  "forum_category_audience_user::",
-  "forum_topic_audience_policy::",
-  "forum_topic_audience_role::",
-  "forum_topic_audience_channel::",
-  "forum_topic_audience_group::",
-  "forum_topic_audience_user::",
-]) {
-  rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`);
-}
-
-const baseIndex = owner.indexOf(".is_topic_visible(tenant_id, topic_id, &scope)");
-const policyIndex = owner.indexOf("load_policy_for_topic(&self.db, tenant_id, &topic)");
-const providerIndex = owner.indexOf(".resolve_for_constraints(");
-if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) {
-  failures.push("current exact storefront visibility must run before richer policy materialization");
-}
-if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) {
-  failures.push("current exact storefront visibility must run before optional owner facts calls");
-}
-
+  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
+  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, &scope)", "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers", "policy.configured_constraints",
+  ".resolve_for_constraints(", "ForumAudienceEvaluator::decide(",
+]) requireText(owner, marker, `exact topic visibility owner is missing ${marker}`);
+for (const forbidden of ["crate::entities", "forum_category_audience_policy::", "forum_topic_audience_policy::"]) rejectText(owner, forbidden, `exact topic visibility owner must reuse policy owners instead of ${forbidden}`);
+for (const marker of ["pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base visibility owner is missing ${marker}`);
+for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) requireText(categoryOwner, marker, `category owner is missing ${marker}`);
+for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) requireText(topicOwner, marker, `topic owner is missing ${marker}`);
+for (const marker of ["pub struct ForumAudienceFactsResolver", "pub struct ForumAudienceEvaluator", "ForumAudienceDecisionReason::ExplicitDeny"]) requireText(evaluator, marker, `audience evaluator is missing ${marker}`);
+for (const marker of ["include!(\"topic_audience_visibility.rs\")", "ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(services, marker, `services surface is missing ${marker}`);
+for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(crate, marker, `crate surface is missing ${marker}`);
 for (const marker of [
-  "pub struct ForumTopicVisibilityService",
-  "pub async fn is_topic_visible",
-  "self.hidden_category_ids_for_scope(tenant_id, scope)",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
-  "all_topic_channel_access_subquery(tenant_id)",
-]) {
-  requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
-}
-for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) {
-  requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
-}
-for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) {
-  requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumAudienceFactsResolver",
-  "pub struct ForumAudienceEvaluator",
-  "ForumAudienceDecisionReason::ExplicitDeny",
-]) {
-  requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
-}
-for (const marker of [
-  "include!(\"topic_audience_visibility.rs\")",
-  "ForumTopicAudienceViewer",
-  "ForumTopicAudienceVisibilityService",
-]) {
-  requireText(services, marker, `forum services surface is missing ${marker}`);
-}
-for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) {
-  requireText(crate, marker, `forum crate surface is missing ${marker}`);
-}
+  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
+  "async fn resolve_recipient_viewer(", "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) requireText(source, marker, `notification consumer is missing ${marker}`);
+for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(source, forbidden, `notification source must not bypass exact owner with ${forbidden}`);
 
-for (const marker of [
-  "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
-  "async fn load_topic_for_viewer(",
-  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_public_topic(",
-  "ForumTopicAudienceViewer::public()",
-  "async fn resolve_recipient_viewer(",
-  "async fn load_mention_target_for_recipient(",
-]) {
-  requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
-}
-for (const forbidden of [
-  "ForumTopicVisibilityScope::storefront(None)",
-  "ForumTopicVisibilityService::new(",
-  "forum_category_audience_policy",
-  "forum_topic_audience_policy",
-]) {
-  rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
-}
-
-if (
-  notificationContract.schema_version !== 6 ||
-  notificationContract.task !== "FORUM-20K" ||
-  notificationContract.downstream_task !== "FORUM-20O" ||
-  notificationContract.composition?.exact_richer_public_owner !== true ||
-  notificationContract.composition?.recipient_specific_target_open !== true ||
-  notificationContract.composition?.recipient_specific_mention_description !== true ||
-  notificationContract.composition?.recipient_specific_mention_audience !== true
-) {
-  failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20O");
-}
-if (
-  notificationConsumer.schema_version !== 1 ||
-  notificationConsumer.task !== "FORUM-20O" ||
-  notificationConsumer.upstream_task !== "FORUM-20N" ||
-  notificationConsumer.composition?.exact_mention_recipient_resolution !== true
-) {
-  failures.push("FORUM-20J topic visibility must remain synchronized with the FORUM-20O notification consumer");
-}
-
-for (const marker of [
-  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers",
-  "base visibility must fail before richer owner facts are requested",
-  "public richer visibility should fail closed",
-  "nonmatching local role should resolve as denied",
-  "topic explicit deny should win",
-  "missing exact membership should deny",
-  "ForumError::CapabilityUnavailable",
-  "cross-tenant topic should resolve as absent",
-  "actor does not match",
-  "assert_eq!(recorded.len(), 2)",
-]) {
-  requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
-}
+if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20J must remain synchronized with FORUM-20K/P");
+if (consumer.schema_version !== 1 || consumer.task !== "FORUM-20P" || consumer.upstream_task !== "FORUM-20O" || consumer.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20J must remain synchronized with FORUM-20P");
+for (const marker of ["exact_topic_visibility_conjoins_base_category_and_topic_audience_layers", "topic explicit deny should win", "ForumError::CapabilityUnavailable", "actor does not match"]) requireText(ownerTest, marker, `exact visibility test is missing ${marker}`);
+for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "deny_user_ids: vec![denied_first, denied_fourth]", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(consumerTest, marker, `topic subscription consumer test is missing ${marker}`);
 
 if (failures.length > 0) {
   console.error("Forum topic audience visibility verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum topic audience visibility contract is source-ready.");

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -18,10 +18,18 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-topic-audience-visibility.json") || "{}");
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-topic-audience-visibility.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const owner = read(contract.owner_file ?? "");
 const baseOwner = read(contract.base_visibility_owner ?? "");
 const categoryOwner = read(contract.category_policy_owner ?? "");
@@ -36,90 +44,247 @@ const testSource = read(contract.test_file ?? "");
 const consumerTestSource = read(contract.notification_consumer_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) failures.push("forum topic audience visibility contract must use schema_version=4");
-if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K" || contract.notification_consumer_task !== "FORUM-20P") failures.push("forum topic audience visibility contract must connect FORUM-20J/K/P notification composition");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("source publication must not claim unexecuted richer visibility evidence");
-for (const delivered of ["public_topic_created_notification", "recipient_target_open_notification", "recipient_mention_description_notification", "recipient_mention_audience_notification", "recipient_topic_subscription_audience_notification"]) if (contract.composition?.[delivered] !== true) failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
+if (contract.schema_version !== 4) {
+  failures.push("forum topic audience visibility contract must use schema_version=4");
+}
+if (
+  contract.task !== "FORUM-20J" ||
+  contract.downstream_notification_task !== "FORUM-20K" ||
+  contract.notification_consumer_task !== "FORUM-20P"
+) {
+  failures.push("forum topic audience visibility contract must connect FORUM-20J/K/P notification composition");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted richer visibility evidence");
+}
+for (const delivered of [
+  "public_topic_created_notification",
+  "recipient_target_open_notification",
+  "recipient_mention_description_notification",
+  "recipient_mention_audience_notification",
+  "recipient_topic_subscription_audience_notification",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "topic and reply page filtering before count and pagination", "category and reply exact richer-audience composition",
-  "create reply and moderate audience write policy", "host trust channel and group provider adapters",
-  "visibility-scoped category and all-read mutations", "initially non-public topic-created descriptor materialization",
-  "search index SEO and deep-link migration to the richer exact owner", "PostgreSQL concurrency and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
+  "topic and reply page filtering before count and pagination",
+  "category and reply exact richer-audience composition",
+  "create reply and moderate audience write policy",
+  "host trust channel and group provider adapters",
+  "visibility-scoped category and all-read mutations",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration to the richer exact owner",
+  "PostgreSQL concurrency and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
+  }
+}
 
-const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20P");
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20P delivered sections");
+}
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
-  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
-  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
-} else failures.push("canonical_plan_sync.status must be pending or synchronized");
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
-  "security.actor_kind != SecurityActorKind::User", "port_context.actor.kind != PortActorKind::User",
-  "actor does not match the viewer", "pub struct ForumTopicAudienceVisibilityService",
-  "pub fn without_facts_provider", "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, &scope)", "find_topic(&self.db, tenant_id, topic_id)",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)", "for layer in &policy.inherited_category_layers",
-  "policy.configured_constraints", ".resolve_for_constraints(", "ForumAudienceEvaluator::decide(",
-  "facts.tenant_id = tenant_id", "facts.user_id = viewer.security.user_id",
-]) requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
+  "pub struct ForumTopicAudienceViewer",
+  "pub fn public() -> Self",
+  "pub fn authenticated(",
+  "security.actor_kind != SecurityActorKind::User",
+  "port_context.actor.kind != PortActorKind::User",
+  "actor does not match the viewer",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub fn without_facts_provider",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, &scope)",
+  "find_topic(&self.db, tenant_id, topic_id)",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers",
+  "policy.configured_constraints",
+  ".resolve_for_constraints(",
+  "ForumAudienceEvaluator::decide(",
+  "facts.tenant_id = tenant_id",
+  "facts.user_id = viewer.security.user_id",
+]) {
+  requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
+}
 for (const forbidden of [
-  "crate::entities", "forum_category_audience_policy::", "forum_category_audience_role::",
-  "forum_category_audience_channel::", "forum_category_audience_group::", "forum_category_audience_user::",
-  "forum_topic_audience_policy::", "forum_topic_audience_role::", "forum_topic_audience_channel::",
-  "forum_topic_audience_group::", "forum_topic_audience_user::",
-]) rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of ${forbidden}`);
+  "crate::entities",
+  "forum_category_audience_policy::",
+  "forum_category_audience_role::",
+  "forum_category_audience_channel::",
+  "forum_category_audience_group::",
+  "forum_category_audience_user::",
+  "forum_topic_audience_policy::",
+  "forum_topic_audience_role::",
+  "forum_topic_audience_channel::",
+  "forum_topic_audience_group::",
+  "forum_topic_audience_user::",
+]) {
+  rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`);
+}
 
 const baseIndex = owner.indexOf(".is_topic_visible(tenant_id, topic_id, &scope)");
 const policyIndex = owner.indexOf("load_policy_for_topic(&self.db, tenant_id, &topic)");
 const providerIndex = owner.indexOf(".resolve_for_constraints(");
-if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) failures.push("current exact storefront visibility must run before richer policy materialization");
-if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) failures.push("current exact storefront visibility must run before optional owner facts calls");
+if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) {
+  failures.push("current exact storefront visibility must run before richer policy materialization");
+}
+if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) {
+  failures.push("current exact storefront visibility must run before optional owner facts calls");
+}
 
-for (const marker of ["pub struct ForumTopicVisibilityService", "pub async fn is_topic_visible", "self.hidden_category_ids_for_scope(tenant_id, scope)", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
-for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
-for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
-for (const marker of ["pub struct ForumAudienceFactsResolver", "pub struct ForumAudienceEvaluator", "ForumAudienceDecisionReason::ExplicitDeny"]) requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
-for (const marker of ["include!(\"topic_audience_visibility.rs\")", "ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(services, marker, `forum services surface is missing ${marker}`);
-for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(crate, marker, `forum crate surface is missing ${marker}`);
+for (const marker of [
+  "pub struct ForumTopicVisibilityService",
+  "pub async fn is_topic_visible",
+  "self.hidden_category_ids_for_scope(tenant_id, scope)",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "all_topic_channel_access_subquery(tenant_id)",
+]) {
+  requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
+}
+for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) {
+  requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
+}
+for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) {
+  requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumAudienceFactsResolver",
+  "pub struct ForumAudienceEvaluator",
+  "ForumAudienceDecisionReason::ExplicitDeny",
+]) {
+  requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
+}
+for (const marker of [
+  "include!(\"topic_audience_visibility.rs\")",
+  "ForumTopicAudienceViewer",
+  "ForumTopicAudienceVisibilityService",
+]) {
+  requireText(services, marker, `forum services surface is missing ${marker}`);
+}
+for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) {
+  requireText(crate, marker, `forum crate surface is missing ${marker}`);
+}
 
 for (const marker of [
   "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
-  "async fn load_active_topic(", "async fn load_topic_for_viewer(",
+  "async fn load_topic_for_viewer(",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
-  "async fn load_topic_for_subscription_audience(", "ForumTopicAudienceViewer::public()",
-  "async fn resolve_recipient_viewer(", "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
-for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_public_topic(",
+  "ForumTopicAudienceViewer::public()",
+  "async fn resolve_recipient_viewer(",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) {
+  requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
+}
+for (const forbidden of [
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
+  "forum_category_audience_policy",
+  "forum_topic_audience_policy",
+]) {
+  rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
+}
 
-if (notificationContract.schema_version !== 7 || notificationContract.task !== "FORUM-20K" || notificationContract.downstream_task !== "FORUM-20P" || notificationContract.composition?.exact_richer_public_owner !== true || notificationContract.composition?.topic_subscription_active_source_recheck !== true || notificationContract.composition?.recipient_specific_target_open !== true || notificationContract.composition?.recipient_specific_mention_description !== true || notificationContract.composition?.recipient_specific_mention_audience !== true || notificationContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20P");
-if (notificationConsumer.schema_version !== 1 || notificationConsumer.task !== "FORUM-20P" || notificationConsumer.upstream_task !== "FORUM-20O" || notificationConsumer.composition?.active_topic_source_recheck !== true || notificationConsumer.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || notificationConsumer.composition?.recipient_specific_topic_visibility !== true || notificationConsumer.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20J topic visibility must remain synchronized with FORUM-20P");
+if (
+  notificationContract.schema_version !== 7 ||
+  notificationContract.task !== "FORUM-20K" ||
+  notificationContract.downstream_task !== "FORUM-20P" ||
+  notificationContract.composition?.exact_richer_public_owner !== true ||
+  notificationContract.composition?.recipient_specific_target_open !== true ||
+  notificationContract.composition?.recipient_specific_mention_description !== true ||
+  notificationContract.composition?.recipient_specific_mention_audience !== true ||
+  notificationContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20P");
+}
+if (
+  notificationConsumer.schema_version !== 1 ||
+  notificationConsumer.task !== "FORUM-20P" ||
+  notificationConsumer.upstream_task !== "FORUM-20O" ||
+  notificationConsumer.composition?.recipient_specific_topic_visibility !== true ||
+  notificationConsumer.composition?.bounded_raw_keyset_scan !== true
+) {
+  failures.push("FORUM-20J topic visibility must remain synchronized with the FORUM-20P notification consumer");
+}
 
 for (const marker of [
-  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers", "base visibility must fail before richer owner facts are requested",
-  "public richer visibility should fail closed", "nonmatching local role should resolve as denied",
-  "topic explicit deny should win", "missing exact membership should deny", "ForumError::CapabilityUnavailable",
-  "cross-tenant topic should resolve as absent", "actor does not match", "assert_eq!(recorded.len(), 2)",
-]) requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
+  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers",
+  "base visibility must fail before richer owner facts are requested",
+  "public richer visibility should fail closed",
+  "nonmatching local role should resolve as denied",
+  "topic explicit deny should win",
+  "missing exact membership should deny",
+  "ForumError::CapabilityUnavailable",
+  "cross-tenant topic should resolve as absent",
+  "actor does not match",
+  "assert_eq!(recorded.len(), 2)",
+]) {
+  requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
+}
 for (const marker of [
   "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "roles_any: vec![UserRole::Customer]", "deny_user_ids: vec![denied_first, denied_fourth]",
-  "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()",
+  "deny_user_ids: vec![denied_first, denied_fourth]",
+  "first_page.recipients().is_empty()",
   "BTreeSet::from([allowed_third, allowed_fifth])",
-]) requireText(consumerTestSource, marker, `topic subscription SQLite scenario is missing ${marker}`);
+]) {
+  requireText(consumerTestSource, marker, `topic subscription SQLite scenario is missing ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum topic audience visibility verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum topic audience visibility contract is source-ready.");

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -18,18 +18,10 @@ function read(relativePath) {
   }
   return readFileSync(absolute, "utf8");
 }
+function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
+function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-function requireText(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
-}
-
-function rejectText(source, marker, message) {
-  if (source.includes(marker)) failures.push(message);
-}
-
-const contractPath =
-  "crates/rustok-forum/contracts/forum-topic-audience-visibility.json";
-const contract = JSON.parse(read(contractPath) || "{}");
+const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-topic-audience-visibility.json") || "{}");
 const owner = read(contract.owner_file ?? "");
 const baseOwner = read(contract.base_visibility_owner ?? "");
 const categoryOwner = read(contract.category_policy_owner ?? "");
@@ -44,247 +36,90 @@ const testSource = read(contract.test_file ?? "");
 const consumerTestSource = read(contract.notification_consumer_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) {
-  failures.push("forum topic audience visibility contract must use schema_version=4");
-}
-if (
-  contract.task !== "FORUM-20J" ||
-  contract.downstream_notification_task !== "FORUM-20K" ||
-  contract.notification_consumer_task !== "FORUM-20P"
-) {
-  failures.push("forum topic audience visibility contract must connect FORUM-20J/K/P notification composition");
-}
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
-  failures.push("source publication must not claim unexecuted richer visibility evidence");
-}
-for (const delivered of [
-  "public_topic_created_notification",
-  "recipient_target_open_notification",
-  "recipient_mention_description_notification",
-  "recipient_mention_audience_notification",
-  "recipient_topic_subscription_audience_notification",
-]) {
-  if (contract.composition?.[delivered] !== true) {
-    failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
-  }
-}
+if (contract.schema_version !== 4) failures.push("forum topic audience visibility contract must use schema_version=4");
+if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K" || contract.notification_consumer_task !== "FORUM-20P") failures.push("forum topic audience visibility contract must connect FORUM-20J/K/P notification composition");
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("source publication must not claim unexecuted richer visibility evidence");
+for (const delivered of ["public_topic_created_notification", "recipient_target_open_notification", "recipient_mention_description_notification", "recipient_mention_audience_notification", "recipient_topic_subscription_audience_notification"]) if (contract.composition?.[delivered] !== true) failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
 for (const residual of [
-  "topic and reply page filtering before count and pagination",
-  "category and reply exact richer-audience composition",
-  "create reply and moderate audience write policy",
-  "host trust channel and group provider adapters",
-  "visibility-scoped category and all-read mutations",
-  "initially non-public topic-created descriptor materialization",
-  "search index SEO and deep-link migration to the richer exact owner",
-  "PostgreSQL concurrency and cross-consumer runtime evidence",
-]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
-  }
-}
+  "topic and reply page filtering before count and pagination", "category and reply exact richer-audience composition",
+  "create reply and moderate audience write policy", "host trust channel and group provider adapters",
+  "visibility-scoped category and all-read mutations", "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration to the richer exact owner", "PostgreSQL concurrency and cross-consumer runtime evidence",
+]) if (!contract.not_delivered?.includes(residual)) failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-];
+const deliveredSlices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
 const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20P") {
-  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20P");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20P delivered sections");
-}
+if (planSync.required_ledger_through !== "FORUM-20P" || JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20P");
 if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
+  if (planSync.current_plan_through !== "FORUM-20G") failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  requireText(plan, "FORUM-20A-G provide", "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row");
+  for (const slice of deliveredSlices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`);
 } else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
-}
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance through P");
+  for (const slice of deliveredSlices) requireText(plan, `### Delivered in \`${slice}\``, `synchronized canonical plan is missing ${slice}`);
+} else failures.push("canonical_plan_sync.status must be pending or synchronized");
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer",
-  "pub fn public() -> Self",
-  "pub fn authenticated(",
-  "security.actor_kind != SecurityActorKind::User",
-  "port_context.actor.kind != PortActorKind::User",
-  "actor does not match the viewer",
-  "pub struct ForumTopicAudienceVisibilityService",
-  "pub fn without_facts_provider",
-  "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(",
-  "ForumTopicVisibilityService::new(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, &scope)",
-  "find_topic(&self.db, tenant_id, topic_id)",
-  "load_policy_for_topic(&self.db, tenant_id, &topic)",
-  "for layer in &policy.inherited_category_layers",
-  "policy.configured_constraints",
-  ".resolve_for_constraints(",
-  "ForumAudienceEvaluator::decide(",
-  "facts.tenant_id = tenant_id",
-  "facts.user_id = viewer.security.user_id",
-]) {
-  requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
-}
+  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
+  "security.actor_kind != SecurityActorKind::User", "port_context.actor.kind != PortActorKind::User",
+  "actor does not match the viewer", "pub struct ForumTopicAudienceVisibilityService",
+  "pub fn without_facts_provider", "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, &scope)", "find_topic(&self.db, tenant_id, topic_id)",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)", "for layer in &policy.inherited_category_layers",
+  "policy.configured_constraints", ".resolve_for_constraints(", "ForumAudienceEvaluator::decide(",
+  "facts.tenant_id = tenant_id", "facts.user_id = viewer.security.user_id",
+]) requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
 for (const forbidden of [
-  "crate::entities",
-  "forum_category_audience_policy::",
-  "forum_category_audience_role::",
-  "forum_category_audience_channel::",
-  "forum_category_audience_group::",
-  "forum_category_audience_user::",
-  "forum_topic_audience_policy::",
-  "forum_topic_audience_role::",
-  "forum_topic_audience_channel::",
-  "forum_topic_audience_group::",
-  "forum_topic_audience_user::",
-]) {
-  rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`);
-}
+  "crate::entities", "forum_category_audience_policy::", "forum_category_audience_role::",
+  "forum_category_audience_channel::", "forum_category_audience_group::", "forum_category_audience_user::",
+  "forum_topic_audience_policy::", "forum_topic_audience_role::", "forum_topic_audience_channel::",
+  "forum_topic_audience_group::", "forum_topic_audience_user::",
+]) rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of ${forbidden}`);
 
 const baseIndex = owner.indexOf(".is_topic_visible(tenant_id, topic_id, &scope)");
 const policyIndex = owner.indexOf("load_policy_for_topic(&self.db, tenant_id, &topic)");
 const providerIndex = owner.indexOf(".resolve_for_constraints(");
-if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) {
-  failures.push("current exact storefront visibility must run before richer policy materialization");
-}
-if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) {
-  failures.push("current exact storefront visibility must run before optional owner facts calls");
-}
+if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) failures.push("current exact storefront visibility must run before richer policy materialization");
+if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) failures.push("current exact storefront visibility must run before optional owner facts calls");
 
-for (const marker of [
-  "pub struct ForumTopicVisibilityService",
-  "pub async fn is_topic_visible",
-  "self.hidden_category_ids_for_scope(tenant_id, scope)",
-  "forum_topic::Column::Status.eq(TopicStatus::Open)",
-  "all_topic_channel_access_subquery(tenant_id)",
-]) {
-  requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
-}
-for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) {
-  requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
-}
-for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) {
-  requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
-}
-for (const marker of [
-  "pub struct ForumAudienceFactsResolver",
-  "pub struct ForumAudienceEvaluator",
-  "ForumAudienceDecisionReason::ExplicitDeny",
-]) {
-  requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
-}
-for (const marker of [
-  "include!(\"topic_audience_visibility.rs\")",
-  "ForumTopicAudienceViewer",
-  "ForumTopicAudienceVisibilityService",
-]) {
-  requireText(services, marker, `forum services surface is missing ${marker}`);
-}
-for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) {
-  requireText(crate, marker, `forum crate surface is missing ${marker}`);
-}
+for (const marker of ["pub struct ForumTopicVisibilityService", "pub async fn is_topic_visible", "self.hidden_category_ids_for_scope(tenant_id, scope)", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
+for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
+for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
+for (const marker of ["pub struct ForumAudienceFactsResolver", "pub struct ForumAudienceEvaluator", "ForumAudienceDecisionReason::ExplicitDeny"]) requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
+for (const marker of ["include!(\"topic_audience_visibility.rs\")", "ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(services, marker, `forum services surface is missing ${marker}`);
+for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(crate, marker, `forum crate surface is missing ${marker}`);
 
 for (const marker of [
   "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
-  "async fn load_topic_for_viewer(",
+  "async fn load_active_topic(", "async fn load_topic_for_viewer(",
   "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
-  "async fn load_public_topic(",
-  "ForumTopicAudienceViewer::public()",
-  "async fn resolve_recipient_viewer(",
-  "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(",
-  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) {
-  requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
-}
-for (const forbidden of [
-  "ForumTopicVisibilityScope::storefront(None)",
-  "ForumTopicVisibilityService::new(",
-  "forum_category_audience_policy",
-  "forum_topic_audience_policy",
-]) {
-  rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
-}
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
+  "async fn load_topic_for_subscription_audience(", "ForumTopicAudienceViewer::public()",
+  "async fn resolve_recipient_viewer(", "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
+for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
 
-if (
-  notificationContract.schema_version !== 7 ||
-  notificationContract.task !== "FORUM-20K" ||
-  notificationContract.downstream_task !== "FORUM-20P" ||
-  notificationContract.composition?.exact_richer_public_owner !== true ||
-  notificationContract.composition?.recipient_specific_target_open !== true ||
-  notificationContract.composition?.recipient_specific_mention_description !== true ||
-  notificationContract.composition?.recipient_specific_mention_audience !== true ||
-  notificationContract.composition?.recipient_specific_topic_subscription_audience !== true
-) {
-  failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20P");
-}
-if (
-  notificationConsumer.schema_version !== 1 ||
-  notificationConsumer.task !== "FORUM-20P" ||
-  notificationConsumer.upstream_task !== "FORUM-20O" ||
-  notificationConsumer.composition?.recipient_specific_topic_visibility !== true ||
-  notificationConsumer.composition?.bounded_raw_keyset_scan !== true
-) {
-  failures.push("FORUM-20J topic visibility must remain synchronized with the FORUM-20P notification consumer");
-}
+if (notificationContract.schema_version !== 7 || notificationContract.task !== "FORUM-20K" || notificationContract.downstream_task !== "FORUM-20P" || notificationContract.composition?.exact_richer_public_owner !== true || notificationContract.composition?.topic_subscription_active_source_recheck !== true || notificationContract.composition?.recipient_specific_target_open !== true || notificationContract.composition?.recipient_specific_mention_description !== true || notificationContract.composition?.recipient_specific_mention_audience !== true || notificationContract.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20P");
+if (notificationConsumer.schema_version !== 1 || notificationConsumer.task !== "FORUM-20P" || notificationConsumer.upstream_task !== "FORUM-20O" || notificationConsumer.composition?.active_topic_source_recheck !== true || notificationConsumer.composition?.stale_public_descriptor_to_non_public_recipient_filtering !== true || notificationConsumer.composition?.recipient_specific_topic_visibility !== true || notificationConsumer.composition?.bounded_raw_keyset_scan !== true) failures.push("FORUM-20J topic visibility must remain synchronized with FORUM-20P");
 
 for (const marker of [
-  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers",
-  "base visibility must fail before richer owner facts are requested",
-  "public richer visibility should fail closed",
-  "nonmatching local role should resolve as denied",
-  "topic explicit deny should win",
-  "missing exact membership should deny",
-  "ForumError::CapabilityUnavailable",
-  "cross-tenant topic should resolve as absent",
-  "actor does not match",
-  "assert_eq!(recorded.len(), 2)",
-]) {
-  requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
-}
+  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers", "base visibility must fail before richer owner facts are requested",
+  "public richer visibility should fail closed", "nonmatching local role should resolve as denied",
+  "topic explicit deny should win", "missing exact membership should deny", "ForumError::CapabilityUnavailable",
+  "cross-tenant topic should resolve as absent", "actor does not match", "assert_eq!(recorded.len(), 2)",
+]) requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
 for (const marker of [
   "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
-  "deny_user_ids: vec![denied_first, denied_fourth]",
-  "first_page.recipients().is_empty()",
+  "roles_any: vec![UserRole::Customer]", "deny_user_ids: vec![denied_first, denied_fourth]",
+  "topic audience should become non-public and deny exact recipients", "first_page.recipients().is_empty()",
   "BTreeSet::from([allowed_third, allowed_fifth])",
-]) {
-  requireText(consumerTestSource, marker, `topic subscription SQLite scenario is missing ${marker}`);
-}
+]) requireText(consumerTestSource, marker, `topic subscription SQLite scenario is missing ${marker}`);
 
 if (failures.length > 0) {
   console.error("Forum topic audience visibility verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
-
 console.log("Forum topic audience visibility contract is source-ready.");

--- a/scripts/verify/verify-forum-topic-audience-visibility.mjs
+++ b/scripts/verify/verify-forum-topic-audience-visibility.mjs
@@ -5,17 +5,31 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT) : path.resolve(scriptDir, "../..");
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
 const failures = [];
+
 function read(relativePath) {
   const absolute = path.join(repoRoot, relativePath);
-  if (!existsSync(absolute)) { failures.push(`${relativePath}: required file is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
-function requireText(source, marker, message) { if (!source.includes(marker)) failures.push(message); }
-function rejectText(source, marker, message) { if (source.includes(marker)) failures.push(message); }
 
-const contract = JSON.parse(read("crates/rustok-forum/contracts/forum-topic-audience-visibility.json") || "{}");
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-topic-audience-visibility.json";
+const contract = JSON.parse(read(contractPath) || "{}");
 const owner = read(contract.owner_file ?? "");
 const baseOwner = read(contract.base_visibility_owner ?? "");
 const categoryOwner = read(contract.category_policy_owner ?? "");
@@ -23,70 +37,254 @@ const topicOwner = read(contract.topic_policy_owner ?? "");
 const evaluator = read(contract.audience_evaluator ?? "");
 const services = read(contract.services_file ?? "");
 const crate = read(contract.crate_file ?? "");
-const source = read(contract.notification_source_file ?? "");
-const visibility = JSON.parse(read(contract.notification_visibility_contract ?? "") || "{}");
-const consumer = JSON.parse(read(contract.notification_consumer_contract ?? "") || "{}");
-const ownerTest = read(contract.test_file ?? "");
-const consumerTest = read(contract.notification_consumer_test_file ?? "");
+const notificationSource = read(contract.notification_source_file ?? "");
+const notificationContract = JSON.parse(read(contract.notification_visibility_contract ?? "") || "{}");
+const notificationConsumer = JSON.parse(read(contract.notification_consumer_contract ?? "") || "{}");
+const testSource = read(contract.test_file ?? "");
+const consumerTestSource = read(contract.notification_consumer_test_file ?? "");
 const plan = read(contract.canonical_plan ?? "");
 
-if (contract.schema_version !== 4) failures.push("forum topic audience visibility contract must use schema_version=4");
-if (contract.task !== "FORUM-20J" || contract.downstream_notification_task !== "FORUM-20K" || contract.notification_consumer_task !== "FORUM-20P") failures.push("topic visibility contract must connect FORUM-20J/K/P");
-if (contract.verification?.execution_status !== "not_run_by_implementation_agent") failures.push("topic visibility contract must not claim unexecuted evidence");
-for (const field of [
-  "exact_topic", "open_status", "route_channel", "public_authenticated_category_floor",
-  "normalized_category_layers", "normalized_topic_layer", "role_and_explicit_user",
-  "trust_channel_group_owner_facts", "public_topic_created_notification",
-  "recipient_target_open_notification", "recipient_mention_description_notification",
-  "recipient_mention_audience_notification", "recipient_topic_subscription_audience_notification",
-]) if (contract.composition?.[field] !== true) failures.push(`topic visibility contract must record ${field}=true`);
+if (contract.schema_version !== 4) {
+  failures.push("forum topic audience visibility contract must use schema_version=4");
+}
+if (
+  contract.task !== "FORUM-20J" ||
+  contract.downstream_notification_task !== "FORUM-20K" ||
+  contract.notification_consumer_task !== "FORUM-20P"
+) {
+  failures.push("forum topic audience visibility contract must connect FORUM-20J/K/P notification composition");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("source publication must not claim unexecuted richer visibility evidence");
+}
+for (const delivered of [
+  "public_topic_created_notification",
+  "recipient_target_open_notification",
+  "recipient_mention_description_notification",
+  "recipient_mention_audience_notification",
+  "recipient_topic_subscription_audience_notification",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum topic audience visibility contract must record ${delivered} as delivered`);
+  }
+}
 for (const residual of [
-  "topic and reply page filtering before count and pagination", "category and reply exact richer-audience composition",
-  "create reply and moderate audience write policy", "host trust channel and group provider adapters",
-  "visibility-scoped category and all-read mutations", "initially non-public topic-created descriptor materialization",
-  "search index SEO and deep-link migration to the richer exact owner", "PostgreSQL concurrency and cross-consumer runtime evidence",
-]) if (!contract.not_delivered?.includes(residual)) failures.push(`topic visibility contract must keep ${residual} open`);
+  "topic and reply page filtering before count and pagination",
+  "category and reply exact richer-audience composition",
+  "create reply and moderate audience write policy",
+  "host trust channel and group provider adapters",
+  "visibility-scoped category and all-read mutations",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration to the richer exact owner",
+  "PostgreSQL concurrency and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum topic audience visibility contract must keep ${residual} explicitly open`);
+  }
+}
 
-const slices = ["FORUM-20H", "FORUM-20I", "FORUM-20J", "FORUM-20K", "FORUM-20L", "FORUM-20M", "FORUM-20N", "FORUM-20O", "FORUM-20P"];
-const sync = contract.canonical_plan_sync ?? {};
-if (sync.required_ledger_through !== "FORUM-20P" || JSON.stringify(sync.required_delivered_sections) !== JSON.stringify(slices)) failures.push("topic visibility contract must require FORUM-20H through FORUM-20P");
-if (sync.status === "pending") {
-  if (sync.current_plan_through !== "FORUM-20G") failures.push("pending plan boundary must remain FORUM-20G");
-  requireText(plan, "FORUM-20A-G provide", "pending plan sync must remain grounded in FORUM-20A-G");
-  for (const slice of slices) rejectText(plan, `### Delivered in \`${slice}\``, `canonical plan contains ${slice}; update plan sync metadata`);
-} else if (sync.status !== "synchronized") failures.push("canonical_plan_sync.status must be pending or synchronized");
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20P") {
+  failures.push("forum topic audience visibility contract must require the canonical ledger through FORUM-20P");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum topic audience visibility contract must require FORUM-20H through FORUM-20P delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-P provide", "synchronized canonical plan must advance the FORUM-20 ledger through P");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
 
 for (const marker of [
-  "pub struct ForumTopicAudienceViewer", "pub fn public() -> Self", "pub fn authenticated(",
-  "pub struct ForumTopicAudienceVisibilityService", "pub async fn is_topic_visible(",
-  "ForumTopicVisibilityScope::storefront_for_viewer(", "ForumTopicVisibilityService::new(self.db.clone())",
-  ".is_topic_visible(tenant_id, topic_id, &scope)", "load_policy_for_topic(&self.db, tenant_id, &topic)",
-  "for layer in &policy.inherited_category_layers", "policy.configured_constraints",
-  ".resolve_for_constraints(", "ForumAudienceEvaluator::decide(",
-]) requireText(owner, marker, `exact topic visibility owner is missing ${marker}`);
-for (const forbidden of ["crate::entities", "forum_category_audience_policy::", "forum_topic_audience_policy::"]) rejectText(owner, forbidden, `exact topic visibility owner must reuse policy owners instead of ${forbidden}`);
-for (const marker of ["pub struct ForumTopicVisibilityService", "forum_topic::Column::Status.eq(TopicStatus::Open)", "all_topic_channel_access_subquery(tenant_id)"]) requireText(baseOwner, marker, `base visibility owner is missing ${marker}`);
-for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) requireText(categoryOwner, marker, `category owner is missing ${marker}`);
-for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) requireText(topicOwner, marker, `topic owner is missing ${marker}`);
-for (const marker of ["pub struct ForumAudienceFactsResolver", "pub struct ForumAudienceEvaluator", "ForumAudienceDecisionReason::ExplicitDeny"]) requireText(evaluator, marker, `audience evaluator is missing ${marker}`);
-for (const marker of ["include!(\"topic_audience_visibility.rs\")", "ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(services, marker, `services surface is missing ${marker}`);
-for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) requireText(crate, marker, `crate surface is missing ${marker}`);
-for (const marker of [
-  "async fn load_topic_for_viewer(", "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
-  ".is_topic_visible(tenant_id, topic_id, None, viewer)", "async fn load_public_topic(",
-  "async fn resolve_recipient_viewer(", "async fn load_mention_target_for_recipient(",
-  "async fn topic_subscription_recipient_visible(", "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
-]) requireText(source, marker, `notification consumer is missing ${marker}`);
-for (const forbidden of ["ForumTopicVisibilityScope::storefront(None)", "ForumTopicVisibilityService::new(", "forum_category_audience_policy", "forum_topic_audience_policy"]) rejectText(source, forbidden, `notification source must not bypass exact owner with ${forbidden}`);
+  "pub struct ForumTopicAudienceViewer",
+  "pub fn public() -> Self",
+  "pub fn authenticated(",
+  "security.actor_kind != SecurityActorKind::User",
+  "port_context.actor.kind != PortActorKind::User",
+  "actor does not match the viewer",
+  "pub struct ForumTopicAudienceVisibilityService",
+  "pub fn without_facts_provider",
+  "pub async fn is_topic_visible(",
+  "ForumTopicVisibilityScope::storefront_for_viewer(",
+  "ForumTopicVisibilityService::new(self.db.clone())",
+  ".is_topic_visible(tenant_id, topic_id, &scope)",
+  "find_topic(&self.db, tenant_id, topic_id)",
+  "load_policy_for_topic(&self.db, tenant_id, &topic)",
+  "for layer in &policy.inherited_category_layers",
+  "policy.configured_constraints",
+  ".resolve_for_constraints(",
+  "ForumAudienceEvaluator::decide(",
+  "facts.tenant_id = tenant_id",
+  "facts.user_id = viewer.security.user_id",
+]) {
+  requireText(owner, marker, `exact richer topic visibility owner is missing ${marker}`);
+}
+for (const forbidden of [
+  "crate::entities",
+  "forum_category_audience_policy::",
+  "forum_category_audience_role::",
+  "forum_category_audience_channel::",
+  "forum_category_audience_group::",
+  "forum_category_audience_user::",
+  "forum_topic_audience_policy::",
+  "forum_topic_audience_role::",
+  "forum_topic_audience_channel::",
+  "forum_topic_audience_group::",
+  "forum_topic_audience_user::",
+]) {
+  rejectText(owner, forbidden, `exact richer topic visibility owner must reuse policy owners instead of direct storage access ${forbidden}`);
+}
 
-if (visibility.schema_version !== 7 || visibility.task !== "FORUM-20K" || visibility.downstream_task !== "FORUM-20P" || visibility.composition?.recipient_specific_topic_subscription_audience !== true) failures.push("FORUM-20J must remain synchronized with FORUM-20K/P");
-if (consumer.schema_version !== 1 || consumer.task !== "FORUM-20P" || consumer.upstream_task !== "FORUM-20O" || consumer.composition?.recipient_specific_topic_visibility !== true) failures.push("FORUM-20J must remain synchronized with FORUM-20P");
-for (const marker of ["exact_topic_visibility_conjoins_base_category_and_topic_audience_layers", "topic explicit deny should win", "ForumError::CapabilityUnavailable", "actor does not match"]) requireText(ownerTest, marker, `exact visibility test is missing ${marker}`);
-for (const marker of ["topic_subscription_audience_filters_exact_recipients_before_cursor_progress", "deny_user_ids: vec![denied_first, denied_fourth]", "BTreeSet::from([allowed_third, allowed_fifth])"]) requireText(consumerTest, marker, `topic subscription consumer test is missing ${marker}`);
+const baseIndex = owner.indexOf(".is_topic_visible(tenant_id, topic_id, &scope)");
+const policyIndex = owner.indexOf("load_policy_for_topic(&self.db, tenant_id, &topic)");
+const providerIndex = owner.indexOf(".resolve_for_constraints(");
+if (baseIndex < 0 || policyIndex < 0 || baseIndex > policyIndex) {
+  failures.push("current exact storefront visibility must run before richer policy materialization");
+}
+if (baseIndex < 0 || providerIndex < 0 || baseIndex > providerIndex) {
+  failures.push("current exact storefront visibility must run before optional owner facts calls");
+}
+
+for (const marker of [
+  "pub struct ForumTopicVisibilityService",
+  "pub async fn is_topic_visible",
+  "self.hidden_category_ids_for_scope(tenant_id, scope)",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+  "all_topic_channel_access_subquery(tenant_id)",
+]) {
+  requireText(baseOwner, marker, `base topic visibility owner is missing ${marker}`);
+}
+for (const marker of ["pub(crate) async fn load_category_audience_policy", "effective_layers"]) {
+  requireText(categoryOwner, marker, `category audience owner is missing ${marker}`);
+}
+for (const marker of ["async fn load_policy_for_topic", "inherited_category_layers", "configured_constraints"]) {
+  requireText(topicOwner, marker, `topic audience owner is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumAudienceFactsResolver",
+  "pub struct ForumAudienceEvaluator",
+  "ForumAudienceDecisionReason::ExplicitDeny",
+]) {
+  requireText(evaluator, marker, `audience evaluator contract is missing ${marker}`);
+}
+for (const marker of [
+  "include!(\"topic_audience_visibility.rs\")",
+  "ForumTopicAudienceViewer",
+  "ForumTopicAudienceVisibilityService",
+]) {
+  requireText(services, marker, `forum services surface is missing ${marker}`);
+}
+for (const marker of ["ForumTopicAudienceViewer", "ForumTopicAudienceVisibilityService"]) {
+  requireText(crate, marker, `forum crate surface is missing ${marker}`);
+}
+
+for (const marker of [
+  "use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};",
+  "async fn load_topic_for_viewer(",
+  "ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())",
+  ".is_topic_visible(tenant_id, topic_id, None, viewer)",
+  "async fn load_public_topic(",
+  "ForumTopicAudienceViewer::public()",
+  "async fn resolve_recipient_viewer(",
+  "async fn load_mention_target_for_recipient(",
+  "async fn topic_subscription_recipient_visible(",
+  "TOPIC_SUBSCRIPTION_AUDIENCE_ACTOR",
+]) {
+  requireText(notificationSource, marker, `notification source is missing richer topic visibility composition ${marker}`);
+}
+for (const forbidden of [
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityService::new(",
+  "forum_category_audience_policy",
+  "forum_topic_audience_policy",
+]) {
+  rejectText(notificationSource, forbidden, `notification source must not bypass the richer owner with ${forbidden}`);
+}
+
+if (
+  notificationContract.schema_version !== 7 ||
+  notificationContract.task !== "FORUM-20K" ||
+  notificationContract.downstream_task !== "FORUM-20P" ||
+  notificationContract.composition?.exact_richer_public_owner !== true ||
+  notificationContract.composition?.recipient_specific_target_open !== true ||
+  notificationContract.composition?.recipient_specific_mention_description !== true ||
+  notificationContract.composition?.recipient_specific_mention_audience !== true ||
+  notificationContract.composition?.recipient_specific_topic_subscription_audience !== true
+) {
+  failures.push("FORUM-20K notification visibility contract must record public and exact recipient composition through FORUM-20P");
+}
+if (
+  notificationConsumer.schema_version !== 1 ||
+  notificationConsumer.task !== "FORUM-20P" ||
+  notificationConsumer.upstream_task !== "FORUM-20O" ||
+  notificationConsumer.composition?.recipient_specific_topic_visibility !== true ||
+  notificationConsumer.composition?.bounded_raw_keyset_scan !== true
+) {
+  failures.push("FORUM-20J topic visibility must remain synchronized with the FORUM-20P notification consumer");
+}
+
+for (const marker of [
+  "exact_topic_visibility_conjoins_base_category_and_topic_audience_layers",
+  "base visibility must fail before richer owner facts are requested",
+  "public richer visibility should fail closed",
+  "nonmatching local role should resolve as denied",
+  "topic explicit deny should win",
+  "missing exact membership should deny",
+  "ForumError::CapabilityUnavailable",
+  "cross-tenant topic should resolve as absent",
+  "actor does not match",
+  "assert_eq!(recorded.len(), 2)",
+]) {
+  requireText(testSource, marker, `richer topic visibility SQLite scenario is missing ${marker}`);
+}
+for (const marker of [
+  "topic_subscription_audience_filters_exact_recipients_before_cursor_progress",
+  "deny_user_ids: vec![denied_first, denied_fourth]",
+  "first_page.recipients().is_empty()",
+  "BTreeSet::from([allowed_third, allowed_fifth])",
+]) {
+  requireText(consumerTestSource, marker, `topic subscription SQLite scenario is missing ${marker}`);
+}
 
 if (failures.length > 0) {
   console.error("Forum topic audience visibility verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }
+
 console.log("Forum topic audience visibility contract is source-ready.");


### PR DESCRIPTION
## Summary

- filter `forum.topic.created` category subscriptions through the exact Forum recipient-context capability before candidate creation
- keep topic-created descriptor materialization public-only while allowing a previously public descriptor to recheck a now non-public topic for each exact recipient
- load only the current active topic record when recipient context is published and preserve the previous public source recheck when it is absent
- scan subscriptions in bounded keyset pages using requested limit plus one lookahead row
- advance the cursor by the last scanned raw subscription rather than the last allowed recipient
- return sparse advancing pages when all scanned recipients are denied or unavailable, using the `NOTIFY-03I` fanout prerequisite
- preserve actor exclusion, muted subscription exclusion, typed retryability, and public-only degraded behavior
- add a focused SQLite scenario covering sparse, mixed, and terminal pages across a stale public descriptor to non-public policy transition
- add the FORUM-20P contract and advance the J/K/L/M/N/O/P machine-contract and source-verifier chain

## Boundary

Initial descriptor materialization for a topic that is already non-public remains deferred. This slice does not add profile privacy/blocking, trust/channel/group facts adapters, final delivery authorization, search/SEO migration, or PostgreSQL concurrency evidence.

The canonical Forum implementation plan still physically ends at FORUM-20G. Machine contracts keep synchronization explicitly pending through FORUM-20P.

## Validation

Tests, Cargo commands, formatting commands, verifiers, and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-notifications --test fanout_sparse_page_sqlite -- --nocapture
cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_source_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_richer_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_mention_audience_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture
node scripts/verify/verify-notifications-source-fanout.mjs
node scripts/verify/verify-forum-topic-audience-visibility.mjs
node scripts/verify/verify-forum-notification-visibility-composition.mjs
node scripts/verify/verify-forum-notification-recipient-context.mjs
node scripts/verify/verify-forum-notification-recipient-host-runtime.mjs
node scripts/verify/verify-forum-notification-recipient-target-open.mjs
node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
cargo xtask module validate forum
```