### PR TITLE
Harden GraphQL cart helper source ownership

### DIFF
--- a/crates/rustok-commerce/docs/public-port-error-safety.md
+++ b/crates/rustok-commerce/docs/public-port-error-safety.md
@@ -83,14 +83,14 @@ available only for actionable domain errors.
   identities plus the same channel/locale context, while pricing keeps its existing
   correlation-aware `PortContext`. Catalog lookup, visibility, pricing, availability,
   title, shipping-profile, metadata, and public response contracts remain unchanged.
-- `rustok-commerce` GraphQL storefront cart helper facade: customer and cart owner-port
-  failures plus the intercepted legacy enrichment, shipping, line-item, pricing, and
-  inventory helper failures retain the original cause only in structured diagnostics.
-  Every diagnostic records an explicit owner, operation, stable public code and
-  retryability, and one GraphQL transport boundary; customer reads also retain their
-  canonical correlation and tenant identity, while legacy helpers retain truthful tenant
-  and resource identity. Existing GraphQL messages, codes, retryability, layered routing,
-  and helper call behavior remain unchanged.
+- `rustok-commerce` GraphQL storefront cart helper facade: customer and intercepted
+  legacy helper failures retain their original cause only in structured diagnostics.
+  The shared cart-envelope mapper records the commerce GraphQL boundary owner and derives
+  `source_owner` only from canonical `cart.*` and `pricing.*` owner codes; unprefixed or
+  foreign codes remain `unknown` instead of being falsely attributed to cart. Stable
+  public code/retryability, the common GraphQL boundary, customer correlation/tenant
+  identity, legacy tenant/resource identity, all existing GraphQL messages and codes,
+  layered routing, helper signatures, owner calls, and success behavior remain unchanged.
 - `rustok-commerce` admin fulfillment reconciliation: list, quarantine, manual resolve,
   and retry paths retain the typed fulfillment or orchestration cause with owner, tenant,
   truthful optional provider-operation identity, operation, stable code, status, and HTTP
@@ -240,9 +240,9 @@ available only for actionable domain errors.
 - `cargo check -p rustok-tax --all-features`
 - Targeted cart promotion, storefront staged checkout recovery, HTTP completion,
   payment-collection, order-refund and line-item owner mapping, GraphQL storefront cart
-  helper diagnostics, order payment settlement, order checkout recovery, order checkout
-  compensation, pricing, payment collection, fulfillment checkout execution, admin
-  fulfillment reconciliation, admin fulfillment routes, admin shipping-option, admin
+  helper source-owner diagnostics, order payment settlement, order checkout recovery,
+  order checkout compensation, pricing, payment collection, fulfillment checkout execution,
+  admin fulfillment reconciliation, admin fulfillment routes, admin shipping-option, admin
   order-route, admin checkout-operation, admin payment-route, admin product-route and
   product shipping-profile prevalidation, order-change owner and orchestration mapping,
   admin order-return owner and orchestration mapping, admin order-detail payment and

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -83,6 +83,14 @@ fn customer_port_graphql_error(
     public_graphql_error(message, code, retryable)
 }
 
