### PR TITLE
Retain storefront shipping enrichment owner context

### DIFF
--- a/crates/rustok-commerce/docs/storefront-shipping-enrichment-context.md
+++ b/crates/rustok-commerce/docs/storefront-shipping-enrichment-context.md
@@ -1,0 +1,54 @@
+# Storefront shipping enrichment owner context
+
+Status: source-ready, unvalidated
+
+This note records one narrow source slice in the reopened ecommerce P0 public-error safety audit. It does not promote ecommerce FBA or FFA status.
+
+## Closed source gap
+
+The shared storefront cart enrichment helper loads fulfillment-owned shipping options and then filters them by cart currency, public channel visibility, and shipping-profile compatibility. Before this slice, a typed `FulfillmentError` from `list_shipping_options` was immediately converted into `CommerceError::Validation(error.to_string())`.
+
+That compatibility conversion is consumed by both the legacy GraphQL cart mutation helper and the `storefront_cart` query. Their outer safe GraphQL boundaries already return static public envelopes, but the original typed owner cause and truthful cart context were no longer available at the shared enrichment boundary.
+
+`storefront_shipping::enrich_cart_delivery_groups` now records the typed fulfillment failure before returning the same compatibility `CommerceError` as before.
+
+The structured event retains:
+
+- the complete typed `FulfillmentError` cause;
+- truthful `rustok_fulfillment` owner identity;
+- tenant and cart identity;
+- public-channel slug;
+- requested and tenant-default locale inputs;
+- the exact `list_shipping_options` owner operation;
+- stable owner code, kind, and retryability;
+- the explicit storefront shipping enrichment boundary.
+
+Database failures are recorded at error level. Validation, missing-resource, and lifecycle rejections are recorded at warning level.
+
+## Preserved contracts
+
+- `enrich_cart_delivery_groups_typed` remains the canonical typed implementation.
+- The compatibility helper keeps the same arguments and `CommerceResult<CartResponse>` return type.
+- The compatibility helper still returns `CommerceError::Validation(error.to_string())` after diagnostics are retained.
+- Cart currency filtering, public-channel visibility, shipping-profile compatibility, selected-option adoption, and successful cart projection remain unchanged.
+- The legacy mutation facade still returns `Cart shipping details are temporarily unavailable` with code `CART_ENRICHMENT_UNAVAILABLE` and `retryable = true`.
+- The storefront cart query remains behind the existing safe query boundary and its static fail-closed codes.
+- No fulfillment entity, service, port, GraphQL type, or architecture status changes.
+
+## Still open
+
+- Replace the compatibility `CommerceError::Validation` bridge with a typed owner boundary once every consumer can accept the typed result directly.
+- Carry request correlation, actor, causation, and deadline context into the fulfillment owner read.
+- Review remaining product persistence, inventory, metadata parsing, and other non-`PortError` GraphQL helper paths.
+- Execute compile, static verifier, transport, and runtime evidence before changing any architecture status.
+
+## Intended focused checks
+
+```bash
+node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
+cargo check -p rustok-commerce --lib
+```
+
+No verification command above was executed as part of this source wave.

--- a/crates/rustok-commerce/src/storefront_shipping.rs
+++ b/crates/rustok-commerce/src/storefront_shipping.rs
@@ -7,9 +7,11 @@ use crate::{
     CommerceResult,
     dto::{CartResponse, CartShippingOptionSummary, ShippingOptionResponse},
 };
-use rustok_fulfillment::{FulfillmentResult, FulfillmentService};
+use rustok_fulfillment::{FulfillmentError, FulfillmentResult, FulfillmentService};
 
 const DEFAULT_SHIPPING_PROFILE_SLUG: &str = "default";
