### PR TITLE
Harden admin order route error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -64,6 +64,12 @@ available only for actionable domain errors.
   operation, truthful optional shipping-option identity, stable public code, status, and
   HTTP boundary. Validation details remain internal while the existing not-found,
   transition, and storage status/code policy stays unchanged.
+- `rustok-commerce` admin order routes: list, detail, mark-paid, ship, deliver, and cancel
+  paths map the typed `OrderError` locally with owner, tenant, actor, route operation,
+  truthful optional order and customer identities, stable public code, status, and HTTP
+  boundary. Typed missing-order identities are adopted from the error while locale
+  fallback, filters, lifecycle inputs, and the existing static response policy stay
+  unchanged.
 - `rustok-commerce` admin order-change owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and order-change identities, stable public code, status, and HTTP boundary. Typed
@@ -139,6 +145,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
@@ -158,10 +165,10 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option and
-  order-change owner and orchestration mapping, admin order-return owner and orchestration
-  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
-  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and transport
-  round-trip tests.
+  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
+  admin order-route, order-change owner and orchestration mapping, admin order-return owner
+  and orchestration mapping, admin order-detail payment and fulfillment mapping, and tax
+  calculation validation, provider-contract, reconciliation, correlation, HTTP-envelope,
+  and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -1,11 +1,13 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
+    http::StatusCode,
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_fulfillment::{FulfillmentError, FulfillmentService};
 use rustok_order::OrderService;
+use rustok_order::error::OrderError;
 use rustok_payment::{PaymentError, PaymentService};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
@@ -19,10 +21,107 @@ use crate::dto::{
     CancelOrderInput, DeliverOrderInput, MarkPaidOrderInput, OrderResponse, ShipOrderInput,
 };
 
+const ADMIN_ORDER_OWNER: &str = "rustok_order.admin_orders";
+const ADMIN_ORDER_BOUNDARY: &str = "commerce_admin_order_http";
 const ADMIN_ORDER_DETAIL_PAYMENT_OWNER: &str = "rustok_payment.admin_order_detail";
 const ADMIN_ORDER_DETAIL_PAYMENT_OPERATION: &str = "find_latest_payment_collection_by_order";
 const ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_order_detail";
 const ADMIN_ORDER_DETAIL_FULFILLMENT_OPERATION: &str = "find_fulfillment_by_order";
+
+type AdminOrderHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+struct AdminOrderErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Option<Uuid>,
+    customer_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminOrderErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        order_id: Option<Uuid>,
+        customer_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            order_id,
+            customer_id,
+            operation,
+        }
+    }
+}
+
+fn admin_order_error_policy(error: &OrderError) -> AdminOrderHttpPolicy {
+    match error {
+        OrderError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        OrderError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "database",
+        ),
+        OrderError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "core",
+        ),
+    }
+}
+
+fn map_admin_order_error(
+    mut context: AdminOrderErrorContext,
+    error: OrderError,
+) -> HttpError {
+    if let OrderError::OrderNotFound(id) = &error {
+        context.order_id = Some(*id);
+    }
+    let (status, code, message, error_kind) = admin_order_error_policy(&error);
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        order_id = ?context.order_id,
+        customer_id = ?context.customer_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_BOUNDARY,
+        "commerce admin order operation failed"
+    );
+    HttpError::new(status, code, message)
+}
 
 /// Show admin ecommerce order
 #[utoipa::path(
@@ -49,6 +148,7 @@ pub async fn list_orders(
     )?;
 
     let pagination = params.pagination.unwrap_or_default();
+    let customer_id = params.customer_id;
     let (orders, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_orders_with_locale_fallback(
             tenant.id,
@@ -56,13 +156,24 @@ pub async fn list_orders(
                 page: pagination.page,
                 per_page: pagination.limit(),
                 status: params.status,
-                customer_id: params.customer_id,
+                customer_id,
             },
             request_context.locale.as_str(),
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    customer_id,
+                    "list_orders",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(PaginatedResponse {
         data: orders,
@@ -102,7 +213,18 @@ pub async fn show_order(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "get_order",
+                ),
+                error,
+            )
+        })?;
     let payment_collection = PaymentService::new(runtime.db_clone())
         .find_latest_collection_by_order(tenant.id, id)
         .await
@@ -273,7 +395,18 @@ pub async fn mark_order_paid(
             input.payment_method,
         )
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "mark_order_paid",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(order))
 }
@@ -313,7 +446,18 @@ pub async fn ship_order(
             input.carrier,
         )
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "ship_order",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(order))
 }
