### PR TITLE
fix(index): enforce strict comparison hash CLI

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -90,6 +90,8 @@ node scripts/verify/index-storage-tooling.mjs hash \
   evidence/index-storage/comparison/comparison.json
 ```
 
+Hash help is accepted only as the sole argument. Mixed help/path invocations and zero or multiple comparison paths fail without producing a digest. The helper hashes the exact file bytes without JSON normalization.
+
 ## Finalize the ADR
 
 ```bash

--- a/scripts/verify/hash-index-storage-comparison-cli.test.mjs
+++ b/scripts/verify/hash-index-storage-comparison-cli.test.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const router = path.resolve('scripts/verify/index-storage-tooling.mjs');
+const run = (...args) => spawnSync(process.execPath, [router, 'hash', ...args], {
+  encoding: 'utf8',
+});
+
+test('hash help aliases are valid only as the sole helper argument', () => {
+  for (const argument of ['--help', '-h']) {
+    const result = run(argument);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /hash-index-storage-comparison\.mjs <comparison\.json>/u);
+    assert.equal(result.stderr, '');
+  }
+});
+
+test('mixed and repeated hash help fail before file access or digest output', () => {
+  for (const args of [
+    ['comparison.json', '--help'],
+    ['--help', 'comparison.json'],
+    ['comparison.json', '-h'],
+    ['-h', 'comparison.json'],
+    ['--help', '--help'],
+    ['-h', '-h'],
+  ]) {
+    const result = run(...args);
+    assert.notEqual(result.status, 0, args.join(' '));
+    assert.match(result.stderr, /--help\/-h must be the only argument/u);
+    assert.doesNotMatch(result.stderr, /missing comparison file/u);
+    assert.equal(result.stdout, '');
+  }
+});
+
+test('hash helper requires exactly one comparison path', () => {
+  for (const args of [[], ['left.json', 'right.json']]) {
+    const result = run(...args);
+    assert.notEqual(result.status, 0, args.join(' '));
+    assert.match(result.stderr, /exactly one comparison\.json path is required/u);
+    assert.equal(result.stdout, '');
+  }
+});
+
+test('hash router digests exact comparison bytes without JSON normalization', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-hash-cli-'));
+  try {
+    const comparisonPath = path.join(root, 'comparison.json');
+    const bytes = Buffer.from('{"scale":"100k"}\r\n', 'utf8');
+    writeFileSync(comparisonPath, bytes);
+    const result = run(comparisonPath);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, `${createHash('sha256').update(bytes).digest('hex')}\n`);
+    assert.equal(result.stderr, '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify/hash-index-storage-comparison.mjs
+++ b/scripts/verify/hash-index-storage-comparison.mjs
@@ -4,15 +4,19 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 
 const prefix = '[hash-index-storage-comparison]';
+const helpArguments = new Set(['--help', '-h']);
 const fail = (message) => {
   console.error(`${prefix} ${message}`);
   process.exit(1);
 };
 
 const args = process.argv.slice(2);
-if (args.includes('--help') || args.includes('-h')) {
+if (args.length === 1 && helpArguments.has(args[0])) {
   console.log('Usage: node scripts/verify/hash-index-storage-comparison.mjs <comparison.json>');
   process.exit(0);
+}
+if (args.some((argument) => helpArguments.has(argument))) {
+  fail('--help/-h must be the only argument');
 }
 if (args.length !== 1) fail('exactly one comparison.json path is required');
 

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -67,6 +67,7 @@ const runContract = (args) => {
     'verify-index-storage-methodology-envelope.mjs',
     'verify-index-storage-finalizer-lifecycle.mjs',
     'verify-index-storage-placeholder-contract.mjs',
+    'verify-index-storage-hash-cli-contract.mjs',
   ]) {
     runScript(script);
   }
@@ -82,6 +83,7 @@ const runFixtures = (args) => {
     scriptPath('compare-index-storage-evidence.test.mjs'),
     scriptPath('compare-index-storage-evidence-lifecycle.test.mjs'),
     scriptPath('comparison-methodology-envelope.test.mjs'),
+    scriptPath('hash-index-storage-comparison-cli.test.mjs'),
     scriptPath('render-index-storage-adr.test.mjs'),
     scriptPath('finalize-index-storage-adr-decision-contract.test.mjs'),
     scriptPath('finalize-index-storage-adr-placeholder.test.mjs'),

--- a/scripts/verify/verify-index-storage-hash-cli-contract.mjs
+++ b/scripts/verify/verify-index-storage-hash-cli-contract.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-storage-hash-cli-contract] ${message}`);
+  process.exit(1);
+};
+
+const helper = read('scripts/verify/hash-index-storage-comparison.mjs');
+const fixture = read('scripts/verify/hash-index-storage-comparison-cli.test.mjs');
+const router = read('scripts/verify/index-storage-tooling.mjs');
+const guide = read('crates/rustok-index/docs/storage-decision.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+requireMarkers(helper, 'comparison hash helper', [
+  "const helpArguments = new Set(['--help', '-h'])",
+  'if (args.length === 1 && helpArguments.has(args[0]))',
+  'if (args.some((argument) => helpArguments.has(argument)))',
+  "fail('--help/-h must be the only argument')",
+  "if (args.length !== 1) fail('exactly one comparison.json path is required')",
+  "createHash('sha256').update(readFileSync(filename)).digest('hex')",
+  'process.stdout.write(`${digest}\\n`)',
+]);
+for (const forbidden of ["args.includes('--help')", "args.includes('-h')"]) {
+  if (helper.includes(forbidden)) fail(`comparison hash helper restored ambiguous help detection: ${forbidden}`);
+}
+
+const soleHelp = helper.indexOf('if (args.length === 1 && helpArguments.has(args[0]))');
+const mixedHelp = helper.indexOf('if (args.some((argument) => helpArguments.has(argument)))');
+const arity = helper.indexOf("if (args.length !== 1) fail('exactly one comparison.json path is required')");
+const evidenceRead = helper.indexOf('if (!existsSync(filename)) fail(`missing comparison file: ${filename}`)');
+const digest = helper.indexOf("createHash('sha256').update(readFileSync(filename)).digest('hex')");
+if ([soleHelp, mixedHelp, arity, evidenceRead, digest].some((index) => index < 0)
+    || !(soleHelp < mixedHelp && mixedHelp < arity && arity < evidenceRead && evidenceRead < digest)) {
+  fail('hash helper order must be sole help -> mixed-help rejection -> arity -> file access -> exact-byte digest');
+}
+
+requireMarkers(fixture, 'comparison hash CLI fixture', [
+  "test('hash help aliases are valid only as the sole helper argument'",
+  "test('mixed and repeated hash help fail before file access or digest output'",
+  "test('hash helper requires exactly one comparison path'",
+  "test('hash router digests exact comparison bytes without JSON normalization'",
+  "['comparison.json', '--help']",
+  "['--help', 'comparison.json']",
+  "['comparison.json', '-h']",
+  "['-h', 'comparison.json']",
+  "['--help', '--help']",
+  "['-h', '-h']",
+  "Buffer.from('{\"scale\":\"100k\"}\\r\\n', 'utf8')",
+  "createHash('sha256').update(bytes).digest('hex')",
+  '/--help\\/-h must be the only argument/u',
+  '/exactly one comparison\\.json path is required/u',
+]);
+
+requireMarkers(router, 'storage tooling router', [
+  "'verify-index-storage-hash-cli-contract.mjs'",
+  "scriptPath('hash-index-storage-comparison-cli.test.mjs')",
+  "case 'hash':",
+  "runScript('hash-index-storage-comparison.mjs', args)",
+]);
+
+requireMarkers(guide, 'storage decision guide', [
+  'Hash help is accepted only as the sole argument.',
+  'Mixed help/path invocations and zero or multiple comparison paths fail without producing a digest.',
+  'The helper hashes the exact file bytes without JSON normalization.',
+]);
+
+console.log('[verify-index-storage-hash-cli-contract] comparison hash help, arity, exact-byte behavior, focused fixtures, router registration, and docs are cross-guarded');


### PR DESCRIPTION
## Summary

- rebuild the strict comparison-hash CLI intent from #2228 on the current Index tooling architecture;
- accept `--help` and `-h` only when either is the sole helper argument;
- reject mixed or repeated help before file access or digest output;
- require exactly one comparison path;
- preserve SHA-256 over the exact file bytes without JSON parsing or normalization;
- add a focused router-level fixture covering both help aliases, both mixed orderings, repeated help, zero/multiple paths, and CRLF exact-byte hashing;
- add a dedicated static guard and register both checks in the canonical `contract` and `fixtures` commands;
- document strict help, arity, and exact-byte behavior.

## Recheck

- confirmed #2228 has no comments or unresolved review threads;
- confirmed current `main` still used ambiguous `args.includes(...)` help detection;
- avoided replacing the expanded general router fixture with its stale #2228 version;
- added a separate focused fixture over the current router instead;
- kept M2 open and did not create benchmark evidence, select a storage model, or alter plan status.

## Validation

Tests, Node/Cargo commands, formatting, workflows, and benchmarks were not run, per maintainer request. Static review covered sole-help ordering, mixed-help rejection before evidence access, exact path arity, CRLF byte hashing, focused fixture scenarios, router registration, documentation, and the five-file compare directly ahead of `main`.

Supersedes #2228.