### PR TITLE
Retain GraphQL query fulfillment owner context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -1,0 +1,72 @@
+# GraphQL query fulfillment owner context
+
+Status: `source_ready_unvalidated`
+
+## Closed gap
+
+The safe commerce GraphQL query facade now intercepts the two direct
+`FulfillmentService` reads mounted by the unchanged `query.rs` source:
+
+- `storefront_shipping_options` delegates `list_shipping_options`;
+- admin `order` delegates `find_by_order`.
+
+Before this slice, `storefront_shipping_options` preserved the typed error only at the
+shared GraphQL query boundary, where tenant, locale inputs, and exact owner operation
+were no longer available. The admin order lookup converted the typed fulfillment cause
+to a string before the generic fail-closed query envelope, losing the typed variant
+entirely.
+
+A private two-method facade now delegates to the canonical
+`rustok_fulfillment::FulfillmentService`, records the original `FulfillmentError`, and
+rethrows the same typed error. Diagnostics retain:
+
+- truthful owner `rustok_fulfillment`;
+- tenant identity;
+- GraphQL query field;
+- exact owner operation;
+- truthful optional order identity;
+- requested and tenant-default locale inputs where present;
+- stable owner code, kind, and retryability;
+- explicit boundary `commerce_graphql_query_fulfillment_facade`.
+
+Database failures use error severity. Validation, missing-resource, and lifecycle
+rejections use warning severity.
+
+## Preserved contracts
+
+- `query.rs` remains unchanged and still imports `rustok_fulfillment::FulfillmentService`.
+- Both existing `FulfillmentService::new(db.clone())` call sites resolve through the
+  private safe facade.
+- The facade returns the canonical `FulfillmentResult` values and rethrows the original
+  typed error.
+- Storefront shipping-option currency, channel-visibility, and shipping-profile
+  filtering remain unchanged.
+- Admin order payment and fulfillment projection behavior remains unchanged.
+- The storefront query keeps the existing `FULFILLMENT_*` message/code/retryability
+  policy.
+- The admin order lookup keeps its existing generic
+  `COMMERCE_QUERY_OPERATION_FAILED` fail-closed envelope after string conversion.
+- GraphQL schema, DTOs, owner service signatures, ports, and successful responses remain
+  unchanged.
+
+## Still open
+
+- Replace legacy direct owner-service query reads with typed ports carrying complete
+  `PortContext` where owner contracts exist.
+- Propagate request correlation, actor, channel, causation, and deadline context into
+  fulfillment query reads rather than reconstructing only local identities.
+- Continue reviewing order, payment, customer, inventory, region, channel, catalog, and
+  remaining commerce query conversions that still pass through dynamic strings.
+- Add compile and transport evidence before promoting any FBA/FFA status.
+
+## Intended checks
+
+```bash
+node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
+node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
+cargo check -p rustok-commerce --lib
+```
+
+Tests, Cargo commands, formatting commands, verifiers, workflow checks, and CI were not
+run for this source wave; validation remains maintainer-owned.

--- a/crates/rustok-commerce/src/graphql/safe_query.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query.rs
@@ -406,7 +406,149 @@ mod source {
         }
     }
 
