### PR TITLE
feat(notifications): reauthorize inbox target opens

### DIFF
--- a/crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "task": "FORUM-20Q",
   "upstream_task": "FORUM-20P",
+  "downstream_task": "FORUM-20R",
   "scope": "Server-owned exact requested group membership facts adapter for authenticated Forum audience evaluation",
   "adapter_file": "apps/server/src/services/forum_audience_group_facts.rs",
   "services_file": "apps/server/src/services/mod.rs",

--- a/crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json
+++ b/crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20R",
+  "upstream_task": "FORUM-20Q",
+  "scope": "Exact recipient-owned stored notification target reauthorization at inbox open time",
+  "notifications_owner_file": "crates/rustok-notifications/src/inbox.rs",
+  "notifications_surface_file": "crates/rustok-notifications/src/lib.rs",
+  "notifications_entity_file": "crates/rustok-notifications/src/entities.rs",
+  "notifications_live_contract": "crates/rustok-notifications/docs/README.md",
+  "source_provider_contract": "crates/rustok-notifications-api/src/provider.rs",
+  "forum_source_provider": "crates/rustok-forum/src/notification_source.rs",
+  "sqlite_proof": "crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json",
+  "source_verifier": "scripts/verify/verify-forum-notification-inbox-open-authorization.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20R",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O",
+      "FORUM-20P",
+      "FORUM-20Q",
+      "FORUM-20R"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "request_identity": "non-nil notification, tenant and recipient identifiers",
+    "ownership_lookup": "notifications owner filters one stored notification by exact id, tenant and recipient",
+    "existence_oracle": "missing, cross-tenant and cross-recipient rows all return unavailable before any source call",
+    "source_resolution": "registered provider is selected from the validated persisted source slug",
+    "target_resolution": "persisted target owner, kind and id are reconstructed through bounded notification API key types",
+    "fresh_authorization": "source provider authorize_target_open is called with the exact tenant, recipient and reconstructed target",
+    "allowed_output": "only the fresh owner-provided root-relative route is returned",
+    "stale_target": "source unavailable decision becomes inbox unavailable",
+    "provider_failure": "source capability and internal failures preserve retryability",
+    "mutation_boundary": "open authorization does not expose the stored row, mutate seen/read/archive state or enqueue delivery attempts"
+  },
+  "composition": {
+    "owner_level_open_service": true,
+    "exact_tenant_recipient_lookup": true,
+    "cross_recipient_no_oracle": true,
+    "validated_source_and_target_keys": true,
+    "source_owned_authorization": true,
+    "fresh_route_only": true,
+    "stale_acl_fail_closed": true,
+    "retryable_provider_failure_preserved": true,
+    "read_state_unchanged": true,
+    "delivery_attempts_unchanged": true,
+    "public_crate_export": true,
+    "sqlite_contract_proof": true,
+    "live_notifications_docs": true
+  },
+  "not_delivered": [
+    "bounded inbox listing API",
+    "seen read and archive state mutations",
+    "recipient privacy and blocking recheck at inbox open",
+    "channel delivery enqueue and transports",
+    "delivery-time target authorization",
+    "host trust facts adapter",
+    "host channel membership facts adapter",
+    "initially non-public topic-created descriptor materialization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-notifications --test inbox_open_authorization_sqlite -- --nocapture",
+      "cargo test -p rustok-notifications --test candidate_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs",
+      "cargo xtask module validate notifications",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-notifications/docs/README.md
+++ b/crates/rustok-notifications/docs/README.md
@@ -116,6 +116,20 @@ The loop remains default-off behind
 `RUSTOK_NOTIFICATIONS_CANDIDATE_WORKER_ENABLED`, requires ready recipient-policy
 ports and `ModuleRegistry`, and never creates channel delivery attempts.
 
+### Inbox open-time target authorization
+
+`NotificationInboxOpenService` loads one stored notification by exact notification,
+tenant, and recipient identity. Missing, cross-tenant, and cross-recipient rows all
+return `Unavailable` without invoking a source provider, preventing a notification
+existence oracle.
+
+For an owned row, the service reconstructs bounded source and target identities and
+calls the registered source provider's `authorize_target_open` method with the
+exact recipient. It returns only the fresh owner-provided route or `Unavailable`.
+Provider capability failures preserve retryability. The service does not expose the
+stored row, mutate `seen/read/archive` state, enqueue delivery attempts, or replace
+recipient privacy policy.
+
 The server starts workers in intake → fanout → candidate order. Invalid or
 unreadable flags remain disabled.
 
@@ -134,8 +148,8 @@ remains deferred.
   policy changes with final candidate commits;
 - PostgreSQL cursor/lease contention evidence and operational health/lag metrics;
 - grouping and bounded moderator-directory expansion;
-- channel delivery enqueue and transports;
-- inbox APIs with open-time authorization/privacy rechecks;
+- channel delivery enqueue and transports with delivery-time authorization;
+- bounded inbox listing/read-state APIs and recipient privacy rechecks;
 - retention, reconciliation, quarantine replay/purge, and full module-owned UI.
 
 ## Maintainer verification
@@ -151,6 +165,7 @@ cargo test -p rustok-notifications --test fanout_sqlite -- --nocapture
 cargo test -p rustok-notifications --test fanout_sparse_page_sqlite -- --nocapture
 cargo test -p rustok-notifications --test candidate_sqlite -- --nocapture
 cargo test -p rustok-notifications --test candidate_worker_sqlite -- --nocapture
+cargo test -p rustok-notifications --test inbox_open_authorization_sqlite -- --nocapture
 cargo test -p rustok-notifications --test outbox_intake_sqlite -- --nocapture
 cargo test -p rustok-notifications --test fanout_worker_sqlite -- --nocapture
 cargo test -p rustok-notifications --test fanout_policy_deferral_sqlite -- --nocapture
@@ -161,10 +176,12 @@ node scripts/verify/verify-notifications-recipient-policy-runtime.mjs
 node scripts/verify/verify-notifications-candidate-worker.mjs
 node scripts/verify/verify-notifications-outbox-intake.mjs
 node scripts/verify/verify-notifications-fanout-worker.mjs
+node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
 cargo xtask module validate notifications
 ```
 
-These commands were not run while publishing `NOTIFY-03D/03E/03F/03G/03H/03I`.
+These commands were not run while publishing `NOTIFY-03D/03E/03F/03G/03H/03I` or
+`FORUM-20R`.
 
 ## Related documents
 

--- a/crates/rustok-notifications/src/inbox.rs
+++ b/crates/rustok-notifications/src/inbox.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use rustok_notifications_api::{
+    AuthorizeNotificationTargetRequest, NotificationOpenAuthorization, NotificationSourceRegistry,
+    NotificationSourceSlug, NotificationTargetKind, NotificationTargetRef, NotificationTargetRoute,
+};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::entities::notification;
+use crate::error::{NotificationError, NotificationResult};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NotificationInboxOpenRequest {
+    pub tenant_id: Uuid,
+    pub recipient_id: Uuid,
+    pub notification_id: Uuid,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum NotificationInboxOpenDecision {
+    Allowed { route: NotificationTargetRoute },
+    Unavailable,
+}
+
+/// Authorizes one stored notification target at the moment an exact recipient opens it.
+///
+/// This service intentionally returns only a fresh owner-provided route. It does not expose the
+/// stored notification row, mutate inbox state, or enqueue a delivery attempt. Missing and
+/// foreign-recipient rows both fail closed as `Unavailable`, preventing a notification-existence
+/// oracle across recipients or tenants.
+#[derive(Clone)]
+pub struct NotificationInboxOpenService {
+    db: DatabaseConnection,
+    registry: Arc<NotificationSourceRegistry>,
+}
+
+impl NotificationInboxOpenService {
+    pub fn new(db: DatabaseConnection, registry: Arc<NotificationSourceRegistry>) -> Self {
+        Self { db, registry }
+    }
+
+    pub async fn authorize_open(
+        &self,
+        request: NotificationInboxOpenRequest,
+    ) -> NotificationResult<NotificationInboxOpenDecision> {
+        validate_request(&request)?;
+
+        let stored = notification::Entity::find_by_id(request.notification_id)
+            .filter(notification::Column::TenantId.eq(request.tenant_id))
+            .filter(notification::Column::RecipientId.eq(request.recipient_id))
+            .one(&self.db)
+            .await?;
+        let Some(stored) = stored else {
+            return Ok(NotificationInboxOpenDecision::Unavailable);
+        };
+
+        let source = NotificationSourceSlug::new(stored.source_slug)
+            .map_err(|_| NotificationError::InvalidDescriptor)?;
+        let target = NotificationTargetRef {
+            owner: NotificationSourceSlug::new(stored.target_owner)
+                .map_err(|_| NotificationError::InvalidDescriptor)?,
+            kind: NotificationTargetKind::new(stored.target_kind)
+                .map_err(|_| NotificationError::InvalidDescriptor)?,
+            id: stored.target_id,
+        };
+        if target.id.is_nil() {
+            return Err(NotificationError::InvalidDescriptor);
+        }
+
+        let provider = self
+            .registry
+            .get(&source)
+            .ok_or(NotificationError::SourceUnavailable)?;
+        match provider
+            .authorize_target_open(AuthorizeNotificationTargetRequest {
+                tenant_id: request.tenant_id,
+                recipient_id: request.recipient_id,
+                target,
+            })
+            .await
+            .map_err(NotificationError::from)?
+        {
+            NotificationOpenAuthorization::Allowed { route } => {
+                Ok(NotificationInboxOpenDecision::Allowed { route })
+            }
+            NotificationOpenAuthorization::Unavailable => {
+                Ok(NotificationInboxOpenDecision::Unavailable)
+            }
+        }
+    }
+}
+
+fn validate_request(request: &NotificationInboxOpenRequest) -> NotificationResult<()> {
+    if request.tenant_id.is_nil()
+        || request.recipient_id.is_nil()
+        || request.notification_id.is_nil()
+    {
+        return Err(NotificationError::Validation(
+            "notification inbox open identity must not be nil".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/rustok-notifications/src/lib.rs
+++ b/crates/rustok-notifications/src/lib.rs
@@ -3,6 +3,7 @@ pub mod entities;
 pub mod error;
 mod fanout;
 mod fanout_worker;
+mod inbox;
 pub mod migrations;
 pub mod model;
 mod outbox_intake;
@@ -33,6 +34,9 @@ pub use fanout_worker::{
     NotificationFanoutSourceWorkItem, NotificationFanoutWorker,
     NotificationFanoutWorkerBatchResult, NotificationFanoutWorkerFailure,
     NotificationFanoutWorkerStage,
+};
+pub use inbox::{
+    NotificationInboxOpenDecision, NotificationInboxOpenRequest, NotificationInboxOpenService,
 };
 pub use outbox_intake::{
     DEFAULT_NOTIFICATION_OUTBOX_INTAKE_BATCH_SIZE, MAX_NOTIFICATION_OUTBOX_INTAKE_BATCH_SIZE,

--- a/crates/rustok-notifications/src/service.rs
+++ b/crates/rustok-notifications/src/service.rs
@@ -8,10 +8,10 @@ use rustok_notifications_api::{
 
 /// Owner-facing access to the registered semantic notification sources.
 ///
-/// The owner schema is available through `NotificationsModule::migrations`, but
-/// inbox, fan-out, preference, digest, and delivery workflows remain private
-/// until their transactional services are introduced. This facade intentionally
-/// exposes no producer database or outbox transport internals.
+/// The owner schema is available through `NotificationsModule::migrations`, and exact inbox target
+/// opens are authorized by `NotificationInboxOpenService`. Bounded inbox listing, read-state,
+/// preference, digest, and delivery workflows remain private until their transactional services are
+/// introduced. This facade intentionally exposes no producer database or outbox transport internals.
 #[derive(Clone, Default)]
 pub struct NotificationsService {
     registry: Arc<NotificationSourceRegistry>,

--- a/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
+++ b/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
@@ -214,7 +214,7 @@ async fn stale_target_and_retryable_owner_failure_remain_distinct() {
     .await
     .expect_err("retryable source failure must not become a stale-target deny");
     assert!(matches!(
-        retryable,
+        &retryable,
         NotificationError::ProviderFailure { retryable: true }
     ));
     assert_eq!(

--- a/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
+++ b/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
@@ -1,0 +1,371 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_core::MigrationSource;
+use rustok_notifications::api::{
+    AuthorizeNotificationTargetRequest, DescribeNotificationRequest, NotificationAudiencePage,
+    NotificationOpenAuthorization, NotificationProviderError, NotificationProviderResult,
+    NotificationSemanticDescriptor, NotificationSourceProvider, NotificationSourceRegistry,
+    NotificationSourceSlug, NotificationTargetRoute, NotificationTypeKey,
+    ResolveNotificationAudienceRequest,
+};
+use rustok_notifications::entities::notification;
+use rustok_notifications::model::{NotificationPriorityValue, NotificationState};
+use rustok_notifications::{
+    NotificationError, NotificationInboxOpenDecision, NotificationInboxOpenRequest,
+    NotificationInboxOpenService, NotificationsModule,
+};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ConnectOptions, ConnectionTrait, Database,
+    DatabaseConnection,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+const SOURCE: &str = "test-source";
+const NOTIFICATION_TYPE: &str = "test.notification";
+const TARGET_KIND: &str = "test.target";
+
+#[derive(Clone, Copy)]
+enum AuthorizationBehavior {
+    Allowed,
+    Unavailable,
+    Error(NotificationProviderError),
+}
+
+#[derive(Clone)]
+struct TestSourceProvider {
+    behavior: AuthorizationBehavior,
+    calls: Arc<Mutex<Vec<AuthorizeNotificationTargetRequest>>>,
+}
+
+#[async_trait]
+impl NotificationSourceProvider for TestSourceProvider {
+    fn slug(&self) -> NotificationSourceSlug {
+        source_slug()
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Inbox open test source"
+    }
+
+    fn supported_types(&self) -> Vec<NotificationTypeKey> {
+        vec![notification_type()]
+    }
+
+    async fn describe_event(
+        &self,
+        _request: DescribeNotificationRequest,
+    ) -> NotificationProviderResult<Option<NotificationSemanticDescriptor>> {
+        Err(NotificationProviderError::Rejected)
+    }
+
+    async fn resolve_audience(
+        &self,
+        _request: ResolveNotificationAudienceRequest,
+    ) -> NotificationProviderResult<NotificationAudiencePage> {
+        Err(NotificationProviderError::Rejected)
+    }
+
+    async fn authorize_target_open(
+        &self,
+        request: AuthorizeNotificationTargetRequest,
+    ) -> NotificationProviderResult<NotificationOpenAuthorization> {
+        self.calls
+            .lock()
+            .expect("inbox open call recorder should stay available")
+            .push(request.clone());
+        match self.behavior {
+            AuthorizationBehavior::Allowed => Ok(NotificationOpenAuthorization::Allowed {
+                route: NotificationTargetRoute::new(format!(
+                    "/modules/test?target={}",
+                    request.target.id
+                ))
+                .expect("test route should remain valid"),
+            }),
+            AuthorizationBehavior::Unavailable => Ok(NotificationOpenAuthorization::Unavailable),
+            AuthorizationBehavior::Error(error) => Err(error),
+        }
+    }
+}
+
+#[tokio::test]
+async fn exact_recipient_gets_fresh_route_without_cross_recipient_oracle() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let other_tenant_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    let other_recipient_id = Uuid::new_v4();
+    insert_tenant(&db, tenant_id).await;
+    insert_tenant(&db, other_tenant_id).await;
+    insert_user(&db, tenant_id, recipient_id).await;
+    insert_user(&db, tenant_id, other_recipient_id).await;
+
+    let target_id = Uuid::new_v4();
+    let notification_id = seed_notification(&db, tenant_id, recipient_id, target_id, SOURCE).await;
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let service = service(
+        db,
+        AuthorizationBehavior::Allowed,
+        calls.clone(),
+    );
+
+    let decision = service
+        .authorize_open(NotificationInboxOpenRequest {
+            tenant_id,
+            recipient_id,
+            notification_id,
+        })
+        .await
+        .expect("exact recipient target should authorize");
+    match decision {
+        NotificationInboxOpenDecision::Allowed { route } => {
+            assert_eq!(
+                route.as_str(),
+                format!("/modules/test?target={target_id}")
+            );
+        }
+        NotificationInboxOpenDecision::Unavailable => {
+            panic!("exact recipient target should be available")
+        }
+    }
+
+    let recorded = calls
+        .lock()
+        .expect("inbox open call recorder should stay available")
+        .clone();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].tenant_id, tenant_id);
+    assert_eq!(recorded[0].recipient_id, recipient_id);
+    assert_eq!(recorded[0].target.owner, source_slug());
+    assert_eq!(recorded[0].target.kind.as_str(), TARGET_KIND);
+    assert_eq!(recorded[0].target.id, target_id);
+
+    for foreign_request in [
+        NotificationInboxOpenRequest {
+            tenant_id,
+            recipient_id: other_recipient_id,
+            notification_id,
+        },
+        NotificationInboxOpenRequest {
+            tenant_id: other_tenant_id,
+            recipient_id,
+            notification_id,
+        },
+        NotificationInboxOpenRequest {
+            tenant_id,
+            recipient_id,
+            notification_id: Uuid::new_v4(),
+        },
+    ] {
+        assert_eq!(
+            service
+                .authorize_open(foreign_request)
+                .await
+                .expect("foreign or missing notification should fail closed"),
+            NotificationInboxOpenDecision::Unavailable
+        );
+    }
+    assert_eq!(
+        calls
+            .lock()
+            .expect("inbox open call recorder should stay available")
+            .len(),
+        1,
+        "foreign and missing rows must not invoke a source provider"
+    );
+}
+
+#[tokio::test]
+async fn stale_target_and_retryable_owner_failure_remain_distinct() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    insert_tenant(&db, tenant_id).await;
+    insert_user(&db, tenant_id, recipient_id).await;
+
+    let notification_id =
+        seed_notification(&db, tenant_id, recipient_id, Uuid::new_v4(), SOURCE).await;
+    let request = NotificationInboxOpenRequest {
+        tenant_id,
+        recipient_id,
+        notification_id,
+    };
+
+    let unavailable = service(
+        db.clone(),
+        AuthorizationBehavior::Unavailable,
+        Arc::new(Mutex::new(Vec::new())),
+    )
+    .authorize_open(request.clone())
+    .await
+    .expect("stale target should fail closed without an error");
+    assert_eq!(unavailable, NotificationInboxOpenDecision::Unavailable);
+
+    let retryable = service(
+        db,
+        AuthorizationBehavior::Error(NotificationProviderError::CapabilityUnavailable {
+            retryable: true,
+        }),
+        Arc::new(Mutex::new(Vec::new())),
+    )
+    .authorize_open(request)
+    .await
+    .expect_err("retryable source failure must not become a stale-target deny");
+    assert!(matches!(
+        retryable,
+        NotificationError::ProviderFailure { retryable: true }
+    ));
+    assert_eq!(
+        retryable.stable_code(),
+        "NOTIFICATION_SOURCE_PROVIDER_FAILURE"
+    );
+    assert!(retryable.is_retryable());
+}
+
+#[tokio::test]
+async fn invalid_stored_source_identity_fails_before_provider_invocation() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let recipient_id = Uuid::new_v4();
+    insert_tenant(&db, tenant_id).await;
+    insert_user(&db, tenant_id, recipient_id).await;
+
+    let notification_id = seed_notification(
+        &db,
+        tenant_id,
+        recipient_id,
+        Uuid::new_v4(),
+        "Invalid Source",
+    )
+    .await;
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let error = service(db, AuthorizationBehavior::Allowed, calls.clone())
+        .authorize_open(NotificationInboxOpenRequest {
+            tenant_id,
+            recipient_id,
+            notification_id,
+        })
+        .await
+        .expect_err("invalid stored source identity must fail closed");
+
+    assert!(matches!(error, NotificationError::InvalidDescriptor));
+    assert!(calls
+        .lock()
+        .expect("inbox open call recorder should stay available")
+        .is_empty());
+}
+
+fn service(
+    db: DatabaseConnection,
+    behavior: AuthorizationBehavior,
+    calls: Arc<Mutex<Vec<AuthorizeNotificationTargetRequest>>>,
+) -> NotificationInboxOpenService {
+    let mut registry = NotificationSourceRegistry::default();
+    registry
+        .register(TestSourceProvider { behavior, calls })
+        .expect("test source provider should register");
+    NotificationInboxOpenService::new(db, Arc::new(registry))
+}
+
+async fn seed_notification(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    recipient_id: Uuid,
+    target_id: Uuid,
+    source_slug: &str,
+) -> Uuid {
+    let now = Utc::now().fixed_offset();
+    let notification_id = Uuid::new_v4();
+    notification::ActiveModel {
+        id: Set(notification_id),
+        tenant_id: Set(tenant_id),
+        recipient_id: Set(recipient_id),
+        source_slug: Set(source_slug.to_string()),
+        source_event_id: Set(Uuid::new_v4()),
+        source_revision: Set(1),
+        notification_type: Set(NOTIFICATION_TYPE.to_string()),
+        template_key: Set(NOTIFICATION_TYPE.to_string()),
+        target_owner: Set(SOURCE.to_string()),
+        target_kind: Set(TARGET_KIND.to_string()),
+        target_id: Set(target_id),
+        actor_id: Set(None),
+        priority: Set(NotificationPriorityValue::Normal),
+        state: Set(NotificationState::Unread),
+        template_data_json: Set(serde_json::json!({"target_id": target_id})),
+        group_key: Set(None),
+        idempotency_key: Set(format!("notification:{notification_id}")),
+        seen_at: Set(None),
+        read_at: Set(None),
+        archived_at: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(db)
+    .await
+    .expect("notification fixture should persist");
+    notification_id
+}
+
+fn source_slug() -> NotificationSourceSlug {
+    NotificationSourceSlug::new(SOURCE).expect("test source slug must remain valid")
+}
+
+fn notification_type() -> NotificationTypeKey {
+    NotificationTypeKey::new(NOTIFICATION_TYPE).expect("test notification type must remain valid")
+}
+
+async fn setup() -> DatabaseConnection {
+    let url = format!(
+        "sqlite:file:notification_inbox_open_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("notification inbox open sqlite database should connect");
+    db.execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .expect("foreign keys should enable");
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE tenants (
+            id TEXT PRIMARY KEY NOT NULL
+        );
+        CREATE TABLE users (
+            id TEXT PRIMARY KEY NOT NULL,
+            tenant_id TEXT NOT NULL,
+            FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
+        );
+        "#,
+    )
+    .await
+    .expect("platform identity fixture should apply");
+    let manager = SchemaManager::new(&db);
+    for migration in NotificationsModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("notification migration should apply");
+    }
+    db
+}
+
+async fn insert_tenant(db: &DatabaseConnection, tenant_id: Uuid) {
+    db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{tenant_id}')"))
+        .await
+        .expect("tenant fixture should persist");
+}
+
+async fn insert_user(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) {
+    db.execute_unprepared(&format!(
+        "INSERT INTO users (id, tenant_id) VALUES ('{user_id}', '{tenant_id}')"
+    ))
+    .await
+    .expect("user fixture should persist");
+}

--- a/scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
+++ b/scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const inbox = read(contract.notifications_owner_file ?? "");
+const surface = read(contract.notifications_surface_file ?? "");
+const entities = read(contract.notifications_entity_file ?? "");
+const docs = read(contract.notifications_live_contract ?? "");
+const providerContract = read(contract.source_provider_contract ?? "");
+const forumProvider = read(contract.forum_source_provider ?? "");
+const proof = read(contract.sqlite_proof ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification inbox open contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20R" || contract.upstream_task !== "FORUM-20Q") {
+  failures.push("forum notification inbox open contract must connect FORUM-20Q/R");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("inbox open authorization must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "owner_level_open_service",
+  "exact_tenant_recipient_lookup",
+  "cross_recipient_no_oracle",
+  "validated_source_and_target_keys",
+  "source_owned_authorization",
+  "fresh_route_only",
+  "stale_acl_fail_closed",
+  "retryable_provider_failure_preserved",
+  "read_state_unchanged",
+  "delivery_attempts_unchanged",
+  "public_crate_export",
+  "sqlite_contract_proof",
+  "live_notifications_docs",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification inbox open contract must record ${delivered} as delivered`);
+  }
+}
+
+for (const residual of [
+  "bounded inbox listing API",
+  "seen read and archive state mutations",
+  "recipient privacy and blocking recheck at inbox open",
+  "channel delivery enqueue and transports",
+  "delivery-time target authorization",
+  "host trust facts adapter",
+  "host channel membership facts adapter",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification inbox open contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+  "FORUM-20Q",
+  "FORUM-20R",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20R") {
+  failures.push("inbox open contract must require the canonical ledger through FORUM-20R");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("inbox open contract must require FORUM-20H through FORUM-20R delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as current");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in FORUM-20A-G",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-R provide", "synchronized canonical plan must advance through R");
+  for (const slice of deliveredSlices) {
+    requireText(plan, `### Delivered in \`${slice}\``, `canonical plan is missing ${slice}`);
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "pub struct NotificationInboxOpenRequest",
+  "pub tenant_id: Uuid",
+  "pub recipient_id: Uuid",
+  "pub notification_id: Uuid",
+  "pub enum NotificationInboxOpenDecision",
+  "Allowed { route: NotificationTargetRoute }",
+  "Unavailable",
+  "pub struct NotificationInboxOpenService",
+  "db: DatabaseConnection",
+  "registry: Arc<NotificationSourceRegistry>",
+  "pub async fn authorize_open(",
+  "notification::Entity::find_by_id(request.notification_id)",
+  ".filter(notification::Column::TenantId.eq(request.tenant_id))",
+  ".filter(notification::Column::RecipientId.eq(request.recipient_id))",
+  "let Some(stored) = stored else",
+  "return Ok(NotificationInboxOpenDecision::Unavailable)",
+  "NotificationSourceSlug::new(stored.source_slug)",
+  "NotificationSourceSlug::new(stored.target_owner)",
+  "NotificationTargetKind::new(stored.target_kind)",
+  "if target.id.is_nil()",
+  ".registry",
+  ".get(&source)",
+  "AuthorizeNotificationTargetRequest {",
+  "tenant_id: request.tenant_id",
+  "recipient_id: request.recipient_id",
+  "target,",
+  ".map_err(NotificationError::from)?",
+  "NotificationOpenAuthorization::Allowed { route }",
+  "NotificationOpenAuthorization::Unavailable",
+  "validate_request(&request)?",
+]) {
+  requireText(inbox, marker, `notification inbox open owner is missing ${marker}`);
+}
+
+const lookupIndex = inbox.indexOf("notification::Entity::find_by_id(request.notification_id)");
+const missingIndex = inbox.indexOf("let Some(stored) = stored else");
+const providerIndex = inbox.indexOf(".authorize_target_open(AuthorizeNotificationTargetRequest");
+if (
+  lookupIndex < 0 ||
+  missingIndex < 0 ||
+  providerIndex < 0 ||
+  !(lookupIndex < missingIndex && missingIndex < providerIndex)
+) {
+  failures.push("exact ownership lookup and unavailable branch must precede the source provider call");
+}
+
+for (const forbidden of [
+  "notification::ActiveModel",
+  "ActiveValue::Set",
+  "delivery_attempt::",
+  "seen_at: Set(",
+  "read_at: Set(",
+  "archived_at: Set(",
+  ".update(&self.db)",
+  ".delete(&self.db)",
+]) {
+  rejectText(inbox, forbidden, `inbox open authorization must not mutate owner state through ${forbidden}`);
+}
+
+for (const marker of [
+  "mod inbox;",
+  "NotificationInboxOpenDecision",
+  "NotificationInboxOpenRequest",
+  "NotificationInboxOpenService",
+]) {
+  requireText(surface, marker, `notifications public surface is missing ${marker}`);
+}
+for (const marker of [
+  "pub source_slug: String",
+  "pub target_owner: String",
+  "pub target_kind: String",
+  "pub target_id: Uuid",
+  "pub seen_at:",
+  "pub read_at:",
+  "pub archived_at:",
+]) {
+  requireText(entities, marker, `notification persistence identity is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct AuthorizeNotificationTargetRequest",
+  "pub tenant_id: Uuid",
+  "pub recipient_id: Uuid",
+  "pub target: NotificationTargetRef",
+  "async fn authorize_target_open(",
+]) {
+  requireText(providerContract, marker, `notification source contract is missing ${marker}`);
+}
+requireText(
+  forumProvider,
+  "async fn authorize_target_open(",
+  "Forum source provider must implement open-time target authorization",
+);
+
+for (const marker of [
+  "exact_recipient_gets_fresh_route_without_cross_recipient_oracle",
+  "stale_target_and_retryable_owner_failure_remain_distinct",
+  "invalid_stored_source_identity_fails_before_provider_invocation",
+  "NotificationInboxOpenService::new",
+  "NotificationInboxOpenDecision::Allowed",
+  "NotificationInboxOpenDecision::Unavailable",
+  "foreign and missing rows must not invoke a source provider",
+  "NotificationProviderError::CapabilityUnavailable",
+  "NotificationError::ProviderFailure { retryable: true }",
+  "NotificationError::InvalidDescriptor",
+]) {
+  requireText(proof, marker, `inbox open SQLite proof is missing ${marker}`);
+}
+
+for (const marker of [
+  "### Inbox open-time target authorization",
+  "Missing, cross-tenant, and cross-recipient rows all",
+  "It returns only the fresh owner-provided route or `Unavailable`.",
+  "bounded inbox listing/read-state APIs and recipient privacy rechecks",
+  "inbox_open_authorization_sqlite",
+]) {
+  requireText(docs, marker, `notifications live contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 1 ||
+  upstream.task !== "FORUM-20Q" ||
+  upstream.upstream_task !== "FORUM-20P" ||
+  upstream.downstream_task !== "FORUM-20R" ||
+  upstream.composition?.notification_source_factory_consumption !== true
+) {
+  failures.push("FORUM-20R must remain linked to the FORUM-20Q host facts contract");
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification inbox open authorization verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification inbox open authorization contract is source-ready.");


### PR DESCRIPTION
## Summary

- add `NotificationInboxOpenService` for exact tenant/recipient-owned stored notifications
- return the same `Unavailable` decision for missing, cross-tenant, and cross-recipient rows before invoking a source provider
- reconstruct persisted source/target identities through bounded notification API key types
- call the registered source provider's `authorize_target_open` method at inbox-open time and return only the fresh route
- preserve retryable provider failures instead of converting temporary owner unavailability into a stale-target deny
- avoid exposing the stored row, mutating seen/read/archive state, or enqueueing delivery attempts
- add SQLite contract coverage, live Notifications documentation, the FORUM-20R machine contract, and a source verifier

## Boundary

This slice implements owner-level open-time target authorization only. Bounded inbox listing, read-state mutations, recipient privacy/blocking rechecks, channel delivery enqueue/transports, delivery-time authorization, trust/channel facts adapters, initially non-public topic-created descriptor materialization, and PostgreSQL cross-consumer evidence remain open.

The canonical Forum implementation plan still physically ends at FORUM-20G. The FORUM-20R contract records synchronization as pending through R without replacing unrelated plan updates.

## Validation

Tests, Cargo commands, formatting commands, verifiers, and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-notifications --test inbox_open_authorization_sqlite -- --nocapture
cargo test -p rustok-notifications --test candidate_sqlite -- --nocapture
cargo test -p rustok-forum --test notification_recipient_target_open_sqlite -- --nocapture
node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
cargo xtask module validate notifications
cargo xtask module validate forum
```