### PR TITLE
fix(index): restore scale evidence orchestration

### DIFF
--- a/.github/workflows/index-storage-scale-evidence.yml
+++ b/.github/workflows/index-storage-scale-evidence.yml
@@ -6,144 +6,51 @@ on:
     paths:
       - "crates/rustok-index/**"
       - "ops/benches/**"
+      - "scripts/verify/*index-storage*.mjs"
+      - "scripts/verify/storage-decision*.mjs"
+      - "scripts/verify/*methodology-envelope*.mjs"
       - "scripts/verify/verify-index-fba.mjs"
-      - "scripts/verify/verify-index-storage-source-oracle.mjs"
-      - "scripts/verify/check-index-storage-read-ordering.mjs"
-      - "scripts/verify/check-index-storage-read-ordering.test.mjs"
-      - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
-      - "scripts/verify/validate-index-storage-evidence.mjs"
-      - "scripts/verify/validate-index-storage-runner-resources.mjs"
-      - "scripts/verify/run-index-storage-validator-core.mjs"
-      - "scripts/verify/index-storage-validator-arguments.test.mjs"
-      - "scripts/verify/validate-index-storage-evidence-core.mjs"
-      - "scripts/verify/compare-index-storage-evidence.mjs"
-      - "scripts/verify/compare-index-storage-evidence-core.mjs"
-      - "scripts/verify/compare-index-storage-evidence.test.mjs"
-      - "scripts/verify/index-storage-database-settings-contract.mjs"
-      - "scripts/verify/index-storage-standalone-tools.test.mjs"
-      - "scripts/verify/verify-index-storage-standalone-tools.mjs"
-      - "scripts/verify/hash-index-storage-comparison.mjs"
-      - "scripts/verify/render-index-storage-adr.mjs"
-      - "scripts/verify/render-index-storage-adr.test.mjs"
-      - "scripts/verify/prepare-index-storage-decision.mjs"
-      - "scripts/verify/finalize-index-storage-adr.mjs"
-      - "scripts/verify/verify-index-storage-adr.mjs"
-      - "scripts/verify/index-storage-decision-tooling.test.mjs"
-      - "scripts/verify/index-storage-tooling.mjs"
-      - "scripts/verify/index-storage-tooling.test.mjs"
-      - "scripts/verify/verify-index-storage-adr-tooling.mjs"
-      - "scripts/verify/verify-index-storage-adr-integrity.mjs"
-      - ".github/workflows/index-storage-smoke.yml"
-      - ".github/workflows/index-storage-scale-evidence.yml"
-      - ".github/workflows/index-storage-scale-run.yml"
-  push:
-    branches:
-      - "agent/index-m2-scale-evidence"
-      - "agent/index-m2-1m-standard-runner"
-    paths:
-      - "crates/rustok-index/**"
-      - "ops/benches/**"
-      - "scripts/verify/verify-index-fba.mjs"
-      - "scripts/verify/verify-index-storage-source-oracle.mjs"
-      - "scripts/verify/check-index-storage-read-ordering.mjs"
-      - "scripts/verify/check-index-storage-read-ordering.test.mjs"
-      - "scripts/verify/verify-index-storage-read-ordering-contract.mjs"
-      - "scripts/verify/validate-index-storage-evidence.mjs"
-      - "scripts/verify/validate-index-storage-runner-resources.mjs"
-      - "scripts/verify/run-index-storage-validator-core.mjs"
-      - "scripts/verify/index-storage-validator-arguments.test.mjs"
-      - "scripts/verify/validate-index-storage-evidence-core.mjs"
-      - "scripts/verify/compare-index-storage-evidence.mjs"
-      - "scripts/verify/compare-index-storage-evidence-core.mjs"
-      - "scripts/verify/compare-index-storage-evidence.test.mjs"
-      - "scripts/verify/index-storage-database-settings-contract.mjs"
-      - "scripts/verify/index-storage-standalone-tools.test.mjs"
-      - "scripts/verify/verify-index-storage-standalone-tools.mjs"
-      - "scripts/verify/hash-index-storage-comparison.mjs"
-      - "scripts/verify/render-index-storage-adr.mjs"
-      - "scripts/verify/render-index-storage-adr.test.mjs"
-      - "scripts/verify/prepare-index-storage-decision.mjs"
-      - "scripts/verify/finalize-index-storage-adr.mjs"
-      - "scripts/verify/verify-index-storage-adr.mjs"
-      - "scripts/verify/index-storage-decision-tooling.test.mjs"
-      - "scripts/verify/index-storage-tooling.mjs"
-      - "scripts/verify/index-storage-tooling.test.mjs"
-      - "scripts/verify/verify-index-storage-adr-tooling.mjs"
-      - "scripts/verify/verify-index-storage-adr-integrity.mjs"
-      - ".github/workflows/index-storage-smoke.yml"
-      - ".github/workflows/index-storage-scale-evidence.yml"
-      - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-*.yml"
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   contract:
     name: Index scale evidence contract