@@ -347,7 +491,18 @@ pub async fn deliver_order(
     let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .deliver_order(tenant.id, auth.user_id, id, input.delivered_signature)
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "deliver_order",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(order))
 }
@@ -381,7 +536,18 @@ pub async fn cancel_order(
     let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .cancel_order(tenant.id, auth.user_id, id, input.reason)
         .await
-        .map_err(super::map_order_error)?;
+        .map_err(|error| {
+            map_admin_order_error(
+                AdminOrderErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    None,
+                    "cancel_order",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(order))
 }

--- a/scripts/verify/verify-commerce-admin-order-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-route-error-context.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const orders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const mapper = between(
+  orders,
+  'fn admin_order_error_policy(',
+  '/// Show admin ecommerce order',
+  'admin order route mapper',
+);
+const listRoute = between(
+  orders,
+  'pub async fn list_orders(',
+  'pub async fn show_order(',
+  'list orders route',
+);
+const showRoute = between(
+  orders,
+  'pub async fn show_order(',
+  'fn map_order_detail_payment_error(',
+  'show order route',
+);
+const markPaidRoute = between(
+  orders,
+  'pub async fn mark_order_paid(',
+  '/// Ship admin ecommerce order',
+  'mark-paid route',
+);
+const shipRoute = between(
+  orders,
+  'pub async fn ship_order(',
+  '/// Deliver admin ecommerce order',
+  'ship order route',
+);
+const deliverRoute = between(
+  orders,
+  'pub async fn deliver_order(',
+  '/// Cancel admin ecommerce order',
+  'deliver order route',
+);
+const cancelStart = orders.indexOf('pub async fn cancel_order(');
+const cancelRoute = cancelStart < 0 ? '' : orders.slice(cancelStart);
+if (cancelStart < 0) failures.push('cancel order route: unable to isolate source block');
+
+for (const [value, label] of [
+  ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
+  ['const ADMIN_ORDER_OWNER: &str = "rustok_order.admin_orders";', 'owner constant'],
+  ['const ADMIN_ORDER_BOUNDARY: &str = "commerce_admin_order_http";', 'HTTP boundary constant'],
+  ['type AdminOrderHttpPolicy = (', 'static HTTP policy type'],
+  ['struct AdminOrderErrorContext {', 'order error context'],
+  ['tenant_id: Uuid,', 'tenant field'],
+  ['actor_id: Uuid,', 'actor field'],
+  ['order_id: Option<Uuid>,', 'order identity field'],
+  ['customer_id: Option<Uuid>,', 'customer identity field'],
+  ["operation: &'static str,", 'operation field'],
+]) requireText(orders, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'validation variant'],
+  ['OrderError::OrderNotFound(_)', 'order not-found variant'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found variant'],
+  ['OrderError::InvalidTransition { .. }', 'transition variant'],
+  ['OrderError::Database(_)', 'database variant'],
+  ['OrderError::Core(_)', 'core variant'],
+  ['StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"commerce_admin_order_invalid"', 'validation code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_order_state_conflict"', 'conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'storage code'],
+  ['"commerce_admin_order_failed"', 'fail-closed code'],
+  ['"Order request is invalid"', 'static validation message'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  ['"Order operation conflicts with the current state"', 'static conflict message'],
+  ['"Order storage is temporarily unavailable"', 'static storage message'],
+  ['"Order operation could not be completed safely"', 'static fail-closed message'],
+  ['if let OrderError::OrderNotFound(id) = &error', 'typed order identity adoption'],
+  ['context.order_id = Some(*id);', 'adopted order identity'],
+  ['error = ?error', 'typed cause log'],
+  ['owner = ADMIN_ORDER_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['customer_id = ?context.customer_id', 'customer identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_ORDER_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [block, operation, identity, serviceCall, label] of [
+  [
+    listRoute,
+    '"list_orders"',
+    'tenant.id,\n                    auth.user_id,\n                    None,\n                    customer_id,',
+    '.list_orders_with_locale_fallback(',
+    'list route',
+  ],
+  [
+    showRoute,
+    '"get_order"',
+    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    '.get_order_with_locale_fallback(',
+    'show route',
+  ],
+  [
+    markPaidRoute,
+    '"mark_order_paid"',
+    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    '.mark_paid(',
+    'mark-paid route',
+  ],
+  [
+    shipRoute,
+    '"ship_order"',
+    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    '.ship_order(',
+    'ship route',
+  ],
+  [
+    deliverRoute,
+    '"deliver_order"',
+    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    '.deliver_order(tenant.id, auth.user_id, id, input.delivered_signature)',
+    'deliver route',
+  ],
+  [
+    cancelRoute,
+    '"cancel_order"',
+    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    '.cancel_order(tenant.id, auth.user_id, id, input.reason)',
+    'cancel route',
+  ],
+]) {
+  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
+  requireText(block, 'map_admin_order_error(', `${label} mapper handoff`);
+  requireText(block, 'AdminOrderErrorContext::new(', `${label} context construction`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, identity, `${label} truthful route identity`);
+  requireText(block, serviceCall, `${label} service contract`);
+}
+
+for (const [value, label] of [
+  ['[Permission::ORDERS_LIST]', 'list permission'],
+  ['[Permission::ORDERS_READ]', 'read permission'],
+  ['[Permission::ORDERS_UPDATE]', 'update permission'],
+  ['let customer_id = params.customer_id;', 'customer filter capture'],
+  ['status: params.status', 'status filter forwarding'],
+  ['customer_id,', 'customer filter forwarding'],
+  ['page: pagination.page', 'pagination page forwarding'],
+  ['per_page: pagination.limit()', 'pagination size forwarding'],
+  ['request_context.locale.as_str()', 'requested locale forwarding'],
+  ['Some(tenant.default_locale.as_str())', 'tenant fallback locale forwarding'],
+  ['input.payment_id', 'payment identity forwarding'],
+  ['input.payment_method', 'payment method forwarding'],
+  ['input.tracking_number', 'tracking forwarding'],
+  ['input.carrier', 'carrier forwarding'],
+]) requireText(orders, value, label);
+
+for (const [value, label] of [
+  ['fn map_order_detail_payment_error(', 'payment detail mapper'],
+  ['fn map_order_detail_fulfillment_error(', 'fulfillment detail mapper'],
+  ['find_latest_collection_by_order(tenant.id, id)', 'payment detail lookup'],
+  ['find_by_order(tenant.id, id)', 'fulfillment detail lookup'],
+  ['map_order_detail_payment_error(tenant.id, id, error)', 'payment detail mapper call'],
+  ['map_order_detail_fulfillment_error(tenant.id, id, error)', 'fulfillment detail mapper call'],
+]) requireText(showRoute + orders, value, label);
+
+const mapperUses =
+  orders.match(/map_admin_order_error\(\s+AdminOrderErrorContext::new\(/g) ?? [];
+if (mapperUses.length !== 6) {
+  failures.push(`expected six context-aware admin order mapper callsites, found ${mapperUses.length}`);
+}
+
+for (const [value, label] of [
+  ['Validation(String)', 'owner validation variant'],
+  ['OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  ['OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  ['OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  ['Database(#[from] DbErr)', 'owner database variant'],
+  ['Core(#[from] rustok_core::Error)', 'owner core variant'],
+]) requireText(orderErrors, value, label);
+
+for (const value of [
+  '.map_err(super::map_order_error)?;',
+  'format!("Order request is invalid:',
+  'error.to_string()',
+  'err.to_string()',
+  'other.to_string()',
+  'HttpError::bad_request("commerce_operation_failed"',
+]) forbidText(orders, value, 'unsafe admin order route public conversion');
+
+if (failures.length > 0) {
+  console.error('Commerce admin order route error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin order routes retain typed causes, route identities, and static public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace the six shared `OrderError` mapper callsites in admin order list, detail, mark-paid, ship, deliver, and cancel routes with one local context-aware typed mapper;
- preserve the existing validation, not-found, state-conflict, storage, and fail-closed HTTP status/code/message policy;
- retain owner, tenant, actor, route operation, truthful optional order and customer identities, stable public code, status, HTTP boundary, and the original typed cause in one structured error event;
- adopt the typed order identity from `OrderNotFound`;
- keep locale fallback, list filters, pagination, permissions, lifecycle inputs, payment/fulfillment detail lookup mappers, service calls, and success responses unchanged;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/admin/orders.rs`
- `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- rebased directly on current `main` after two unrelated commits landed;
- branch is directly ahead of current `main` by one commit and is not behind;
- final diff is limited to the three intended files;
- source was re-read to confirm six local mapper callsites and no shared order mapper callsites;
- all current `OrderError` variants are covered exhaustively with static public envelopes;
- permissions, locale fallback, filters, pagination, service calls, lifecycle inputs, detail lookup mappers, and success contracts remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
cargo check -p rustok-commerce --lib
```