### PR TITLE
Retain payment collection admission context

### DIFF
--- a/crates/rustok-payment/docs/payment-collection-admission-context.md
+++ b/crates/rustok-payment/docs/payment-collection-admission-context.md
@@ -1,0 +1,126 @@
+# Payment collection owner admission context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the owner-side structured-context gap for admission
+rejections in `PaymentCollectionPort`:
+
+- `create_or_reuse_collection` write-policy admission;
+- `create_or_reuse_collection` write-semantics admission;
+- `read_collection_status` read-policy admission.
+
+Before this slice, the port called `PortContext::require_policy` and
+`PortContext::require_write_semantics` directly with `?`. A rejection therefore
+returned the original `PortError`, but the payment owner did not record the
+available correlation, actor, channel, locale, deadline, exact owner operation,
+or the admission phase that rejected the request.
+
+This slice is deliberately limited to payment collection admission. Tenant-id
+parsing, request validation, provider execution, collection lifecycle mapping,
+checkout consumers, compensation consumers, and transport adapters remain
+separate concerns.
+
+## Delivered source contract
+
+Both public owner operations now select their canonical owner operation before
+admission:
+
+- `create_or_reuse_collection` uses `create_or_reuse_collection`;
+- `read_collection_status` uses `read_collection_status`.
+
+The write path delegates admission to a payment-owned helper that:
+
+1. requires `PortCallPolicy::write()`;
+2. records a rejection with admission phase `policy` before returning the
+   original `PortError`;
+3. requires write semantics;
+4. records a rejection with admission phase `write_semantics` before returning
+   the original `PortError`.
+
+The read path delegates admission to a payment-owned helper that requires
+`PortCallPolicy::read()` and records phase `policy` before returning the original
+`PortError`.
+
+Admission diagnostics record:
+
+- truthful owner `rustok_payment`;
+- exact owner operation;
+- admission phase;
+- correlation id and tenant id;
+- actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original error code, message, typed kind, and retryability;
+- boundary `payment_collection_port`.
+
+Unavailable, timeout, and invariant failures use error severity. Other
+admission rejections use warning severity.
+
+## Preserved behavior
+
+This slice does not change:
+
+- public `PaymentCollectionPort` trait signatures;
+- create/reuse request fields or status request identity;
+- status snapshot fields or typed status conversion;
+- write policy or write-semantics requirements;
+- read policy requirements;
+- tenant UUID parsing or its validation code/message;
+- reusable collection lookup by cart;
+- create-after-read behavior;
+- race adoption after a create error;
+- granular owner operation labels for existing lookup, race adoption, and
+  collection creation errors;
+- payment validation, not-found, lifecycle, provider, reconciliation,
+  configuration, or database `PortError` codes and public messages;
+- provider ids or provider operation diagnostics;
+- retryability values;
+- checkout payment execution or compensation consumer behavior;
+- FBA, FFA, or ecommerce audit status.
+
+Admission helpers return the same original `PortError` produced by
+`PortContext`; they only emit structured diagnostics before propagation.
+
+## Static evidence
+
+`scripts/verify/verify-payment-collection-admission-context.mjs` guards:
+
+- stable payment owner and boundary identity;
+- canonical read and write owner operations;
+- operation selection before admission and tenant parsing;
+- read-policy admission without write semantics;
+- write-policy admission followed by write-semantics admission;
+- distinct `policy` and `write_semantics` diagnostic phases;
+- complete available `PortContext` fields;
+- original error code, message, typed kind, and retryability;
+- technical versus ordinary rejection severity;
+- existing create/read/race owner mappings;
+- unchanged status request and snapshot mapping;
+- stable payment public `PortError` messages;
+- absence of the old direct context-dropping admission paths.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- payment tenant-context validation diagnostics;
+- remaining payment execution and compensation consumers;
+- storefront customer read consumers;
+- remaining order, fulfillment, inventory, customer, tax, and promotion
+  adapters;
+- non-`PortError` public envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-payment-collection-admission-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-payment --lib
+```

--- a/crates/rustok-payment/src/ports.rs
+++ b/crates/rustok-payment/src/ports.rs
@@ -7,6 +7,11 @@ use uuid::Uuid;
 
 use crate::{PaymentCollectionResponse, PaymentCollectionStatusKind};
 
+const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";
+const PAYMENT_COLLECTION_OWNER: &str = "rustok_payment";
+const CREATE_OR_REUSE_COLLECTION_OPERATION: &str = "create_or_reuse_collection";
+const READ_COLLECTION_STATUS_OPERATION: &str = "read_collection_status";
+
 /// Transport-neutral owner boundary for payment collection create/reuse flows.
 #[async_trait]
 pub trait PaymentCollectionPort: Send + Sync {
@@ -74,8 +79,8 @@ impl PaymentCollectionPort for crate::PaymentService {
         context: PortContext,
         request: PaymentCollectionCreateOrReuseRequest,
     ) -> Result<PaymentCollectionResponse, PortError> {
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;
+        require_payment_collection_write_admission(&context, owner_operation)?;
         let tenant_id = parse_port_tenant_id(&context)?;
 
         if let Some(cart_id) = request.cart_id {
@@ -141,15 +146,99 @@ impl PaymentCollectionPort for crate::PaymentService {
         context: PortContext,
         request: PaymentCollectionStatusRequest,
     ) -> Result<PaymentCollectionStatusSnapshot, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
+        let owner_operation = READ_COLLECTION_STATUS_OPERATION;
+        require_payment_collection_read_admission(&context, owner_operation)?;
         let tenant_id = parse_port_tenant_id(&context)?;
         let response = self
             .get_collection(tenant_id, request.collection_id)
             .await
-            .map_err(|error| {
-                payment_error_to_port_error(&context, "read_collection_status", error)
-            })?;
+            .map_err(|error| payment_error_to_port_error(&context, owner_operation, error))?;
         Ok(PaymentCollectionStatusSnapshot::from_response(&response))
+    }
+}
+
+fn require_payment_collection_read_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::read()).map_err(|error| {
+        log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);
+        error
+    })
+}
+
+fn require_payment_collection_write_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).map_err(|error| {
+        log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);
+        error
+    })?;
+    context.require_write_semantics().map_err(|error| {
+        log_payment_collection_admission_rejection(
+            context,
+            owner_operation,
+            "write_semantics",
+            &error,
+        );
+        error
+    })
+}
+
+fn log_payment_collection_admission_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner = PAYMENT_COLLECTION_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                admission,
+                code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+                "payment collection admission failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner = PAYMENT_COLLECTION_OWNER,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                operation = owner_operation,
+                admission,
+                code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+                "payment collection admission was rejected"
+            );
+        }
     }
 }
 

--- a/scripts/verify/verify-payment-collection-admission-context.mjs
+++ b/scripts/verify/verify-payment-collection-admission-context.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-payment/src/ports.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const createBlock = between(
+  source,
+  '    async fn create_or_reuse_collection(',
+  '    async fn read_collection_status(',
+  'create or reuse implementation',
+);
+const readBlock = between(
+  source,
+  '    async fn read_collection_status(',
+  '\n}\n\nfn require_payment_collection_read_admission(',
+  'status read implementation',
+);
+const readAdmission = between(
+  source,
+  'fn require_payment_collection_read_admission(',
+  'fn require_payment_collection_write_admission(',
+  'read admission helper',
+);
+const writeAdmission = between(
+  source,
+  'fn require_payment_collection_write_admission(',
+  'fn log_payment_collection_admission_rejection(',
+  'write admission helper',
+);
+const admissionLogger = between(
+  source,
+  'fn log_payment_collection_admission_rejection(',
+  'fn parse_port_tenant_id(',
+  'admission diagnostic helper',
+);
+const ownerMapper = between(
+  source,
+  'fn payment_error_to_port_error(',
+  '\n}',
+  'payment owner mapper',
+);
+
+for (const [value, label] of [
+  ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
+  ['const PAYMENT_COLLECTION_OWNER: &str = "rustok_payment";', 'truthful payment owner'],
+  ['const CREATE_OR_REUSE_COLLECTION_OPERATION: &str = "create_or_reuse_collection";', 'write owner operation'],
+  ['const READ_COLLECTION_STATUS_OPERATION: &str = "read_collection_status";', 'read owner operation'],
+]) requireText(source, value, label);
+
+for (const [content, values, label] of [
+  [
+    createBlock,
+    [
+      'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
+      'require_payment_collection_write_admission(&context, owner_operation)?;',
+      'let tenant_id = parse_port_tenant_id(&context)?;',
+    ],
+    'write admission ordering',
+  ],
+  [
+    readBlock,
+    [
+      'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
+      'require_payment_collection_read_admission(&context, owner_operation)?;',
+      'let tenant_id = parse_port_tenant_id(&context)?;',
+    ],
+    'read admission ordering',
+  ],
+]) {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value);
+    if (index < 0) failures.push(`${label}: missing ${value}`);
+    if (index >= 0 && index <= previous) failures.push(`${label}: ${value} is out of order`);
+    previous = index;
+  }
+}
+
+for (const [value, label] of [
+  ['context.require_policy(PortCallPolicy::read())', 'read policy'],
+  ['log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);', 'read policy diagnostics'],
+]) requireText(readAdmission, value, label);
+forbidText(readAdmission, 'require_write_semantics', 'read admission must remain non-write');
+
+for (const [value, label] of [
+  ['context.require_policy(PortCallPolicy::write())', 'write policy'],
+  ['log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);', 'write policy diagnostics'],
+  ['context.require_write_semantics()', 'write semantics'],
+  ['"write_semantics"', 'write semantics diagnostic classification'],
+]) requireText(writeAdmission, value, label);
+
+for (const [value, label] of [
+  ['context: &PortContext', 'retained context input'],
+  ["owner_operation: &'static str", 'exact owner operation input'],
+  ["admission: &'static str", 'admission phase input'],
+  ['error: &PortError', 'original port error input'],
+  ['error = ?error', 'original error'],
+  ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['operation = owner_operation', 'owner operation field'],
+  ['admission,', 'admission phase field'],
+  ['code = %error.code', 'error code'],
+  ['internal_message = %error.message', 'error message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
+  ['tracing::error!(', 'technical severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
+  ['"payment collection admission failed"', 'technical event'],
+  ['"payment collection admission was rejected"', 'rejection event'],
+]) requireText(admissionLogger, value, label);
+
+for (const [value, label] of [
+  ['"create_or_reuse_collection.read_existing"', 'existing collection read mapping'],
+  ['"create_or_reuse_collection.adopt_race"', 'race adoption mapping'],
+  ['"create_or_reuse_collection.create"', 'collection create mapping'],
+  ['find_reusable_collection_by_cart(tenant_id, cart_id)', 'reusable collection lookup'],
+  ['create_collection(', 'collection creation'],
+]) requireText(createBlock, value, label);
+
+for (const [value, label] of [
+  ['get_collection(tenant_id, request.collection_id)', 'status collection identity'],
+  ['payment_error_to_port_error(&context, owner_operation, error)', 'status owner mapping'],
+  ['PaymentCollectionStatusSnapshot::from_response(&response)', 'status snapshot mapping'],
+]) requireText(readBlock, value, label);
+
+for (const [value, label] of [
+  ['PortError::validation("payment.validation", "payment request is invalid")', 'stable validation envelope'],
+  ['PortError::unavailable(', 'stable unavailable envelope'],
+  ['"payment provider outcome requires reconciliation"', 'stable reconciliation envelope'],
+  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
+]) requireText(source, value, label);
+
+forbidText(createBlock, 'context.require_policy(', 'direct write policy admission');
+forbidText(createBlock, 'context.require_write_semantics()', 'direct write semantics admission');
+forbidText(readBlock, 'context.require_policy(', 'direct read policy admission');
+forbidText(source, 'context.require_policy(PortCallPolicy::write())?;', 'context-dropping write policy rejection');
+forbidText(source, 'context.require_write_semantics()?;', 'context-dropping write semantics rejection');
+forbidText(source, 'context.require_policy(PortCallPolicy::read())?;', 'context-dropping read policy rejection');
+
+if (failures.length > 0) {
+  console.error('Payment collection admission context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Payment collection read/write admission rejections retain truthful owner context without changing collection lifecycle or public PortError behavior',
+);


### PR DESCRIPTION
## Summary

- select the canonical payment owner operation before read/write admission;
- route `create_or_reuse_collection` through a payment-owned write admission helper that records both policy and write-semantics rejection context;
- route `read_collection_status` through a payment-owned read admission helper;
- attribute admission failures to truthful owner `rustok_payment`, exact operations `create_or_reuse_collection` or `read_collection_status`, and explicit admission phases `policy` or `write_semantics`;
- record correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, original code/message/kind/retryability, and boundary `payment_collection_port`;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary admission rejection;
- return the original `PortError` unchanged after diagnostics;
- preserve tenant parsing, reusable lookup, create/race adoption, status projection, provider/lifecycle/storage mappings, public codes/messages, and retryability;
- add a focused static verifier and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-payment/src/ports.rs`
- `scripts/verify/verify-payment-collection-admission-context.mjs`
- `crates/rustok-payment/docs/payment-collection-admission-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe payment mapper cleanup. It closes only `PaymentCollectionPort` read/write admission rejection context. Payment tenant-id validation diagnostics, payment execution and compensation consumers, storefront customer reads, other owner adapters, and non-`PortError` envelopes remain open. No FBA/FFA or audit status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- diff contains exactly the three scoped files;
- operation selection precedes admission and tenant parsing on both public operations;
- write policy and write-semantics rejection phases are separately guarded;
- read admission remains read-only;
- full available `PortContext` and original `PortError` fields are statically guarded;
- existing create/read/race/provider/storage mappings and public envelopes remain intact;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-payment-collection-admission-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment --lib
```