### PR TITLE
fix(index): harden comparator output lifecycle

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -31,6 +31,8 @@ Global `--help` and `-h` are accepted only as the sole router argument. The `pac
 
 Only `comparison.json` emitted through the official comparator wrapper is valid decision input. Direct output from `compare-index-storage-evidence-core.mjs` is intentionally incomplete because it does not finalize the observed PostgreSQL database-settings methodology. Do not add the missing fields by hand.
 
+A real comparison attempt revokes any previous `comparison.json` decision-input marker before packet ordering preflight. The comparator core and PostgreSQL methodology finalization run in a unique private staging directory. Finalized Markdown is published before `comparison.json`, so JSON is the last success marker exposed to decision preparation. Core failure, incomplete output, methodology failure, or publication failure leaves no decision-input JSON and no staging residue.
+
 The accepted methodology contains the exact ordered `comparable_database_fields` contract:
 
 - `server_version_num`;

--- a/scripts/verify/compare-index-storage-evidence-lifecycle.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence-lifecycle.test.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { runComparatorCoreWithAtomicComparison } from './compare-index-storage-evidence.mjs';
+
+const comparator = path.resolve('scripts/verify/compare-index-storage-evidence.mjs');
+const runComparator = (...args) => spawnSync(process.execPath, [comparator, ...args], {
+  encoding: 'utf8',
+});
+const quietStream = { write: () => true };
+const stagingEntries = (output) => readdirSync(output)
+  .filter((entry) => entry.startsWith('.comparison-staging-'));
+const stagedOutputFrom = (args) => {
+  const outputIndex = args.lastIndexOf('--output');
+  assert.notEqual(outputIndex, -1);
+  return args[outputIndex + 1];
+};
+
+const withOutput = (prefix, callback) => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  const output = path.join(root, 'comparison');
+  mkdirSync(output);
+  try {
+    callback({ root, output });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('direct comparator help is valid only as the sole argument', () => {
+  for (const help of ['--help', '-h']) {
+    const result = runComparator(help);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /compare-index-storage-evidence\.mjs --input <dir>/u);
+  }
+
+  const mixed = runComparator('--help', '--output', 'comparison');
+  assert.notEqual(mixed.status, 0);
+  assert.match(mixed.stderr, /help must be the only argument/u);
+  assert.equal(mixed.stdout, '');
+});
+
+test('direct comparator rejects duplicate output before evidence access', () => {
+  const result = runComparator(
+    '--input', 'missing-evidence',
+    '--output', 'first-comparison',
+    '--output', 'second-comparison',
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--output was provided more than once/u);
+  assert.doesNotMatch(result.stderr, /missing evidence file/u);
+});
+
+test('comparator publishes finalized markdown before JSON and removes staging', () => {
+  withOutput('rustok-index-comparator-publish-', ({ output }) => {
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    writeFileSync(path.join(output, 'comparison.md'), 'stale markdown\n', 'utf8');
+    const publication = [];
+
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"core":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'core markdown\n', 'utf8');
+      return { status: 0, stdout: '', stderr: '' };
+    };
+    const finalizeComparison = ({ output: staged }) => {
+      writeFileSync(path.join(staged, 'comparison.json'), '{"finalized":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'finalized markdown\n', 'utf8');
+    };
+    const fsRename = (source, destination) => {
+      publication.push(path.basename(destination));
+      const bytes = readFileSync(source);
+      writeFileSync(destination, bytes);
+      rmSync(source, { force: true });
+    };
+
+    const status = runComparatorCoreWithAtomicComparison({
+      inputs: ['packet-100k', 'packet-1m'],
+      output,
+      spawn,
+      finalizeComparison,
+      rename: fsRename,
+      stdout: quietStream,
+      stderr: quietStream,
+    });
+
+    assert.equal(status, 0);
+    assert.deepEqual(publication, ['comparison.md', 'comparison.json']);
+    assert.equal(readFileSync(path.join(output, 'comparison.json'), 'utf8'), '{"finalized":true}\n');
+    assert.equal(readFileSync(path.join(output, 'comparison.md'), 'utf8'), 'finalized markdown\n');
+    assert.deepEqual(stagingEntries(output), []);
+  });
+});
+
+test('comparator core failure cannot publish a partial decision input', () => {
+  withOutput('rustok-index-comparator-core-failure-', ({ output }) => {
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"partial":', 'utf8');
+      return { status: 1, stdout: '', stderr: 'core failed\n' };
+    };
+
+    const status = runComparatorCoreWithAtomicComparison({
+      inputs: ['packet-100k', 'packet-1m'],
+      output,
+      spawn,
+      stdout: quietStream,
+      stderr: quietStream,
+    });
+
+    assert.equal(status, 1);
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
+    assert.deepEqual(stagingEntries(output), []);
+  });
+});
+
+test('post-processing failure leaves no decision input or staging residue', () => {
+  withOutput('rustok-index-comparator-finalize-failure-', ({ output }) => {
+    writeFileSync(path.join(output, 'comparison.json'), '{"stale":true}\n', 'utf8');
+    const spawn = (_executable, args) => {
+      const staged = stagedOutputFrom(args);
+      writeFileSync(path.join(staged, 'comparison.json'), '{"core":true}\n', 'utf8');
+      writeFileSync(path.join(staged, 'comparison.md'), 'core markdown\n', 'utf8');
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    assert.throws(
+      () => runComparatorCoreWithAtomicComparison({
+        inputs: ['packet-100k', 'packet-1m'],
+        output,
+        spawn,
+        finalizeComparison: () => {
+          throw new Error('methodology finalization failed');
+        },
+        stdout: quietStream,
+        stderr: quietStream,
+      }),
+      /methodology finalization failed/u,
+    );
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
+    assert.deepEqual(stagingEntries(output), []);
+  });
+});
+
+test('missing staged output after successful core leaves no decision input', () => {
+  withOutput('rustok-index-comparator-missing-output-', ({ output }) => {
+    const spawn = () => ({ status: 0, stdout: '', stderr: '' });
+    assert.throws(
+      () => runComparatorCoreWithAtomicComparison({
+        inputs: ['packet-100k', 'packet-1m'],
+        output,
+        spawn,
+        finalizeComparison: () => {},
+        stdout: quietStream,
+        stderr: quietStream,
+      }),
+      /without complete comparison outputs/u,
+    );
+    assert.equal(existsSync(path.join(output, 'comparison.json')), false);
+    assert.deepEqual(stagingEntries(output), []);
+  });
+});

--- a/scripts/verify/compare-index-storage-evidence.mjs
+++ b/scripts/verify/compare-index-storage-evidence.mjs
@@ -129,6 +129,7 @@ export const runComparatorCoreWithAtomicComparison = ({
   output,
   spawn = spawnSync,
   finalizeComparison = finalizeDatabaseSettingsContract,
+  rename = renameSync,
   stdout = process.stdout,
   stderr = process.stderr,
 }) => {
@@ -151,8 +152,8 @@ export const runComparatorCoreWithAtomicComparison = ({
       throw new Error('comparator core exited successfully without complete comparison outputs');
     }
 
-    renameSync(stagedMarkdown, outputMarkdown);
-    renameSync(stagedJson, outputJson);
+    rename(stagedMarkdown, outputMarkdown);
+    rename(stagedJson, outputJson);
     published = true;
     return 0;
   } finally {

--- a/scripts/verify/compare-index-storage-evidence.mjs
+++ b/scripts/verify/compare-index-storage-evidence.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs';
 import {
@@ -10,17 +20,25 @@ import {
 } from './index-storage-database-settings-contract.mjs';
 
 const prefix = '[compare-index-storage-evidence]';
+const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
 
 const preflightArgs = (args) => {
   const inputs = [];
   let output = 'evidence/index-storage/comparison';
+  let outputProvided = false;
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
-    if (argument === '--help' || argument === '-h') return null;
+    if (argument === '--help' || argument === '-h') {
+      if (args.length !== 1) throw new Error('help must be the only argument');
+      return null;
+    }
     if (argument === '--input' && args[index + 1] && !args[index + 1].startsWith('--')) {
       inputs.push(args[++index]);
     } else if (argument === '--output' && args[index + 1] && !args[index + 1].startsWith('--')) {
+      if (outputProvided) throw new Error('--output was provided more than once');
       output = args[++index];
+      outputProvided = true;
     } else {
       return null;
     }
@@ -90,18 +108,83 @@ const finalizeDatabaseSettingsContract = ({ inputs, output }) => {
   writeFileSync(markdownPath, lines.join('\n'));
 };
 
-const main = async () => {
-  const parsed = preflightArgs(process.argv.slice(2));
-  if (parsed !== null) {
-    for (const input of parsed.inputs) validatePacketReadOrdering(input);
-  }
-  await import('./compare-index-storage-evidence-core.mjs');
-  if (parsed !== null) finalizeDatabaseSettingsContract(parsed);
+const forwardOutput = (stream, value) => {
+  if (typeof value === 'string' && value.length !== 0) stream.write(value);
 };
 
-try {
-  await main();
-} catch (error) {
-  console.error(`${prefix} ${error.message}`);
-  process.exitCode = 1;
+const runCore = ({ args, spawn = spawnSync, stdout = process.stdout, stderr = process.stderr }) => {
+  const result = spawn(process.execPath, [corePath, ...args], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  forwardOutput(stdout, result.stdout);
+  forwardOutput(stderr, result.stderr);
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`comparator core terminated by signal ${result.signal}`);
+  return result.status ?? 1;
+};
+
+export const runComparatorCoreWithAtomicComparison = ({
+  inputs,
+  output,
+  spawn = spawnSync,
+  finalizeComparison = finalizeDatabaseSettingsContract,
+  stdout = process.stdout,
+  stderr = process.stderr,
+}) => {
+  const outputJson = path.join(output, 'comparison.json');
+  const outputMarkdown = path.join(output, 'comparison.md');
+  rmSync(outputJson, { force: true });
+  mkdirSync(output, { recursive: true });
+  const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'));
+  let published = false;
+  try {
+    const args = inputs.flatMap((input) => ['--input', input]);
+    args.push('--output', stagingRoot);
+    const status = runCore({ args, spawn, stdout, stderr });
+    if (status !== 0) return status;
+
+    finalizeComparison({ inputs, output: stagingRoot });
+    const stagedJson = path.join(stagingRoot, 'comparison.json');
+    const stagedMarkdown = path.join(stagingRoot, 'comparison.md');
+    if (!existsSync(stagedJson) || !existsSync(stagedMarkdown)) {
+      throw new Error('comparator core exited successfully without complete comparison outputs');
+    }
+
+    renameSync(stagedMarkdown, outputMarkdown);
+    renameSync(stagedJson, outputJson);
+    published = true;
+    return 0;
+  } finally {
+    try {
+      rmSync(stagingRoot, { recursive: true, force: true });
+    } catch (error) {
+      if (!published) throw error;
+      forwardOutput(stderr, `${prefix} unable to remove staging directory: ${error.message}\n`);
+    }
+  }
+};
+
+const main = () => {
+  const args = process.argv.slice(2);
+  const parsed = preflightArgs(args);
+  if (parsed === null) {
+    const status = runCore({ args });
+    if (status !== 0) process.exitCode = status;
+    return;
+  }
+
+  rmSync(path.join(parsed.output, 'comparison.json'), { force: true });
+  for (const input of parsed.inputs) validatePacketReadOrdering(input);
+  const status = runComparatorCoreWithAtomicComparison(parsed);
+  if (status !== 0) process.exitCode = status;
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptPath)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`${prefix} ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -63,6 +63,7 @@ const runContract = (args) => {
     'verify-index-storage-decision-preparation-lifecycle.mjs',
     'verify-index-storage-decision-text-schema.mjs',
     'verify-index-storage-router-arguments.mjs',
+    'verify-index-storage-comparator-lifecycle.mjs',
   ]) {
     runScript(script);
   }
