### PR TITLE
Harden admin payment route error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -77,6 +77,13 @@ available only for actionable domain errors.
   identities. Dynamic validation/conflict details remain internal, all current
   compensation variants have explicit HTTP and sweep-code policies, and existing route,
   provider-registry, worker, limit, and response contracts stay unchanged.
+- `rustok-commerce` admin payment routes: payment collection and refund lists/details plus
+  authorize, capture, cancel, create-refund, complete-refund, and cancel-refund operations
+  retain the typed payment or payment-orchestration cause with owner, source owner, tenant,
+  actor, route operation, and truthful optional collection, refund, order, cart, and
+  customer identities. Validation, provider, reconciliation, configuration, and storage
+  details stay internal while the existing status/code/message policy, idempotency header,
+  provider registry, filter, pagination, service, and response contracts remain unchanged.
 - `rustok-commerce` admin order-change owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and order-change identities, stable public code, status, and HTTP boundary. Typed
@@ -154,6 +161,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
@@ -174,9 +182,10 @@ available only for actionable domain errors.
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
   admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
-  admin order-route, admin checkout-operation, order-change owner and orchestration mapping,
-  admin order-return owner and orchestration mapping, admin order-detail payment and
-  fulfillment mapping, and tax calculation validation, provider-contract, reconciliation,
-  correlation, HTTP-envelope, and transport round-trip tests.
+  admin order-route, admin checkout-operation, admin payment-route, order-change owner and
+  orchestration mapping, admin order-return owner and orchestration mapping, admin
+  order-detail payment and fulfillment mapping, and tax calculation validation,
+  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
+  tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/payments.rs
+++ b/crates/rustok-commerce/src/controllers/admin/payments.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
+use rustok_payment::error::PaymentError;
 use rustok_payment::PaymentService;
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
@@ -19,8 +20,67 @@ use crate::dto::{
     CompleteRefundInput, CreateRefundInput, ListPaymentCollectionsInput, ListRefundsInput,
     PaymentCollectionResponse, RefundResponse,
 };
+use crate::PaymentOrchestrationError;
 
 const MAX_REFUND_CREATION_KEY_LENGTH: usize = 191;
+const ADMIN_PAYMENT_OWNER: &str = "rustok_payment.admin_payments";
+const ADMIN_PAYMENT_BOUNDARY: &str = "commerce_admin_payment_http";
+
+type AdminPaymentHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+#[derive(Clone, Copy)]
+struct AdminPaymentErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    payment_collection_id: Option<Uuid>,
+    refund_id: Option<Uuid>,
+    order_id: Option<Uuid>,
+    cart_id: Option<Uuid>,
+    customer_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminPaymentErrorContext {
+    fn new(tenant_id: Uuid, actor_id: Uuid, operation: &'static str) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            payment_collection_id: None,
+            refund_id: None,
+            order_id: None,
+            cart_id: None,
+            customer_id: None,
+            operation,
+        }
+    }
+
+    fn with_payment_collection_id(mut self, payment_collection_id: Option<Uuid>) -> Self {
+        self.payment_collection_id = payment_collection_id;
+        self
+    }
+
+    fn with_refund_id(mut self, refund_id: Option<Uuid>) -> Self {
+        self.refund_id = refund_id;
+        self
+    }
+
+    fn with_filters(
+        mut self,
+        order_id: Option<Uuid>,
+        cart_id: Option<Uuid>,
+        customer_id: Option<Uuid>,
+    ) -> Self {
+        self.order_id = order_id;
+        self.cart_id = cart_id;
+        self.customer_id = customer_id;
+        self
+    }
+}
 
 #[utoipa::path(
     get,
@@ -41,6 +101,9 @@ pub async fn list_payment_collections(
         "Permission denied: payments:read required",
     )?;
     let pagination = params.pagination.unwrap_or_default();
+    let order_id = params.order_id;
+    let cart_id = params.cart_id;
+    let customer_id = params.customer_id;
     let (collections, total) = PaymentService::new(runtime.db_clone())
         .list_collections(
             tenant.id,
@@ -48,13 +111,23 @@ pub async fn list_payment_collections(
                 page: pagination.page,
                 per_page: pagination.limit(),
                 status: params.status,
-                order_id: params.order_id,
-                cart_id: params.cart_id,
-                customer_id: params.customer_id,
+                order_id,
+                cart_id,
+                customer_id,
             },
         )
         .await