-    # Pull-request runs exist only to cancel an older PR-ref execution through
-    # concurrency. Heavy scale evidence is emitted once from push/dispatch.
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - name: Publish push-run identity
-        if: ${{ github.event_name == 'push' && github.ref_name == 'agent/index-m2-1m-standard-runner' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 2009,
-              body: `Index scale push run: **${context.runId}** on commit \`${context.sha}\`. The 100k and guarded 1m jobs start independently after the contract gate.`,
-            });
       - uses: actions/checkout@v7
-      - name: Verify Index storage command and repository contracts
+      - name: Verify Index storage JavaScript syntax
+        shell: bash
         run: |
-          node --check scripts/verify/index-storage-tooling.mjs
-          node --check scripts/verify/index-storage-tooling.test.mjs
-          node --check scripts/verify/check-index-storage-read-ordering.mjs
-          node --check scripts/verify/check-index-storage-read-ordering.test.mjs
-          node --check scripts/verify/verify-index-storage-read-ordering-contract.mjs
-          node --check scripts/verify/index-storage-standalone-tools.test.mjs
-          node --check scripts/verify/verify-index-storage-standalone-tools.mjs
-          node scripts/verify/index-storage-tooling.mjs contract
-      - name: Verify scale evidence validator syntax
-        run: |
-          node --check scripts/verify/validate-index-storage-evidence.mjs
-          node --check scripts/verify/validate-index-storage-runner-resources.mjs
-          node --check scripts/verify/run-index-storage-validator-core.mjs
-          node --check scripts/verify/index-storage-validator-arguments.test.mjs
-          node --check scripts/verify/validate-index-storage-evidence-core.mjs
-      - name: Test scale evidence validator arguments
+          set -euo pipefail
+          find scripts/verify -maxdepth 1 -type f \
+            \( -name '*index-storage*.mjs' -o \
+               -name 'storage-decision*.mjs' -o \
+               -name '*methodology-envelope*.mjs' -o \
+               -name 'verify-index-fba.mjs' \) \
+            -print0 \
+            | sort -z \
+            | xargs -0 -n1 node --check
+      - name: Verify reusable and orchestration workflow contracts
+        run: node scripts/verify/verify-index-storage-scale-run-contract.mjs
+      - name: Verify Index storage repository contracts
+        run: node scripts/verify/index-storage-tooling.mjs contract
+      - name: Test direct evidence validator arguments
         run: node --test scripts/verify/index-storage-validator-arguments.test.mjs
-      - name: Verify cross-scale comparator syntax
-        run: |
-          node --check scripts/verify/index-storage-database-settings-contract.mjs
-          node --check scripts/verify/compare-index-storage-evidence.mjs
-          node --check scripts/verify/compare-index-storage-evidence-core.mjs
-      - name: Verify storage decision and ADR tooling syntax
-        run: |
-          node --check scripts/verify/hash-index-storage-comparison.mjs
-          node --check scripts/verify/render-index-storage-adr.mjs
-          node --check scripts/verify/render-index-storage-adr.test.mjs
-          node --check scripts/verify/prepare-index-storage-decision.mjs
-          node --check scripts/verify/finalize-index-storage-adr.mjs
-          node --check scripts/verify/verify-index-storage-adr.mjs
-          node --check scripts/verify/verify-index-storage-adr-integrity.mjs
-          node --check scripts/verify/index-storage-decision-tooling.test.mjs
-      - name: Test storage tooling command routing
-        run: node --test scripts/verify/index-storage-tooling.test.mjs
-      - name: Test storage standalone, comparison, ordering, decision, and ADR fixtures
+      - name: Test Index storage fixture suites
         run: node scripts/verify/index-storage-tooling.mjs fixtures
 
   evidence-100k:
