### PR TITLE
fix(index): bound reusable scale workflow inputs

### DIFF
--- a/.github/workflows/index-storage-scale-run-contract.yml
+++ b/.github/workflows/index-storage-scale-run-contract.yml
@@ -1,0 +1,37 @@
+name: Index Storage Scale Run Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-run-contract.yml"
+      - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+      - "crates/rustok-index/docs/implementation-plan.md"
+  push:
+    branches:
+      - main
+      - "agent/**"
+    paths:
+      - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-run-contract.yml"
+      - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+      - "crates/rustok-index/docs/implementation-plan.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Reusable scale workflow contract
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify contract script syntax
+        run: node --check scripts/verify/verify-index-storage-scale-run-contract.mjs
+      - name: Verify fail-closed scale workflow inputs
+        run: node scripts/verify/verify-index-storage-scale-run-contract.mjs

--- a/.github/workflows/index-storage-scale-run.yml
+++ b/.github/workflows/index-storage-scale-run.yml
@@ -39,7 +39,63 @@ env:
   INDEX_BENCH_REQUIRE_GITHUB_PROVENANCE: "1"
 
 jobs:
+  validate-inputs:
+    name: Validate scale evidence inputs
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Require canonical reusable workflow inputs
+        shell: bash
+        env:
+          REQUESTED_SCALE: ${{ inputs.scale }}
+          REQUESTED_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          REQUESTED_RUNNER_LABEL: ${{ inputs.runner_label }}
+          REQUESTED_MINIMUM_FREE_BYTES: ${{ inputs.minimum_free_bytes }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          MAXIMUM_FREE_BYTES=9007199254740991
+
+          case "$REQUESTED_SCALE" in
+            100k|1m) ;;
+            *)
+              echo "::error::scale must be 100k or 1m; got ${REQUESTED_SCALE}"
+              exit 1
+              ;;
+          esac
+          if ! [[ "$REQUESTED_TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::timeout_minutes must be a positive integer; got ${REQUESTED_TIMEOUT_MINUTES}"
+            exit 1
+          fi
+          if (( REQUESTED_TIMEOUT_MINUTES > 360 )); then
+            echo "::error::timeout_minutes must not exceed 360; got ${REQUESTED_TIMEOUT_MINUTES}"
+            exit 1
+          fi
+          if [[ -z "${REQUESTED_RUNNER_LABEL//[[:space:]]/}" ]]; then
+            echo "::error::runner_label must be non-empty"
+            exit 1
+          fi
+          if [[ "$REQUESTED_RUNNER_LABEL" =~ [[:cntrl:]] ]]; then
+            echo "::error::runner_label must not contain control characters"
+            exit 1
+          fi
+          if (( ${#REQUESTED_RUNNER_LABEL} > 128 )); then
+            echo "::error::runner_label must not exceed 128 bytes"
+            exit 1
+          fi
+          if ! [[ "$REQUESTED_MINIMUM_FREE_BYTES" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::minimum_free_bytes must be a positive integer; got ${REQUESTED_MINIMUM_FREE_BYTES}"
+            exit 1
+          fi
+          if (( ${#REQUESTED_MINIMUM_FREE_BYTES} > ${#MAXIMUM_FREE_BYTES} )) ||
+            { (( ${#REQUESTED_MINIMUM_FREE_BYTES} == ${#MAXIMUM_FREE_BYTES} )) &&
+              [[ "$REQUESTED_MINIMUM_FREE_BYTES" > "$MAXIMUM_FREE_BYTES" ]]; }; then
+            echo "::error::minimum_free_bytes must not exceed ${MAXIMUM_FREE_BYTES}; got ${REQUESTED_MINIMUM_FREE_BYTES}"
+            exit 1
+          fi
+
   evidence:
+    needs: validate-inputs
     name: PostgreSQL ${{ inputs.scale }} evidence
     runs-on: ${{ inputs.runner_label }}
     timeout-minutes: ${{ inputs.timeout_minutes }}

--- a/scripts/verify/verify-index-storage-scale-run-contract.mjs
+++ b/scripts/verify/verify-index-storage-scale-run-contract.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync(
+  new URL('../../.github/workflows/index-storage-scale-run.yml', import.meta.url),
+  'utf8',
+);
+const plan = readFileSync(
+  new URL('../../crates/rustok-index/docs/implementation-plan.md', import.meta.url),
+  'utf8',
+);
+const prefix = '[verify-index-storage-scale-run-contract]';
+const fail = (message) => {
+  console.error(`${prefix} ${message}`);
+  process.exit(1);
+};
+
+const validateStart = workflow.indexOf('  validate-inputs:\n');
+const evidenceStart = workflow.indexOf('  evidence:\n');
+if (validateStart < 0) fail('reusable scale workflow is missing validate-inputs job');
+if (evidenceStart < 0) fail('reusable scale workflow is missing evidence job');
+if (validateStart > evidenceStart) {
+  fail('validate-inputs job must appear before the evidence job');
+}
+
+const validateBlock = workflow.slice(validateStart, evidenceStart);
+for (const marker of [
+  '    runs-on: ubuntu-slim',
+  '    timeout-minutes: 5',
+  '          REQUESTED_SCALE: ${{ inputs.scale }}',
+  '          REQUESTED_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}',
+  '          REQUESTED_RUNNER_LABEL: ${{ inputs.runner_label }}',
+  '          REQUESTED_MINIMUM_FREE_BYTES: ${{ inputs.minimum_free_bytes }}',
+  '          set -euo pipefail',
+  '          export LC_ALL=C',
+  '          MAXIMUM_FREE_BYTES=9007199254740991',
+  '          case "$REQUESTED_SCALE" in',
+  '            100k|1m) ;;',
+  '          if ! [[ "$REQUESTED_TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]]; then',
+  '          if (( REQUESTED_TIMEOUT_MINUTES > 360 )); then',
+  '          if [[ -z "${REQUESTED_RUNNER_LABEL//[[:space:]]/}" ]]; then',
+  '          if [[ "$REQUESTED_RUNNER_LABEL" =~ [[:cntrl:]] ]]; then',
+  '          if (( ${#REQUESTED_RUNNER_LABEL} > 128 )); then',
+  '          if ! [[ "$REQUESTED_MINIMUM_FREE_BYTES" =~ ^[1-9][0-9]*$ ]]; then',
+  '          if (( ${#REQUESTED_MINIMUM_FREE_BYTES} > ${#MAXIMUM_FREE_BYTES} )) ||',
+]) {
+  if (!validateBlock.includes(marker)) fail(`validate-inputs job is missing ${marker}`);
+}
+for (const forbidden of [
+  'actions/checkout',
+  'dtolnay/rust-toolchain',
+  'services:',
+  'postgres:',
+  'cargo build',
+]) {
+  if (validateBlock.includes(forbidden)) {
+    fail(`validate-inputs job must remain lightweight; found ${forbidden}`);
+  }
+}
+
+const evidenceBlock = workflow.slice(evidenceStart);
+const needsIndex = evidenceBlock.indexOf('    needs: validate-inputs\n');
+const runnerIndex = evidenceBlock.indexOf('    runs-on: ${{ inputs.runner_label }}\n');
+const servicesIndex = evidenceBlock.indexOf('    services:\n');
+if (needsIndex < 0) fail('evidence job must depend on validate-inputs');
+if (runnerIndex < 0 || servicesIndex < 0) {
+  fail('evidence job is missing runner or service allocation markers');
+}
+if (needsIndex > runnerIndex || needsIndex > servicesIndex) {
+  fail('evidence dependency must be declared before runner and service allocation');
+}
+if (!evidenceBlock.includes('          if (( available_bytes < MINIMUM_FREE_BYTES )); then')) {
+  fail('evidence job must retain the runner disk-capacity gate');
+}
+
+const planMarker = [
+  '- [x] Validate reusable scale workflow inputs on a fixed runner before custom',
+  '      runner, PostgreSQL service, toolchain, compilation, or benchmark allocation.',
+].join('\n');
+if (!plan.includes(planMarker)) {
+  fail('Index implementation plan must record the completed scale-input gate');
+}
+
+console.log(`${prefix} reusable scale workflow input validation is fail closed`);

--- a/scripts/verify/verify-index-storage-scale-run-contract.mjs
+++ b/scripts/verify/verify-index-storage-scale-run-contract.mjs
@@ -6,10 +6,6 @@ const workflow = readFileSync(
   new URL('../../.github/workflows/index-storage-scale-run.yml', import.meta.url),
   'utf8',
 );
-const plan = readFileSync(
-  new URL('../../crates/rustok-index/docs/implementation-plan.md', import.meta.url),
-  'utf8',
-);
 const prefix = '[verify-index-storage-scale-run-contract]';
 const fail = (message) => {
   console.error(`${prefix} ${message}`);
@@ -72,14 +68,6 @@ if (needsIndex > runnerIndex || needsIndex > servicesIndex) {
 }
 if (!evidenceBlock.includes('          if (( available_bytes < MINIMUM_FREE_BYTES )); then')) {
   fail('evidence job must retain the runner disk-capacity gate');
-}
-
-const planMarker = [
-  '- [x] Validate reusable scale workflow inputs on a fixed runner before custom',
-  '      runner, PostgreSQL service, toolchain, compilation, or benchmark allocation.',
-].join('\n');
-if (!plan.includes(planMarker)) {
-  fail('Index implementation plan must record the completed scale-input gate');
 }
 
 console.log(`${prefix} reusable scale workflow input validation is fail closed`);


### PR DESCRIPTION
## Summary

- rebuild the reviewed reusable scale-input gate from #2218 in a new branch and PR;
- validate only canonical `100k` and `1m` scales on a fixed lightweight runner before custom runner or PostgreSQL allocation;
- require positive integer timeouts capped at GitHub Actions' 360-minute limit;
- reject blank, control-character, and oversized runner labels before scheduling heavy evidence work;
- require positive integer disk thresholds bounded to the exact integer range used safely by workflow and Bash arithmetic;
- make the heavy evidence job depend on the input gate;
- retain the self-triggering static workflow contract for validation order, lightweight boundaries, input bounds, and runtime disk checks.

## Recheck

- confirmed #2218 has no comments or unresolved review threads;
- confirmed `index-storage-scale-run.yml` is byte-identical in current `main` and the #2218 merge base;
- preserved the reviewed three-file/four-commit branch diff without touching the recently merged smoke and scale-evidence validator lifecycle;
- kept M2 open and did not synthesize replacement evidence or a storage decision.

## Validation

Tests, Node/Cargo commands, formatting, workflows, and benchmarks were not run, per maintainer request. Static review covered lightweight gate ordering, scale enumeration, timeout bounds, runner-label shape and length, disk-threshold exact-integer bounds, heavy-job dependency, PostgreSQL allocation ordering, runtime disk capacity checks, and the three-file compare against current `main`.

Supersedes #2218.