-        .map_err(super::map_payment_error)?;
+        .map_err(|error| {
+            map_admin_payment_error(
+                AdminPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    "list_payment_collections",
+                )
+                .with_filters(order_id, cart_id, customer_id),
+                error,
+            )
+        })?;
     Ok(Json(PaginatedResponse {
         data: collections,
         meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
@@ -82,7 +155,17 @@ pub async fn show_payment_collection(
     let collection = PaymentService::new(runtime.db_clone())
         .get_collection(tenant.id, id)
         .await
-        .map_err(super::map_payment_error)?;
+        .map_err(|error| {
+            map_admin_payment_error(
+                AdminPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    "show_payment_collection",
+                )
+                .with_payment_collection_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(collection))
 }
 
@@ -110,7 +193,17 @@ pub async fn authorize_payment_collection(
         .with_provider_registry(runtime.payment_provider_registry())
         .authorize_collection(tenant.id, id, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    "authorize_payment_collection",
+                )
+                .with_payment_collection_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(collection))
 }
 
@@ -138,7 +231,17 @@ pub async fn capture_payment_collection(
         .with_provider_registry(runtime.payment_provider_registry())
         .capture_collection(tenant.id, id, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    "capture_payment_collection",
+                )
+                .with_payment_collection_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(collection))
 }
 
@@ -166,7 +269,17 @@ pub async fn cancel_payment_collection(
         .with_provider_registry(runtime.payment_provider_registry())
         .cancel_collection(tenant.id, id, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    "cancel_payment_collection",
+                )
+                .with_payment_collection_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(collection))
 }
 
@@ -204,7 +317,13 @@ pub async fn create_refund(
         .with_provider_registry(runtime.payment_provider_registry())
         .create_refund_idempotent(tenant.id, id, creation_key, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(tenant.id, auth.user_id, "create_refund")
+                    .with_payment_collection_id(Some(id)),
+                error,
+            )
+        })?;
     Ok((StatusCode::CREATED, Json(refund)))
 }
 
@@ -227,19 +346,28 @@ pub async fn list_refunds(
         "Permission denied: payments:read required",
     )?;
     let pagination = params.pagination.unwrap_or_default();
+    let payment_collection_id = params.payment_collection_id;
+    let order_id = params.order_id;
     let (refunds, total) = PaymentService::new(runtime.db_clone())
         .list_refunds(
             tenant.id,
             ListRefundsInput {
                 page: pagination.page,
                 per_page: pagination.limit(),
-                payment_collection_id: params.payment_collection_id,
-                order_id: params.order_id,
+                payment_collection_id,
+                order_id,
                 status: params.status,
             },
         )
         .await
