### PR TITLE
Harden storefront line item owner context

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -76,6 +76,13 @@ available only for actionable domain errors.
   ownership helper returns the already verified customer identity without a second
   lookup, while filters, pagination, service arguments, responses, and existing payment
   status/code/message envelopes remain unchanged.
+- `rustok-commerce` storefront line-item owner reads: product persistence failures across
+  variant, product, and translation lookups retain tenant, truthful optional variant and
+  product identities, public-channel slug, locale when available, operation, stable code,
+  status, and HTTP boundary. Public-channel inventory failures retain variant and product
+  identities plus the same channel/locale context, while pricing keeps its existing
+  correlation-aware `PortContext`. Catalog lookup, visibility, pricing, availability,
+  title, shipping-profile, metadata, and public response contracts remain unchanged.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -193,6 +200,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs`
 - `node scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs`
 - `node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs`
+- `node scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
@@ -222,14 +230,14 @@ available only for actionable domain errors.
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, storefront staged checkout recovery, HTTP completion,
-  payment-collection and order-refund mapping, order payment settlement, order checkout
-  recovery, order checkout compensation, pricing, payment collection, fulfillment checkout
-  execution, admin fulfillment reconciliation, admin fulfillment routes, admin
-  shipping-option, admin order-route, admin checkout-operation, admin payment-route, admin
-  product-route and product shipping-profile prevalidation, order-change owner and
-  orchestration mapping, admin order-return owner and orchestration mapping, admin
-  order-detail payment and fulfillment mapping, and tax calculation validation,
-  provider-contract, reconciliation, correlation, HTTP-envelope, and transport round-trip
-  tests.
+  payment-collection, order-refund and line-item owner mapping, order payment settlement,
+  order checkout recovery, order checkout compensation, pricing, payment collection,
+  fulfillment checkout execution, admin fulfillment reconciliation, admin fulfillment
+  routes, admin shipping-option, admin order-route, admin checkout-operation, admin
+  payment-route, admin product-route and product shipping-profile prevalidation,
+  order-change owner and orchestration mapping, admin order-return owner and orchestration
+  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
+  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and
+  transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
+++ b/crates/rustok-commerce/src/controllers/store/line_item_resolution.rs
@@ -23,6 +23,8 @@ fn map_storefront_line_item_database_error(
     tenant_id: Uuid,
     variant_id: Option<Uuid>,
     product_id: Option<Uuid>,
+    public_channel_slug: Option<&str>,
+    locale: Option<&str>,
 ) -> HttpError {
     let status = axum::http::StatusCode::SERVICE_UNAVAILABLE;
     let code = "commerce_store_catalog_unavailable";
@@ -33,6 +35,8 @@ fn map_storefront_line_item_database_error(
         tenant_id = %tenant_id,
         variant_id = ?variant_id,
         product_id = ?product_id,
+        channel = ?public_channel_slug,
+        locale = ?locale,
         error_kind = "database",
         public_code = code,
         status = %status,
@@ -73,6 +77,9 @@ fn map_storefront_line_item_inventory_error(
     operation: &'static str,
     tenant_id: Uuid,
     variant_id: Uuid,
+    product_id: Uuid,
+    public_channel_slug: Option<&str>,
+    locale: Option<&str>,
 ) -> HttpError {
     let (status, code, message, error_kind) = match &error {
         CommerceError::Validation(_) => (
@@ -122,6 +129,9 @@ fn map_storefront_line_item_inventory_error(
         operation,
         tenant_id = %tenant_id,
         variant_id = %variant_id,
+        product_id = %product_id,
+        channel = ?public_channel_slug,
+        locale = ?locale,
         error_kind,
         public_code = code,
         status = %status,
@@ -156,6 +166,8 @@ pub(crate) async fn resolve_store_line_item_input(
                 tenant_id,
                 Some(input.variant_id),
                 None,
+                public_channel_slug,
+                Some(locale),
             )
         })?
         .ok_or(HttpError::not_found(
@@ -174,6 +186,8 @@ pub(crate) async fn resolve_store_line_item_input(
                 tenant_id,
                 Some(variant.id),
                 Some(variant.product_id),
+                public_channel_slug,
+                Some(locale),
             )
         })?
         .ok_or(HttpError::not_found(
@@ -201,6 +215,8 @@ pub(crate) async fn resolve_store_line_item_input(
                 tenant_id,
                 Some(variant.id),
                 Some(product_model.id),
+                public_channel_slug,
+                Some(locale),
             )
         })?;
     let variant_translation_models = variant_translation::Entity::find()
@@ -214,6 +230,8 @@ pub(crate) async fn resolve_store_line_item_input(
                 tenant_id,
                 Some(variant.id),
                 Some(product_model.id),
+                public_channel_slug,
+                Some(locale),
             )
         })?;
 
@@ -252,8 +270,15 @@ pub(crate) async fn resolve_store_line_item_input(
             input.quantity,
             &resolved_price,
         );
-    validate_store_variant_inventory(db, tenant_id, &variant, input.quantity, public_channel_slug)
-        .await?;
+    validate_store_variant_inventory(
+        db,
+        tenant_id,
+        &variant,
+        input.quantity,
+        public_channel_slug,
+        Some(locale),
+    )
+    .await?;
 
     let base_title = crate::controllers::store::pick_product_translation(
         &product_translation_models,
@@ -322,6 +347,8 @@ pub(crate) async fn validate_store_line_item_quantity(
                 tenant_id,
                 Some(variant_id),
                 None,
+                public_channel_slug,
+                None,
             )
         })?
         .ok_or(HttpError::not_found(
@@ -335,6 +362,7 @@ pub(crate) async fn validate_store_line_item_quantity(
         &variant,
         requested_quantity,
         public_channel_slug,
+        None,
     )
     .await
 }
@@ -345,6 +373,7 @@ async fn validate_store_variant_inventory(
     variant: &product_variant::Model,
     requested_quantity: i32,
     public_channel_slug: Option<&str>,
+    locale: Option<&str>,
 ) -> HttpResult<()> {
     let available = check_variant_availability_for_public_channel(
         db,
@@ -363,6 +392,9 @@ async fn validate_store_variant_inventory(
             "check_variant_availability",
             tenant_id,
             variant.id,
+            variant.product_id,
+            public_channel_slug,
+            locale,
         )
     })?;
     if !available {

--- a/scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const boundary = read(
+  'crates/rustok-commerce/src/controllers/store/line_item_resolution.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const databaseMapper = between(
+  boundary,
+  'fn map_storefront_line_item_database_error(',
+  'fn map_storefront_line_item_pricing_error(',
+  'database mapper',
+);
+const pricingMapper = between(
+  boundary,
+  'fn map_storefront_line_item_pricing_error(',
+  'fn map_storefront_line_item_inventory_error(',
+  'pricing mapper',
+);
+const inventoryMapper = between(
+  boundary,
+  'fn map_storefront_line_item_inventory_error(',
+  'pub(crate) async fn resolve_store_line_item_input(',
+  'inventory mapper',
+);
+const resolver = between(
+  boundary,
+  'pub(crate) async fn resolve_store_line_item_input(',
+  'pub(crate) async fn validate_store_line_item_quantity(',
+  'line item resolver',
+);
+const quantityValidator = between(
+  boundary,
+  'pub(crate) async fn validate_store_line_item_quantity(',
+  'async fn validate_store_variant_inventory(',
+  'quantity validator',
+);
+const inventoryValidator = from(
+  boundary,
+  'async fn validate_store_variant_inventory(',
+  'inventory validator',
+);
+
+for (const [value, label] of [
+  ['public_channel_slug: Option<&str>,', 'database channel parameter'],
+  ['locale: Option<&str>,', 'database locale parameter'],
+  ['owner = "rustok_product.persistence"', 'database owner'],
+  ['operation,', 'database operation'],
+  ['tenant_id = %tenant_id', 'database tenant'],
+  ['variant_id = ?variant_id', 'database variant identity'],
+  ['product_id = ?product_id', 'database product identity'],
+  ['channel = ?public_channel_slug', 'database channel log'],
+  ['locale = ?locale', 'database locale log'],
+  ['error_kind = "database"', 'database error kind'],
+  ['public_code = code', 'database public code'],
+  ['status = %status', 'database status'],
+  ['boundary = "commerce_storefront_line_item_http"', 'database boundary'],
+  ['"commerce_store_catalog_unavailable"', 'database public code value'],
+  ['"Store catalog is temporarily unavailable"', 'database public message'],
+]) requireText(databaseMapper, value, label);
+
+for (const [value, label] of [
+  ['context: &PortContext', 'pricing port context'],
+  ['correlation_id = %context.correlation_id', 'pricing correlation log'],
+  ['channel = ?context.channel', 'pricing channel log'],
+  ['variant_id = %variant_id', 'pricing variant identity'],
+  ['product_id = %product_id', 'pricing product identity'],
+  ['port_error_to_http_error(error.clone())', 'pricing public mapper'],
+]) requireText(pricingMapper, value, label);
+
+for (const [value, label] of [
+  ['product_id: Uuid,', 'inventory product parameter'],
+  ['public_channel_slug: Option<&str>,', 'inventory channel parameter'],
+  ['locale: Option<&str>,', 'inventory locale parameter'],
+  ['owner = "rustok_inventory.public_channel"', 'inventory owner'],
+  ['variant_id = %variant_id', 'inventory variant identity'],
+  ['product_id = %product_id', 'inventory product identity'],
+  ['channel = ?public_channel_slug', 'inventory channel log'],
+  ['locale = ?locale', 'inventory locale log'],
+  ['CommerceError::Validation(_)', 'inventory validation variant'],
+  ['CommerceError::ProductNotFound(_)', 'inventory product not found variant'],
+  ['CommerceError::VariantNotFound(_)', 'inventory variant not found variant'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'inventory profile not found variant'],
+  ['CommerceError::InsufficientInventory { .. }', 'inventory insufficient variant'],
+  ['CommerceError::Database(_)', 'inventory database variant'],
+  ['"commerce_store_inventory_invalid"', 'inventory invalid code'],
+  ['"commerce_store_not_found"', 'inventory not found code'],
+  ['"commerce_store_inventory_insufficient"', 'inventory insufficient code'],
+  ['"commerce_store_inventory_unavailable"', 'inventory unavailable code'],
+  ['"commerce_store_inventory_failed"', 'inventory fail closed code'],
+  ['HttpError::new(status, code, message)', 'inventory stable envelope'],
+]) requireText(inventoryMapper, value, label);
+
+for (const [value, label] of [
+  ['"load_variant"', 'variant database operation'],
+  ['"load_product"', 'product database operation'],
+  ['"load_product_translations"', 'product translation operation'],
+  ['"load_variant_translations"', 'variant translation operation'],
+  ['public_channel_slug,\n                Some(locale),', 'localized database context'],
+  ['store_line_item_pricing_port_context(', 'pricing context construction'],
+  ['pricing_port_context.clone()', 'pricing context forwarding'],
+  ['map_storefront_line_item_pricing_error(', 'pricing mapper call'],
+  ['validate_store_variant_inventory(', 'inventory validation call'],
+  ['public_channel_slug,\n        Some(locale),', 'localized inventory context'],
+  ['product_model.status != product::ProductStatus::Active', 'active product guard'],
+  ['product_model.published_at.is_none()', 'published product guard'],
+  ['is_metadata_visible_for_public_channel', 'channel visibility guard'],
+  ['pick_product_translation(', 'product translation fallback'],
+  ['pick_variant_translation(', 'variant translation fallback'],
+  ['effective_shipping_profile_slug(', 'shipping profile resolution'],
+  ['seller_snapshot_metadata(', 'seller metadata'],
+  ['merge_metadata(', 'metadata merge'],
+]) requireText(resolver, value, label);
+
+for (const [value, label] of [
+  ['"load_variant_for_quantity_validation"', 'quantity database operation'],
+  ['public_channel_slug,\n                None,', 'quantity database context'],
+  ['validate_store_variant_inventory(', 'quantity inventory validation'],
+  ['public_channel_slug,\n        None,', 'quantity inventory context'],
+  ['"commerce_store_not_found"', 'quantity not found code'],
+]) requireText(quantityValidator, value, label);
+
+for (const [value, label] of [
+  ['locale: Option<&str>,', 'inventory validator locale'],
+  ['check_variant_availability_for_public_channel(', 'inventory owner call'],
+  ['variant_id: variant.id', 'inventory variant forwarding'],
+  ['inventory_policy: &variant.inventory_policy', 'inventory policy forwarding'],
+  ['requested_quantity,', 'requested quantity forwarding'],
+  ['public_channel_slug,', 'public channel forwarding'],
+  ['"check_variant_availability"', 'inventory operation'],
+  ['variant.product_id,', 'inventory product identity forwarding'],
+  ['locale,', 'inventory locale forwarding'],
+  ['"Requested quantity is not available"', 'insufficient response message'],
+]) requireText(inventoryValidator, value, label);
+
+const databaseMapperUses =
+  boundary.match(/map_storefront_line_item_database_error\(/g) ?? [];
+if (databaseMapperUses.length !== 6) {
+  failures.push(
+    `expected database mapper definition plus five uses, found ${databaseMapperUses.length}`,
+  );
+}
+const inventoryMapperUses =
+  boundary.match(/map_storefront_line_item_inventory_error\(/g) ?? [];
+if (inventoryMapperUses.length !== 2) {
+  failures.push(
+    `expected inventory mapper definition plus one use, found ${inventoryMapperUses.length}`,
+  );
+}
+const localizedDatabaseContexts =
+  resolver.match(/public_channel_slug,\s+Some\(locale\),/g) ?? [];
+if (localizedDatabaseContexts.length !== 5) {
+  failures.push(
+    `expected four localized database contexts plus one inventory context, found ${localizedDatabaseContexts.length}`,
+  );
+}
+
+for (const value of [
+  'err.to_string()',
+  'error.to_string()',
+  'error.message',
+  'HttpError::bad_request("commerce_store_invalid", error',
+  'HttpError::bad_request("commerce_store_invalid", err',
+  'eprintln!(',
+  'dbg!(',
+]) forbidText(boundary, value, 'unsafe line item mapping');
+
+if (failures.length > 0) {
+  console.error('Commerce storefront line-item owner-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront line-item catalog and inventory failures retain channel, locale, and owner identities',
+);


### PR DESCRIPTION
## Summary

- add public-channel slug and locale context to all storefront line-item product-persistence failure mappings;
- add truthful product identity plus channel/locale context to public-channel inventory failure mapping;
- preserve the existing correlation-aware pricing `PortContext` path;
- preserve catalog reads, tenant filters, visibility guards, pricing arguments, inventory availability checks, title/shipping-profile/metadata construction, and public status/code/message contracts;
- add a focused verifier and update the ecommerce public-error safety plan.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/store/line_item_resolution.rs`
- `scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Validation

- branch is directly ahead of current `main` and is not behind;
- production diff is limited to context propagation and structured logging fields;
- source was re-read to confirm five database mapper callsites, one inventory mapper callsite, four localized catalog mappings, localized add-line inventory validation, and channel-only quantity validation;
- existing pricing correlation/channel logging and all public envelopes remain unchanged;
- the focused verifier was read statically to confirm exact source markers, mapper counts, context propagation, owner identities, stable public contracts, and unsafe conversion prohibitions;
- the existing broad line-item verifier remains compatible because mapper names, typed variants, stable codes/messages, and required log fields are preserved;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs
node scripts/verify/verify-commerce-storefront-line-item-http-error-safety.mjs
cargo check -p rustok-commerce --lib
```