+const STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY: &str =
+    "commerce_storefront_shipping_enrichment";
 
 pub fn normalize_shipping_profile_slug(value: &str) -> Option<String> {
     let normalized = value.trim().to_ascii_lowercase();
@@ -173,6 +175,7 @@ pub async fn enrich_cart_delivery_groups(
     requested_locale: Option<&str>,
     tenant_default_locale: Option<&str>,
 ) -> CommerceResult<CartResponse> {
+    let cart_id = cart.id;
     enrich_cart_delivery_groups_typed(
         db,
         tenant_id,
@@ -182,7 +185,79 @@ pub async fn enrich_cart_delivery_groups(
         tenant_default_locale,
     )
     .await
-    .map_err(|error| crate::CommerceError::Validation(error.to_string()))
+    .map_err(|error| {
+        log_cart_delivery_group_enrichment_error(
+            &error,
+            tenant_id,
+            cart_id,
+            public_channel_slug,
+            requested_locale,
+            tenant_default_locale,
+        );
+        crate::CommerceError::Validation(error.to_string())
+    })
+}
+
+fn log_cart_delivery_group_enrichment_error(
+    error: &FulfillmentError,
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    public_channel_slug: Option<&str>,
+    requested_locale: Option<&str>,
+    tenant_default_locale: Option<&str>,
+) {
+    let (owner_code, owner_kind, owner_retryable) = match error {
+        FulfillmentError::Validation(_) => ("fulfillment.validation", "validation", false),
+        FulfillmentError::ShippingOptionNotFound(_) => (
+            "fulfillment.shipping_option_not_found",
+            "not_found",
+            false,
+        ),
+        FulfillmentError::FulfillmentNotFound(_) => {
+            ("fulfillment.fulfillment_not_found", "not_found", false)
+        }
+        FulfillmentError::InvalidTransition { .. } => {
+            ("fulfillment.invalid_transition", "conflict", false)
+        }
+        FulfillmentError::Database(_) => (
+            "fulfillment.database_unavailable",
+            "unavailable",
+            true,
+        ),
+    };
+
+    match error {
+        FulfillmentError::Database(_) => tracing::error!(
+            error = ?error,
+            owner = "rustok_fulfillment",
+            tenant_id = %tenant_id,
+            cart_id = %cart_id,
+            public_channel_slug = ?public_channel_slug,
+            requested_locale = ?requested_locale,
+            tenant_default_locale = ?tenant_default_locale,
+            operation = "list_shipping_options",
+            owner_code,
+            owner_kind,
+            owner_retryable,
+            boundary = STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY,
+            "storefront cart shipping enrichment owner read failed"
+        ),
+        _ => tracing::warn!(
+            error = ?error,
+            owner = "rustok_fulfillment",
+            tenant_id = %tenant_id,
+            cart_id = %cart_id,
+            public_channel_slug = ?public_channel_slug,
+            requested_locale = ?requested_locale,
+            tenant_default_locale = ?tenant_default_locale,
+            operation = "list_shipping_options",
+            owner_code,
+            owner_kind,
+            owner_retryable,
+            boundary = STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY,
+            "storefront cart shipping enrichment owner read was rejected"
+        ),
+    }
 }
 
 fn extract_allowed_shipping_profile_slugs_from_metadata(

--- a/scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const shipping = read('crates/rustok-commerce/src/storefront_shipping.rs');
+const helper = read('crates/rustok-commerce/src/graphql/mutations/helpers.rs');
+const helperFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const query = read('crates/rustok-commerce/src/graphql/query.rs');
+const queryFacade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['FulfillmentError, FulfillmentResult, FulfillmentService', 'typed fulfillment import'],
+  ['const STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY: &str =', 'shared enrichment boundary'],
+  ['"commerce_storefront_shipping_enrichment"', 'stable enrichment boundary value'],
+  ['let cart_id = cart.id;', 'cart identity retained before move'],
+  ['enrich_cart_delivery_groups_typed(', 'typed enrichment delegation'],
+  ['log_cart_delivery_group_enrichment_error(', 'typed cause logger'],
+  ['FulfillmentError::Validation(_)', 'validation classification'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option classification'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment classification'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition classification'],
+  ['FulfillmentError::Database(_)', 'database classification'],
+  ['owner = "rustok_fulfillment"', 'truthful owner identity'],
+  ['tenant_id = %tenant_id', 'tenant context'],
+  ['cart_id = %cart_id', 'cart context'],
+  ['public_channel_slug = ?public_channel_slug', 'channel context'],
+  ['requested_locale = ?requested_locale', 'requested locale context'],
+  ['tenant_default_locale = ?tenant_default_locale', 'default locale context'],
+  ['operation = "list_shipping_options"', 'exact owner operation'],
+  ['owner_code,', 'stable owner code'],
+  ['owner_kind,', 'owner error kind'],
+  ['owner_retryable,', 'owner retryability'],
+  ['boundary = STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY', 'boundary logging'],
+  ['crate::CommerceError::Validation(error.to_string())', 'compatibility error preservation'],
+]) {
+  requireText(shipping, value, label);
+}
+
+const typedCalls = shipping.match(/enrich_cart_delivery_groups_typed\(/g) ?? [];
+if (typedCalls.length !== 2) {
+  failures.push(`expected typed enrichment definition plus one compatibility call, found ${typedCalls.length}`);
+}
+const compatibilityMappers =
+  shipping.match(/crate::CommerceError::Validation\(error\.to_string\(\)\)/g) ?? [];
+if (compatibilityMappers.length !== 1) {
+  failures.push(`expected one unchanged compatibility mapper, found ${compatibilityMappers.length}`);
+}
+
+for (const [source, value, label] of [
+  [helper, 'enrich_cart_delivery_groups(', 'legacy mutation helper enrichment call'],
+  [helperFacade, '"Cart shipping details are temporarily unavailable"', 'mutation public message'],
+  [helperFacade, '"CART_ENRICHMENT_UNAVAILABLE"', 'mutation public code'],
+  [query, 'let cart = enrich_cart_delivery_groups(', 'storefront cart query enrichment call'],
+  [queryFacade, 'impl From<crate::CommerceError> for BoundaryError', 'query compatibility boundary'],
+  [queryFacade, '"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE"', 'query unavailable code'],
+  [queryFacade, '"COMMERCE_QUERY_OPERATION_FAILED"', 'query fail-closed code'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const value of [
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+]) {
+  forbidText(shipping, value, 'shared shipping enrichment public conversion');
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront shipping enrichment context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Shared storefront cart shipping enrichment retains typed fulfillment owner diagnostics before the existing compatibility and GraphQL envelopes',
+);


### PR DESCRIPTION
## Summary

- retain the typed `FulfillmentError` before shared storefront cart shipping enrichment converts it into the existing compatibility `CommerceError`;
- record truthful fulfillment owner, tenant, cart, public-channel slug, locale inputs, exact owner operation, stable owner code/kind/retryability, and the explicit enrichment boundary;
- use error severity for database failures and warning severity for validation, missing-resource, and lifecycle rejections;
- preserve the canonical typed enrichment implementation, compatibility return type, existing error conversion, cart filtering, selected-option adoption, and all successful projections;
- cover both the legacy GraphQL cart mutation helper and the `storefront_cart` query through their existing shared call;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/storefront_shipping.rs`
- `scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs`
- `crates/rustok-commerce/docs/storefront-shipping-enrichment-context.md`

GraphQL mutation/query source, safe facades, fulfillment entities/services/ports, public types, and architecture statuses remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adapter cleanup and the review of non-`PortError` GraphQL envelopes. It closes typed fulfillment-cause loss at the shared cart shipping enrichment compatibility boundary. Typed owner-port cutover and request correlation/actor/causation propagation remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` and is not behind;
- both GraphQL consumers continue to call the same shared enrichment helper;
- `enrich_cart_delivery_groups_typed` remains the canonical implementation;
- the compatibility helper still returns `CommerceError::Validation(error.to_string())` after diagnostics are retained;
- currency, channel visibility, shipping-profile filtering, selected-option adoption, arguments, return types, and success behavior remain unchanged;
- existing safe mutation/query public envelopes remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
cargo check -p rustok-commerce --lib
```