### PR TITLE
Harden admin product route error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -84,6 +84,12 @@ available only for actionable domain errors.
   customer identities. Validation, provider, reconciliation, configuration, and storage
   details stay internal while the existing status/code/message policy, idempotency header,
   provider registry, filter, pagination, service, and response contracts remain unchanged.
+- `rustok-commerce` admin product routes: list count/page/translation/tag reads plus detail,
+  create, update, delete, publish, and unpublish owner calls retain the typed commerce cause
+  with tenant, actor, exact owner operation, and truthful optional product and variant
+  identities. Database, validation, conflict, inventory, state, and fail-closed outcomes
+  preserve the existing static HTTP policy while locale fallback, filters, metrics,
+  pagination, shipping-profile validation, service arguments, and responses stay unchanged.
 - `rustok-commerce` admin order-change owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and order-change identities, stable public code, status, and HTTP boundary. Typed
@@ -162,6 +168,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs`
+- `node scripts/verify/verify-commerce-admin-product-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
@@ -182,10 +189,10 @@ available only for actionable domain errors.
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
   admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
-  admin order-route, admin checkout-operation, admin payment-route, order-change owner and
-  orchestration mapping, admin order-return owner and orchestration mapping, admin
-  order-detail payment and fulfillment mapping, and tax calculation validation,
-  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
-  tests.
+  admin order-route, admin checkout-operation, admin payment-route, admin product-route,
+  order-change owner and orchestration mapping, admin order-return owner and orchestration
+  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
+  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and transport
+  round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -6,85 +6,17 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_product::CatalogService;
-use rustok_web::{HttpError, HttpResult};
+use rustok_web::HttpResult;
 use uuid::Uuid;
 
 use super::super::{
     CommerceHttpRuntime,
     common::{PaginatedResponse, ensure_permissions},
-    products::{ListProductsParams, ProductListItem},
+    products::{
+        AdminProductErrorContext, ListProductsParams, ProductListItem, map_admin_product_error,
+    },
 };
-use crate::{
-    CommerceError,
-    dto::{CreateProductInput, ProductResponse, UpdateProductInput},
-};
-
-fn map_product_write_error(error: CommerceError) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
-        CommerceError::Database(_) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "commerce_admin_product_storage_unavailable",
-            "Product storage is temporarily unavailable",
-            "database",
-        ),
-        CommerceError::ProductNotFound(_) | CommerceError::VariantNotFound(_) => (
-            StatusCode::NOT_FOUND,
-            "commerce_admin_not_found",
-            "Commerce resource not found",
-            "not_found",
-        ),
-        CommerceError::DuplicateHandle { .. } => (
-            StatusCode::CONFLICT,
-            "commerce_admin_product_handle_conflict",
-            "A product with this handle already exists",
-            "duplicate_handle",
-        ),
-        CommerceError::DuplicateSku(_) => (
-            StatusCode::CONFLICT,
-            "commerce_admin_product_sku_conflict",
-            "A product variant with this SKU already exists",
-            "duplicate_sku",
-        ),
-        CommerceError::InvalidPrice(_)
-        | CommerceError::InvalidOptionCombination
-        | CommerceError::Validation(_)
-        | CommerceError::NoVariants => (
-            StatusCode::BAD_REQUEST,
-            "commerce_admin_product_invalid",
-            "Product request is invalid",
-            "validation",
-        ),
-        CommerceError::InsufficientInventory { .. } => (
-            StatusCode::CONFLICT,
-            "commerce_admin_product_inventory_conflict",
-            "Product inventory conflicts with the requested operation",
-            "inventory_conflict",
-        ),
-        CommerceError::CannotDeletePublished => (
-            StatusCode::CONFLICT,
-            "commerce_admin_product_state_conflict",
-            "Product operation conflicts with the current state",
-            "state_conflict",
-        ),
-        CommerceError::ShippingProfileNotFound(_)
-        | CommerceError::DuplicateShippingProfileSlug(_)
-        | CommerceError::Rich(_)
-        | CommerceError::Core(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "commerce_admin_product_failed",
-            "Product operation could not be completed safely",
-            "unexpected_owner_error",
-        ),
-    };
-    super::admin_public_error(
-        &error,
-        "rustok_product.catalog",
-        error_kind,
-        status,
-        code,
-        message,
-    )
-}
+use crate::dto::{CreateProductInput, ProductResponse, UpdateProductInput};
 
 /// List admin ecommerce products
 #[utoipa::path(
