### PR TITLE
Harden storefront staged checkout error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -49,6 +49,12 @@ available only for actionable domain errors.
   Validation, missing-resource, transition, and database causes are logged with
   correlation identity and stable codes while the existing public envelopes remain
   static.
+- `rustok-commerce` storefront staged checkout recovery: the typed recovering-checkout
+  cause is emitted only through structured logging with owner, correlation id, tenant,
+  channel, actor, cart, operation, error kind, stable public code, retryability, and
+  runtime boundary. Raw `eprintln!` debug output is removed while reconciliation,
+  compensation-pending, temporary-unavailable, and checkout-failed public outcomes remain
+  unchanged across REST, GraphQL, native, and mounted transports.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -162,6 +168,7 @@ available only for actionable domain errors.
 
 - `node scripts/verify/verify-port-error-public-safety.mjs`
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
+- `node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
@@ -190,13 +197,14 @@ available only for actionable domain errors.
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, order payment settlement, order checkout recovery, order
-  checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
-  admin order-route, admin checkout-operation, admin payment-route, admin product-route and
-  product shipping-profile prevalidation, order-change owner and orchestration mapping,
-  admin order-return owner and orchestration mapping, admin order-detail payment and
-  fulfillment mapping, and tax calculation validation, provider-contract, reconciliation,
-  correlation, HTTP-envelope, and transport round-trip tests.
+- Targeted cart promotion, storefront staged checkout recovery, order payment settlement,
+  order checkout recovery, order checkout compensation, pricing, payment collection,
+  fulfillment checkout execution, admin fulfillment reconciliation, admin fulfillment
+  routes, admin shipping-option, admin order-route, admin checkout-operation, admin
+  payment-route, admin product-route and product shipping-profile prevalidation,
+  order-change owner and orchestration mapping, admin order-return owner and orchestration
+  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
+  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and transport
+  round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
+++ b/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
@@ -17,6 +17,11 @@ use crate::storefront_checkout_runtime::{
     StorefrontCheckoutCompletionCommand, StorefrontCheckoutRuntime,
 };
 
+const STOREFRONT_STAGED_CHECKOUT_OWNER: &str =
+    "rustok_commerce.recovering_staged_checkout";
+const STOREFRONT_STAGED_CHECKOUT_BOUNDARY: &str =
+    "commerce_storefront_staged_checkout_runtime";
+
 #[derive(Debug, Error)]
 pub enum StorefrontStagedCheckoutRuntimeError {
     #[error("checkout request is invalid")]
@@ -258,7 +263,7 @@ pub async fn complete_storefront_checkout_input(
     crate::RecoveringStagedCheckoutService::new(staged, compensation)
         .complete_checkout(tenant_id, actor_id, idempotency_key, checkout_input)
         .await
-        .map_err(|error| map_checkout_error(tenant_id, cart_id, error))
+        .map_err(|error| map_checkout_error(&cart_port_context, cart_id, actor_id, error))
 }
 
 async fn resolve_customer_id(
@@ -344,32 +349,50 @@ fn map_owner_port_error(
 }
 
 fn map_checkout_error(
-    tenant_id: Uuid,
+    context: &PortContext,
     cart_id: Uuid,
+    actor_id: Uuid,
     error: crate::RecoveringStagedCheckoutError,
 ) -> StorefrontStagedCheckoutRuntimeError {
-    eprintln!("DEBUG STAGED CHECKOUT ERROR: {error:?}");
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        cart_id = %cart_id,
-        operation = "complete_storefront_checkout",
-        "storefront staged checkout failed"
-    );
-    match error {
+    let (public, error_kind) = match &error {
         crate::RecoveringStagedCheckoutError::StagedAndCompensation {
             compensation: crate::CheckoutCompensationError::ManualReconciliation(_),
             ..
-        } => StorefrontStagedCheckoutRuntimeError::ReconciliationRequired,
-        crate::RecoveringStagedCheckoutError::StagedAndCompensation { .. } => {
-            StorefrontStagedCheckoutRuntimeError::CompensationPending
-        }
-        crate::RecoveringStagedCheckoutError::StagedAndJournal { .. }
-        | crate::RecoveringStagedCheckoutError::Journal(_) => {
-            StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable
-        }
-        crate::RecoveringStagedCheckoutError::Staged(_) => {
-            StorefrontStagedCheckoutRuntimeError::CheckoutFailed
-        }
-    }
+        } => (
+            StorefrontStagedCheckoutRuntimeError::ReconciliationRequired,
+            "manual_reconciliation",
+        ),
+        crate::RecoveringStagedCheckoutError::StagedAndCompensation { .. } => (
+            StorefrontStagedCheckoutRuntimeError::CompensationPending,
+            "compensation_pending",
+        ),
+        crate::RecoveringStagedCheckoutError::StagedAndJournal { .. } => (
+            StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable,
+            "staged_and_journal",
+        ),
+        crate::RecoveringStagedCheckoutError::Journal(_) => (
+            StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable,
+            "journal",
+        ),
+        crate::RecoveringStagedCheckoutError::Staged(_) => (
+            StorefrontStagedCheckoutRuntimeError::CheckoutFailed,
+            "staged",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = STOREFRONT_STAGED_CHECKOUT_OWNER,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        channel = ?context.channel,
+        actor_id = %actor_id,
+        cart_id = %cart_id,
+        operation = "complete_storefront_checkout",
+        error_kind,
+        public_code = public.public_code(),
+        retryable = public.retryable(),
+        boundary = STOREFRONT_STAGED_CHECKOUT_BOUNDARY,
+        "storefront staged checkout failed"
+    );
+    public
 }

--- a/scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
@@ -51,6 +51,32 @@ for (const [source, value, label] of [
   [stagedRuntime, 'pub const fn retryable(&self)', 'stable checkout retryability contract'],
   [stagedRuntime, 'StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable', 'temporary dependency failure classification'],
   [stagedRuntime, 'map_owner_port_error(', 'owner port failure classification'],
+  [stagedRuntime, 'const STOREFRONT_STAGED_CHECKOUT_OWNER: &str =', 'staged checkout owner constant'],
+  [stagedRuntime, '"rustok_commerce.recovering_staged_checkout";', 'staged checkout owner value'],
+  [stagedRuntime, 'const STOREFRONT_STAGED_CHECKOUT_BOUNDARY: &str =', 'staged checkout boundary constant'],
+  [stagedRuntime, '"commerce_storefront_staged_checkout_runtime";', 'staged checkout boundary value'],
+  [stagedRuntime, 'fn map_checkout_error(', 'typed staged checkout mapper'],
+  [stagedRuntime, '.map_err(|error| map_checkout_error(&cart_port_context, cart_id, actor_id, error))', 'context-aware staged checkout callsite'],
+  [stagedRuntime, 'crate::RecoveringStagedCheckoutError::StagedAndCompensation {', 'staged and compensation branch'],
+  [stagedRuntime, 'compensation: crate::CheckoutCompensationError::ManualReconciliation(_)', 'manual reconciliation branch'],
+  [stagedRuntime, 'crate::RecoveringStagedCheckoutError::StagedAndJournal { .. }', 'staged and journal branch'],
+  [stagedRuntime, 'crate::RecoveringStagedCheckoutError::Journal(_)', 'journal branch'],
+  [stagedRuntime, 'crate::RecoveringStagedCheckoutError::Staged(_)', 'staged failure branch'],
+  [stagedRuntime, 'StorefrontStagedCheckoutRuntimeError::ReconciliationRequired', 'reconciliation outcome'],
+  [stagedRuntime, 'StorefrontStagedCheckoutRuntimeError::CompensationPending', 'compensation pending outcome'],
+  [stagedRuntime, 'StorefrontStagedCheckoutRuntimeError::CheckoutFailed', 'checkout failed outcome'],
+  [stagedRuntime, 'error = ?error', 'typed recovery error log'],
+  [stagedRuntime, 'owner = STOREFRONT_STAGED_CHECKOUT_OWNER', 'staged checkout owner log'],
+  [stagedRuntime, 'correlation_id = %context.correlation_id', 'correlation log'],
+  [stagedRuntime, 'tenant_id = %context.tenant_id', 'tenant log'],
+  [stagedRuntime, 'channel = ?context.channel', 'channel log'],
+  [stagedRuntime, 'actor_id = %actor_id', 'actor log'],
+  [stagedRuntime, 'cart_id = %cart_id', 'cart log'],
+  [stagedRuntime, 'operation = "complete_storefront_checkout"', 'operation log'],
+  [stagedRuntime, 'error_kind,', 'error-kind log'],
+  [stagedRuntime, 'public_code = public.public_code()', 'public code log'],
+  [stagedRuntime, 'retryable = public.retryable()', 'retryability log'],
+  [stagedRuntime, 'boundary = STOREFRONT_STAGED_CHECKOUT_BOUNDARY', 'runtime boundary log'],
   [graphqlCheckout, 'complete_storefront_checkout_input(', 'GraphQL staged checkout entrypoint'],
   [graphqlCheckout, 'payment_provider_registry_from_context(ctx)', 'GraphQL host provider registry'],
   [graphqlCheckout, 'storefront_checkout_graphql_error', 'GraphQL stable checkout mapper'],
@@ -106,10 +132,24 @@ for (const [source, value, label] of [
   [nativeCheckout, 'ServerFnError::new(error.to_string())', 'native raw checkout error display'],
   [nativeCheckout, 'ServerFn(error.to_string())', 'native transport raw server error display'],
   [stagedRuntime, '#[error("checkout request is invalid: {0}")]', 'runtime validation detail display'],
+  [stagedRuntime, 'eprintln!(', 'staged checkout raw stderr output'],
+  [stagedRuntime, 'println!(', 'staged checkout stdout output'],
+  [stagedRuntime, 'dbg!(', 'staged checkout debug macro'],
+  [stagedRuntime, 'DEBUG STAGED CHECKOUT ERROR', 'staged checkout debug marker'],
   [orderPorts, 'match order.status.as_str()', 'raw checkout order lifecycle matching'],
   [orderPorts, '"confirmed" | "paid" | "shipped" | "delivered"', 'raw checkout order lifecycle alternatives'],
 ]) {
   forbidText(source, value, label);
+}
+
+const stagedMapperUses =
+  stagedRuntime.match(
+    /map_checkout_error\(&cart_port_context, cart_id, actor_id, error\)/g,
+  ) ?? [];
+if (stagedMapperUses.length !== 1) {
+  failures.push(
+    `expected one context-aware staged checkout mapper callsite, found ${stagedMapperUses.length}`,
+  );
 }
 
 if (failures.length > 0) {
@@ -119,5 +159,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ REST, GraphQL, native, and mounted storefront checkout delegate to the shared staged runtime and publish stable checkout/payment errors; journaled compatibility and order recovery use the same typed recovery policy',
+  '✔ REST, GraphQL, native, and mounted storefront checkout delegate to the shared staged runtime; recovery failures retain typed correlation context without raw stderr output',
 );


### PR DESCRIPTION
## Summary

- remove the raw `eprintln!` of `RecoveringStagedCheckoutError` from the shared staged storefront runtime;
- retain the typed recovery cause in one structured event with owner, correlation id, tenant, channel, actor, cart, operation, error kind, public code, retryability, and runtime boundary;
- preserve the existing reconciliation-required, compensation-pending, temporarily-unavailable, and checkout-failed classifications;
- preserve every public checkout code, message, retryability contract, staged pipeline argument, provider registry composition, and REST/GraphQL/native/mounted delegation;
- extend the existing staged-checkout cutover verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs`
- `scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files;
- production source was re-read to confirm one context-aware recovery mapper callsite and exhaustive handling of all current `RecoveringStagedCheckoutError` variants;
- the raw stderr debug output and marker are absent;
- public enum, code, message, retryability, checkout pipeline, provider registry, and transport delegation contracts remain unchanged;
- the existing verifier was read statically to confirm exact source markers, one mapper callsite, structured fields, and stderr/debug prohibitions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
cargo check -p rustok-commerce --lib
```