### PR TITLE
fix(index): harden accepted ADR finalization lifecycle

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -59,6 +59,8 @@ node scripts/verify/index-storage-tooling.mjs prepare \
 
 `prepare` requires an explicit prototype choice. It does not rank candidates or select a winner. It validates the decision-ready comparison and its exact observed database-settings methodology, copies the evidence commit, computes the SHA-256 of the exact comparison-file bytes, creates rejection entries for exactly the two unselected prototypes, and refuses to overwrite an existing decision unless `--force` is provided. The draft is written to a staged file and renamed only after the complete JSON is on disk.
 
+The generated draft has `status: proposed`. Change it to `accepted` only after the evidence and rationales have been reviewed. The finalizer rejects a proposed decision and accepts only a real `YYYY-MM-DD` calendar date with a year from `0001` through `9999`, including the correct Gregorian leap-year rules.
+
 The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects any remaining preparation marker.
 
 [`storage-decision.example.json`](storage-decision.example.json) shows the same decision fields and references [`storage-decision.schema.json`](storage-decision.schema.json). Its relative `$schema` is valid because the two files are colocated in the documentation directory. A generated decision under `evidence/index-storage/...` intentionally omits `$schema` rather than recording a false relative path; `$schema` remains an optional finalizer field when it correctly points to a colocated schema file.
@@ -91,8 +93,12 @@ node scripts/verify/index-storage-tooling.mjs render \
 
 Finalization snapshots the exact comparison and decision bytes before rendering. The generated ADR records both `Comparison SHA-256` and `Decision SHA-256`, so reviewers can verify the two source documents used to produce it.
 
+Malformed command lines and output paths that collide with either input are non-destructive. A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read. If the replacement evidence, accepted decision, renderer, or publication step fails, no stale ADR is left behind.
+
 The finalizer fails closed unless:
 
+- the decision status is `accepted`;
+- `decision_date` is a real ISO calendar date using Gregorian month and leap-year rules;
 - the comparison contains the exact ten-field observed PostgreSQL database-settings methodology;
 - the comparison is decision-ready;
 - every decision-contract flag is true;

