### PR TITLE
Retain GraphQL cart pricing context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-cart-pricing-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-pricing-context.md
@@ -1,0 +1,61 @@
+# GraphQL storefront cart pricing context
+
+Status: `source_ready_unvalidated`
+
+This slice continues the still-open ecommerce public-error mapper cleanup without changing
+FBA/FFA status.
+
+## Closed source gap
+
+The GraphQL storefront cart resolver creates pricing `PortContext` values with cart and line-item
+correlation identity, then consumes them in `PricingReadPort` calls. Before this slice, the
+returned `PortError` reached the shared public cart mapper without consumer-side access to the
+original tenant, channel, actor, locale, causation, correlation, or exact pricing operation.
+
+`safe_cart.rs` now mounts a private `ContextualPricingReadPort` through a local
+`rustok_pricing` import shim. The included `cart.rs` source remains unchanged. Both pricing
+constructors in that resolver now return the contextual adapter, which delegates to the canonical
+`rustok_pricing::in_process_pricing_read_port`.
+
+The adapter implements the complete current `PricingReadPort` trait:
+
+- resolve product price;
+- read one price-list projection;
+- list active price-list projections;
+- read admin product pricing projection;
+- read storefront product pricing projection;
+- preview a variant discount.
+
+Each failed pricing owner call records `owner = "rustok_pricing"`, correlation id, tenant,
+channel, locale, actor kind/id, causation id, exact operation, typed owner code/kind, owner
+retryability, and the `commerce_graphql_cart` boundary before returning the same `PortError` to
+the existing public mapper.
+
+## Preserved contracts
+
+- Existing `CART_*` GraphQL messages, codes, and retryability remain unchanged.
+- Existing cart/pricing source-owner classification remains unchanged.
+- Resolver mutation signatures, request construction, pricing arguments, access checks, cart
+  owner calls, success responses, and layered helper routing remain unchanged.
+- The adapter neither mutates pricing requests nor relabels pricing errors as cart errors.
+- No owner implementation, port trait, or public transport type changes.
+
+## Still open
+
+- Apply equivalent original-context retention to the pricing constructor created inside the
+  legacy `reprice_storefront_cart_line_items` helper path.
+- Move original pre-`PortError` technical causes into correlation-aware owner-side logging where
+  a pricing mapper does not already retain them.
+- Execute compile, static verifier, transport, and runtime evidence before changing any
+  architecture status.
+
+## Intended verification
+
+```bash
+node scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+cargo check -p rustok-commerce --lib
+```
+
+No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -97,13 +97,13 @@ mod cart_context_boundary {
 mod cart_storefront_owner_boundary {
     use std::sync::Arc;
 
-    use rustok_api::{PortContext, PortError};
     use ::rustok_cart::{
         CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,
         CartStorefrontCreateRequest, CartStorefrontLineItemPricingRequest,
         CartStorefrontLineItemQuantityRequest, CartStorefrontPort, CartStorefrontReadRequest,
         CartStorefrontRemoveLineItemRequest, CartStorefrontRepriceRequest,
     };
+    use rustok_api::{PortContext, PortError};
 
     const CART_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";
 
@@ -251,6 +251,148 @@ mod cart_storefront_owner_boundary {
     }
 }
 
+mod pricing_read_owner_boundary {
+    use std::sync::Arc;
+
+    use ::rustok_pricing::{
+        ActivePriceListProjectionRequest, ActivePriceListProjectionSnapshot,
+        AdminProductPricingProjectionRequest, PriceListProjectionRequest,
+        PriceListProjectionSnapshot, PreviewVariantDiscountRequest, PricingReadPort,
+        ResolveProductPriceRequest, ResolvedProductPriceSnapshot,
+        StorefrontProductPricingProjectionRequest,
+    };
+    use rustok_api::{PortContext, PortError};
+
+    const PRICING_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";
+
+    fn retain_pricing_owner_context<T>(
+        context: &PortContext,
+        operation: &'static str,
+        result: Result<T, PortError>,
+    ) -> Result<T, PortError> {
+        result.map_err(|error| {
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_pricing",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                channel = ?context.channel,
+                locale = %context.locale,
+                actor_kind = ?context.actor.kind,
+                actor_id = %context.actor.id,
+                causation_id = ?context.causation_id,
+                operation,
+                owner_code = %error.code,
+                owner_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                boundary = PRICING_GRAPHQL_OWNER_BOUNDARY,
+                "commerce GraphQL storefront cart pricing owner call failed"
+            );
+            error
+        })
+    }
+
+    struct ContextualPricingReadPort {
+        inner: Arc<dyn PricingReadPort>,
+    }
+
+    #[async_trait::async_trait]
+    impl PricingReadPort for ContextualPricingReadPort {
+        async fn resolve_product_price(
+            &self,
+            context: PortContext,
+            request: ResolveProductPriceRequest,
+        ) -> Result<ResolvedProductPriceSnapshot, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.resolve_product_price(context, request).await;
+            retain_pricing_owner_context(&error_context, "resolve_product_price", result)
+        }
+
+        async fn read_price_list_projection(
+            &self,
+            context: PortContext,
+            request: PriceListProjectionRequest,
+        ) -> Result<PriceListProjectionSnapshot, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .read_price_list_projection(context, request)
+                .await;
+            retain_pricing_owner_context(&error_context, "read_price_list_projection", result)
+        }
+
+        async fn list_active_price_list_projections(
+            &self,
+            context: PortContext,
+            request: ActivePriceListProjectionRequest,
+        ) -> Result<Vec<ActivePriceListProjectionSnapshot>, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .list_active_price_list_projections(context, request)
+                .await;
+            retain_pricing_owner_context(
+                &error_context,
+                "list_active_price_list_projections",
+                result,
+            )
+        }
+
+        async fn read_admin_product_pricing_projection(
+            &self,
+            context: PortContext,
+            request: AdminProductPricingProjectionRequest,
+        ) -> Result<::rustok_pricing::AdminPricingProductDetail, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .read_admin_product_pricing_projection(context, request)
+                .await;
+            retain_pricing_owner_context(
+                &error_context,
+                "read_admin_product_pricing_projection",
+                result,
+            )
+        }
+
+        async fn read_storefront_product_pricing_projection(
+            &self,
+            context: PortContext,
+            request: StorefrontProductPricingProjectionRequest,
+        ) -> Result<Option<::rustok_pricing::StorefrontPricingProductDetail>, PortError> {
+            let error_context = context.clone();
+            let result = self
+                .inner
+                .read_storefront_product_pricing_projection(context, request)
+                .await;
+            retain_pricing_owner_context(
+                &error_context,
+                "read_storefront_product_pricing_projection",
+                result,
+            )
+        }
+
+        async fn preview_variant_discount(
+            &self,
+            context: PortContext,
+            request: PreviewVariantDiscountRequest,
+        ) -> Result<::rustok_pricing::PriceAdjustmentPreview, PortError> {
+            let error_context = context.clone();
+            let result = self.inner.preview_variant_discount(context, request).await;
+            retain_pricing_owner_context(&error_context, "preview_variant_discount", result)
+        }
+    }
+
+    pub(crate) fn in_process_pricing_read_port(
+        db: sea_orm::DatabaseConnection,
+        event_bus: rustok_outbox::TransactionalEventBus,
+    ) -> Arc<dyn PricingReadPort> {
+        Arc::new(ContextualPricingReadPort {
+            inner: ::rustok_pricing::in_process_pricing_read_port(db, event_bus),
+        })
+    }
+}
+
 mod rustok_cart_shim {
     pub use ::rustok_cart::{
         CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,
@@ -261,6 +403,11 @@ mod rustok_cart_shim {
     pub(crate) use super::cart_storefront_owner_boundary::in_process_cart_storefront_port;
 }
 
+mod rustok_pricing_shim {
+    pub use ::rustok_pricing::{ResolveProductPriceRequest, ResolvedPrice};
+    pub(crate) use super::pricing_read_owner_boundary::in_process_pricing_read_port;
+}
+
 mod async_graphql_shim {
     pub use ::async_graphql::{Context, Error, MaybeUndefined, Object};
 
@@ -269,5 +416,6 @@ mod async_graphql_shim {
 
 use self::async_graphql_shim as async_graphql;
 use self::rustok_cart_shim as rustok_cart;
+use self::rustok_pricing_shim as rustok_pricing;
 
 include!("cart.rs");

--- a/scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_cart.rs');
+const source = read('crates/rustok-commerce/src/graphql/mutations/cart.rs');
+const helperSource = read('crates/rustok-commerce/src/graphql/mutations/helpers.rs');
+const helperFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const pricingBoundary =
+  facade.split('mod pricing_read_owner_boundary {')[1]?.split('mod rustok_cart_shim {')[0] ?? '';
+
+for (const [value, label] of [
+  ['mod pricing_read_owner_boundary {', 'pricing owner boundary module'],
+  ['const PRICING_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";', 'pricing boundary constant'],
+  ['fn retain_pricing_owner_context<T>(', 'pricing context retention mapper'],
+  ['struct ContextualPricingReadPort {', 'contextual pricing adapter'],
+  ['impl PricingReadPort for ContextualPricingReadPort', 'complete pricing adapter implementation'],
+  ['inner: Arc<dyn PricingReadPort>', 'pricing owner delegation'],
+  ['inner: ::rustok_pricing::in_process_pricing_read_port(db, event_bus)', 'canonical pricing constructor'],
+  ['mod rustok_pricing_shim {', 'pricing import shim'],
+  ['use self::rustok_pricing_shim as rustok_pricing;', 'resolver pricing shim alias'],
+  ['pub(crate) use super::pricing_read_owner_boundary::in_process_pricing_read_port;', 'contextual pricing constructor export'],
+  ['pub use ::rustok_pricing::{ResolveProductPriceRequest, ResolvedPrice};', 'resolver pricing API re-export'],
+  ['correlation_id = %context.correlation_id', 'correlation logging'],
+  ['tenant_id = %context.tenant_id', 'tenant logging'],
+  ['channel = ?context.channel', 'channel logging'],
+  ['locale = %context.locale', 'locale logging'],
+  ['actor_kind = ?context.actor.kind', 'actor kind logging'],
+  ['actor_id = %context.actor.id', 'actor id logging'],
+  ['causation_id = ?context.causation_id', 'causation logging'],
+  ['owner_code = %error.code', 'owner code logging'],
+  ['owner_kind = ?error.kind', 'owner kind logging'],
+  ['owner_retryable = error.retryable', 'owner retryability logging'],
+  ['owner = "rustok_pricing"', 'pricing owner logging'],
+  ['boundary = PRICING_GRAPHQL_OWNER_BOUNDARY', 'boundary logging'],
+  ['include!("cart.rs");', 'unchanged resolver inclusion'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const operation of [
+  'resolve_product_price',
+  'read_price_list_projection',
+  'list_active_price_list_projections',
+  'read_admin_product_pricing_projection',
+  'read_storefront_product_pricing_projection',
+  'preview_variant_discount',
+]) {
+  requireText(pricingBoundary, `"${operation}"`, `${operation} diagnostic operation`);
+  requireText(pricingBoundary, `.${operation}(context, request)`, `${operation} owner delegation`);
+}
+
+for (const [pattern, expected, label] of [
+  [/let error_context = context\.clone\(\);/g, 6, 'pricing context clone count'],
+  [/retain_pricing_owner_context\(/g, 6, 'pricing context retention call count'],
+  [/owner = "rustok_pricing"/g, 1, 'pricing owner event count'],
+  [/::rustok_pricing::in_process_pricing_read_port\(db, event_bus\)/g, 1, 'canonical pricing constructor count'],
+]) {
+  const count = pricingBoundary.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'format!("{error}")',
+]) {
+  forbidText(pricingBoundary, value, 'pricing owner context boundary');
+}
+
+for (const [value, label] of [
+  ['use rustok_pricing::{ResolveProductPriceRequest, in_process_pricing_read_port};', 'resolver pricing constructor import'],
+  ['rustok_pricing::ResolvedPrice', 'resolver pricing result type'],
+  ['.map_err(cart_port_error)?', 'existing public cart mapper callsites'],
+  ['async fn add_storefront_cart_line_item(', 'add line item mutation'],
+  ['async fn update_storefront_cart_line_item(', 'update line item mutation'],
+]) {
+  requireText(source, value, label);
+}
+
+const resolverPricingConstructors = source.match(/in_process_pricing_read_port\(/g) ?? [];
+if (resolverPricingConstructors.length !== 2) {
+  failures.push(`expected two resolver pricing constructors, found ${resolverPricingConstructors.length}`);
+}
+const legacyPricingConstructors = helperSource.match(/in_process_pricing_read_port\(/g) ?? [];
+if (legacyPricingConstructors.length !== 1) {
+  failures.push(`expected one still-open legacy helper pricing constructor, found ${legacyPricingConstructors.length}`);
+}
+
+for (const [value, label] of [
+  ['pub(crate) fn cart_port_error(error: PortError)', 'stable public cart mapper signature'],
+  ['"CART_REQUEST_INVALID"', 'cart validation envelope'],
+  ['"CART_RESOURCE_NOT_FOUND"', 'cart not-found envelope'],
+  ['"CART_STATE_CONFLICT"', 'cart conflict envelope'],
+  ['"CART_ACCESS_DENIED"', 'cart forbidden envelope'],
+  ['"CART_TEMPORARILY_UNAVAILABLE"', 'cart availability envelope'],
+  ['"CART_OPERATION_FAILED"', 'cart invariant envelope'],
+  ['Some(("pricing", _)) => "rustok_pricing"', 'pricing source-owner classification'],
+  ['source_owner = cart_port_source_owner(&error)', 'source-owner boundary logging'],
+]) {
+  requireText(helperFacade, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL storefront cart pricing context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL cart resolver pricing calls retain their original PortContext and exact owner operation while public CART_* envelopes remain unchanged',
+);


### PR DESCRIPTION
## Summary

- mount a private `PricingReadPort` decorator in the GraphQL cart facade;
- preserve the original `PortContext` for pricing failures created by the cart resolver;
- log correlation id, tenant, channel, locale, actor, causation, exact owner operation, typed owner code/kind, and owner retryability;
- implement the complete current six-method `PricingReadPort` trait and delegate to the canonical pricing owner;
- preserve all existing public `CART_*` messages, codes, retryability, pricing requests, cart behavior, and success responses;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_cart.rs`
- `scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs`
- `crates/rustok-commerce/docs/graphql-cart-pricing-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adapter cleanup. It closes consumer-side context loss for the two pricing-port constructors mounted directly by `cart.rs`. The legacy repricing helper constructor and pre-`PortError` raw-cause retention remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- `cart.rs` remains included unchanged and resolves its pricing constructor through the local shim;
- the adapter implements the complete current `PricingReadPort` trait;
- pricing root exports required request, response, and detail types;
- the static guard locks all six exact operations, original-context fields, canonical owner delegation, two resolver constructors, one explicitly still-open legacy constructor, and unchanged public `CART_*` envelopes;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
node scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```