### PR TITLE
Retain legacy GraphQL cart pricing context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-cart-pricing-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-pricing-context.md
@@ -7,15 +7,18 @@ FBA/FFA status.
 
 ## Closed source gap
 
-The GraphQL storefront cart resolver creates pricing `PortContext` values with cart and line-item
-correlation identity, then consumes them in `PricingReadPort` calls. Before this slice, the
-returned `PortError` reached the shared public cart mapper without consumer-side access to the
-original tenant, channel, actor, locale, causation, correlation, or exact pricing operation.
+The GraphQL storefront cart resolver and its legacy repricing helper create pricing `PortContext`
+values with cart and line-item correlation identity, then consume them in `PricingReadPort` calls.
+Before these slices, returned `PortError` values reached the shared public cart mapper without
+consumer-side access to the original tenant, channel, actor, locale, causation, correlation, or
+exact pricing operation.
 
-`safe_cart.rs` now mounts a private `ContextualPricingReadPort` through a local
-`rustok_pricing` import shim. The included `cart.rs` source remains unchanged. Both pricing
-constructors in that resolver now return the contextual adapter, which delegates to the canonical
-`rustok_pricing::in_process_pricing_read_port`.
+`safe_cart.rs` mounts one private `ContextualPricingReadPort` through a local `rustok_pricing`
+import shim. Both pricing constructors in the included `cart.rs` resolver use that adapter.
+`safe_legacy_helpers.rs` now includes the unchanged `helpers.rs` source behind a second local
+pricing shim and routes its `reprice_storefront_cart_line_items` constructor to the same adapter.
+The canonical owner constructor remains
+`rustok_pricing::in_process_pricing_read_port` and is called only inside the shared decorator.
 
 The adapter implements the complete current `PricingReadPort` trait:
 
@@ -35,17 +38,18 @@ the existing public mapper.
 
 - Existing `CART_*` GraphQL messages, codes, and retryability remain unchanged.
 - Existing cart/pricing source-owner classification remains unchanged.
-- Resolver mutation signatures, request construction, pricing arguments, access checks, cart
-  owner calls, success responses, and layered helper routing remain unchanged.
+- Resolver and helper function signatures, request construction, pricing arguments, access checks,
+  cart owner calls, success responses, and layered helper exports remain unchanged.
+- `cart.rs` and `helpers.rs` remain included unchanged through their safe facades.
 - The adapter neither mutates pricing requests nor relabels pricing errors as cart errors.
 - No owner implementation, port trait, or public transport type changes.
 
 ## Still open
 
-- Apply equivalent original-context retention to the pricing constructor created inside the
-  legacy `reprice_storefront_cart_line_items` helper path.
-- Move original pre-`PortError` technical causes into correlation-aware owner-side logging where
-  a pricing mapper does not already retain them.
+- Move original pre-`PortError` technical causes into correlation-aware owner-side pricing logging
+  where a mapper does not already retain them.
+- Review non-pricing legacy helper errors that still reach `legacy_graphql_error` only as
+  `async_graphql::Error` values without typed owner context.
 - Execute compile, static verifier, transport, and runtime evidence before changing any
   architecture status.
 

--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -12,7 +12,7 @@ pub mod checkout;
 pub mod fulfillment;
 #[path = "safe_order_helpers.rs"]
 pub mod helpers;
-#[path = "helpers.rs"]
+#[path = "safe_legacy_helpers.rs"]
 mod legacy_helpers;
 pub mod pricing;
 pub mod provider_operations;

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -393,6 +393,8 @@ mod pricing_read_owner_boundary {
     }
 }
 