-        .map_err(super::map_payment_error)?;
+        .map_err(|error| {
+            map_admin_payment_error(
+                AdminPaymentErrorContext::new(tenant.id, auth.user_id, "list_refunds")
+                    .with_payment_collection_id(payment_collection_id)
+                    .with_filters(order_id, None, None),
+                error,
+            )
+        })?;
     Ok(Json(PaginatedResponse {
         data: refunds,
         meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
@@ -267,7 +395,13 @@ pub async fn show_refund(
     let refund = PaymentService::new(runtime.db_clone())
         .get_refund(tenant.id, id)
         .await
-        .map_err(super::map_payment_error)?;
+        .map_err(|error| {
+            map_admin_payment_error(
+                AdminPaymentErrorContext::new(tenant.id, auth.user_id, "show_refund")
+                    .with_refund_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(refund))
 }
 
@@ -295,7 +429,13 @@ pub async fn complete_refund(
         .with_provider_registry(runtime.payment_provider_registry())
         .complete_refund(tenant.id, id, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(tenant.id, auth.user_id, "complete_refund")
+                    .with_refund_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(refund))
 }
 
@@ -323,8 +463,156 @@ pub async fn cancel_refund(
         .with_provider_registry(runtime.payment_provider_registry())
         .cancel_refund(tenant.id, id, input)
         .await
-        .map_err(super::map_payment_orchestration_error)?;
+        .map_err(|error| {
+            map_admin_payment_orchestration_error(
+                AdminPaymentErrorContext::new(tenant.id, auth.user_id, "cancel_refund")
+                    .with_refund_id(Some(id)),
+                error,
+            )
+        })?;
     Ok(Json(refund))
+}
+
+fn payment_error_policy(error: &PaymentError) -> AdminPaymentHttpPolicy {
+    match error {
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PaymentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::BAD_GATEWAY,
+            "commerce_admin_payment_provider_invalid_response",
+            "Payment provider returned an invalid response; reconciliation may be required",
+            "provider_invalid_response",
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment provider outcome is unknown and requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        PaymentError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "database",
+        ),
+    }
+}
+
+fn reserved_refund_error_policy(error: &PaymentError) -> AdminPaymentHttpPolicy {
+    match error {
+        PaymentError::ProviderOutcomeUnknown { .. }
+        | PaymentError::ProviderInvalidResponse { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_admin_refund_reconciliation_required",
+            "Refund remains reserved while the provider outcome is reconciled",
+            "refund_reconciliation_required",
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_refund_provider_unavailable",
+            "Refund remains reserved and the provider operation may be retried safely",
+            "refund_provider_unavailable",
+        ),
+        error => payment_error_policy(error),
+    }
+}
+
+fn adopt_payment_error_identity(context: &mut AdminPaymentErrorContext, error: &PaymentError) {
+    match error {
+        PaymentError::PaymentCollectionNotFound(id) | PaymentError::PaymentNotFound(id) => {
+            context.payment_collection_id = Some(*id);
+        }
+        PaymentError::RefundNotFound(id) => context.refund_id = Some(*id),
+        _ => {}
+    }
+}
+
+fn admin_payment_http_error<E>(
+    context: &AdminPaymentErrorContext,
+    error: &E,
+    source_owner: &'static str,
+    policy: AdminPaymentHttpPolicy,
+) -> HttpError
+where
+    E: std::fmt::Debug,
+{
+    let (status, code, message, error_kind) = policy;
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_PAYMENT_OWNER,
+        source_owner,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        payment_collection_id = ?context.payment_collection_id,
+        refund_id = ?context.refund_id,
+        order_id = ?context.order_id,
+        cart_id = ?context.cart_id,
+        customer_id = ?context.customer_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_PAYMENT_BOUNDARY,
+        "commerce admin payment operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_payment_error(
+    mut context: AdminPaymentErrorContext,
+    error: PaymentError,
+) -> HttpError {
+    adopt_payment_error_identity(&mut context, &error);
+    let policy = payment_error_policy(&error);
+    admin_payment_http_error(&context, &error, "rustok_payment", policy)
+}
+
+fn map_admin_payment_orchestration_error(
+    mut context: AdminPaymentErrorContext,
+    error: PaymentOrchestrationError,
+) -> HttpError {
+    let policy = match &error {
+        PaymentOrchestrationError::Payment(source)
+        | PaymentOrchestrationError::Provider(source) => {
+            adopt_payment_error_identity(&mut context, source);
+            payment_error_policy(source)
+        }
+        PaymentOrchestrationError::ProviderAfterRefundReservation { refund_id, source } => {
+            context.refund_id = Some(*refund_id);
+            reserved_refund_error_policy(source)
+        }
+    };
+    admin_payment_http_error(&context, &error, "rustok_payment", policy)
 }
 
 fn refund_creation_key(headers: &HeaderMap) -> HttpResult<String> {

--- a/scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs
@@ -11,8 +11,10 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const payments = read('crates/rustok-commerce/src/controllers/admin/payments.rs');
-const admin = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
 const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const paymentOrchestration = read(
+  'crates/rustok-commerce/src/services/payment_orchestration.rs',
+);
 const paymentService = read('crates/rustok-payment/src/services/payment.rs');
 const failures = [];
 
@@ -32,17 +34,41 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const listHandler = between(
+const listCollectionsRoute = between(
   payments,
   'pub async fn list_payment_collections(',
-  '#[utoipa::path(\n    get,\n    path = "/admin/payment-collections/{id}"',
-  'payment collection list handler',
+  'pub async fn show_payment_collection(',
+  'payment collection list route',
 );
-const mapper = between(
-  admin,
-  'pub(crate) fn map_payment_error(error: PaymentError)',
-  'fn map_reserved_refund_provider_error(error: PaymentError)',
-  'admin payment mapper',
+const listRefundsRoute = between(
+  payments,
+  'pub async fn list_refunds(',
+  'pub async fn show_refund(',
+  'refund list route',
+);
+const paymentPolicy = between(
+  payments,
+  'fn payment_error_policy(',
+  'fn reserved_refund_error_policy(',
+  'admin payment policy',
+);
+const reservedRefundPolicy = between(
+  payments,
+  'fn reserved_refund_error_policy(',
+  'fn adopt_payment_error_identity(',
+  'admin reserved refund policy',
+);
+const logger = between(
+  payments,
+  'fn admin_payment_http_error<E>(',
+  'fn map_admin_payment_error(',
+  'admin payment logger',
+);
+const orchestrationMapper = between(
+  payments,
+  'fn map_admin_payment_orchestration_error(',
+  'fn refund_creation_key(',
+  'admin payment orchestration mapper',
 );
 const serviceList = between(
   paymentService,
@@ -52,37 +78,32 @@ const serviceList = between(
 );
 
 for (const [value, label] of [
-  ['Permission::PAYMENTS_READ', 'payment read permission'],
-  ['PaymentService::new(runtime.db_clone())', 'payment service construction'],
-  ['.list_collections(', 'payment collection list call'],
-  ['tenant.id,', 'tenant argument'],
-  ['page: pagination.page', 'page argument'],
-  ['per_page: pagination.limit()', 'per-page argument'],
-  ['status: params.status', 'status filter argument'],
-  ['order_id: params.order_id', 'order filter argument'],
-  ['cart_id: params.cart_id', 'cart filter argument'],
-  ['customer_id: params.customer_id', 'customer filter argument'],
-  ['.map_err(super::map_payment_error)?;', 'typed payment error mapper'],
-  ['PaginationMeta::new(pagination.page, pagination.limit(), total)', 'pagination response metadata'],
-]) {
-  requireText(listHandler, value, label);
-}
-
-for (const value of [
-  'commerce_operation_failed',
-  'err.to_string()',
-  'error.to_string()',
-  'other.to_string()',
-]) {
-  forbidText(payments, value, 'unsafe admin payment public conversion');
-}
-
-const paymentMapperUses = payments.match(/super::map_payment_error/g) ?? [];
-if (paymentMapperUses.length !== 4) {
-  failures.push(
-    `expected four typed PaymentService callsites (collection list/detail and refund list/detail), found ${paymentMapperUses.length}`,
-  );
-}
+  ['use rustok_payment::error::PaymentError;', 'typed payment error import'],
+  ['use crate::PaymentOrchestrationError;', 'typed orchestration import'],
+  [
+    'const ADMIN_PAYMENT_OWNER: &str = "rustok_payment.admin_payments";',
+    'admin payment owner constant',
+  ],
+  [
+    'const ADMIN_PAYMENT_BOUNDARY: &str = "commerce_admin_payment_http";',
+    'admin payment boundary constant',
+  ],
+  ['type AdminPaymentHttpPolicy = (', 'static payment policy type'],
+  ['struct AdminPaymentErrorContext {', 'typed payment context'],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['actor_id: Uuid,', 'actor context field'],
+  ['payment_collection_id: Option<Uuid>,', 'collection context field'],
+  ['refund_id: Option<Uuid>,', 'refund context field'],
+  ['order_id: Option<Uuid>,', 'order context field'],
+  ['cart_id: Option<Uuid>,', 'cart context field'],
+  ['customer_id: Option<Uuid>,', 'customer context field'],
+  ["operation: &'static str,", 'operation context field'],
+  ['fn map_admin_payment_error(', 'local owner mapper'],
+  [
+    'fn map_admin_payment_orchestration_error(',
+    'local orchestration mapper',
+  ],
+]) requireText(payments, value, label);
 
 for (const [value, label] of [
   ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found variant'],
@@ -104,9 +125,177 @@ for (const [value, label] of [
   ['"commerce_admin_payment_reconciliation_required"', 'reconciliation code'],
   ['"commerce_admin_payment_provider_not_configured"', 'provider configuration code'],
   ['"commerce_admin_payment_storage_unavailable"', 'storage unavailable code'],
+  ['"Payment request is invalid"', 'static validation message'],
+  [
+    '"Payment operation conflicts with the current state"',
+    'static transition message',
+  ],
+  [
+    '"Payment provider is temporarily unavailable"',
+    'static provider unavailable message',
+  ],
+]) requireText(paymentPolicy, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::ProviderOutcomeUnknown { .. }', 'reserved unknown-outcome variant'],
+  ['PaymentError::ProviderInvalidResponse { .. }', 'reserved invalid-response variant'],
+  ['PaymentError::ProviderUnavailable { .. }', 'reserved unavailable variant'],
+  [
+    '"commerce_admin_refund_reconciliation_required"',
+    'reserved refund reconciliation code',
+  ],
+  [
+    '"Refund remains reserved while the provider outcome is reconciled"',
+    'reserved refund reconciliation message',
+  ],
+  [
+    '"commerce_admin_refund_provider_unavailable"',
+    'reserved refund retry code',
+  ],
+  [
+    '"Refund remains reserved and the provider operation may be retried safely"',
+    'reserved refund retry message',
+  ],
+  ['error => payment_error_policy(error)', 'reserved refund fallback'],
+]) requireText(reservedRefundPolicy, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed cause log'],
+  ['owner = ADMIN_PAYMENT_OWNER', 'owner log'],
+  ['source_owner,', 'source owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  [
+    'payment_collection_id = ?context.payment_collection_id',
+    'collection identity log',
+  ],
+  ['refund_id = ?context.refund_id', 'refund identity log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['cart_id = ?context.cart_id', 'cart identity log'],
+  ['customer_id = ?context.customer_id', 'customer identity log'],
+  ['operation = %context.operation', 'route operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_PAYMENT_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(logger, value, label);
+
+for (const [value, label] of [
+  ['PaymentOrchestrationError::Payment(source)', 'owner orchestration variant'],
+  ['PaymentOrchestrationError::Provider(source)', 'provider orchestration variant'],
+  [
+    'PaymentOrchestrationError::ProviderAfterRefundReservation { refund_id, source }',
+    'reserved refund orchestration variant',
+  ],
+  ['adopt_payment_error_identity(&mut context, source)', 'nested identity adoption'],
+  ['context.refund_id = Some(*refund_id);', 'reserved refund identity adoption'],
+  ['reserved_refund_error_policy(source)', 'reserved refund policy selection'],
+  [
+    'admin_payment_http_error(&context, &error, "rustok_payment", policy)',
+    'single orchestration log handoff',
+  ],
+]) requireText(orchestrationMapper, value, label);
+
+for (const [value, label] of [
+  ['Permission::PAYMENTS_READ', 'payment read permission'],
+  ['PaymentService::new(runtime.db_clone())', 'payment service construction'],
+  ['.list_collections(', 'payment collection list call'],
+  ['tenant.id,', 'tenant argument'],
+  ['page: pagination.page', 'page argument'],
+  ['per_page: pagination.limit()', 'per-page argument'],
+  ['status: params.status', 'status filter argument'],
+  ['let order_id = params.order_id;', 'order filter capture'],
+  ['let cart_id = params.cart_id;', 'cart filter capture'],
+  ['let customer_id = params.customer_id;', 'customer filter capture'],
+  ['order_id,', 'order filter forwarding'],
+  ['cart_id,', 'cart filter forwarding'],
+  ['customer_id,', 'customer filter forwarding'],
+  ['"list_payment_collections"', 'list route operation'],
+  ['.with_filters(order_id, cart_id, customer_id)', 'list filter context'],
+  ['PaginationMeta::new(pagination.page, pagination.limit(), total)', 'pagination response metadata'],
+]) requireText(listCollectionsRoute, value, label);
+
+for (const [value, label] of [
+  ['let payment_collection_id = params.payment_collection_id;', 'refund collection filter capture'],
+  ['let order_id = params.order_id;', 'refund order filter capture'],
+  ['payment_collection_id,', 'refund collection filter forwarding'],
+  ['order_id,', 'refund order filter forwarding'],
+  ['status: params.status', 'refund status filter forwarding'],
+  ['"list_refunds"', 'refund list operation'],
+  ['.with_payment_collection_id(payment_collection_id)', 'refund collection context'],
+  ['.with_filters(order_id, None, None)', 'refund order context'],
+]) requireText(listRefundsRoute, value, label);
+
+for (const [handler, permission, operation, serviceCall, identity, mapper, label] of [
+  ['show_payment_collection', 'PAYMENTS_READ', 'show_payment_collection', '.get_collection(tenant.id, id)', '.with_payment_collection_id(Some(id))', 'map_admin_payment_error(', 'collection detail'],
+  ['authorize_payment_collection', 'PAYMENTS_UPDATE', 'authorize_payment_collection', '.authorize_collection(tenant.id, id, input)', '.with_payment_collection_id(Some(id))', 'map_admin_payment_orchestration_error(', 'collection authorize'],
+  ['capture_payment_collection', 'PAYMENTS_UPDATE', 'capture_payment_collection', '.capture_collection(tenant.id, id, input)', '.with_payment_collection_id(Some(id))', 'map_admin_payment_orchestration_error(', 'collection capture'],
+  ['cancel_payment_collection', 'PAYMENTS_UPDATE', 'cancel_payment_collection', '.cancel_collection(tenant.id, id, input)', '.with_payment_collection_id(Some(id))', 'map_admin_payment_orchestration_error(', 'collection cancel'],
+  ['create_refund', 'PAYMENTS_UPDATE', 'create_refund', '.create_refund_idempotent(tenant.id, id, creation_key, input)', '.with_payment_collection_id(Some(id))', 'map_admin_payment_orchestration_error(', 'refund create'],
+  ['show_refund', 'PAYMENTS_READ', 'show_refund', '.get_refund(tenant.id, id)', '.with_refund_id(Some(id))', 'map_admin_payment_error(', 'refund detail'],
+  ['complete_refund', 'PAYMENTS_UPDATE', 'complete_refund', '.complete_refund(tenant.id, id, input)', '.with_refund_id(Some(id))', 'map_admin_payment_orchestration_error(', 'refund complete'],
+  ['cancel_refund', 'PAYMENTS_UPDATE', 'cancel_refund', '.cancel_refund(tenant.id, id, input)', '.with_refund_id(Some(id))', 'map_admin_payment_orchestration_error(', 'refund cancel'],
 ]) {
-  requireText(mapper, value, label);
+  const start = `pub async fn ${handler}(`;
+  const startIndex = payments.indexOf(start);
+  const nextIndex = payments.indexOf('\n#[utoipa::path(', startIndex + start.length);
+  const block = startIndex < 0
+    ? ''
+    : payments.slice(startIndex, nextIndex < 0 ? payments.length : nextIndex);
+  if (startIndex < 0) failures.push(`${label}: unable to isolate handler`);
+  requireText(block, `Permission::${permission}`, `${label} permission`);
+  requireText(block, `"${operation}"`, `${label} operation`);
+  requireText(block, serviceCall, `${label} service contract`);
+  requireText(block, identity, `${label} truthful identity`);
+  requireText(block, mapper, `${label} local mapper`);
 }
+
+for (const [value, label] of [
+  [
+    '.with_provider_registry(runtime.payment_provider_registry())',
+    'provider registry forwarding',
+  ],
+  ['refund_creation_key(&headers)?', 'refund idempotency validation'],
+  ['"refund_idempotency_key_required"', 'required idempotency code'],
+  ['"refund_idempotency_key_invalid"', 'invalid idempotency code'],
+  ['MAX_REFUND_CREATION_KEY_LENGTH', 'idempotency length bound'],
+  ['Ok((StatusCode::CREATED, Json(refund)))', 'refund creation response'],
+]) requireText(payments, value, label);
+
+const ownerMapperUses =
+  payments.match(/map_admin_payment_error\(\s+AdminPaymentErrorContext::new\(/g) ?? [];
+if (ownerMapperUses.length !== 4) {
+  failures.push(
+    `expected four context-aware payment owner mapper callsites, found ${ownerMapperUses.length}`,
+  );
+}
+const orchestrationMapperUses =
+  payments.match(
+    /map_admin_payment_orchestration_error\(\s+AdminPaymentErrorContext::new\(/g,
+  ) ?? [];
+if (orchestrationMapperUses.length !== 6) {
+  failures.push(
+    `expected six context-aware payment orchestration mapper callsites, found ${orchestrationMapperUses.length}`,
+  );
+}
+const providerRegistryUses =
+  payments.match(/\.with_provider_registry\(runtime\.payment_provider_registry\(\)\)/g) ?? [];
+if (providerRegistryUses.length !== 6) {
+  failures.push(
+    `expected six provider-registry orchestration callsites, found ${providerRegistryUses.length}`,
+  );
+}
+
+for (const value of [
+  '.map_err(super::map_payment_error)?;',
+  '.map_err(super::map_payment_orchestration_error)?;',
+  'HttpError::new(StatusCode::CONFLICT, "checkout_operation_conflict", message)',
+  'err.to_string()',
+  'error.to_string()',
+  'other.to_string()',
+  'commerce_operation_failed',
+]) forbidText(payments, value, 'unsafe admin payment public conversion');
 
 for (const [value, label] of [
   ['Validation(String)', 'owner validation variant'],
@@ -120,9 +309,14 @@ for (const [value, label] of [
   ['ProviderOutcomeUnknown {', 'owner unknown-outcome variant'],
   ['ProviderConfiguration { provider_id: String }', 'owner configuration variant'],
   ['Database(#[from] DbErr)', 'owner database variant'],
-]) {
-  requireText(paymentErrors, value, label);
-}
+]) requireText(paymentErrors, value, label);
+
+for (const [value, label] of [
+  ['Provider(#[source] PaymentError)', 'orchestration provider variant'],
+  ['ProviderAfterRefundReservation {', 'orchestration reserved-refund variant'],
+  ['refund_id: Uuid,', 'orchestration refund identity'],
+  ['Payment(#[from] PaymentError)', 'orchestration owner variant'],
+]) requireText(paymentOrchestration, value, label);
 
 for (const [value, label] of [
   ['-> PaymentResult<(Vec<PaymentCollectionResponse>, u64)>', 'typed list result'],
@@ -135,14 +329,14 @@ for (const [value, label] of [
   ['query.clone().count(&self.db).await?', 'service count propagation'],
   ['.all(&self.db)', 'service page query'],
   ['items.push(self.build_response(row).await?);', 'response build propagation'],
-]) {
-  requireText(serviceList, value, label);
-}
+]) requireText(serviceList, value, label);
 
 if (failures.length > 0) {
-  console.error('Commerce admin payment collection list HTTP error-safety verification failed:');
+  console.error('Commerce admin payment route error-context verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Admin payment collection list uses the typed payment HTTP mapper');
+console.log(
+  '✔ Admin payment routes retain typed causes and use static public envelopes',
+);


### PR DESCRIPTION
## Summary

- replace four shared payment owner mapper callsites and six shared payment orchestration mapper callsites in admin payment collection/refund routes with local context-aware typed mappers;
- preserve the existing not-found, validation, state-conflict, provider, reconciliation, configuration, storage, and reserved-refund HTTP status/code/message policy;
- retain owner, source owner, tenant, actor, route operation, truthful optional payment collection, refund, order, cart, and customer identities, stable public code, status, HTTP boundary, and the original typed cause in one structured error event;
- adopt typed collection/refund identities from `PaymentError` and reserved refund identity from `PaymentOrchestrationError`;
- preserve permissions, filters, pagination, provider-registry wiring, refund idempotency validation, service calls, and success responses;
- expand the existing admin payment verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/admin/payments.rs`
- `scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- rebased directly on current `main` after one unrelated notifications commit landed;
- branch is directly ahead of current `main` by one commit and is not behind;
- final diff is limited to the three intended files;
- source was re-read to confirm four owner and six orchestration local mapper callsites with zero shared payment mapper callsites;
- all current `PaymentError` and `PaymentOrchestrationError` variants are covered with static public envelopes;
- permissions, filters, pagination, provider registry, idempotency header validation, service arguments, and success contracts remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```