### PR TITLE
Harden storefront order refund error context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -69,6 +69,13 @@ available only for actionable domain errors.
   transition, provider-unavailable/configuration/rejected, reconciliation, and storage
   outcomes preserve the existing public envelopes while cart access, repricing, context
   metadata, service arguments, reusable response, and created response remain unchanged.
+- `rustok-commerce` storefront order refund listing: the single payment read retains the
+  typed payment cause with payment owner, tenant, actor, verified customer, order,
+  truthful optional payment-collection and refund identities, channel id/slug, locale,
+  exact operation, error kind, stable public code, status, and HTTP boundary. The
+  ownership helper returns the already verified customer identity without a second
+  lookup, while filters, pagination, service arguments, responses, and existing payment
+  status/code/message envelopes remain unchanged.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -185,6 +192,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
 - `node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs`
 - `node scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs`
+- `node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
@@ -213,14 +221,15 @@ available only for actionable domain errors.
 - `cargo check -p rustok-payment --all-features`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
-- Targeted cart promotion, storefront staged checkout recovery, HTTP completion and
-  payment-collection mapping, order payment settlement, order checkout recovery, order
-  checkout compensation, pricing, payment collection, fulfillment checkout execution,
-  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option,
-  admin order-route, admin checkout-operation, admin payment-route, admin product-route and
-  product shipping-profile prevalidation, order-change owner and orchestration mapping,
-  admin order-return owner and orchestration mapping, admin order-detail payment and
-  fulfillment mapping, and tax calculation validation, provider-contract, reconciliation,
-  correlation, HTTP-envelope, and transport round-trip tests.
+- Targeted cart promotion, storefront staged checkout recovery, HTTP completion,
+  payment-collection and order-refund mapping, order payment settlement, order checkout
+  recovery, order checkout compensation, pricing, payment collection, fulfillment checkout
+  execution, admin fulfillment reconciliation, admin fulfillment routes, admin
+  shipping-option, admin order-route, admin checkout-operation, admin payment-route, admin
+  product-route and product shipping-profile prevalidation, order-change owner and
+  orchestration mapping, admin order-return owner and orchestration mapping, admin
+  order-detail payment and fulfillment mapping, and tax calculation validation,
+  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
+  tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -23,6 +23,54 @@ use crate::dto::{
     OrderChangeResponse, OrderResponse, OrderReturnResponse, RefundResponse,
 };
 
+const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
+const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
+
+type StorefrontOrderPaymentHttpPolicy = (
+    StatusCode,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+#[derive(Clone, Copy)]
+struct StorefrontOrderPaymentErrorContext<'a> {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    customer_id: Uuid,
+    order_id: Uuid,
+    payment_collection_id: Option<Uuid>,
+    refund_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    channel_slug: Option<&'a str>,
+    locale: &'a str,
+    operation: &'static str,
+}
+
+impl<'a> StorefrontOrderPaymentErrorContext<'a> {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        customer_id: Uuid,
+        order_id: Uuid,
+        request_context: &'a RequestContext,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            customer_id,
+            order_id,
+            payment_collection_id: None,
+            refund_id: None,
+            channel_id: request_context.channel_id,
+            channel_slug: request_context.channel_slug.as_deref(),
+            locale: request_context.locale.as_str(),
+            operation,
+        }
+    }
+}
+
 fn map_storefront_customer_port_error(
     error: PortError,
     operation: &'static str,
@@ -92,32 +140,55 @@ fn map_storefront_order_error(
     HttpError::new(status, code, message)
 }
 
-fn map_storefront_payment_error(
-    error: PaymentError,
-    operation: &'static str,
-    tenant_id: Uuid,
-    order_id: Uuid,
-) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
+fn storefront_order_payment_error_policy(
+    context: &mut StorefrontOrderPaymentErrorContext<'_>,
+    error: &PaymentError,
+) -> StorefrontOrderPaymentHttpPolicy {
+    match error {
         PaymentError::Validation(_) => (
             StatusCode::BAD_REQUEST,
             "commerce_store_payment_invalid",
             "Payment request is invalid",
             "validation",
         ),
-        PaymentError::PaymentCollectionNotFound(_)
-        | PaymentError::PaymentNotFound(_)
-        | PaymentError::RefundNotFound(_) => (
-            StatusCode::NOT_FOUND,
-            "commerce_store_payment_not_found",
-            "Payment resource was not found",
-            "not_found",
-        ),
-        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+        PaymentError::PaymentCollectionNotFound(payment_collection_id) => {
+            context.payment_collection_id = Some(*payment_collection_id);
+            (
+                StatusCode::NOT_FOUND,
+                "commerce_store_payment_not_found",
+                "Payment resource was not found",
+                "payment_collection_not_found",
+            )
+        }
+        PaymentError::PaymentNotFound(payment_collection_id) => {
+            context.payment_collection_id = Some(*payment_collection_id);
+            (
+                StatusCode::NOT_FOUND,
+                "commerce_store_payment_not_found",
+                "Payment resource was not found",
+                "payment_not_found",
+            )
+        }
+        PaymentError::RefundNotFound(refund_id) => {
+            context.refund_id = Some(*refund_id);
+            (
+                StatusCode::NOT_FOUND,
+                "commerce_store_payment_not_found",
+                "Payment resource was not found",
+                "refund_not_found",
+            )
+        }
+        PaymentError::InvalidTransition { .. } => (
             StatusCode::CONFLICT,
             "commerce_store_payment_state_conflict",
             "Payment operation conflicts with the current state",
             "state_conflict",
+        ),
+        PaymentError::ProviderRejected { .. } => (
+            StatusCode::CONFLICT,
+            "commerce_store_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "provider_rejected",
         ),
         PaymentError::ProviderUnavailable { .. } => (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -149,16 +220,32 @@ fn map_storefront_payment_error(
             "Payment service is temporarily unavailable",
             "database",
         ),
-    };
+    }
+}
+
+fn map_storefront_payment_error(
+    mut context: StorefrontOrderPaymentErrorContext<'_>,
+    error: PaymentError,
+) -> HttpError {
+    let (status, code, message, error_kind) =
+        storefront_order_payment_error_policy(&mut context, &error);
     tracing::error!(
         error = ?error,
-        operation,
-        tenant_id = %tenant_id,
-        order_id = %order_id,
+        owner = STOREFRONT_ORDER_PAYMENT_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        customer_id = %context.customer_id,
+        order_id = %context.order_id,
+        payment_collection_id = ?context.payment_collection_id,
+        refund_id = ?context.refund_id,
+        channel_id = ?context.channel_id,
+        channel = ?context.channel_slug,
+        locale = %context.locale,
+        operation = %context.operation,
         error_kind,
         public_code = code,
         status = %status,
-        boundary = "commerce_storefront_order_http",
+        boundary = STOREFRONT_ORDER_PAYMENT_BOUNDARY,
         "storefront payment read failed"
     );
     HttpError::new(status, code, message)
@@ -193,7 +280,7 @@ async fn ensure_customer_owns_order(
     auth: &rustok_api::AuthContext,
     order_id: Uuid,
     operation: &'static str,
-) -> HttpResult<()> {
+) -> HttpResult<Uuid> {
     let customer_id = current_storefront_customer_id(runtime, tenant_id, auth, operation)
         .await?
         .ok_or_else(|| {
@@ -214,7 +301,7 @@ async fn ensure_customer_owns_order(
         ));
     }
 
-    Ok(())
+    Ok(customer_id)
 }
 
 /// Get current storefront customer
@@ -404,7 +491,9 @@ pub async fn list_order_refunds(
 ) -> HttpResult<Json<PaginatedResponse<RefundResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_refunds_access").await?;
+    let customer_id =
+        ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_refunds_access")
+            .await?;
 
     let payment_service = PaymentService::new(runtime.db_clone());
     let (items, total) = payment_service
@@ -420,7 +509,17 @@ pub async fn list_order_refunds(
         )
         .await
         .map_err(|error| {
-            map_storefront_payment_error(error, "list_order_refunds", tenant.id, id)
+            map_storefront_payment_error(
+                StorefrontOrderPaymentErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    customer_id,
+                    id,
+                    &request_context,
+                    "list_order_refunds",
+                ),
+                error,
+            )
         })?;
 
     Ok(Json(PaginatedResponse {

--- a/scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const policy = between(
+  controller,
+  'fn storefront_order_payment_error_policy(',
+  'fn map_storefront_payment_error(',
+  'storefront order payment policy',
+);
+const mapper = between(
+  controller,
+  'fn map_storefront_payment_error(',
+  'async fn current_storefront_customer_id(',
+  'storefront order payment mapper',
+);
+const ownership = between(
+  controller,
+  'async fn ensure_customer_owns_order(',
+  '/// Get current storefront customer',
+  'order ownership helper',
+);
+const refundRoute = between(
+  controller,
+  'pub async fn list_order_refunds(',
+  '/// List order changes for the current customer',
+  'order refund route',
+);
+
+for (const [value, label] of [
+  [
+    'const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";',
+    'payment owner constant',
+  ],
+  [
+    'const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";',
+    'payment boundary constant',
+  ],
+  ['type StorefrontOrderPaymentHttpPolicy = (', 'payment policy type'],
+  [
+    'struct StorefrontOrderPaymentErrorContext<\'a> {',
+    'typed payment context',
+  ],
+  ['tenant_id: Uuid,', 'tenant context field'],
+  ['actor_id: Uuid,', 'actor context field'],
+  ['customer_id: Uuid,', 'customer context field'],
+  ['order_id: Uuid,', 'order context field'],
+  ['payment_collection_id: Option<Uuid>,', 'collection context field'],
+  ['refund_id: Option<Uuid>,', 'refund context field'],
+  ['channel_id: Option<Uuid>,', 'channel ID context field'],
+  ['channel_slug: Option<&\'a str>,', 'channel slug context field'],
+  ['locale: &\'a str,', 'locale context field'],
+  ['operation: &\'static str,', 'operation context field'],
+  ['payment_collection_id: None,', 'empty collection identity'],
+  ['refund_id: None,', 'empty refund identity'],
+  ['channel_id: request_context.channel_id,', 'channel ID adoption'],
+  [
+    'channel_slug: request_context.channel_slug.as_deref(),',
+    'channel slug adoption',
+  ],
+  ['locale: request_context.locale.as_str(),', 'locale adoption'],
+]) requireText(controller, value, label);
+
+for (const [value, label] of [
+  ['PaymentError::Validation(_)', 'validation variant'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['"commerce_store_payment_invalid"', 'validation code'],
+  ['"Payment request is invalid"', 'validation message'],
+  ['"validation"', 'validation kind'],
+  [
+    'PaymentError::PaymentCollectionNotFound(payment_collection_id)',
+    'collection not-found variant',
+  ],
+  [
+    'context.payment_collection_id = Some(*payment_collection_id);',
+    'collection identity adoption',
+  ],
+  [
+    'PaymentError::PaymentNotFound(payment_collection_id)',
+    'payment not-found variant',
+  ],
+  ['"payment_not_found"', 'payment not-found kind'],
+  ['PaymentError::RefundNotFound(refund_id)', 'refund not-found variant'],
+  ['context.refund_id = Some(*refund_id);', 'refund identity adoption'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['"commerce_store_payment_not_found"', 'not-found code'],
+  ['"Payment resource was not found"', 'not-found message'],
+  ['PaymentError::InvalidTransition { .. }', 'transition variant'],
+  ['"state_conflict"', 'transition kind'],
+  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
+  ['"provider_rejected"', 'provider rejected kind'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['"commerce_store_payment_state_conflict"', 'state conflict code'],
+  [
+    '"Payment operation conflicts with the current state"',
+    'state conflict message',
+  ],
+  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  [
+    '"commerce_store_payment_provider_unavailable"',
+    'provider unavailable code',
+  ],
+  [
+    '"Payment provider is temporarily unavailable"',
+    'provider unavailable message',
+  ],
+  [
+    'PaymentError::ProviderInvalidResponse { .. }',
+    'invalid provider response variant',
+  ],
+  ['StatusCode::BAD_GATEWAY', 'bad gateway status'],
+  [
+    '"commerce_store_payment_provider_invalid_response"',
+    'invalid provider response code',
+  ],
+  [
+    '"Payment provider returned an invalid response"',
+    'invalid provider response message',
+  ],
+  [
+    'PaymentError::ProviderOutcomeUnknown { .. }',
+    'unknown provider outcome variant',
+  ],
+  [
+    '"commerce_store_payment_reconciliation_required"',
+    'reconciliation code',
+  ],
+  ['"Payment state requires reconciliation"', 'reconciliation message'],
+  [
+    'PaymentError::ProviderConfiguration { .. }',
+    'provider configuration variant',
+  ],
+  [
+    '"commerce_store_payment_provider_not_configured"',
+    'provider configuration code',
+  ],
+  [
+    '"Payment provider is not configured for this tenant"',
+    'provider configuration message',
+  ],
+  ['PaymentError::Database(_)', 'database variant'],
+  ['"commerce_store_payment_unavailable"', 'database code'],
+  ['"Payment service is temporarily unavailable"', 'database message'],
+  ['"database"', 'database kind'],
+]) requireText(policy, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed payment cause log'],
+  ['owner = STOREFRONT_ORDER_PAYMENT_OWNER', 'owner log'],
+  ['tenant_id = %context.tenant_id', 'tenant log'],
+  ['actor_id = %context.actor_id', 'actor log'],
+  ['customer_id = %context.customer_id', 'customer log'],
+  ['order_id = %context.order_id', 'order log'],
+  [
+    'payment_collection_id = ?context.payment_collection_id',
+    'collection identity log',
+  ],
+  ['refund_id = ?context.refund_id', 'refund identity log'],
+  ['channel_id = ?context.channel_id', 'channel ID log'],
+  ['channel = ?context.channel_slug', 'channel slug log'],
+  ['locale = %context.locale', 'locale log'],
+  ['operation = %context.operation', 'operation log'],
+  ['error_kind,', 'error kind log'],
+  ['public_code = code', 'public code log'],
+  ['status = %status', 'status log'],
+  ['boundary = STOREFRONT_ORDER_PAYMENT_BOUNDARY', 'boundary log'],
+  ['HttpError::new(status, code, message)', 'stable public envelope'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  [') -> HttpResult<Uuid> {', 'ownership helper return type'],
+  ['Ok(customer_id)', 'verified customer return'],
+  ['.get_order(tenant_id, order_id)', 'order ownership read'],
+  ['order.customer_id != Some(customer_id)', 'ownership comparison'],
+  ['"commerce_store_customer_required"', 'customer-required envelope'],
+  ['"commerce_store_order_access_denied"', 'access-denied envelope'],
+]) requireText(ownership, value, label);
+
+for (const [value, label] of [
+  [
+    'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
+    'channel guard',
+  ],
+  ['let customer_id =', 'verified customer binding'],
+  [
+    'ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_refunds_access")',
+    'ownership helper call',
+  ],
+  ['PaymentService::new(runtime.db_clone())', 'payment service construction'],
+  ['.list_refunds(', 'refund list call'],
+  ['page: params.pagination.page,', 'page forwarding'],
+  ['per_page: params.pagination.per_page,', 'per-page forwarding'],
+  ['payment_collection_id: None,', 'collection filter contract'],
+  ['order_id: Some(id),', 'order filter contract'],
+  ['status: params.status,', 'status filter forwarding'],
+  ['StorefrontOrderPaymentErrorContext::new(', 'typed mapper context'],
+  ['tenant.id,', 'tenant context forwarding'],
+  ['auth.user_id,', 'actor context forwarding'],
+  ['customer_id,', 'customer context forwarding'],
+  ['id,', 'order context forwarding'],
+  ['&request_context,', 'request context forwarding'],
+  ['"list_order_refunds"', 'route operation'],
+  [
+    'PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)',
+    'pagination response contract',
+  ],
+]) requireText(refundRoute, value, label);
+
+for (const value of [
+  'Validation(String),',
+  'PaymentCollectionNotFound(Uuid),',
+  'PaymentNotFound(Uuid),',
+  'RefundNotFound(Uuid),',
+  'InvalidTransition { from: String, to: String },',
+  'ProviderUnavailable {',
+  'ProviderRejected {',
+  'ProviderInvalidResponse {',
+  'ProviderOutcomeUnknown {',
+  'ProviderConfiguration { provider_id: String },',
+  'Database(#[from] DbErr),',
+]) requireText(paymentErrors, value, 'payment source enum');
+
+const mapperUses = controller.match(/map_storefront_payment_error\(/g) ?? [];
+if (mapperUses.length !== 2) {
+  failures.push(
+    `expected payment mapper definition plus one route use, found ${mapperUses.length}`,
+  );
+}
+
+for (const value of [
+  'map_storefront_payment_error(error, "list_order_refunds", tenant.id, id)',
+  'error.to_string()',
+  'err.to_string()',
+  'error.message',
+  'HttpError::bad_request(error',
+  'HttpError::internal(error',
+]) forbidText(controller, value, 'stale or unsafe refund mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce storefront order-refund error-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront order refund failures retain typed route context and stable public contracts',
+);


### PR DESCRIPTION
## Summary

- replace the storefront order-refund payment mapper's tenant/order-only context with one typed context-aware HTTP mapper;
- retain the typed `PaymentError` with payment owner, tenant, actor, verified customer, order, truthful optional payment-collection and refund identities, channel id/slug, locale, exact operation, error kind, public code, status, and HTTP boundary;
- return the already verified customer ID from the ownership helper so the refund route does not perform a second customer lookup;
- preserve the existing validation, not-found, transition/provider-rejected, provider unavailable/invalid/configuration, reconciliation-required, and storage status/code/message contracts;
- preserve ownership checks, refund filters, pagination, service arguments, success response, all other storefront order routes, and the existing broad order guard;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/store/orders.rs`
- `scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is one commit directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files and retains five concurrent product/admin commits;
- production source was re-read to confirm one typed payment mapper callsite and exhaustive handling of all current `PaymentError` variants;
- `PaymentCollectionNotFound` and `PaymentNotFound` adopt the owner-provided collection identity, while `RefundNotFound` adopts the refund identity;
- ownership helper returns the already verified customer ID without changing access-denied behavior for other routes;
- the focused verifier was read statically to confirm source enum coverage, exact public policy, one route callsite, ownership/filter/pagination contracts, and stale/raw mapping prohibitions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
node scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```