### PR TITLE
fix(index): enforce strict comparison hash CLI

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -80,6 +80,8 @@ node scripts/verify/index-storage-tooling.mjs hash \
   evidence/index-storage/comparison/comparison.json
 ```
 
+Hash help is accepted only as the sole argument. Mixed help/path invocations and zero or multiple comparison paths fail without producing a digest. The helper hashes the exact file bytes without JSON normalization.
+
 ## Finalize the ADR
 
 ```bash

--- a/scripts/verify/hash-index-storage-comparison.mjs
+++ b/scripts/verify/hash-index-storage-comparison.mjs
@@ -4,15 +4,19 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 
 const prefix = '[hash-index-storage-comparison]';
+const helpArguments = new Set(['--help', '-h']);
 const fail = (message) => {
   console.error(`${prefix} ${message}`);
   process.exit(1);
 };
 
 const args = process.argv.slice(2);
-if (args.includes('--help') || args.includes('-h')) {
+if (args.length === 1 && helpArguments.has(args[0])) {
   console.log('Usage: node scripts/verify/hash-index-storage-comparison.mjs <comparison.json>');
   process.exit(0);
+}
+if (args.some((argument) => helpArguments.has(argument))) {
+  fail('--help/-h must be the only argument');
 }
 if (args.length !== 1) fail('exactly one comparison.json path is required');
 

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -58,6 +58,7 @@ const runContract = (args) => {
     'verify-index-storage-standalone-tools.mjs',
     'verify-index-storage-adr-tooling.mjs',
     'verify-index-storage-adr-integrity.mjs',
+    'verify-index-storage-hash-cli-contract.mjs',
   ]) {
     runScript(script);
   }

--- a/scripts/verify/index-storage-tooling.test.mjs
+++ b/scripts/verify/index-storage-tooling.test.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
@@ -92,6 +93,52 @@ test('forwards hash help to the exact-byte comparison helper', () => {
   const result = run('hash', '--help');
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /hash-index-storage-comparison\.mjs <comparison\.json>/u);
+});
+
+test('forwards short hash help to the exact-byte comparison helper', () => {
+  const result = run('hash', '-h');
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /hash-index-storage-comparison\.mjs <comparison\.json>/u);
+});
+
+test('rejects mixed hash help in every ordering', () => {
+  for (const args of [
+    ['comparison.json', '--help'],
+    ['--help', 'comparison.json'],
+    ['comparison.json', '-h'],
+    ['-h', 'comparison.json'],
+    ['--help', '--help'],
+  ]) {
+    const result = run('hash', ...args);
+    assert.notEqual(result.status, 0, args.join(' '));
+    assert.match(result.stderr, /--help\/-h must be the only argument/u);
+    assert.equal(result.stdout, '');
+  }
+});
+
+test('rejects missing or multiple comparison hash paths', () => {
+  for (const args of [[], ['left.json', 'right.json']]) {
+    const result = run('hash', ...args);
+    assert.notEqual(result.status, 0, args.join(' '));
+    assert.match(result.stderr, /exactly one comparison\.json path is required/u);
+    assert.equal(result.stdout, '');
+  }
+});
+
+test('hashes the exact comparison bytes through the router', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-tooling-hash-'));
+  try {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const bytes = Buffer.from('{"scale":"100k"}\r\n', 'utf8');
+    writeFileSync(comparisonPath, bytes);
+    const result = run('hash', comparisonPath);
+    assert.equal(result.status, 0, result.stderr);
+    const expected = createHash('sha256').update(bytes).digest('hex');
+    assert.equal(result.stdout, `${expected}\n`);
+    assert.equal(result.stderr, '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('forwards comparator help without rewriting its arguments', () => {

--- a/scripts/verify/verify-index-storage-hash-cli-contract.mjs
+++ b/scripts/verify/verify-index-storage-hash-cli-contract.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-hash-cli-contract] ${message}`);
+  process.exit(1);
+};
+
+const helper = read('scripts/verify/hash-index-storage-comparison.mjs');
+const fixture = read('scripts/verify/index-storage-tooling.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(helper, 'comparison hash helper', [
+  "const helpArguments = new Set(['--help', '-h'])",
+  'if (args.length === 1 && helpArguments.has(args[0]))',
+  'if (args.some((argument) => helpArguments.has(argument)))',
+  "fail('--help/-h must be the only argument')",
+  "if (args.length !== 1) fail('exactly one comparison.json path is required')",
+  "createHash('sha256').update(readFileSync(filename)).digest('hex')",
+  'process.stdout.write(`${digest}\\n`)',
+]);
+for (const forbidden of ["args.includes('--help')", "args.includes('-h')"]) {
+  if (helper.includes(forbidden)) fail(`comparison hash helper restored ambiguous help detection: ${forbidden}`);
+}
+
+requireMarkers(fixture, 'storage tooling fixture', [
+  "test('forwards hash help to the exact-byte comparison helper'",
+  "test('forwards short hash help to the exact-byte comparison helper'",
+  "test('rejects mixed hash help in every ordering'",
+  "test('rejects missing or multiple comparison hash paths'",
+  "test('hashes the exact comparison bytes through the router'",
+  "['comparison.json', '--help']",
+  "['--help', 'comparison.json']",
+  "['comparison.json', '-h']",
+  "['-h', 'comparison.json']",
+  "['--help', '--help']",
+  "Buffer.from('{\"scale\":\"100k\"}\\r\\n', 'utf8')",
+  "createHash('sha256').update(bytes).digest('hex')",
+  '/--help\\/-h must be the only argument/u',
+  '/exactly one comparison\\.json path is required/u',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-hash-cli-contract.mjs'",
+  "case 'hash':",
+  "runScript('hash-index-storage-comparison.mjs', args)",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'Hash help is accepted only as the sole argument.',
+  'Mixed help/path invocations and zero or multiple comparison paths fail without producing a digest.',
+  'The helper hashes the exact file bytes without JSON normalization.',
+]);
+
+console.log('[verify-index-storage-hash-cli-contract] comparison hash help, arity, and exact-byte behavior are cross-guarded');


### PR DESCRIPTION
## What changed

- rebuild the useful hash-helper fix from #2165 directly on current `main`;
- accept `--help` and `-h` only when either is the sole helper argument;
- reject mixed help/path invocations with an explicit non-zero diagnostic before any file access or digest output;
- retain the exact one-path arity contract for zero or multiple comparison paths;
- verify both help aliases, both mixed-argument orderings, repeated help, missing/multiple paths, and successful SHA-256 generation;
- exercise a `CRLF` comparison fixture so the success case proves that exact file bytes are hashed without JSON normalization;
- add a dedicated static contract verifier and register it in the canonical Index `contract` command;
- document the help, arity, and exact-byte behavior.

## Recheck

The old #2165 branch was 37 commits behind `main` and covered only `comparison.json --help`. It did not cover `--help comparison.json`, either `-h` ordering, repeated help, zero/multiple paths, or a successful exact-byte digest.

This replacement closes the whole ambiguous CLI surface while keeping the helper intentionally small. The branch is one commit directly ahead of current `main`, is not behind, and changes only five Index decision-tooling files.

This does not select a PostgreSQL storage model or advance M2 beyond replacement same-commit 100k/1m evidence, comparison, and a human-accepted ADR.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request. Static review covered the helper condition ordering, all fixture scenarios, exact-byte fixture content, contract registration, documentation markers, and the final compare against `main`.

Supersedes #2165.