### PR TITLE
fix(index): reject embedded decision placeholders

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -59,7 +59,7 @@ node scripts/verify/index-storage-tooling.mjs prepare \
 
 `prepare` requires an explicit prototype choice. It does not rank candidates or select a winner. It validates the decision-ready comparison and its exact observed database-settings methodology, copies the evidence commit, computes the SHA-256 of the exact comparison-file bytes, creates rejection entries for exactly the two unselected prototypes, and refuses to overwrite an existing decision unless `--force` is provided. The draft is written to a staged file and renamed only after the complete JSON is on disk.
 
-The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects any remaining preparation marker.
+The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects the exact marker at any position inside selection, rejection, operations, migration, or rollback rationale text.
 
 [`storage-decision.example.json`](storage-decision.example.json) shows the same decision fields and references [`storage-decision.schema.json`](storage-decision.schema.json). Its relative `$schema` is valid because the two files are colocated in the documentation directory. A generated decision under `evidence/index-storage/...` intentionally omits `$schema` rather than recording a false relative path; `$schema` remains an optional finalizer field when it correctly points to a colocated schema file.
 
@@ -101,7 +101,7 @@ The finalizer fails closed unless:
 - every displayed metric and cross-scale ratio is present and numeric;
 - the decision identifies the same comparison commit;
 - `comparison_sha256` matches the exact comparison-file bytes;
-- no preparation placeholder remains;
+- no preparation placeholder remains anywhere in required rationale text;
 - selection, rejection, operations, migration, and rollback rationales are all present.
 
 The standalone renderer enforces the same methodology contract even when invoked directly. Recomputing `comparison_sha256` after removing or changing the methodology does not make the input acceptable.

