### PR TITLE
fix(index): reject embedded decision placeholders

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -67,7 +67,7 @@ The generated draft has `status: proposed`. Change it to `accepted` only after t
 
 The preparation command accepts only `--comparison`, `--selected`, `--owner`, `--date`, and `--output`, plus one standalone `--force` flag. Help is valid only as the sole argument, and unknown, incomplete, mixed-help, or duplicate options fail before changing decision state. A valid forced replacement creates a unique same-directory staging location before withdrawing the stale draft, then validates the comparison and publishes the complete replacement with one rename. Failure after stale-draft withdrawal leaves no decision file and no staging residue.
 
-The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects any remaining preparation marker.
+The generated draft contains `TODO(index-storage-decision):` markers. Replace every marker with measured and operational reasoning before finalization. The finalizer rejects the exact marker at any position inside selection, rejection, operations, migration, or rollback rationale text.
 
 [`storage-decision.example.json`](storage-decision.example.json) shows the same decision fields and references [`storage-decision.schema.json`](storage-decision.schema.json). Its relative `$schema` is valid because the two files are colocated in the documentation directory. A generated decision under `evidence/index-storage/...` intentionally omits `$schema` rather than recording a false relative path; `$schema` remains an optional finalizer field when it correctly points to a colocated schema file.
 
@@ -115,7 +115,7 @@ The finalizer fails closed unless:
 - every displayed metric and cross-scale ratio is present and numeric;
 - the decision identifies the same comparison commit;
 - `comparison_sha256` matches the exact comparison-file bytes;
-- no preparation placeholder remains;
+- no preparation placeholder remains anywhere in required rationale text;
 - selection, rejection, operations, migration, and rollback rationales are all present.
 
 The standalone renderer enforces the same methodology contract even when invoked directly. Recomputing `comparison_sha256` after removing or changing the methodology does not make the input acceptable.

