### PR TITLE
Harden admin product shipping profile error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -87,9 +87,12 @@ available only for actionable domain errors.
 - `rustok-commerce` admin product routes: list count/page/translation/tag reads plus detail,
   create, update, delete, publish, and unpublish owner calls retain the typed commerce cause
   with tenant, actor, exact owner operation, and truthful optional product and variant
-  identities. Database, validation, conflict, inventory, state, and fail-closed outcomes
-  preserve the existing static HTTP policy while locale fallback, filters, metrics,
-  pagination, shipping-profile validation, service arguments, and responses stay unchanged.
+  identities. Product create/update shipping-profile prevalidation now retains the typed
+  commerce cause with tenant, actor, exact validation operation, and truthful optional
+  product and shipping-profile identities. Database, validation, conflict, inventory,
+  state, and fail-closed outcomes preserve the existing static HTTP policy while locale
+  fallback, filters, metrics, pagination, slug normalization, validation service arguments,
+  catalog service arguments, and responses stay unchanged.
 - `rustok-commerce` admin order-change owner routes: create, list, detail, and cancel paths
   map the typed `OrderError` locally with owner, tenant, route operation, truthful optional
   order and order-change identities, stable public code, status, and HTTP boundary. Typed
@@ -169,6 +172,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-payment-list-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-product-route-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-product-shipping-profile-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-owner-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-change-orchestration-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-order-return-owner-error-context.mjs`
@@ -189,10 +193,10 @@ available only for actionable domain errors.
 - Targeted cart promotion, order payment settlement, order checkout recovery, order
   checkout compensation, pricing, payment collection, fulfillment checkout execution,
   admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
-  admin order-route, admin checkout-operation, admin payment-route, admin product-route,
-  order-change owner and orchestration mapping, admin order-return owner and orchestration
-  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
-  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and transport
-  round-trip tests.
+  admin order-route, admin checkout-operation, admin payment-route, admin product-route and
+  product shipping-profile prevalidation, order-change owner and orchestration mapping,
+  admin order-return owner and orchestration mapping, admin order-detail payment and
+  fulfillment mapping, and tax calculation validation, provider-contract, reconciliation,
+  correlation, HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -6,7 +6,7 @@ use axum::{
 use rustok_api::Permission;
 use rustok_api::{AuthContext, TenantContext};
 use rustok_product::CatalogService;
-use rustok_web::HttpResult;
+use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use super::super::{
@@ -16,7 +16,145 @@ use super::super::{
         AdminProductErrorContext, ListProductsParams, ProductListItem, map_admin_product_error,
     },
 };
-use crate::dto::{CreateProductInput, ProductResponse, UpdateProductInput};
+use crate::{
+    CommerceError, ShippingProfileService,
+    dto::{CreateProductInput, ProductResponse, UpdateProductInput},
+    storefront_shipping::normalize_shipping_profile_slug,
+};
+
+const ADMIN_PRODUCT_SHIPPING_PROFILE_OWNER: &str = "rustok_commerce.shipping_profile";
+const ADMIN_PRODUCT_SHIPPING_PROFILE_BOUNDARY: &str =
+    "commerce_admin_product_shipping_profile_http";
+
+type AdminProductShippingProfileHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+#[derive(Clone, Copy)]
+struct AdminProductShippingProfileErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    product_id: Option<Uuid>,
+    shipping_profile_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminProductShippingProfileErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        product_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            product_id,
+            shipping_profile_id: None,
+            operation,
+        }
+    }
+}
+
+fn admin_product_shipping_profile_error_policy(
+    error: &CommerceError,
+) -> AdminProductShippingProfileHttpPolicy {
+    match error {
+        CommerceError::ShippingProfileNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        CommerceError::DuplicateShippingProfileSlug(_) => (
+            StatusCode::CONFLICT,
+            "commerce_admin_shipping_profile_conflict",
+            "A shipping profile with this slug already exists",
+            "duplicate_slug",
+        ),
+        CommerceError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_shipping_profile_invalid",
+            "Shipping profile request is invalid",
+            "validation",
+        ),
+        CommerceError::Database(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_shipping_profile_storage_unavailable",
+            "Shipping profile storage is temporarily unavailable",
+            "database",
+        ),
+        CommerceError::ProductNotFound(_)
+        | CommerceError::VariantNotFound(_)
+        | CommerceError::DuplicateHandle { .. }
+        | CommerceError::DuplicateSku(_)
+        | CommerceError::InvalidPrice(_)
+        | CommerceError::InsufficientInventory { .. }
+        | CommerceError::InvalidOptionCombination
+        | CommerceError::NoVariants
+        | CommerceError::CannotDeletePublished
+        | CommerceError::Rich(_)
+        | CommerceError::Core(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_shipping_profile_failed",
+            "Shipping profile operation could not be completed safely",
+            "unexpected_commerce_error",
+        ),
+    }
+}
+
+fn adopt_admin_product_shipping_profile_error_identity(
+    context: &mut AdminProductShippingProfileErrorContext,
+    error: &CommerceError,
+) {
+    if let CommerceError::ShippingProfileNotFound(id) = error {
+        context.shipping_profile_id = Some(*id);
+    }
+}
+
+fn map_admin_product_shipping_profile_error(
+    mut context: AdminProductShippingProfileErrorContext,
+    error: CommerceError,
+) -> HttpError {
+    adopt_admin_product_shipping_profile_error_identity(&mut context, &error);
+    let (status, code, message, error_kind) =
+        admin_product_shipping_profile_error_policy(&error);
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_PRODUCT_SHIPPING_PROFILE_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        product_id = ?context.product_id,
+        shipping_profile_id = ?context.shipping_profile_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_PRODUCT_SHIPPING_PROFILE_BOUNDARY,
+        "commerce admin product shipping-profile validation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+async fn validate_admin_product_shipping_profile_input(
+    db: &sea_orm::DatabaseConnection,
+    context: AdminProductShippingProfileErrorContext,
+    shipping_profile_slug: Option<&str>,
+) -> HttpResult<()> {
+    let Some(slug) = shipping_profile_slug.and_then(normalize_shipping_profile_slug) else {
+        return Ok(());
+    };
+
+    ShippingProfileService::new(db.clone())
+        .ensure_shipping_profile_slug_exists(context.tenant_id, &slug)
+        .await
+        .map_err(|error| map_admin_product_shipping_profile_error(context, error))?;
+
+    Ok(())
+}
 
 /// List admin ecommerce products
 #[utoipa::path(
@@ -62,9 +200,14 @@ pub async fn create_product(
         "Permission denied: products:create required",
     )?;
 
-    super::validate_product_shipping_profile_input(
+    validate_admin_product_shipping_profile_input(
         runtime.db(),
-        tenant.id,
+        AdminProductShippingProfileErrorContext::new(
+            tenant.id,
+            auth.user_id,
+            None,
+            "create_product_shipping_profile_validation",
+        ),
         input.shipping_profile_slug.as_deref(),
     )
     .await?;
@@ -134,9 +277,14 @@ pub async fn update_product(
         "Permission denied: products:update required",
     )?;
 
-    super::validate_product_shipping_profile_input(
+    validate_admin_product_shipping_profile_input(
         runtime.db(),
-        tenant.id,
+        AdminProductShippingProfileErrorContext::new(
+            tenant.id,
+            auth.user_id,
+            Some(id),
+            "update_product_shipping_profile_validation",
+        ),
         input.shipping_profile_slug.as_deref(),
     )
     .await?;

--- a/scripts/verify/verify-commerce-admin-product-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-product-route-error-context.mjs
@@ -249,7 +249,7 @@ for (const [block, permission, operation, productIdentity, serviceCall, response
   ],
 ]) {
   requireText(block, permission, `${label} permission`);
-  requireText(block, 'validate_product_shipping_profile_input(', `${label} shipping validation`);
+  requireText(block, 'validate_admin_product_shipping_profile_input(', `${label} shipping validation`);
   requireText(block, operation, `${label} operation`);
   requireText(block, productIdentity, `${label} product identity`);
   requireText(block, serviceCall, `${label} service contract`);
@@ -299,10 +299,12 @@ if (wrapperMapperUses.length !== 2) {
   );
 }
 const shippingValidationUses =
-  adminProducts.match(/validate_product_shipping_profile_input\(/g) ?? [];
+  adminProducts.match(
+    /validate_admin_product_shipping_profile_input\(\s+runtime\.db\(\),\s+AdminProductShippingProfileErrorContext::new\(/g,
+  ) ?? [];
 if (shippingValidationUses.length !== 2) {
   failures.push(
-    `expected two product shipping-profile validation callsites, found ${shippingValidationUses.length}`,
+    `expected two context-aware product shipping-profile validation callsites, found ${shippingValidationUses.length}`,
   );
 }
 
@@ -315,6 +317,7 @@ for (const [content, label] of [
     'fn map_product_database_error(',
     'fn map_product_write_error(',
     'super::admin_public_error(',
+    'super::validate_product_shipping_profile_input(',
     'err.to_string()',
     'error.to_string()',
     'other.to_string()',

--- a/scripts/verify/verify-commerce-admin-product-shipping-profile-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-product-shipping-profile-error-context.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const adminProducts = read('crates/rustok-commerce/src/controllers/admin/products.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const policy = between(
+  adminProducts,
+  'fn admin_product_shipping_profile_error_policy(',
+  'fn adopt_admin_product_shipping_profile_error_identity(',
+  'shipping-profile policy',
+);
+const identityAdoption = between(
+  adminProducts,
+  'fn adopt_admin_product_shipping_profile_error_identity(',
+  'fn map_admin_product_shipping_profile_error(',
+  'shipping-profile identity adoption',
+);
+const mapper = between(
+  adminProducts,
+  'fn map_admin_product_shipping_profile_error(',
+  'async fn validate_admin_product_shipping_profile_input(',
+  'shipping-profile mapper',
+);
+const validator = between(
+  adminProducts,
+  'async fn validate_admin_product_shipping_profile_input(',
+  '/// List admin ecommerce products',
+  'shipping-profile validator',
+);
+const createRoute = between(
+  adminProducts,
+  'pub async fn create_product(',
+  '/// Show admin ecommerce product',
+  'create product route',
+);
+const updateRoute = between(
+  adminProducts,
+  'pub async fn update_product(',
+  '/// Delete admin ecommerce product',
+  'update product route',
+);
+
+for (const [value, label] of [
+  [
+    'const ADMIN_PRODUCT_SHIPPING_PROFILE_OWNER: &str = "rustok_commerce.shipping_profile";',
+    'owner constant',
+  ],
+  [
+    'const ADMIN_PRODUCT_SHIPPING_PROFILE_BOUNDARY: &str =',
+    'boundary constant declaration',
+  ],
+  [
+    '"commerce_admin_product_shipping_profile_http";',
+    'boundary constant value',
+  ],
+  ['type AdminProductShippingProfileHttpPolicy = (', 'static policy type'],
+  [
+    'struct AdminProductShippingProfileErrorContext {',
+    'typed validation context',
+  ],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['actor_id: Uuid,', 'actor context field'],
+  ['product_id: Option<Uuid>,', 'product context field'],
+  ['shipping_profile_id: Option<Uuid>,', 'profile context field'],
+  ["operation: &'static str,", 'operation context field'],
+  ['fn map_admin_product_shipping_profile_error(', 'typed mapper'],
+  [
+    'async fn validate_admin_product_shipping_profile_input(',
+    'local validation helper',
+  ],
+]) requireText(adminProducts, value, label);
+
+for (const [value, label] of [
+  ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found variant'],
+  [
+    'CommerceError::DuplicateShippingProfileSlug(_)',
+    'duplicate profile slug variant',
+  ],
+  ['CommerceError::Validation(_)', 'validation variant'],
+  ['CommerceError::Database(_)', 'database variant'],
+  ['CommerceError::ProductNotFound(_)', 'unexpected product variant'],
+  ['CommerceError::VariantNotFound(_)', 'unexpected variant variant'],
+  ['CommerceError::DuplicateHandle { .. }', 'unexpected duplicate handle variant'],
+  ['CommerceError::DuplicateSku(_)', 'unexpected duplicate SKU variant'],
+  ['CommerceError::InvalidPrice(_)', 'unexpected invalid price variant'],
+  [
+    'CommerceError::InsufficientInventory { .. }',
+    'unexpected inventory variant',
+  ],
+  [
+    'CommerceError::InvalidOptionCombination',
+    'unexpected option combination variant',
+  ],
+  ['CommerceError::NoVariants', 'unexpected no-variants variant'],
+  [
+    'CommerceError::CannotDeletePublished',
+    'unexpected published-state variant',
+  ],
+  ['CommerceError::Rich(_)', 'unexpected rich variant'],
+  ['CommerceError::Core(_)', 'unexpected core variant'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::BAD_REQUEST', 'bad-request status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  [
+    '"commerce_admin_shipping_profile_conflict"',
+    'duplicate slug conflict code',
+  ],
+  [
+    '"commerce_admin_shipping_profile_invalid"',
+    'validation code',
+  ],
+  [
+    '"commerce_admin_shipping_profile_storage_unavailable"',
+    'storage code',
+  ],
+  ['"commerce_admin_shipping_profile_failed"', 'fail-closed code'],
+  ['"Commerce resource not found"', 'static not-found message'],
+  [
+    '"A shipping profile with this slug already exists"',
+    'static duplicate slug message',
+  ],
+  [
+    '"Shipping profile request is invalid"',
+    'static validation message',
+  ],
+  [
+    '"Shipping profile storage is temporarily unavailable"',
+    'static storage message',
+  ],
+  [
+    '"Shipping profile operation could not be completed safely"',
+    'static fail-closed message',
+  ],
+]) requireText(policy, value, label);
+
+for (const [value, label] of [
+  [
+    'if let CommerceError::ShippingProfileNotFound(id) = error',
+    'typed profile identity variant',
+  ],
+  [
+    'context.shipping_profile_id = Some(*id);',
+    'typed profile identity adoption',
+  ],
+]) requireText(identityAdoption, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed cause log'],
+  ['owner = ADMIN_PRODUCT_SHIPPING_PROFILE_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['product_id = ?context.product_id', 'product identity log'],
+  [
+    'shipping_profile_id = ?context.shipping_profile_id',
+    'profile identity log',
+  ],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error-kind log'],
+  ['public_code = code', 'public code log'],
+  ['status = %status', 'status log'],
+  [
+    'boundary = ADMIN_PRODUCT_SHIPPING_PROFILE_BOUNDARY',
+    'boundary log',
+  ],
+  ['HttpError::new(status, code, message)', 'static envelope'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  [
+    'shipping_profile_slug.and_then(normalize_shipping_profile_slug)',
+    'slug normalization',
+  ],
+  ['return Ok(());', 'absent slug no-op'],
+  ['ShippingProfileService::new(db.clone())', 'profile service construction'],
+  [
+    '.ensure_shipping_profile_slug_exists(context.tenant_id, &slug)',
+    'owner validation call',
+  ],
+  [
+    '.map_err(|error| map_admin_product_shipping_profile_error(context, error))?;',
+    'context-aware error mapping',
+  ],
+]) requireText(validator, value, label);
+
+for (const [
+  block,
+  permission,
+  productIdentity,
+  operation,
+  serviceCall,
+  response,
+  label,
+] of [
+  [
+    createRoute,
+    'Permission::PRODUCTS_CREATE',
+    'None,',
+    '"create_product_shipping_profile_validation"',
+    '.create_product(tenant.id, auth.user_id, input)',
+    'Ok((StatusCode::CREATED, Json(product)))',
+    'create route',
+  ],
+  [
+    updateRoute,
+    'Permission::PRODUCTS_UPDATE',
+    'Some(id)',
+    '"update_product_shipping_profile_validation"',
+    '.update_product(tenant.id, auth.user_id, id, input)',
+    'Ok(Json(product))',
+    'update route',
+  ],
+]) {
+  requireText(block, permission, `${label} permission`);
+  requireText(
+    block,
+    'validate_admin_product_shipping_profile_input(',
+    `${label} local validator`,
+  );
+  requireText(
+    block,
+    'AdminProductShippingProfileErrorContext::new(',
+    `${label} typed context`,
+  );
+  requireText(block, 'tenant.id', `${label} tenant identity`);
+  requireText(block, 'auth.user_id', `${label} actor identity`);
+  requireText(block, productIdentity, `${label} product identity`);
+  requireText(block, operation, `${label} operation`);
+  requireText(
+    block,
+    'input.shipping_profile_slug.as_deref()',
+    `${label} profile slug forwarding`,
+  );
+  requireText(block, serviceCall, `${label} catalog service contract`);
+  requireText(block, response, `${label} response contract`);
+}
+
+const validationUses =
+  adminProducts.match(
+    /validate_admin_product_shipping_profile_input\(\s+runtime\.db\(\),\s+AdminProductShippingProfileErrorContext::new\(/g,
+  ) ?? [];
+if (validationUses.length !== 2) {
+  failures.push(
+    `expected two context-aware product shipping-profile validation callsites, found ${validationUses.length}`,
+  );
+}
+
+for (const value of [
+  'super::validate_product_shipping_profile_input(',
+  'super::map_shipping_profile_error(',
+  'err.to_string()',
+  'error.to_string()',
+  'other.to_string()',
+  'format!("Shipping profile',
+]) forbidText(adminProducts, value, 'stale or unsafe product shipping-profile mapping');
+
+if (failures.length > 0) {
+  console.error(
+    'Commerce admin product shipping-profile error-context verification failed:',
+  );
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce admin product shipping-profile validation retains typed causes and route context',
+);


### PR DESCRIPTION
## Summary

- replace product create/update shipping-profile prevalidation through the shared admin mapper with a local context-aware typed mapper;
- retain tenant, actor, exact validation operation, truthful optional product and shipping-profile identities, stable public code, status, HTTP boundary, and the original `CommerceError` cause;
- preserve the existing shipping-profile 404/409/400/503/500 status, code, and static message policy;
- preserve slug normalization, absent-slug no-op behavior, validation service arguments, permissions, CatalogService arguments, route delegation, and success responses;
- add a focused verifier, align the existing admin product route verifier, and update the ecommerce public-error safety plan.

## Scope

Four files only:

- `crates/rustok-commerce/src/controllers/admin/products.rs`
- `scripts/verify/verify-commerce-admin-product-shipping-profile-error-context.mjs`
- `scripts/verify/verify-commerce-admin-product-route-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the four intended files;
- production source was re-read to confirm exactly two context-aware prevalidation callsites;
- all current `CommerceError` variants retain the previous shipping-profile public policy or fail closed;
- typed `ShippingProfileNotFound` identities are adopted into structured logging;
- both verifier files were read statically to confirm block markers, exact callsite patterns, and the removal of the stale shared-validator expectation;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-admin-product-shipping-profile-error-context.mjs
node scripts/verify/verify-commerce-admin-product-route-error-context.mjs
cargo check -p rustok-commerce --lib
```