### PR TITLE
fix(index): reject whitespace-only decision text

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -65,6 +65,8 @@ The generated draft contains `TODO(index-storage-decision):` markers. Replace ev
 
 [`storage-decision.example.json`](storage-decision.example.json) shows the same decision fields and references [`storage-decision.schema.json`](storage-decision.schema.json). Its relative `$schema` is valid because the two files are colocated in the documentation directory. A generated decision under `evidence/index-storage/...` intentionally omits `$schema` rather than recording a false relative path; `$schema` remains an optional finalizer field when it correctly points to a colocated schema file.
 
+The decision schema requires at least one non-whitespace character in the owner and every selection, rejection, operational, migration, and rollback narrative. Whitespace-only text is rejected before a decision is treated as schema-valid. This keeps schema validation aligned with preparation, rendering, and finalization, which all trim required human-authored text before accepting it.
+
 The example is intentionally not finalizable until its markers are replaced. The decision must explain:
 
 - why the selected prototype is preferred;

--- a/crates/rustok-index/docs/storage-decision.schema.json
+++ b/crates/rustok-index/docs/storage-decision.schema.json
@@ -32,7 +32,8 @@
     },
     "owner": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "comparison_commit": {
       "type": "string",
@@ -48,22 +49,26 @@
     },
     "selection_rationale": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "rejection_rationales": {
       "type": "object"
     },
     "operational_tradeoffs": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "migration_strategy": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "rollback_strategy": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "\\S"
     }
   },
   "allOf": [
@@ -81,8 +86,8 @@
             "additionalProperties": false,
             "required": ["typed_eav", "hot_projection"],
             "properties": {
-              "typed_eav": { "type": "string", "minLength": 1 },
-              "hot_projection": { "type": "string", "minLength": 1 }
+              "typed_eav": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "hot_projection": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }
@@ -102,8 +107,8 @@
             "additionalProperties": false,
             "required": ["jsonb", "hot_projection"],
             "properties": {
-              "jsonb": { "type": "string", "minLength": 1 },
-              "hot_projection": { "type": "string", "minLength": 1 }
+              "jsonb": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "hot_projection": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }
@@ -123,8 +128,8 @@
             "additionalProperties": false,
             "required": ["jsonb", "typed_eav"],
             "properties": {
-              "jsonb": { "type": "string", "minLength": 1 },
-              "typed_eav": { "type": "string", "minLength": 1 }
+              "jsonb": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "typed_eav": { "type": "string", "minLength": 1, "pattern": "\\S" }
             }
           }
         }

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -61,6 +61,7 @@ const runContract = (args) => {
     'verify-index-storage-renderer-lifecycle.mjs',
     'verify-index-storage-adr-verifier-cli.mjs',
     'verify-index-storage-decision-preparation-lifecycle.mjs',
+    'verify-index-storage-decision-text-schema.mjs',
   ]) {
     runScript(script);
   }
@@ -76,6 +77,7 @@ const runFixtures = (args) => {
     scriptPath('render-index-storage-adr.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),
+    scriptPath('storage-decision-schema-text.test.mjs'),
   ], 'Index storage fixture suites');
 };
 

--- a/scripts/verify/storage-decision-schema-text.test.mjs
+++ b/scripts/verify/storage-decision-schema-text.test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const schema = JSON.parse(readFileSync(
+  new URL('../../crates/rustok-index/docs/storage-decision.schema.json', import.meta.url),
+  'utf8',
+));
+
+const prototypes = ['jsonb', 'typed_eav', 'hot_projection'];
+const requiredTopLevelText = [
+  'owner',
+  'selection_rationale',
+  'operational_tradeoffs',
+  'migration_strategy',
+  'rollback_strategy',
+];
+
+const requireTextContract = (definition, label) => {
+  assert.equal(definition?.type, 'string', `${label} must be a string`);
+  assert.equal(definition?.minLength, 1, `${label} must retain minLength 1`);
+  assert.equal(definition?.pattern, '\\S', `${label} must require one non-whitespace character`);
+};
+
+const selectedBranch = (prototype) => schema.allOf.find(
+  (entry) => entry?.if?.properties?.selected_prototype?.const === prototype,
+);
+
+const acceptsText = (definition, value) => typeof value === 'string'
+  && value.length >= definition.minLength
+  && new RegExp(definition.pattern, 'u').test(value);
+
+const everyTextDefinition = () => {
+  const definitions = requiredTopLevelText.map((field) => [
+    field,
+    schema.properties[field],
+  ]);
+  for (const prototype of prototypes) {
+    const branch = selectedBranch(prototype);
+    for (const [rejected, definition] of Object.entries(
+      branch?.then?.properties?.rejection_rationales?.properties ?? {},
+    )) {
+      definitions.push([`${prototype}.rejection_rationales.${rejected}`, definition]);
+    }
+  }
+  return definitions;
+};
+
+test('requires non-whitespace text for every top-level decision narrative', () => {
+  for (const field of requiredTopLevelText) {
+    requireTextContract(schema.properties[field], field);
+  }
+});
+
+test('requires non-whitespace text for every conditional rejection rationale', () => {
+  for (const selected of prototypes) {
+    const branch = selectedBranch(selected);
+    assert.ok(branch, `missing schema branch for ${selected}`);
+    const rejection = branch.then.properties.rejection_rationales;
+    const expected = prototypes.filter((prototype) => prototype !== selected);
+    assert.deepEqual(rejection.required, expected);
+    assert.deepEqual(Object.keys(rejection.properties), expected);
+    assert.equal(rejection.additionalProperties, false);
+    for (const rejected of expected) {
+      requireTextContract(
+        rejection.properties[rejected],
+        `${selected}.rejection_rationales.${rejected}`,
+      );
+    }
+  }
+});
+
+test('rejects empty and whitespace-only values while accepting reviewed text', () => {
+  for (const [label, definition] of everyTextDefinition()) {
+    for (const value of ['', ' ', '   ', '\n', '\t', ' \n\t ']) {
+      assert.equal(acceptsText(definition, value), false, `${label} accepted ${JSON.stringify(value)}`);
+    }
+    for (const value of ['reviewed', ' reviewed ', '\nreviewed\t']) {
+      assert.equal(acceptsText(definition, value), true, `${label} rejected ${JSON.stringify(value)}`);
+    }
+  }
+});