@@ -141,7 +73,17 @@ pub async fn create_product(
     let product = service
         .create_product(tenant.id, auth.user_id, input)
         .await
-        .map_err(map_product_write_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "create_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(product)))
 }
@@ -203,7 +145,17 @@ pub async fn update_product(
     let product = service
         .update_product(tenant.id, auth.user_id, id, input)
         .await
-        .map_err(map_product_write_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    "update_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(product))
 }

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -26,8 +26,44 @@ use crate::{
 
 use super::common::{PaginatedResponse, PaginationMeta, PaginationParams, ensure_permissions};
 
-fn map_product_service_error(error: CommerceError) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
+const ADMIN_PRODUCT_OWNER: &str = "rustok_product.catalog";
+const ADMIN_PRODUCT_BOUNDARY: &str = "commerce_admin_product_http";
+
+type AdminProductHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+#[derive(Clone, Copy)]
+pub(crate) struct AdminProductErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    product_id: Option<Uuid>,
+    variant_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminProductErrorContext {
+    pub(crate) fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        product_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            product_id,
+            variant_id: None,
+            operation,
+        }
+    }
+}
+
+fn product_error_policy(error: &CommerceError) -> AdminProductHttpPolicy {
+    match error {
         CommerceError::Database(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_admin_product_storage_unavailable",
@@ -82,21 +118,41 @@ fn map_product_service_error(error: CommerceError) -> HttpError {
             "Product operation could not be completed safely",
             "unexpected_owner_error",
         ),
-    };
+    }
+}
+
+fn adopt_product_error_identity(
+    context: &mut AdminProductErrorContext,
+    error: &CommerceError,
+) {
+    match error {
+        CommerceError::ProductNotFound(id) => context.product_id = Some(*id),
+        CommerceError::VariantNotFound(id) => context.variant_id = Some(*id),
+        _ => {}
+    }
+}
+
+pub(crate) fn map_admin_product_error(
+    mut context: AdminProductErrorContext,
+    error: CommerceError,
+) -> HttpError {
+    adopt_product_error_identity(&mut context, &error);
+    let (status, code, message, error_kind) = product_error_policy(&error);
     tracing::error!(
         error = ?error,
-        owner = "rustok_product.catalog",
+        owner = ADMIN_PRODUCT_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        product_id = ?context.product_id,
+        variant_id = ?context.variant_id,
+        operation = %context.operation,
         error_kind,
         public_code = code,
         status = %status,
-        boundary = "commerce_admin_product_http",
+        boundary = ADMIN_PRODUCT_BOUNDARY,
         "commerce admin product operation failed"
     );
     HttpError::new(status, code, message)
-}
-
-fn map_product_database_error(error: sea_orm::DbErr) -> HttpError {
-    map_product_service_error(CommerceError::Database(error))
 }
 
 /// Shared admin product list handler.
@@ -147,7 +203,17 @@ pub async fn list_products(
         .clone()
         .count(runtime.db())
         .await
-        .map_err(map_product_database_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "list_products_count",
+                ),
+                CommerceError::Database(error),
+            )
+        })?;
     metrics::record_read_path_query(
         "http",
         "commerce.list_products",
@@ -163,7 +229,17 @@ pub async fn list_products(
         .limit(pagination.limit())
         .all(runtime.db())
         .await
-        .map_err(map_product_database_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "list_products_page",
+                ),
+                CommerceError::Database(error),
+            )
+        })?;
     metrics::record_read_path_query(
         "http",
         "commerce.list_products",
@@ -184,7 +260,17 @@ pub async fn list_products(
             .filter(product_translation::Column::ProductId.is_in(product_ids))
             .all(runtime.db())
             .await
-            .map_err(map_product_database_error)?;
+            .map_err(|error| {
+                map_admin_product_error(
+                    AdminProductErrorContext::new(
+                        tenant.id,
+                        auth.user_id,
+                        None,
+                        "list_product_translations",
+                    ),
+                    CommerceError::Database(error),
+                )
+            })?;
         metrics::record_read_path_query(
             "http",
             "commerce.list_products",
@@ -211,7 +297,17 @@ pub async fn list_products(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(map_product_service_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "list_product_tags",
+                ),
+                error,
+            )
+        })?;
 
     let items = products
         .into_iter()
@@ -297,7 +393,17 @@ pub async fn show_product(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(map_product_service_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    "show_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(product))
 }
@@ -319,7 +425,17 @@ pub async fn delete_product(
     service
         .delete_product(tenant.id, auth.user_id, id)
         .await
-        .map_err(map_product_service_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    "delete_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -341,7 +457,17 @@ pub async fn publish_product(
     let product = service
         .publish_product(tenant.id, auth.user_id, id)
         .await
-        .map_err(map_product_service_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    "publish_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(product))
 }
@@ -363,7 +489,17 @@ pub async fn unpublish_product(
     let product = service
         .unpublish_product(tenant.id, auth.user_id, id)
         .await
-        .map_err(map_product_service_error)?;
+        .map_err(|error| {
+            map_admin_product_error(
+                AdminProductErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(id),
+                    "unpublish_product",
+                ),
+                error,
+            )
+        })?;
 
     Ok(Json(product))
 }

--- a/scripts/verify/verify-commerce-admin-product-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-product-route-error-context.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const products = read('crates/rustok-commerce/src/controllers/products.rs');
+const adminProducts = read('crates/rustok-commerce/src/controllers/admin/products.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const policy = between(
+  products,
+  'fn product_error_policy(',
+  'fn adopt_product_error_identity(',
+  'admin product policy',
+);
+const identityAdoption = between(
+  products,
+  'fn adopt_product_error_identity(',
+  'pub(crate) fn map_admin_product_error(',
+  'admin product identity adoption',
+);
+const mapper = between(
+  products,
+  'pub(crate) fn map_admin_product_error(',
+  '/// Shared admin product list handler.',
+  'admin product mapper',
+);
+const listRoute = between(
+  products,
+  'pub async fn list_products(',
+  'fn pick_product_translation',
+  'admin product list route',
+);
+const showRoute = between(
+  products,
+  'pub async fn show_product(',
+  '/// Shared admin product delete handler.',
+  'admin product show route',
+);
+const deleteRoute = between(
+  products,
+  'pub async fn delete_product(',
+  '/// Shared admin product publish handler.',
+  'admin product delete route',
+);
+const publishRoute = between(
+  products,
+  'pub async fn publish_product(',
+  '/// Shared admin product unpublish handler.',
+  'admin product publish route',
+);
+const unpublishRoute = between(
+  products,
+  'pub async fn unpublish_product(',
+  '#[derive(Debug, serde::Deserialize',
+  'admin product unpublish route',
+);
+const createRoute = between(
+  adminProducts,
+  'pub async fn create_product(',
+  '/// Show admin ecommerce product',
+  'admin product create route',
+);
+const updateRoute = between(
+  adminProducts,
+  'pub async fn update_product(',
+  '/// Delete admin ecommerce product',
+  'admin product update route',
+);
+
+for (const [value, label] of [
+  ['const ADMIN_PRODUCT_OWNER: &str = "rustok_product.catalog";', 'owner constant'],
+  [
+    'const ADMIN_PRODUCT_BOUNDARY: &str = "commerce_admin_product_http";',
+    'HTTP boundary constant',
+  ],
+  ['type AdminProductHttpPolicy = (', 'static policy type'],
+  ['pub(crate) struct AdminProductErrorContext {', 'shared typed context'],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['actor_id: Uuid,', 'actor context field'],
+  ['product_id: Option<Uuid>,', 'product identity field'],
+  ['variant_id: Option<Uuid>,', 'variant identity field'],
+  ["operation: &'static str,", 'operation field'],
+  ['pub(crate) fn new(', 'shared context constructor'],
+  ['pub(crate) fn map_admin_product_error(', 'shared typed mapper'],
+]) requireText(products, value, label);
+
+for (const [value, label] of [
+  ['CommerceError::Database(_)', 'database variant'],
+  ['CommerceError::ProductNotFound(_)', 'product not-found variant'],
+  ['CommerceError::VariantNotFound(_)', 'variant not-found variant'],
+  ['CommerceError::DuplicateHandle { .. }', 'duplicate handle variant'],
+  ['CommerceError::DuplicateSku(_)', 'duplicate SKU variant'],
+  ['CommerceError::InvalidPrice(_)', 'invalid price variant'],
+  ['CommerceError::InvalidOptionCombination', 'invalid option combination variant'],
+  ['CommerceError::Validation(_)', 'validation variant'],
+  ['CommerceError::NoVariants', 'no variants variant'],
+  ['CommerceError::InsufficientInventory { .. }', 'inventory conflict variant'],
+  ['CommerceError::CannotDeletePublished', 'published-state variant'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'shipping profile variant'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping profile conflict variant'],
+  ['CommerceError::Rich(_)', 'rich owner variant'],
+  ['CommerceError::Core(_)', 'core owner variant'],
+  ['"commerce_admin_product_storage_unavailable"', 'storage code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_product_handle_conflict"', 'handle conflict code'],
+  ['"commerce_admin_product_sku_conflict"', 'SKU conflict code'],
+  ['"commerce_admin_product_invalid"', 'validation code'],
+  ['"commerce_admin_product_inventory_conflict"', 'inventory conflict code'],
+  ['"commerce_admin_product_state_conflict"', 'state conflict code'],
+  ['"commerce_admin_product_failed"', 'fail-closed code'],
+  ['"Product storage is temporarily unavailable"', 'static storage message'],
+  ['"Product request is invalid"', 'static validation message'],
+  [
+    '"Product operation could not be completed safely"',
+    'static fail-closed message',
+  ],
+]) requireText(policy, value, label);
+
+for (const [value, label] of [
+  ['CommerceError::ProductNotFound(id)', 'typed product identity variant'],
+  ['context.product_id = Some(*id)', 'typed product identity adoption'],
+  ['CommerceError::VariantNotFound(id)', 'typed variant identity variant'],
+  ['context.variant_id = Some(*id)', 'typed variant identity adoption'],
+]) requireText(identityAdoption, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed cause log'],
+  ['owner = ADMIN_PRODUCT_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['product_id = ?context.product_id', 'product identity log'],
+  ['variant_id = ?context.variant_id', 'variant identity log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public-code log'],
+  ['status = %status', 'status log'],
+  ['boundary = ADMIN_PRODUCT_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['Permission::PRODUCTS_LIST', 'list permission'],
+  ['let requested_limit = params', 'requested limit capture'],
+  ['let pagination = params.pagination.unwrap_or_default();', 'list pagination'],
+  ['.unwrap_or(request_context.locale.as_str())', 'locale fallback'],
+  ['product::Column::TenantId.eq(tenant.id)', 'tenant filter'],
+  ['product::Column::Status.eq(status)', 'status filter'],
+  ['product::Column::Vendor.eq(vendor)', 'vendor filter'],
+  ['product::Column::ProductType.eq(product_type)', 'product type filter'],
+  ['product_translation_title_search_condition(', 'localized search filter'],
+  ['"list_products_count"', 'count operation'],
+  ['"list_products_page"', 'page operation'],
+  ['"list_product_translations"', 'translations operation'],
+  ['"list_product_tags"', 'tag operation'],
+  ['CommerceError::Database(error)', 'typed database wrapping'],
+  ['.offset(pagination.offset())', 'page offset'],
+  ['.limit(pagination.limit())', 'page limit'],
+  ['.load_product_tag_map(', 'tag map owner call'],
+  ['pick_product_translation(items, locale, tenant.default_locale.as_str())', 'translation fallback'],
+  ['metrics::record_read_path_query(', 'query metrics'],
+  ['metrics::record_read_path_budget(', 'budget metrics'],
+  ['PaginationMeta::new(pagination.page, pagination.limit(), total)', 'pagination response'],
+]) requireText(listRoute, value, label);
+
+for (const [block, permission, operation, serviceCall, response, label] of [
+  [
+    showRoute,
+    'Permission::PRODUCTS_READ',
+    '"show_product"',
+    '.get_product_with_locale_fallback(',
+    'Ok(Json(product))',
+    'show route',
+  ],
+  [
+    deleteRoute,
+    'Permission::PRODUCTS_DELETE',
+    '"delete_product"',
+    '.delete_product(tenant.id, auth.user_id, id)',
+    'Ok(StatusCode::NO_CONTENT)',
+    'delete route',
+  ],
+  [
+    publishRoute,
+    'Permission::PRODUCTS_UPDATE',
+    '"publish_product"',
+    '.publish_product(tenant.id, auth.user_id, id)',
+    'Ok(Json(product))',
+    'publish route',
+  ],
+  [
+    unpublishRoute,
+    'Permission::PRODUCTS_UPDATE',
+    '"unpublish_product"',
+    '.unpublish_product(tenant.id, auth.user_id, id)',
+    'Ok(Json(product))',
+    'unpublish route',
+  ],
+]) {
+  requireText(block, permission, `${label} permission`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, 'Some(id)', `${label} product identity`);
+  requireText(block, serviceCall, `${label} service contract`);
+  requireText(block, 'map_admin_product_error(', `${label} local mapper`);
+  requireText(block, response, `${label} response contract`);
+}
+
+for (const [block, permission, operation, productIdentity, serviceCall, response, label] of [
+  [
+    createRoute,
+    'Permission::PRODUCTS_CREATE',
+    '"create_product"',
+    'None,',
+    '.create_product(tenant.id, auth.user_id, input)',
+    'Ok((StatusCode::CREATED, Json(product)))',
+    'create route',
+  ],
+  [
+    updateRoute,
+    'Permission::PRODUCTS_UPDATE',
+    '"update_product"',
+    'Some(id)',
+    '.update_product(tenant.id, auth.user_id, id, input)',
+    'Ok(Json(product))',
+    'update route',
+  ],
+]) {
+  requireText(block, permission, `${label} permission`);
+  requireText(block, 'validate_product_shipping_profile_input(', `${label} shipping validation`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, productIdentity, `${label} product identity`);
+  requireText(block, serviceCall, `${label} service contract`);
+  requireText(block, 'map_admin_product_error(', `${label} shared mapper`);
+  requireText(block, response, `${label} response contract`);
+}
+
+for (const [value, label] of [
+  [
+    'products::{\n        AdminProductErrorContext, ListProductsParams, ProductListItem, map_admin_product_error,',
+    'shared product mapper import',
+  ],
+  [
+    'super::super::products::list_products(state, tenant, auth, request_context, query).await',
+    'list delegation',
+  ],
+  [
+    'super::super::products::show_product(state, tenant, auth, request_context, path).await',
+    'show delegation',
+  ],
+  [
+    'super::super::products::delete_product(state, tenant, auth, path).await',
+    'delete delegation',
+  ],
+  [
+    'super::super::products::publish_product(state, tenant, auth, path).await',
+    'publish delegation',
+  ],
+  [
+    'super::super::products::unpublish_product(state, tenant, auth, path).await',
+    'unpublish delegation',
+  ],
+]) requireText(adminProducts, value, label);
+
+const sharedMapperUses =
+  products.match(/map_admin_product_error\(\s+AdminProductErrorContext::new\(/g) ?? [];
+if (sharedMapperUses.length !== 8) {
+  failures.push(
+    `expected eight context-aware shared product mapper callsites, found ${sharedMapperUses.length}`,
+  );
+}
+const wrapperMapperUses =
+  adminProducts.match(/map_admin_product_error\(\s+AdminProductErrorContext::new\(/g) ?? [];
+if (wrapperMapperUses.length !== 2) {
+  failures.push(
+    `expected two context-aware product write mapper callsites, found ${wrapperMapperUses.length}`,
+  );
+}
+const shippingValidationUses =
+  adminProducts.match(/validate_product_shipping_profile_input\(/g) ?? [];
+if (shippingValidationUses.length !== 2) {
+  failures.push(
+    `expected two product shipping-profile validation callsites, found ${shippingValidationUses.length}`,
+  );
+}
+
+for (const [content, label] of [
+  [products, 'shared product controller'],
+  [adminProducts, 'admin product wrapper'],
+]) {
+  for (const value of [
+    'fn map_product_service_error(',
+    'fn map_product_database_error(',
+    'fn map_product_write_error(',
+    'super::admin_public_error(',
+    'err.to_string()',
+    'error.to_string()',
+    'other.to_string()',
+  ]) forbidText(content, value, `${label} stale or unsafe mapper`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce admin product route error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin product routes retain typed causes and truthful route context',
+);


### PR DESCRIPTION
## Summary

- replace the two duplicated admin product mappers with one shared context-aware typed mapper;
- cover list count/page/translation/tag reads plus detail, create, update, delete, publish, and unpublish owner calls;
- preserve the existing storage, not-found, validation, duplicate, inventory, state-conflict, and fail-closed HTTP status/code/message policy;
- retain tenant, actor, exact owner operation, truthful optional product and variant identities, stable public code, status, HTTP boundary, and the original typed cause in one structured error event;
- adopt typed product and variant identities from `CommerceError`;
- preserve permissions, locale fallback, filters, metrics, pagination, tag loading, shipping-profile validation, CatalogService arguments, route delegation, and success responses;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/products.rs`
- `crates/rustok-commerce/src/controllers/admin/products.rs`
- `scripts/verify/verify-commerce-admin-product-route-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- one unrelated notifications commit landed after the branch was created; it does not overlap these four files and GitHub reports the PR mergeable against current `main`;
- final diff is limited to the four intended files;
- source was re-read to confirm eight shared-controller and two write-wrapper context-aware mapper callsites;
- all current `CommerceError` variants are covered with the existing static public policy;
- permissions, locale/filter/metrics/pagination behavior, shipping-profile validation, service calls, route delegation, and response contracts remain unchanged;
- the focused verifier was read statically to confirm block markers and expected callsite counts;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-product-route-error-context.mjs
cargo check -p rustok-commerce --lib
```