### PR TITLE
feat(forum): publish group audience facts

### DIFF
--- a/apps/server/src/services/forum_audience_group_facts.rs
+++ b/apps/server/src/services/forum_audience_group_facts.rs
@@ -1,0 +1,338 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_forum::{
+    ForumAudienceFacts, ForumAudienceFactsPort, ForumAudienceFactsRequest,
+    SharedForumAudienceFactsPort, MAX_FORUM_AUDIENCE_GROUPS,
+};
+use rustok_groups::{
+    GroupMembershipEnforcementReadPort, GroupMembershipEnforcementService,
+    ReadGroupMembershipEnforcementRequest, SharedGroupMembershipEnforcementReadPort,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+const INVALID_REQUEST_CODE: &str = "forum.audience_group_facts.invalid_request";
+const TENANT_MISMATCH_CODE: &str = "forum.audience_group_facts.tenant_mismatch";
+const ACTOR_MISMATCH_CODE: &str = "forum.audience_group_facts.actor_mismatch";
+const OWNER_RESPONSE_CODE: &str = "forum.audience_group_facts.owner_response_invalid";
+const PARTIAL_PROVIDER_CODE: &str = "forum.audience_group_facts.partial_provider_unavailable";
+
+/// Server-owned adapter from Forum's bounded audience-facts capability to the
+/// Groups-owned effective-membership read port.
+///
+/// The adapter resolves only requested group identifiers. Trust and channel
+/// facts remain unsupported: when no requested group membership already
+/// decides the positive-selector union, those dimensions return typed
+/// retryable unavailability instead of being misrepresented as negative facts.
+#[derive(Clone)]
+pub(crate) struct ServerForumAudienceGroupFactsPort {
+    groups: SharedGroupMembershipEnforcementReadPort,
+}
+
+impl ServerForumAudienceGroupFactsPort {
+    pub(crate) fn new(groups: SharedGroupMembershipEnforcementReadPort) -> Self {
+        Self { groups }
+    }
+
+    pub(crate) fn from_db(db: DatabaseConnection) -> Self {
+        Self::new(Arc::new(GroupMembershipEnforcementService::new(db)))
+    }
+
+    pub(crate) fn shared(db: DatabaseConnection) -> SharedForumAudienceFactsPort {
+        Arc::new(Self::from_db(db))
+    }
+}
+
+#[async_trait]
+impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
+    async fn resolve_forum_audience_facts(
+        &self,
+        context: PortContext,
+        request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError> {
+        validate_request(&context, &request)?;
+
+        let mut group_memberships = Vec::with_capacity(request.group_ids.len());
+        for group_id in &request.group_ids {
+            let state = self
+                .groups
+                .read_membership_enforcement(
+                    context.clone(),
+                    ReadGroupMembershipEnforcementRequest {
+                        group_id: *group_id,
+                        user_id: request.user_id,
+                    },
+                )
+                .await?;
+            validate_owner_state(&request, *group_id, &state)?;
+            if state.active_member {
+                group_memberships.push(*group_id);
+            }
+        }
+
+        if group_memberships.is_empty()
+            && (request.include_trust_level || !request.channel_slugs.is_empty())
+        {
+            return Err(partial_provider_unavailable());
+        }
+
+        Ok(ForumAudienceFacts {
+            tenant_id: request.tenant_id,
+            user_id: request.user_id,
+            trust_level: None,
+            channel_memberships: Vec::new(),
+            group_memberships,
+        })
+    }
+}
+
+fn validate_request(
+    context: &PortContext,
+    request: &ForumAudienceFactsRequest,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::read())?;
+    if request.tenant_id.is_nil()
+        || request.user_id.is_nil()
+        || request.group_ids.iter().any(Uuid::is_nil)
+        || request.group_ids.len() > MAX_FORUM_AUDIENCE_GROUPS
+    {
+        return Err(PortError::validation(
+            INVALID_REQUEST_CODE,
+            "Forum audience group facts request is invalid",
+        ));
+    }
+    if context.tenant_id != request.tenant_id.to_string() {
+        return Err(PortError::validation(
+            TENANT_MISMATCH_CODE,
+            "Forum audience group facts tenant does not match the caller context",
+        ));
+    }
+    if context.actor.kind != PortActorKind::User
+        || Uuid::parse_str(&context.actor.id).ok() != Some(request.user_id)
+    {
+        return Err(PortError::forbidden(
+            ACTOR_MISMATCH_CODE,
+            "Forum audience group facts require the exact requested user actor",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_owner_state(
+    request: &ForumAudienceFactsRequest,
+    group_id: Uuid,
+    state: &rustok_groups::GroupMembershipEffectiveState,
+) -> Result<(), PortError> {
+    if state.tenant_id != request.tenant_id
+        || state.group_id != group_id
+        || state.user_id != request.user_id
+    {
+        return Err(PortError::invariant_violation(
+            OWNER_RESPONSE_CODE,
+            "Groups owner returned a different audience membership identity",
+        ));
+    }
+    Ok(())
+}
+
+fn partial_provider_unavailable() -> PortError {
+    PortError::unavailable(
+        PARTIAL_PROVIDER_CODE,
+        "Forum trust or channel audience facts are not available from the group facts adapter",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use chrono::Utc;
+    use rustok_api::{PortActor, PortErrorKind};
+    use rustok_groups::{
+        GroupMembershipEffectiveState, GroupMembershipEffectiveStatus, GroupMembershipStatus,
+        GroupRole,
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct StaticGroupMembershipPort {
+        active_groups: BTreeSet<Uuid>,
+        calls: Arc<Mutex<Vec<Uuid>>>,
+    }
+
+    #[async_trait]
+    impl GroupMembershipEnforcementReadPort for StaticGroupMembershipPort {
+        async fn read_membership_enforcement(
+            &self,
+            context: PortContext,
+            request: ReadGroupMembershipEnforcementRequest,
+        ) -> Result<GroupMembershipEffectiveState, PortError> {
+            context.require_policy(PortCallPolicy::read())?;
+            self.calls
+                .lock()
+                .expect("group fact call recorder should stay available")
+                .push(request.group_id);
+            let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+                PortError::validation("test.invalid_tenant", "Test tenant is invalid")
+            })?;
+            let active = self.active_groups.contains(&request.group_id);
+            Ok(GroupMembershipEffectiveState {
+                tenant_id,
+                group_id: request.group_id,
+                user_id: request.user_id,
+                membership_id: active.then(Uuid::new_v4),
+                role: active.then_some(GroupRole::Member),
+                stored_status: active.then_some(GroupMembershipStatus::Active),
+                membership_revision: active.then_some(1),
+                effective_status: if active {
+                    GroupMembershipEffectiveStatus::Active
+                } else {
+                    GroupMembershipEffectiveStatus::Missing
+                },
+                active_member: active,
+                denied_reentry: false,
+                enforcement: None,
+                evaluated_at: Utc::now(),
+            })
+        }
+    }
+
+    fn user_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
+        PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(user_id.to_string()),
+            "en",
+            "forum-group-facts-test",
+        )
+        .with_deadline(Duration::from_secs(2))
+    }
+
+    fn adapter(
+        active_groups: impl IntoIterator<Item = Uuid>,
+    ) -> (ServerForumAudienceGroupFactsPort, Arc<Mutex<Vec<Uuid>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let groups: SharedGroupMembershipEnforcementReadPort = Arc::new(StaticGroupMembershipPort {
+            active_groups: active_groups.into_iter().collect(),
+            calls: calls.clone(),
+        });
+        (ServerForumAudienceGroupFactsPort::new(groups), calls)
+    }
+
+    #[tokio::test]
+    async fn group_facts_resolve_only_requested_active_memberships() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let first = Uuid::new_v4();
+        let active = Uuid::new_v4();
+        let third = Uuid::new_v4();
+        let requested = vec![first, active, third];
+        let (adapter, calls) = adapter([active]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, user_id),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: false,
+                    channel_slugs: Vec::new(),
+                    group_ids: requested.clone(),
+                },
+            )
+            .await
+            .expect("requested group facts should resolve");
+
+        assert_eq!(facts.tenant_id, tenant_id);
+        assert_eq!(facts.user_id, user_id);
+        assert_eq!(facts.group_memberships, vec![active]);
+        assert!(facts.trust_level.is_none());
+        assert!(facts.channel_memberships.is_empty());
+        assert_eq!(
+            *calls
+                .lock()
+                .expect("group fact call recorder should stay available"),
+            requested
+        );
+    }
+
+    #[tokio::test]
+    async fn active_group_match_short_circuits_unsupported_positive_dimensions() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let active = Uuid::new_v4();
+        let (adapter, _) = adapter([active]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, user_id),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: true,
+                    channel_slugs: vec!["mobile".to_string()],
+                    group_ids: vec![active],
+                },
+            )
+            .await
+            .expect("an active requested group should decide the positive-selector union");
+
+        assert_eq!(facts.group_memberships, vec![active]);
+    }
+
+    #[tokio::test]
+    async fn unsupported_dimensions_are_retryable_when_groups_do_not_decide() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let (adapter, _) = adapter([]);
+
+        let error = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, user_id),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: true,
+                    channel_slugs: vec!["mobile".to_string()],
+                    group_ids: vec![Uuid::new_v4()],
+                },
+            )
+            .await
+            .expect_err("unsupported owner facts must not be converted into a final deny");
+
+        assert_eq!(error.kind, PortErrorKind::Unavailable);
+        assert!(error.retryable);
+        assert_eq!(error.code, PARTIAL_PROVIDER_CODE);
+    }
+
+    #[tokio::test]
+    async fn foreign_user_context_is_rejected_before_owner_calls() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let (adapter, calls) = adapter([]);
+
+        let error = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, Uuid::new_v4()),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: false,
+                    channel_slugs: Vec::new(),
+                    group_ids: vec![Uuid::new_v4()],
+                },
+            )
+            .await
+            .expect_err("foreign user facts lookup must fail closed");
+
+        assert_eq!(error.kind, PortErrorKind::Forbidden);
+        assert!(calls
+            .lock()
+            .expect("group fact call recorder should stay available")
+            .is_empty());
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -41,6 +41,8 @@ pub mod mcp_runtime;
 pub mod mcp_scaffold_workspace;
 pub mod module_event_dispatcher;
 pub mod module_lifecycle;
