### PR TITLE
Retain checkout inventory boundary context

### DIFF
--- a/crates/rustok-commerce/docs/checkout-inventory-boundary-context.md
+++ b/crates/rustok-commerce/docs/checkout-inventory-boundary-context.md
@@ -1,0 +1,77 @@
+# Checkout inventory boundary context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice retains the complete inventory `PortContext` when the durable checkout inventory
+reservation executor receives an owner error or detects an invalid owner response.
+
+The covered owner operations are:
+
+- `reserve_inventory_by_identity`;
+- `release_inventory_by_identity`.
+
+Both the direct `PortError` paths and the synthetic response-mismatch paths now pass through the
+same structured diagnostic boundary before the existing reservation journal write.
+
+## Retained context
+
+The diagnostic event records:
+
+- truthful owner: `rustok_inventory`;
+- correlation and tenant identity;
+- actor, channel and locale;
+- causation and traceparent;
+- idempotency key and deadline;
+- exact owner operation;
+- cart line and reservation identity;
+- original port code, typed kind and retryability;
+- explicit boundary: `commerce_checkout_inventory_reservation`.
+
+Unavailable, timeout and invariant failures use error severity. Validation, not-found, conflict and
+forbidden failures use warning severity.
+
+## Compatibility
+
+The following behavior is intentionally unchanged:
+
+- reservation planning and replay adoption;
+- immutable cart snapshot validation;
+- reserve and release request DTOs;
+- reservation identity and external-id semantics;
+- provider response validation;
+- journal `record_error` code and message payloads;
+- `Boundary` and `BoundaryAndJournal` public error variants;
+- retryability propagation;
+- checkpoint and release state transitions;
+- operation, reservation and inventory owner ports.
+
+The same cloned `PortContext` is used for the owner call and the subsequent diagnostic event. No
+technical cause is added to the public error or journal payload.
+
+## Plan alignment
+
+This advances the open ecommerce P0 correlation-safe inventory mapper/adapter cleanup. It closes
+consumer-side context loss at the durable checkout inventory reserve/release boundary.
+
+Still open:
+
+- inventory owner read/write admission diagnostics outside this executor;
+- checkout inventory availability consumer context;
+- remaining inventory HTTP/GraphQL/admin adapters;
+- request-context propagation gaps in other ecommerce owners;
+- runtime and cross-backend evidence.
+
+No FBA or FFA status is promoted by this source-only slice.
+
+## Intended validation
+
+```bash
+node scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce --lib
+```
+
+Tests, Cargo commands, formatting commands, verifier execution, workflow checks and CI were not run
+for this slice, per maintainer instruction.