@@ -76,6 +77,7 @@ const runFixtures = (args) => {
     scriptPath('check-index-storage-read-ordering.test.mjs'),
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
+    scriptPath('compare-index-storage-evidence-lifecycle.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),

--- a/scripts/verify/verify-index-storage-comparator-lifecycle.mjs
+++ b/scripts/verify/verify-index-storage-comparator-lifecycle.mjs
@@ -29,7 +29,7 @@ requireMarkers(wrapper, 'comparator lifecycle wrapper', [
   'spawn = spawnSync',
   'finalizeComparison = finalizeDatabaseSettingsContract',
   'rename = renameSync',
-  "rmSync(outputJson, { force: true })",
+  'rmSync(outputJson, { force: true })',
   "const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'))",
   "args.push('--output', stagingRoot)",
   'const status = runCore({ args, spawn, stdout, stderr })',
@@ -75,10 +75,12 @@ if ([stagingCreate, coreRun, methodology, markdownPublish, jsonPublish, cleanup]
 }
 
 requireMarkers(core, 'byte-preserved comparator core', [
-  "const prefix = '[compare-index-storage-evidence]'",
-  'decision_ready:',
-  'comparison.json',
-  'comparison.md',
+  'const die = (message) =>',
+  "const resultDigestContract = 'ordered_length_prefixed_json_v1'",
+  'const canonicalPrototypes = [',
+  'decision_ready: decisionContract.required_scales_present',
+  "writeFileSync(path.join(output, 'comparison.json')",
+  "writeFileSync(path.join(output, 'comparison.md')",
 ]);
 
 requireMarkers(fixture, 'comparator lifecycle fixture', [

--- a/scripts/verify/verify-index-storage-comparator-lifecycle.mjs
+++ b/scripts/verify/verify-index-storage-comparator-lifecycle.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-comparator-lifecycle] ${message}`);
+  process.exit(1);
+};
+
+const wrapper = read('scripts/verify/compare-index-storage-evidence.mjs');
+const core = read('scripts/verify/compare-index-storage-evidence-core.mjs');
+const fixture = read('scripts/verify/compare-index-storage-evidence-lifecycle.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(wrapper, 'comparator lifecycle wrapper', [
+  "const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url))",
+  "if (args.length !== 1) throw new Error('help must be the only argument')",
+  "if (outputProvided) throw new Error('--output was provided more than once')",
+  'export const runComparatorCoreWithAtomicComparison = ({',
+  'spawn = spawnSync',
+  'finalizeComparison = finalizeDatabaseSettingsContract',
+  'rename = renameSync',
+  "rmSync(outputJson, { force: true })",
+  "const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'))",
+  "args.push('--output', stagingRoot)",
+  'const status = runCore({ args, spawn, stdout, stderr })',
+  'finalizeComparison({ inputs, output: stagingRoot })',
+  "throw new Error('comparator core exited successfully without complete comparison outputs')",
+  'rename(stagedMarkdown, outputMarkdown)',
+  'rename(stagedJson, outputJson)',
+  'rmSync(stagingRoot, { recursive: true, force: true })',
+  "rmSync(path.join(parsed.output, 'comparison.json'), { force: true })",
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input)',
+]);
+
+for (const forbidden of [
+  "await import('./compare-index-storage-evidence-core.mjs')",
+  'shell: true',
+  'execSync(',
+  'execFileSync(',
+]) {
+  if (wrapper.includes(forbidden)) fail(`comparator lifecycle wrapper contains forbidden behavior: ${forbidden}`);
+}
+
+const staleRevoke = wrapper.indexOf("rmSync(path.join(parsed.output, 'comparison.json'), { force: true })");
+const ordering = wrapper.indexOf('for (const input of parsed.inputs) validatePacketReadOrdering(input)');
+const lifecycleRun = wrapper.indexOf('const status = runComparatorCoreWithAtomicComparison(parsed)');
+if ([staleRevoke, ordering, lifecycleRun].some((index) => index < 0)
+    || !(staleRevoke < ordering && ordering < lifecycleRun)) {
+  fail('real comparison ordering must be stale JSON revocation -> packet ordering preflight -> isolated comparator lifecycle');
+}
+
+const stagingCreate = wrapper.indexOf("const stagingRoot = mkdtempSync(path.join(output, '.comparison-staging-'))");
+const coreRun = wrapper.indexOf('const status = runCore({ args, spawn, stdout, stderr })');
+const methodology = wrapper.indexOf('finalizeComparison({ inputs, output: stagingRoot })');
+const markdownPublish = wrapper.indexOf('rename(stagedMarkdown, outputMarkdown)');
+const jsonPublish = wrapper.indexOf('rename(stagedJson, outputJson)');
+const cleanup = wrapper.indexOf('rmSync(stagingRoot, { recursive: true, force: true })');
+if ([stagingCreate, coreRun, methodology, markdownPublish, jsonPublish, cleanup].some((index) => index < 0)
+    || !(stagingCreate < coreRun
+      && coreRun < methodology
+      && methodology < markdownPublish
+      && markdownPublish < jsonPublish
+      && jsonPublish < cleanup)) {
+  fail('comparator lifecycle order must be staging -> core -> methodology -> Markdown publication -> JSON publication -> cleanup');
+}
+
+requireMarkers(core, 'byte-preserved comparator core', [
+  "const prefix = '[compare-index-storage-evidence]'",
+  'decision_ready:',
+  'comparison.json',
+  'comparison.md',
+]);
+
+requireMarkers(fixture, 'comparator lifecycle fixture', [
+  "test('direct comparator help is valid only as the sole argument'",
+  "test('direct comparator rejects duplicate output before evidence access'",
+  "test('comparator publishes finalized markdown before JSON and removes staging'",
+  "test('comparator core failure cannot publish a partial decision input'",
+  "test('post-processing failure leaves no decision input or staging residue'",
+  "test('missing staged output after successful core leaves no decision input'",
+  "assert.deepEqual(publication, ['comparison.md', 'comparison.json'])",
+  "entry.startsWith('.comparison-staging-')",
+  'assert.deepEqual(stagingEntries(output), [])',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-comparator-lifecycle.mjs'",
+  "scriptPath('compare-index-storage-evidence-lifecycle.test.mjs')",
+  "runScript('compare-index-storage-evidence.mjs', args)",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'A real comparison attempt revokes any previous `comparison.json` decision-input marker before packet ordering preflight.',
+  'The comparator core and PostgreSQL methodology finalization run in a unique private staging directory.',
+  'Finalized Markdown is published before `comparison.json`, so JSON is the last success marker exposed to decision preparation.',
+]);
+
+console.log('[verify-index-storage-comparator-lifecycle] strict comparator arguments, stale-marker revocation, child-process isolation, staged methodology, Markdown-first/JSON-last publication, cleanup, fixtures, router registration, and docs are cross-guarded');


### PR DESCRIPTION
## Summary

- rebuild #2181 on the current Index tooling surface while keeping the comparator core unchanged;
- accept comparator help only as the sole argument and reject duplicate `--output` before evidence access;
- revoke stale `comparison.json` before ordering preflight for every real comparison attempt;
- execute the comparator core in a child process inside a unique private output-directory staging location;
- finalize the observed PostgreSQL methodology only in staging;
- publish finalized `comparison.md` first and `comparison.json` last, making JSON the decision-input success marker;
- clean staging after success, core failure, incomplete output, or post-processing failure;
- add focused lifecycle fixtures, a dedicated static cross-guard, canonical router registration, and synchronized documentation.

## Recheck

- confirmed the current wrapper still imported the fail-fast core in process and post-processed published files in place;
- confirmed #2181 has no comments or unresolved review threads;
- added an injected rename seam solely to prove Markdown-first/JSON-last ordering while retaining `renameSync` in production;
- kept M2 open and did not create benchmark evidence or choose a storage model.

## Validation

Tests, Node/Cargo commands, formatting, verifiers, workflows, and benchmarks were not run, per maintainer request. Static review covered the five-file diff, help/duplicate-output preflight, stale-marker revocation, child-process status/signal/error handling, staging locality, methodology ordering, incomplete output, publication order, cleanup, byte-preserved core markers, router registration, and documentation.

Supersedes #2181.