### PR TITLE
fix(index): enforce the exact comparison methodology envelope

### DIFF
--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -14,12 +14,28 @@ export const comparableDatabaseFields = Object.freeze([
 export const databaseSettingsSource =
   'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata';
 
+export const comparisonMethodologyKeys = Object.freeze([
+  'source_oracle',
+  'result_digest',
+  'evidence_validation',
+  'first_run',
+  'warm_run',
+  'automatic_winner_selection',
+  'comparable_database_fields',
+  'database_settings_source',
+]);
+
 const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
 export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) => {
   const methodology = comparison?.methodology;
   if (!methodology || typeof methodology !== 'object' || Array.isArray(methodology)) {
     fail('comparison.methodology must be an object');
+  }
+  const actualKeys = Object.keys(methodology).sort();
+  const expectedKeys = [...comparisonMethodologyKeys].sort();
+  if (!sameJson(actualKeys, expectedKeys)) {
+    fail('comparison methodology must contain exactly the canonical methodology fields');
   }
   if (!sameJson(methodology.comparable_database_fields, comparableDatabaseFields)) {
     fail(
@@ -28,7 +44,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata; database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
     );
   }
   return methodology;

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -85,6 +85,11 @@ const scale = (name, factor) => ({
 const comparison = () => ({
   generated_at: '2026-07-24T12:00:00Z',
   methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
     automatic_winner_selection: false,
     comparable_database_fields: [...comparableDatabaseFields],
     database_settings_source: databaseSettingsSource,
@@ -198,7 +203,48 @@ test('rejects a comparison without the canonical database-settings methodology',
       '--output', decisionPath,
     ]);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract/u);
+    assert.match(result.stderr, /comparison methodology must contain exactly the canonical methodology fields/u);
+    assert.equal(existsSync(decisionPath), false);
+  });
+});
+
+test('rejects a renamed comparison methodology field', () => {
+  withFixture((root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const value = comparison();
+    value.methodology.cold_run = value.methodology.first_run;
+    delete value.methodology.first_run;
+    writeJson(comparisonPath, value);
+    const result = run(prepareScript, [
+      '--comparison', comparisonPath,
+      '--selected', 'typed_eav',
+      '--owner', 'Index maintainers',
+      '--date', '2026-07-24',
+      '--output', decisionPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /comparison methodology must contain exactly the canonical methodology fields/u);
+    assert.equal(existsSync(decisionPath), false);
+  });
+});
+
+test('rejects an additional comparison methodology field', () => {
+  withFixture((root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const value = comparison();
+    value.methodology.unreviewed_note = 'must not become decision input';
+    writeJson(comparisonPath, value);
+    const result = run(prepareScript, [
+      '--comparison', comparisonPath,
+      '--selected', 'typed_eav',
+      '--owner', 'Index maintainers',
+      '--date', '2026-07-24',
+      '--output', decisionPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /comparison methodology must contain exactly the canonical methodology fields/u);
     assert.equal(existsSync(decisionPath), false);
   });
 });

--- a/scripts/verify/render-index-storage-adr.test.mjs
+++ b/scripts/verify/render-index-storage-adr.test.mjs
@@ -98,6 +98,11 @@ const ratios = {
 const validComparison = () => ({
   generated_at: '2026-07-24T12:00:00Z',
   methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
     automatic_winner_selection: false,
     comparable_database_fields: [...comparableDatabaseFields],
     database_settings_source: databaseSettingsSource,
@@ -179,7 +184,20 @@ test('rejects core-only comparison without observed database-settings methodolog
     assert.notEqual(result.status, 0);
     assert.match(
       result.stderr,
-      /comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract/u,
+      /comparison methodology must contain exactly the canonical methodology fields/u,
+    );
+  });
+});
+
+test('rejects an additional methodology field before rendering', () => {
+  withFixture((root) => {
+    const comparison = validComparison();
+    comparison.methodology.unreviewed_note = 'must not reach the ADR';
+    const { result } = run(root, comparison, validDecision(comparison));
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /comparison methodology must contain exactly the canonical methodology fields/u,
     );
   });
 });


### PR DESCRIPTION
## What changed

- rebuild the useful part of #2154 on current `main`;
- define the exact eight-field methodology envelope emitted by the official comparator and its database-settings finalizer;
- reject missing, renamed, and additional methodology fields before decision preparation or ADR rendering;
- retain the exact ordered PostgreSQL database-settings field contract and canonical provenance string;
- align the decision-preparation and direct-render fixtures with the real eight-field comparison output;
- add direct regressions for missing, renamed, and additional methodology fields.

## Recheck

The old #2154 branch was 15 commits behind `main` and its three-file patch did not update the comparison fixtures. Applying that gate unchanged would make the existing decision and renderer fixture suites reject their own nominal inputs because those fixtures contained only three methodology fields.

This replacement keeps the fail-closed exact-envelope intent while making the change self-contained. It does not select a storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

The branch is directly ahead of current `main`, is not behind, and changes only three Index verification files.

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request.

Supersedes #2154.