### PR TITLE
feat(notifications): recheck inbox recipient privacy

### DIFF
--- a/crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json
+++ b/crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "task": "FORUM-20R",
   "upstream_task": "FORUM-20Q",
+  "downstream_task": "FORUM-20S",
   "scope": "Exact recipient-owned stored notification target reauthorization at inbox open time",
   "notifications_owner_file": "crates/rustok-notifications/src/inbox.rs",
   "notifications_surface_file": "crates/rustok-notifications/src/lib.rs",

--- a/crates/rustok-forum/contracts/forum-notification-inbox-open-privacy.json
+++ b/crates/rustok-forum/contracts/forum-notification-inbox-open-privacy.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20S",
+  "upstream_task": "FORUM-20R",
+  "scope": "Current recipient privacy and blocking policy recheck before stored notification target authorization",
+  "notifications_owner_file": "crates/rustok-notifications/src/inbox.rs",
+  "recipient_policy_owner_file": "crates/rustok-notifications/src/candidate.rs",
+  "notifications_surface_file": "crates/rustok-notifications/src/lib.rs",
+  "notifications_live_contract": "crates/rustok-notifications/docs/README.md",
+  "forum_source_provider": "crates/rustok-forum/src/notification_source.rs",
+  "sqlite_proof": "crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-notification-inbox-open-authorization.json",
+  "source_verifier": "scripts/verify/verify-forum-notification-inbox-open-privacy.mjs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_plan_sync": {
+    "status": "pending",
+    "required_ledger_through": "FORUM-20S",
+    "required_delivered_sections": [
+      "FORUM-20H",
+      "FORUM-20I",
+      "FORUM-20J",
+      "FORUM-20K",
+      "FORUM-20L",
+      "FORUM-20M",
+      "FORUM-20N",
+      "FORUM-20O",
+      "FORUM-20P",
+      "FORUM-20Q",
+      "FORUM-20R",
+      "FORUM-20S"
+    ],
+    "current_plan_through": "FORUM-20G",
+    "follow_up": "Synchronize the canonical plan without replacing unrelated concurrent task updates"
+  },
+  "policy": {
+    "ownership_gate": "exact notification, tenant and recipient lookup completes before any privacy or source call",
+    "recipient_policy": "the injected Notifications recipient policy is mandatory for every owned row",
+    "policy_identity": "tenant, recipient, actor, source event identity, notification type and target are reconstructed from the stored row",
+    "suppression": "any recipient policy suppression becomes inbox unavailable without invoking the source provider",
+    "policy_failure": "recipient policy failures preserve retryability through NotificationError::RecipientPolicyFailure",
+    "source_order": "source-owned authorize_target_open runs only after recipient policy allow",
+    "allowed_output": "only the fresh source-owned route is returned",
+    "mutation_boundary": "privacy and target authorization do not mutate seen read archive state or delivery attempts"
+  },
+  "composition": {
+    "mandatory_recipient_policy_dependency": true,
+    "exact_policy_request_identity": true,
+    "privacy_before_source_authorization": true,
+    "suppression_fail_closed": true,
+    "suppression_reason_not_exposed": true,
+    "retryable_policy_failure_preserved": true,
+    "cross_recipient_no_oracle_preserved": true,
+    "fresh_source_route_preserved": true,
+    "read_state_unchanged": true,
+    "delivery_attempts_unchanged": true,
+    "sqlite_contract_proof": true,
+    "live_notifications_docs": true
+  },
+  "not_delivered": [
+    "bounded inbox listing API",
+    "seen read and archive state mutations",
+    "channel delivery enqueue and transports",
+    "delivery-time target authorization",
+    "host trust facts adapter",
+    "host channel membership facts adapter",
+    "initially non-public topic-created descriptor materialization",
+    "search index SEO and deep-link migration",
+    "PostgreSQL and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-notifications --test inbox_open_authorization_sqlite -- --nocapture",
+      "cargo test -p rustok-notifications --test candidate_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs",
+      "node scripts/verify/verify-forum-notification-inbox-open-privacy.mjs",
+      "cargo xtask module validate notifications",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-notifications/docs/README.md
+++ b/crates/rustok-notifications/docs/README.md
@@ -116,19 +116,22 @@ The loop remains default-off behind
 `RUSTOK_NOTIFICATIONS_CANDIDATE_WORKER_ENABLED`, requires ready recipient-policy
 ports and `ModuleRegistry`, and never creates channel delivery attempts.
 
-### Inbox open-time target authorization
+### Inbox open-time authorization
 
 `NotificationInboxOpenService` loads one stored notification by exact notification,
 tenant, and recipient identity. Missing, cross-tenant, and cross-recipient rows all
-return `Unavailable` without invoking a source provider, preventing a notification
-existence oracle.
+return `Unavailable` before recipient policy or source authorization, preventing a
+notification existence oracle.
 
-For an owned row, the service reconstructs bounded source and target identities and
-calls the registered source provider's `authorize_target_open` method with the
-exact recipient. It returns only the fresh owner-provided route or `Unavailable`.
-Provider capability failures preserve retryability. The service does not expose the
-stored row, mutate `seen/read/archive` state, enqueue delivery attempts, or replace
-recipient privacy policy.
+For an owned row, the service reconstructs bounded source and target identities,
+then evaluates the same injected Profiles/Social Graph recipient policy used during
+candidate processing. Suppression returns `Unavailable` without invoking the source
+provider, while temporary policy failures preserve retryability.
+
+Only an allowed recipient reaches the registered source provider's
+`authorize_target_open` method. The service returns only the fresh owner-provided
+route or `Unavailable`. It does not expose the stored row, mutate
+`seen/read/archive` state, or enqueue delivery attempts.
 
 The server starts workers in intake → fanout → candidate order. Invalid or
 unreadable flags remain disabled.
@@ -149,7 +152,7 @@ remains deferred.
 - PostgreSQL cursor/lease contention evidence and operational health/lag metrics;
 - grouping and bounded moderator-directory expansion;
 - channel delivery enqueue and transports with delivery-time authorization;
-- bounded inbox listing/read-state APIs and recipient privacy rechecks;
+- bounded inbox listing and seen/read/archive state APIs;
 - retention, reconciliation, quarantine replay/purge, and full module-owned UI.
 
 ## Maintainer verification
@@ -177,11 +180,12 @@ node scripts/verify/verify-notifications-candidate-worker.mjs
 node scripts/verify/verify-notifications-outbox-intake.mjs
 node scripts/verify/verify-notifications-fanout-worker.mjs
 node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
+node scripts/verify/verify-forum-notification-inbox-open-privacy.mjs
 cargo xtask module validate notifications
 ```
 
 These commands were not run while publishing `NOTIFY-03D/03E/03F/03G/03H/03I` or
-`FORUM-20R`.
+`FORUM-20R/20S`.
 
 ## Related documents
 

--- a/crates/rustok-notifications/src/inbox.rs
+++ b/crates/rustok-notifications/src/inbox.rs
@@ -8,6 +8,10 @@ use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::candidate::{
+    NotificationRecipientPolicy, NotificationRecipientPolicyDecision,
+    NotificationRecipientPolicyRequest,
+};
 use crate::entities::notification;
 use crate::error::{NotificationError, NotificationResult};
 
@@ -30,16 +34,26 @@ pub enum NotificationInboxOpenDecision {
 /// This service intentionally returns only a fresh owner-provided route. It does not expose the
 /// stored notification row, mutate inbox state, or enqueue a delivery attempt. Missing and
 /// foreign-recipient rows both fail closed as `Unavailable`, preventing a notification-existence
-/// oracle across recipients or tenants.
+/// oracle across recipients or tenants. Owned rows must pass current recipient privacy policy
+/// before the source provider is asked to authorize the target.
 #[derive(Clone)]
 pub struct NotificationInboxOpenService {
     db: DatabaseConnection,
     registry: Arc<NotificationSourceRegistry>,
+    policy: Arc<dyn NotificationRecipientPolicy>,
 }
 
 impl NotificationInboxOpenService {
-    pub fn new(db: DatabaseConnection, registry: Arc<NotificationSourceRegistry>) -> Self {
-        Self { db, registry }
+    pub fn new(
+        db: DatabaseConnection,
+        registry: Arc<NotificationSourceRegistry>,
+        policy: Arc<dyn NotificationRecipientPolicy>,
+    ) -> Self {
+        Self {
+            db,
+            registry,
+            policy,
+        }
     }
 
     pub async fn authorize_open(
@@ -57,7 +71,7 @@ impl NotificationInboxOpenService {
             return Ok(NotificationInboxOpenDecision::Unavailable);
         };
 
-        let source = NotificationSourceSlug::new(stored.source_slug)
+        let source = NotificationSourceSlug::new(stored.source_slug.clone())
             .map_err(|_| NotificationError::InvalidDescriptor)?;
         let target = NotificationTargetRef {
             owner: NotificationSourceSlug::new(stored.target_owner)
@@ -68,6 +82,31 @@ impl NotificationInboxOpenService {
         };
         if target.id.is_nil() {
             return Err(NotificationError::InvalidDescriptor);
+        }
+
+        match self
+            .policy
+            .evaluate(NotificationRecipientPolicyRequest {
+                tenant_id: request.tenant_id,
+                recipient_id: request.recipient_id,
+                actor_id: stored.actor_id,
+                source_slug: source.as_str().to_string(),
+                source_event_id: stored.source_event_id,
+                source_revision: stored.source_revision,
+                notification_type: stored.notification_type,
+                target: target.clone(),
+            })
+            .await
+        {
+            Ok(NotificationRecipientPolicyDecision::Allow) => {}
+            Ok(NotificationRecipientPolicyDecision::Suppress { .. }) => {
+                return Ok(NotificationInboxOpenDecision::Unavailable);
+            }
+            Err(error) => {
+                return Err(NotificationError::RecipientPolicyFailure {
+                    retryable: error.retryable,
+                });
+            }
         }
 
         let provider = self

--- a/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
+++ b/crates/rustok-notifications/tests/inbox_open_authorization_sqlite.rs
@@ -10,15 +10,17 @@ use rustok_notifications::api::{
     NotificationSourceSlug, NotificationTargetRoute, NotificationTypeKey,
     ResolveNotificationAudienceRequest,
 };
-use rustok_notifications::entities::notification;
+use rustok_notifications::entities::{delivery_attempt, notification};
 use rustok_notifications::model::{NotificationPriorityValue, NotificationState};
 use rustok_notifications::{
     NotificationError, NotificationInboxOpenDecision, NotificationInboxOpenRequest,
-    NotificationInboxOpenService, NotificationsModule,
+    NotificationInboxOpenService, NotificationRecipientPolicy,
+    NotificationRecipientPolicyDecision, NotificationRecipientPolicyError,
+    NotificationRecipientPolicyRequest, NotificationRecipientSuppression, NotificationsModule,
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ConnectOptions, ConnectionTrait, Database,
-    DatabaseConnection,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectOptions, ConnectionTrait, Database,
+    DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
 };
 use sea_orm_migration::SchemaManager;
 use uuid::Uuid;
@@ -74,7 +76,7 @@ impl NotificationSourceProvider for TestSourceProvider {
     ) -> NotificationProviderResult<NotificationOpenAuthorization> {
         self.calls
             .lock()
-            .expect("inbox open call recorder should stay available")
+            .expect("source authorization call recorder should stay available")
             .push(request.clone());
         match self.behavior {
             AuthorizationBehavior::Allowed => Ok(NotificationOpenAuthorization::Allowed {
@@ -90,25 +92,57 @@ impl NotificationSourceProvider for TestSourceProvider {
     }
 }
 
+#[derive(Clone)]
+struct StaticRecipientPolicy {
+    result: Result<NotificationRecipientPolicyDecision, NotificationRecipientPolicyError>,
+    calls: Arc<Mutex<Vec<NotificationRecipientPolicyRequest>>>,
+}
+
+#[async_trait]
+impl NotificationRecipientPolicy for StaticRecipientPolicy {
+    async fn evaluate(
+        &self,
+        request: NotificationRecipientPolicyRequest,
+    ) -> Result<NotificationRecipientPolicyDecision, NotificationRecipientPolicyError> {
+        self.calls
+            .lock()
+            .expect("recipient policy call recorder should stay available")
+            .push(request);
+        self.result
+    }
+}
+
 #[tokio::test]
-async fn exact_recipient_gets_fresh_route_without_cross_recipient_oracle() {
+async fn exact_recipient_passes_privacy_then_gets_fresh_route_without_oracle() {
     let db = setup().await;
     let tenant_id = Uuid::new_v4();
     let other_tenant_id = Uuid::new_v4();
     let recipient_id = Uuid::new_v4();
     let other_recipient_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
     insert_tenant(&db, tenant_id).await;
     insert_tenant(&db, other_tenant_id).await;
     insert_user(&db, tenant_id, recipient_id).await;
     insert_user(&db, tenant_id, other_recipient_id).await;
 
     let target_id = Uuid::new_v4();
-    let notification_id = seed_notification(&db, tenant_id, recipient_id, target_id, SOURCE).await;
-    let calls = Arc::new(Mutex::new(Vec::new()));
+    let notification_id = seed_notification(
+        &db,
+        tenant_id,
+        recipient_id,
+        Some(actor_id),
+        target_id,
+        SOURCE,
+    )
+    .await;
+    let policy_calls = Arc::new(Mutex::new(Vec::new()));
+    let source_calls = Arc::new(Mutex::new(Vec::new()));
     let service = service(
-        db,
+        db.clone(),
+        Ok(NotificationRecipientPolicyDecision::Allow),
         AuthorizationBehavior::Allowed,
-        calls.clone(),
+        policy_calls.clone(),
+        source_calls.clone(),
     );
 
     let decision = service
@@ -131,16 +165,26 @@ async fn exact_recipient_gets_fresh_route_without_cross_recipient_oracle() {
         }
     }
 
-    let recorded = calls
+    let recorded_policy = policy_calls
         .lock()
-        .expect("inbox open call recorder should stay available")
+        .expect("recipient policy call recorder should stay available")
         .clone();
-    assert_eq!(recorded.len(), 1);
-    assert_eq!(recorded[0].tenant_id, tenant_id);
-    assert_eq!(recorded[0].recipient_id, recipient_id);
-    assert_eq!(recorded[0].target.owner, source_slug());
-    assert_eq!(recorded[0].target.kind.as_str(), TARGET_KIND);
-    assert_eq!(recorded[0].target.id, target_id);
+    assert_eq!(recorded_policy.len(), 1);
+    assert_eq!(recorded_policy[0].tenant_id, tenant_id);
+    assert_eq!(recorded_policy[0].recipient_id, recipient_id);
+    assert_eq!(recorded_policy[0].actor_id, Some(actor_id));
+    assert_eq!(recorded_policy[0].source_slug, SOURCE);
+    assert_eq!(recorded_policy[0].notification_type, NOTIFICATION_TYPE);
+    assert_eq!(recorded_policy[0].target.id, target_id);
+
+    let recorded_source = source_calls
+        .lock()
+        .expect("source authorization call recorder should stay available")
+        .clone();
+    assert_eq!(recorded_source.len(), 1);
+    assert_eq!(recorded_source[0].tenant_id, tenant_id);
+    assert_eq!(recorded_source[0].recipient_id, recipient_id);
+    assert_eq!(recorded_source[0].target.id, target_id);
 
     for foreign_request in [
         NotificationInboxOpenRequest {
@@ -168,64 +212,112 @@ async fn exact_recipient_gets_fresh_route_without_cross_recipient_oracle() {
         );
     }
     assert_eq!(
-        calls
+        policy_calls
             .lock()
-            .expect("inbox open call recorder should stay available")
+            .expect("recipient policy call recorder should stay available")
+            .len(),
+        1,
+        "foreign and missing rows must not invoke recipient policy"
+    );
+    assert_eq!(
+        source_calls
+            .lock()
+            .expect("source authorization call recorder should stay available")
             .len(),
         1,
         "foreign and missing rows must not invoke a source provider"
     );
+
+    let stored = notification::Entity::find_by_id(notification_id)
+        .one(&db)
+        .await
+        .expect("notification read should succeed")
+        .expect("notification should remain stored");
+    assert_eq!(stored.state, NotificationState::Unread);
+    assert!(stored.seen_at.is_none());
+    assert!(stored.read_at.is_none());
+    assert!(stored.archived_at.is_none());
+    assert_eq!(
+        delivery_attempt::Entity::find()
+            .filter(delivery_attempt::Column::NotificationId.eq(notification_id))
+            .count(&db)
+            .await
+            .expect("delivery attempt count should succeed"),
+        0
+    );
 }
 
 #[tokio::test]
-async fn stale_target_and_retryable_owner_failure_remain_distinct() {
+async fn privacy_suppression_and_retryable_failure_stop_before_source_authorization() {
     let db = setup().await;
     let tenant_id = Uuid::new_v4();
     let recipient_id = Uuid::new_v4();
     insert_tenant(&db, tenant_id).await;
     insert_user(&db, tenant_id, recipient_id).await;
-
-    let notification_id =
-        seed_notification(&db, tenant_id, recipient_id, Uuid::new_v4(), SOURCE).await;
+    let notification_id = seed_notification(
+        &db,
+        tenant_id,
+        recipient_id,
+        None,
+        Uuid::new_v4(),
+        SOURCE,
+    )
+    .await;
     let request = NotificationInboxOpenRequest {
         tenant_id,
         recipient_id,
         notification_id,
     };
 
-    let unavailable = service(
+    let suppressed_source_calls = Arc::new(Mutex::new(Vec::new()));
+    let suppressed = service(
         db.clone(),
-        AuthorizationBehavior::Unavailable,
+        Ok(NotificationRecipientPolicyDecision::Suppress {
+            reason: NotificationRecipientSuppression::Blocked,
+        }),
+        AuthorizationBehavior::Allowed,
         Arc::new(Mutex::new(Vec::new())),
+        suppressed_source_calls.clone(),
     )
     .authorize_open(request.clone())
     .await
-    .expect("stale target should fail closed without an error");
-    assert_eq!(unavailable, NotificationInboxOpenDecision::Unavailable);
+    .expect("privacy suppression should fail closed without a source error");
+    assert_eq!(suppressed, NotificationInboxOpenDecision::Unavailable);
+    assert!(
+        suppressed_source_calls
+            .lock()
+            .expect("source authorization call recorder should stay available")
+            .is_empty(),
+        "suppressed recipient must not reach source authorization"
+    );
 
+    let retryable_source_calls = Arc::new(Mutex::new(Vec::new()));
     let retryable = service(
         db,
-        AuthorizationBehavior::Error(NotificationProviderError::CapabilityUnavailable {
-            retryable: true,
-        }),
+        Err(NotificationRecipientPolicyError::retryable()),
+        AuthorizationBehavior::Allowed,
         Arc::new(Mutex::new(Vec::new())),
+        retryable_source_calls.clone(),
     )
     .authorize_open(request)
     .await
-    .expect_err("retryable source failure must not become a stale-target deny");
-    assert!(matches!(
-        &retryable,
-        NotificationError::ProviderFailure { retryable: true }
-    ));
+    .expect_err("retryable privacy failure must not become a permanent deny");
     assert_eq!(
         retryable.stable_code(),
-        "NOTIFICATION_SOURCE_PROVIDER_FAILURE"
+        "NOTIFICATION_RECIPIENT_POLICY_FAILURE"
     );
     assert!(retryable.is_retryable());
+    assert!(
+        retryable_source_calls
+            .lock()
+            .expect("source authorization call recorder should stay available")
+            .is_empty(),
+        "failed recipient policy must not reach source authorization"
+    );
 }
 
 #[tokio::test]
-async fn invalid_stored_source_identity_fails_before_provider_invocation() {
+async fn stale_target_provider_failure_and_invalid_source_remain_distinct() {
     let db = setup().await;
     let tenant_id = Uuid::new_v4();
     let recipient_id = Uuid::new_v4();
@@ -236,43 +328,116 @@ async fn invalid_stored_source_identity_fails_before_provider_invocation() {
         &db,
         tenant_id,
         recipient_id,
+        None,
+        Uuid::new_v4(),
+        SOURCE,
+    )
+    .await;
+    let request = NotificationInboxOpenRequest {
+        tenant_id,
+        recipient_id,
+        notification_id,
+    };
+
+    let unavailable = service(
+        db.clone(),
+        Ok(NotificationRecipientPolicyDecision::Allow),
+        AuthorizationBehavior::Unavailable,
+        Arc::new(Mutex::new(Vec::new())),
+        Arc::new(Mutex::new(Vec::new())),
+    )
+    .authorize_open(request.clone())
+    .await
+    .expect("stale target should fail closed without an error");
+    assert_eq!(unavailable, NotificationInboxOpenDecision::Unavailable);
+
+    let provider_error = service(
+        db.clone(),
+        Ok(NotificationRecipientPolicyDecision::Allow),
+        AuthorizationBehavior::Error(NotificationProviderError::CapabilityUnavailable {
+            retryable: true,
+        }),
+        Arc::new(Mutex::new(Vec::new())),
+        Arc::new(Mutex::new(Vec::new())),
+    )
+    .authorize_open(request)
+    .await
+    .expect_err("retryable source failure must not become a stale-target deny");
+    assert_eq!(
+        provider_error.stable_code(),
+        "NOTIFICATION_SOURCE_PROVIDER_FAILURE"
+    );
+    assert!(provider_error.is_retryable());
+
+    let invalid_notification_id = seed_notification(
+        &db,
+        tenant_id,
+        recipient_id,
+        None,
         Uuid::new_v4(),
         "Invalid Source",
     )
     .await;
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let error = service(db, AuthorizationBehavior::Allowed, calls.clone())
-        .authorize_open(NotificationInboxOpenRequest {
-            tenant_id,
-            recipient_id,
-            notification_id,
-        })
-        .await
-        .expect_err("invalid stored source identity must fail closed");
-
-    assert!(matches!(error, NotificationError::InvalidDescriptor));
-    assert!(calls
-        .lock()
-        .expect("inbox open call recorder should stay available")
-        .is_empty());
+    let policy_calls = Arc::new(Mutex::new(Vec::new()));
+    let source_calls = Arc::new(Mutex::new(Vec::new()));
+    let invalid = service(
+        db,
+        Ok(NotificationRecipientPolicyDecision::Allow),
+        AuthorizationBehavior::Allowed,
+        policy_calls.clone(),
+        source_calls.clone(),
+    )
+    .authorize_open(NotificationInboxOpenRequest {
+        tenant_id,
+        recipient_id,
+        notification_id: invalid_notification_id,
+    })
+    .await
+    .expect_err("invalid stored source identity must fail closed");
+    assert!(matches!(invalid, NotificationError::InvalidDescriptor));
+    assert!(
+        policy_calls
+            .lock()
+            .expect("recipient policy call recorder should stay available")
+            .is_empty()
+    );
+    assert!(
+        source_calls
+            .lock()
+            .expect("source authorization call recorder should stay available")
+            .is_empty()
+    );
 }
 
 fn service(
     db: DatabaseConnection,
+    policy_result: Result<NotificationRecipientPolicyDecision, NotificationRecipientPolicyError>,
     behavior: AuthorizationBehavior,
-    calls: Arc<Mutex<Vec<AuthorizeNotificationTargetRequest>>>,
+    policy_calls: Arc<Mutex<Vec<NotificationRecipientPolicyRequest>>>,
+    source_calls: Arc<Mutex<Vec<AuthorizeNotificationTargetRequest>>>,
 ) -> NotificationInboxOpenService {
     let mut registry = NotificationSourceRegistry::default();
     registry
-        .register(TestSourceProvider { behavior, calls })
+        .register(TestSourceProvider {
+            behavior,
+            calls: source_calls,
+        })
         .expect("test source provider should register");
-    NotificationInboxOpenService::new(db, Arc::new(registry))
+    NotificationInboxOpenService::new(
+        db,
+        Arc::new(registry),
+        Arc::new(StaticRecipientPolicy {
+            result: policy_result,
+            calls: policy_calls,
+        }),
+    )
 }
 
 async fn seed_notification(
     db: &DatabaseConnection,
     tenant_id: Uuid,
     recipient_id: Uuid,
+    actor_id: Option<Uuid>,
     target_id: Uuid,
     source_slug: &str,
 ) -> Uuid {
@@ -290,7 +455,7 @@ async fn seed_notification(
         target_owner: Set(SOURCE.to_string()),
         target_kind: Set(TARGET_KIND.to_string()),
         target_id: Set(target_id),
-        actor_id: Set(None),
+        actor_id: Set(actor_id),
         priority: Set(NotificationPriorityValue::Normal),
         state: Set(NotificationState::Unread),
         template_data_json: Set(serde_json::json!({"target_id": target_id})),

--- a/scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
+++ b/scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
@@ -43,8 +43,12 @@ const plan = read(contract.canonical_plan ?? "");
 if (contract.schema_version !== 1) {
   failures.push("forum notification inbox open contract must use schema_version=1");
 }
-if (contract.task !== "FORUM-20R" || contract.upstream_task !== "FORUM-20Q") {
-  failures.push("forum notification inbox open contract must connect FORUM-20Q/R");
+if (
+  contract.task !== "FORUM-20R" ||
+  contract.upstream_task !== "FORUM-20Q" ||
+  contract.downstream_task !== "FORUM-20S"
+) {
+  failures.push("forum notification inbox open contract must connect FORUM-20Q/R/S");
 }
 if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
   failures.push("inbox open authorization must not claim unexecuted evidence");
@@ -143,16 +147,18 @@ for (const marker of [
   "pub struct NotificationInboxOpenService",
   "db: DatabaseConnection",
   "registry: Arc<NotificationSourceRegistry>",
+  "policy: Arc<dyn NotificationRecipientPolicy>",
   "pub async fn authorize_open(",
   "notification::Entity::find_by_id(request.notification_id)",
   ".filter(notification::Column::TenantId.eq(request.tenant_id))",
   ".filter(notification::Column::RecipientId.eq(request.recipient_id))",
   "let Some(stored) = stored else",
   "return Ok(NotificationInboxOpenDecision::Unavailable)",
-  "NotificationSourceSlug::new(stored.source_slug)",
+  "NotificationSourceSlug::new(stored.source_slug.clone())",
   "NotificationSourceSlug::new(stored.target_owner)",
   "NotificationTargetKind::new(stored.target_kind)",
   "if target.id.is_nil()",
+  ".evaluate(NotificationRecipientPolicyRequest {",
   ".registry",
   ".get(&source)",
   "AuthorizeNotificationTargetRequest {",
@@ -169,14 +175,16 @@ for (const marker of [
 
 const lookupIndex = inbox.indexOf("notification::Entity::find_by_id(request.notification_id)");
 const missingIndex = inbox.indexOf("let Some(stored) = stored else");
+const policyIndex = inbox.indexOf(".evaluate(NotificationRecipientPolicyRequest {");
 const providerIndex = inbox.indexOf(".authorize_target_open(AuthorizeNotificationTargetRequest");
 if (
   lookupIndex < 0 ||
   missingIndex < 0 ||
+  policyIndex < 0 ||
   providerIndex < 0 ||
-  !(lookupIndex < missingIndex && missingIndex < providerIndex)
+  !(lookupIndex < missingIndex && missingIndex < policyIndex && policyIndex < providerIndex)
 ) {
-  failures.push("exact ownership lookup and unavailable branch must precede the source provider call");
+  failures.push("exact ownership lookup and unavailable branch must precede policy and source calls");
 }
 
 for (const forbidden of [
@@ -227,25 +235,25 @@ requireText(
 );
 
 for (const marker of [
-  "exact_recipient_gets_fresh_route_without_cross_recipient_oracle",
-  "stale_target_and_retryable_owner_failure_remain_distinct",
-  "invalid_stored_source_identity_fails_before_provider_invocation",
+  "exact_recipient_passes_privacy_then_gets_fresh_route_without_oracle",
+  "privacy_suppression_and_retryable_failure_stop_before_source_authorization",
+  "stale_target_provider_failure_and_invalid_source_remain_distinct",
   "NotificationInboxOpenService::new",
   "NotificationInboxOpenDecision::Allowed",
   "NotificationInboxOpenDecision::Unavailable",
   "foreign and missing rows must not invoke a source provider",
   "NotificationProviderError::CapabilityUnavailable",
-  "NotificationError::ProviderFailure { retryable: true }",
+  "NOTIFICATION_SOURCE_PROVIDER_FAILURE",
   "NotificationError::InvalidDescriptor",
 ]) {
   requireText(proof, marker, `inbox open SQLite proof is missing ${marker}`);
 }
 
 for (const marker of [
-  "### Inbox open-time target authorization",
+  "### Inbox open-time authorization",
   "Missing, cross-tenant, and cross-recipient rows all",
-  "It returns only the fresh owner-provided route or `Unavailable`.",
-  "bounded inbox listing/read-state APIs and recipient privacy rechecks",
+  "Only an allowed recipient reaches the registered source provider",
+  "bounded inbox listing and seen/read/archive state APIs",
   "inbox_open_authorization_sqlite",
 ]) {
   requireText(docs, marker, `notifications live contract is missing ${marker}`);

--- a/scripts/verify/verify-forum-notification-inbox-open-privacy.mjs
+++ b/scripts/verify/verify-forum-notification-inbox-open-privacy.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-notification-inbox-open-privacy.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const inbox = read(contract.notifications_owner_file ?? "");
+const policyOwner = read(contract.recipient_policy_owner_file ?? "");
+const docs = read(contract.notifications_live_contract ?? "");
+const forumProvider = read(contract.forum_source_provider ?? "");
+const proof = read(contract.sqlite_proof ?? "");
+const upstream = JSON.parse(read(contract.upstream_contract ?? "") || "{}");
+const plan = read(contract.canonical_plan ?? "");
+
+if (contract.schema_version !== 1) {
+  failures.push("forum notification inbox privacy contract must use schema_version=1");
+}
+if (contract.task !== "FORUM-20S" || contract.upstream_task !== "FORUM-20R") {
+  failures.push("forum notification inbox privacy contract must connect FORUM-20R/S");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("inbox privacy recheck must not claim unexecuted evidence");
+}
+
+for (const delivered of [
+  "mandatory_recipient_policy_dependency",
+  "exact_policy_request_identity",
+  "privacy_before_source_authorization",
+  "suppression_fail_closed",
+  "suppression_reason_not_exposed",
+  "retryable_policy_failure_preserved",
+  "cross_recipient_no_oracle_preserved",
+  "fresh_source_route_preserved",
+  "read_state_unchanged",
+  "delivery_attempts_unchanged",
+  "sqlite_contract_proof",
+  "live_notifications_docs",
+]) {
+  if (contract.composition?.[delivered] !== true) {
+    failures.push(`forum notification inbox privacy contract must record ${delivered} as delivered`);
+  }
+}
+
+for (const residual of [
+  "bounded inbox listing API",
+  "seen read and archive state mutations",
+  "channel delivery enqueue and transports",
+  "delivery-time target authorization",
+  "host trust facts adapter",
+  "host channel membership facts adapter",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum notification inbox privacy contract must keep ${residual} explicitly open`);
+  }
+}
+
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+  "FORUM-20Q",
+  "FORUM-20R",
+  "FORUM-20S",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20S") {
+  failures.push("inbox privacy contract must require the canonical ledger through FORUM-20S");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("inbox privacy contract must require FORUM-20H through FORUM-20S delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as current");
+  }
+  requireText(
+    plan,
+    "FORUM-20A-G provide",
+    "pending canonical plan synchronization must remain grounded in FORUM-20A-G",
+  );
+  for (const slice of deliveredSlices) {
+    rejectText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+    );
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-S provide", "synchronized canonical plan must advance through S");
+  for (const slice of deliveredSlices) {
+    requireText(plan, `### Delivered in \`${slice}\``, `canonical plan is missing ${slice}`);
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
+}
+
+for (const marker of [
+  "policy: Arc<dyn NotificationRecipientPolicy>",
+  "policy: Arc<dyn NotificationRecipientPolicy>,",
+  ".evaluate(NotificationRecipientPolicyRequest {",
+  "tenant_id: request.tenant_id",
+  "recipient_id: request.recipient_id",
+  "actor_id: stored.actor_id",
+  "source_slug: source.as_str().to_string()",
+  "source_event_id: stored.source_event_id",
+  "source_revision: stored.source_revision",
+  "notification_type: stored.notification_type",
+  "target: target.clone()",
+  "Ok(NotificationRecipientPolicyDecision::Allow) => {}",
+  "Ok(NotificationRecipientPolicyDecision::Suppress { .. })",
+  "return Ok(NotificationInboxOpenDecision::Unavailable)",
+  "NotificationError::RecipientPolicyFailure",
+  "retryable: error.retryable",
+  ".authorize_target_open(AuthorizeNotificationTargetRequest",
+]) {
+  requireText(inbox, marker, `notification inbox privacy owner is missing ${marker}`);
+}
+
+const lookupIndex = inbox.indexOf("notification::Entity::find_by_id(request.notification_id)");
+const missingIndex = inbox.indexOf("let Some(stored) = stored else");
+const policyIndex = inbox.indexOf(".evaluate(NotificationRecipientPolicyRequest {");
+const suppressionIndex = inbox.indexOf("Ok(NotificationRecipientPolicyDecision::Suppress { .. })");
+const providerIndex = inbox.indexOf(".authorize_target_open(AuthorizeNotificationTargetRequest");
+if (
+  lookupIndex < 0 ||
+  missingIndex < 0 ||
+  policyIndex < 0 ||
+  suppressionIndex < 0 ||
+  providerIndex < 0 ||
+  !(lookupIndex < missingIndex && missingIndex < policyIndex && policyIndex < suppressionIndex && suppressionIndex < providerIndex)
+) {
+  failures.push("ownership and recipient policy decisions must precede source authorization");
+}
+
+for (const forbidden of [
+  "NotificationRecipientPolicyDecision::Suppress { reason }",
+  "reason.stable_code()",
+  "notification::ActiveModel",
+  "delivery_attempt::",
+  "seen_at: Set(",
+  "read_at: Set(",
+  "archived_at: Set(",
+]) {
+  rejectText(inbox, forbidden, `inbox privacy recheck must not expose or mutate through ${forbidden}`);
+}
+
+for (const marker of [
+  "pub trait NotificationRecipientPolicy",
+  "pub struct NotificationRecipientPolicyRequest",
+  "pub actor_id: Option<Uuid>",
+  "pub source_event_id: Uuid",
+  "pub source_revision: i64",
+  "pub notification_type: String",
+  "pub target: NotificationTargetRef",
+  "pub struct NotificationRecipientPolicyError",
+]) {
+  requireText(policyOwner, marker, `recipient policy owner is missing ${marker}`);
+}
+requireText(
+  forumProvider,
+  "async fn authorize_target_open(",
+  "Forum source provider must remain the target authorization owner",
+);
+
+for (const marker of [
+  "exact_recipient_passes_privacy_then_gets_fresh_route_without_oracle",
+  "privacy_suppression_and_retryable_failure_stop_before_source_authorization",
+  "stale_target_provider_failure_and_invalid_source_remain_distinct",
+  "NotificationRecipientPolicyDecision::Suppress",
+  "NotificationRecipientSuppression::Blocked",
+  "suppressed recipient must not reach source authorization",
+  "NotificationRecipientPolicyError::retryable()",
+  "NOTIFICATION_RECIPIENT_POLICY_FAILURE",
+  "failed recipient policy must not reach source authorization",
+  "stored.state, NotificationState::Unread",
+  "delivery_attempt::Entity::find()",
+]) {
+  requireText(proof, marker, `inbox privacy SQLite proof is missing ${marker}`);
+}
+
+for (const marker of [
+  "### Inbox open-time authorization",
+  "evaluates the same injected Profiles/Social Graph recipient policy",
+  "Suppression returns `Unavailable` without invoking the source provider",
+  "Only an allowed recipient reaches the registered source provider",
+  "bounded inbox listing and seen/read/archive state APIs",
+  "verify-forum-notification-inbox-open-privacy.mjs",
+]) {
+  requireText(docs, marker, `notifications live contract is missing ${marker}`);
+}
+
+if (
+  upstream.schema_version !== 1 ||
+  upstream.task !== "FORUM-20R" ||
+  upstream.upstream_task !== "FORUM-20Q" ||
+  upstream.downstream_task !== "FORUM-20S" ||
+  upstream.composition?.source_owned_authorization !== true
+) {
+  failures.push("FORUM-20S must remain linked to the FORUM-20R open authorization contract");
+}
+
+if (failures.length > 0) {
+  console.error("Forum notification inbox open privacy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum notification inbox open privacy contract is source-ready.");


### PR DESCRIPTION
## Summary

- make recipient policy a mandatory dependency of `NotificationInboxOpenService`
- reconstruct the exact recipient-policy request from the owned stored notification
- evaluate current Profiles/Social Graph privacy and blocking policy before source target authorization
- return the same `Unavailable` decision for policy suppression without exposing the suppression reason
- preserve retryable recipient-policy failures as `NOTIFICATION_RECIPIENT_POLICY_FAILURE`
- keep missing/cross-tenant/cross-recipient rows outside both recipient-policy and source-provider calls
- preserve fresh source-owned target authorization only after recipient policy allows
- retain no-mutation guarantees for seen/read/archive state and delivery attempts
- add combined SQLite evidence, live Notifications documentation, the FORUM-20S contract, and R/S source verifiers

## Boundary

This slice implements inbox-open recipient privacy/blocking reauthorization only. Bounded inbox listing, seen/read/archive mutations, channel delivery enqueue/transports, delivery-time authorization, trust/channel facts adapters, initially non-public topic-created descriptor materialization, search/SEO migration, and PostgreSQL cross-consumer evidence remain open.

The canonical Forum implementation plan still physically ends at FORUM-20G. The FORUM-20S contract records synchronization as pending through S without replacing unrelated plan updates.

## Validation

Tests, Cargo commands, formatting commands, verifiers, and CI were not run at the maintainer's request.

Intended commands:

```bash
cargo test -p rustok-notifications --test inbox_open_authorization_sqlite -- --nocapture
cargo test -p rustok-notifications --test candidate_sqlite -- --nocapture
node scripts/verify/verify-forum-notification-inbox-open-authorization.mjs
node scripts/verify/verify-forum-notification-inbox-open-privacy.mjs
cargo xtask module validate notifications
cargo xtask module validate forum
```