### PR TITLE
Retain customer read policy rejection context

### DIFF
--- a/crates/rustok-customer/docs/read-port-policy-context.md
+++ b/crates/rustok-customer/docs/read-port-policy-context.md
@@ -1,0 +1,75 @@
+# Customer read port policy context
+
+Status: `source_ready_unvalidated`
+
+## Closed gap
+
+`CustomerReadPort` previously called `PortContext::require_policy` before assigning the
+owner operation. A missing or invalid read deadline therefore returned a typed
+`PortError` without a customer-specific structured event tying the rejection to the
+exact owner method and original call context.
+
+All four read methods now:
+
+1. assign their canonical owner operation first;
+2. delegate read admission to one shared helper;
+3. log a rejected admission with the complete available `PortContext`;
+4. return the original `PortError` unchanged.
+
+The diagnostic event records:
+
+- owner `rustok_customer`;
+- correlation and tenant identity;
+- actor, channel, locale, causation, traceparent, and deadline context;
+- exact owner operation;
+- original port code, typed kind, and retryability;
+- boundary `customer_read_port`.
+
+## Covered operations
+
+- `read_customer_projection`
+- `read_customer_projection_by_user`
+- `list_customer_projections`
+- `list_profile_enrichment`
+
+This includes the owner method used by the three current commerce GraphQL customer
+identity reads.
+
+## Preserved contracts
+
+The change does not alter:
+
+- the `CustomerReadPort` trait;
+- request or response DTOs;
+- the in-process provider factory;
+- read deadline requirements;
+- tenant parsing or list validation;
+- customer service calls;
+- existing customer error-to-`PortError` codes, kinds, messages, and retryability;
+- GraphQL not-found handling (`unauthenticated` or optional `None`);
+- GraphQL fallback envelopes or successful responses.
+
+The policy helper rethrows the exact original `PortError` after diagnostics are retained.
+
+## Still open
+
+This slice does not claim full customer transport completion. Remaining work includes:
+
+- retaining consumer-side `PortContext` at every non-owner GraphQL, REST, native, and
+  operator mapping boundary;
+- auditing customer write adapters and profile transports;
+- adding runtime/transport evidence and compile validation;
+- completing the wider ecommerce correlation-safe mapper cleanup.
+
+No ecommerce FBA/FFA status is promoted.
+
+## Intended verification
+
+```bash
+node scripts/verify/verify-customer-read-policy-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-customer --lib
+cargo check -p rustok-commerce --lib
+```
+
+These commands were not run for this source wave; validation remains maintainer-owned.

--- a/crates/rustok-customer/src/ports.rs
+++ b/crates/rustok-customer/src/ports.rs
@@ -9,6 +9,7 @@ use crate::dto::{CustomerResponse, ListCustomersInput};
 use crate::error::CustomerError;
 
 const MAX_CUSTOMERS_PER_PAGE: u64 = 100;
+const CUSTOMER_READ_PORT_BOUNDARY: &str = "customer_read_port";
 
 /// Transport-neutral owner boundary for customer read projections used by checkout/order flows.
 #[async_trait]
@@ -87,8 +88,8 @@ impl CustomerReadPort for crate::CustomerService {
         context: PortContext,
         request: CustomerProjectionRequest,
     ) -> Result<CustomerResponse, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
         let owner_operation = "read_customer_projection";
+        require_customer_read_policy(&context, owner_operation)?;
         let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
         self.get_customer(tenant_id, request.customer_id)
             .await
@@ -100,8 +101,8 @@ impl CustomerReadPort for crate::CustomerService {
         context: PortContext,
         request: CustomerUserProjectionRequest,
     ) -> Result<CustomerResponse, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
         let owner_operation = "read_customer_projection_by_user";
+        require_customer_read_policy(&context, owner_operation)?;
         let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
         self.get_customer_by_user(tenant_id, request.user_id)
             .await
@@ -113,8 +114,8 @@ impl CustomerReadPort for crate::CustomerService {
         context: PortContext,
         request: CustomerListProjectionRequest,
     ) -> Result<CustomerListProjectionResponse, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
         let owner_operation = "list_customer_projections";
+        require_customer_read_policy(&context, owner_operation)?;
         validate_customer_list_projection_request(&context, owner_operation, &request)?;
         let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
         let (items, total) = self
@@ -136,13 +137,42 @@ impl CustomerReadPort for crate::CustomerService {
         context: PortContext,
         request: CustomerProfileEnrichmentRequest,
     ) -> Result<Vec<CustomerProfileEnrichment>, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
         let owner_operation = "list_profile_enrichment";
+        require_customer_read_policy(&context, owner_operation)?;
         let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
         crate::CustomerService::list_profile_enrichment(self, tenant_id, &request.user_ids)
             .await
             .map_err(|error| customer_error_to_port_error(&context, owner_operation, error))
     }