--- a/scripts/verify/verify-index-storage-decision-text-schema.mjs
+++ b/scripts/verify/verify-index-storage-decision-text-schema.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-decision-text-schema] ${message}`);
+  process.exit(1);
+};
+
+const schema = JSON.parse(read('crates/rustok-index/docs/storage-decision.schema.json'));
+const fixture = read('scripts/verify/storage-decision-schema-text.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+const prototypes = ['jsonb', 'typed_eav', 'hot_projection'];
+const topLevelText = [
+  'owner',
+  'selection_rationale',
+  'operational_tradeoffs',
+  'migration_strategy',
+  'rollback_strategy',
+];
+
+const requireTextContract = (definition, label) => {
+  if (definition?.type !== 'string') fail(`${label} must be a string`);
+  if (definition?.minLength !== 1) fail(`${label} must retain minLength 1`);
+  if (definition?.pattern !== '\\S') {
+    fail(`${label} must require at least one non-whitespace character`);
+  }
+};
+
+for (const field of topLevelText) {
+  requireTextContract(schema.properties?.[field], `storage decision schema ${field}`);
+}
+
+if (!Array.isArray(schema.allOf) || schema.allOf.length !== prototypes.length) {
+  fail('storage decision schema must retain one conditional rejection branch per prototype');
+}
+for (const selected of prototypes) {
+  const branch = schema.allOf.find(
+    (entry) => entry?.if?.properties?.selected_prototype?.const === selected,
+  );
+  if (!branch) fail(`storage decision schema is missing the ${selected} branch`);
+  const rejection = branch.then?.properties?.rejection_rationales;
+  const expected = prototypes.filter((prototype) => prototype !== selected);
+  if (rejection?.additionalProperties !== false) {
+    fail(`${selected} rejection rationales must reject additional properties`);
+  }
+  if (JSON.stringify(rejection?.required) !== JSON.stringify(expected)) {
+    fail(`${selected} rejection rationale requirements drifted`);
+  }
+  if (JSON.stringify(Object.keys(rejection?.properties ?? {})) !== JSON.stringify(expected)) {
+    fail(`${selected} rejection rationale properties drifted`);
+  }
+  for (const rejected of expected) {
+    requireTextContract(
+      rejection.properties[rejected],
+      `storage decision schema ${selected}.rejection_rationales.${rejected}`,
+    );
+  }
+}
+
+for (const marker of [
+  "test('requires non-whitespace text for every top-level decision narrative'",
+  "test('requires non-whitespace text for every conditional rejection rationale'",
+  "test('rejects empty and whitespace-only values while accepting reviewed text'",
+  "assert.equal(definition?.pattern, '\\\\S'",
+  "for (const value of ['', ' ', '   ', '\\n', '\\t', ' \\n\\t '])",
+  "for (const value of ['reviewed', ' reviewed ', '\\nreviewed\\t'])",
+]) {
+  if (!fixture.includes(marker)) fail(`decision text schema fixture is missing marker: ${marker}`);
+}
+
+for (const marker of [
+  "'verify-index-storage-decision-text-schema.mjs'",
+  "scriptPath('storage-decision-schema-text.test.mjs')",
+]) {
+  if (!router.includes(marker)) fail(`storage tooling router is missing marker: ${marker}`);
+}
+
+for (const marker of [
+  'The decision schema requires at least one non-whitespace character in the owner and every selection, rejection, operational, migration, and rollback narrative.',
+  'Whitespace-only text is rejected before a decision is treated as schema-valid.',
+]) {
+  if (!guide.includes(marker)) fail(`storage decision guide is missing marker: ${marker}`);
+}
+
+console.log('[verify-index-storage-decision-text-schema] top-level and conditional decision narratives require non-whitespace text, with fixture, router, and documentation coverage');


### PR DESCRIPTION
## Summary

- rebuild #2175 on the current `main` and retain `minLength: 1` for every required human-authored decision field;
- require at least one non-whitespace character in owner, selection, operational, migration, and rollback text;
- apply the same contract to every conditional rejection rationale for JSONB, typed EAV, and hot projection selections;
- add a focused schema semantics fixture covering empty, whitespace-only, and reviewed text;
- add a static schema cross-guard, canonical router registration, and synchronized decision documentation.

## Recheck

- confirmed the current schema still allowed whitespace-only narrative text;
- confirmed runtime preparation, rendering, and finalization already trim required text and therefore rejected schema-valid whitespace-only values;
- preserved the exact selected-prototype and rejection-rationale branch structure;
- kept M2 open and did not claim benchmark evidence or a storage decision.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request. Static review covered JSON parsing, all five top-level narrative fields, all six conditional rejection properties, exact branch ordering, whitespace semantics, fixture markers, router registration, documentation, and the five-file compare against `main`.

Supersedes #2175.