+    # Pull requests stop after the lightweight contract. Heavy evidence is an
+    # explicit owner action on one selected ref through workflow_dispatch.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: contract
     uses: ./.github/workflows/index-storage-scale-run.yml
     with:
@@ -153,21 +60,19 @@ jobs:
       minimum_free_bytes: 6000000000
 
   evidence-1m:
-    # Generate replacement 100k and 1m packets from this exact commit after the
-    # shared contract gate. The comparator rejects mixed provenance, PostgreSQL
-    # settings, repetitions/churn parameters, or candidate/workload shapes.
+    # One dispatch runs both scales from the exact same checkout SHA. The
+    # comparator additionally rejects mixed report provenance or methodology.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: contract
     uses: ./.github/workflows/index-storage-scale-run.yml
     with:
       scale: 1m
       timeout_minutes: 300
-      # Prefer an explicitly configured larger runner. Otherwise the hosted image
-      # may proceed only after the reusable job verifies at least 35 GB free;
-      # the inspected historical 100k runner reported about 93 GB free before evidence.
       runner_label: ${{ vars.INDEX_BENCH_LARGE_RUNNER || 'ubuntu-latest' }}
       minimum_free_bytes: 35000000000
 
   comparison:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Cross-scale storage comparison
     needs:
       - evidence-100k

--- a/.github/workflows/index-storage-scale-run-contract.yml
+++ b/.github/workflows/index-storage-scale-run-contract.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-evidence.yml"
       - ".github/workflows/index-storage-scale-run-contract.yml"
       - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+      - "crates/rustok-index/README.md"
+      - "crates/rustok-index/docs/storage-evidence-runbook.md"
       - "crates/rustok-index/docs/implementation-plan.md"
   push:
     branches:
@@ -13,8 +16,11 @@ on:
       - "agent/**"
     paths:
       - ".github/workflows/index-storage-scale-run.yml"
+      - ".github/workflows/index-storage-scale-evidence.yml"
       - ".github/workflows/index-storage-scale-run-contract.yml"
       - "scripts/verify/verify-index-storage-scale-run-contract.mjs"
+      - "crates/rustok-index/README.md"
+      - "crates/rustok-index/docs/storage-evidence-runbook.md"
       - "crates/rustok-index/docs/implementation-plan.md"
 
 permissions:
@@ -26,12 +32,12 @@ concurrency:
 
 jobs:
   contract:
-    name: Reusable scale workflow contract
+    name: Reusable scale and orchestration contract
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: Verify contract script syntax
         run: node --check scripts/verify/verify-index-storage-scale-run-contract.mjs
-      - name: Verify fail-closed scale workflow inputs
+      - name: Verify fail-closed scale workflow orchestration
         run: node scripts/verify/verify-index-storage-scale-run-contract.mjs

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -44,7 +44,7 @@ a rewrite goal.
 - M2 read/query benchmark harness: implemented
 - M2 transactional mutation/WAL harness: implemented
 - M2 persistent churn/VACUUM harness: implemented
-- M2 PostgreSQL evidence and storage ADR: pending
+- M2 replacement evidence and storage ADR: pending
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
 configuration, scheduler, errors, and server composition have been deleted.
@@ -95,13 +95,15 @@ that logical cardinality is preserved, captures baseline/after-churn table stats
 and schema size, executes ordinary `VACUUM (ANALYZE)`, and captures the same data
 again with VACUUM duration. It deliberately does not use `VACUUM FULL`.
 