--- a/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
+++ b/scripts/verify/finalize-index-storage-adr-placeholder.test.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  comparableDatabaseFields,
+  databaseSettingsSource,
+} from './index-storage-database-settings-contract.mjs';
+
+const finalizer = path.resolve('scripts/verify/finalize-index-storage-adr.mjs');
+const placeholderPrefix = 'TODO(index-storage-decision):';
+
+const writeJson = (filename, value) => {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const comparison = () => ({
+  methodology: {
+    source_oracle: 'normalized idx_bench_source workload result digests',
+    result_digest: 'ordered_length_prefixed_json_v1',
+    evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities',
+    first_run: 'first EXPLAIN ANALYZE repetition',
+    warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison',
+    automatic_winner_selection: false,
+    comparable_database_fields: [...comparableDatabaseFields],
+    database_settings_source: databaseSettingsSource,
+  },
+});
+
+const decision = () => ({
+  status: 'accepted',
+  decision_date: '2026-07-25',
+  owner: 'Index maintainers',
+  comparison_commit: '0123456789abcdef0123456789abcdef01234567',
+  comparison_sha256: '0'.repeat(64),
+  selected_prototype: 'typed_eav',
+  selection_rationale: 'Measured evidence supports the selected prototype.',
+  rejection_rationales: {
+    jsonb: 'JSONB was not selected.',
+    hot_projection: 'Hot projection was not selected.',
+  },
+  operational_tradeoffs: 'Monitor relation growth, WAL, and VACUUM behavior.',
+  migration_strategy: 'Backfill and verify parity before cutover.',
+  rollback_strategy: 'Retain the previous path until cutover verification completes.',
+});
+
+const scenarios = [
+  {
+    label: 'decision.selection_rationale',
+    apply: (value) => {
+      value.selection_rationale = `Reviewed: ${placeholderPrefix} explain the selected prototype.`;
+    },
+  },
+  {
+    label: 'decision.operational_tradeoffs',
+    apply: (value) => {
+      value.operational_tradeoffs = `Reviewed operations.\n${placeholderPrefix} explain monitoring trade-offs.`;
+    },
+  },
+  {
+    label: 'decision.migration_strategy',
+    apply: (value) => {
+      value.migration_strategy = `Backfill first; ${placeholderPrefix} explain the final cutover.`;
+    },
+  },
+  {
+    label: 'decision.rollback_strategy',
+    apply: (value) => {
+      value.rollback_strategy = `Retain the old path. ${placeholderPrefix} explain rollback verification.`;
+    },
+  },
+  {
+    label: 'decision.rejection_rationales.jsonb',
+    apply: (value) => {
+      value.rejection_rationales.jsonb = `Reviewed JSONB. ${placeholderPrefix} explain its rejection.`;
+    },
+  },
+  {
+    label: 'decision.rejection_rationales.hot_projection',
+    apply: (value) => {
+      value.rejection_rationales.hot_projection = `Reviewed projection.\n${placeholderPrefix} explain its rejection.`;
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  test(`finalizer rejects an embedded preparation placeholder in ${scenario.label}`, () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-decision-placeholder-'));
+    try {
+      const comparisonPath = path.join(root, 'comparison.json');
+      const decisionPath = path.join(root, 'decision.json');
+      const outputPath = path.join(root, 'adr.md');
+      const decisionValue = decision();
+      scenario.apply(decisionValue);
+      writeJson(comparisonPath, comparison());
+      writeJson(decisionPath, decisionValue);
+
+      const result = spawnSync(process.execPath, [
+        finalizer,
+        '--comparison', comparisonPath,
+        '--decision', decisionPath,
+        '--output', outputPath,
+      ], { encoding: 'utf8' });
+
+      assert.notEqual(result.status, 0);
+      assert.match(
+        result.stderr,
+        new RegExp(`${scenario.label.replaceAll('.', '\\.') } still contains a preparation placeholder`, 'u'),
+      );
+      assert.equal(existsSync(outputPath), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -129,7 +129,7 @@ const requireIsoCalendarDate = (value, label) => {
 
 const requireDecisionText = (value, label) => {
   if (typeof value !== 'string' || value.trim().length === 0) return;
-  if (value.trim().startsWith(placeholderPrefix)) {
+  if (value.includes(placeholderPrefix)) {
     fail(`${label} still contains a preparation placeholder`);
   }
 };

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -66,6 +66,7 @@ const runContract = (args) => {
     'verify-index-storage-comparator-lifecycle.mjs',
     'verify-index-storage-methodology-envelope.mjs',
     'verify-index-storage-finalizer-lifecycle.mjs',
+    'verify-index-storage-placeholder-contract.mjs',
   ]) {
     runScript(script);
   }
@@ -83,6 +84,7 @@ const runFixtures = (args) => {
     scriptPath('comparison-methodology-envelope.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
     scriptPath('finalize-index-storage-adr-decision-contract.test.mjs'),
+    scriptPath('finalize-index-storage-adr-placeholder.test.mjs'),
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),
     scriptPath('storage-decision-schema-text.test.mjs'),

--- a/scripts/verify/verify-index-storage-placeholder-contract.mjs
+++ b/scripts/verify/verify-index-storage-placeholder-contract.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-placeholder-contract] ${message}`);
+  process.exit(1);
+};
+
+const finalizer = read('scripts/verify/finalize-index-storage-adr.mjs');
+const fixture = read('scripts/verify/finalize-index-storage-adr-placeholder.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(finalizer, 'ADR finalizer', [
+  "const placeholderPrefix = 'TODO(index-storage-decision):'",
+  'if (value.includes(placeholderPrefix))',
+  "'selection_rationale'",
+  "'operational_tradeoffs'",
+  "'migration_strategy'",
+  "'rollback_strategy'",
+  'requireDecisionText(decision[field], `decision.${field}`);',
+  'requireDecisionText(rationale, `decision.rejection_rationales.${prototype}`);',
+  'still contains a preparation placeholder',
+]);
+if (finalizer.includes('startsWith(placeholderPrefix)')) {
+  fail('ADR finalizer restored prefix-only placeholder detection');
+}
+
+requireMarkers(fixture, 'placeholder fixture', [
+  "status: 'accepted'",
+  "source_oracle: 'normalized idx_bench_source workload result digests'",
+  "result_digest: 'ordered_length_prefixed_json_v1'",
+  "evidence_validation: 'fail closed on report shape, metrics, plans, effects, ordering, digest semantics, and cardinalities'",
+  "first_run: 'first EXPLAIN ANALYZE repetition'",
+  "warm_run: 'median after the first repetition; not a guaranteed OS cold-cache comparison'",
+  'automatic_winner_selection: false',
+  'comparable_database_fields: [...comparableDatabaseFields]',
+  'database_settings_source: databaseSettingsSource',
+  "label: 'decision.selection_rationale'",
+  "label: 'decision.operational_tradeoffs'",
+  "label: 'decision.migration_strategy'",
+  "label: 'decision.rollback_strategy'",
+  "label: 'decision.rejection_rationales.jsonb'",
+  "label: 'decision.rejection_rationales.hot_projection'",
+  'still contains a preparation placeholder',
+  'assert.equal(existsSync(outputPath), false)',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-placeholder-contract.mjs'",
+  "scriptPath('finalize-index-storage-adr-placeholder.test.mjs')",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'The finalizer rejects the exact marker at any position inside selection, rejection, operations, migration, or rollback rationale text.',
+  '- no preparation placeholder remains anywhere in required rationale text;',
+]);
+
+console.log('[verify-index-storage-placeholder-contract] embedded decision placeholders are rejected across every required rationale field');


### PR DESCRIPTION
## Summary

- rebuild #2226 on top of the accepted-finalizer lifecycle now in `main`;
- reject the exact `TODO(index-storage-decision):` marker at any position in required rationale text rather than only at the beginning;
- preserve strict finalizer arguments, accepted-status/date gates, collision safety, stale-output revocation, renderer isolation, and staged publication;
- cover selection, operations, migration, rollback, and both rejection-rationale fields with accepted decisions and the exact eight-field methodology envelope;
- add a dedicated static placeholder contract and register both it and the fixture in canonical tooling;
- document that reviewed prefixes, embedded newlines, or other surrounding text do not make a remaining preparation marker valid.

## Recheck

- confirmed #2226 has no comments or unresolved review threads;
- rejected the old finalizer blob because it predated the accepted-status and replacement lifecycle merged in #2260;
- applied only the one-line predicate change to the current finalizer;
- preserved current router, finalizer lifecycle guard, methodology contract, and documentation;
- kept M2 open and did not create benchmark evidence or select a storage model.

## Validation

Tests, Node/Cargo commands, formatting, workflows, and benchmarks were not run, per maintainer request. Static review covered exact substring matching, all six rationale locations, accepted/full-methodology fixture inputs, output absence on rejection, router registration, documentation, and the five-file compare directly ahead of `main`.

Supersedes #2226.