### PR TITLE
fix(index): align evidence guards and finalizer lifecycle

### DIFF
--- a/crates/rustok-index/docs/storage-decision.md
+++ b/crates/rustok-index/docs/storage-decision.md
@@ -103,7 +103,7 @@ node scripts/verify/index-storage-tooling.mjs render \
 
 Finalization snapshots the exact comparison and decision bytes before rendering. The generated ADR records both `Comparison SHA-256` and `Decision SHA-256`, so reviewers can verify the two source documents used to produce it.
 
-The finalizer accepts only `--comparison`, `--decision`, and `--output`; help is valid only as the sole argument. Malformed command lines and output paths that collide with either input are non-destructive. A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read. If the replacement evidence, accepted decision, renderer, or publication step fails, no stale ADR is left behind.
+The finalizer accepts only `--comparison`, `--decision`, and `--output`; help is valid only as the sole argument. Malformed command lines and output paths that collide with either input are non-destructive. A valid replacement attempt rejects any input path inside the output staging namespace, revokes the existing ADR and every matching stale staging path before evidence is read, then publishes through a unique same-directory staging directory. If the replacement evidence, accepted decision, renderer, or publication step fails, no stale ADR or staging residue is left behind.
 
 The finalizer fails closed unless:
 

--- a/ops/benches/src/index_storage/sql/common.rs
+++ b/ops/benches/src/index_storage/sql/common.rs
@@ -115,13 +115,24 @@ CREATE INDEX link_target_lookup ON {schema}.link (
 }
 
 pub fn assert_full_link_identity_sql(sql: String) -> String {
+    // Guard-only legacy fragments stay split in source so repository scans do not
+    // mistake this assertion table for generated candidate SQL.
     for legacy in [
         "tenant_id, source_entity, source_entity_id, source_locale, link_name,\n    ordinal, target_entity, target_entity_id, target_locale",
-        "product_variant.source_entity = 'product' AND product_variant.source_entity_id",
+        concat!(
+            "product_variant.source_entity = 'product' AND ",
+            "product_variant.source_entity_id"
+        ),
         "product_variant.target_entity = 'variant' JOIN",
-        "variant_channel.source_entity = 'variant' AND variant_channel.source_entity_id",
+        concat!(
+            "variant_channel.source_entity = 'variant' AND ",
+            "variant_channel.source_entity_id"
+        ),
         "variant_channel.target_entity = 'sales_channel' JOIN",
-        "link.source_entity = 'product' AND link.source_locale",
+        concat!(
+            "link.source_entity = 'product' AND ",
+            "link.source_locale"
+        ),
     ] {
         assert!(
             !sql.contains(legacy),

--- a/scripts/verify/compare-index-storage-evidence.test.mjs
+++ b/scripts/verify/compare-index-storage-evidence.test.mjs
@@ -166,7 +166,9 @@ function writePacket(root, scale, overrides = {}) {
   const read = {
     generated_at: generatedAt,
     provenance: { ...reportProvenance },
-    result_digest_contract: overrides.readDigestContract ?? resultDigestContract,
+    result_digest_contract: Object.hasOwn(overrides, 'readDigestContract')
+      ? overrides.readDigestContract
+      : resultDigestContract,
     database: databaseMetadata(overrides.database),
     dataset: {
       scale: values.serialized,
@@ -349,13 +351,13 @@ test('rejects provenance digest contract drift', () => {
 test('rejects source workload without canonical ordering', () => {
   withFixture((root) => expectFailure(root, {
     sourceSql: { status_equality: 'SELECT entity_id FROM idx_bench_source.product LIMIT 100' },
-  }, /missing canonical ordering marker/));
+  }, /must end with canonical ordering marker/g));
 });
 
 test('rejects candidate workload without canonical ordering', () => {
   withFixture((root) => expectFailure(root, {
     candidateSql: { jsonb: { keyset_page: 'SELECT entity_id, price_minor FROM idx_bench_jsonb.entity LIMIT 100' } },
-  }, /missing canonical ordering marker/));
+  }, /must end with canonical ordering marker/g));
 });
 
 test('rejects missing read execution timing', () => {

--- a/scripts/verify/finalize-index-storage-adr.mjs
+++ b/scripts/verify/finalize-index-storage-adr.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -165,62 +166,82 @@ const insertDecisionDigest = (markdown, decisionSha256) => {
   return markdown.replace(line, `${line}\n- Decision SHA-256: \`${decisionSha256}\``);
 };
 
+const outputStagingPrefix = (output) => `${path.basename(output)}.tmp-`;
+
+const isOutputStagingPath = (filename, output) => {
+  const resolvedInput = path.resolve(filename);
+  const resolvedParent = path.resolve(path.dirname(output) || '.');
+  return path.dirname(resolvedInput) === resolvedParent
+    && path.basename(resolvedInput).startsWith(outputStagingPrefix(output));
+};
+
+const revokePublishedState = (output) => {
+  const parent = path.dirname(output) || '.';
+  if (existsSync(parent)) {
+    for (const entry of readdirSync(parent)) {
+      if (entry.startsWith(outputStagingPrefix(output))) {
+        rmSync(path.join(parent, entry), { recursive: true, force: true });
+      }
+    }
+  }
+  rmSync(output, { force: true });
+};
+
 const main = () => {
   const args = parseArgs();
   if (args === null) return;
-  const stagedOutput = `${args.output}.tmp-${process.pid}`;
   const resolvedOutput = path.resolve(args.output);
-  const resolvedStagedOutput = path.resolve(stagedOutput);
   for (const [label, filename] of [['comparison', args.comparison], ['decision', args.decision]]) {
     const resolvedInput = path.resolve(filename);
     if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);
-    if (resolvedStagedOutput === resolvedInput) {
+    if (isOutputStagingPath(filename, args.output)) {
       fail(`ADR staging path must not overwrite the ${label} input`);
     }
   }
-  rmSync(args.output, { force: true });
-  rmSync(stagedOutput, { force: true });
 
-  const comparison = readJsonBytes(args.comparison, 'comparison');
-  const decision = readJsonBytes(args.decision, 'decision');
-  requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
-  requireDecisionEnvelope(decision.value);
-  requireAcceptedDecision(decision.value);
-  requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');
-  rejectPlaceholders(decision.value);
-
-  const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rustok-index-storage-adr-'));
+  const parent = path.dirname(args.output) || '.';
+  if (parent !== '.') mkdirSync(parent, { recursive: true });
+  revokePublishedState(args.output);
+  const stagingRoot = mkdtempSync(path.join(parent, outputStagingPrefix(args.output)));
+  const stagedOutput = path.join(stagingRoot, path.basename(args.output));
   try {
-    const comparisonPath = path.join(temporaryRoot, 'comparison.json');
-    const decisionPath = path.join(temporaryRoot, 'decision.json');
-    const renderedPath = path.join(temporaryRoot, 'adr.md');
-    writeFileSync(comparisonPath, comparison.bytes);
-    writeFileSync(decisionPath, decision.bytes);
+    const comparison = readJsonBytes(args.comparison, 'comparison');
+    const decision = readJsonBytes(args.decision, 'decision');
+    requireComparisonDatabaseSettingsMethodology(comparison.value, fail);
+    requireDecisionEnvelope(decision.value);
+    requireAcceptedDecision(decision.value);
+    requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');
+    rejectPlaceholders(decision.value);
 
-    const result = spawnSync(process.execPath, [
-      path.join(scriptDirectory, 'render-index-storage-adr.mjs'),
-      '--comparison', comparisonPath,
-      '--decision', decisionPath,
-      '--output', renderedPath,
-    ], { encoding: 'utf8' });
-    if (result.error) fail(`failed to start strict ADR renderer: ${result.error.message}`);
-    if (result.signal) fail(`strict ADR renderer terminated by signal ${result.signal}`);
-    if (result.status !== 0) {
-      const detail = result.stderr?.trim() || result.stdout?.trim() || `exit status ${result.status}`;
-      fail(`strict ADR renderer failed: ${detail}`);
-    }
-
-    const markdown = insertDecisionDigest(readFileSync(renderedPath, 'utf8'), decision.sha256);
-    const parent = path.dirname(args.output);
-    if (parent && parent !== '.') mkdirSync(parent, { recursive: true });
+    const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rustok-index-storage-adr-'));
     try {
+      const comparisonPath = path.join(temporaryRoot, 'comparison.json');
+      const decisionPath = path.join(temporaryRoot, 'decision.json');
+      const renderedPath = path.join(temporaryRoot, 'adr.md');
+      writeFileSync(comparisonPath, comparison.bytes);
+      writeFileSync(decisionPath, decision.bytes);
+
+      const result = spawnSync(process.execPath, [
+        path.join(scriptDirectory, 'render-index-storage-adr.mjs'),
+        '--comparison', comparisonPath,
+        '--decision', decisionPath,
+        '--output', renderedPath,
+      ], { encoding: 'utf8' });
+      if (result.error) fail(`failed to start strict ADR renderer: ${result.error.message}`);
+      if (result.signal) fail(`strict ADR renderer terminated by signal ${result.signal}`);
+      if (result.status !== 0) {
+        const detail = result.stderr?.trim() || result.stdout?.trim() || `exit status ${result.status}`;
+        fail(`strict ADR renderer failed: ${detail}`);
+      }
+
+      const markdown = insertDecisionDigest(readFileSync(renderedPath, 'utf8'), decision.sha256);
       writeFileSync(stagedOutput, markdown, 'utf8');
       renameSync(stagedOutput, args.output);
     } finally {
-      if (existsSync(stagedOutput)) rmSync(stagedOutput, { force: true });
+      rmSync(temporaryRoot, { recursive: true, force: true });
     }
   } finally {
-    rmSync(temporaryRoot, { recursive: true, force: true });
+    rmSync(stagingRoot, { recursive: true, force: true });
   }
 
   console.log(`${prefix} wrote ${args.output}`);

--- a/scripts/verify/verify-index-storage-adr-integrity.mjs
+++ b/scripts/verify/verify-index-storage-adr-integrity.mjs
@@ -102,8 +102,8 @@ requireMarkers(orderingGuard, 'terminal ordering guard', [
   'executableSql.trimEnd().endsWith(marker)',
   "test('packet runs terminal ordering preflight before the canonical validator'",
   "test('compare runs terminal ordering preflight before the canonical comparator'",
-  'standalone validator must preflight ordering before importing its core',
-  'standalone comparator must preflight every input before importing its core',
+  'standalone validator must revoke stale provenance, preflight ordering/resources, then run its isolated core',
+  'standalone comparator must revoke stale JSON, preflight every input, then run its atomic lifecycle',
   'packet terminal ordering preflight must run before the canonical validator',
   'comparison terminal ordering preflight must run before the canonical comparator',
   'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
@@ -113,8 +113,9 @@ requireMarkers(standaloneGuard, 'standalone evidence guard', [
   "const gitBlobSha = (bytes) => createHash('sha1')",
   "'dabc18d59360c300352ab3afb2510f0a0ff22796'",
   "'97ef0e8a216735e457c4c827d975462b84b009b3'",
-  'validator wrapper must run terminal-ordering preflight before importing its core',
-  'comparator wrapper must preflight every input before importing its core',
+  'runValidatorCoreWithAtomicProvenance',
+  'runComparatorCoreWithAtomicComparison',
+  'has lifecycle markers out of order',
 ]);
 requireMarkers(standaloneFixture, 'standalone evidence fixture', [
   "test('direct validator rejects non-executable terminal ordering before its core'",
@@ -165,9 +166,11 @@ requireMarkers(preparer, 'decision preparer', [
   'refusing to overwrite existing decision without --force',
   'comparison_commit: commit',
   'comparison_sha256: sha256',
-  'const stagedOutput = `${args.output}.tmp-${process.pid}`',
+  "const stagingRoot = mkdtempSync(path.join(parent || '.', `.${path.basename(args.output)}.tmp-`))",
+  'const stagedOutput = path.join(stagingRoot, path.basename(args.output))',
+  'if (args.force) rmSync(args.output, { force: true })',
   'renameSync(stagedOutput, args.output)',
-  'if (existsSync(stagedOutput)) rmSync(stagedOutput, { force: true })',
+  'rmSync(stagingRoot, { recursive: true, force: true })',
 ]);
 forbidMarkers(preparer, 'decision preparer', [
   "$schema: './storage-decision.schema.json'",
@@ -186,7 +189,10 @@ requireMarkers(finalizer, 'ADR finalizer', [
   'writeFileSync(decisionPath, decision.bytes)',
   "path.join(scriptDirectory, 'render-index-storage-adr.mjs')",
   'Decision SHA-256:',
-  'const stagedOutput = `${args.output}.tmp-${process.pid}`',
+  'const outputStagingPrefix = (output) => `${path.basename(output)}.tmp-`',
+  'const revokePublishedState = (output) =>',
+  'const stagingRoot = mkdtempSync(path.join(parent, outputStagingPrefix(args.output)))',
+  'rmSync(stagingRoot, { recursive: true, force: true })',
   'rmSync(temporaryRoot, { recursive: true, force: true })',
 ]);
 forbidMarkers(finalizer, 'ADR finalizer', ['shell: true', 'execSync(', 'process.exit(']);
@@ -224,7 +230,7 @@ requireMarkers(guide, 'storage decision guide', [
   'Only `comparison.json` emitted through the official comparator wrapper is valid decision input.',
   'Direct output from `compare-index-storage-evidence-core.mjs` is intentionally incomplete',
   'exact ordered `comparable_database_fields` contract',
-  'The comparator rejects cross-scale drift in any field',
+  'The comparator rejects intra-packet or cross-scale drift in any field',
   'The standalone renderer enforces the same methodology contract even when invoked directly.',
   'Recomputing `comparison_sha256` after removing or changing the methodology does not make the input acceptable.',
   'Comparison SHA-256',
@@ -238,28 +244,24 @@ forbidMarkers(guide, 'storage decision guide', [
   'Copy the printed 64-character digest into `comparison_sha256`',
 ]);
 
-for (const [label, workflow] of [
-  ['smoke workflow', smokeWorkflow],
-  ['scale workflow', scaleWorkflow],
-]) {
-  requireMarkers(workflow, label, [
-    'scripts/verify/check-index-storage-read-ordering.mjs',
-    'scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
-    'scripts/verify/validate-index-storage-evidence-core.mjs',
-    'scripts/verify/compare-index-storage-evidence-core.mjs',
-    'scripts/verify/index-storage-standalone-tools.test.mjs',
-    'scripts/verify/verify-index-storage-standalone-tools.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'node --check scripts/verify/verify-index-storage-read-ordering-contract.mjs',
-    'node --check scripts/verify/index-storage-standalone-tools.test.mjs',
-    'node --check scripts/verify/verify-index-storage-standalone-tools.mjs',
-    'scripts/verify/verify-index-storage-adr.mjs',
-    'node --check scripts/verify/verify-index-storage-adr.mjs',
-    'scripts/verify/verify-index-storage-adr-integrity.mjs',
-    'node --check scripts/verify/verify-index-storage-adr-integrity.mjs',
-  ]);
-}
+requireMarkers(smokeWorkflow, 'smoke workflow', [
+  'scripts/verify/check-index-storage-read-ordering.mjs',
+  'scripts/verify/check-index-storage-read-ordering.test.mjs',
+  'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
+  'scripts/verify/index-storage-standalone-tools.test.mjs',
+  'scripts/verify/verify-index-storage-standalone-tools.mjs',
+  'scripts/verify/verify-index-storage-adr.mjs',
+  'scripts/verify/verify-index-storage-adr-integrity.mjs',
+  'node --check scripts/verify/verify-index-storage-adr-integrity.mjs',
+]);
+requireMarkers(scaleWorkflow, 'scale workflow', [
+  'scripts/verify/*index-storage*.mjs',
+  'scripts/verify/storage-decision*.mjs',
+  'scripts/verify/*methodology-envelope*.mjs',
+  'find scripts/verify -maxdepth 1 -type f',
+  'node scripts/verify/index-storage-tooling.mjs contract',
+  'node scripts/verify/index-storage-tooling.mjs fixtures',
+  "if: ${{ github.event_name == 'workflow_dispatch' }}",
+]);
 
 console.log('[verify-index-storage-adr-integrity] executable SQL ordering, observed database-settings methodology, standalone evidence entrypoints, atomic decision preparation, byte-bound finalization, saved ADR verification, fixtures, docs, and workflows are cross-guarded');

--- a/scripts/verify/verify-index-storage-adr-tooling.mjs
+++ b/scripts/verify/verify-index-storage-adr-tooling.mjs
@@ -90,7 +90,7 @@ for (const marker of [
   'read-report.json database metadata observed from the active PostgreSQL benchmark session',
   'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
   'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
-  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+  'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
 ]) {
   if (!databaseSettingsContract.includes(marker)) {
     fail(`database settings contract is missing marker: ${marker}`);
@@ -136,8 +136,12 @@ for (const marker of [
   'rendered ADR must contain exactly one Comparison SHA-256 line',
   'Decision SHA-256:',
   '--output must not overwrite the ${label} input',
-  'const stagedOutput = `${args.output}.tmp-${process.pid}`',
+  'const outputStagingPrefix = (output) => `${path.basename(output)}.tmp-`',
+  'const isOutputStagingPath = (filename, output) =>',
+  'const revokePublishedState = (output) =>',
+  'const stagingRoot = mkdtempSync(path.join(parent, outputStagingPrefix(args.output)))',
   'renameSync(stagedOutput, args.output)',
+  'rmSync(stagingRoot, { recursive: true, force: true })',
 ]) {
   if (!adrFinalizer.includes(marker)) fail(`ADR finalizer is missing contract marker: ${marker}`);
 }
@@ -197,7 +201,7 @@ for (const marker of [
   "createHash('sha256')",
   'exactly one comparison.json path is required',
   'readFileSync(filename)',
-  'process.stdout.write(`${digest}\n`)',
+  'process.stdout.write(`${digest}\\n`)',
 ]) {
   if (!digestHelper.includes(marker)) fail(`comparison digest helper is missing marker: ${marker}`);
 }
@@ -325,17 +329,15 @@ for (const [name, workflow, markers] of [
     '--root evidence/index-storage/smoke',
   ]],
   ['scale evidence', scaleWorkflow, [
-    'scripts/verify/index-storage-database-settings-contract.mjs',
-    'scripts/verify/prepare-index-storage-decision.mjs',
-    'scripts/verify/finalize-index-storage-adr.mjs',
-    'scripts/verify/index-storage-decision-tooling.test.mjs',
-    'node --check scripts/verify/index-storage-database-settings-contract.mjs',
-    'node --check scripts/verify/prepare-index-storage-decision.mjs',
-    'node --check scripts/verify/finalize-index-storage-adr.mjs',
+    'scripts/verify/*index-storage*.mjs',
+    'scripts/verify/storage-decision*.mjs',
+    'scripts/verify/*methodology-envelope*.mjs',
+    'find scripts/verify -maxdepth 1 -type f',
     'node scripts/verify/index-storage-tooling.mjs contract',
-    'node --test scripts/verify/index-storage-tooling.test.mjs',
+    'node --test scripts/verify/index-storage-validator-arguments.test.mjs',
     'node scripts/verify/index-storage-tooling.mjs fixtures',
     'node scripts/verify/index-storage-tooling.mjs compare',
+    "if: ${{ github.event_name == 'workflow_dispatch' }}",
   ]],
   ['scale run', scaleRunWorkflow, [
     'node scripts/verify/index-storage-tooling.mjs packet',

--- a/scripts/verify/verify-index-storage-finalizer-lifecycle.mjs
+++ b/scripts/verify/verify-index-storage-finalizer-lifecycle.mjs
@@ -31,17 +31,23 @@ requireMarkers(finalizer, 'accepted ADR finalizer', [
   'decision.status must be accepted before ADR finalization',
   'const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);',
   'year === 0 || month < 1 || month > 12 || day < 1 || day > monthLengths[month - 1]',
-  'const stagedOutput = `${args.output}.tmp-${process.pid}`;',
+  'const outputStagingPrefix = (output) => `${path.basename(output)}.tmp-`;',
+  'const isOutputStagingPath = (filename, output) =>',
   'ADR staging path must not overwrite the ${label} input',
-  'rmSync(args.output, { force: true });',
-  'rmSync(stagedOutput, { force: true });',
+  'const revokePublishedState = (output) =>',
+  'entry.startsWith(outputStagingPrefix(output))',
+  'rmSync(path.join(parent, entry), { recursive: true, force: true });',
+  'rmSync(output, { force: true });',
+  'revokePublishedState(args.output);',
+  'const stagingRoot = mkdtempSync(path.join(parent, outputStagingPrefix(args.output)));',
   "const comparison = readJsonBytes(args.comparison, 'comparison');",
   'requireComparisonDatabaseSettingsMethodology(comparison.value, fail);',
   'requireAcceptedDecision(decision.value);',
   "requireIsoCalendarDate(decision.value.decision_date, 'decision.decision_date');",
   "path.join(scriptDirectory, 'render-index-storage-adr.mjs')",
-  'writeFileSync(stagedOutput, markdown, \'utf8\')',
+  "writeFileSync(stagedOutput, markdown, 'utf8')",
   'renameSync(stagedOutput, args.output)',
+  'rmSync(stagingRoot, { recursive: true, force: true })',
   'rmSync(temporaryRoot, { recursive: true, force: true })',
 ]);
 
@@ -50,9 +56,9 @@ for (const forbidden of ['shell: true', 'execSync(', 'process.exit(']) {
 }
 
 const collision = finalizer.indexOf('if (resolvedOutput === resolvedInput) fail(`--output must not overwrite the ${label} input`);');
-const stagingCollision = finalizer.indexOf('if (resolvedStagedOutput === resolvedInput)');
-const revokeOutput = finalizer.indexOf('rmSync(args.output, { force: true });');
-const revokeStaging = finalizer.indexOf('rmSync(stagedOutput, { force: true });');
+const stagingCollision = finalizer.indexOf('if (isOutputStagingPath(filename, args.output))');
+const revokeState = finalizer.indexOf('revokePublishedState(args.output);');
+const stagingCreate = finalizer.indexOf('const stagingRoot = mkdtempSync(path.join(parent, outputStagingPrefix(args.output)));');
 const evidenceRead = finalizer.indexOf("const comparison = readJsonBytes(args.comparison, 'comparison');");
 const methodology = finalizer.indexOf('requireComparisonDatabaseSettingsMethodology(comparison.value, fail);');
 const accepted = finalizer.indexOf('requireAcceptedDecision(decision.value);');
@@ -60,19 +66,21 @@ const calendarDate = finalizer.indexOf("requireIsoCalendarDate(decision.value.de
 const renderer = finalizer.indexOf('const result = spawnSync(process.execPath, [');
 const stageWrite = finalizer.indexOf("writeFileSync(stagedOutput, markdown, 'utf8')");
 const publish = finalizer.indexOf('renameSync(stagedOutput, args.output)');
-if ([collision, stagingCollision, revokeOutput, revokeStaging, evidenceRead, methodology,
-  accepted, calendarDate, renderer, stageWrite, publish].some((index) => index < 0)
+const stagingCleanup = finalizer.indexOf('rmSync(stagingRoot, { recursive: true, force: true });');
+if ([collision, stagingCollision, revokeState, stagingCreate, evidenceRead, methodology,
+  accepted, calendarDate, renderer, stageWrite, publish, stagingCleanup].some((index) => index < 0)
     || !(collision < stagingCollision
-      && stagingCollision < revokeOutput
-      && revokeOutput < revokeStaging
-      && revokeStaging < evidenceRead
+      && stagingCollision < revokeState
+      && revokeState < stagingCreate
+      && stagingCreate < evidenceRead
       && evidenceRead < methodology
       && methodology < accepted
       && accepted < calendarDate
       && calendarDate < renderer
       && renderer < stageWrite
-      && stageWrite < publish)) {
-  fail('finalizer order must be collision gates -> stale revocation -> evidence/methodology -> accepted decision/date -> renderer -> staged publication');
+      && stageWrite < publish
+      && publish < stagingCleanup)) {
+  fail('finalizer order must be collision gates -> stale-prefix revocation -> unique staging -> evidence/methodology -> accepted decision/date -> renderer -> atomic publication -> cleanup');
 }
 
 requireMarkers(fixture, 'accepted ADR finalizer fixture', [
@@ -115,10 +123,10 @@ requireMarkers(guide, 'storage decision guide', [
   'The generated draft has `status: proposed`.',
   'The finalizer rejects a proposed decision',
   'The finalizer accepts only `--comparison`, `--decision`, and `--output`',
-  'A valid replacement attempt revokes any existing ADR and process-specific staged output before evidence is read.',
+  'A valid replacement attempt rejects any input path inside the output staging namespace, revokes the existing ADR and every matching stale staging path before evidence is read, then publishes through a unique same-directory staging directory.',
   '- the decision status is `accepted`;',
   '- `decision_date` is a real ISO calendar date using Gregorian month and leap-year rules;',
   'the exact eight-field methodology envelope',
 ]);
 
-console.log('[verify-index-storage-finalizer-lifecycle] accepted status, Gregorian dates, non-destructive CLI/collisions, stale-output revocation, staged publication, canonical fixtures, router registration, and docs are cross-guarded');
+console.log('[verify-index-storage-finalizer-lifecycle] accepted status, Gregorian dates, non-destructive CLI/collisions, stale-prefix revocation, unique staged publication, canonical fixtures, router registration, and docs are cross-guarded');

--- a/scripts/verify/verify-index-storage-read-ordering-contract.mjs
+++ b/scripts/verify/verify-index-storage-read-ordering-contract.mjs
@@ -15,6 +15,7 @@ const benchmarkRunner = read('ops/benches/src/index_storage/runner.rs');
 const databaseMetadata = read('ops/benches/src/index_storage/database_metadata.rs');
 const mutationRunner = read('ops/benches/src/index_storage/mutation_runner.rs');
 const maintenanceRunner = read('ops/benches/src/index_storage/maintenance_runner.rs');
+const reportProvenance = read('ops/benches/src/index_storage/report_provenance.rs');
 const connection = read('ops/benches/src/index_storage/connection.rs');
 const preflight = read('scripts/verify/check-index-storage-read-ordering.mjs');
 const fixture = read('scripts/verify/check-index-storage-read-ordering.test.mjs');
@@ -113,24 +114,34 @@ for (const [label, content, benchmark] of [
 requireMarkers(benchmarkModule, 'benchmark report writer', [
   'pub use database_metadata::DatabaseMetadata;',
   'ensure_database_metadata_stable, read_database_metadata',
-  'pub use runner::{BenchmarkReport, run, write_report};',
-  'write_report(&config.output_path, &report)?',
+  'pub use report_provenance::write_provenance_bound_report;',
+  'write_provenance_bound_report(&config.output_path, &report, &config.run_provenance)?',
 ]);
 requireMarkers(benchmarkBinary, 'read evidence executable', [
-  'BenchmarkConfig, run, write_report',
-  'write_report(&config.output_path, &report)?',
+  'BenchmarkConfig, run, write_provenance_bound_report',
+  'write_provenance_bound_report(&config.output_path, &report, &config.run_provenance)?',
+]);
+requireMarkers(reportProvenance, 'provenance-bound report publication', [
+  '#[serde(flatten)]',
+  "provenance: &'a BenchmarkRunProvenance",
+  'pub fn write_provenance_bound_report<T: Serialize>',
+  'let staged = path.with_file_name',
+  'fs::write(&staged, serde_json::to_vec_pretty(&envelope)?)',
+  'fs::rename(&staged, path)',
+  'if staged.exists()',
 ]);
 for (const [label, content] of [
   ['benchmark module', benchmarkModule],
   ['read evidence executable', benchmarkBinary],
 ]) {
   for (const forbidden of [
+    'write_report(&config.output_path, &report)?',
     'write_report_with_session_metadata',
     'serde_json::to_value(report)',
     'database.insert(field.to_owned()',
   ]) {
     if (content.includes(forbidden)) {
-      fail(`${label} restored post-hoc deterministic session metadata injection: ${forbidden}`);
+      fail(`${label} restored unbound or post-hoc report publication: ${forbidden}`);
     }
   }
 }
@@ -150,7 +161,7 @@ requireMarkers(preflight, 'read ordering preflight', [
   "['extra_float_digits', '3']",
   'const requireSessionMetadata = (read, directory) =>',
   'requireSessionMetadata(read, directory);',
-  'deterministic session metadata and executable terminal ordering verified',
+  'benchmark run provenance, deterministic session metadata, and executable terminal ordering verified',
   'const maskSqlText = (text) =>',
   'const identifierContinuation = /[A-Za-z0-9_$]/u',
   'const isEscapeStringQuote = (sql, quoteIndex) =>',
@@ -212,7 +223,7 @@ requireMarkers(databaseSettingsContract, 'shared database settings contract', [
   'read-report.json database metadata observed from the active PostgreSQL benchmark session',
   'export const requireComparisonDatabaseSettingsMethodology = (comparison, fail) =>',
   'comparable_database_fields must exactly match the canonical PostgreSQL database-settings contract',
-  'database_settings_source must identify metadata observed from the active PostgreSQL benchmark session',
+  'comparison methodology database_settings_source must identify read metadata observed from the active PostgreSQL benchmark session after exact equality with mutation and maintenance active-session metadata',
 ]);
 requireMarkers(prepareDecision, 'decision preparation database settings gate', [
   "from './index-storage-database-settings-contract.mjs'",
@@ -246,46 +257,50 @@ if (finalizeDatabaseGate < 0 || finalizeRenderer < 0 || finalizeDatabaseGate > f
 
 requireMarkers(validatorWrapper, 'standalone validator wrapper', [
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-  'validatePacketReadOrdering(evidenceRoot);',
-  "await import('./validate-index-storage-evidence-core.mjs')",
+  "import { runValidatorCoreWithAtomicProvenance } from './run-index-storage-validator-core.mjs'",
+  "import { validateRunnerResourceSnapshots } from './validate-index-storage-runner-resources.mjs'",
+  "const corePath = fileURLToPath(new URL('./validate-index-storage-evidence-core.mjs', import.meta.url))",
+  'runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })',
 ]);
+const validatorInvalidation = validatorWrapper.indexOf('invalidatePacketProvenance(evidenceRoot);');
 const validatorOrdering = validatorWrapper.indexOf('validatePacketReadOrdering(evidenceRoot);');
-const validatorCore = validatorWrapper.indexOf("await import('./validate-index-storage-evidence-core.mjs')");
-if (validatorOrdering < 0 || validatorCore < 0 || validatorOrdering > validatorCore) {
-  fail('standalone validator must preflight ordering before importing its core');
+const validatorResources = validatorWrapper.indexOf('validateRunnerResourceSnapshots(evidenceRoot);');
+const validatorCore = validatorWrapper.indexOf('runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })');
+if ([validatorInvalidation, validatorOrdering, validatorResources, validatorCore].some((index) => index < 0)
+    || !(validatorInvalidation < validatorOrdering
+      && validatorOrdering < validatorResources
+      && validatorResources < validatorCore)) {
+  fail('standalone validator must revoke stale provenance, preflight ordering/resources, then run its isolated core');
 }
 
 requireMarkers(comparatorWrapper, 'standalone comparator wrapper', [
-  "import { readFileSync, writeFileSync } from 'node:fs'",
-  "import path from 'node:path'",
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
   "from './index-storage-database-settings-contract.mjs'",
   'comparableDatabaseFields,',
   'databaseSettingsSource,',
   'const finalizeDatabaseSettingsContract = ({ inputs, output }) =>',
+  "const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url))",
   'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
   'cross-scale database setting ${field} mismatch',
   'methodology.comparable_database_fields = comparableDatabaseFields;',
   'methodology.database_settings_source = databaseSettingsSource;',
   'Compared PostgreSQL fields:',
-  "await import('./compare-index-storage-evidence-core.mjs')",
-  'if (parsed !== null) finalizeDatabaseSettingsContract(parsed);',
+  'runComparatorCoreWithAtomicComparison(parsed)',
 ]);
+const standaloneComparisonRevocation = comparatorWrapper.indexOf(
+  "rmSync(path.join(parsed.output, 'comparison.json'), { force: true });",
+);
 const standaloneCompareOrdering = comparatorWrapper.indexOf(
   'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
 );
 const standaloneComparatorCore = comparatorWrapper.indexOf(
-  "await import('./compare-index-storage-evidence-core.mjs')",
+  'runComparatorCoreWithAtomicComparison(parsed)',
 );
-const standaloneComparatorFinalization = comparatorWrapper.indexOf(
-  'if (parsed !== null) finalizeDatabaseSettingsContract(parsed);',
-);
-if (standaloneCompareOrdering < 0 || standaloneComparatorCore < 0
-    || standaloneCompareOrdering > standaloneComparatorCore) {
-  fail('standalone comparator must preflight every input before importing its core');
-}
-if (standaloneComparatorFinalization < 0 || standaloneComparatorCore > standaloneComparatorFinalization) {
-  fail('standalone comparator must finalize the full database-settings contract after its core');
+if ([standaloneComparisonRevocation, standaloneCompareOrdering, standaloneComparatorCore]
+  .some((index) => index < 0)
+    || !(standaloneComparisonRevocation < standaloneCompareOrdering
+      && standaloneCompareOrdering < standaloneComparatorCore)) {
+  fail('standalone comparator must revoke stale JSON, preflight every input, then run its atomic lifecycle');
 }
 
 requireMarkers(standaloneFixture, 'standalone evidence fixture', [
@@ -300,8 +315,9 @@ requireMarkers(standaloneGuard, 'standalone evidence guard', [
   "const gitBlobSha = (bytes) => createHash('sha1')",
   "'dabc18d59360c300352ab3afb2510f0a0ff22796'",
   "'97ef0e8a216735e457c4c827d975462b84b009b3'",
-  'validator wrapper must run terminal-ordering preflight before importing its core',
-  'comparator wrapper must preflight every input before importing its core',
+  'runValidatorCoreWithAtomicProvenance',
+  'runComparatorCoreWithAtomicComparison',
+  'has lifecycle markers out of order',
 ]);
 
 requireMarkers(router, 'storage tooling router', [
@@ -332,24 +348,27 @@ requireMarkers(routerFixture, 'storage tooling router fixture', [
   'assert.doesNotMatch(result.stderr, /missing evidence file: .*mutation-report\\.json/u)',
 ]);
 
-for (const [label, workflow] of [
-  ['smoke workflow', smokeWorkflow],
-  ['scale workflow', scaleWorkflow],
-]) {
-  requireMarkers(workflow, label, [
-    'scripts/verify/check-index-storage-read-ordering.mjs',
-    'scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
-    'scripts/verify/validate-index-storage-evidence-core.mjs',
-    'scripts/verify/compare-index-storage-evidence-core.mjs',
-    'scripts/verify/index-storage-standalone-tools.test.mjs',
-    'scripts/verify/verify-index-storage-standalone-tools.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'node --check scripts/verify/index-storage-standalone-tools.test.mjs',
-    'node --check scripts/verify/verify-index-storage-standalone-tools.mjs',
-  ]);
-}
+requireMarkers(smokeWorkflow, 'smoke workflow', [
+  'scripts/verify/check-index-storage-read-ordering.mjs',
+  'scripts/verify/check-index-storage-read-ordering.test.mjs',
+  'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
+  'scripts/verify/validate-index-storage-evidence-core.mjs',
+  'scripts/verify/compare-index-storage-evidence-core.mjs',
+  'scripts/verify/index-storage-standalone-tools.test.mjs',
+  'scripts/verify/verify-index-storage-standalone-tools.mjs',
+  'node --check scripts/verify/check-index-storage-read-ordering.mjs',
+  'node --check scripts/verify/verify-index-storage-standalone-tools.mjs',
+]);
+requireMarkers(scaleWorkflow, 'scale workflow', [
+  'scripts/verify/*index-storage*.mjs',
+  'scripts/verify/storage-decision*.mjs',
+  'scripts/verify/*methodology-envelope*.mjs',
+  'find scripts/verify -maxdepth 1 -type f',
+  'node scripts/verify/index-storage-tooling.mjs contract',
+  'node --test scripts/verify/index-storage-validator-arguments.test.mjs',
+  'node scripts/verify/index-storage-tooling.mjs fixtures',
+  "if: ${{ github.event_name == 'workflow_dispatch' }}",
+]);
 requireMarkers(scaleRunWorkflow, 'scale run workflow', [
   'node scripts/verify/index-storage-tooling.mjs packet',
 ]);

--- a/scripts/verify/verify-index-storage-source-oracle.mjs
+++ b/scripts/verify/verify-index-storage-source-oracle.mjs
@@ -282,8 +282,8 @@ for (const marker of [
   'executableSql.trimEnd().endsWith(marker)',
   "test('packet runs terminal ordering preflight before the canonical validator'",
   "test('compare runs terminal ordering preflight before the canonical comparator'",
-  'standalone validator must preflight ordering before importing its core',
-  'standalone comparator must preflight every input before importing its core',
+  'standalone validator must revoke stale provenance, preflight ordering/resources, then run its isolated core',
+  'standalone comparator must revoke stale JSON, preflight every input, then run its atomic lifecycle',
   'packet terminal ordering preflight must run before the canonical validator',
   'comparison terminal ordering preflight must run before the canonical comparator',
   'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
@@ -291,20 +291,49 @@ for (const marker of [
   if (!orderingGuard.includes(marker)) fail(`terminal ordering guard missing ${marker}`);
 }
 
-for (const [wrapper, label, markers] of [
+const requireLifecycleOrder = (content, label, markers) => {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = content.indexOf(marker);
+    if (index < 0) fail(`${label} missing lifecycle marker ${marker}`);
+    if (index <= previous) fail(`${label} lifecycle marker is out of order: ${marker}`);
+    previous = index;
+  }
+};
+
+for (const [wrapper, label, markers, orderedMarkers, forbiddenMarkers] of [
   [validatorWrapper, 'validator wrapper', [
     "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
+    "import { runValidatorCoreWithAtomicProvenance } from './run-index-storage-validator-core.mjs'",
+    "import { validateRunnerResourceSnapshots } from './validate-index-storage-runner-resources.mjs'",
+    "const corePath = fileURLToPath(new URL('./validate-index-storage-evidence-core.mjs', import.meta.url))",
+    'runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })',
+  ], [
+    'invalidatePacketProvenance(evidenceRoot);',
     'validatePacketReadOrdering(evidenceRoot);',
+    'validateRunnerResourceSnapshots(evidenceRoot);',
+    'runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })',
+  ], [
     "await import('./validate-index-storage-evidence-core.mjs')",
   ]],
   [comparatorWrapper, 'comparator wrapper', [
     "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-    'for (const input of inputs) validatePacketReadOrdering(input);',
+    "const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url))",
+    'runComparatorCoreWithAtomicComparison(parsed)',
+  ], [
+    "rmSync(path.join(parsed.output, 'comparison.json'), { force: true });",
+    'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
+    'runComparatorCoreWithAtomicComparison(parsed)',
+  ], [
     "await import('./compare-index-storage-evidence-core.mjs')",
   ]],
 ]) {
   for (const marker of markers) {
     if (!wrapper.includes(marker)) fail(`${label} missing strict entrypoint marker ${marker}`);
+  }
+  requireLifecycleOrder(wrapper, label, orderedMarkers);
+  for (const marker of forbiddenMarkers) {
+    if (wrapper.includes(marker)) fail(`${label} restored obsolete direct core import ${marker}`);
   }
   if (wrapper.includes('migrated to inspect the preserved core directly')) {
     fail(`${label} still contains the temporary compatibility marker shim`);
@@ -314,8 +343,9 @@ for (const marker of [
   "const gitBlobSha = (bytes) => createHash('sha1')",
   "'dabc18d59360c300352ab3afb2510f0a0ff22796'",
   "'97ef0e8a216735e457c4c827d975462b84b009b3'",
-  'validator wrapper must run terminal-ordering preflight before importing its core',
-  'comparator wrapper must preflight every input before importing its core',
+  'runValidatorCoreWithAtomicProvenance',
+  'runComparatorCoreWithAtomicComparison',
+  'has lifecycle markers out of order',
 ]) {
   if (!standaloneGuard.includes(marker)) fail(`standalone evidence guard missing ${marker}`);
 }
@@ -341,12 +371,10 @@ for (const marker of [
   if (!toolingRouter.includes(marker)) fail(`storage tooling router missing independent integrity wiring ${marker}`);
 }
 for (const marker of [
-  "const prefix = '[verify-index-storage-adr-integrity]'",
+  'console.error(`[verify-index-storage-adr-integrity] ${message}`)',
   "const orderingGuard = read('scripts/verify/verify-index-storage-read-ordering-contract.mjs')",
   "const standaloneGuard = read('scripts/verify/verify-index-storage-standalone-tools.mjs')",
-  'executableSql.trimEnd().endsWith(marker)',
-  "test('packet runs terminal ordering preflight before the canonical validator'",
-  "test('compare runs terminal ordering preflight before the canonical comparator'",
+  'has lifecycle markers out of order',
   "runScript('finalize-index-storage-adr.mjs', args)",
   "runScript('verify-index-storage-adr.mjs', args)",
   'ADR bytes differ from deterministic finalization',
@@ -354,28 +382,30 @@ for (const marker of [
 ]) {
   if (!adrIntegrityGuard.includes(marker)) fail(`ADR integrity guard missing cross-protection marker ${marker}`);
 }
-for (const [label, workflow] of [
-  ['smoke', smokeWorkflow],
-  ['scale', scaleWorkflow],
+for (const marker of [
+  'scripts/verify/check-index-storage-read-ordering.mjs',
+  'scripts/verify/check-index-storage-read-ordering.test.mjs',
+  'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
+  'scripts/verify/validate-index-storage-evidence-core.mjs',
+  'scripts/verify/compare-index-storage-evidence-core.mjs',
+  'scripts/verify/index-storage-standalone-tools.test.mjs',
+  'scripts/verify/verify-index-storage-standalone-tools.mjs',
+  'node --check scripts/verify/check-index-storage-read-ordering.mjs',
+  'node --check scripts/verify/verify-index-storage-adr-integrity.mjs',
 ]) {
-  for (const marker of [
-    'scripts/verify/check-index-storage-read-ordering.mjs',
-    'scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'scripts/verify/verify-index-storage-read-ordering-contract.mjs',
-    'scripts/verify/validate-index-storage-evidence-core.mjs',
-    'scripts/verify/compare-index-storage-evidence-core.mjs',
-    'scripts/verify/index-storage-standalone-tools.test.mjs',
-    'scripts/verify/verify-index-storage-standalone-tools.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.mjs',
-    'node --check scripts/verify/check-index-storage-read-ordering.test.mjs',
-    'node --check scripts/verify/verify-index-storage-read-ordering-contract.mjs',
-    'node --check scripts/verify/index-storage-standalone-tools.test.mjs',
-    'node --check scripts/verify/verify-index-storage-standalone-tools.mjs',
-    'scripts/verify/verify-index-storage-adr-integrity.mjs',
-    'node --check scripts/verify/verify-index-storage-adr-integrity.mjs',
-  ]) {
-    if (!workflow.includes(marker)) fail(`${label} workflow missing integrity wiring ${marker}`);
-  }
+  if (!smokeWorkflow.includes(marker)) fail(`smoke workflow missing integrity wiring ${marker}`);
+}
+for (const marker of [
+  'scripts/verify/*index-storage*.mjs',
+  'scripts/verify/storage-decision*.mjs',
+  'scripts/verify/*methodology-envelope*.mjs',
+  'find scripts/verify -maxdepth 1 -type f',
+  'node scripts/verify/index-storage-tooling.mjs contract',
+  'node --test scripts/verify/index-storage-validator-arguments.test.mjs',
+  'node scripts/verify/index-storage-tooling.mjs fixtures',
+  "if: ${{ github.event_name == 'workflow_dispatch' }}",
+]) {
+  if (!scaleWorkflow.includes(marker)) fail(`scale workflow missing integrity wiring ${marker}`);
 }
 
 console.log('[verify-index-storage-source-oracle] source oracle, deterministic PostgreSQL string semantics, byte-preserved evidence cores, self-described ordered digests, complete metrics, executable SQL entrypoints, and ADR integrity wiring are independently guarded');

--- a/scripts/verify/verify-index-storage-standalone-tools.mjs
+++ b/scripts/verify/verify-index-storage-standalone-tools.mjs
@@ -44,32 +44,44 @@ const forbidMarkers = (content, label, markers) => {
     if (content.includes(marker)) fail(`${label} contains forbidden marker: ${marker}`);
   }
 };
+const requireOrder = (content, label, markers) => {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = content.indexOf(marker);
+    if (index < 0) fail(`${label} is missing ordered marker: ${marker}`);
+    if (index <= previous) fail(`${label} has lifecycle markers out of order: ${marker}`);
+    previous = index;
+  }
+};
 
 requireMarkers(validator, 'validator wrapper', [
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
+  "import { runValidatorCoreWithAtomicProvenance } from './run-index-storage-validator-core.mjs'",
+  "import { validateRunnerResourceSnapshots } from './validate-index-storage-runner-resources.mjs'",
   "const supportedScales = new Set(['smoke', '100k', '1m'])",
-  'validatePacketReadOrdering(evidenceRoot);',
-  "await import('./validate-index-storage-evidence-core.mjs')",
+  "const corePath = fileURLToPath(new URL('./validate-index-storage-evidence-core.mjs', import.meta.url))",
+  'runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })',
 ]);
-const validatorPreflight = validator.indexOf('validatePacketReadOrdering(evidenceRoot);');
-const validatorCore = validator.indexOf("await import('./validate-index-storage-evidence-core.mjs')");
-if (validatorPreflight < 0 || validatorCore < 0 || validatorPreflight > validatorCore) {
-  fail('validator wrapper must run terminal-ordering preflight before importing its core');
-}
+requireOrder(validator, 'validator wrapper', [
+  'invalidatePacketProvenance(evidenceRoot);',
+  'validatePacketReadOrdering(evidenceRoot);',
+  'validateRunnerResourceSnapshots(evidenceRoot);',
+  'runValidatorCoreWithAtomicProvenance({ evidenceRoot, corePath })',
+]);
 
 requireMarkers(comparator, 'comparator wrapper', [
   "import { validatePacketReadOrdering } from './check-index-storage-read-ordering.mjs'",
-  "if (argument === '--help' || argument === '-h') return null",
+  "const corePath = fileURLToPath(new URL('./compare-index-storage-evidence-core.mjs', import.meta.url))",
+  "if (argument === '--help' || argument === '-h')",
   "argument === '--input'",
   "argument === '--output'",
-  'for (const input of inputs) validatePacketReadOrdering(input);',
-  "await import('./compare-index-storage-evidence-core.mjs')",
+  'runComparatorCoreWithAtomicComparison(parsed)',
 ]);
-const comparatorPreflight = comparator.indexOf('for (const input of inputs) validatePacketReadOrdering(input);');
-const comparatorCore = comparator.indexOf("await import('./compare-index-storage-evidence-core.mjs')");
-if (comparatorPreflight < 0 || comparatorCore < 0 || comparatorPreflight > comparatorCore) {
-  fail('comparator wrapper must preflight every input before importing its core');
-}
+requireOrder(comparator, 'comparator wrapper', [
+  "rmSync(path.join(parsed.output, 'comparison.json'), { force: true });",
+  'for (const input of parsed.inputs) validatePacketReadOrdering(input);',
+  'runComparatorCoreWithAtomicComparison(parsed)',
+]);
 
 requireMarkers(sourceOracleGuard, 'source-oracle guard', [
   "read('scripts/verify/validate-index-storage-evidence-core.mjs')",
@@ -84,14 +96,14 @@ forbidMarkers(validator, 'validator wrapper', [
   'const resultDigestContract =',
   'shell: true',
   'execSync(',
-  'spawnSync(',
+  "await import('./validate-index-storage-evidence-core.mjs')",
 ]);
 forbidMarkers(comparator, 'comparator wrapper', [
   'migrated to inspect the preserved core directly',
   'const resultDigestContract =',
   'shell: true',
   'execSync(',
-  'spawnSync(',
+  "await import('./compare-index-storage-evidence-core.mjs')",
 ]);
 
-console.log('[verify-index-storage-standalone-tools] direct validator and comparator enforce executable SQL ordering before byte-preserved core execution');
+console.log('[verify-index-storage-standalone-tools] direct validator and comparator preserve ordering, lifecycle, and byte-preserved core execution');


### PR DESCRIPTION
## Summary

- fix a false-positive FBA source scan by keeping guard-only legacy SQL fragments split while preserving the runtime assertions;
- align source-oracle, read-ordering, standalone, ADR tooling, and ADR integrity guards with the already merged provenance-bound validator and atomic comparator lifecycles;
- repair comparator regressions so an explicit missing digest contract is not silently replaced by a default and terminal-ordering failures match the canonical preflight diagnostic;
- harden accepted-ADR finalization by rejecting inputs inside the output staging namespace, revoking every stale matching staging path before evidence access, publishing through a unique same-directory staging directory, and cleaning residue on failure;
- update focused finalizer contracts and storage-decision documentation for the actual lifecycle.

## Owner-run findings

A canonical Index Storage Scale Evidence run was dispatched as run `30218611746`. It failed closed in the lightweight contract before PostgreSQL or heavy runners were allocated. The investigation found stale cross-guards left behind by the previously merged lifecycle/provenance work and one real finalizer stale-staging defect. No replacement 100k/1m packet was produced by the failed run.

The temporary launcher, source snapshot, diagnostic workflow changes, and patch payload were removed. The branch was rebuilt as one commit directly on current `main` and contains only the ten Index files in this PR.

## Validation performed

Executed from the exact final file set:

```bash
node scripts/verify/index-storage-tooling.mjs contract
node --test scripts/verify/index-storage-validator-arguments.test.mjs
node scripts/verify/index-storage-tooling.mjs fixtures
```

Results:

- all 16 static Index contracts passed;
- all 11 validator lifecycle tests passed;
- all 108 canonical Index storage fixtures passed.

PostgreSQL replacement benchmarks have not yet been rerun on the final merge commit. After this PR is merged, the canonical workflow will be dispatched on that exact `main` SHA so 100k, 1m, and comparison share the final code commit.