+    mod rustok_fulfillment_shim {
+        use ::rustok_fulfillment::{
+            FulfillmentError, FulfillmentResponse, FulfillmentResult, ShippingOptionResponse,
+        };
+        use ::sea_orm::DatabaseConnection;
+        use ::uuid::Uuid;
+
+        const GRAPHQL_QUERY_FULFILLMENT_BOUNDARY: &str =
+            "commerce_graphql_query_fulfillment_facade";
+
+        pub struct FulfillmentService {
+            inner: ::rustok_fulfillment::FulfillmentService,
+        }
+
+        impl FulfillmentService {
+            pub fn new(db: DatabaseConnection) -> Self {
+                Self {
+                    inner: ::rustok_fulfillment::FulfillmentService::new(db),
+                }
+            }
+
+            pub async fn list_shipping_options(
+                &self,
+                tenant_id: Uuid,
+                requested_locale: Option<&str>,
+                tenant_default_locale: Option<&str>,
+            ) -> FulfillmentResult<Vec<ShippingOptionResponse>> {
+                self.inner
+                    .list_shipping_options(
+                        tenant_id,
+                        requested_locale,
+                        tenant_default_locale,
+                    )
+                    .await
+                    .map_err(|error| {
+                        log_fulfillment_query_error(
+                            &error,
+                            tenant_id,
+                            "storefront_shipping_options",
+                            "list_shipping_options",
+                            None,
+                            requested_locale,
+                            tenant_default_locale,
+                        );
+                        error
+                    })
+            }
+
+            pub async fn find_by_order(
+                &self,
+                tenant_id: Uuid,
+                order_id: Uuid,
+            ) -> FulfillmentResult<Option<FulfillmentResponse>> {
+                self.inner
+                    .find_by_order(tenant_id, order_id)
+                    .await
+                    .map_err(|error| {
+                        log_fulfillment_query_error(
+                            &error,
+                            tenant_id,
+                            "order",
+                            "find_by_order",
+                            Some(order_id),
+                            None,
+                            None,
+                        );
+                        error
+                    })
+            }
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn log_fulfillment_query_error(
+            error: &FulfillmentError,
+            tenant_id: Uuid,
+            query_field: &'static str,
+            operation: &'static str,
+            order_id: Option<Uuid>,
+            requested_locale: Option<&str>,
+            tenant_default_locale: Option<&str>,
+        ) {
+            let (owner_code, owner_kind, owner_retryable) = match error {
+                FulfillmentError::Validation(_) =>
+                    ("fulfillment.validation", "validation", false),
+                FulfillmentError::ShippingOptionNotFound(_) => (
+                    "fulfillment.shipping_option_not_found",
+                    "not_found",
+                    false,
+                ),
+                FulfillmentError::FulfillmentNotFound(_) => (
+                    "fulfillment.fulfillment_not_found",
+                    "not_found",
+                    false,
+                ),
+                FulfillmentError::InvalidTransition { .. } => (
+                    "fulfillment.invalid_transition",
+                    "conflict",
+                    false,
+                ),
+                FulfillmentError::Database(_) => (
+                    "fulfillment.database_unavailable",
+                    "unavailable",
+                    true,
+                ),
+            };
+
+            match error {
+                FulfillmentError::Database(_) => tracing::error!(
+                    error = ?error,
+                    owner = "rustok_fulfillment",
+                    tenant_id = %tenant_id,
+                    query_field,
+                    operation,
+                    order_id = ?order_id,
+                    requested_locale = ?requested_locale,
+                    tenant_default_locale = ?tenant_default_locale,
+                    owner_code,
+                    owner_kind,
+                    owner_retryable,
+                    boundary = GRAPHQL_QUERY_FULFILLMENT_BOUNDARY,
+                    "commerce GraphQL query fulfillment owner read failed"
+                ),
+                _ => tracing::warn!(
+                    error = ?error,
+                    owner = "rustok_fulfillment",
+                    tenant_id = %tenant_id,
+                    query_field,
+                    operation,
+                    order_id = ?order_id,
+                    requested_locale = ?requested_locale,
+                    tenant_default_locale = ?tenant_default_locale,
+                    owner_code,
+                    owner_kind,
+                    owner_retryable,
+                    boundary = GRAPHQL_QUERY_FULFILLMENT_BOUNDARY,
+                    "commerce GraphQL query fulfillment owner read was rejected"
+                ),
+            }
+        }
+    }
+
     use self::rustok_api_shim as rustok_api;
+    use self::rustok_fulfillment_shim as rustok_fulfillment;
 
     include!("query.rs");
 }