+}
+
+fn require_customer_read_policy(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(|error| {
+            tracing::warn!(
+                error = ?error,
+                owner = "rustok_customer",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                code = %error.code,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = CUSTOMER_READ_PORT_BOUNDARY,
+                "customer read port admission was rejected"
+            );
+            error
+        })
 }
 
 fn validate_customer_list_projection_request(

--- a/scripts/verify/verify-customer-read-policy-context.mjs
+++ b/scripts/verify/verify-customer-read-policy-context.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const customer = read('crates/rustok-customer/src/ports.rs');
+const commerceQuery = read('crates/rustok-commerce/src/graphql/query.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['const CUSTOMER_READ_PORT_BOUNDARY: &str = "customer_read_port";', 'stable owner boundary'],
+  ['fn require_customer_read_policy(', 'shared read policy helper'],
+  ['.require_policy(PortCallPolicy::read())', 'canonical read policy'],
+  ['owner = "rustok_customer"', 'truthful owner identity'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['operation = owner_operation', 'exact owner operation'],
+  ['code = %error.code', 'stable public code'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'owner retryability'],
+  ['boundary = CUSTOMER_READ_PORT_BOUNDARY', 'boundary context'],
+  ['"customer read port admission was rejected"', 'stable diagnostic event'],
+]) {
+  requireText(customer, value, label);
+}
+
+const policyCalls = customer.match(/require_customer_read_policy\(&context, owner_operation\)\?;/g) ?? [];
+if (policyCalls.length !== 4) {
+  failures.push(`expected four customer read policy calls, found ${policyCalls.length}`);
+}
+
+for (const operation of [
+  'read_customer_projection',
+  'read_customer_projection_by_user',
+  'list_customer_projections',
+  'list_profile_enrichment',
+]) {
+  const assignment = `let owner_operation = "${operation}";`;
+  const assignmentIndex = customer.indexOf(assignment);
+  const policyIndex = customer.indexOf(
+    'require_customer_read_policy(&context, owner_operation)?;',
+    assignmentIndex,
+  );
+  if (assignmentIndex < 0 || policyIndex < assignmentIndex) {
+    failures.push(`${operation}: owner operation must be assigned before policy admission`);
+  }
+}
+
+forbidText(
+  customer,
+  '        context.require_policy(PortCallPolicy::read())?;',
+  'direct unlogged customer read policy admission',
+);
+
+for (const [value, label] of [
+  ['"customer.database_unavailable"', 'database mapping'],
+  ['"customer.customer_not_found"', 'customer not-found mapping'],
+  ['"customer.customer_by_user_not_found"', 'user not-found mapping'],
+  ['"customer.duplicate_email"', 'duplicate email mapping'],
+  ['"customer.duplicate_user_link"', 'duplicate user-link mapping'],
+  ['"customer.validation"', 'validation mapping'],
+  ['"customer.profile_unavailable"', 'profile mapping'],
+  ['"customer storage is temporarily unavailable"', 'stable storage message'],
+  ['"customer request is invalid"', 'stable validation message'],
+]) {
+  requireText(customer, value, label);
+}
+
+const graphqlCustomerConstructors =
+  commerceQuery.match(/in_process_customer_read_port\(db\.clone\(\)\)/g) ?? [];
+if (graphqlCustomerConstructors.length !== 3) {
+  failures.push(
+    `expected three unchanged commerce GraphQL customer read constructors, found ${graphqlCustomerConstructors.length}`,
+  );
+}
+for (const [value, label] of [
+  ['"customer.customer_by_user_not_found" => {', 'storefront unauthenticated not-found branch'],
+  ['Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)', 'optional customer not-found branch'],
+  ['async_graphql::Error::new(error.message)', 'existing GraphQL fallback mapping'],
+]) {
+  requireText(commerceQuery, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Customer read policy context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Customer read owner operations retain complete PortContext when read policy admission is rejected',
+);


### PR DESCRIPTION
## Summary

- assign each canonical `CustomerReadPort` owner operation before read-policy admission;
- route all four read methods through one shared policy helper;
- retain rejected admission context with truthful customer owner, correlation and tenant identity, actor, channel, locale, causation, traceparent, deadline, exact operation, original port code/kind/retryability, and the explicit owner boundary;
- return the original `PortError` unchanged after diagnostics;
- preserve customer service calls, DTOs, tenant/list validation, existing owner error mappings, and all public transport behavior;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-customer/src/ports.rs`
- `scripts/verify/verify-customer-read-policy-context.mjs`
- `crates/rustok-customer/docs/read-port-policy-context.md`

Commerce GraphQL source, customer service implementations, public DTOs, error codes/messages, and architecture statuses remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe customer mapper cleanup. It closes the owner-side context gap where read deadline/policy rejection occurred before the canonical owner operation was assigned or a customer-specific structured event was emitted. Consumer-side transport context retention and remaining customer write/profile adapters remain open. No FBA/FFA status is promoted.

## Validation

- branch is directly ahead of current `main` by three commits and is not behind;
- all four `CustomerReadPort` methods assign their exact operation before admission;
- all four methods call the shared policy helper;
- the helper delegates to the unchanged `PortCallPolicy::read()` requirement and rethrows the original error;
- existing customer error-to-`PortError` mappings and stable messages remain unchanged;
- the three current commerce GraphQL customer read constructors and their not-found/fallback branches remain unchanged;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-customer-read-policy-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-customer --lib
cargo check -p rustok-commerce --lib
```