### PR TITLE
Harden GraphQL cart helper diagnostics

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -83,6 +83,14 @@ available only for actionable domain errors.
   identities plus the same channel/locale context, while pricing keeps its existing
   correlation-aware `PortContext`. Catalog lookup, visibility, pricing, availability,
   title, shipping-profile, metadata, and public response contracts remain unchanged.
+- `rustok-commerce` GraphQL storefront cart helper facade: customer and cart owner-port
+  failures plus the intercepted legacy enrichment, shipping, line-item, pricing, and
+  inventory helper failures retain the original cause only in structured diagnostics.
+  Every diagnostic records an explicit owner, operation, stable public code and
+  retryability, and one GraphQL transport boundary; customer reads also retain their
+  canonical correlation and tenant identity, while legacy helpers retain truthful tenant
+  and resource identity. Existing GraphQL messages, codes, retryability, layered routing,
+  and helper call behavior remain unchanged.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -201,6 +209,7 @@ available only for actionable domain errors.
 - `node scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs`
 - `node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs`
 - `node scripts/verify/verify-commerce-storefront-line-item-owner-context.mjs`
+- `node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
 - `node scripts/verify/verify-cart-promotion-port-error-safety.mjs`
 - `node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`
 - `node scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
@@ -230,14 +239,14 @@ available only for actionable domain errors.
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, storefront staged checkout recovery, HTTP completion,
-  payment-collection, order-refund and line-item owner mapping, order payment settlement,
-  order checkout recovery, order checkout compensation, pricing, payment collection,
-  fulfillment checkout execution, admin fulfillment reconciliation, admin fulfillment
-  routes, admin shipping-option, admin order-route, admin checkout-operation, admin
-  payment-route, admin product-route and product shipping-profile prevalidation,
-  order-change owner and orchestration mapping, admin order-return owner and orchestration
-  mapping, admin order-detail payment and fulfillment mapping, and tax calculation
-  validation, provider-contract, reconciliation, correlation, HTTP-envelope, and
-  transport round-trip tests.
+  payment-collection, order-refund and line-item owner mapping, GraphQL storefront cart
+  helper diagnostics, order payment settlement, order checkout recovery, order checkout
+  compensation, pricing, payment collection, fulfillment checkout execution, admin
+  fulfillment reconciliation, admin fulfillment routes, admin shipping-option, admin
+  order-route, admin checkout-operation, admin payment-route, admin product-route and
+  product shipping-profile prevalidation, order-change owner and orchestration mapping,
+  admin order-return owner and orchestration mapping, admin order-detail payment and
+  fulfillment mapping, and tax calculation validation, provider-contract,
+  reconciliation, correlation, HTTP-envelope, and transport round-trip tests.
 
 No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -8,6 +8,8 @@ use uuid::Uuid;
 use super::super::types::AddStorefrontCartLineItemInput;
 pub(crate) use super::legacy_helpers::*;
 
+const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";
+
 fn public_graphql_error(
     message: &'static str,
     code: &'static str,
@@ -34,17 +36,6 @@ fn customer_port_graphql_error(
     operation: &'static str,
     error: PortError,
 ) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        correlation_id = %context.correlation_id,
-        tenant_id = %context.tenant_id,
-        operation,
-        owner_code = %error.code,
-        owner_kind = ?error.kind,
-        owner_retryable = error.retryable,
-        "commerce GraphQL storefront customer owner port failed"
-    );
-
     let (message, code, retryable) = match &error.kind {
         PortErrorKind::Validation => (
             "Customer request is invalid",
@@ -73,19 +64,26 @@ fn customer_port_graphql_error(
             false,
         ),
     };
+
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_customer",
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        owner_code = %error.code,
+        owner_kind = ?error.kind,
+        owner_retryable = error.retryable,
+        public_code = code,
+        public_retryable = retryable,
+        boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+        "commerce GraphQL storefront customer owner port failed"
+    );
+
     public_graphql_error(message, code, retryable)
 }
 
 pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        operation = "storefront_cart_port",
-        owner_code = %error.code,
-        owner_kind = ?error.kind,
-        owner_retryable = error.retryable,
-        "commerce GraphQL storefront cart owner port failed"
-    );
-
     let (message, code, retryable) = match &error.kind {
         PortErrorKind::Validation => ("Cart request is invalid", "CART_REQUEST_INVALID", false),
         PortErrorKind::NotFound => (
@@ -114,6 +112,20 @@ pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
             false,
         ),
     };
