### PR TITLE
fix(index): align JSONB read ordering markers

### DIFF
--- a/ops/benches/src/index_storage/sql/jsonb.rs
+++ b/ops/benches/src/index_storage/sql/jsonb.rs
@@ -113,7 +113,7 @@ pub fn workloads(context: &WorkloadContext) -> Vec<Workload> {
         Workload {
             name: "price_range_sort",
             sql: format!(
-                "SELECT entity_id, (payload->>'price_minor')::bigint AS price_minor FROM idx_bench_jsonb.entity WHERE tenant_id = {tenant} AND module_name = 'product' AND entity_name = 'product' AND schema_version = 1 AND locale = {locale} AND (payload->>'price_minor')::bigint BETWEEN 20000 AND 80000 ORDER BY (payload->>'price_minor')::bigint, entity_id LIMIT 100"
+                "SELECT entity_id, (payload->>'price_minor')::bigint AS price_minor FROM idx_bench_jsonb.entity WHERE tenant_id = {tenant} AND module_name = 'product' AND entity_name = 'product' AND schema_version = 1 AND locale = {locale} AND (payload->>'price_minor')::bigint BETWEEN 20000 AND 80000 ORDER BY price_minor, entity_id LIMIT 100"
             ),
         },
         Workload {
@@ -131,7 +131,7 @@ pub fn workloads(context: &WorkloadContext) -> Vec<Workload> {
         Workload {
             name: "keyset_page",
             sql: format!(
-                "SELECT entity_id, (payload->>'price_minor')::bigint AS price_minor FROM idx_bench_jsonb.entity WHERE tenant_id = {tenant} AND module_name = 'product' AND entity_name = 'product' AND schema_version = 1 AND locale = {locale} AND ((payload->>'price_minor')::bigint, entity_id) > ({anchor_price}, {anchor_id}) ORDER BY (payload->>'price_minor')::bigint, entity_id LIMIT 100"
+                "SELECT entity_id, (payload->>'price_minor')::bigint AS price_minor FROM idx_bench_jsonb.entity WHERE tenant_id = {tenant} AND module_name = 'product' AND entity_name = 'product' AND schema_version = 1 AND locale = {locale} AND ((payload->>'price_minor')::bigint, entity_id) > ({anchor_price}, {anchor_id}) ORDER BY price_minor, entity_id LIMIT 100"
             ),
         },
         Workload {


### PR DESCRIPTION
## Summary

- make JSONB `price_range_sort` and `keyset_page` end with the same canonical `ORDER BY price_minor, entity_id LIMIT 100` marker required by the shared read workload contract;
- preserve the underlying JSONB expression in the select list and keyset predicate;
- fix the identical fail-closed panic observed in both replacement `100k` and `1m` runs from Actions run `30220486083`.

## Evidence failure

Both scale jobs built successfully, passed runner capacity checks, and failed before executing benchmark SQL with:

```text
read workload price_range_sort must end with canonical ordering marker ORDER BY price_minor, entity_id LIMIT 100
```

The generated JSONB query selected the expression as alias `price_minor` but ordered by the expression instead of the canonical alias, unlike source, typed EAV, and hot projection workloads.

After merge, replacement evidence must be rerun on the new exact `main` SHA; artifacts from run `30220486083` are diagnostic only and must not be reused.