### PR TITLE
Harden storefront payment collection error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -62,6 +62,13 @@ available only for actionable domain errors.
   compensation-pending, and reconciliation-required status/code/message contracts remain
   unchanged while idempotency validation, checkout input forwarding, provider registry,
   staged runtime arguments, and the response contract stay intact.
+- `rustok-commerce` storefront payment-collection creation: reusable lookup and create
+  calls retain the typed payment cause with payment owner, tenant, actor, cart, truthful
+  optional customer identity, channel id/slug, locale, exact operation, error kind,
+  stable public code, status, and HTTP boundary. Validation, missing-resource,
+  transition, provider-unavailable/configuration/rejected, reconciliation, and storage
+  outcomes preserve the existing public envelopes while cart access, repricing, context
+  metadata, service arguments, reusable response, and created response remain unchanged.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -177,6 +184,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - `node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
 - `node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs`
+- `node scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
@@ -205,14 +213,14 @@ available only for actionable domain errors.
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, storefront staged checkout recovery and HTTP completion mapping,
-  order payment settlement, order checkout recovery, order checkout compensation, pricing,
-  payment collection, fulfillment checkout execution, admin fulfillment reconciliation,
-  admin fulfillment routes, admin shipping-option, admin order-route, admin
-  checkout-operation, admin payment-route, admin product-route and product shipping-profile
-  prevalidation, order-change owner and orchestration mapping, admin order-return owner and
-  orchestration mapping, admin order-detail payment and fulfillment mapping, and tax
-  calculation validation, provider-contract, reconciliation, correlation, HTTP-envelope,
-  and transport round-trip tests.
+- Targeted cart promotion, storefront staged checkout recovery, HTTP completion and
+  payment-collection mapping, order payment settlement, order checkout recovery, order
+  checkout compensation, pricing, payment collection, fulfillment checkout execution,
+  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
+  admin order-route, admin checkout-operation, admin payment-route, admin product-route and
+  product shipping-profile prevalidation, order-change owner and orchestration mapping,
+  admin order-return owner and orchestration mapping, admin order-detail payment and
+  fulfillment mapping, and tax calculation validation, provider-contract, reconciliation,
+  correlation, HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/store/checkout.rs
+++ b/crates/rustok-commerce/src/controllers/store/checkout.rs
@@ -18,8 +18,17 @@ const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";
 const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 191;
 const STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront_staged_checkout_runtime";
 const STOREFRONT_CHECKOUT_BOUNDARY: &str = "commerce_storefront_checkout_http";
+const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";
+const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str =
+    "commerce_storefront_payment_collection_http";
 
 type StorefrontCheckoutHttpPolicy = (StatusCode, &'static str);
+type StorefrontPaymentCollectionHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
 
 #[derive(Clone, Copy)]
 struct StorefrontCheckoutErrorContext<'a> {
@@ -52,6 +61,40 @@ impl<'a> StorefrontCheckoutErrorContext<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
+struct StorefrontPaymentCollectionErrorContext<'a> {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    cart_id: Uuid,
+    customer_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    channel_slug: Option<&'a str>,
+    locale: &'a str,
+    operation: &'static str,
+}
+
+impl<'a> StorefrontPaymentCollectionErrorContext<'a> {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        cart_id: Uuid,
+        customer_id: Option<Uuid>,
+        request_context: &'a RequestContext,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            cart_id,
+            customer_id,
+            channel_id: request_context.channel_id,
+            channel_slug: request_context.channel_slug.as_deref(),
+            locale: request_context.locale.as_str(),
+            operation,
+        }
+    }
+}
+
 /// Create payment collection from storefront cart
 #[utoipa::path(
     post,
@@ -74,6 +117,7 @@ pub async fn create_payment_collection(
 ) -> HttpResult<(StatusCode, Json<PaymentCollectionResponse>)> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
+    let actor_id = super::checkout_actor_id(auth.0.as_ref());
     let customer_id =
         super::current_customer_id_for_db(runtime.db(), tenant.id, auth.0.as_ref()).await?;
     let cart_storefront_port = in_process_cart_storefront_port(runtime.db_clone());
