### PR TITLE
Retain GraphQL cart owner context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-cart-owner-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-owner-context.md
@@ -1,0 +1,58 @@
+# GraphQL storefront cart owner context
+
+Status: `source_ready_unvalidated`
+
+This slice advances the still-open ecommerce public-error mapper cleanup without changing
+FBA/FFA status.
+
+## Closed source gap
+
+The GraphQL storefront cart resolver previously consumed a `PortContext` in each
+`CartStorefrontPort` call and then passed only the returned `PortError` to the public mapper.
+The public envelope stayed safe, but consumer-side diagnostics lost the original correlation,
+tenant, channel, actor, causation, locale, idempotency, and exact owner-operation context.
+
+`safe_cart.rs` now mounts a local `ContextualCartStorefrontPort` adapter through a private
+`rustok_cart` import shim. The included `cart.rs` source and its success-path behavior remain
+unchanged. The adapter delegates to the canonical
+`rustok_cart::in_process_cart_storefront_port` and records the original `PortContext` for all
+transport-neutral storefront cart operations:
+
+- read and create storefront cart;
+- add, update quantity, update pricing, and remove line item;
+- update storefront context;
+- reprice storefront line items.
+
+Each failed owner call records `owner = "rustok_cart"`, correlation id, tenant, channel,
+locale, actor kind/id, causation id, idempotency key, exact operation, typed owner code/kind,
+owner retryability, and the `commerce_graphql_cart` boundary before returning the same
+`PortError` to the existing public mapper.
+
+## Preserved contracts
+
+- Existing `CART_*` GraphQL messages, codes, and retryability remain unchanged.
+- The resolver source, mutation signatures, request construction, access checks, service
+  arguments, success responses, and layered helper routing remain unchanged.
+- The adapter does not relabel pricing errors as cart errors; pricing continues through the
+  existing source-owner classifier at the public boundary.
+- No owner implementation, port trait, or public transport type changes.
+
+## Still open
+
+- Retain the original `PortContext` and exact operation for pricing calls created inside the
+  GraphQL cart resolver and legacy repricing helper path.
+- Move original pre-`PortError` technical causes into correlation-aware owner-side cart logging
+  before conversion where they are not already retained.
+- Execute compile, static verifier, transport, and runtime evidence before changing any
+  architecture status.
+
+## Intended verification
+
+```bash
+node scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-context-error-safety.mjs
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+cargo check -p rustok-commerce --lib
+```
+
+No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -94,6 +94,173 @@ mod cart_context_boundary {
     }
 }
 