--- a/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const comparison = () => ({
+  methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
+});
+
+const decision = (overrides = {}) => ({
+  status: 'accepted',
+  decision_date: '2026-07-25',
+  owner: 'Index maintainers',
+  comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+  comparison_sha256: '0'.repeat(64),
+  selected_prototype: 'typed_eav',
+  selection_rationale: 'Measured evidence supports the selected prototype.',
+  rejection_rationales: {
+    jsonb: 'JSONB was not selected.',
+    hot_projection: 'Hot projection was not selected.',
+  },
+  operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+  migration_strategy: 'Backfill and verify parity before cutover.',
+  rollback_strategy: 'Retain the previous path until cutover verification completes.',
+  ...overrides,
+});
+
+const runFinalizerArgs = (args) => spawnSync(process.execPath, [finalizer, ...args], {
+  encoding: 'utf8',
+});
+
+const stagedOutputPath = (outputPath) => `${outputPath}.tmp-${process.pid}`;
+const stagingEntries = (root) => readdirSync(root)
+  .filter((entry) => entry.startsWith('adr.md.tmp-'));
+
+const runFinalizer = (root, decisionValue, staleOutput = null, staleStaging = null) => {
+  const comparisonPath = path.join(root, 'comparison.json');
+  const decisionPath = path.join(root, 'decision.json');
+  const outputPath = path.join(root, 'adr.md');
+  writeJson(comparisonPath, comparison());
+  writeJson(decisionPath, decisionValue);
+  if (staleOutput !== null) writeFileSync(outputPath, staleOutput, 'utf8');
+  if (staleStaging !== null) writeFileSync(stagedOutputPath(outputPath), staleStaging, 'utf8');
+  return {
+    comparisonPath,
+    decisionPath,
+    outputPath,
+    result: runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]),
+  };
+};
+
+const withFixture = (prefix, callback) => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('finalizer accepts help only as the sole argument', () => {
+  const result = runFinalizerArgs(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^Usage: node scripts\/verify\/finalize-index-storage-adr\.mjs /u);
+  assert.equal(result.stderr, '');
+});
+
+test('finalizer rejects mixed help without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-help-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs(['--help', '--output', outputPath]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--help\/-h must be the only argument/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer rejects unknown options without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-unknown-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs([
+      '--comparison', 'missing-comparison.json',
+      '--decision', 'missing-decision.json',
+      '--output', outputPath,
+      '--format', 'markdown',
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown argument: --format/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer output collision preserves the comparison bytes', () => {
+  withFixture('rustok-index-finalizer-collision-', (root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    writeJson(comparisonPath, comparison());
+    writeJson(decisionPath, decision());
+    const original = readFileSync(comparisonPath);
+    const result = runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', comparisonPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--output must not overwrite the comparison input/u);
+    assert.deepEqual(readFileSync(comparisonPath), original);
+  });
+});
+
+test('finalizer staging collision preserves the comparison bytes', () => {
+  withFixture('rustok-index-finalizer-staging-collision-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const comparisonPath = stagedOutputPath(outputPath);
+    const decisionPath = path.join(root, 'decision.json');
+    writeJson(comparisonPath, comparison());
+    writeJson(decisionPath, decision());
+    const original = readFileSync(comparisonPath);
+    const result = runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ADR staging path must not overwrite the comparison input/u);
+    assert.deepEqual(readFileSync(comparisonPath), original);
+  });
+});
+
+test('real finalization attempts revoke stale ADR and staging before evidence access', () => {
+  withFixture('rustok-index-finalizer-missing-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const stagingPath = stagedOutputPath(outputPath);
+    writeFileSync(outputPath, 'stale ADR\n', 'utf8');
+    writeFileSync(stagingPath, 'stale staging\n', 'utf8');
+    const result = runFinalizerArgs([
+      '--comparison', path.join(root, 'missing-comparison.json'),
+      '--decision', path.join(root, 'missing-decision.json'),
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing comparison/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.equal(existsSync(stagingPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects impossible decision dates without leaving stale output', () => {
+  for (const invalidDate of ['2026-02-29', '2026-04-31', '0000-01-01', '2026-13-01']) {
+    withFixture('rustok-index-decision-date-', (root) => {
+      const { outputPath, result } = runFinalizer(
+        root,
+        decision({ decision_date: invalidDate }),
+        'stale ADR\n',
+        'stale staging\n',
+      );
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /decision\.decision_date must be a real ISO calendar date/u);
+      assert.equal(existsSync(outputPath), false);
+      assert.deepEqual(stagingEntries(root), []);
+    });
+  }
+});
+
+test('finalizer accepts a real leap date before renderer validation', () => {
+  withFixture('rustok-index-decision-leap-date-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision({ decision_date: '2024-02-29' }),
+      'stale ADR\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(result.stderr, /decision\.decision_date/u);
+    assert.match(result.stderr, /strict ADR renderer failed/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects a proposed decision without leaving stale output', () => {
+  withFixture('rustok-index-decision-status-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision({ status: 'proposed' }),
+      'stale ADR\n',
+      'stale staging\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /decision\.status must be accepted before ADR finalization/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('renderer failure leaves neither stale ADR nor staged output', () => {
+  withFixture('rustok-index-finalizer-render-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision(),
+      'stale ADR\n',
+      'stale staging\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /strict ADR renderer failed/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -20,6 +20,7 @@ import { requireComparisonDatabaseSettingsMethodology } from './index-storage-da
 const prefix = '[finalize-index-storage-adr]';
 const placeholderPrefix = 'TODO(index-storage-decision):';
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const allowedArguments = new Set(['--comparison', '--decision', '--output']);
 const requiredDecisionKeys = [
   'status',
   'decision_date',
@@ -49,19 +50,23 @@ const usage = () => {
 const parseArgs = () => {
   const values = new Map();
   const args = process.argv.slice(2);
+  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+    usage();
+    return null;
+  }
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') {
-      usage();
-      return null;
+      fail('--help/-h must be the only argument');
     }
-    if (!argument.startsWith('--') || !args[index + 1] || args[index + 1].startsWith('--')) {
-      fail(`unknown or incomplete argument: ${argument}`);
+    if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`);
+    if (!args[index + 1] || args[index + 1].startsWith('--')) {
+      fail(`incomplete argument: ${argument}`);
     }
     if (values.has(argument)) fail(`${argument} was provided more than once`);
     values.set(argument, args[++index]);
   }
-  for (const argument of ['--comparison', '--decision', '--output']) {
+  for (const argument of allowedArguments) {
     if (!values.has(argument)) fail(`${argument} is required`);
   }
   return {
@@ -98,6 +103,27 @@ const requireDecisionEnvelope = (decision) => {
   if (Object.hasOwn(decision, '$schema')
       && decision.$schema !== './storage-decision.schema.json') {
     fail('decision.$schema must reference ./storage-decision.schema.json when present');
+  }
+};
+
+const requireAcceptedDecision = (decision) => {
+  if (decision.status !== 'accepted') {
+    fail('decision.status must be accepted before ADR finalization');
+  }
+};
+
+const requireIsoCalendarDate = (value, label) => {
+  const match = typeof value === 'string'
+    ? /^(\d{4})-(\d{2})-(\d{2})$/u.exec(value)
+    : null;
+  if (!match) fail(`${label} must be a real ISO calendar date`);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const monthLengths = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (year === 0 || month < 1 || month > 12 || day < 1 || day > monthLengths[month - 1]) {
+    fail(`${label} must be a real ISO calendar date`);
   }
 };
 
@@ -142,15 +168,25 @@ const insertDecisionDigest = (markdown, decisionSha256) => {
 const main = () => {
   const args = parseArgs();
   if (args === null) return;
+  const stagedOutput = `${args.output}.tmp-${process.pid}`;
   const resolvedOutput = path.resolve(args.output);
+  const resolvedStagedOutput = path.resolve(stagedOutput);
   for (const [label, filename] of [['comparison', args.comparison], ['decision', args.decision]]) {
-    if (resolvedOutput === path.resolve(filename)) fail(`--output must not overwrite the ${label} input`);
+    const resolvedInput = path.resolve(filename);
+    if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);
+    if (resolvedStagedOutput === resolvedInput) {
+      fail(`ADR staging path must not overwrite the ${label} input`);
+    }
   }
+  rmSync(args.output, { force: true });
+  rmSync(stagedOutput, { force: true });
 
   const comparison = readJsonBytes(args.comparison, 'comparison');
   const decision = readJsonBytes(args.decision, 'decision');
   requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
   requireDecisionEnvelope(decision.value);
+  requireAcceptedDecision(decision.value);
+  requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');
   rejectPlaceholders(decision.value);
 
   const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rustok-index-storage-adr-'));
@@ -177,7 +213,6 @@ const main = () => {
     const markdown = insertDecisionDigest(readFileSync(renderedPath, 'utf8'), decision.sha256);
     const parent = path.dirname(args.output);
     if (parent && parent !== '.') mkdirSync(parent, { recursive: true });
-    const stagedOutput = `${args.output}.tmp-${process.pid}`;
     try {
       writeFileSync(stagedOutput, markdown, 'utf8');
       renameSync(stagedOutput, args.output);

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -142,6 +142,7 @@ const prepare = (root) => {
 
 const completeDecision = (decision) => ({
   ...decision,
+  status: 'accepted',
   selection_rationale: 'Typed EAV provides the selected balance of measured query behavior and schema evolution.',
   rejection_rationales: {
     jsonb: 'JSONB was not selected because its measured and operational trade-offs were less suitable.',
@@ -175,6 +176,7 @@ test('prepares an exact-comparison-bound manual decision draft', () => {
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const decision = JSON.parse(readFileSync(decisionPath, 'utf8'));
     assert.equal(Object.hasOwn(decision, '$schema'), false);
+    assert.equal(decision.status, 'proposed');
     assert.equal(decision.comparison_commit, commit);
     assert.equal(decision.comparison_sha256, sha256(comparisonBytes));
     assert.equal(decision.selected_prototype, 'typed_eav');
@@ -241,6 +243,9 @@ test('rejects an unedited prepared decision', () => {
   withFixture((root) => {
     const fixture = prepare(root);
     assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+    const decision = JSON.parse(readFileSync(fixture.decisionPath, 'utf8'));
+    decision.status = 'accepted';
+    writeJson(fixture.decisionPath, decision);
     const result = run(finalizeScript, [
       '--comparison', fixture.comparisonPath,
       '--decision', fixture.decisionPath,

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -71,6 +71,7 @@ const runFixtures = (args) => {
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
+    scriptPath('finalize-index-storage-adr-decision-contract.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
   ], 'Index storage fixture suites');
 };

--- a/scripts/verify/verify-index-storage-adr-integrity.mjs
+++ b/scripts/verify/verify-index-storage-adr-integrity.mjs
@@ -23,6 +23,7 @@ const preparer = read('scripts/verify/prepare-index-storage-decision.mjs');
 const finalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
 const verifier = read('scripts/verify/verify-index-storage-adr.mjs');
 const fixture = read('scripts/verify/index-storage-decision-tooling.test.mjs');
+const finalizerContractFixture = read('scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs');
 const guide = read('crates/rustok-index/docs/storage-decision.md');
 const smokeWorkflow = read('.github/workflows/index-storage-smoke.yml');
 const scaleWorkflow = read('.github/workflows/index-storage-scale-evidence.yml');
@@ -44,6 +45,7 @@ requireMarkers(router, 'storage tooling router', [
   "'verify-index-storage-adr-integrity.mjs'",
   "scriptPath('check-index-storage-read-ordering.test.mjs')",
   "scriptPath('index-storage-standalone-tools.test.mjs')",
+  "scriptPath('finalize-index-storage-adr-decision-contract.test.mjs')",
   "runScript('check-index-storage-read-ordering.mjs', ['--input', packetRoot])",
   "runScript('check-index-storage-read-ordering.mjs', orderingArgs)",
   "case 'prepare':",
@@ -176,20 +178,78 @@ forbidMarkers(preparer, 'decision preparer', [
 ]);
 
 requireMarkers(finalizer, 'ADR finalizer', [
+  "const allowedArguments = new Set(['--comparison', '--decision', '--output'])",
+  "if (args.length === 1 && (args[0] === '--help' || args[0] === '-h'))",
+  "fail('--help/-h must be the only argument')",
+  'if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`)',
   'const requiredDecisionKeys = [',
   "const allowedDecisionKeys = new Set(['$schema', ...requiredDecisionKeys])",
   'decision is missing required field ${key}',
   'decision contains unsupported field ${key}',
   'decision.$schema must reference ./storage-decision.schema.json when present',
+  'const requireAcceptedDecision = (decision) =>',
+  'decision.status must be accepted before ADR finalization',
+  'const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);',
+  'year === 0 || month < 1 || month > 12 || day < 1 || day > monthLengths[month - 1]',
+  'decision.decision_date must be a real ISO calendar date',
+  'requireAcceptedDecision(decision.value);',
   'still contains a preparation placeholder',
+  'const stagedOutput = `${args.output}.tmp-${process.pid}`;',
+  'ADR staging path must not overwrite the ${label} input',
+  'rmSync(args.output, { force: true });',
+  'rmSync(stagedOutput, { force: true });',
   'writeFileSync(comparisonPath, comparison.bytes)',
   'writeFileSync(decisionPath, decision.bytes)',
   "path.join(scriptDirectory, 'render-index-storage-adr.mjs')",
   'Decision SHA-256:',
-  'const stagedOutput = `${args.output}.tmp-${process.pid}`',
   'rmSync(temporaryRoot, { recursive: true, force: true })',
 ]);
+const finalizerOutputCollisionGate = finalizer.indexOf(
+  'if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);',
+);
+const finalizerStagingCollisionGate = finalizer.indexOf(
+  'if (resolvedStagedOutput === resolvedInput)',
+);
+const finalizerOutputRevocation = finalizer.indexOf('rmSync(args.output, { force: true });');
+const finalizerStagingRevocation = finalizer.indexOf('rmSync(stagedOutput, { force: true });');
+const finalizerEvidenceRead = finalizer.indexOf("const comparison = readJsonBytes(args.comparison, 'comparison');");
+if (finalizerOutputCollisionGate < 0
+    || finalizerStagingCollisionGate < 0
+    || finalizerOutputRevocation < 0
+    || finalizerStagingRevocation < 0
+    || finalizerEvidenceRead < 0
+    || finalizerOutputCollisionGate > finalizerStagingCollisionGate
+    || finalizerStagingCollisionGate > finalizerOutputRevocation
+    || finalizerOutputRevocation > finalizerStagingRevocation
+    || finalizerStagingRevocation > finalizerEvidenceRead) {
+  fail('ADR finalizer must check output and staging collisions, revoke stale publication paths, then read evidence');
+}
 forbidMarkers(finalizer, 'ADR finalizer', ['shell: true', 'execSync(', 'process.exit(']);
+
+requireMarkers(finalizerContractFixture, 'ADR finalizer decision-contract fixture', [
+  "test('finalizer accepts help only as the sole argument'",
+  "test('finalizer rejects mixed help without changing an existing ADR'",
+  "test('finalizer rejects unknown options without changing an existing ADR'",
+  "test('finalizer output collision preserves the comparison bytes'",
+  "test('finalizer staging collision preserves the comparison bytes'",
+  "test('real finalization attempts revoke stale ADR and staging before evidence access'",
+  "test('finalizer rejects impossible decision dates without leaving stale output'",
+  "test('finalizer accepts a real leap date before renderer validation'",
+  "test('finalizer rejects a proposed decision without leaving stale output'",
+  "test('renderer failure leaves neither stale ADR nor staged output'",
+  '--help/-h must be the only argument',
+  'unknown argument: --format',
+  "source_oracle: 'normalized idx_bench_source workload result digests'",
+  "result_digest: 'ordered_length_prefixed_json_v1'",
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  'database_settings_source: databaseSettingsSource',
+  "'0000-01-01'",
+  "decision({ decision_date: '2024-02-29' })",
+  'decision.status must be accepted before ADR finalization',
+  'decision.decision_date must be a real ISO calendar date',
+  'assert.equal(existsSync(outputPath), false)',
+  'assert.deepEqual(stagingEntries(root), [])',
+]);
 
 requireMarkers(verifier, 'saved ADR verifier', [
   "const prefix = '[verify-index-storage-adr]'",
@@ -212,6 +272,9 @@ requireMarkers(fixture, 'decision tooling fixture', [
   "test('rejects unsupported fields in the decision envelope'",
   "test('finalizes an ADR bound to exact comparison and decision bytes'",
   "test('rejects a saved ADR changed after finalization'",
+  "assert.equal(decision.status, 'proposed')",
+  "status: 'accepted'",
+  "decision.status = 'accepted';",
   "Object.hasOwn(decision, '$schema'), false",
   'String.fromCharCode(96)',
   'ADR bytes differ from deterministic finalization',
@@ -224,7 +287,12 @@ requireMarkers(guide, 'storage decision guide', [
   'Only `comparison.json` emitted through the official comparator wrapper is valid decision input.',
   'Direct output from `compare-index-storage-evidence-core.mjs` is intentionally incomplete',
   'exact ordered `comparable_database_fields` contract',
-  'The comparator rejects cross-scale drift in any field',
+  'The comparator rejects intra-packet or cross-scale drift in any field',
+  'The generated draft has `status: proposed`.',
+  'Change it to `accepted` only after the evidence and rationales have been reviewed.',
+  'a year from `0001` through `9999`',
+  'Malformed command lines and output paths that collide with either input are non-destructive.',
+  'A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read.',
   'The standalone renderer enforces the same methodology contract even when invoked directly.',
   'Recomputing `comparison_sha256` after removing or changing the methodology does not make the input acceptable.',
   'Comparison SHA-256',
@@ -262,4 +330,4 @@ for (const [label, workflow] of [
   ]);
 }
 
-console.log('[verify-index-storage-adr-integrity] executable SQL ordering, observed database-settings methodology, standalone evidence entrypoints, atomic decision preparation, byte-bound finalization, saved ADR verification, fixtures, docs, and workflows are cross-guarded');
+console.log('[verify-index-storage-adr-integrity] executable SQL ordering, observed database-settings methodology, standalone evidence entrypoints, atomic decision preparation, strict finalizer CLI and replacement lifecycle, accepted byte-bound finalization, saved ADR verification, fixtures, docs, and workflows are cross-guarded');


### PR DESCRIPTION
## What changed

- rebuild the useful lifecycle work from #2158 directly on current `main`;
- restrict the ADR finalizer to `--comparison`, `--decision`, and `--output`, with help accepted only as the sole argument;
- require `status: accepted` before finalization while preserving `prepare` as a `proposed` draft workflow;
- validate `decision_date` arithmetically as a real Gregorian `YYYY-MM-DD` date, including leap-year handling and rejecting year `0000`;
- guard both the final output path and process-specific staging path against comparison/decision input collisions;
- revoke stale ADR and staging files before any real replacement attempt reads evidence;
- preserve malformed CLI and collision failures as non-destructive;
- retain staged publication and cleanup on renderer or publication failure;
- add a dedicated lifecycle fixture suite and route it through the canonical `fixtures` command;
- update the main decision tooling fixture so successful finalization explicitly transitions `proposed` to `accepted`;
- cross-guard parser, collision, revocation, evidence-read, date, status, fixture, and documentation ordering.

## Recheck

The old #2158 branch omitted a required fixture update: its new accepted-status gate would make the existing successful end-to-end finalization scenario fail because that fixture still submitted the generated `proposed` draft unchanged.

This replacement also closes a staging-path collision that #2158 did not cover. A comparison or decision path equal to `${output}.tmp-${process.pid}` can no longer be overwritten during publication.

The branch is one commit directly ahead of current `main`, is not behind, and changes only six Index decision/finalization files. It remains compatible with the exact eight-field methodology envelope work because the dedicated lifecycle fixture already uses the canonical envelope.

This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request.

Supersedes #2158.