--- a/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+const placeholderPrefix = 'TODO(index-storage-decision):';
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const comparison = () => ({
+  methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
+});
+
+const decision = () => ({
+  status: 'accepted',
+  decision_date: '2026-07-25',
+  owner: 'Index maintainers',
+  comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+  comparison_sha256: '0'.repeat(64),
+  selected_prototype: 'typed_eav',
+  selection_rationale: 'Measured evidence supports the selected prototype.',
+  rejection_rationales: {
+    jsonb: 'JSONB was not selected.',
+    hot_projection: 'Hot projection was not selected.',
+  },
+  operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+  migration_strategy: 'Backfill and verify parity before cutover.',
+  rollback_strategy: 'Retain the previous path until cutover verification completes.',
+});
+
+const scenarios = [
+  {
+    label: 'decision.selection_rationale',
+    apply: (value) => {
+      value.selection_rationale = `Reviewed: ${placeholderPrefix} explain the selected prototype.`;
+    },
+  },
+  {
+    label: 'decision.operational_tradeoffs',
+    apply: (value) => {
+      value.operational_tradeoffs = `Reviewed operations.\n${placeholderPrefix} explain monitoring trade-offs.`;
+    },
+  },
+  {
+    label: 'decision.migration_strategy',
+    apply: (value) => {
+      value.migration_strategy = `Backfill first; ${placeholderPrefix} explain the final cutover.`;
+    },
+  },
+  {
+    label: 'decision.rollback_strategy',
+    apply: (value) => {
+      value.rollback_strategy = `Retain the old path. ${placeholderPrefix} explain rollback verification.`;
+    },
+  },
+  {
+    label: 'decision.rejection_rationales.jsonb',
+    apply: (value) => {
+      value.rejection_rationales.jsonb = `Reviewed JSONB. ${placeholderPrefix} explain its rejection.`;
+    },
+  },
+  {
+    label: 'decision.rejection_rationales.hot_projection',
+    apply: (value) => {
+      value.rejection_rationales.hot_projection = `Reviewed projection.\n${placeholderPrefix} explain its rejection.`;
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  test(`finalizer rejects an embedded preparation placeholder in ${scenario.label}`, () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-decision-placeholder-'));
+    try {
+      const comparisonPath = path.join(root, 'comparison.json');
+      const decisionPath = path.join(root, 'decision.json');
+      const outputPath = path.join(root, 'adr.md');
+      const decisionValue = decision();
+      scenario.apply(decisionValue);
+      writeJson(comparisonPath, comparison());
+      writeJson(decisionPath, decisionValue);
+
+      const result = spawnSync(process.execPath, [
+        finalizer,
+        '--comparison', comparisonPath,
+        '--decision', decisionPath,
+        '--output', outputPath,
+      ], { encoding: 'utf8' });
+
+      assert.notEqual(result.status, 0);
+      assert.match(
+        result.stderr,
+        new RegExp(`${scenario.label.replaceAll('.', '\\.') } still contains a preparation placeholder`, 'u'),
+      );
+      assert.equal(existsSync(outputPath), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -103,7 +103,7 @@ const requireDecisionEnvelope = (decision) => {
 
 const requireDecisionText = (value, label) => {
   if (typeof value !== 'string' || value.trim().length === 0) return;
-  if (value.trim().startsWith(placeholderPrefix)) {
+  if (value.includes(placeholderPrefix)) {
     fail(`${label} still contains a preparation placeholder`);
   }
 };

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -58,6 +58,7 @@ const runContract = (args) => {
     'verify-index-storage-standalone-tools.mjs',
     'verify-index-storage-adr-tooling.mjs',
     'verify-index-storage-adr-integrity.mjs',
+    'verify-index-storage-placeholder-contract.mjs',
   ]) {
     runScript(script);
   }
@@ -71,6 +72,7 @@ const runFixtures = (args) => {
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
+    scriptPath('finalize-index-storage-adr-placeholder.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
   ], 'Index storage fixture suites');
 };

--- a/scripts/verify/verify-index-storage-placeholder-contract.mjs
+++ b/scripts/verify/verify-index-storage-placeholder-contract.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-placeholder-contract] ${message}`);
+  process.exit(1);
+};
+
+const finalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
+const fixture = read('scripts/verify/finalize-index-storage-adr-placeholder.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(finalizer, 'ADR finalizer', [
+  "const placeholderPrefix = 'TODO(index-storage-decision):'",
+  'if (value.includes(placeholderPrefix))',
+  "'selection_rationale'",
+  "'operational_tradeoffs'",
+  "'migration_strategy'",
+  "'rollback_strategy'",
+  'requireDecisionText(decision[field], `decision.${field}`);',
+  'requireDecisionText(rationale, `decision.rejection_rationales.${prototype}`);',
+  'still contains a preparation placeholder',
+]);
+if (finalizer.includes('startsWith(placeholderPrefix)')) {
+  fail('ADR finalizer restored prefix-only placeholder detection');
+}
+
+requireMarkers(fixture, 'placeholder fixture', [
+  "status: 'accepted'",
+  "source_oracle: 'normalized idx_bench_source workload result digests'",
+  "result_digest: 'ordered_length_prefixed_json_v1'",
+  "evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities'",
+  "first_run: 'first EXPLAIN ANALYZE repetition'",
+  "warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison'",
+  'automatic_winner_selection: false',
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  'database_settings_source: databaseSettingsSource',
+  "label: 'decision.selection_rationale'",
+  "label: 'decision.operational_tradeoffs'",
+  "label: 'decision.migration_strategy'",
+  "label: 'decision.rollback_strategy'",
+  "label: 'decision.rejection_rationales.jsonb'",
+  "label: 'decision.rejection_rationales.hot_projection'",
+  'still contains a preparation placeholder',
+  'assert.equal(existsSync(outputPath), false)',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-placeholder-contract.mjs'",
+  "scriptPath('finalize-index-storage-adr-placeholder.test.mjs')",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'The finalizer rejects the exact marker at any position inside selection, rejection, operations, migration, or rollback rationale text.',
+  '- no preparation placeholder remains anywhere in required rationale text;',
+]);
+
+console.log('[verify-index-storage-placeholder-contract] embedded decision placeholders are rejected across every required rationale field');


### PR DESCRIPTION
## What changed

- rebuild the useful placeholder protection from #2163 directly on current `main`;
- reject the exact `TODO(index-storage-decision):` marker at any position inside required rationale text instead of only at the beginning;
- cover selection, operational, migration, rollback, and both rejection-rationale fields;
- use an accepted decision and the canonical eight-field comparison methodology envelope in the focused fixture so the regression remains compatible with the replacement work in #2221 and #2224;
- route the focused fixture through the canonical Index `fixtures` command;
- add a dedicated static verifier that guards the field traversal, exact substring check, fixture coverage, router integration, and documentation contract;
- document that reviewed prefixes, newlines, or other ordinary text do not make a remaining preparation marker acceptable.

## Recheck

The old #2163 branch was 36 commits behind `main` and covered only one hidden-marker case in `selection_rationale`. Its fixture also used `status: proposed` and only the three-field database-settings subset of comparison methodology, so later accepted-status and exact-methodology gates could prevent the test from reaching the placeholder behavior it was intended to verify.

This replacement checks all six required rationale locations with an accepted decision and the full canonical methodology envelope. The branch is one commit directly ahead of current `main`, is not behind, and changes only five Index decision-tooling files.

This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request. Static review covered the finalizer condition, six fixture scenarios, canonical fixture inputs, router registration, dedicated guard markers, documentation wording, and the final compare against `main`.

Supersedes #2163.