+pub(crate) use pricing_read_owner_boundary::in_process_pricing_read_port as contextual_pricing_read_port;
+
 mod rustok_cart_shim {
     pub use ::rustok_cart::{
         CartStorefrontAddLineItemRequest, CartStorefrontContextUpdateRequest,

--- a/crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs
@@ -1,0 +1,10 @@
+mod rustok_pricing_shim {
+    pub use ::rustok_pricing::{
+        PriceResolutionContext, PricingReadPort, ResolveProductPriceRequest, ResolvedPrice,
+    };
+    pub(crate) use super::super::cart::contextual_pricing_read_port as in_process_pricing_read_port;
+}
+
+use self::rustok_pricing_shim as rustok_pricing;
+
+include!("helpers.rs");

--- a/scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
@@ -10,7 +10,9 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
+const routing = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
 const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_cart.rs');
+const legacyFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs');
 const source = read('crates/rustok-commerce/src/graphql/mutations/cart.rs');
 const helperSource = read('crates/rustok-commerce/src/graphql/mutations/helpers.rs');
 const helperFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
@@ -34,9 +36,10 @@ for (const [value, label] of [
   ['impl PricingReadPort for ContextualPricingReadPort', 'complete pricing adapter implementation'],
   ['inner: Arc<dyn PricingReadPort>', 'pricing owner delegation'],
   ['inner: ::rustok_pricing::in_process_pricing_read_port(db, event_bus)', 'canonical pricing constructor'],
-  ['mod rustok_pricing_shim {', 'pricing import shim'],
+  ['pub(crate) use pricing_read_owner_boundary::in_process_pricing_read_port as contextual_pricing_read_port;', 'shared contextual pricing export'],
+  ['mod rustok_pricing_shim {', 'resolver pricing import shim'],
   ['use self::rustok_pricing_shim as rustok_pricing;', 'resolver pricing shim alias'],
-  ['pub(crate) use super::pricing_read_owner_boundary::in_process_pricing_read_port;', 'contextual pricing constructor export'],
+  ['pub(crate) use super::pricing_read_owner_boundary::in_process_pricing_read_port;', 'resolver contextual constructor export'],
   ['pub use ::rustok_pricing::{ResolveProductPriceRequest, ResolvedPrice};', 'resolver pricing API re-export'],
   ['correlation_id = %context.correlation_id', 'correlation logging'],
   ['tenant_id = %context.tenant_id', 'tenant logging'],
@@ -88,6 +91,28 @@ for (const value of [
 }
 
 for (const [value, label] of [
+  ['#[path = "safe_legacy_helpers.rs"]\nmod legacy_helpers;', 'safe legacy helper routing'],
+]) {
+  requireText(routing, value, label);
+}
+for (const value of ['#[path = "helpers.rs"]\nmod legacy_helpers;']) {
+  forbidText(routing, value, 'unsafe legacy helper routing');
+}
+
+for (const [value, label] of [
+  ['mod rustok_pricing_shim {', 'legacy pricing shim'],
+  ['PriceResolutionContext, PricingReadPort, ResolveProductPriceRequest, ResolvedPrice,', 'legacy pricing API re-export'],
+  ['super::super::cart::contextual_pricing_read_port as in_process_pricing_read_port', 'shared contextual pricing constructor reuse'],
+  ['use self::rustok_pricing_shim as rustok_pricing;', 'legacy pricing shim alias'],
+  ['include!("helpers.rs");', 'unchanged legacy helper inclusion'],
+]) {
+  requireText(legacyFacade, value, label);
+}
+for (const value of ['::rustok_pricing::in_process_pricing_read_port']) {
+  forbidText(legacyFacade, value, 'legacy canonical constructor bypass');
+}
+
+for (const [value, label] of [
   ['use rustok_pricing::{ResolveProductPriceRequest, in_process_pricing_read_port};', 'resolver pricing constructor import'],
   ['rustok_pricing::ResolvedPrice', 'resolver pricing result type'],
   ['.map_err(cart_port_error)?', 'existing public cart mapper callsites'],
@@ -101,9 +126,17 @@ const resolverPricingConstructors = source.match(/in_process_pricing_read_port\(
 if (resolverPricingConstructors.length !== 2) {
   failures.push(`expected two resolver pricing constructors, found ${resolverPricingConstructors.length}`);
 }
+for (const [value, label] of [
+  ['let pricing_read_port = in_process_pricing_read_port(db.clone(), event_bus.clone());', 'legacy repricing constructor'],
+  ['storefront_pricing_port_context(tenant_id, request_context, cart.id, line_item.id)', 'legacy repricing context'],
+  ['.resolve_product_price(', 'legacy pricing owner call'],
+  ['.map_err(cart_port_error)?', 'legacy public cart mapper'],
+]) {
+  requireText(helperSource, value, label);
+}
 const legacyPricingConstructors = helperSource.match(/in_process_pricing_read_port\(/g) ?? [];
 if (legacyPricingConstructors.length !== 1) {
-  failures.push(`expected one still-open legacy helper pricing constructor, found ${legacyPricingConstructors.length}`);
+  failures.push(`expected one legacy helper pricing constructor routed through the facade, found ${legacyPricingConstructors.length}`);
 }
 
 for (const [value, label] of [
@@ -127,5 +160,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL cart resolver pricing calls retain their original PortContext and exact owner operation while public CART_* envelopes remain unchanged',
+  '✔ Commerce GraphQL cart resolver and legacy repricing calls share contextual pricing owner diagnostics while public CART_* envelopes remain unchanged',
 );


### PR DESCRIPTION
## Summary

- route the unchanged legacy `helpers.rs` source through a new safe facade;
- reuse the existing contextual `PricingReadPort` decorator from `safe_cart.rs` instead of duplicating it;
- preserve the original `PortContext` for pricing failures inside `reprice_storefront_cart_line_items`;
- keep the canonical pricing constructor isolated inside the shared decorator;
- preserve all existing public `CART_*` messages, codes, retryability, helper signatures, pricing requests, cart updates, and success responses;
- extend the focused static guard and pricing context evidence.

## Scope

Five files only:

- `crates/rustok-commerce/src/graphql/mutations/mod.rs`
- `crates/rustok-commerce/src/graphql/mutations/safe_cart.rs`
- `crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs`
- `scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs`
- `crates/rustok-commerce/docs/graphql-cart-pricing-context.md`

`cart.rs`, `helpers.rs`, `safe_helpers.rs`, the public mapper, owner traits, and owner implementations remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adapter cleanup. It closes consumer-side pricing context loss for the remaining GraphQL cart legacy repricing path. Pre-`PortError` technical-cause retention and non-pricing legacy `async_graphql::Error` paths remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- legacy helper routing now points to `safe_legacy_helpers.rs`;
- the facade includes the unchanged `helpers.rs` and replaces only its pricing constructor;
- direct resolver and legacy helper pricing calls share the same complete six-method decorator;
- the static guard locks safe routing, shared constructor reuse, one canonical owner constructor, three GraphQL cart pricing constructor sites, exact context logging, and unchanged public `CART_*` envelopes;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
node scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```