+fn cart_port_source_owner(error: &PortError) -> &'static str {
+    match error.code.split_once('.') {
+        Some(("cart", _)) => "rustok_cart",
+        Some(("pricing", _)) => "rustok_pricing",
+        _ => "unknown",
+    }
+}
+
 pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
     let (message, code, retryable) = match &error.kind {
         PortErrorKind::Validation => ("Cart request is invalid", "CART_REQUEST_INVALID", false),
@@ -115,7 +123,8 @@ pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
 
     tracing::error!(
         error = ?error,
-        owner = "rustok_cart",
+        owner = "rustok_commerce.graphql_cart_helper",
+        source_owner = cart_port_source_owner(&error),
         operation = "storefront_cart_port",
         owner_code = %error.code,
         owner_kind = ?error.kind,
@@ -123,7 +132,7 @@ pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
         public_code = code,
         public_retryable = retryable,
         boundary = STOREFRONT_CART_HELPER_BOUNDARY,
-        "commerce GraphQL storefront cart owner port failed"
+        "commerce GraphQL storefront cart or pricing owner port failed"
     );
 
     public_graphql_error(message, code, retryable)

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -49,7 +49,6 @@ for (const [value, label] of [
   ['owner = "rustok_customer"', 'customer owner logging'],
   ['owner = "rustok_commerce.graphql_cart_helper"', 'commerce boundary owner logging'],
   ['source_owner = cart_port_source_owner(&error)', 'typed source owner logging'],
-  ['owner = "rustok_commerce.graphql_cart_helper"', 'legacy helper owner logging'],
   ['correlation_id = %context.correlation_id', 'customer correlation logging'],
   ['tenant_id = %context.tenant_id', 'customer tenant logging'],
   ['owner_code = %error.code', 'owner code logging'],
@@ -90,6 +89,7 @@ for (const [pattern, expected, label] of [
   [/public_code = code/g, 3, 'public code log count'],
   [/public_retryable = retryable/g, 3, 'public retryability log count'],
   [/boundary = STOREFRONT_CART_HELPER_BOUNDARY/g, 3, 'boundary log count'],
+  [/owner = "rustok_commerce\.graphql_cart_helper"/g, 2, 'commerce boundary owner count'],
   [/source_owner = cart_port_source_owner\(&error\)/g, 1, 'source owner log count'],
 ]) {
   const count = facadeSource.match(pattern)?.length ?? 0;

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -41,9 +41,14 @@ for (const [value, label] of [
   ['PortError, PortErrorKind', 'port error imports'],
   ['const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";', 'shared GraphQL boundary'],
   ['fn customer_port_graphql_error(', 'customer mapper'],
+  ['fn cart_port_source_owner(', 'cart source-owner classifier'],
   ['pub(crate) fn cart_port_error(', 'cart mapper'],
+  ['Some(("cart", _)) => "rustok_cart"', 'cart owner classification'],
+  ['Some(("pricing", _)) => "rustok_pricing"', 'pricing owner classification'],
+  ['_ => "unknown"', 'unknown owner classification'],
   ['owner = "rustok_customer"', 'customer owner logging'],
-  ['owner = "rustok_cart"', 'cart owner logging'],
+  ['owner = "rustok_commerce.graphql_cart_helper"', 'commerce boundary owner logging'],
+  ['source_owner = cart_port_source_owner(&error)', 'typed source owner logging'],
   ['owner = "rustok_commerce.graphql_cart_helper"', 'legacy helper owner logging'],
   ['correlation_id = %context.correlation_id', 'customer correlation logging'],
   ['tenant_id = %context.tenant_id', 'customer tenant logging'],
@@ -85,6 +90,7 @@ for (const [pattern, expected, label] of [
   [/public_code = code/g, 3, 'public code log count'],
   [/public_retryable = retryable/g, 3, 'public retryability log count'],
   [/boundary = STOREFRONT_CART_HELPER_BOUNDARY/g, 3, 'boundary log count'],
+  [/source_owner = cart_port_source_owner\(&error\)/g, 1, 'source owner log count'],
 ]) {
   const count = facadeSource.match(pattern)?.length ?? 0;
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
@@ -115,5 +121,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers retain explicit owners, stable public diagnostics, and one transport boundary while layered routing stays private',
+  '✔ Commerce GraphQL storefront cart helpers retain truthful cart/pricing source ownership, stable public diagnostics, and one transport boundary while layered helper routing stays private',
 );


### PR DESCRIPTION
## Summary

- stop attributing every shared storefront cart GraphQL `PortError` to `rustok_cart`;
- keep the GraphQL facade itself as the diagnostic boundary owner;
- derive `source_owner` only from canonical `cart.*` and `pricing.*` owner-code prefixes;
- classify unprefixed or foreign codes as `unknown` instead of fabricating owner identity;
- preserve every existing public `CART_*` message, code, retryability value, helper signature, callsite, and success response;
- strengthen the focused verifier and synchronize the ecommerce public-error safety documentation.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs`
- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
- `crates/rustok-commerce/docs/public-port-error-safety.md`

## Plan alignment

This corrects a false-complete diagnostic claim discovered while continuing the still-open ecommerce P0 mapper-cleanup item. Correlation propagation for the remaining contextless cart helper callsites remains open; no FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- final diff is limited to the three intended files;
- pricing owner codes are canonically emitted with the `pricing.*` prefix and cart owner codes with `cart.*`;
- unknown prefixes fail closed to `source_owner = "unknown"`;
- the static guard locks cart/pricing/unknown classification, boundary ownership, source-owner logging, and all existing public-envelope assertions;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```