### PR TITLE
Harden admin order change orchestration error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -69,6 +69,12 @@ available only for actionable domain errors.
   order and order-change identities, stable public code, status, and HTTP boundary. Typed
   missing-resource identities are adopted from the error while validation, conflict,
   storage, and fail-closed responses preserve the existing static policy.
+- `rustok-commerce` admin order-change orchestration route: apply retains the top-level
+  typed post-order cause with orchestration and source owner, tenant, actor, route
+  operation, truthful optional order, order-change, payment-collection, payment, and
+  reserved-refund identities, stable public code, status, and HTTP boundary. Nested order,
+  payment, provider, validation, and reserved-refund outcomes preserve the existing static
+  status, code, and message policy without delegating through a second generic error event.
 - `rustok-commerce` admin order-return owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and return identities, stable public code, status, and HTTP boundary. Validation,
@@ -134,6 +140,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-detail-payment-error-context.mjs`
@@ -152,9 +159,9 @@ available only for actionable domain errors.
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
   admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option and
-  order-change owner mapping, admin order-return owner and orchestration mapping, admin
-  order-detail payment and fulfillment mapping, and tax calculation validation,
-  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
-  tests.
+  order-change owner and orchestration mapping, admin order-return owner and orchestration
+  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
+  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and transport
+  round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/changes.rs
+++ b/crates/rustok-commerce/src/controllers/admin/changes.rs
@@ -7,6 +7,7 @@ use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_order::OrderService;
 use rustok_order::error::OrderError;
+use rustok_payment::error::PaymentError;
 use rustok_web::{HttpError, HttpResult};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -19,14 +20,24 @@ use super::{
 };
 use crate::services::OrderChangeOrchestrationService;
 use crate::{
-    ApplyOrderChangeResult, ExchangeDifferenceRefundInput,
+    ApplyOrderChangeResult, ExchangeDifferenceRefundInput, PaymentOrchestrationError,
+    PostOrderOrchestrationError,
     dto::{
         CancelOrderChangeInput, CreateOrderChangeInput, ListOrderChangesInput, OrderChangeResponse,
     },
 };
 
 const ADMIN_ORDER_CHANGE_OWNER: &str = "rustok_order.admin_changes";
+const ADMIN_ORDER_CHANGE_ORCHESTRATION_OWNER: &str =
+    "rustok_commerce.admin_order_change_orchestration";
 const ADMIN_ORDER_CHANGE_BOUNDARY: &str = "commerce_admin_order_change_http";
+
+type AdminOrderChangeHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
 
 struct AdminOrderChangeErrorContext {
     tenant_id: Uuid,
@@ -51,36 +62,48 @@ impl AdminOrderChangeErrorContext {
     }
 }
 
-fn map_admin_order_change_error(
-    mut context: AdminOrderChangeErrorContext,
-    error: OrderError,
-) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
+struct AdminOrderChangeOrchestrationErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Option<Uuid>,
+    order_change_id: Option<Uuid>,
+    payment_collection_id: Option<Uuid>,
+    payment_id: Option<Uuid>,
+    refund_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminOrderChangeOrchestrationErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        order_change_id: Uuid,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            order_id: None,
+            order_change_id: Some(order_change_id),
+            payment_collection_id: None,
+            payment_id: None,
+            refund_id: None,
+            operation,
+        }
+    }
+}
+
+fn admin_order_change_order_error_policy(error: &OrderError) -> AdminOrderChangeHttpPolicy {
+    match error {
         OrderError::Validation(_) => (
             StatusCode::BAD_REQUEST,
             "commerce_admin_order_invalid",
             "Order request is invalid",
             "validation",
         ),
-        OrderError::OrderNotFound(id) => {
-            context.order_id = Some(*id);
-            (
-                StatusCode::NOT_FOUND,
-                "commerce_admin_not_found",
-                "Commerce resource not found",
-                "not_found",
-            )
-        }
-        OrderError::OrderChangeNotFound(id) => {
-            context.order_change_id = Some(*id);
-            (
-                StatusCode::NOT_FOUND,
-                "commerce_admin_not_found",
-                "Commerce resource not found",
-                "not_found",
-            )
-        }
-        OrderError::OrderReturnNotFound(_) => (
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
             StatusCode::NOT_FOUND,
             "commerce_admin_not_found",
             "Commerce resource not found",
@@ -104,7 +127,118 @@ fn map_admin_order_change_error(
             "Order operation could not be completed safely",
             "core",
         ),
-    };
+    }
+}
+
+fn admin_order_change_payment_error_policy(error: &PaymentError) -> AdminOrderChangeHttpPolicy {
+    match error {
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PaymentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::BAD_GATEWAY,
+            "commerce_admin_payment_provider_invalid_response",
+            "Payment provider returned an invalid response; reconciliation may be required",
+            "provider_invalid_response",
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment provider outcome is unknown and requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        PaymentError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "database",
+        ),
+    }
+}
+
+fn admin_order_change_reserved_refund_error_policy(
+    error: &PaymentError,
+) -> AdminOrderChangeHttpPolicy {
+    match error {
+        PaymentError::ProviderOutcomeUnknown { .. }
+        | PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_refund_reconciliation_required",
+            "Refund remains reserved while the provider outcome is reconciled",
+            "refund_reconciliation_required",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_refund_provider_unavailable",
+            "Refund remains reserved and the provider operation may be retried safely",
+            "refund_provider_unavailable",
+        ),
+        error => admin_order_change_payment_error_policy(error),
+    }
+}
+
+fn adopt_order_change_order_error_identity(
+    context: &mut AdminOrderChangeOrchestrationErrorContext,
+    error: &OrderError,
+) {
+    match error {
+        OrderError::OrderNotFound(id) => context.order_id = Some(*id),
+        OrderError::OrderChangeNotFound(id) => context.order_change_id = Some(*id),
+        _ => {}
+    }
+}
+
+fn adopt_order_change_payment_error_identity(
+    context: &mut AdminOrderChangeOrchestrationErrorContext,
+    error: &PaymentError,
+) {
+    match error {
+        PaymentError::PaymentCollectionNotFound(id) => context.payment_collection_id = Some(*id),
+        PaymentError::PaymentNotFound(id) => context.payment_id = Some(*id),
+        PaymentError::RefundNotFound(id) => context.refund_id = Some(*id),
+        _ => {}
+    }
+}
+
+fn map_admin_order_change_error(
+    mut context: AdminOrderChangeErrorContext,
+    error: OrderError,
+) -> HttpError {
+    match &error {
+        OrderError::OrderNotFound(id) => context.order_id = Some(*id),
+        OrderError::OrderChangeNotFound(id) => context.order_change_id = Some(*id),
+        _ => {}
+    }
+    let (status, code, message, error_kind) = admin_order_change_order_error_policy(&error);
     tracing::error!(
         error = ?error,
         owner = ADMIN_ORDER_CHANGE_OWNER,
@@ -117,6 +251,70 @@ fn map_admin_order_change_error(
         status = %status,
         boundary = ADMIN_ORDER_CHANGE_BOUNDARY,
         "commerce admin order change owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_order_change_orchestration_error(
+    mut context: AdminOrderChangeOrchestrationErrorContext,
+    error: PostOrderOrchestrationError,
+) -> HttpError {
+    let (status, code, message, error_kind, source_owner) = match &error {
+        PostOrderOrchestrationError::Order(source) => {
+            adopt_order_change_order_error_identity(&mut context, source);
+            let (status, code, message, error_kind) =
+                admin_order_change_order_error_policy(source);
+            (status, code, message, error_kind, "rustok_order")
+        }
+        PostOrderOrchestrationError::Payment(source) => {
+            adopt_order_change_payment_error_identity(&mut context, source);
+            let (status, code, message, error_kind) =
+                admin_order_change_payment_error_policy(source);
+            (status, code, message, error_kind, "rustok_payment")
+        }
+        PostOrderOrchestrationError::PaymentOrchestration(source) => match source {
+            PaymentOrchestrationError::Provider(source)
+            | PaymentOrchestrationError::Payment(source) => {
+                adopt_order_change_payment_error_identity(&mut context, source);
+                let (status, code, message, error_kind) =
+                    admin_order_change_payment_error_policy(source);
+                (status, code, message, error_kind, "rustok_payment")
+            }
+            PaymentOrchestrationError::ProviderAfterRefundReservation {
+                refund_id,
+                source,
+            } => {
+                context.refund_id = Some(*refund_id);
+                let (status, code, message, error_kind) =
+                    admin_order_change_reserved_refund_error_policy(source);
+                (status, code, message, error_kind, "rustok_payment")
+            }
+        },
+        PostOrderOrchestrationError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_post_order_invalid",
+            "Post-order request is invalid",
+            "validation",
+            "rustok_commerce",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_CHANGE_ORCHESTRATION_OWNER,
+        source_owner,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        order_id = ?context.order_id,
+        order_change_id = ?context.order_change_id,
+        payment_collection_id = ?context.payment_collection_id,
+        payment_id = ?context.payment_id,
+        refund_id = ?context.refund_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_CHANGE_BOUNDARY,
+        "commerce admin order change orchestration failed"
     );
     HttpError::new(status, code, message)
 }
@@ -296,11 +494,22 @@ pub async fn apply_order_change(
         "Permission denied: orders:update required",
     )?;
 
+    let actor_id = auth.user_id;
     let result = OrderChangeOrchestrationService::new(runtime.db_clone(), runtime.event_bus())
         .with_payment_provider_registry(runtime.payment_provider_registry())
         .apply_order_change(tenant.id, id, input.difference_refund, input.metadata)
         .await
-        .map_err(super::map_post_order_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_order_change_orchestration_error(
+                AdminOrderChangeOrchestrationErrorContext::new(
+                    tenant.id,
+                    actor_id,
+                    id,
+                    "apply_order_change",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(result))
 }

--- a/scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const changes = read('crates/rustok-commerce/src/controllers/admin/changes.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const postOrder = read('crates/rustok-commerce/src/services/post_order.rs');
+const paymentOrchestration = read(
+  'crates/rustok-commerce/src/services/payment_orchestration.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const orderPolicy = between(
+  changes,
+  'fn admin_order_change_order_error_policy(',
+  'fn admin_order_change_payment_error_policy(',
+  'order policy',
+);
+const paymentPolicy = between(
+  changes,
+  'fn admin_order_change_payment_error_policy(',
+  'fn admin_order_change_reserved_refund_error_policy(',
+  'payment policy',
+);
+const reservedRefundPolicy = between(
+  changes,
+  'fn admin_order_change_reserved_refund_error_policy(',
+  'fn adopt_order_change_order_error_identity(',
+  'reserved refund policy',
+);
+const mapper = between(
+  changes,
+  'fn map_admin_order_change_orchestration_error(',
+  '/// Create admin order change preview',
+  'order-change orchestration mapper',
+);
+const applyRoute = between(
+  changes,
+  'pub async fn apply_order_change(',
+  '/// Cancel admin order change',
+  'apply order change route',
+);
+
+for (const [value, label] of [
+  ['use rustok_payment::error::PaymentError;', 'typed payment import'],
+  ['PaymentOrchestrationError,', 'typed payment orchestration import'],
+  ['PostOrderOrchestrationError,', 'typed post-order import'],
+  [
+    'const ADMIN_ORDER_CHANGE_ORCHESTRATION_OWNER: &str =',
+    'orchestration owner constant',
+  ],
+  [
+    'const ADMIN_ORDER_CHANGE_BOUNDARY: &str = "commerce_admin_order_change_http";',
+    'HTTP boundary constant',
+  ],
+  ['type AdminOrderChangeHttpPolicy = (', 'static HTTP policy type'],
+  ['struct AdminOrderChangeOrchestrationErrorContext {', 'orchestration context'],
+  ['tenant_id: Uuid,', 'tenant field'],
+  ['actor_id: Uuid,', 'actor field'],
+  ['order_id: Option<Uuid>,', 'order identity field'],
+  ['order_change_id: Option<Uuid>,', 'change identity field'],
+  ['payment_collection_id: Option<Uuid>,', 'collection identity field'],
+  ['payment_id: Option<Uuid>,', 'payment identity field'],
+  ['refund_id: Option<Uuid>,', 'refund identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(changes, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'order validation variant'],
+  ['OrderError::OrderNotFound(_)', 'order not-found variant'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found variant'],
+  ['OrderError::InvalidTransition { .. }', 'order transition variant'],
+  ['OrderError::Database(_)', 'order database variant'],
+  ['OrderError::Core(_)', 'order core variant'],
+  ['"commerce_admin_order_invalid"', 'order validation code'],
+  ['"commerce_admin_order_state_conflict"', 'order conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'order storage code'],
+  ['"commerce_admin_order_failed"', 'order fail-closed code'],
+  ['"Order request is invalid"', 'static order validation message'],
+  ['"Order operation could not be completed safely"', 'static order fail-closed message'],
+]) requireText(orderPolicy, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found variant'],
+  ['PaymentError::PaymentNotFound(_)', 'payment not-found variant'],
+  ['PaymentError::RefundNotFound(_)', 'refund not-found variant'],
+  ['PaymentError::Validation(_)', 'payment validation variant'],
+  ['PaymentError::InvalidTransition { .. }', 'payment transition variant'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejection variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'provider invalid-response variant'],
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'provider unknown-outcome variant'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration variant'],
+  ['PaymentError::Database(_)', 'payment database variant'],
+  ['StatusCode::BAD_GATEWAY', 'bad-gateway status'],
+  ['"commerce_admin_payment_invalid"', 'payment validation code'],
+  ['"commerce_admin_payment_state_conflict"', 'payment conflict code'],
+  ['"commerce_admin_payment_provider_unavailable"', 'provider unavailable code'],
+  ['"commerce_admin_payment_provider_invalid_response"', 'provider response code'],
+  ['"commerce_admin_payment_reconciliation_required"', 'payment reconciliation code'],
+  ['"commerce_admin_payment_provider_not_configured"', 'provider configuration code'],
+  ['"commerce_admin_payment_storage_unavailable"', 'payment storage code'],
+]) requireText(paymentPolicy, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'reserved unknown-outcome variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'reserved invalid-response variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'reserved unavailable variant'],
+  ['"commerce_admin_refund_reconciliation_required"', 'refund reconciliation code'],
+  ['"Refund remains reserved while the provider outcome is reconciled"', 'refund reconciliation message'],
+  ['"commerce_admin_refund_provider_unavailable"', 'refund retry code'],
+  [
+    '"Refund remains reserved and the provider operation may be retried safely"',
+    'refund retry message',
+  ],
+  ['error => admin_order_change_payment_error_policy(error)', 'reserved fallback policy'],
+]) requireText(reservedRefundPolicy, value, label);
+
+for (const [value, label] of [
+  ['error: PostOrderOrchestrationError,', 'owned top-level cause'],
+  ['PostOrderOrchestrationError::Order(source)', 'nested order branch'],
+  ['PostOrderOrchestrationError::Payment(source)', 'nested payment branch'],
+  ['PostOrderOrchestrationError::PaymentOrchestration(source)', 'payment orchestration branch'],
+  ['PostOrderOrchestrationError::Validation(_)', 'orchestration validation branch'],
+  ['PaymentOrchestrationError::Provider(source)', 'provider branch'],
+  ['PaymentOrchestrationError::Payment(source)', 'payment owner branch'],
+  ['PaymentOrchestrationError::ProviderAfterRefundReservation {', 'reserved refund branch'],
+  ['context.refund_id = Some(*refund_id);', 'reserved refund identity adoption'],
+  ['adopt_order_change_order_error_identity(&mut context, source)', 'order identity adoption'],
+  ['adopt_order_change_payment_error_identity(&mut context, source)', 'payment identity adoption'],
+  ['"commerce_admin_post_order_invalid"', 'post-order validation code'],
+  ['"Post-order request is invalid"', 'post-order validation message'],
+  ['error = ?error', 'typed top-level cause log'],
+  ['owner = ADMIN_ORDER_CHANGE_ORCHESTRATION_OWNER', 'orchestration owner log'],
+  ['source_owner,', 'source owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['order_change_id = ?context.order_change_id', 'change identity log'],
+  ['payment_collection_id = ?context.payment_collection_id', 'collection identity log'],
+  ['payment_id = ?context.payment_id', 'payment identity log'],
+  ['refund_id = ?context.refund_id', 'refund identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_CHANGE_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['[Permission::ORDERS_UPDATE]', 'update permission'],
+  ['let actor_id = auth.user_id;', 'actor capture'],
+  ['.with_payment_provider_registry(runtime.payment_provider_registry())', 'provider registry contract'],
+  ['.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)', 'service contract'],
+  ['.map_err(|error| {', 'typed mapping closure'],
+  ['map_admin_order_change_orchestration_error(', 'local mapper handoff'],
+  ['AdminOrderChangeOrchestrationErrorContext::new(', 'context construction'],
+  ['tenant.id,\n                    actor_id,\n                    id,\n                    "apply_order_change",', 'truthful route context'],
+]) requireText(applyRoute, value, label);
+
+const mapperUses =
+  changes.match(
+    /map_admin_order_change_orchestration_error\(\s+AdminOrderChangeOrchestrationErrorContext::new\(/g,
+  ) ?? [];
+if (mapperUses.length !== 1) {
+  failures.push(`expected one context-aware order-change orchestration callsite, found ${mapperUses.length}`);
+}
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
+  [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
+  [paymentErrors, 'RefundNotFound(Uuid)', 'owner refund variant'],
+  [paymentErrors, 'ProviderUnavailable {', 'owner provider unavailable variant'],
+  [paymentErrors, 'ProviderRejected {', 'owner provider rejection variant'],
+  [paymentErrors, 'ProviderInvalidResponse {', 'owner provider response variant'],
+  [paymentErrors, 'ProviderOutcomeUnknown {', 'owner provider outcome variant'],
+  [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner provider configuration variant'],
+  [postOrder, 'Order(#[from] rustok_order::error::OrderError)', 'post-order order variant'],
+  [postOrder, 'Payment(#[from] rustok_payment::error::PaymentError)', 'post-order payment variant'],
+  [postOrder, 'PaymentOrchestration(#[from] PaymentOrchestrationError)', 'post-order orchestration variant'],
+  [postOrder, 'Validation(String)', 'post-order validation variant'],
+  [paymentOrchestration, 'Provider(#[source] PaymentError)', 'payment orchestration provider variant'],
+  [paymentOrchestration, 'ProviderAfterRefundReservation {', 'payment orchestration reserved variant'],
+  [paymentOrchestration, 'Payment(#[from] PaymentError)', 'payment orchestration owner variant'],
+]) requireText(ownerSource, value, label);
+
+for (const value of [
+  '.map_err(super::map_post_order_orchestration_error)?;',
+  'format!("Post-order request is invalid:',
+  'format!("Payment request is invalid:',
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(changes, value, 'unsafe admin order-change orchestration public conversion');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order-change orchestration error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order-change orchestration retains typed causes and static public envelopes',
+);

--- a/scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
@@ -33,7 +33,7 @@ const between = (content, start, end, label) => {
 const mapper = between(
   changes,
   'fn map_admin_order_change_error(',
-  '/// Create admin order change preview',
+  'fn map_admin_order_change_orchestration_error(',
   'admin order-change owner mapper',
 );
 const createRoute = between(
@@ -77,20 +77,38 @@ for (const [value, label] of [
   ['order_id: Option<Uuid>,', 'order identity field'],
   ['order_change_id: Option<Uuid>,', 'change identity field'],
   ["operation: &'static str,", 'operation field'],
+  ['fn admin_order_change_order_error_policy(', 'shared typed order policy'],
 ]) requireText(changes, value, label);
 
 for (const [value, label] of [
   ['mut context: AdminOrderChangeErrorContext,', 'mutable typed context'],
   ['error: OrderError,', 'owned typed cause'],
+  ['OrderError::OrderNotFound(id)', 'order identity adoption'],
+  ['OrderError::OrderChangeNotFound(id)', 'change identity adoption'],
+  ['context.order_id = Some(*id)', 'typed order identity adoption'],
+  ['context.order_change_id = Some(*id)', 'typed change identity adoption'],
+  ['admin_order_change_order_error_policy(&error)', 'typed policy handoff'],
+  ['error = ?error', 'typed internal cause'],
+  ['owner = ADMIN_ORDER_CHANGE_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['order_change_id = ?context.order_change_id', 'change identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_CHANGE_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
   ['OrderError::Validation(_)', 'validation variant'],
-  ['OrderError::OrderNotFound(id)', 'order not-found variant'],
+  ['OrderError::OrderNotFound(_)', 'order not-found variant'],
   ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
-  ['OrderError::OrderChangeNotFound(id)', 'change not-found variant'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found variant'],
   ['OrderError::InvalidTransition { .. }', 'transition variant'],
   ['OrderError::Database(_)', 'database variant'],
   ['OrderError::Core(_)', 'core variant'],
-  ['context.order_id = Some(*id);', 'typed order identity adoption'],
-  ['context.order_change_id = Some(*id);', 'typed change identity adoption'],
   ['StatusCode::BAD_REQUEST', 'bad-request status'],
   ['StatusCode::NOT_FOUND', 'not-found status'],
   ['StatusCode::CONFLICT', 'conflict status'],
@@ -106,18 +124,7 @@ for (const [value, label] of [
   ['"Order operation conflicts with the current state"', 'static conflict message'],
   ['"Order storage is temporarily unavailable"', 'static storage message'],
   ['"Order operation could not be completed safely"', 'static fail-closed message'],
-  ['error = ?error', 'typed internal cause'],
-  ['owner = ADMIN_ORDER_CHANGE_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['order_id = ?context.order_id', 'order identity log'],
-  ['order_change_id = ?context.order_change_id', 'change identity log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public-code log'],
-  ['status = %status', 'status log'],
-  ['boundary = ADMIN_ORDER_CHANGE_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
-]) requireText(mapper, value, label);
+]) requireText(changes, value, label);
 
 for (const [block, operation, identity, serviceCall, label] of [
   [
@@ -160,7 +167,7 @@ for (const [block, operation, identity, serviceCall, label] of [
 for (const [value, label] of [
   ['[Permission::ORDERS_READ]', 'read permission'],
   ['[Permission::ORDERS_UPDATE]', 'update permission'],
-  ['let actor_id = auth.user_id;', 'create actor capture'],
+  ['let actor_id = auth.user_id;', 'actor capture'],
   ['let order_id = params.order_id;', 'list order filter capture'],
   ['page: pagination.page', 'pagination page forwarding'],
   ['per_page: pagination.limit()', 'pagination size forwarding'],
@@ -169,16 +176,13 @@ for (const [value, label] of [
   ['change_type: params.change_type', 'list type forwarding'],
 ]) requireText(changes, value, label);
 
-requireText(
-  applyRoute,
-  '.map_err(super::map_post_order_orchestration_error)?;',
-  'unchanged apply orchestration mapping',
-);
-requireText(
-  applyRoute,
-  '.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)',
-  'apply service contract',
-);
+for (const [value, label] of [
+  ['.map_err(|error| {', 'apply typed mapping closure'],
+  ['map_admin_order_change_orchestration_error(', 'apply local orchestration mapper'],
+  ['AdminOrderChangeOrchestrationErrorContext::new(', 'apply orchestration context'],
+  ['"apply_order_change"', 'apply operation'],
+  ['.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)', 'apply service contract'],
+]) requireText(applyRoute, value, label);
 
 const ownerMapperUses =
   changes.match(
@@ -188,9 +192,11 @@ if (ownerMapperUses.length !== 4) {
   failures.push(`expected four context-aware order-change owner mapper callsites, found ${ownerMapperUses.length}`);
 }
 const orchestrationMapperUses =
-  changes.match(/\.map_err\(super::map_post_order_orchestration_error\)\?;/g) ?? [];
+  changes.match(
+    /map_admin_order_change_orchestration_error\(\s+AdminOrderChangeOrchestrationErrorContext::new\(/g,
+  ) ?? [];
 if (orchestrationMapperUses.length !== 1) {
-  failures.push(`expected one unchanged order-change orchestration mapper callsite, found ${orchestrationMapperUses.length}`);
+  failures.push(`expected one context-aware order-change orchestration mapper callsite, found ${orchestrationMapperUses.length}`);
 }
 
 for (const [value, label] of [
@@ -205,12 +211,13 @@ for (const [value, label] of [
 
 for (const value of [
   '.map_err(super::map_order_error)?;',
+  '.map_err(super::map_post_order_orchestration_error)?;',
   'format!("Order request is invalid:',
   'error.to_string()',
   'err.to_string()',
   'other.to_string()',
   'HttpError::bad_request("commerce_operation_failed"',
-]) forbidText(changes, value, 'unsafe admin order-change owner public conversion');
+]) forbidText(changes, value, 'unsafe admin order-change public conversion');
 
 if (failures.length > 0) {
   console.error('Commerce admin order-change owner error-context verification failed:');


### PR DESCRIPTION
## Summary

- replace the shared post-order mapper in admin apply-order-change with one local context-aware typed orchestration mapper;
- preserve existing order, payment, provider, validation, refund reconciliation, and refund retry HTTP status/code/message policies;
- retain orchestration owner, source owner, tenant, actor, route operation, truthful optional order, order-change, payment-collection, payment, and refund identities, stable public code, status, HTTP boundary, and the original top-level typed cause in one structured error event;
- adopt typed resource identities from nested owner errors and the reserved refund id from `ProviderAfterRefundReservation`;
- keep owner routes, permissions, provider registry wiring, service calls, input forwarding, and success responses unchanged;
- add a focused orchestration verifier, align the owner verifier, and update the ecommerce error-safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/changes.rs`
- `scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
- `scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the four intended files;
- source was re-read to confirm four unchanged local owner callsites and one local apply orchestration callsite;
- all current `PostOrderOrchestrationError`, `PaymentOrchestrationError`, `OrderError`, and `PaymentError` variants are covered by static policies;
- reserved-refund reconciliation and retry envelopes remain distinct;
- permissions, provider registry wiring, service calls, input forwarding, and success contracts remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs
node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs
cargo check -p rustok-commerce --lib
```