### PR TITLE
fix(index): reject ambiguous router arguments

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -27,6 +27,8 @@ node scripts/verify/index-storage-tooling.mjs compare \
 
 The router dispatches Node directly without shell evaluation. It exposes the canonical static guards, packet validator, comparator, exact-byte hashing, decision preparation, ADR finalization, and saved-ADR verification paths.
 
+Global `--help` and `-h` are accepted only as the sole router argument. The `packet` command rejects repeated `--scale` or `--root` options before invoking ordering checks or evidence validation. This prevents malformed scripted invocations from silently changing the effective evidence scale or packet root.
+
 Only `comparison.json` emitted through the official comparator wrapper is valid decision input. Direct output from `compare-index-storage-evidence-core.mjs` is intentionally incomplete because it does not finalize the observed PostgreSQL database-settings methodology. Do not add the missing fields by hand.
 
 The accepted methodology contains the exact ordered `comparable_database_fields` contract:

--- a/scripts/verify/index-storage-tooling-arguments.test.mjs
+++ b/scripts/verify/index-storage-tooling-arguments.test.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const script = path.resolve('scripts/verify/index-storage-tooling.mjs');
+const run = (...args) => spawnSync(process.execPath, [script, ...args], {
+  encoding: 'utf8',
+});
+
+const assertPreflightFailure = (result, pattern) => {
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, pattern);
+  assert.doesNotMatch(result.stderr, /check-index-storage-read-ordering/u);
+  assert.doesNotMatch(result.stderr, /validate-index-storage-evidence/u);
+};
+
+test('prints usage for an empty command line', () => {
+  const result = run();
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage:/u);
+});
+
+test('accepts global help only as the sole argument', () => {
+  for (const help of ['--help', '-h']) {
+    const result = run(help);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/u);
+  }
+
+  for (const help of ['--help', '-h']) {
+    const mixed = run(help, 'packet');
+    assertPreflightFailure(mixed, /help must be the only argument/u);
+    assert.equal(mixed.stdout, '');
+  }
+});
+
+test('rejects duplicate packet scale before invoking evidence tooling', () => {
+  const result = run('packet', '--scale', 'smoke', '--scale', '1m');
+  assertPreflightFailure(result, /--scale was provided more than once/u);
+});
+
+test('rejects duplicate packet root before invoking evidence tooling', () => {
+  const result = run(
+    'packet',
+    '--scale', 'smoke',
+    '--root', 'first-evidence-root',
+    '--root', 'second-evidence-root',
+  );
+  assertPreflightFailure(result, /--root was provided more than once/u);
+});
+
+test('duplicate packet options fail before later value validation', () => {
+  const duplicateScale = run('packet', '--scale', '10m', '--scale', '100k');
+  assertPreflightFailure(duplicateScale, /--scale was provided more than once/u);
+  assert.doesNotMatch(duplicateScale.stderr, /packet --scale must be/u);
+
+  const duplicateRoot = run(
+    'packet',
+    '--root', 'first-evidence-root',
+    '--root', 'second-evidence-root',
+    '--scale', '100k',
+  );
+  assertPreflightFailure(duplicateRoot, /--root was provided more than once/u);
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -62,6 +62,7 @@ const runContract = (args) => {
     'verify-index-storage-adr-verifier-cli.mjs',
     'verify-index-storage-decision-preparation-lifecycle.mjs',
     'verify-index-storage-decision-text-schema.mjs',
+    'verify-index-storage-router-arguments.mjs',
   ]) {
     runScript(script);
   }
@@ -71,6 +72,7 @@ const runFixtures = (args) => {
   if (args.length !== 0) fail('fixtures does not accept arguments');
   runNode([
     '--test',
+    scriptPath('index-storage-tooling-arguments.test.mjs'),
     scriptPath('check-index-storage-read-ordering.test.mjs'),
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
@@ -87,8 +89,10 @@ const parsePacketArgs = (args) => {
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--scale' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (scale !== null) fail('--scale was provided more than once');
       scale = args[++index];
     } else if (argument === '--root' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (root !== null) fail('--root was provided more than once');
       root = args[++index];
     } else {
       fail(`unknown or incomplete packet argument: ${argument}`);
@@ -139,7 +143,12 @@ const runCompare = (args) => {
 };
 
 const [command, ...args] = process.argv.slice(2);
-if (!command || command === '--help' || command === '-h') {
+if (!command) {
+  usage();
+  process.exit(0);
+}
+if (command === '--help' || command === '-h') {
+  if (args.length !== 0) fail('help must be the only argument');
   usage();
   process.exit(0);
 }

--- a/scripts/verify/verify-index-storage-router-arguments.mjs
+++ b/scripts/verify/verify-index-storage-router-arguments.mjs
@@ -32,7 +32,6 @@ requireMarkers(router, 'storage tooling router', [
 
 for (const forbidden of [
   "if (!command || command === '--help' || command === '-h')",
-  "scale = args[++index];\n    } else if (argument === '--root'",
 ]) {
   if (router.includes(forbidden)) fail(`storage tooling router contains ambiguous behavior: ${forbidden}`);
 }

--- a/scripts/verify/verify-index-storage-router-arguments.mjs
+++ b/scripts/verify/verify-index-storage-router-arguments.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-router-arguments] ${message}`);
+  process.exit(1);
+};
+
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const fixture = read('scripts/verify/index-storage-tooling-arguments.test.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(router, 'storage tooling router', [
+  'const [command, ...args] = process.argv.slice(2)',
+  'if (!command) {',
+  "if (command === '--help' || command === '-h') {",
+  "if (args.length !== 0) fail('help must be the only argument')",
+  "if (scale !== null) fail('--scale was provided more than once')",
+  "if (root !== null) fail('--root was provided more than once')",
+  "'verify-index-storage-router-arguments.mjs'",
+  "scriptPath('index-storage-tooling-arguments.test.mjs')",
+]);
+
+for (const forbidden of [
+  "if (!command || command === '--help' || command === '-h')",
+  "scale = args[++index];\n    } else if (argument === '--root'",
+]) {
+  if (router.includes(forbidden)) fail(`storage tooling router contains ambiguous behavior: ${forbidden}`);
+}
+
+const commandParse = router.indexOf('const [command, ...args] = process.argv.slice(2)');
+const missingCommand = router.indexOf('if (!command) {');
+const helpGate = router.indexOf("if (command === '--help' || command === '-h') {");
+const switchDispatch = router.indexOf('switch (command) {');
+if ([commandParse, missingCommand, helpGate, switchDispatch].some((index) => index < 0)
+    || !(commandParse < missingCommand && missingCommand < helpGate && helpGate < switchDispatch)) {
+  fail('global router arguments must be validated before command dispatch');
+}
+
+const scaleDuplicate = router.indexOf("if (scale !== null) fail('--scale was provided more than once')");
+const scaleAssign = router.indexOf('scale = args[++index]');
+const rootDuplicate = router.indexOf("if (root !== null) fail('--root was provided more than once')");
+const rootAssign = router.indexOf('root = args[++index]');
+const scaleValidation = router.indexOf("if (!['smoke', '100k', '1m'].includes(scale))");
+if ([scaleDuplicate, scaleAssign, rootDuplicate, rootAssign, scaleValidation].some((index) => index < 0)
+    || !(scaleDuplicate < scaleAssign
+      && rootDuplicate < rootAssign
+      && scaleAssign < scaleValidation
+      && rootAssign < scaleValidation)) {
+  fail('duplicate packet options must fail before assignment and scale validation');
+}
+
+requireMarkers(fixture, 'router argument fixture', [
+  "test('prints usage for an empty command line'",
+  "test('accepts global help only as the sole argument'",
+  "for (const help of ['--help', '-h'])",
+  "test('rejects duplicate packet scale before invoking evidence tooling'",
+  "test('rejects duplicate packet root before invoking evidence tooling'",
+  "test('duplicate packet options fail before later value validation'",
+  'assert.doesNotMatch(result.stderr, /check-index-storage-read-ordering/u)',
+  'assert.doesNotMatch(result.stderr, /validate-index-storage-evidence/u)',
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'Global `--help` and `-h` are accepted only as the sole router argument.',
+  'The `packet` command rejects repeated `--scale` or `--root` options before invoking ordering checks or evidence validation.',
+]);
+
+console.log('[verify-index-storage-router-arguments] global help and packet value options fail closed before dispatch, with fixture, router, and documentation coverage');


### PR DESCRIPTION
## Summary

- rebuild the useful router argument protections from #2178 on the current Index tooling surface;
- accept global `--help` and `-h` only as the sole router argument while preserving empty-command usage output;
- reject repeated `packet --scale` and `packet --root` values before assignment, scale validation, ordering preflight, or evidence validation;
- add a focused argument fixture for both help aliases, duplicate options, failure precedence, and pre-dispatch behavior;
- add a dedicated static cross-guard, canonical `contract`/`fixtures` registration, and synchronized storage-decision documentation.

## Recheck

- confirmed the current router still accepted mixed top-level help and silently used the last repeated packet value;
- confirmed #2178 has no comments or unresolved review threads;
- removed a brittle substring guard after static review and retained explicit positional ordering checks instead;
- kept the M2 benchmark and ADR items open.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request. Static review covered the four-file diff, both help aliases, empty invocation, duplicate scale/root ordering, pre-dispatch failure, fixture markers, static positional checks, router registration, documentation, and preservation of all unrelated `main` changes.

Supersedes #2178.