--- a/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const query = read('crates/rustok-commerce/src/graphql/query.rs');
+const facade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['mod rustok_fulfillment_shim {', 'private fulfillment facade'],
+  ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'safe fulfillment routing'],
+  ['inner: ::rustok_fulfillment::FulfillmentService', 'canonical fulfillment delegate'],
+  ['::rustok_fulfillment::FulfillmentService::new(db)', 'canonical constructor isolation'],
+  ['pub async fn list_shipping_options(', 'shipping option list facade'],
+  ['pub async fn find_by_order(', 'order fulfillment facade'],
+  ['FulfillmentResult<Vec<ShippingOptionResponse>>', 'shipping option typed result'],
+  ['FulfillmentResult<Option<FulfillmentResponse>>', 'order fulfillment typed result'],
+  ['"storefront_shipping_options"', 'storefront query field'],
+  ['"list_shipping_options"', 'shipping option owner operation'],
+  ['"order"', 'admin order query field'],
+  ['"find_by_order"', 'order fulfillment owner operation'],
+  ['FulfillmentError::Validation(_)', 'validation classification'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found classification'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found classification'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition classification'],
+  ['FulfillmentError::Database(_)', 'database classification'],
+  ['owner = "rustok_fulfillment"', 'truthful owner'],
+  ['tenant_id = %tenant_id', 'tenant context'],
+  ['query_field,', 'query field context'],
+  ['operation,', 'owner operation context'],
+  ['order_id = ?order_id', 'order context'],
+  ['requested_locale = ?requested_locale', 'requested locale context'],
+  ['tenant_default_locale = ?tenant_default_locale', 'default locale context'],
+  ['owner_code,', 'stable owner code'],
+  ['owner_kind,', 'owner kind'],
+  ['owner_retryable,', 'owner retryability'],
+  ['"commerce_graphql_query_fulfillment_facade"', 'explicit facade boundary'],
+  ['error\n                    })', 'original typed error rethrow'],
+]) {
+  requireText(facade, value, label);
+}
+
+for (const [value, label] of [
+  ['use rustok_fulfillment::FulfillmentService;', 'unchanged query import'],
+  ['let mut options = FulfillmentService::new(db.clone())', 'storefront constructor call'],
+  ['.list_shipping_options(', 'storefront shipping option call'],
+  ['let fulfillment = FulfillmentService::new(db.clone())', 'admin order constructor call'],
+  ['.find_by_order(tenant_id, id)', 'admin order fulfillment call'],
+  ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'existing admin order public conversion'],
+]) {
+  requireText(query, value, label);
+}
+
+const sourceConstructors = query.match(/FulfillmentService::new\(db\.clone\(\)\)/g) ?? [];
+if (sourceConstructors.length !== 2) {
+  failures.push(`expected exactly two query fulfillment constructors, found ${sourceConstructors.length}`);
+}
+
+const canonicalConstructors =
+  facade.match(/::rustok_fulfillment::FulfillmentService::new\(db\)/g) ?? [];
+if (canonicalConstructors.length !== 1) {
+  failures.push(`expected one canonical fulfillment constructor, found ${canonicalConstructors.length}`);
+}
+
+for (const value of [
+  '"Fulfillment query is invalid"',
+  '"FULFILLMENT_REQUEST_INVALID"',
+  '"Fulfillment resource was not found"',
+  '"FULFILLMENT_RESOURCE_NOT_FOUND"',
+  '"Fulfillment state conflicts with this query"',
+  '"FULFILLMENT_STATE_CONFLICT"',
+  '"Fulfillment data is temporarily unavailable"',
+  '"FULFILLMENT_TEMPORARILY_UNAVAILABLE"',
+  '"Commerce query could not be completed safely"',
+  '"COMMERCE_QUERY_OPERATION_FAILED"',
+]) {
+  requireText(facade, value, 'existing public GraphQL envelope');
+}
+
+forbidText(
+  query,
+  '::rustok_fulfillment::FulfillmentService',
+  'query source must remain facade-routed',
+);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL query fulfillment context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL query fulfillment reads retain typed owner diagnostics before existing public mappings',
+);


### PR DESCRIPTION
## Summary

- route the unchanged commerce `query.rs` fulfillment import through a private safe facade;
- delegate the existing storefront shipping-option list and admin order fulfillment lookup to the canonical `rustok_fulfillment::FulfillmentService`;
- retain the original typed `FulfillmentError` before the existing `?` or `to_string()` GraphQL conversions;
- record truthful fulfillment owner, tenant, query field, exact owner operation, optional order identity, locale inputs, stable owner code/kind/retryability, and the explicit query facade boundary;
- preserve all existing storefront filtering, admin order projections, public GraphQL messages, codes, retryability, and successful behavior;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/safe_query.rs`
- `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
- `crates/rustok-commerce/docs/graphql-query-fulfillment-context.md`

`query.rs`, fulfillment services/DTOs/ports, GraphQL schema/types, shared query mappings, and architecture statuses remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper/adapter cleanup and the review of non-`PortError` GraphQL envelopes. It closes typed fulfillment-cause context loss for the two direct commerce GraphQL query reads. Typed owner-port cutover and full request correlation/actor/channel/causation propagation remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` by three commits and is not behind;
- `query.rs` remains unchanged and keeps exactly two `FulfillmentService::new(db.clone())` call sites;
- both calls resolve through the private safe facade;
- the canonical fulfillment constructor remains isolated inside the facade;
- facade methods return the canonical `FulfillmentResult` types and rethrow the original typed error;
- storefront currency/channel/profile filtering and admin order projections remain unchanged;
- existing `FULFILLMENT_*` and `COMMERCE_QUERY_OPERATION_FAILED` public envelopes remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
cargo check -p rustok-commerce --lib
```