+mod cart_storefront_owner_boundary {
+    use std::sync::Arc;
+
+    use rustok_api::{PortContext, PortError};
+    use rustok_cart::{
+        CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,
+        CartStorefrontCreateRequest, CartStorefrontLineItemPricingRequest,
+        CartStorefrontLineItemQuantityRequest, CartStorefrontPort, CartStorefrontReadRequest,
+        CartStorefrontRemoveLineItemRequest, CartStorefrontRepriceRequest,
+    };
+
+    const CART_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";
+
+    fn retain_cart_owner_context<T>(
+        context: &PortContext,
+        operation: &'static str,
+        result: Result<T, PortError>,
+    ) -> Result<T, PortError> {
+        result.map_err(|error| {
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_cart",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                locale = %context.locale,
+                actor_kind = ?context.actor.kind,
+                actor_id = %context.actor.id,
+                causation_id = ?context.causation_id,
+                idempotency_key = ?context.idempotency_key,
+                operation,
+                owner_code = %error.code,
+                owner_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                boundary = CART_GRAPHQL_OWNER_BOUNDARY,
+                "commerce GraphQL storefront cart owner call failed"
+            );
+            error
+        })
+    }
+
+    struct ContextualCartStorefrontPort {
+        inner: Arc<dyn CartStorefrontPort>,
+    }
+
+    #[async_trait::async_trait]
+    impl CartStorefrontPort for ContextualCartStorefrontPort {
+        async fn read_storefront_cart(
+            &self,
+            context: PortContext,
+            request: CartStorefrontReadRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.read_storefront_cart(context, request).await;
+            retain_cart_owner_context(&error_context, "read_storefront_cart", result)
+        }
+
+        async fn create_storefront_cart(
+            &self,
+            context: PortContext,
+            request: CartStorefrontCreateRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.create_storefront_cart(context, request).await;
+            retain_cart_owner_context(&error_context, "create_storefront_cart", result)
+        }
+
+        async fn add_storefront_line_item(
+            &self,
+            context: PortContext,
+            request: CartStorefrontAddLineItemRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.add_storefront_line_item(context, request).await;
+            retain_cart_owner_context(&error_context, "add_storefront_line_item", result)
+        }
+
+        async fn update_storefront_context(
+            &self,
+            context: PortContext,
+            request: CartStorefrontContextUpdateRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.update_storefront_context(context, request).await;
+            retain_cart_owner_context(&error_context, "update_storefront_context", result)
+        }
+
+        async fn update_storefront_line_item_quantity(
+            &self,
+            context: PortContext,
+            request: CartStorefrontLineItemQuantityRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .update_storefront_line_item_quantity(context, request)
+                .await;
+            retain_cart_owner_context(
+                &error_context,
+                "update_storefront_line_item_quantity",
+                result,
+            )
+        }
+
+        async fn update_storefront_line_item_pricing(
+            &self,
+            context: PortContext,
+            request: CartStorefrontLineItemPricingRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .update_storefront_line_item_pricing(context, request)
+                .await;
+            retain_cart_owner_context(
+                &error_context,
+                "update_storefront_line_item_pricing",
+                result,
+            )
+        }
+
+        async fn remove_storefront_line_item(
+            &self,
+            context: PortContext,
+            request: CartStorefrontRemoveLineItemRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .remove_storefront_line_item(context, request)
+                .await;
+            retain_cart_owner_context(&error_context, "remove_storefront_line_item", result)
+        }
+
+        async fn reprice_storefront_line_items(
+            &self,
+            context: PortContext,
+            request: CartStorefrontRepriceRequest,
+        ) -> Result<rustok_cart::CartResponse, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .reprice_storefront_line_items(context, request)
+                .await;
+            retain_cart_owner_context(&error_context, "reprice_storefront_line_items", result)
+        }
+    }
+
+    pub(crate) fn in_process_cart_storefront_port(
+        db: sea_orm::DatabaseConnection,
+    ) -> Arc<dyn CartStorefrontPort> {
+        Arc::new(ContextualCartStorefrontPort {
+            inner: rustok_cart::in_process_cart_storefront_port(db),
+        })
+    }
+}
+
+mod rustok_cart_shim {
+    pub use ::rustok_cart::{
+        CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,
+        CartStorefrontCreateRequest, CartStorefrontLineItemPricingRequest,
+        CartStorefrontLineItemQuantityRequest, CartStorefrontReadRequest,
+        CartStorefrontRemoveLineItemRequest,
+    };
+    pub(crate) use super::cart_storefront_owner_boundary::in_process_cart_storefront_port;
+}
+
 mod async_graphql_shim {
     pub use ::async_graphql::{Context, Error, MaybeUndefined, Object};
 
@@ -101,5 +268,6 @@ mod async_graphql_shim {
 }
 
 use self::async_graphql_shim as async_graphql;
+use self::rustok_cart_shim as rustok_cart;
 
 include!("cart.rs");

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -98,7 +98,7 @@ mod cart_storefront_owner_boundary {
     use std::sync::Arc;
 
     use rustok_api::{PortContext, PortError};
-    use rustok_cart::{
+    use ::rustok_cart::{
         CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,
         CartStorefrontCreateRequest, CartStorefrontLineItemPricingRequest,
         CartStorefrontLineItemQuantityRequest, CartStorefrontPort, CartStorefrontReadRequest,
@@ -145,7 +145,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontReadRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self.inner.read_storefront_cart(context, request).await;
             retain_cart_owner_context(&error_context, "read_storefront_cart", result)
@@ -155,7 +155,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontCreateRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self.inner.create_storefront_cart(context, request).await;
             retain_cart_owner_context(&error_context, "create_storefront_cart", result)
@@ -165,7 +165,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontAddLineItemRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self.inner.add_storefront_line_item(context, request).await;
             retain_cart_owner_context(&error_context, "add_storefront_line_item", result)
@@ -175,7 +175,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontContextUpdateRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self.inner.update_storefront_context(context, request).await;
             retain_cart_owner_context(&error_context, "update_storefront_context", result)
@@ -185,7 +185,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontLineItemQuantityRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self
                 .inner
@@ -202,7 +202,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontLineItemPricingRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self
                 .inner
@@ -219,7 +219,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontRemoveLineItemRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self
                 .inner
@@ -232,7 +232,7 @@ mod cart_storefront_owner_boundary {
             &self,
             context: PortContext,
             request: CartStorefrontRepriceRequest,
-        ) -> Result<rustok_cart::CartResponse, PortError> {
+        ) -> Result<::rustok_cart::CartResponse, PortError> {
             let error_context = context.clone();
             let result = self
                 .inner
@@ -246,7 +246,7 @@ mod cart_storefront_owner_boundary {
         db: sea_orm::DatabaseConnection,
     ) -> Arc<dyn CartStorefrontPort> {
         Arc::new(ContextualCartStorefrontPort {
-            inner: rustok_cart::in_process_cart_storefront_port(db),
+            inner: ::rustok_cart::in_process_cart_storefront_port(db),
         })
     }
 }

--- a/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
@@ -67,7 +67,7 @@ for (const operation of [
 
 for (const [pattern, expected, label] of [
   [/let error_context = context\.clone\(\);/g, 8, 'owner context clone count'],
-  [/retain_cart_owner_context\(/g, 9, 'context retention call count'],
+  [/retain_cart_owner_context\(/g, 8, 'context retention call count'],
   [/owner = "rustok_cart"/g, 1, 'cart owner event count'],
   [/::rustok_cart::in_process_cart_storefront_port\(db\)/g, 1, 'canonical constructor count'],
 ]) {

--- a/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_cart.rs');
+const source = read('crates/rustok-commerce/src/graphql/mutations/cart.rs');
+const helperFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['mod cart_storefront_owner_boundary {', 'cart owner boundary module'],
+  ['const CART_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";', 'cart boundary constant'],
+  ['fn retain_cart_owner_context<T>(', 'context retention mapper'],
+  ['struct ContextualCartStorefrontPort {', 'contextual cart adapter'],
+  ['impl CartStorefrontPort for ContextualCartStorefrontPort', 'cart adapter implementation'],
+  ['inner: Arc<dyn CartStorefrontPort>', 'owner port delegation'],
+  ['inner: ::rustok_cart::in_process_cart_storefront_port(db)', 'canonical cart owner constructor'],
+  ['mod rustok_cart_shim {', 'cart import shim'],
+  ['use self::rustok_cart_shim as rustok_cart;', 'resolver cart shim alias'],
+  ['pub(crate) use super::cart_storefront_owner_boundary::in_process_cart_storefront_port;', 'contextual constructor export'],
+  ['correlation_id = %context.correlation_id', 'correlation logging'],
+  ['tenant_id = %context.tenant_id', 'tenant logging'],
+  ['channel = ?context.channel', 'channel logging'],
+  ['locale = %context.locale', 'locale logging'],
+  ['actor_kind = ?context.actor.kind', 'actor kind logging'],
+  ['actor_id = %context.actor.id', 'actor id logging'],
+  ['causation_id = ?context.causation_id', 'causation logging'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency logging'],
+  ['owner_code = %error.code', 'owner code logging'],
+  ['owner_kind = ?error.kind', 'owner kind logging'],
+  ['owner_retryable = error.retryable', 'owner retryability logging'],
+  ['owner = "rustok_cart"', 'cart owner logging'],
+  ['boundary = CART_GRAPHQL_OWNER_BOUNDARY', 'boundary logging'],
+  ['include!("cart.rs");', 'unchanged resolver inclusion'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const operation of [
+  'read_storefront_cart',
+  'create_storefront_cart',
+  'add_storefront_line_item',
+  'update_storefront_context',
+  'update_storefront_line_item_quantity',
+  'update_storefront_line_item_pricing',
+  'remove_storefront_line_item',
+  'reprice_storefront_line_items',
+]) {
+  requireText(facade, `"${operation}"`, `${operation} diagnostic operation`);
+  requireText(facade, `.inner\n                .${operation}(`, `${operation} owner delegation`);
+}
+
+for (const [pattern, expected, label] of [
+  [/let error_context = context\.clone\(\);/g, 8, 'owner context clone count'],
+  [/retain_cart_owner_context\(/g, 9, 'context retention call count'],
+  [/owner = "rustok_cart"/g, 1, 'cart owner event count'],
+  [/::rustok_cart::in_process_cart_storefront_port\(db\)/g, 1, 'canonical constructor count'],
+]) {
+  const count = facade.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'format!("{error}")',
+]) {
+  forbidText(facade, value, 'cart owner context boundary');
+}
+
+for (const [value, label] of [
+  ['in_process_cart_storefront_port,', 'resolver owner constructor import'],
+  ['.map_err(cart_port_error)?', 'existing cart public mapper callsites'],
+  ['async fn create_storefront_cart(', 'create cart mutation'],
+  ['async fn add_storefront_cart_line_item(', 'add line item mutation'],
+  ['async fn update_storefront_cart_context(', 'update cart context mutation'],
+  ['async fn update_storefront_cart_line_item(', 'update line item mutation'],
+  ['async fn remove_storefront_cart_line_item(', 'remove line item mutation'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const [value, label] of [
+  ['pub(crate) fn cart_port_error(error: PortError)', 'stable public cart mapper signature'],
+  ['"CART_REQUEST_INVALID"', 'cart validation envelope'],
+  ['"CART_RESOURCE_NOT_FOUND"', 'cart not-found envelope'],
+  ['"CART_STATE_CONFLICT"', 'cart conflict envelope'],
+  ['"CART_ACCESS_DENIED"', 'cart forbidden envelope'],
+  ['"CART_TEMPORARILY_UNAVAILABLE"', 'cart availability envelope'],
+  ['"CART_OPERATION_FAILED"', 'cart invariant envelope'],
+  ['source_owner = cart_port_source_owner(&error)', 'source owner boundary logging'],
+]) {
+  requireText(helperFacade, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL storefront cart owner context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL storefront cart owner calls retain the original PortContext and exact operation while public CART_* envelopes remain unchanged',
+);

--- a/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
@@ -62,7 +62,7 @@ for (const operation of [
   'reprice_storefront_line_items',
 ]) {
   requireText(facade, `"${operation}"`, `${operation} diagnostic operation`);
-  requireText(facade, `.inner\n                .${operation}(`, `${operation} owner delegation`);
+  requireText(facade, `.${operation}(context, request)`, `${operation} owner delegation`);
 }
 
 for (const [pattern, expected, label] of [


### PR DESCRIPTION
## Summary

- mount a private `CartStorefrontPort` decorator in the GraphQL cart facade;
- preserve the original `PortContext` for every storefront cart owner failure;
- log correlation id, tenant, channel, locale, actor, causation, idempotency, exact owner operation, typed owner code/kind, and owner retryability;
- delegate to the canonical `rustok_cart::in_process_cart_storefront_port` without changing the resolver source;
- preserve all existing `CART_*` GraphQL messages, codes, retryability, requests, access checks, service arguments, and success responses;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_cart.rs`
- `scripts/verify/verify-commerce-graphql-cart-owner-context.mjs`
- `crates/rustok-commerce/docs/graphql-cart-owner-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adaptor cleanup. It closes consumer-side context loss for all eight `CartStorefrontPort` methods mounted by the GraphQL cart facade. Pricing context propagation and pre-`PortError` raw cart-cause retention remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- `cart.rs` is included unchanged and resolves its cart constructor through the local shim;
- the adapter implements the complete current `CartStorefrontPort` trait;
- the static guard locks all eight exact operations, original-context fields, canonical owner delegation, unchanged resolver routing, and unchanged public `CART_*` envelopes;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
node scripts/verify/verify-commerce-graphql-cart-context-error-safety.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```