### PR TITLE
Harden GraphQL order and shipping helper context

### DIFF
--- a/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
@@ -7,6 +7,74 @@ pub(crate) use super::cart_safe_helpers::*;
 use crate::storefront_shipping::normalize_shipping_profile_slug;
 use crate::{CommerceError, ShippingProfileService};
 
+const STOREFRONT_ORDER_GRAPHQL_OWNER: &str = "rustok_order.storefront_access";
+const SHIPPING_PROFILE_GRAPHQL_OWNER: &str = "rustok_commerce.shipping_profiles";
+const STOREFRONT_GRAPHQL_HELPER_BOUNDARY: &str = "commerce_storefront_graphql_helper";
+
+type StorefrontGraphqlPolicy = (&'static str, &'static str, bool, &'static str);
+
+#[derive(Clone, Copy)]
+struct StorefrontOrderGraphqlErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    customer_id: Uuid,
+    order_id: Option<Uuid>,
+    order_return_id: Option<Uuid>,
+    order_change_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl StorefrontOrderGraphqlErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        customer_id: Uuid,
+        order_id: Uuid,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            customer_id,
+            order_id: Some(order_id),
+            order_return_id: None,
+            order_change_id: None,
+            operation,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ShippingProfileGraphqlErrorContext<'a> {
+    tenant_id: Uuid,
+    requested_slug: Option<&'a str>,
+    requested_profile_count: Option<usize>,
+    shipping_profile_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl<'a> ShippingProfileGraphqlErrorContext<'a> {
+    fn single(tenant_id: Uuid, requested_slug: &'a str, operation: &'static str) -> Self {
+        Self {
+            tenant_id,
+            requested_slug: Some(requested_slug),
+            requested_profile_count: Some(1),
+            shipping_profile_id: None,
+            operation,
+        }
+    }
+
+    fn batch(tenant_id: Uuid, requested_profile_count: usize, operation: &'static str) -> Self {
+        Self {
+            tenant_id,
+            requested_slug: None,
+            requested_profile_count: Some(requested_profile_count),
+            shipping_profile_id: None,
+            operation,
+        }
+    }
+}
+
 fn public_graphql_error(
     message: &'static str,
     code: &'static str,
@@ -18,84 +86,139 @@ fn public_graphql_error(
     })
 }
 
-fn order_graphql_error(
-    tenant_id: Uuid,
-    order_id: Uuid,
-    operation: &'static str,
-    error: OrderError,
-) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        order_id = %order_id,
-        operation,
-        "commerce GraphQL storefront order helper failed"
-    );
-
-    let (message, code, retryable) = match &error {
-        OrderError::Validation(_) => ("Order request is invalid", "ORDER_REQUEST_INVALID", false),
-        OrderError::OrderNotFound(_)
-        | OrderError::OrderReturnNotFound(_)
-        | OrderError::OrderChangeNotFound(_) => (
-            "Order resource was not found",
-            "ORDER_RESOURCE_NOT_FOUND",
+fn storefront_order_graphql_error_policy(
+    context: &mut StorefrontOrderGraphqlErrorContext,
+    error: &OrderError,
+) -> StorefrontGraphqlPolicy {
+    match error {
+        OrderError::Validation(_) => (
+            "Order request is invalid",
+            "ORDER_REQUEST_INVALID",
             false,
+            "validation",
         ),
+        OrderError::OrderNotFound(order_id) => {
+            context.order_id = Some(*order_id);
+            (
+                "Order resource was not found",
+                "ORDER_RESOURCE_NOT_FOUND",
+                false,
+                "order_not_found",
+            )
+        }
+        OrderError::OrderReturnNotFound(order_return_id) => {
+            context.order_return_id = Some(*order_return_id);
+            (
+                "Order resource was not found",
+                "ORDER_RESOURCE_NOT_FOUND",
+                false,
+                "order_return_not_found",
+            )
+        }
+        OrderError::OrderChangeNotFound(order_change_id) => {
+            context.order_change_id = Some(*order_change_id);
+            (
+                "Order resource was not found",
+                "ORDER_RESOURCE_NOT_FOUND",
+                false,
+                "order_change_not_found",
+            )
+        }
         OrderError::InvalidTransition { .. } => (
             "Order operation conflicts with the current state",
             "ORDER_STATE_CONFLICT",
             false,
+            "state_conflict",
         ),
         OrderError::Database(_) => (
             "Order service is temporarily unavailable",
             "ORDER_TEMPORARILY_UNAVAILABLE",
             true,
+            "database",
         ),
         OrderError::Core(_) => (
             "Order operation could not be completed safely",
             "ORDER_OPERATION_FAILED",
             false,
+            "core",
         ),
-    };
+    }
+}
 
+fn order_graphql_error(
+    mut context: StorefrontOrderGraphqlErrorContext,
+    error: OrderError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) =
+        storefront_order_graphql_error_policy(&mut context, &error);
+    tracing::error!(
+        error = ?error,
+        owner = STOREFRONT_ORDER_GRAPHQL_OWNER,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        customer_id = %context.customer_id,
+        order_id = ?context.order_id,
+        order_return_id = ?context.order_return_id,
+        order_change_id = ?context.order_change_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = STOREFRONT_GRAPHQL_HELPER_BOUNDARY,
+        "commerce GraphQL storefront order helper failed"
+    );
     public_graphql_error(message, code, retryable)
 }
 
