### PR TITLE
fix(index): harden accepted ADR finalization lifecycle

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -63,6 +63,8 @@ node scripts/verify/index-storage-tooling.mjs prepare \
 
 `prepare` requires an explicit prototype choice. It does not rank candidates or select a winner. It validates the decision-ready comparison and its exact observed database-settings methodology, copies the evidence commit, computes the SHA-256 of the exact comparison-file bytes, creates rejection entries for exactly the two unselected prototypes, and refuses to overwrite an existing decision unless `--force` is provided. The draft is written to a staged file and renamed only after the complete JSON is on disk.
 
+The generated draft has `status: proposed`. Change it to `accepted` only after the evidence and rationales have been reviewed. The finalizer rejects a proposed decision and accepts only a real `YYYY-MM-DD` calendar date with a year from `0001` through `9999`, including the correct Gregorian leap-year rules.
+
 The preparation command accepts only `--comparison`, `--selected`, `--owner`, `--date`, and `--output`, plus one standalone `--force` flag. Help is valid only as the sole argument, and unknown, incomplete, mixed-help, or duplicate options fail before changing decision state. A valid forced replacement creates a unique same-directory staging location before withdrawing the stale draft, then validates the comparison and publishes the complete replacement with one rename. Failure after stale-draft withdrawal leaves no decision file and no staging residue.
 
 The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects any remaining preparation marker.
@@ -99,9 +101,13 @@ node scripts/verify/index-storage-tooling.mjs render \
 
 Finalization snapshots the exact comparison and decision bytes before rendering. The generated ADR records both `Comparison SHA-256` and `Decision SHA-256`, so reviewers can verify the two source documents used to produce it.
 
+The finalizer accepts only `--comparison`, `--decision`, and `--output`; help is valid only as the sole argument. Malformed command lines and output paths that collide with either input are non-destructive. A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read. If the replacement evidence, accepted decision, renderer, or publication step fails, no stale ADR is left behind.
+
 The finalizer fails closed unless:
 
-- the comparison contains the exact ten-field observed PostgreSQL database-settings methodology;
+- the decision status is `accepted`;
+- `decision_date` is a real ISO calendar date using Gregorian month and leap-year rules;
+- the comparison contains the exact eight-field methodology envelope, including the ordered ten-field observed PostgreSQL database-settings contract;
 - the comparison is decision-ready;
 - every decision-contract flag is true;
 - `100k` and `1m` evidence are present and share the same full commit;