-No candidate is selected until smoke/100k/1m read, mutation, and maintenance
-reports are archived, compared, and recorded in the storage ADR.
+No candidate is selected until replacement `100k` and `1m` read, mutation, and
+maintenance reports from one commit are archived, compared, and recorded in the
+storage ADR.
 
 ## Docs
 
 - [Module documentation](./docs/README.md)
 - [Live implementation plan](./docs/implementation-plan.md)
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)
+- [M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)
 - [Index Engine rewrite ADR](../../DECISIONS/2026-07-23-index-engine-rewrite.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-index/docs/storage-evidence-runbook.md
+++ b/crates/rustok-index/docs/storage-evidence-runbook.md
@@ -1,0 +1,106 @@
+# Index M2 replacement evidence runbook
+
+This runbook is the owner-operated handoff from the completed Index benchmark
+harness to the remaining M2 evidence and storage-decision work. It does not make
+a storage choice and it does not mark any M2 evidence item complete by itself.
+
+## Trigger model
+
+Pull requests run only the lightweight contract job. That job checks the
+JavaScript syntax for the Index verification surface, the reusable workflow
+input contract, repository guards, direct validator arguments, and the canonical
+fixture suites. It does not allocate PostgreSQL or a heavy runner.
+
+Heavy replacement evidence runs only through an explicit `workflow_dispatch`.
+Select the exact branch, tag, or commit that should own both replacement packets.
+One dispatch uses one selected Git ref and fans out `100k` and `1m` from the same checkout SHA.
+The comparison job starts only after both validated scale jobs succeed.
+
+The scale workflow intentionally has no automatic push trigger. This prevents an
+ordinary branch update from unexpectedly allocating the large runner or creating
+partial replacement evidence.
+
+## Before dispatch
+
+1. Select an immutable commit that contains every benchmark, SQL, verifier, and
+   workflow correction intended for the decision run.
+2. Confirm that no later code change is expected to alter candidate DDL, dataset
+   generation, workload SQL, report shape, provenance, or validation.
+3. Configure `INDEX_BENCH_LARGE_RUNNER` when a larger runner is available. When it
+   is absent, the `1m` job uses `ubuntu-latest` but still fails before building if
+   the root filesystem has less than 35,000,000,000 free bytes.
+4. Start **Index Storage Scale Evidence** manually and select the same ref reviewed
+   in step 1.
+
+## Expected job graph
+
+The dispatch executes this fail-closed sequence:
+
+1. `contract` on `ubuntu-slim`;
+2. independent `evidence-100k` and `evidence-1m` reusable jobs;
+3. `comparison` only after both scale jobs succeed.
+
+Each scale job builds the three release executables, captures runner resources,
+runs read, mutation, and maintenance evidence, validates the complete packet, and
+uploads the validated directory. The comparison job downloads both packets by the
+same `${{ github.sha }}` artifact identity, runs the official comparator wrapper,
+requires `decision_ready: true`, and uploads the comparison directory.
+
+## Artifact identity and retention
+
+Successful evidence and comparison artifacts are retained for 90 days. Their
+canonical names are:
+
+- `index-storage-100k-<full commit SHA>`;
+- `index-storage-1m-<full commit SHA>`;
+- `index-storage-comparison-<full commit SHA>`.
+
+Failure diagnostics are retained for 14 days and are not decision evidence. A
+failed or cancelled scale job prevents the comparison job from running.
+
+Do not combine artifacts from different run IDs or commit SHAs. Do not rename a
+diagnostic artifact into a successful evidence identity. The report-level run
+provenance and packet validator remain authoritative even when artifact names
+look correct.
+
+## Archival handoff
+
+Before the 90-day retention window expires:
+
+1. download all three successful artifacts from one workflow run;
+2. preserve their directory layout as `100k`, `1m`, and `comparison`;
+3. record the workflow run ID, exact full commit SHA, PostgreSQL image,
+   repetitions, churn cycles, and runner labels in the evidence review;
+4. re-run the canonical packet and comparison commands against the downloaded
+   directories before committing or otherwise retaining them as project evidence;
+5. review `comparison.md` and `comparison.json` together before preparing the
+   manual decision.
+
+The official commands are:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs packet \
+  --scale 100k --root evidence/index-storage/100k
+node scripts/verify/index-storage-tooling.mjs packet \
+  --scale 1m --root evidence/index-storage/1m
+node scripts/verify/index-storage-tooling.mjs compare \
+  --input evidence/index-storage/100k \
+  --input evidence/index-storage/1m \
+  --output evidence/index-storage/comparison
+```
+
+Regenerating the comparison is expected to revoke a stale comparison success
+marker before validation and to publish `comparison.json` last. A regenerated
+comparison must remain byte-consistent with the reviewed evidence contract before
+it is used to prepare a decision.
+
+## Completion boundary
+
+The repository owner performs the benchmark and validation commands. A workflow
+success alone is not permission to select a model. Reviewers must compare buffers,
+planner stability, latency, ingestion, relation size, WAL, dead tuples, VACUUM,
+and operational complexity across both scales.
+
+M2 remains open until the replacement packets are archived, the comparison is reviewed, and the ADR is accepted.
+Only after that decision may the rejected prototype implementations and schemas
+be deleted.

--- a/scripts/verify/verify-index-storage-scale-run-contract.mjs
+++ b/scripts/verify/verify-index-storage-scale-run-contract.mjs
@@ -2,26 +2,44 @@
 
 import { readFileSync } from 'node:fs';
 
-const workflow = readFileSync(
-  new URL('../../.github/workflows/index-storage-scale-run.yml', import.meta.url),
-  'utf8',
-);
+const root = new URL('../../', import.meta.url);
+const read = (filename) => readFileSync(new URL(filename, root), 'utf8');
 const prefix = '[verify-index-storage-scale-run-contract]';
 const fail = (message) => {
   console.error(`${prefix} ${message}`);
   process.exit(1);
 };
 
-const validateStart = workflow.indexOf('  validate-inputs:\n');
-const evidenceStart = workflow.indexOf('  evidence:\n');
+const reusableWorkflow = read('.github/workflows/index-storage-scale-run.yml');
+const orchestrationWorkflow = read('.github/workflows/index-storage-scale-evidence.yml');
+const contractWorkflow = read('.github/workflows/index-storage-scale-run-contract.yml');
+const readme = read('crates/rustok-index/README.md');
+const runbook = read('crates/rustok-index/docs/storage-evidence-runbook.md');
+
+const requireMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (!content.includes(marker)) fail(`${label} is missing contract marker: ${marker}`);
+  }
+};
+
+const forbidMarkers = (content, label, markers) => {
+  for (const marker of markers) {
+    if (content.includes(marker)) fail(`${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const countMarker = (content, marker) => content.split(marker).length - 1;
+
+const validateStart = reusableWorkflow.indexOf('  validate-inputs:\n');
+const evidenceStart = reusableWorkflow.indexOf('  evidence:\n');
 if (validateStart < 0) fail('reusable scale workflow is missing validate-inputs job');
 if (evidenceStart < 0) fail('reusable scale workflow is missing evidence job');
 if (validateStart > evidenceStart) {
   fail('validate-inputs job must appear before the evidence job');
 }
 
-const validateBlock = workflow.slice(validateStart, evidenceStart);
-for (const marker of [
+const validateBlock = reusableWorkflow.slice(validateStart, evidenceStart);
+requireMarkers(validateBlock, 'reusable validate-inputs job', [
   '    runs-on: ubuntu-slim',
   '    timeout-minutes: 5',
   '          REQUESTED_SCALE: ${{ inputs.scale }}',
@@ -40,34 +58,138 @@ for (const marker of [
   '          if (( ${#REQUESTED_RUNNER_LABEL} > 128 )); then',
   '          if ! [[ "$REQUESTED_MINIMUM_FREE_BYTES" =~ ^[1-9][0-9]*$ ]]; then',
   '          if (( ${#REQUESTED_MINIMUM_FREE_BYTES} > ${#MAXIMUM_FREE_BYTES} )) ||',
-]) {
-  if (!validateBlock.includes(marker)) fail(`validate-inputs job is missing ${marker}`);
-}
-for (const forbidden of [
+]);
+forbidMarkers(validateBlock, 'reusable validate-inputs job', [
   'actions/checkout',
   'dtolnay/rust-toolchain',
   'services:',
   'postgres:',
   'cargo build',
-]) {
-  if (validateBlock.includes(forbidden)) {
-    fail(`validate-inputs job must remain lightweight; found ${forbidden}`);
-  }
-}
+]);
 
-const evidenceBlock = workflow.slice(evidenceStart);
-const needsIndex = evidenceBlock.indexOf('    needs: validate-inputs\n');
-const runnerIndex = evidenceBlock.indexOf('    runs-on: ${{ inputs.runner_label }}\n');
-const servicesIndex = evidenceBlock.indexOf('    services:\n');
-if (needsIndex < 0) fail('evidence job must depend on validate-inputs');
+const reusableEvidenceBlock = reusableWorkflow.slice(evidenceStart);
+const needsIndex = reusableEvidenceBlock.indexOf('    needs: validate-inputs\n');
+const runnerIndex = reusableEvidenceBlock.indexOf('    runs-on: ${{ inputs.runner_label }}\n');
+const servicesIndex = reusableEvidenceBlock.indexOf('    services:\n');
+if (needsIndex < 0) fail('reusable evidence job must depend on validate-inputs');
 if (runnerIndex < 0 || servicesIndex < 0) {
-  fail('evidence job is missing runner or service allocation markers');
+  fail('reusable evidence job is missing runner or service allocation markers');
 }
 if (needsIndex > runnerIndex || needsIndex > servicesIndex) {
-  fail('evidence dependency must be declared before runner and service allocation');
+  fail('reusable evidence dependency must be declared before runner and service allocation');
 }
-if (!evidenceBlock.includes('          if (( available_bytes < MINIMUM_FREE_BYTES )); then')) {
-  fail('evidence job must retain the runner disk-capacity gate');
+requireMarkers(reusableEvidenceBlock, 'reusable evidence job', [
+  '          if (( available_bytes < MINIMUM_FREE_BYTES )); then',
+  '          name: index-storage-${{ inputs.scale }}-${{ github.sha }}',
+  '          retention-days: 90',
+]);
+
+requireMarkers(orchestrationWorkflow, 'scale evidence orchestration workflow', [
+  '  workflow_dispatch:',
+  '  pull_request:',
+  '      - "crates/rustok-index/**"',
+  '      - "ops/benches/**"',
+  '      - "scripts/verify/*index-storage*.mjs"',
+  '      - "scripts/verify/storage-decision*.mjs"',
+  '      - "scripts/verify/*methodology-envelope*.mjs"',
+  '      - "scripts/verify/verify-index-fba.mjs"',
+  '      - ".github/workflows/index-storage-*.yml"',
+  '  contents: read',
+]);
+forbidMarkers(orchestrationWorkflow, 'scale evidence orchestration workflow', [
+  '\n  push:\n',
+  'agent/index-m2-scale-evidence',
+  'agent/index-m2-1m-standard-runner',
+  'actions/github-script',
+  'issue_number: 2009',
+  '  issues: write',
+  '  pull-requests: write',
+]);
+
+const contractStart = orchestrationWorkflow.indexOf('  contract:\n');
+const evidence100kStart = orchestrationWorkflow.indexOf('  evidence-100k:\n');
+const evidence1mStart = orchestrationWorkflow.indexOf('  evidence-1m:\n');
+const comparisonStart = orchestrationWorkflow.indexOf('  comparison:\n');
+if ([contractStart, evidence100kStart, evidence1mStart, comparisonStart].some((index) => index < 0)) {
+  fail('scale evidence orchestration workflow is missing a canonical job');
+}
+if (!(contractStart < evidence100kStart
+    && evidence100kStart < evidence1mStart
+    && evidence1mStart < comparisonStart)) {
+  fail('scale evidence jobs must remain ordered contract, 100k, 1m, comparison');
 }
 
-console.log(`${prefix} reusable scale workflow input validation is fail closed`);
+const contractBlock = orchestrationWorkflow.slice(contractStart, evidence100kStart);
+requireMarkers(contractBlock, 'scale evidence contract job', [
+  '    runs-on: ubuntu-slim',
+  '    timeout-minutes: 10',
+  '          find scripts/verify -maxdepth 1 -type f',
+  "               -name '*methodology-envelope*.mjs' -o \\",
+  '            | xargs -0 -n1 node --check',
+  '        run: node scripts/verify/verify-index-storage-scale-run-contract.mjs',
+  '        run: node scripts/verify/index-storage-tooling.mjs contract',
+  '        run: node --test scripts/verify/index-storage-validator-arguments.test.mjs',
+  '        run: node scripts/verify/index-storage-tooling.mjs fixtures',
+]);
+forbidMarkers(contractBlock, 'scale evidence contract job', [
+  "if: ${{ github.event_name != 'pull_request' }}",
+  'services:',
+  'postgres:',
+  'cargo build',
+]);
+
+const dispatchGate = "    if: ${{ github.event_name == 'workflow_dispatch' }}\n";
+if (countMarker(orchestrationWorkflow, dispatchGate) !== 3) {
+  fail('100k, 1m, and comparison jobs must each require explicit workflow_dispatch');
+}
+const evidence100kBlock = orchestrationWorkflow.slice(evidence100kStart, evidence1mStart);
+const evidence1mBlock = orchestrationWorkflow.slice(evidence1mStart, comparisonStart);
+const comparisonBlock = orchestrationWorkflow.slice(comparisonStart);
+requireMarkers(evidence100kBlock, '100k evidence job', [
+  dispatchGate.trimEnd(),
+  '    needs: contract',
+  '    uses: ./.github/workflows/index-storage-scale-run.yml',
+  '      scale: 100k',
+]);
+requireMarkers(evidence1mBlock, '1m evidence job', [
+  dispatchGate.trimEnd(),
+  '    needs: contract',
+  '    uses: ./.github/workflows/index-storage-scale-run.yml',
+  '      scale: 1m',
+  "      runner_label: ${{ vars.INDEX_BENCH_LARGE_RUNNER || 'ubuntu-latest' }}",
+  '      minimum_free_bytes: 35000000000',
+]);
+requireMarkers(comparisonBlock, 'cross-scale comparison job', [
+  dispatchGate.trimEnd(),
+  '      - evidence-100k',
+  '      - evidence-1m',
+  '          name: index-storage-100k-${{ github.sha }}',
+  '          name: index-storage-1m-${{ github.sha }}',
+  '          node scripts/verify/index-storage-tooling.mjs compare',
+  '          name: index-storage-comparison-${{ github.sha }}',
+]);
+
+requireMarkers(contractWorkflow, 'scale workflow contract workflow', [
+  '      - ".github/workflows/index-storage-scale-run.yml"',
+  '      - ".github/workflows/index-storage-scale-evidence.yml"',
+  '      - ".github/workflows/index-storage-scale-run-contract.yml"',
+  '      - "scripts/verify/verify-index-storage-scale-run-contract.mjs"',
+  '      - "crates/rustok-index/README.md"',
+  '      - "crates/rustok-index/docs/storage-evidence-runbook.md"',
+  '        run: node scripts/verify/verify-index-storage-scale-run-contract.mjs',
+]);
+
+requireMarkers(readme, 'Index README', [
+  'M2 replacement evidence and storage ADR: pending',
+  '[M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)',
+]);
+requireMarkers(runbook, 'replacement evidence runbook', [
+  'Pull requests run only the lightweight contract job.',
+  'Heavy replacement evidence runs only through an explicit `workflow_dispatch`.',
+  'One dispatch uses one selected Git ref and fans out `100k` and `1m` from the same checkout SHA.',
+  'Do not combine artifacts from different run IDs or commit SHAs.',
+  'Successful evidence and comparison artifacts are retained for 90 days.',
+  'M2 remains open until the replacement packets are archived, the comparison is reviewed, and the ADR is accepted.',
+]);
+
+console.log(`${prefix} reusable inputs and owner-dispatched scale orchestration are fail closed`);


### PR DESCRIPTION
## Summary

- make the Index scale-evidence workflow run its lightweight contract on pull requests instead of skipping the only PR job;
- remove dead push triggers tied to deleted `agent/index-m2-*` branches and the stale comment mutation against PR #2009;
- require an explicit `workflow_dispatch` before allocating either scale runner or generating the comparison;
- keep one dispatch bound to one selected ref so `100k`, `1m`, and comparison artifacts share the same checkout SHA;
- replace the stale per-file PR path list with bounded Index verifier globs that include the current lifecycle, methodology, hash, decision, and workflow contracts;
- consolidate JavaScript syntax checks over the maintained Index verification surface;
- extend the reusable scale-workflow verifier to cross-guard orchestration triggers, permissions, job ordering, dispatch gates, artifact identities, documentation, and the separate contract workflow;
- add an owner-run replacement evidence runbook and link it from the Index README.

## Recheck

- confirmed no open Index PR or issue remained to supersede;
- confirmed the current workflow skipped `contract` for every pull request;
- confirmed its only push branches were two deleted historical evidence branches;
- confirmed the explicit path list omitted several recently merged Index verifier and fixture files;
- confirmed the two commits added to `main` after branch creation touch only Commerce files;
- kept M2 open and did not create, alter, or mark replacement evidence complete.

## Validation

Tests, Node/Cargo commands, formatters, workflows, and benchmarks were not run, per maintainer request. Static review covered YAML trigger shape, PR-only lightweight execution, three explicit dispatch gates, same-SHA artifact names, comparison dependencies, bounded verifier globs, removal of write permissions and stale branch/comment behavior, static contract markers, runbook retention/handoff rules, and the five-file compare against current `main`.