### PR TITLE
fix(index): enforce the exact comparison methodology envelope

### DIFF
--- a/scripts/verify/comparison-methodology-envelope.test.mjs
+++ b/scripts/verify/comparison-methodology-envelope.test.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  comparisonMethodologyKeys,
+  databaseSettingsSource,
+  requireComparisonDatabaseSettingsMethodology,
+} from './index-storage-database-settings-contract.mjs';
+
+const prepareScript = path.resolve('scripts/verify/prepare-index-storage-decision.mjs');
+const renderScript = path.resolve('scripts/verify/render-index-storage-adr.mjs');
+const envelopeError = /comparison methodology must contain exactly the canonical methodology fields/u;
+
+const methodology = () => ({
+  source_oracle: 'normalized idx_bench_source workload result digests',
+  result_digest: 'ordered_length_prefixed_json_v1',
+  evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+  first_run: 'first EXPLAIN ANALYZE repetition',
+  warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+  automatic_winner_selection: false,
+  comparable_database_fields: [...comparableDatabaseFields],
+  database_settings_source: databaseSettingsSource,
+});
+
+const requireMethodology = (value) => requireComparisonDatabaseSettingsMethodology(
+  { methodology: value },
+  (message) => { throw new Error(message); },
+);
+
+const writeJson = (filename, value) => writeFileSync(
+  filename,
+  `${JSON.stringify(value, null, 2)}\n`,
+  'utf8',
+);
+
+const run = (script, args) => spawnSync(process.execPath, [script, ...args], {
+  encoding: 'utf8',
+});
+
+const withFixture = (callback) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-methodology-envelope-'));
+  try {
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('accepts exactly the canonical comparison methodology envelope', () => {
+  const value = methodology();
+  assert.deepEqual(Object.keys(value), [...comparisonMethodologyKeys]);
+  assert.equal(requireMethodology(value), value);
+});
+
+test('rejects a missing comparison methodology field', () => {
+  const value = methodology();
+  delete value.first_run;
+  assert.throws(() => requireMethodology(value), envelopeError);
+});
+
+test('rejects a renamed comparison methodology field', () => {
+  const value = methodology();
+  value.cold_run = value.first_run;
+  delete value.first_run;
+  assert.throws(() => requireMethodology(value), envelopeError);
+});
+
+test('rejects an additional comparison methodology field', () => {
+  const value = methodology();
+  value.unreviewed_note = 'must not become decision input';
+  assert.throws(() => requireMethodology(value), envelopeError);
+});
+
+test('decision preparation rejects methodology drift before publishing a draft', () => {
+  withFixture((root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const value = methodology();
+    value.unreviewed_note = 'must not become decision input';
+    writeJson(comparisonPath, { methodology: value });
+
+    const result = run(prepareScript, [
+      '--comparison', comparisonPath,
+      '--selected', 'typed_eav',
+      '--owner', 'Index maintainers',
+      '--date', '2026-07-26',
+      '--output', decisionPath,
+    ]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, envelopeError);
+    assert.equal(existsSync(decisionPath), false);
+  });
+});
+
+test('direct ADR rendering rejects methodology drift before publishing output', () => {
+  withFixture((root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    const outputPath = path.join(root, 'adr.md');
+    const value = methodology();
+    value.unreviewed_note = 'must not reach the ADR';
+    writeJson(comparisonPath, { methodology: value });
+    writeJson(decisionPath, {});
+
+    const result = run(renderScript, [
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, envelopeError);
+    assert.equal(existsSync(outputPath), false);
+  });
+});

--- a/scripts/verify/index-storage-database-settings-contract.mjs
+++ b/scripts/verify/index-storage-database-settings-contract.mjs
@@ -14,12 +14,28 @@ export const comparableDatabaseFields = Object.freeze([
 export const databaseSettingsSource =
   'read-report.json database metadata observed from the active PostgreSQL benchmark session after exact equality was verified against mutation-report.json and maintenance-report.json active-session metadata';
 
+export const comparisonMethodologyKeys = Object.freeze([
+  'source_oracle',
+  'result_digest',
+  'evidence_validation',
+  'first_run',
+  'warm_run',
+  'automatic_winner_selection',
+  'comparable_database_fields',
+  'database_settings_source',
+]);
+
 const sameJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
 export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) => {
   const methodology = comparison?.methodology;
   if (!methodology || typeof methodology !== 'object' || Array.isArray(methodology)) {
     fail('comparison.methodology must be an object');
+  }
+  const actualKeys = Object.keys(methodology).sort();
+  const expectedKeys = [...comparisonMethodologyKeys].sort();
+  if (!sameJson(actualKeys, expectedKeys)) {
+    fail('comparison methodology must contain exactly the canonical methodology fields');
   }
   if (!sameJson(methodology.comparable_database_fields, comparableDatabaseFields)) {
     fail(
@@ -28,7 +44,7 @@ export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =
   }
   if (methodology.database_settings_source !== databaseSettingsSource) {
     fail(
-      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata; database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+      'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
     );
   }
   return methodology;

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -64,6 +64,7 @@ const runContract = (args) => {
     'verify-index-storage-decision-text-schema.mjs',
     'verify-index-storage-router-arguments.mjs',
     'verify-index-storage-comparator-lifecycle.mjs',
+    'verify-index-storage-methodology-envelope.mjs',
   ]) {
     runScript(script);
   }
@@ -78,6 +79,7 @@ const runFixtures = (args) => {
     scriptPath('index-storage-standalone-tools.test.mjs'),
     scriptPath('compare-index-storage-evidence.test.mjs'),
     scriptPath('compare-index-storage-evidence-lifecycle.test.mjs'),
+    scriptPath('comparison-methodology-envelope.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),

--- a/scripts/verify/verify-index-storage-methodology-envelope.mjs
+++ b/scripts/verify/verify-index-storage-methodology-envelope.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-methodology-envelope] ${message}`);
+  process.exit(1);
+};
+
+const contract = read('scripts/verify/index-storage-database-settings-contract.mjs');
+const fixture = read('scripts/verify/comparison-methodology-envelope.test.mjs');
+const preparer = read('scripts/verify/prepare-index-storage-decision.mjs');
+const renderer = read('scripts/verify/render-index-storage-adr-core.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(contract, 'comparison methodology contract', [
+  'export const comparisonMethodologyKeys = Object.freeze([',
+  "'source_oracle'",
+  "'result_digest'",
+  "'evidence_validation'",
+  "'first_run'",
+  "'warm_run'",
+  "'automatic_winner_selection'",
+  "'comparable_database_fields'",
+  "'database_settings_source'",
+  'const actualKeys = Object.keys(methodology).sort()',
+  'const expectedKeys = [...comparisonMethodologyKeys].sort()',
+  "fail('comparison methodology must contain exactly the canonical methodology fields')",
+  'methodology.comparable_database_fields',
+  'methodology.database_settings_source',
+]);
+
+const keysStart = contract.indexOf('export const comparisonMethodologyKeys = Object.freeze([');
+const shapeGate = contract.indexOf('const actualKeys = Object.keys(methodology).sort()');
+const databaseFieldsGate = contract.indexOf('if (!sameJson(methodology.comparable_database_fields');
+const sourceGate = contract.indexOf('if (methodology.database_settings_source !== databaseSettingsSource)');
+if ([keysStart, shapeGate, databaseFieldsGate, sourceGate].some((index) => index < 0)
+    || !(keysStart < shapeGate && shapeGate < databaseFieldsGate && databaseFieldsGate < sourceGate)) {
+  fail('comparison methodology validation must check exact keys before PostgreSQL field and source values');
+}
+
+requireMarkers(preparer, 'decision preparer', [
+  "from './index-storage-database-settings-contract.mjs'",
+  'requireComparisonDatabaseSettingsMethodology(comparison, fail)',
+]);
+requireMarkers(renderer, 'ADR renderer core', [
+  "from './index-storage-database-settings-contract.mjs'",
+  'requireComparisonDatabaseSettingsMethodology(comparison, fail)',
+]);
+
+requireMarkers(fixture, 'comparison methodology fixture', [
+  "test('accepts exactly the canonical comparison methodology envelope'",
+  "test('rejects a missing comparison methodology field'",
+  "test('rejects a renamed comparison methodology field'",
+  "test('rejects an additional comparison methodology field'",
+  "test('decision preparation rejects methodology drift before publishing a draft'",
+  "test('direct ADR rendering rejects methodology drift before publishing output'",
+  'assert.equal(existsSync(decisionPath), false)',
+  'assert.equal(existsSync(outputPath), false)',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-methodology-envelope.mjs'",
+  "scriptPath('comparison-methodology-envelope.test.mjs')",
+]);
+
+console.log('[verify-index-storage-methodology-envelope] exact eight-field comparison methodology shape is enforced before decision preparation and ADR rendering, with focused fixtures and router coverage');


### PR DESCRIPTION
## Summary

- rebuild the exact-envelope intent from #2221 on the current Index tooling architecture;
- define the canonical eight-field comparison methodology key set;
- reject missing, renamed, or additional methodology fields before PostgreSQL field/source validation;
- retain the exact ordered database-settings field contract and canonical source string;
- add a focused fixture that tests the contract directly and proves decision preparation and direct ADR rendering fail before publishing output;
- add a dedicated static cross-guard and register both checks in the canonical `contract` and `fixtures` commands.

## Recheck

- confirmed #2221 has no comments or unresolved review threads;
- confirmed current `main` still accepted shortened or extended methodology objects as long as the two PostgreSQL-specific fields matched;
- avoided replacing the newer decision and renderer lifecycle fixtures with stale #2221 versions;
- added a separate regression suite over the current preparation and rendering entrypoints instead;
- kept M2 open and did not create benchmark evidence or select a storage model.

## Validation

Tests, Node/Cargo commands, formatting, workflows, and benchmarks were not run, per maintainer request. Static review covered the exact eight-key set, missing/renamed/additional fields, validation ordering, non-publication of decision and ADR outputs on failure, current preparation/renderer contract calls, router registration, and the four-file compare against current `main`.

Supersedes #2221.