--- a/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const comparison = () => ({
+  methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
+});
+
+const decision = (overrides = {}) => ({
+  status: 'accepted',
+  decision_date: '2026-07-25',
+  owner: 'Index maintainers',
+  comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+  comparison_sha256: '0'.repeat(64),
+  selected_prototype: 'typed_eav',
+  selection_rationale: 'Measured evidence supports the selected prototype.',
+  rejection_rationales: {
+    jsonb: 'JSONB was not selected.',
+    hot_projection: 'Hot projection was not selected.',
+  },
+  operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+  migration_strategy: 'Backfill and verify parity before cutover.',
+  rollback_strategy: 'Retain the previous path until cutover verification completes.',
+  ...overrides,
+});
+
+const runFinalizerArgs = (args) => spawnSync(process.execPath, [finalizer, ...args], {
+  encoding: 'utf8',
+});
+
+const stagedOutputPath = (outputPath) => `${outputPath}.tmp-${process.pid}`;
+const stagingEntries = (root) => readdirSync(root)
+  .filter((entry) => entry.startsWith('adr.md.tmp-'));
+
+const runFinalizer = (root, decisionValue, staleOutput = null, staleStaging = null) => {
+  const comparisonPath = path.join(root, 'comparison.json');
+  const decisionPath = path.join(root, 'decision.json');
+  const outputPath = path.join(root, 'adr.md');
+  writeJson(comparisonPath, comparison());
+  writeJson(decisionPath, decisionValue);
+  if (staleOutput !== null) writeFileSync(outputPath, staleOutput, 'utf8');
+  if (staleStaging !== null) writeFileSync(stagedOutputPath(outputPath), staleStaging, 'utf8');
+  return {
+    comparisonPath,
+    decisionPath,
+    outputPath,
+    result: runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]),
+  };
+};
+
+const withFixture = (prefix, callback) => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('finalizer accepts help only as the sole argument', () => {
+  const result = runFinalizerArgs(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^Usage: node scripts\/verify\/finalize-index-storage-adr\.mjs /u);
+  assert.equal(result.stderr, '');
+});
+
+test('finalizer rejects mixed help without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-help-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs(['--help', '--output', outputPath]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--help\/-h must be the only argument/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer rejects unknown options without changing an existing ADR', () => {
+  withFixture('rustok-index-finalizer-unknown-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const original = Buffer.from('accepted ADR\n', 'utf8');
+    writeFileSync(outputPath, original);
+    const result = runFinalizerArgs([
+      '--comparison', 'missing-comparison.json',
+      '--decision', 'missing-decision.json',
+      '--output', outputPath,
+      '--format', 'markdown',
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown argument: --format/u);
+    assert.doesNotMatch(result.stderr, /missing comparison/u);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(readFileSync(outputPath), original);
+  });
+});
+
+test('finalizer output collision preserves the comparison bytes', () => {
+  withFixture('rustok-index-finalizer-collision-', (root) => {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const decisionPath = path.join(root, 'decision.json');
+    writeJson(comparisonPath, comparison());
+    writeJson(decisionPath, decision());
+    const original = readFileSync(comparisonPath);
+    const result = runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', comparisonPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--output must not overwrite the comparison input/u);
+    assert.deepEqual(readFileSync(comparisonPath), original);
+  });
+});
+
+test('finalizer staging collision preserves the comparison bytes', () => {
+  withFixture('rustok-index-finalizer-staging-collision-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const comparisonPath = stagedOutputPath(outputPath);
+    const decisionPath = path.join(root, 'decision.json');
+    writeJson(comparisonPath, comparison());
+    writeJson(decisionPath, decision());
+    const original = readFileSync(comparisonPath);
+    const result = runFinalizerArgs([
+      '--comparison', comparisonPath,
+      '--decision', decisionPath,
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ADR staging path must not overwrite the comparison input/u);
+    assert.deepEqual(readFileSync(comparisonPath), original);
+  });
+});
+
+test('real finalization attempts revoke stale ADR and staging before evidence access', () => {
+  withFixture('rustok-index-finalizer-missing-', (root) => {
+    const outputPath = path.join(root, 'adr.md');
+    const stagingPath = stagedOutputPath(outputPath);
+    writeFileSync(outputPath, 'stale ADR\n', 'utf8');
+    writeFileSync(stagingPath, 'stale staging\n', 'utf8');
+    const result = runFinalizerArgs([
+      '--comparison', path.join(root, 'missing-comparison.json'),
+      '--decision', path.join(root, 'missing-decision.json'),
+      '--output', outputPath,
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing comparison/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.equal(existsSync(stagingPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects impossible decision dates without leaving stale output', () => {
+  for (const invalidDate of ['2026-02-29', '2026-04-31', '0000-01-01', '2026-13-01']) {
+    withFixture('rustok-index-decision-date-', (root) => {
+      const { outputPath, result } = runFinalizer(
+        root,
+        decision({ decision_date: invalidDate }),
+        'stale ADR\n',
+        'stale staging\n',
+      );
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /decision\.decision_date must be a real ISO calendar date/u);
+      assert.equal(existsSync(outputPath), false);
+      assert.deepEqual(stagingEntries(root), []);
+    });
+  }
+});
+
+test('finalizer accepts a real leap date before renderer validation', () => {
+  withFixture('rustok-index-decision-leap-date-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision({ decision_date: '2024-02-29' }),
+      'stale ADR\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(result.stderr, /decision\.decision_date/u);
+    assert.match(result.stderr, /strict ADR renderer failed/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('finalizer rejects a proposed decision without leaving stale output', () => {
+  withFixture('rustok-index-decision-status-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision({ status: 'proposed' }),
+      'stale ADR\n',
+      'stale staging\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /decision\.status must be accepted before ADR finalization/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});
+
+test('renderer failure leaves neither stale ADR nor staged output', () => {
+  withFixture('rustok-index-finalizer-render-', (root) => {
+    const { outputPath, result } = runFinalizer(
+      root,
+      decision(),
+      'stale ADR\n',
+      'stale staging\n',
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /strict ADR renderer failed/u);
+    assert.equal(existsSync(outputPath), false);
+    assert.deepEqual(stagingEntries(root), []);
+  });
+});

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -20,6 +20,7 @@ import { requireComparisonDatabaseSettingsMethodology } from './index-storage-da
 const prefix = '[finalize-index-storage-adr]';
 const placeholderPrefix = 'TODO(index-storage-decision):';
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const allowedArguments = new Set(['--comparison', '--decision', '--output']);
 const requiredDecisionKeys = [
   'status',
   'decision_date',
@@ -49,19 +50,23 @@ const usage = () => {
 const parseArgs = () => {
   const values = new Map();
   const args = process.argv.slice(2);
+  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+    usage();
+    return null;
+  }
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--help' || argument === '-h') {
-      usage();
-      return null;
+      fail('--help/-h must be the only argument');
     }
-    if (!argument.startsWith('--') || !args[index + 1] || args[index + 1].startsWith('--')) {
-      fail(`unknown or incomplete argument: ${argument}`);
+    if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`);
+    if (!args[index + 1] || args[index + 1].startsWith('--')) {
+      fail(`incomplete argument: ${argument}`);
     }
     if (values.has(argument)) fail(`${argument} was provided more than once`);
     values.set(argument, args[++index]);
   }
-  for (const argument of ['--comparison', '--decision', '--output']) {
+  for (const argument of allowedArguments) {
     if (!values.has(argument)) fail(`${argument} is required`);
   }
   return {
@@ -98,6 +103,27 @@ const requireDecisionEnvelope = (decision) => {
   if (Object.hasOwn(decision, '$schema')
       && decision.$schema !== './storage-decision.schema.json') {
     fail('decision.$schema must reference ./storage-decision.schema.json when present');
+  }
+};
+
+const requireAcceptedDecision = (decision) => {
+  if (decision.status !== 'accepted') {
+    fail('decision.status must be accepted before ADR finalization');
+  }
+};
+
+const requireIsoCalendarDate = (value, label) => {
+  const match = typeof value === 'string'
+    ? /^(\d{4})-(\d{2})-(\d{2})$/u.exec(value)
+    : null;
+  if (!match) fail(`${label} must be a real ISO calendar date`);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const monthLengths = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (year === 0 || month < 1 || month > 12 || day < 1 || day > monthLengths[month - 1]) {
+    fail(`${label} must be a real ISO calendar date`);
   }
 };
 
@@ -142,15 +168,25 @@ const insertDecisionDigest = (markdown, decisionSha256) => {
 const main = () => {
   const args = parseArgs();
   if (args === null) return;
+  const stagedOutput = `${args.output}.tmp-${process.pid}`;
   const resolvedOutput = path.resolve(args.output);
+  const resolvedStagedOutput = path.resolve(stagedOutput);
   for (const [label, filename] of [['comparison', args.comparison], ['decision', args.decision]]) {
-    if (resolvedOutput === path.resolve(filename)) fail(`--output must not overwrite the ${label} input`);
+    const resolvedInput = path.resolve(filename);
+    if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);
+    if (resolvedStagedOutput === resolvedInput) {
+      fail(`ADR staging path must not overwrite the ${label} input`);
+    }
   }
+  rmSync(args.output, { force: true });
+  rmSync(stagedOutput, { force: true });
 
   const comparison = readJsonBytes(args.comparison, 'comparison');
   const decision = readJsonBytes(args.decision, 'decision');
   requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
   requireDecisionEnvelope(decision.value);
+  requireAcceptedDecision(decision.value);
+  requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');
   rejectPlaceholders(decision.value);
 
   const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rustok-index-storage-adr-'));
@@ -177,7 +213,6 @@ const main = () => {
     const markdown = insertDecisionDigest(readFileSync(renderedPath, 'utf8'), decision.sha256);
     const parent = path.dirname(args.output);
     if (parent && parent !== '.') mkdirSync(parent, { recursive: true });
-    const stagedOutput = `${args.output}.tmp-${process.pid}`;
     try {
       writeFileSync(stagedOutput, markdown, 'utf8');
       renameSync(stagedOutput, args.output);

--- a/scripts/verify/index-storage-decision-tooling.test.mjs
+++ b/scripts/verify/index-storage-decision-tooling.test.mjs
@@ -85,6 +85,11 @@ const scale = (name, factor) => ({
 const comparison = () => ({
   generated_at: '2026-07-24T12:00:00Z',
   methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
     automatic_winner_selection: false,
     comparable_database_fields: [...comparableDatabaseFields],
     database_settings_source: databaseSettingsSource,
@@ -142,6 +147,7 @@ const prepare = (root) => {
 
 const completeDecision = (decision) => ({
   ...decision,
+  status: 'accepted',
   selection_rationale: 'Typed EAV provides the selected balance of measured query behavior and schema evolution.',
   rejection_rationales: {
     jsonb: 'JSONB was not selected because its measured and operational trade-offs were less suitable.',
@@ -175,6 +181,7 @@ test('prepares an exact-comparison-bound manual decision draft', () => {
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const decision = JSON.parse(readFileSync(decisionPath, 'utf8'));
     assert.equal(Object.hasOwn(decision, '$schema'), false);
+    assert.equal(decision.status, 'proposed');
     assert.equal(decision.comparison_commit, commit);
     assert.equal(decision.comparison_sha256, sha256(comparisonBytes));
     assert.equal(decision.selected_prototype, 'typed_eav');
@@ -198,7 +205,7 @@ test('rejects a comparison without the canonical database-settings methodology',
       '--output', decisionPath,
     ]);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract/u);
+    assert.match(result.stderr, /comparison methodology must contain exactly the canonical methodology fields/u);
     assert.equal(existsSync(decisionPath), false);
   });
 });
@@ -241,6 +248,9 @@ test('rejects an unedited prepared decision', () => {
   withFixture((root) => {
     const fixture = prepare(root);
     assert.equal(fixture.result.status, 0, fixture.result.stderr || fixture.result.stdout);
+    const decision = JSON.parse(readFileSync(fixture.decisionPath, 'utf8'));
+    decision.status = 'accepted';
+    writeJson(fixture.decisionPath, decision);
     const result = run(finalizeScript, [
       '--comparison', fixture.comparisonPath,
       '--decision', fixture.decisionPath,

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -65,6 +65,7 @@ const runContract = (args) => {
     'verify-index-storage-router-arguments.mjs',
     'verify-index-storage-comparator-lifecycle.mjs',
     'verify-index-storage-methodology-envelope.mjs',
+    'verify-index-storage-finalizer-lifecycle.mjs',
   ]) {
     runScript(script);
   }
@@ -81,6 +82,7 @@ const runFixtures = (args) => {
     scriptPath('compare-index-storage-evidence-lifecycle.test.mjs'),
     scriptPath('comparison-methodology-envelope.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
+    scriptPath('finalize-index-storage-adr-decision-contract.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),
     scriptPath('storage-decision-schema-text.test.mjs'),

--- a/scripts/verify/verify-index-storage-finalizer-lifecycle.mjs
+++ b/scripts/verify/verify-index-storage-finalizer-lifecycle.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-finalizer-lifecycle] ${message}`);
+  process.exit(1);
+};
+
+const finalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
+const fixture = read('scripts/verify/finalize-index-storage-adr-decision-contract.test.mjs');
+const decisionFixture = read('scripts/verify/index-storage-decision-tooling.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(finalizer, 'accepted ADR finalizer', [
+  "const allowedArguments = new Set(['--comparison', '--decision', '--output'])",
+  "if (args.length === 1 && (args[0] === '--help' || args[0] === '-h'))",
+  "fail('--help/-h must be the only argument')",
+  'if (!allowedArguments.has(argument)) fail(`unknown argument: ${argument}`)',
+  'if (values.has(argument)) fail(`${argument} was provided more than once`)',
+  'const requireAcceptedDecision = (decision) =>',
+  'decision.status must be accepted before ADR finalization',
+  'const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);',
+  'year === 0 || month < 1 || month > 12 || day < 1 || day > monthLengths[month - 1]',
+  'const stagedOutput = `${args.output}.tmp-${process.pid}`;',
+  'ADR staging path must not overwrite the ${label} input',
+  'rmSync(args.output, { force: true });',
+  'rmSync(stagedOutput, { force: true });',
+  "const comparison = readJsonBytes(args.comparison, 'comparison');",
+  'requireComparisonDatabaseSettingsMethodology(comparison.value, fail);',
+  'requireAcceptedDecision(decision.value);',
+  "requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');",
+  "path.join(scriptDirectory, 'render-index-storage-adr.mjs')",
+  'writeFileSync(stagedOutput, markdown, \'utf8\')',
+  'renameSync(stagedOutput, args.output)',
+  'rmSync(temporaryRoot, { recursive: true, force: true })',
+]);
+
+for (const forbidden of ['shell: true', 'execSync(', 'process.exit(']) {
+  if (finalizer.includes(forbidden)) fail(`accepted ADR finalizer contains forbidden behavior: ${forbidden}`);
+}
+
+const collision = finalizer.indexOf('if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);');
+const stagingCollision = finalizer.indexOf('if (resolvedStagedOutput === resolvedInput)');
+const revokeOutput = finalizer.indexOf('rmSync(args.output, { force: true });');
+const revokeStaging = finalizer.indexOf('rmSync(stagedOutput, { force: true });');
+const evidenceRead = finalizer.indexOf("const comparison = readJsonBytes(args.comparison, 'comparison');");
+const methodology = finalizer.indexOf('requireComparisonDatabaseSettingsMethodology(comparison.value, fail);');
+const accepted = finalizer.indexOf('requireAcceptedDecision(decision.value);');
+const calendarDate = finalizer.indexOf("requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');");
+const renderer = finalizer.indexOf('const result = spawnSync(process.execPath, [');
+const stageWrite = finalizer.indexOf("writeFileSync(stagedOutput, markdown, 'utf8')");
+const publish = finalizer.indexOf('renameSync(stagedOutput, args.output)');
+if ([collision, stagingCollision, revokeOutput, revokeStaging, evidenceRead, methodology,
+  accepted, calendarDate, renderer, stageWrite, publish].some((index) => index < 0)
+    || !(collision < stagingCollision
+      && stagingCollision < revokeOutput
+      && revokeOutput < revokeStaging
+      && revokeStaging < evidenceRead
+      && evidenceRead < methodology
+      && methodology < accepted
+      && accepted < calendarDate
+      && calendarDate < renderer
+      && renderer < stageWrite
+      && stageWrite < publish)) {
+  fail('finalizer order must be collision gates -> stale revocation -> evidence/methodology -> accepted decision/date -> renderer -> staged publication');
+}
+
+requireMarkers(fixture, 'accepted ADR finalizer fixture', [
+  "test('finalizer accepts help only as the sole argument'",
+  "test('finalizer rejects mixed help without changing an existing ADR'",
+  "test('finalizer rejects unknown options without changing an existing ADR'",
+  "test('finalizer output collision preserves the comparison bytes'",
+  "test('finalizer staging collision preserves the comparison bytes'",
+  "test('real finalization attempts revoke stale ADR and staging before evidence access'",
+  "test('finalizer rejects impossible decision dates without leaving stale output'",
+  "test('finalizer accepts a real leap date before renderer validation'",
+  "test('finalizer rejects a proposed decision without leaving stale output'",
+  "test('renderer failure leaves neither stale ADR nor staged output'",
+  "'0000-01-01'",
+  "decision({ decision_date: '2024-02-29' })",
+  'assert.equal(existsSync(outputPath), false)',
+  'assert.deepEqual(stagingEntries(root), [])',
+]);
+
+requireMarkers(decisionFixture, 'canonical decision fixture', [
+  "source_oracle: 'normalized idx_bench_source workload result digests'",
+  "result_digest: 'ordered_length_prefixed_json_v1'",
+  "evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities'",
+  "first_run: 'first EXPLAIN ANALYZE repetition'",
+  "warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison'",
+  "status: 'accepted'",
+  "assert.equal(decision.status, 'proposed')",
+  "decision.status = 'accepted'",
+  'comparison methodology must contain exactly the canonical methodology fields',
+]);
+
+requireMarkers(router, 'Index storage router', [
+  "'verify-index-storage-finalizer-lifecycle.mjs'",
+  "scriptPath('finalize-index-storage-adr-decision-contract.test.mjs')",
+  "scriptPath('index-storage-decision-tooling.test.mjs')",
+  "runScript('finalize-index-storage-adr.mjs', args)",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'The generated draft has `status: proposed`.',
+  'The finalizer rejects a proposed decision',
+  'The finalizer accepts only `--comparison`, `--decision`, and `--output`',
+  'A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read.',
+  '- the decision status is `accepted`;',
+  '- `decision_date` is a real ISO calendar date using Gregorian month and leap-year rules;',
+  'the exact eight-field methodology envelope',
+]);
+
+console.log('[verify-index-storage-finalizer-lifecycle] accepted status, Gregorian dates, non-destructive CLI/collisions, stale-output revocation, staged publication, canonical fixtures, router registration, and docs are cross-guarded');


### PR DESCRIPTION
## Summary

- rebuild the accepted-ADR finalization lifecycle from #2224 on the current Index tooling architecture;
- restrict the finalizer to `--comparison`, `--decision`, and `--output`, with help valid only as the sole argument;
- require an explicitly `accepted` decision and a real Gregorian `YYYY-MM-DD` date before rendering;
- reject output and process-specific staging collisions before mutating publication state;
- revoke stale ADR and staging paths before evidence access on every real replacement attempt;
- retain renderer isolation, staged publication, and cleanup after renderer or publication failure;
- add a focused lifecycle fixture and dedicated static cross-guard;
- register both in the canonical `contract` and `fixtures` commands;
- repair the canonical decision fixture so it carries the exact eight-field methodology envelope, asserts the generated `proposed` state, and transitions completed decisions to `accepted`.

## Recheck

- confirmed #2224 has no comments or unresolved review threads;
- confirmed the production finalizer and previous integrity guard were unchanged since the #2224 merge base;
- avoided replacing the expanded router, documentation, or integrity guard with stale versions;
- found and fixed a real integration gap left after #2257: the canonical decision fixture still used a shortened methodology object that the new exact-envelope production gate rejects;
- kept M2 open and did not create benchmark evidence, select a storage model, or alter plan status.

## Validation

Tests, Node/Cargo commands, formatting, workflows, and benchmarks were not run, per maintainer request. Static review covered strict arguments, non-destructive malformed CLI and collisions, stale publication revocation ordering, accepted status, Gregorian leap-year/date validation, renderer isolation, staged publication and cleanup, the exact methodology fixture envelope, router registration, documentation, and the six-file compare against current `main`.

Supersedes #2224.