-fn shipping_profile_graphql_error(
-    tenant_id: Uuid,
-    operation: &'static str,
-    error: CommerceError,
-) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        operation,
-        "commerce GraphQL shipping profile helper failed"
-    );
-
-    let (message, code, retryable) = match &error {
-        CommerceError::Validation(_)
-        | CommerceError::InvalidPrice(_)
-        | CommerceError::InvalidOptionCombination
-        | CommerceError::NoVariants => (
+fn shipping_profile_graphql_error_policy(
+    context: &mut ShippingProfileGraphqlErrorContext<'_>,
+    error: &CommerceError,
+) -> StorefrontGraphqlPolicy {
+    match error {
+        CommerceError::Validation(_) => (
             "Shipping profile request is invalid",
             "SHIPPING_PROFILE_REQUEST_INVALID",
             false,
+            "validation",
         ),
-        CommerceError::ShippingProfileNotFound(_) => (
-            "Shipping profile was not found",
-            "SHIPPING_PROFILE_NOT_FOUND",
+        CommerceError::InvalidPrice(_) => (
+            "Shipping profile request is invalid",
+            "SHIPPING_PROFILE_REQUEST_INVALID",
             false,
+            "invalid_price",
         ),
+        CommerceError::InvalidOptionCombination => (
+            "Shipping profile request is invalid",
+            "SHIPPING_PROFILE_REQUEST_INVALID",
+            false,
+            "invalid_option_combination",
+        ),
+        CommerceError::NoVariants => (
+            "Shipping profile request is invalid",
+            "SHIPPING_PROFILE_REQUEST_INVALID",
+            false,
+            "no_variants",
+        ),
+        CommerceError::ShippingProfileNotFound(shipping_profile_id) => {
+            context.shipping_profile_id = Some(*shipping_profile_id);
+            (
+                "Shipping profile was not found",
+                "SHIPPING_PROFILE_NOT_FOUND",
+                false,
+                "shipping_profile_not_found",
+            )
+        }
         CommerceError::DuplicateShippingProfileSlug(_) => (
             "Shipping profile conflicts with the current state",
             "SHIPPING_PROFILE_STATE_CONFLICT",
             false,
+            "duplicate_shipping_profile_slug",
         ),
         CommerceError::Database(_) => (
             "Shipping profile service is temporarily unavailable",
             "SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE",
             true,
+            "database",
         ),
         CommerceError::ProductNotFound(_)
         | CommerceError::VariantNotFound(_)
@@ -108,9 +231,31 @@ fn shipping_profile_graphql_error(
             "Shipping profile operation could not be completed safely",
             "SHIPPING_PROFILE_OPERATION_FAILED",
             false,
+            "unexpected_owner_error",
         ),
-    };
+    }
+}
 
+fn shipping_profile_graphql_error(
+    mut context: ShippingProfileGraphqlErrorContext<'_>,
+    error: CommerceError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) =
+        shipping_profile_graphql_error_policy(&mut context, &error);
+    tracing::error!(
+        error = ?error,
+        owner = SHIPPING_PROFILE_GRAPHQL_OWNER,
+        tenant_id = %context.tenant_id,
+        requested_slug = ?context.requested_slug,
+        requested_profile_count = ?context.requested_profile_count,
+        shipping_profile_id = ?context.shipping_profile_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = STOREFRONT_GRAPHQL_HELPER_BOUNDARY,
+        "commerce GraphQL shipping profile helper failed"
+    );
     public_graphql_error(message, code, retryable)
 }
 
@@ -136,7 +281,16 @@ pub(crate) async fn ensure_storefront_order_access(
         .get_order(tenant_id, order_id)
         .await
         .map_err(|error| {
-            order_graphql_error(tenant_id, order_id, "ensure_storefront_order_access", error)
+            order_graphql_error(
+                StorefrontOrderGraphqlErrorContext::new(
+                    tenant_id,
+                    auth.user_id,
+                    customer_id,
+                    order_id,
+                    "ensure_storefront_order_access",
+                ),
+                error,
+            )
         })?;
 
     if order.customer_id != Some(customer_id) {
@@ -153,7 +307,7 @@ pub(crate) async fn validate_product_shipping_profile_input(
     tenant_id: Uuid,
     shipping_profile_slug: Option<&str>,
 ) -> Result<()> {
-    let Some(slug) = shipping_profile_slug.and_then(|s| normalize_shipping_profile_slug(s)) else {
+    let Some(slug) = shipping_profile_slug.and_then(normalize_shipping_profile_slug) else {
         return Ok(());
     };
 
@@ -162,8 +316,11 @@ pub(crate) async fn validate_product_shipping_profile_input(
         .await
         .map_err(|error| {
             shipping_profile_graphql_error(
-                tenant_id,
-                "validate_product_shipping_profile_input",
+                ShippingProfileGraphqlErrorContext::single(
+                    tenant_id,
+                    &slug,
+                    "validate_product_shipping_profile_input",
+                ),
                 error,
             )
         })?;
@@ -185,8 +342,11 @@ pub(crate) async fn validate_shipping_option_profile_inputs(
         .await
         .map_err(|error| {
             shipping_profile_graphql_error(
-                tenant_id,
-                "validate_shipping_option_profile_inputs",
+                ShippingProfileGraphqlErrorContext::batch(
+                    tenant_id,
+                    slugs.len(),
+                    "validate_shipping_option_profile_inputs",
+                ),
                 error,
             )
         })?;

--- a/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
@@ -105,6 +105,12 @@ for (const [value, label] of [
 ]) requireText(facadeSource, value, label);
 
 for (const [value, label] of [
+  ['async_graphql::Error::new(message)', 'static GraphQL public message'],
+  ['extensions.set("code", code)', 'GraphQL public code extension'],
+  ['extensions.set("retryable", retryable)', 'GraphQL retryability extension'],
+]) requireText(facadeSource, value, label);
+
+for (const [value, label] of [
   ['OrderError::Validation(_)', 'order validation mapping'],
   ['OrderError::OrderNotFound(order_id)', 'order not-found mapping'],
   ['context.order_id = Some(*order_id);', 'typed order identity adoption'],

--- a/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
@@ -11,6 +11,8 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 const moduleSource = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
 const facadeSource = read('crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs');
+const orderErrors = read('crates/rustok-order/src/error.rs');
+const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const failures = [];
 
 const requireText = (source, value, label) => {
@@ -19,71 +21,254 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const orderPolicy = between(
+  facadeSource,
+  'fn storefront_order_graphql_error_policy(',
+  'fn order_graphql_error(',
+  'order GraphQL policy',
+);
+const orderMapper = between(
+  facadeSource,
+  'fn order_graphql_error(',
+  'fn shipping_profile_graphql_error_policy(',
+  'order GraphQL mapper',
+);
+const shippingPolicy = between(
+  facadeSource,
+  'fn shipping_profile_graphql_error_policy(',
+  'fn shipping_profile_graphql_error(',
+  'shipping-profile GraphQL policy',
+);
+const shippingMapper = between(
+  facadeSource,
+  'fn shipping_profile_graphql_error(',
+  'pub(crate) async fn ensure_storefront_order_access(',
+  'shipping-profile GraphQL mapper',
+);
+const orderAccess = between(
+  facadeSource,
+  'pub(crate) async fn ensure_storefront_order_access(',
+  'pub(crate) async fn validate_product_shipping_profile_input(',
+  'storefront order access helper',
+);
+const productValidation = between(
+  facadeSource,
+  'pub(crate) async fn validate_product_shipping_profile_input(',
+  'pub(crate) async fn validate_shipping_option_profile_inputs(',
+  'product shipping-profile helper',
+);
+const optionValidation = facadeSource.slice(
+  facadeSource.indexOf('pub(crate) async fn validate_shipping_option_profile_inputs('),
+);
 
 for (const [value, label] of [
   ['#[path = "safe_helpers.rs"]\nmod cart_safe_helpers;', 'private cart facade routing'],
   ['#[path = "safe_order_helpers.rs"]\npub mod helpers;', 'public order facade routing'],
-]) {
-  requireText(moduleSource, value, label);
-}
+]) requireText(moduleSource, value, label);
+
+for (const [value, label] of [
+  [
+    'const STOREFRONT_ORDER_GRAPHQL_OWNER: &str = "rustok_order.storefront_access";',
+    'order owner constant',
+  ],
+  [
+    'const SHIPPING_PROFILE_GRAPHQL_OWNER: &str = "rustok_commerce.shipping_profiles";',
+    'shipping owner constant',
+  ],
+  [
+    'const STOREFRONT_GRAPHQL_HELPER_BOUNDARY: &str = "commerce_storefront_graphql_helper";',
+    'GraphQL helper boundary',
+  ],
+  ['type StorefrontGraphqlPolicy = (', 'GraphQL policy type'],
+  ['struct StorefrontOrderGraphqlErrorContext {', 'typed order context'],
+  ['actor_id: Uuid,', 'order actor context'],
+  ['customer_id: Uuid,', 'order customer context'],
+  ['order_id: Option<Uuid>,', 'order identity context'],
+  ['order_return_id: Option<Uuid>,', 'order-return identity context'],
+  ['order_change_id: Option<Uuid>,', 'order-change identity context'],
+  ['struct ShippingProfileGraphqlErrorContext<\'a> {', 'typed shipping context'],
+  ['requested_slug: Option<&\'a str>,', 'requested slug context'],
+  ['requested_profile_count: Option<usize>,', 'requested profile count'],
+  ['shipping_profile_id: Option<Uuid>,', 'shipping-profile identity context'],
+  ['fn single(', 'single-profile context constructor'],
+  ['fn batch(', 'batch-profile context constructor'],
+]) requireText(facadeSource, value, label);
+
+for (const [value, label] of [
+  ['OrderError::Validation(_)', 'order validation mapping'],
+  ['OrderError::OrderNotFound(order_id)', 'order not-found mapping'],
+  ['context.order_id = Some(*order_id);', 'typed order identity adoption'],
+  ['OrderError::OrderReturnNotFound(order_return_id)', 'order-return mapping'],
+  ['context.order_return_id = Some(*order_return_id);', 'typed return identity adoption'],
+  ['OrderError::OrderChangeNotFound(order_change_id)', 'order-change mapping'],
+  ['context.order_change_id = Some(*order_change_id);', 'typed change identity adoption'],
+  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
+  ['OrderError::Database(_)', 'order database mapping'],
+  ['OrderError::Core(_)', 'order fallback mapping'],
+  ['"Order request is invalid"', 'order validation message'],
+  ['"ORDER_REQUEST_INVALID"', 'order validation code'],
+  ['"Order resource was not found"', 'order not-found message'],
+  ['"ORDER_RESOURCE_NOT_FOUND"', 'order not-found code'],
+  ['"Order operation conflicts with the current state"', 'order conflict message'],
+  ['"ORDER_STATE_CONFLICT"', 'order conflict code'],
+  ['"Order service is temporarily unavailable"', 'order availability message'],
+  ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order availability code'],
+  ['"Order operation could not be completed safely"', 'order fallback message'],
+  ['"ORDER_OPERATION_FAILED"', 'order fallback code'],
+]) requireText(orderPolicy, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed order cause log'],
+  ['owner = STOREFRONT_ORDER_GRAPHQL_OWNER', 'order owner log'],
+  ['tenant_id = %context.tenant_id', 'order tenant log'],
+  ['actor_id = %context.actor_id', 'order actor log'],
+  ['customer_id = %context.customer_id', 'order customer log'],
+  ['order_id = ?context.order_id', 'order identity log'],
+  ['order_return_id = ?context.order_return_id', 'return identity log'],
+  ['order_change_id = ?context.order_change_id', 'change identity log'],
+  ['operation = %context.operation', 'order operation log'],
+  ['error_kind,', 'order error-kind log'],
+  ['public_code = code', 'order public-code log'],
+  ['retryable,', 'order retryability log'],
+  ['boundary = STOREFRONT_GRAPHQL_HELPER_BOUNDARY', 'order boundary log'],
+  ['public_graphql_error(message, code, retryable)', 'order public envelope'],
+]) requireText(orderMapper, value, label);
+
+for (const [value, label] of [
+  ['CommerceError::Validation(_)', 'shipping validation mapping'],
+  ['CommerceError::InvalidPrice(_)', 'shipping price mapping'],
+  ['CommerceError::InvalidOptionCombination', 'shipping option mapping'],
+  ['CommerceError::NoVariants', 'shipping no-variants mapping'],
+  [
+    'CommerceError::ShippingProfileNotFound(shipping_profile_id)',
+    'shipping not-found mapping',
+  ],
+  [
+    'context.shipping_profile_id = Some(*shipping_profile_id);',
+    'typed shipping identity adoption',
+  ],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping conflict mapping'],
+  ['CommerceError::Database(_)', 'shipping database mapping'],
+  ['CommerceError::ProductNotFound(_)', 'shipping fail-closed product mapping'],
+  ['CommerceError::VariantNotFound(_)', 'shipping fail-closed variant mapping'],
+  ['CommerceError::DuplicateHandle { .. }', 'shipping duplicate handle fallback'],
+  ['CommerceError::DuplicateSku(_)', 'shipping duplicate SKU fallback'],
+  ['CommerceError::InsufficientInventory { .. }', 'shipping inventory fallback'],
+  ['CommerceError::CannotDeletePublished', 'shipping state fallback'],
+  ['CommerceError::Rich(_)', 'shipping rich fallback'],
+  ['CommerceError::Core(_)', 'shipping core fallback'],
+  ['"Shipping profile request is invalid"', 'shipping validation message'],
+  ['"SHIPPING_PROFILE_REQUEST_INVALID"', 'shipping validation code'],
+  ['"Shipping profile was not found"', 'shipping not-found message'],
+  ['"SHIPPING_PROFILE_NOT_FOUND"', 'shipping not-found code'],
+  ['"Shipping profile conflicts with the current state"', 'shipping conflict message'],
+  ['"SHIPPING_PROFILE_STATE_CONFLICT"', 'shipping conflict code'],
+  ['"Shipping profile service is temporarily unavailable"', 'shipping availability message'],
+  ['"SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE"', 'shipping availability code'],
+  [
+    '"Shipping profile operation could not be completed safely"',
+    'shipping fallback message',
+  ],
+  ['"SHIPPING_PROFILE_OPERATION_FAILED"', 'shipping fallback code'],
+]) requireText(shippingPolicy, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'typed shipping cause log'],
+  ['owner = SHIPPING_PROFILE_GRAPHQL_OWNER', 'shipping owner log'],
+  ['tenant_id = %context.tenant_id', 'shipping tenant log'],
+  ['requested_slug = ?context.requested_slug', 'requested slug log'],
+  ['requested_profile_count = ?context.requested_profile_count', 'profile count log'],
+  ['shipping_profile_id = ?context.shipping_profile_id', 'shipping identity log'],
+  ['operation = %context.operation', 'shipping operation log'],
+  ['error_kind,', 'shipping error-kind log'],
+  ['public_code = code', 'shipping public-code log'],
+  ['retryable,', 'shipping retryability log'],
+  ['boundary = STOREFRONT_GRAPHQL_HELPER_BOUNDARY', 'shipping boundary log'],
+  ['public_graphql_error(message, code, retryable)', 'shipping public envelope'],
+]) requireText(shippingMapper, value, label);
+
+for (const [value, label] of [
+  ['ctx.data::<AuthContext>()', 'authenticated actor lookup'],
+  ['resolve_optional_storefront_customer_id(', 'safe customer lookup reuse'],
+  ['Some(auth),', 'authenticated customer context'],
+  ['OrderService::new(db.clone(), event_bus.clone())', 'order service construction'],
+  ['.get_order(tenant_id, order_id)', 'order owner call'],
+  ['StorefrontOrderGraphqlErrorContext::new(', 'typed order mapper context'],
+  ['auth.user_id,', 'actor identity forwarding'],
+  ['customer_id,', 'customer identity forwarding'],
+  ['"ensure_storefront_order_access"', 'order operation'],
+  ['order.customer_id != Some(customer_id)', 'ownership comparison'],
+  ['GraphQLError>::permission_denied(', 'ownership denial contract'],
+]) requireText(orderAccess, value, label);
+
+for (const [value, label] of [
+  ['shipping_profile_slug.and_then(normalize_shipping_profile_slug)', 'slug normalization'],
+  ['ShippingProfileService::new(db.clone())', 'shipping service construction'],
+  ['.ensure_shipping_profile_slug_exists(tenant_id, &slug)', 'single slug owner call'],
+  ['ShippingProfileGraphqlErrorContext::single(', 'single shipping context'],
+  ['&slug,', 'normalized slug context'],
+  ['"validate_product_shipping_profile_input"', 'single validation operation'],
+]) requireText(productValidation, value, label);
+
+for (const [value, label] of [
+  ['let Some(slugs) = allowed_shipping_profile_slugs else', 'absent batch no-op'],
+  ['ShippingProfileService::new(db.clone())', 'batch service construction'],
+  ['.ensure_shipping_profile_slugs_exist(tenant_id, slugs.iter())', 'batch owner call'],
+  ['ShippingProfileGraphqlErrorContext::batch(', 'batch shipping context'],
+  ['slugs.len(),', 'batch profile count'],
+  ['"validate_shipping_option_profile_inputs"', 'batch validation operation'],
+]) requireText(optionValidation, value, label);
+
+for (const [ownerSource, value, label] of [
+  [orderErrors, 'Validation(String)', 'owner order validation variant'],
+  [orderErrors, 'OrderNotFound(Uuid)', 'owner order-not-found variant'],
+  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
+  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
+  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner transition variant'],
+  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
+  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
+  [commerceErrors, 'ShippingProfileNotFound(Uuid)', 'owner shipping not-found variant'],
+  [commerceErrors, 'DuplicateShippingProfileSlug(String)', 'owner shipping conflict variant'],
+  [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'owner commerce database variant'],
+  [commerceErrors, 'Rich(#[source] Box<RichError>)', 'owner commerce rich variant'],
+  [commerceErrors, 'Core(#[from] CoreError)', 'owner commerce core variant'],
+]) requireText(ownerSource, value, label);
 
 for (const value of [
   'async_graphql::Error::new(error.message)',
   'async_graphql::Error::new(error.to_string())',
   'async_graphql::Error::new(format!("{error}"))',
+  'public_graphql_error(error',
+  'error.message',
+  'err.to_string()',
+  'eprintln!(',
+  'dbg!(',
   'ensure_storefront_order_access,',
   'validate_product_shipping_profile_input,',
   'validate_shipping_option_profile_inputs,',
-]) {
-  forbidText(facadeSource, value, 'order and shipping safe helper facade');
-}
-
-for (const [value, label] of [
-  ['fn order_graphql_error(', 'order mapper'],
-  ['OrderError::Validation(_)', 'order validation mapping'],
-  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
-  ['OrderError::OrderReturnNotFound(_)', 'order-return not-found mapping'],
-  ['OrderError::OrderChangeNotFound(_)', 'order-change not-found mapping'],
-  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
-  ['OrderError::Database(_)', 'order database mapping'],
-  ['OrderError::Core(_)', 'order fallback mapping'],
-  ['"ORDER_REQUEST_INVALID"', 'order validation code'],
-  ['"ORDER_RESOURCE_NOT_FOUND"', 'order not-found code'],
-  ['"ORDER_STATE_CONFLICT"', 'order conflict code'],
-  ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order availability code'],
-  ['"ORDER_OPERATION_FAILED"', 'order fallback code'],
-  ['fn shipping_profile_graphql_error(', 'shipping-profile mapper'],
-  ['CommerceError::Validation(_)', 'shipping validation mapping'],
-  ['CommerceError::ShippingProfileNotFound(_)', 'shipping not-found mapping'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping conflict mapping'],
-  ['CommerceError::Database(_)', 'shipping database mapping'],
-  ['CommerceError::Rich(_)', 'shipping rich fallback mapping'],
-  ['CommerceError::Core(_)', 'shipping core fallback mapping'],
-  ['"SHIPPING_PROFILE_REQUEST_INVALID"', 'shipping validation code'],
-  ['"SHIPPING_PROFILE_NOT_FOUND"', 'shipping not-found code'],
-  ['"SHIPPING_PROFILE_STATE_CONFLICT"', 'shipping conflict code'],
-  ['"SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE"', 'shipping availability code'],
-  ['"SHIPPING_PROFILE_OPERATION_FAILED"', 'shipping fallback code'],
-  ['super::cart_safe_helpers::resolve_optional_storefront_customer_id(', 'safe customer lookup reuse'],
-  ['pub(crate) async fn ensure_storefront_order_access(', 'safe order-access helper'],
-  ['pub(crate) async fn validate_product_shipping_profile_input(', 'safe product shipping helper'],
-  ['pub(crate) async fn validate_shipping_option_profile_inputs(', 'safe option shipping helper'],
-  ['tenant_id = %tenant_id', 'tenant logging'],
-  ['order_id = %order_id', 'order logging'],
-  ['operation,', 'operation logging'],
-  ['extensions.set("retryable", retryable)', 'retryability extension'],
-]) {
-  requireText(facadeSource, value, label);
-}
+]) forbidText(facadeSource, value, 'order and shipping safe helper facade');
 
 const orderMapperCalls = facadeSource.match(/order_graphql_error\(/g) ?? [];
 if (orderMapperCalls.length !== 2) {
   failures.push(`expected order mapper definition plus one call, found ${orderMapperCalls.length}`);
 }
-
 const shippingMapperCalls = facadeSource.match(/shipping_profile_graphql_error\(/g) ?? [];
 if (shippingMapperCalls.length !== 3) {
   failures.push(`expected shipping mapper definition plus two calls, found ${shippingMapperCalls.length}`);
+}
+const publicEnvelopeCalls = facadeSource.match(/public_graphql_error\(/g) ?? [];
+if (publicEnvelopeCalls.length !== 3) {
+  failures.push(`expected public envelope definition plus two mapper calls, found ${publicEnvelopeCalls.length}`);
 }
 
 if (failures.length > 0) {
@@ -93,5 +278,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL order access and shipping-profile helpers expose stable public envelopes with internal structured logs',
+  '✔ Commerce GraphQL order access and shipping-profile helpers retain typed context and stable public envelopes',
 );


### PR DESCRIPTION
## Summary

- add typed GraphQL error contexts for storefront order access and shipping-profile validation helpers;
- retain owner, tenant, actor, verified customer, truthful optional order/return/change/profile identities, requested slug or batch count, operation, error kind, stable public code, retryability, and GraphQL boundary;
- preserve every existing GraphQL message/code/retryable contract;
- preserve authentication, customer lookup, order ownership, slug normalization, shipping-profile service calls, helper signatures, and facade routing;
- strengthen the existing source verifier instead of adding a duplicate guard.

## Scope

Two files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs`
- `scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs`

## Validation

- branch is directly ahead of current `main` and is not behind;
- production source was re-read to confirm exhaustive current `OrderError` and `CommerceError` handling;
- typed `OrderNotFound`, `OrderReturnNotFound`, `OrderChangeNotFound`, and `ShippingProfileNotFound` identities are adopted from owner errors;
- order access passes authenticated actor and verified customer identity without a second lookup;
- single shipping validation records the normalized slug, while batch validation records only the truthful profile count;
- external helper signatures, service arguments, ownership checks, public GraphQL extensions, and facade exports remain unchanged;
- the verifier was read statically to confirm policy, context, mapper counts, source enum markers, and unsafe dynamic error prohibitions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-order-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```