@@ -114,9 +158,14 @@ pub async fn create_payment_collection(
         .await
         .map_err(|error| {
             payment_collection_http_error(
-                tenant.id,
-                cart.id,
-                "find_reusable_collection_by_cart",
+                StorefrontPaymentCollectionErrorContext::new(
+                    tenant.id,
+                    actor_id,
+                    cart.id,
+                    cart.customer_id,
+                    &request_context,
+                    "find_reusable_collection_by_cart",
+                ),
                 error,
             )
         })?
@@ -140,7 +189,17 @@ pub async fn create_payment_collection(
         )
         .await
         .map_err(|error| {
-            payment_collection_http_error(tenant.id, cart.id, "create_collection", error)
+            payment_collection_http_error(
+                StorefrontPaymentCollectionErrorContext::new(
+                    tenant.id,
+                    actor_id,
+                    cart.id,
+                    cart.customer_id,
+                    &request_context,
+                    "create_collection",
+                ),
+                error,
+            )
         })?;
 
     Ok((StatusCode::CREATED, Json(collection)))
@@ -313,57 +372,90 @@ fn storefront_checkout_http_error(
     HttpError::new(status, code, message)
 }
 
-fn payment_collection_http_error(
-    tenant_id: Uuid,
-    cart_id: Uuid,
-    operation: &'static str,
-    error: PaymentError,
-) -> HttpError {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        cart_id = %cart_id,
-        operation,
-        "storefront payment collection operation failed"
-    );
+fn payment_collection_error_policy(
+    error: &PaymentError,
+) -> StorefrontPaymentCollectionHttpPolicy {
     match error {
-        PaymentError::Validation(_) => HttpError::bad_request(
+        PaymentError::Validation(_) => (
+            StatusCode::BAD_REQUEST,
             "payment_request_invalid",
             "Payment collection request is invalid",
+            "validation",
         ),
         PaymentError::PaymentCollectionNotFound(_)
         | PaymentError::PaymentNotFound(_)
-        | PaymentError::RefundNotFound(_) => HttpError::not_found(
+        | PaymentError::RefundNotFound(_) => (
+            StatusCode::NOT_FOUND,
             "payment_resource_not_found",
             "Payment resource was not found",
+            "not_found",
         ),
-        PaymentError::InvalidTransition { .. } => HttpError::new(
+        PaymentError::InvalidTransition { .. } => (
             StatusCode::CONFLICT,
             "payment_state_conflict",
             "Payment lifecycle conflicts with the requested operation",
+            "state_conflict",
         ),
-        PaymentError::ProviderUnavailable { .. } | PaymentError::ProviderConfiguration { .. } => {
-            HttpError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "payment_temporarily_unavailable",
-                "Payment service is temporarily unavailable",
-            )
-        }
-        PaymentError::ProviderRejected { .. } => HttpError::new(
+        PaymentError::ProviderUnavailable { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "payment_temporarily_unavailable",
+            "Payment service is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "payment_temporarily_unavailable",
+            "Payment service is temporarily unavailable",
+            "provider_configuration",
+        ),
+        PaymentError::ProviderRejected { .. } => (
             StatusCode::CONFLICT,
             "payment_provider_rejected",
             "Payment provider rejected the requested operation",
+            "provider_rejected",
         ),
-        PaymentError::ProviderInvalidResponse { .. }
-        | PaymentError::ProviderOutcomeUnknown { .. } => HttpError::new(
+        PaymentError::ProviderInvalidResponse { .. } => (
             StatusCode::CONFLICT,
             "payment_reconciliation_required",
             "Payment operation requires reconciliation",
+            "provider_invalid_response",
         ),
-        PaymentError::Database(_) => HttpError::new(
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            StatusCode::CONFLICT,
+            "payment_reconciliation_required",
+            "Payment operation requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        PaymentError::Database(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
             "payment_storage_unavailable",
             "Payment service is temporarily unavailable",
+            "database",
         ),
     }
+}
+
+fn payment_collection_http_error(
+    context: StorefrontPaymentCollectionErrorContext<'_>,
+    error: PaymentError,
+) -> HttpError {
+    let (status, code, message, error_kind) = payment_collection_error_policy(&error);
+    tracing::error!(
+        error = ?error,
+        owner = STOREFRONT_PAYMENT_COLLECTION_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        cart_id = %context.cart_id,
+        customer_id = ?context.customer_id,
+        channel_id = ?context.channel_id,
+        channel = ?context.channel_slug,
+        locale = %context.locale,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY,
+        "storefront payment collection operation failed"
+    );
+    HttpError::new(status, code, message)
 }

--- a/scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const checkout = read('crates/rustok-commerce/src/controllers/store/checkout.rs');
+const paymentError = read('crates/rustok-payment/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const route = between(
+  checkout,
+  'pub async fn create_payment_collection(',
+  '/// Complete storefront cart checkout',
+  'payment collection route',
+);
+const policy = between(
+  checkout,
+  'fn payment_collection_error_policy(',
+  'fn payment_collection_http_error(',
+  'payment collection policy',
+);
+const mapper = checkout.slice(
+  checkout.indexOf('fn payment_collection_http_error('),
+);
+
+for (const [value, label] of [
+  [
+    'const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";',
+    'payment owner constant',
+  ],
+  [
+    'const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str =',
+    'payment boundary constant',
+  ],
+  [
+    '"commerce_storefront_payment_collection_http";',
+    'payment boundary value',
+  ],
+  [
+    'type StorefrontPaymentCollectionHttpPolicy = (',
+    'payment policy type',
+  ],
+  [
+    'struct StorefrontPaymentCollectionErrorContext<\'a> {',
+    'typed payment context',
+  ],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['actor_id: Uuid,', 'actor context field'],
+  ['cart_id: Uuid,', 'cart context field'],
+  ['customer_id: Option<Uuid>,', 'customer context field'],
+  ['channel_id: Option<Uuid>,', 'channel id context field'],
+  ['channel_slug: Option<&\'a str>,', 'channel slug context field'],
+  ['locale: &\'a str,', 'locale context field'],
+  ['operation: &\'static str,', 'operation context field'],
+  ['channel_id: request_context.channel_id,', 'channel id adoption'],
+  [
+    'channel_slug: request_context.channel_slug.as_deref(),',
+    'channel slug adoption',
+  ],
+  ['locale: request_context.locale.as_str(),', 'locale adoption'],
+]) requireText(checkout, value, label);
+
+for (const [value, label] of [
+  [
+    'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
+    'storefront channel guard',
+  ],
+  [
+    'let actor_id = super::checkout_actor_id(auth.0.as_ref());',
+    'actor resolution',
+  ],
+  [
+    'super::current_customer_id_for_db(runtime.db(), tenant.id, auth.0.as_ref()).await?;',
+    'customer resolution',
+  ],
+  ['in_process_cart_storefront_port(runtime.db_clone())', 'cart storefront port'],
+  ['CartStorefrontReadRequest {', 'cart read request'],
+  ['cart_id: input.cart_id,', 'input cart identity'],
+  ['super::ensure_store_cart_access(&cart, customer_id)?;', 'cart access guard'],
+  [
+    'super::ensure_cart_allows_payment_collection(&cart)?;',
+    'payment collection lifecycle guard',
+  ],
+  [
+    'super::reprice_storefront_cart_line_items_for_db(',
+    'cart repricing',
+  ],
+  [
+    'super::resolve_context_from_cart_for_db(runtime.db(), tenant.id, &request_context, &cart)',
+    'cart context resolution',
+  ],
+  [
+    '.find_reusable_collection_by_cart(tenant.id, cart.id)',
+    'reusable collection lookup',
+  ],
+  ['.create_collection(', 'collection creation'],
+  ['cart_id: Some(cart.id),', 'created collection cart id'],
+  ['order_id: None,', 'created collection order contract'],
+  ['customer_id: cart.customer_id,', 'created collection customer id'],
+  ['currency_code: cart.currency_code.clone(),', 'currency forwarding'],
+  ['amount: cart.total_amount,', 'amount forwarding'],
+  ['super::cart_context_metadata(&cart, &context)', 'metadata forwarding'],
+  ['return Ok((StatusCode::OK, Json(existing)));', 'reusable response'],
+  ['Ok((StatusCode::CREATED, Json(collection)))', 'created response'],
+  [
+    '"find_reusable_collection_by_cart"',
+    'reusable lookup operation',
+  ],
+  ['"create_collection"', 'create operation'],
+]) requireText(route, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::Validation(_)', 'validation variant'],
+  ['"payment_request_invalid"', 'validation code'],
+  ['"Payment collection request is invalid"', 'validation message'],
+  ['"validation"', 'validation kind'],
+  ['PaymentError::PaymentCollectionNotFound(_)', 'collection missing variant'],
+  ['PaymentError::PaymentNotFound(_)', 'payment missing variant'],
+  ['PaymentError::RefundNotFound(_)', 'refund missing variant'],
+  ['StatusCode::NOT_FOUND', 'missing status'],
+  ['"payment_resource_not_found"', 'missing code'],
+  ['"Payment resource was not found"', 'missing message'],
+  ['"not_found"', 'missing kind'],
+  ['PaymentError::InvalidTransition { .. }', 'transition variant'],
+  ['"payment_state_conflict"', 'transition code'],
+  [
+    '"Payment lifecycle conflicts with the requested operation"',
+    'transition message',
+  ],
+  ['"state_conflict"', 'transition kind'],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['"provider_unavailable"', 'provider unavailable kind'],
+  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration variant'],
+  ['"provider_configuration"', 'provider configuration kind'],
+  ['"payment_temporarily_unavailable"', 'temporary code'],
+  ['"Payment service is temporarily unavailable"', 'temporary message'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
+  ['"payment_provider_rejected"', 'provider rejected code'],
+  [
+    '"Payment provider rejected the requested operation"',
+    'provider rejected message',
+  ],
+  ['"provider_rejected"', 'provider rejected kind'],
+  [
+    'PaymentError::ProviderInvalidResponse { .. }',
+    'invalid provider response variant',
+  ],
+  ['"provider_invalid_response"', 'invalid provider response kind'],
+  [
+    'PaymentError::ProviderOutcomeUnknown { .. }',
+    'unknown provider outcome variant',
+  ],
+  ['"provider_outcome_unknown"', 'unknown provider outcome kind'],
+  ['"payment_reconciliation_required"', 'reconciliation code'],
+  [
+    '"Payment operation requires reconciliation"',
+    'reconciliation message',
+  ],
+  ['PaymentError::Database(_)', 'database variant'],
+  ['"payment_storage_unavailable"', 'database code'],
+  ['"database"', 'database kind'],
+  ['StatusCode::BAD_REQUEST', 'bad request status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+]) requireText(policy, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed payment cause log'],
+  ['owner = STOREFRONT_PAYMENT_COLLECTION_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['cart_id = %context.cart_id', 'cart log'],
+  ['customer_id = ?context.customer_id', 'customer log'],
+  ['channel_id = ?context.channel_id', 'channel id log'],
+  ['channel = ?context.channel_slug', 'channel slug log'],
+  ['locale = %context.locale', 'locale log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error kind log'],
+  ['public_code = code', 'public code log'],
+  ['status = %status', 'status log'],
+  ['boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'stable public envelope'],
+]) requireText(mapper, value, label);
+
+for (const value of [
+  'Validation(String),',
+  'PaymentCollectionNotFound(Uuid),',
+  'PaymentNotFound(Uuid),',
+  'RefundNotFound(Uuid),',
+  'InvalidTransition { from: String, to: String },',
+  'ProviderUnavailable {',
+  'ProviderRejected {',
+  'ProviderInvalidResponse {',
+  'ProviderOutcomeUnknown {',
+  'ProviderConfiguration { provider_id: String },',
+  'Database(#[from] DbErr),',
+]) requireText(paymentError, value, 'payment source enum');
+
+const mapperUses =
+  route.match(
+    /payment_collection_http_error\(\s+StorefrontPaymentCollectionErrorContext::new\(/g,
+  ) ?? [];
+if (mapperUses.length !== 2) {
+  failures.push(
+    `expected two context-aware payment collection mapper callsites, found ${mapperUses.length}`,
+  );
+}
+
+for (const value of [
+  'payment_collection_http_error(tenant.id, cart.id',
+  'payment_collection_http_error(\n                tenant.id',
+  'error.to_string()',
+  'err.to_string()',
+  'HttpError::bad_request(error',
+  'HttpError::internal(error',
+]) forbidText(checkout, value, 'stale or unsafe payment collection mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce storefront payment collection error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront payment collection failures retain typed route context and stable public contracts',
+);


### PR DESCRIPTION
## Summary

- replace the storefront payment-collection mapper's minimal tenant/cart log with one context-aware typed HTTP mapper;
- retain the typed `PaymentError` with payment owner, tenant, actor, cart, truthful optional customer identity, channel id/slug, locale, exact operation, error kind, public code, status, and HTTP boundary;
- preserve the existing validation, not-found, transition, provider-unavailable/configuration/rejected, reconciliation-required, and storage status/code/message contracts;
- preserve cart access, repricing, context metadata, reusable collection lookup, collection creation arguments, and both success responses;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/store/checkout.rs`
- `scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended commerce files and retains the concurrent notifications commit;
- production source was re-read to confirm exactly two context-aware mapper callsites and exhaustive handling of all current `PaymentError` variants;
- the existing public status/code/message policy remains unchanged while provider configuration, invalid response, and unknown outcome keep truthful internal error kinds;
- checkout completion, idempotency, cart access/repricing, service arguments, metadata, reusable response, and created response contracts remain unchanged;
- the focused verifier was read statically to confirm exact source markers, source enum coverage, two mapper callsites, and stale/raw mapping prohibitions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs
node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
cargo check -p rustok-commerce --lib
```