--- a/crates/rustok-commerce/src/services/checkout_inventory_reservation_executor.rs
+++ b/crates/rustok-commerce/src/services/checkout_inventory_reservation_executor.rs
@@ -1,4 +1,6 @@
-use rustok_api::{PLATFORM_FALLBACK_LOCALE, PortActor, PortContext, PortError};
+use rustok_api::{
+    PLATFORM_FALLBACK_LOCALE, PortActor, PortContext, PortError, PortErrorKind,
+};
 use rustok_cart::PreparedCartCheckoutSnapshot;
 use rustok_inventory::{
     InventoryIdentityReservationReleaseRequest, InventoryIdentityReservationRequest,
@@ -19,6 +21,7 @@ use super::{
 };
 
 const DEFAULT_INVENTORY_PORT_DEADLINE_SECONDS: u64 = 2;
+const CHECKOUT_INVENTORY_BOUNDARY: &str = "commerce_checkout_inventory_reservation";
 
 #[derive(Debug, Error)]
 pub enum CheckoutInventoryExecutionError {
@@ -134,19 +137,20 @@ impl CheckoutInventoryReservationExecutor {
                 }
             }
 
+            let port_context = inventory_port_context(InventoryPortContextInput {
+                tenant_id,
+                actor: actor.clone(),
+                snapshot,
+                operation_id,
+                cart_line_item_id: line.id,
+                idempotency_key: planned.external_id.as_str(),
+                deadline: self.port_deadline,
+                action: "reserve",
+            });
             let provider_result = self
                 .reservation_port
                 .reserve_inventory_by_identity(
-                    inventory_port_context(InventoryPortContextInput {
-                        tenant_id,
-                        actor: actor.clone(),
-                        snapshot,
-                        operation_id,
-                        cart_line_item_id: line.id,
-                        idempotency_key: planned.external_id.as_str(),
-                        deadline: self.port_deadline,
-                        action: "reserve",
-                    }),
+                    port_context.clone(),
                     InventoryIdentityReservationRequest {
                         reservation_id: planned.reservation_id,
                         external_id: planned.external_id.clone(),
@@ -169,6 +173,8 @@ impl CheckoutInventoryReservationExecutor {
                 Err(boundary) => {
                     return Err(self
                         .record_boundary_failure(
+                            &port_context,
+                            "reserve_inventory_by_identity",
                             tenant_id,
                             line.id,
                             planned.reservation_id,
@@ -188,7 +194,14 @@ impl CheckoutInventoryReservationExecutor {
                     "inventory owner returned a reservation that does not match the persisted checkout identity",
                 );
                 return Err(self
-                    .record_boundary_failure(tenant_id, line.id, planned.reservation_id, boundary)
+                    .record_boundary_failure(
+                        &port_context,
+                        "reserve_inventory_by_identity",
+                        tenant_id,
+                        line.id,
+                        planned.reservation_id,
+                        boundary,
+                    )
                     .await);
             }
 
@@ -244,19 +257,20 @@ impl CheckoutInventoryReservationExecutor {
                 }
                 status if status == CheckoutInventoryReservationStatus::Planned.as_str() => {}
                 status if status == CheckoutInventoryReservationStatus::Reserved.as_str() => {
+                    let port_context = inventory_port_context(InventoryPortContextInput {
+                        tenant_id,
+                        actor: actor.clone(),
+                        snapshot,
+                        operation_id,
+                        cart_line_item_id: reservation.cart_line_item_id,
+                        idempotency_key: reservation.external_id.as_str(),
+                        deadline: self.port_deadline,
+                        action: "release",
+                    });
                     let boundary = self
                         .reservation_port
                         .release_inventory_by_identity(
-                            inventory_port_context(InventoryPortContextInput {
-                                tenant_id,
-                                actor: actor.clone(),
-                                snapshot,
-                                operation_id,
-                                cart_line_item_id: reservation.cart_line_item_id,
-                                idempotency_key: reservation.external_id.as_str(),
-                                deadline: self.port_deadline,
-                                action: "release",
-                            }),
+                            port_context.clone(),
                             InventoryIdentityReservationReleaseRequest {
                                 reservation_id: reservation.reservation_id,
                                 external_id: reservation.external_id.clone(),
@@ -268,6 +282,8 @@ impl CheckoutInventoryReservationExecutor {
                         Err(error) => {
                             return Err(self
                                 .record_boundary_failure(
+                                    &port_context,
+                                    "release_inventory_by_identity",
                                     tenant_id,
                                     reservation.cart_line_item_id,
                                     reservation.reservation_id,
@@ -286,6 +302,8 @@ impl CheckoutInventoryReservationExecutor {
                         );
                         return Err(self
                             .record_boundary_failure(
+                                &port_context,
+                                "release_inventory_by_identity",
                                 tenant_id,
                                 reservation.cart_line_item_id,
                                 reservation.reservation_id,
@@ -340,11 +358,20 @@ impl CheckoutInventoryReservationExecutor {
 
     async fn record_boundary_failure(
         &self,
+        port_context: &PortContext,
+        owner_operation: &'static str,
         tenant_id: Uuid,
         cart_line_item_id: Uuid,
         reservation_id: Uuid,
         boundary: PortError,
     ) -> CheckoutInventoryExecutionError {
+        log_checkout_inventory_boundary_failure(
+            port_context,
+            owner_operation,
+            cart_line_item_id,
+            reservation_id,
+            &boundary,
+        );
         match self
             .reservation_journal
             .record_error(
@@ -370,6 +397,63 @@ impl CheckoutInventoryReservationExecutor {
                 retryable: boundary.retryable,
                 journal: Box::new(journal),
             },
+        }
+    }
+}
+
+fn log_checkout_inventory_boundary_failure(
+    context: &PortContext,
+    owner_operation: &'static str,
+    cart_line_item_id: Uuid,
+    reservation_id: Uuid,
+    boundary_error: &PortError,
+) {
+    match &boundary_error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?boundary_error,
+                owner = "rustok_inventory",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                cart_line_item_id = %cart_line_item_id,
+                reservation_id = %reservation_id,
+                code = %boundary_error.code,
+                error_kind = ?boundary_error.kind,
+                retryable = boundary_error.retryable,
+                boundary = CHECKOUT_INVENTORY_BOUNDARY,
+                "checkout inventory owner boundary failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?boundary_error,
+                owner = "rustok_inventory",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                cart_line_item_id = %cart_line_item_id,
+                reservation_id = %reservation_id,
+                code = %boundary_error.code,
+                error_kind = ?boundary_error.kind,
+                retryable = boundary_error.retryable,
+                boundary = CHECKOUT_INVENTORY_BOUNDARY,
+                "checkout inventory owner boundary was rejected"
+            );
         }
     }
 }

--- a/scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
+++ b/scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL(
+    'crates/rustok-commerce/src/services/checkout_inventory_reservation_executor.rs',
+    root,
+  ),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  [
+    'const CHECKOUT_INVENTORY_BOUNDARY: &str = "commerce_checkout_inventory_reservation";',
+    'stable checkout inventory boundary',
+  ],
+  ['PortErrorKind,', 'typed port error classification import'],
+  ['let port_context = inventory_port_context(InventoryPortContextInput {', 'retained port context'],
+  ['port_context.clone()', 'same context delegated to owner port'],
+  ['&port_context,\n                            "reserve_inventory_by_identity"', 'reserve operation context'],
+  ['&port_context,\n                                    "release_inventory_by_identity"', 'release operation context'],
+  ['fn log_checkout_inventory_boundary_failure(', 'shared structured diagnostic helper'],
+  ['owner = "rustok_inventory"', 'truthful owner identity'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['operation = owner_operation', 'exact owner operation'],
+  ['cart_line_item_id = %cart_line_item_id', 'cart line identity'],
+  ['reservation_id = %reservation_id', 'reservation identity'],
+  ['code = %boundary_error.code', 'stable port code'],
+  ['error_kind = ?boundary_error.kind', 'typed port error kind'],
+  ['retryable = boundary_error.retryable', 'port retryability'],
+  ['boundary = CHECKOUT_INVENTORY_BOUNDARY', 'explicit boundary identity'],
+  ['"checkout inventory owner boundary failed"', 'error diagnostic event'],
+  ['"checkout inventory owner boundary was rejected"', 'warning diagnostic event'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'error severity classification'],
+]) {
+  requireText(value, label);
+}
+
+const retainedContexts =
+  source.match(/let port_context = inventory_port_context\(InventoryPortContextInput \{/g) ?? [];
+if (retainedContexts.length !== 2) {
+  failures.push(`expected two retained checkout inventory contexts, found ${retainedContexts.length}`);
+}
+
+const delegatedContexts = source.match(/port_context\.clone\(\)/g) ?? [];
+if (delegatedContexts.length !== 2) {
+  failures.push(`expected two cloned contexts delegated to inventory owner, found ${delegatedContexts.length}`);
+}
+
+const boundaryCalls = source.match(/\.record_boundary_failure\(/g) ?? [];
+if (boundaryCalls.length !== 4) {
+  failures.push(`expected four inventory boundary failure paths, found ${boundaryCalls.length}`);
+}
+
+const helperIndex = source.indexOf('log_checkout_inventory_boundary_failure(');
+const journalIndex = source.indexOf('.reservation_journal\n            .record_error(', helperIndex);
+if (helperIndex < 0 || journalIndex < helperIndex) {
+  failures.push('structured diagnostics must run before the existing reservation journal write');
+}
+
+for (const [value, label] of [
+  ['boundary.code.clone()', 'journal code preservation'],
+  ['boundary.message.clone()', 'journal message preservation'],
+  ['code: boundary.code', 'public error code preservation'],
+  ['message: boundary.message', 'public error message preservation'],
+  ['retryable: boundary.retryable', 'public retryability preservation'],
+  ['CheckoutInventoryExecutionError::Boundary {', 'boundary error variant'],
+  ['CheckoutInventoryExecutionError::BoundaryAndJournal {', 'boundary and journal error variant'],
+  ['"inventory.reservation_response_mismatch"', 'reserve mismatch code'],
+  ['"inventory.release_response_mismatch"', 'release mismatch code'],
+  ['.with_causation_id(input.operation_id.to_string())', 'causation construction'],
+  ['.with_idempotency_key(input.idempotency_key.to_string())', 'idempotency construction'],
+  ['.with_deadline(input.deadline)', 'deadline construction'],
+]) {
+  requireText(value, label);
+}
+
+forbidText(
+  '.reserve_inventory_by_identity(\n                    inventory_port_context(',
+  'inline reserve context that cannot be reused for diagnostics',
+);
+forbidText(
+  '.release_inventory_by_identity(\n                            inventory_port_context(',
+  'inline release context that cannot be reused for diagnostics',
+);
+
+if (failures.length > 0) {
+  console.error('Checkout inventory boundary context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Checkout inventory reserve/release failures retain the complete owner PortContext before journaling',
+);


### PR DESCRIPTION
## Summary

- retain the exact `PortContext` used for durable checkout inventory reserve/release owner calls;
- reuse that context for direct owner `PortError` paths and synthetic owner-response mismatch paths;
- record truthful inventory owner, correlation and tenant identity, actor, channel, locale, causation, traceparent, idempotency key, deadline, exact owner operation, cart-line/reservation identity, port code/kind/retryability, and the explicit checkout inventory boundary;
- use error severity for unavailable, timeout, and invariant failures and warning severity for validation/not-found/conflict/forbidden rejections;
- emit diagnostics before the existing reservation journal write;
- preserve journal payloads, public error variants, retryability, state transitions, replay behavior, and owner request/response DTOs;
- add a focused static guard and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/services/checkout_inventory_reservation_executor.rs`
- `scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs`
- `crates/rustok-commerce/docs/checkout-inventory-boundary-context.md`

Inventory owner ports, reservation journals, checkout operation journals, DTOs, public errors, and architecture statuses remain unchanged.

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe inventory mapper/adapter cleanup. It closes consumer-side context loss for durable checkout inventory `reserve_inventory_by_identity` and `release_inventory_by_identity` calls. Inventory owner admission diagnostics, checkout availability context, and remaining inventory adapters remain open. No FBA/FFA status is promoted.

## Validation

- the branch diff contains exactly the three scoped files;
- both owner calls retain one `PortContext` and delegate a clone of that same value;
- all four direct/synthetic failure paths pass the retained context and exact owner operation to one diagnostic helper;
- structured diagnostics run before the unchanged `reservation_journal.record_error` call;
- existing journal code/message payloads, `Boundary`/`BoundaryAndJournal` variants, retryability propagation, mismatch codes, idempotency construction, and checkout state transitions remain unchanged;
- newer `main` commits touch only Notifications/Index paths and do not overlap this slice;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Intended focused checks:

```bash
node scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce --lib
```