+
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_cart",
+        operation = "storefront_cart_port",
+        owner_code = %error.code,
+        owner_kind = ?error.kind,
+        owner_retryable = error.retryable,
+        public_code = code,
+        public_retryable = retryable,
+        boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+        "commerce GraphQL storefront cart owner port failed"
+    );
+
     public_graphql_error(message, code, retryable)
 }
 
@@ -158,9 +170,14 @@ fn legacy_graphql_error(
 ) -> async_graphql::Error {
     tracing::error!(
         error = ?error,
+        owner = "rustok_commerce.graphql_cart_helper",
         tenant_id = %tenant_id,
         resource_id = ?resource_id,
         operation,
+        error_kind = "legacy_graphql_error",
+        public_code = code,
+        public_retryable = retryable,
+        boundary = STOREFRONT_CART_HELPER_BOUNDARY,
         "commerce GraphQL storefront cart helper failed"
     );
     public_graphql_error(message, code, retryable)

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -39,13 +39,21 @@ for (const value of [
 
 for (const [value, label] of [
   ['PortError, PortErrorKind', 'port error imports'],
+  ['const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";', 'shared GraphQL boundary'],
   ['fn customer_port_graphql_error(', 'customer mapper'],
   ['pub(crate) fn cart_port_error(', 'cart mapper'],
+  ['owner = "rustok_customer"', 'customer owner logging'],
+  ['owner = "rustok_cart"', 'cart owner logging'],
+  ['owner = "rustok_commerce.graphql_cart_helper"', 'legacy helper owner logging'],
   ['correlation_id = %context.correlation_id', 'customer correlation logging'],
   ['tenant_id = %context.tenant_id', 'customer tenant logging'],
   ['owner_code = %error.code', 'owner code logging'],
   ['owner_kind = ?error.kind', 'owner kind logging'],
   ['owner_retryable = error.retryable', 'owner retryability logging'],
+  ['error_kind = "legacy_graphql_error"', 'legacy error kind logging'],
+  ['public_code = code', 'public code logging'],
+  ['public_retryable = retryable', 'public retryability logging'],
+  ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'transport boundary logging'],
   ['PortErrorKind::Validation', 'validation mapping'],
   ['PortErrorKind::NotFound', 'not-found mapping'],
   ['PortErrorKind::Conflict', 'conflict mapping'],
@@ -73,6 +81,15 @@ for (const [value, label] of [
   requireText(facadeSource, value, label);
 }
 
+for (const [pattern, expected, label] of [
+  [/public_code = code/g, 3, 'public code log count'],
+  [/public_retryable = retryable/g, 3, 'public retryability log count'],
+  [/boundary = STOREFRONT_CART_HELPER_BOUNDARY/g, 3, 'boundary log count'],
+]) {
+  const count = facadeSource.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
 for (const operation of [
   'resolve_optional_storefront_customer_id',
   'enrich_storefront_cart',
@@ -98,5 +115,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers remain behind stable public envelopes while layered helper routing stays private',
+  '✔ Commerce GraphQL storefront cart helpers retain explicit owners, stable public diagnostics, and one transport boundary while layered routing stays private',
 );


### PR DESCRIPTION
## Summary

- add one explicit GraphQL storefront cart-helper boundary to customer, cart, and intercepted legacy helper diagnostics;
- retain explicit owner identity for customer, cart, and commerce helper failures;
- record stable public code and retryability next to the original internal cause before returning the existing safe GraphQL envelope;
- preserve customer correlation/tenant context and legacy tenant/resource/operation context;
- keep every existing GraphQL message, code, retryability value, helper signature, layered routing path, owner call, and success response unchanged;
- strengthen the focused source verifier and update the ecommerce public-error safety documentation.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs`
- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Plan alignment

This advances the still-open ecommerce P0 item for correlation-safe mapper cleanup and non-`PortError` public envelope diagnostics. It does not claim the broad audit item is complete and does not promote FBA/FFA status.

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files;
- source was re-read to confirm the customer, cart, and legacy helper paths map stable public values before structured logging;
- the guard requires three owner/public-code/retryability/boundary diagnostic paths while preserving the existing public-envelope and layered-routing assertions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```