### PR TITLE
Retain legacy GraphQL shipping option owner context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-cart-shipping-option-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-shipping-option-context.md
@@ -1,0 +1,49 @@
+# GraphQL cart shipping option owner context
+
+Status: source-ready, unvalidated
+
+This note records one narrow source slice in the reopened ecommerce P0 public-error safety audit. It does not promote ecommerce FBA or FFA status.
+
+## Closed source gap
+
+The legacy GraphQL storefront cart helper validates selected shipping options by constructing `FulfillmentService` and calling `get_shipping_option`. The helper returns `async_graphql::Error`, so the typed `FulfillmentError` was previously converted before the safe GraphQL boundary could retain truthful fulfillment owner diagnostics.
+
+`safe_legacy_helpers.rs` now mounts a private fulfillment import shim. The included `helpers.rs` source remains unchanged, but its single `FulfillmentService::new` call resolves to a facade that delegates to the canonical `rustok_fulfillment::FulfillmentService`.
+
+Before returning the original typed error, the facade records:
+
+- the complete `FulfillmentError` cause;
+- truthful `rustok_fulfillment` owner identity;
+- tenant and shipping-option identity;
+- requested and tenant-default locale inputs;
+- the exact `get_shipping_option` owner operation;
+- stable owner code, kind, and retryability;
+- the explicit legacy GraphQL cart helper boundary.
+
+Database failures are recorded at error level. Validation, not-found, and lifecycle rejections are recorded at warning level. The facade returns the same `FulfillmentResult<ShippingOptionResponse>` as the canonical owner service.
+
+## Preserved contracts
+
+- `helpers.rs` remains included unchanged through `safe_legacy_helpers.rs`.
+- Shipping-option lookup arguments and locale fallback inputs are unchanged.
+- Currency, public-channel visibility, and shipping-profile compatibility checks are unchanged.
+- The outer safe helper still returns `Selected shipping option is invalid` with code `SHIPPING_OPTION_INVALID` and `retryable = false`.
+- No fulfillment entity, owner service, public transport type, or owner port changes.
+
+## Still open
+
+- Replace the legacy shipping-option service construction with a typed owner port once the owner projection carries every field required by currency, channel-visibility, and shipping-profile compatibility policy.
+- Retain request correlation, actor, channel, cart, and causation context across that typed owner call.
+- Review cart enrichment, product persistence, inventory, metadata parsing, and the remaining non-pricing legacy helper errors that still reach `legacy_graphql_error` as `async_graphql::Error` values.
+- Execute compile, static verifier, transport, and runtime evidence before changing any architecture status.
+
+## Intended focused checks
+
+```bash
+node scripts/verify/verify-commerce-graphql-cart-shipping-option-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+node scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
+cargo check -p rustok-commerce --lib
+```
+
+No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs
@@ -1,3 +1,110 @@
+mod rustok_fulfillment_shim {
+    use ::rustok_fulfillment::{FulfillmentError, FulfillmentResult, ShippingOptionResponse};
+    use sea_orm::DatabaseConnection;
+    use uuid::Uuid;
+
+    const STOREFRONT_CART_LEGACY_HELPER_BOUNDARY: &str =
+        "commerce_graphql_storefront_cart_legacy_helper";
+
+    pub struct FulfillmentService {
+        inner: ::rustok_fulfillment::FulfillmentService,
+    }
+
+    impl FulfillmentService {
+        pub fn new(db: DatabaseConnection) -> Self {
+            Self {
+                inner: ::rustok_fulfillment::FulfillmentService::new(db),
+            }
+        }
+
+        pub async fn get_shipping_option(
+            &self,
+            tenant_id: Uuid,
+            shipping_option_id: Uuid,
+            requested_locale: Option<&str>,
+            tenant_default_locale: Option<&str>,
+        ) -> FulfillmentResult<ShippingOptionResponse> {
+            self.inner
+                .get_shipping_option(
+                    tenant_id,
+                    shipping_option_id,
+                    requested_locale,
+                    tenant_default_locale,
+                )
+                .await
+                .map_err(|error| {
+                    log_shipping_option_error(
+                        &error,
+                        tenant_id,
+                        shipping_option_id,
+                        requested_locale,
+                        tenant_default_locale,
+                    );
+                    error
+                })
+        }
+    }
+
+    fn log_shipping_option_error(
+        error: &FulfillmentError,
+        tenant_id: Uuid,
+        shipping_option_id: Uuid,
+        requested_locale: Option<&str>,
+        tenant_default_locale: Option<&str>,
+    ) {
+        let (owner_code, owner_kind, owner_retryable) = match error {
+            FulfillmentError::Validation(_) => ("fulfillment.validation", "validation", false),
+            FulfillmentError::ShippingOptionNotFound(_) => (
+                "fulfillment.shipping_option_not_found",
+                "not_found",
+                false,
+            ),
+            FulfillmentError::FulfillmentNotFound(_) => {
+                ("fulfillment.fulfillment_not_found", "not_found", false)
+            }
+            FulfillmentError::InvalidTransition { .. } => {
+                ("fulfillment.invalid_transition", "conflict", false)
+            }
+            FulfillmentError::Database(_) => (
+                "fulfillment.database_unavailable",
+                "unavailable",
+                true,
+            ),
+        };
+
+        match error {
+            FulfillmentError::Database(_) => tracing::error!(
+                error = ?error,
+                owner = "rustok_fulfillment",
+                tenant_id = %tenant_id,
+                shipping_option_id = %shipping_option_id,
+                requested_locale = ?requested_locale,
+                tenant_default_locale = ?tenant_default_locale,
+                operation = "get_shipping_option",
+                owner_code,
+                owner_kind,
+                owner_retryable,
+                boundary = STOREFRONT_CART_LEGACY_HELPER_BOUNDARY,
+                "fulfillment owner shipping option lookup failed"
+            ),
+            _ => tracing::warn!(
+                error = ?error,
+                owner = "rustok_fulfillment",
+                tenant_id = %tenant_id,
+                shipping_option_id = %shipping_option_id,
+                requested_locale = ?requested_locale,
+                tenant_default_locale = ?tenant_default_locale,
+                operation = "get_shipping_option",
+                owner_code,
+                owner_kind,
+                owner_retryable,
+                boundary = STOREFRONT_CART_LEGACY_HELPER_BOUNDARY,
+                "fulfillment owner shipping option lookup was rejected"
+            ),
+        }
+    }
+}
+
 mod rustok_pricing_shim {
     pub use ::rustok_pricing::{
         PriceResolutionContext, PricingReadPort, ResolveProductPriceRequest, ResolvedPrice,
@@ -5,6 +112,7 @@ mod rustok_pricing_shim {
     pub(crate) use super::super::cart::contextual_pricing_read_port as in_process_pricing_read_port;
 }
 
+use self::rustok_fulfillment_shim as rustok_fulfillment;
 use self::rustok_pricing_shim as rustok_pricing;
 
 include!("helpers.rs");

--- a/scripts/verify/verify-commerce-graphql-cart-shipping-option-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-shipping-option-context.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const routing = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs');
+const helperSource = read('crates/rustok-commerce/src/graphql/mutations/helpers.rs');
+const publicFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['#[path = "safe_legacy_helpers.rs"]\nmod legacy_helpers;', 'safe legacy helper routing'],
+]) {
+  requireText(routing, value, label);
+}
+for (const value of ['#[path = "helpers.rs"]\nmod legacy_helpers;']) {
+  forbidText(routing, value, 'unsafe legacy helper routing');
+}
+
+for (const [value, label] of [
+  ['mod rustok_fulfillment_shim {', 'fulfillment import shim'],
+  ['pub struct FulfillmentService {', 'contextual fulfillment facade'],
+  ['inner: ::rustok_fulfillment::FulfillmentService', 'canonical fulfillment owner field'],
+  ['inner: ::rustok_fulfillment::FulfillmentService::new(db)', 'canonical fulfillment constructor'],
+  ['pub async fn get_shipping_option(', 'shipping option interception'],
+  ['log_shipping_option_error(', 'typed fulfillment cause logging'],
+  ['FulfillmentError::Validation(_)', 'validation classification'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found classification'],
+  ['FulfillmentError::Database(_)', 'database classification'],
+  ['owner = "rustok_fulfillment"', 'truthful fulfillment owner'],
+  ['tenant_id = %tenant_id', 'tenant context'],
+  ['shipping_option_id = %shipping_option_id', 'shipping option identity'],
+  ['requested_locale = ?requested_locale', 'requested locale context'],
+  ['tenant_default_locale = ?tenant_default_locale', 'default locale context'],
+  ['operation = "get_shipping_option"', 'exact owner operation'],
+  ['owner_code,', 'stable owner code'],
+  ['owner_kind,', 'typed owner kind'],
+  ['owner_retryable,', 'owner retryability'],
+  ['boundary = STOREFRONT_CART_LEGACY_HELPER_BOUNDARY', 'legacy helper boundary'],
+  ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'fulfillment shim alias'],
+  ['include!("helpers.rs");', 'unchanged legacy helper inclusion'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const [value, label] of [
+  ['use rustok_fulfillment::FulfillmentService;', 'legacy fulfillment service import'],
+  ['let option = FulfillmentService::new(db.clone())', 'legacy fulfillment constructor call'],
+  ['.get_shipping_option(', 'legacy shipping option owner call'],
+]) {
+  requireText(helperSource, value, label);
+}
+
+const canonicalConstructors =
+  facade.match(/::rustok_fulfillment::FulfillmentService::new\(/g) ?? [];
+if (canonicalConstructors.length !== 1) {
+  failures.push(
+    `expected one canonical fulfillment constructor in the facade, found ${canonicalConstructors.length}`,
+  );
+}
+const legacyConstructors = helperSource.match(/FulfillmentService::new\(/g) ?? [];
+if (legacyConstructors.length !== 1) {
+  failures.push(
+    `expected one legacy fulfillment constructor routed through the facade, found ${legacyConstructors.length}`,
+  );
+}
+
+for (const [value, label] of [
+  ['"validate_selected_shipping_option"', 'public operation mapping'],
+  ['"Selected shipping option is invalid"', 'unchanged public message'],
+  ['"SHIPPING_OPTION_INVALID"', 'unchanged public code'],
+  ['false,', 'unchanged public retryability'],
+]) {
+  requireText(publicFacade, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL cart shipping option context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Legacy GraphQL cart shipping option lookup retains typed fulfillment owner diagnostics while the public SHIPPING_OPTION_INVALID envelope remains unchanged',
+);


### PR DESCRIPTION
## Summary

- route the unchanged legacy `helpers.rs` fulfillment import through a private safe facade;
- delegate the existing shipping-option lookup to the canonical `rustok_fulfillment::FulfillmentService`;
- retain the typed `FulfillmentError` before `async_graphql::Error` conversion;
- log truthful fulfillment owner, tenant, shipping-option, locale, exact operation, stable owner code/kind/retryability, and the explicit legacy helper boundary;
- preserve the existing `SHIPPING_OPTION_INVALID` public envelope and all successful validation behavior;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_legacy_helpers.rs`
- `scripts/verify/verify-commerce-graphql-cart-shipping-option-context.mjs`
- `crates/rustok-commerce/docs/graphql-cart-shipping-option-context.md`

`helpers.rs`, `safe_helpers.rs`, fulfillment entities/services/ports, public GraphQL types, and the master architecture statuses remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adapter cleanup and the review of non-pricing legacy GraphQL helper errors. It closes pre-GraphQL typed-cause loss for the selected shipping-option fulfillment lookup. Typed owner-port cutover and full request correlation remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- the legacy helper source remains included unchanged;
- the single legacy `FulfillmentService::new` call is routed through the facade;
- the canonical fulfillment constructor is isolated inside the facade;
- the facade returns the same `FulfillmentResult<ShippingOptionResponse>` and rethrows the original typed error;
- public message, code, retryability, currency/channel/profile checks, arguments, and success behavior remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-shipping-option-context.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
node scripts/verify/verify-commerce-graphql-cart-pricing-context.mjs
cargo check -p rustok-commerce --lib
```