### PR TITLE
Retain tax calculation policy rejection context

### DIFF
--- a/crates/rustok-tax/docs/calculation-port-policy-context.md
+++ b/crates/rustok-tax/docs/calculation-port-policy-context.md
@@ -1,0 +1,72 @@
+# Tax calculation port policy context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the owner-side policy-admission context gap in the canonical
+`TaxCalculationPort::calculate_tax` implementation.
+
+Before this change, `PortContext::require_policy(PortCallPolicy::read())` ran before
+the tax owner operation was assigned. A deadline or policy rejection therefore left
+the tax owner without a dedicated structured event containing the full available
+request context.
+
+The port now:
+
+- assigns `calculate_tax` before policy admission;
+- delegates admission to one tax-owned helper using the unchanged read policy;
+- records the truthful `rustok_tax` owner and stable `tax_calculation_port` boundary;
+- retains correlation id, tenant, actor, channel, locale, causation id, traceparent,
+  idempotency key, and deadline;
+- retains the exact owner operation and original `PortError` code, kind, and
+  retryability;
+- emits error severity for unavailable, timeout, and invariant failures and warning
+  severity for ordinary policy or validation rejection;
+- returns the original `PortError` unchanged after diagnostics.
+
+## Preserved behavior
+
+The change does not alter:
+
+- `PortCallPolicy::read()` admission semantics;
+- tax request or result DTOs;
+- currency, rate, taxable-target, exempt-customer, or total validation;
+- `TaxService::calculate` delegation;
+- stable public validation and invariant messages;
+- provider result validation or existing unit-test source;
+- runtime composition, FBA, or FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-tax-calculation-policy-context.mjs` fixes the following source
+contract:
+
+- owner operation assignment precedes policy admission;
+- the shared helper performs the unchanged read-policy check;
+- rejected admission logs the complete available `PortContext` and original typed
+  error fields;
+- the original error is rethrown;
+- existing tax service mapping and public validation/result envelopes remain intact;
+- direct admission before owner-operation assignment is forbidden.
+
+## Validation status
+
+Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and
+CI were not run by the implementation agent, per maintainer instruction.
+
+Suggested focused checks:
+
+```bash
+node scripts/verify/verify-tax-calculation-policy-context.mjs
+node scripts/verify/verify-tax-calculation-error-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-tax --lib
+```
+
+## Remaining work
+
+This does not close consumer-side tax transport context retention, promotion cleanup,
+mounted checkout compensation, or the remaining order, payment, fulfillment,
+inventory, customer, and ecommerce adapter mapper work. Architecture status must not
+be promoted from source inspection alone.

--- a/crates/rustok-tax/src/ports.rs
+++ b/crates/rustok-tax/src/ports.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use rust_decimal::Decimal;
-use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
 use std::{collections::HashSet, sync::Arc};
 use uuid::Uuid;
 
 use crate::{CalculatedTaxLine, TaxCalculationInput, TaxCalculationResult, TaxError};
+
+const TAX_CALCULATION_PORT_BOUNDARY: &str = "tax_calculation_port";
 
 /// Transport-neutral owner boundary for tax calculation.
 #[async_trait]
@@ -29,8 +31,8 @@ impl TaxCalculationPort for crate::TaxService {
         context: PortContext,
         request: TaxCalculationInput,
     ) -> Result<TaxCalculationResult, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
         let owner_operation = "calculate_tax";
+        require_tax_calculation_policy(&context, owner_operation)?;
         let expected_currency = validate_tax_request(&context, owner_operation, &request)?;
         let customer_tax_exempt = request.customer_tax_exempt;
         let taxable_targets = request
@@ -52,6 +54,67 @@ impl TaxCalculationPort for crate::TaxService {
             &result,
         )?;
         Ok(result)
+    }
+}
+
+fn require_tax_calculation_policy(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::read()).map_err(|error| {
+        log_tax_calculation_policy_rejection(context, owner_operation, &error);
+        error
+    })
+}
+
+fn log_tax_calculation_policy_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: &PortError,
+) {
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner = "rustok_tax",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                code = %error.code,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = TAX_CALCULATION_PORT_BOUNDARY,
+                "tax calculation policy admission failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner = "rustok_tax",
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                code = %error.code,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = TAX_CALCULATION_PORT_BOUNDARY,
+                "tax calculation policy admission was rejected"
+            );
+        }
     }
 }
 

--- a/scripts/verify/verify-tax-calculation-error-context.mjs
+++ b/scripts/verify/verify-tax-calculation-error-context.mjs
@@ -33,8 +33,14 @@ const between = (content, start, end, label) => {
 const calculationPort = between(
   source,
   'impl TaxCalculationPort for crate::TaxService {',
-  'fn validate_tax_request(',
+  'fn require_tax_calculation_policy(',
   'tax calculation port',
+);
+const policyHelper = between(
+  source,
+  'fn require_tax_calculation_policy(',
+  'fn validate_tax_request(',
+  'tax calculation policy helper',
 );
 const requestMapper = between(
   source,
@@ -56,13 +62,36 @@ const ownerMapper = between(
 );
 
 for (const [value, label] of [
-  ['use rustok_api::{PortCallPolicy, PortContext, PortError};', 'typed port imports'],
-  ['context.require_policy(PortCallPolicy::read())?;', 'read policy requirement'],
+  [
+    'use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};',
+    'typed port imports',
+  ],
   ['let owner_operation = "calculate_tax";', 'owner operation'],
+  [
+    'require_tax_calculation_policy(&context, owner_operation)?;',
+    'read policy requirement',
+  ],
   ['tax_error_to_port_error(&context, owner_operation, error)', 'context-aware owner mapper call'],
   ['validate_tax_request(&context, owner_operation, &request)', 'context-aware request validation'],
   ['validate_tax_result(', 'context-aware result validation'],
 ]) requireText(calculationPort, value, label);
+
+for (const [value, label] of [
+  [
+    'context.require_policy(PortCallPolicy::read()).map_err(|error| {',
+    'unchanged read policy admission',
+  ],
+  [
+    'log_tax_calculation_policy_rejection(context, owner_operation, &error);',
+    'policy rejection diagnostics',
+  ],
+  ['owner = "rustok_tax"', 'policy owner log'],
+  ['correlation_id = %context.correlation_id', 'policy correlation log'],
+  ['tenant_id = %context.tenant_id', 'policy tenant log'],
+  ['channel = ?context.channel', 'policy channel log'],
+  ['operation = owner_operation', 'policy operation log'],
+  ['boundary = TAX_CALCULATION_PORT_BOUNDARY', 'policy boundary log'],
+]) requireText(policyHelper, value, label);
 
 for (const [content, label] of [
   [requestMapper, 'tax request mapper'],
@@ -104,6 +133,7 @@ for (const value of [
   'PortError::validation("tax.validation", message)',
   'PortError::invariant_violation(code, detail)',
   '.map_err(tax_error_to_port_error)',
+  'context.require_policy(PortCallPolicy::read())?;\n        let owner_operation',
 ]) forbidText(source, value, 'unsafe tax public mapping');
 
 for (const [value, label] of [

--- a/scripts/verify/verify-tax-calculation-policy-context.mjs
+++ b/scripts/verify/verify-tax-calculation-policy-context.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(new URL('crates/rustok-tax/src/ports.rs', root), 'utf8');
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  [
+    'const TAX_CALCULATION_PORT_BOUNDARY: &str = "tax_calculation_port";',
+    'stable tax calculation owner boundary',
+  ],
+  ['PortErrorKind', 'typed port error classification import'],
+  ['let owner_operation = "calculate_tax";', 'owner operation assignment'],
+  [
+    'require_tax_calculation_policy(&context, owner_operation)?;',
+    'shared policy admission helper',
+  ],
+  ['fn require_tax_calculation_policy(', 'policy helper definition'],
+  [
+    'context.require_policy(PortCallPolicy::read()).map_err(|error| {',
+    'unchanged read policy admission',
+  ],
+  [
+    'log_tax_calculation_policy_rejection(context, owner_operation, &error);',
+    'rejection diagnostics before rethrow',
+  ],
+  ['fn log_tax_calculation_policy_rejection(', 'structured diagnostic helper'],
+  ['owner = "rustok_tax"', 'truthful tax owner'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['operation = owner_operation', 'exact owner operation'],
+  ['code = %error.code', 'original port code'],
+  ['error_kind = ?error.kind', 'original port kind'],
+  ['retryable = error.retryable', 'original retryability'],
+  ['boundary = TAX_CALCULATION_PORT_BOUNDARY', 'boundary identity'],
+  ['"tax calculation policy admission failed"', 'error diagnostic event'],
+  [
+    '"tax calculation policy admission was rejected"',
+    'warning diagnostic event',
+  ],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'severity classification',
+  ],
+]) {
+  requireText(value, label);
+}
+
+const operationIndex = source.indexOf('let owner_operation = "calculate_tax";');
+const policyIndex = source.indexOf('require_tax_calculation_policy(&context, owner_operation)?;');
+const validationIndex = source.indexOf(
+  'let expected_currency = validate_tax_request(&context, owner_operation, &request)?;',
+);
+if (!(operationIndex >= 0 && operationIndex < policyIndex && policyIndex < validationIndex)) {
+  failures.push('calculate_tax must assign operation, admit policy, then validate request');
+}
+
+for (const [value, label] of [
+  ['error\n    })', 'original PortError rethrow'],
+  [
+    '.map_err(|error| tax_error_to_port_error(&context, owner_operation, error))?',
+    'existing owner error mapping',
+  ],
+  ['PortError::validation(code, "tax request is invalid")', 'stable request envelope'],
+  [
+    'PortError::invariant_violation(code, "tax calculation result is invalid")',
+    'stable result envelope',
+  ],
+  ['PortError::validation("tax.validation", "tax request is invalid")', 'stable service envelope'],
+  ['validate_tax_result(', 'existing result validation'],
+]) {
+  requireText(value, label);
+}
+
+forbidText(
+  'context.require_policy(PortCallPolicy::read())?;\n        let owner_operation',
+  'policy admission before owner operation',
+);
+
+if (failures.length > 0) {
+  console.error('Tax calculation policy context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Tax calculation policy rejections retain complete owner context and the original PortError',
+);


### PR DESCRIPTION
## Summary

- assign the canonical tax owner operation before read-policy admission;
- route `TaxCalculationPort::calculate_tax` admission through one tax-owned helper using the unchanged `PortCallPolicy::read()` contract;
- retain truthful `rustok_tax` owner context for deadline and policy rejection, including correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, exact operation, original code/kind/retryability, and the stable `tax_calculation_port` boundary;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary rejection;
- rethrow the original `PortError` unchanged after diagnostics;
- preserve tax request/result validation, service delegation, DTOs, stable public validation/invariant messages, and existing test source;
- add a focused policy-context guard, align the existing tax error-context verifier with the shared helper, and add a source-ready/unvalidated evidence note.

## Scope

Four files only:

- `crates/rustok-tax/src/ports.rs`
- `scripts/verify/verify-tax-calculation-policy-context.mjs`
- `scripts/verify/verify-tax-calculation-error-context.mjs`
- `crates/rustok-tax/docs/calculation-port-policy-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe tax mapper cleanup. It closes the owner-side gap where tax read-policy/deadline rejection occurred before the owner operation was assigned or a tax-specific structured event was emitted. Consumer-side tax transport context and remaining promotion, compensation, order, payment, fulfillment, inventory, customer, and ecommerce adapters remain open. No FBA/FFA status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- diff contains exactly the four scoped files;
- owner operation assignment precedes policy admission and request validation;
- the helper performs the unchanged read-policy check, logs the full available context, and rethrows the original error;
- stable tax request, provider-result, and service validation envelopes remain unchanged;
- the existing tax error-context verifier is synchronized with the new helper rather than retaining a stale inline-admission expectation;
- concurrent `main` changes touched only Index and Notifications/Forum files and did not overlap this slice;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-tax-calculation-policy-context.mjs
node scripts/verify/verify-tax-calculation-error-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-tax --lib
```

Internal PR #2256 was used only to delete a superseded technical branch. The final branch was rebuilt directly from current `main`; its temporary handoff file and staging history are absent from this PR.