+#[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+pub mod forum_audience_group_facts;
 #[cfg(feature = "mod-forum")]
 pub mod forum_notification_recipient_context;
 #[cfg(feature = "mod-notifications")]

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -292,6 +292,14 @@ pub fn build_shared_runtime_extensions_with_host_providers(
         extensions.insert(policy);
     }
 
+    #[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+    {
+        let audience_facts = crate::services::forum_audience_group_facts::ServerForumAudienceGroupFactsPort::shared(
+            db.clone(),
+        );
+        extensions.insert(audience_facts);
+    }
+
     #[cfg(feature = "mod-forum")]
     {
         let recipient_context = crate::services::forum_notification_recipient_context::ServerForumNotificationRecipientContextPort::shared(
@@ -400,6 +408,8 @@ mod tests {
         assert!(extensions.contains::<rustok_mcp::McpManagementRuntime>());
         #[cfg(feature = "mod-forum")]
         assert!(extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>());
+        #[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+        assert!(extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>());
         #[cfg(feature = "mod-notifications")]
         assert!(
             rustok_notifications::api::notification_source_registry_from_extensions(

--- a/crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20Q",
+  "upstream_task": "FORUM-20P",
+  "scope": "Server-owned exact requested group membership facts adapter for authenticated Forum audience evaluation",
+  "adapter_file": "apps/server/src/services/forum_audience_group_facts.rs",
+  "services_file": "apps/server/src/services/mod.rs",
+  "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
+  "forum_audience_owner_file": "crates/rustok-forum/src/audience.rs",
+  "groups_owner_port_file": "crates/rustok-groups/src/ports.rs",
+  "groups_owner_service_file": "crates/rustok-groups/src/membership_enforcement.rs",
+  "notification_source_file": "crates/rustok-forum/src/notification_source.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-topic-subscription-audience.json",
+  "source_verifier": "scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20Q",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O",
+      "FORUM-20P",
+      "FORUM-20Q"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "request": "exact tenant and user plus at most 32 requested group IDs",
+    "caller": "tenant-matching exact user PortContext with read deadline semantics",
+    "owner": "Groups-owned effective membership enforcement read port",
+    "membership_truth": "active_member from the Groups owner-clock effective state",
+    "positive_union": "an active requested group may decide the positive-selector union even when unsupported trust or channel selectors are also requested",
+    "partial_provider": "when requested groups do not decide and trust or channel facts are required, return typed retryable unavailable instead of a false deny",
+    "identity_validation": "validate exact tenant, user and group identity on every Groups owner response",
+    "storage_access": "no direct Groups entity or table access from the server adapter or Forum"
+  },
+  "composition": {
+    "feature_guarded_server_adapter": true,
+    "groups_owner_port_reuse": true,
+    "bounded_requested_group_calls": true,
+    "exact_user_actor_validation": true,
+    "owner_response_identity_validation": true,
+    "active_memberships_only": true,
+    "positive_union_short_circuit": true,
+    "unsupported_dimension_retryability": true,
+    "runtime_extension_publication": true,
+    "publication_before_notification_source_materialization": true,
+    "notification_source_factory_consumption": true,
+    "inline_contract_tests": true
+  },
+  "not_delivered": [
+    "host trust facts adapter",
+    "host channel membership facts adapter",
+    "profile privacy and blocking policy",
+    "final notification creation and delivery authorization",
+    "initially non-public topic-created descriptor materialization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-server --features mod-forum,mod-groups,mod-notifications forum_audience_group_facts -- --nocapture",
+      "cargo test -p rustok-server --features mod-forum,mod-groups,mod-notifications host_runtime_extensions_register_admin_mutation_providers -- --nocapture",
+      "cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const adapter = read(contract.adapter_file ?? "");
+const services = read(contract.services_file ?? "");
+const runtime = read(contract.runtime_composition_file ?? "");
+const forumAudienceOwner = read(contract.forum_audience_owner_file ?? "");
+const groupsOwnerPort = read(contract.groups_owner_port_file ?? "");
+const groupsOwnerService = read(contract.groups_owner_service_file ?? "");
+const notificationSource = read(contract.notification_source_file ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum audience group facts host contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20Q" || contract.upstream_task !== "FORUM-20P") {
+  failures.push("forum audience group facts host contract must connect FORUM-20P/Q");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("group facts publication must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "feature_guarded_server_adapter",
+  "groups_owner_port_reuse",
+  "bounded_requested_group_calls",
+  "exact_user_actor_validation",
+  "owner_response_identity_validation",
+  "active_memberships_only",
+  "positive_union_short_circuit",
+  "unsupported_dimension_retryability",
+  "runtime_extension_publication",
+  "publication_before_notification_source_materialization",
+  "notification_source_factory_consumption",
+  "inline_contract_tests",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum audience group facts contract must record ${delivered} as delivered`);
+  }
+}
+for (const residual of [
+  "host trust facts adapter",
+  "host channel membership facts adapter",
+  "profile privacy and blocking policy",
+  "final notification creation and delivery authorization",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum audience group facts contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+  "FORUM-20Q",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20Q") {
+  failures.push("forum audience group facts contract must require the canonical ledger through FORUM-20Q");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum audience group facts contract must require FORUM-20H through FORUM-20Q delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-Q provide", "synchronized canonical plan must advance the FORUM-20 ledger through Q");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "pub(crate) struct ServerForumAudienceGroupFactsPort",
+  "groups: SharedGroupMembershipEnforcementReadPort",
+  "impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort",
+  "context.require_policy(PortCallPolicy::read())",
+  "request.group_ids.len() > MAX_FORUM_AUDIENCE_GROUPS",
+  "context.actor.kind != PortActorKind::User",
+  "Uuid::parse_str(&context.actor.id).ok() != Some(request.user_id)",
+  "for group_id in &request.group_ids",
+  ".read_membership_enforcement(",
+  "validate_owner_state(&request, *group_id, &state)",
+  "if state.active_member",
+  "group_memberships.push(*group_id)",
+  "request.include_trust_level || !request.channel_slugs.is_empty()",
+  "return Err(partial_provider_unavailable())",
+  "PortError::unavailable(",
+  "state.tenant_id != request.tenant_id",
+  "state.group_id != group_id",
+  "state.user_id != request.user_id",
+  "GroupMembershipEnforcementService::new(db)",
+]) {
+  requireText(adapter, marker, `forum group facts adapter is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "rustok_groups::entities",
+  "membership_state::Entity",
+  "group_memberships",
+  "EntityTrait",
+  "QueryFilter",
+  "ColumnTrait",
+  "SELECT ",
+]) {
+  rejectText(adapter, forbidden, `forum group facts adapter must reuse the Groups owner instead of ${forbidden}`);
+}
+
+for (const marker of [
+  "#[cfg(all(feature = \"mod-forum\", feature = \"mod-groups\"))]",
+  "pub mod forum_audience_group_facts;",
+]) {
+  requireText(services, marker, `server services surface is missing ${marker}`);
+}
+for (const marker of [
+  "ServerForumAudienceGroupFactsPort::shared(",
+  "extensions.insert(audience_facts)",
+  "extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>()",
+]) {
+  requireText(runtime, marker, `server runtime group facts composition is missing ${marker}`);
+}
+const publicationIndex = runtime.indexOf("extensions.insert(audience_facts)");
+const materializationIndex = runtime.indexOf(
+  "materialize_notification_source_registry(&mut extensions, &host)",
+);
+if (publicationIndex < 0 || materializationIndex < 0 || publicationIndex > materializationIndex) {
+  failures.push("group audience facts capability must be published before notification source materialization");
+}
+
+for (const marker of [
+  "pub trait GroupMembershipEnforcementReadPort: Send + Sync",
+  "async fn read_membership_enforcement(",
+  "pub type SharedGroupMembershipEnforcementReadPort",
+]) {
+  requireText(groupsOwnerPort, marker, `Groups owner port is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct GroupMembershipEnforcementService",
+  "pub fn new(db: DatabaseConnection) -> Self",
+  "impl GroupMembershipEnforcementReadPort for GroupMembershipEnforcementService",
+  "read_effective_state_owned(",
+]) {
+  requireText(groupsOwnerService, marker, `Groups owner service is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumAudienceFactsResolver",
+  ".resolve_forum_audience_facts(context, request.clone())",
+  "pub struct ForumAudienceEvaluator",
+  "constraints.group_members_any",
+]) {
+  requireText(forumAudienceOwner, marker, `Forum audience owner is missing ${marker}`);
+}
+requireText(
+  notificationSource,
+  "host.shared_get::<SharedForumAudienceFactsPort>()",
+  "Forum notification source factory must consume the published audience facts capability",
+);
+
+for (const marker of [
+  "group_facts_resolve_only_requested_active_memberships",
+  "active_group_match_short_circuits_unsupported_positive_dimensions",
+  "unsupported_dimensions_are_retryable_when_groups_do_not_decide",
+  "foreign_user_context_is_rejected_before_owner_calls",
+  "assert_eq!(facts.group_memberships, vec![active])",
+  "assert_eq!(error.kind, PortErrorKind::Unavailable)",
+  "assert!(error.retryable)",
+]) {
+  requireText(adapter, marker, `forum group facts inline contract test is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 1 ||
+  upstream.task !== "FORUM-20P" ||
+  upstream.upstream_task !== "FORUM-20O" ||
+  upstream.composition?.recipient_specific_topic_visibility !== true ||
+  upstream.composition?.notification_sparse_page_prerequisite !== true
+) {
+  failures.push("FORUM-20Q group facts adapter must remain grounded in the FORUM-20P notification consumer");
+}
+
+for (const marker of [
+  "## `FORUM-20` — ACL and visibility inheritance",
+  "notifications, search, SEO and deep links must call the same",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing the visibility boundary ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum audience group facts host runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum audience group facts host runtime contract is source-ready.");

--- a/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
@@ -157,7 +157,9 @@ for (const marker of [
 for (const forbidden of [
   "rustok_groups::entities",
   "membership_state::Entity",
-  "group_memberships",
+  "group_membership::Entity",
+  "membership_enforcement_state::Entity",
+  "forum_group_memberships",
   "EntityTrait",
   "QueryFilter",
   "ColumnTrait",


### PR DESCRIPTION
## Summary

- add a server-owned `SharedForumAudienceFactsPort` adapter backed by the Groups-owned effective membership read port
- resolve only the exact bounded group IDs requested by Forum for the exact tenant and user actor
- return only active owner-clock group memberships and validate every owner response identity
- preserve positive-selector union semantics: an active requested group may decide even when trust or channel selectors are also present
- return typed retryable unavailability when groups do not decide and unsupported trust or channel facts remain necessary
- publish the adapter only for `mod-forum + mod-groups` before notification source materialization
- add inline adapter contract tests, host-extension publication evidence, the FORUM-20Q machine contract, and a source verifier

## Boundary

This slice delivers the group-membership facts adapter only. Trust facts, channel-membership facts, profile privacy/blocking, initially non-public topic-created descriptor materialization, final delivery authorization, search/SEO migration, and PostgreSQL cross-consumer evidence remain open.

The canonical Forum implementation plan still physically ends at FORUM-20G. The FORUM-20Q contract records synchronization as pending through Q without replacing unrelated plan updates.

## Validation

Tests, Cargo commands, formatting commands, verifiers, and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-server --features mod-forum,mod-groups,mod-notifications forum_audience_group_facts -- --nocapture
cargo test -p rustok-server --features mod-forum,mod-groups,mod-notifications host_runtime_extensions_register_admin_mutation_providers -- --nocapture
cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
cargo test -p rustok-forum --test topic_audience_visibility_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_topic_subscription_audience_sqlite -- --nocapture
node scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
cargo xtask module validate forum
```