### PR TITLE
Retain payment collection tenant context

### DIFF
--- a/crates/rustok-payment/docs/payment-collection-tenant-context.md
+++ b/crates/rustok-payment/docs/payment-collection-tenant-context.md
@@ -1,0 +1,122 @@
+# Payment collection tenant validation owner context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the owner-side structured-context gap for invalid tenant
+identity in `PaymentCollectionPort`:
+
+- `create_or_reuse_collection` tenant UUID validation;
+- `read_collection_status` tenant UUID validation.
+
+Both public operations already selected a canonical owner operation and completed
+policy admission before parsing `PortContext.tenant_id`. Before this slice, tenant
+parsing returned `payment.tenant_id_invalid` directly from a context-free closure.
+The original validation envelope was stable, but the payment owner did not record
+the available correlation, actor, channel, locale, deadline, exact owner operation,
+or the UUID parse cause.
+
+This slice is deliberately limited to tenant UUID validation. Payment collection
+admission diagnostics were closed by the preceding slice. Request validation,
+provider execution, collection lifecycle mapping, checkout consumers,
+compensation consumers, and transport adapters remain separate concerns.
+
+## Delivered source contract
+
+Both public owner operations now pass their already-selected canonical operation
+to the tenant parser:
+
+- `create_or_reuse_collection` passes `create_or_reuse_collection`;
+- `read_collection_status` passes `read_collection_status`.
+
+The payment-owned tenant parser now:
+
+1. parses the existing `PortContext.tenant_id` as a UUID;
+2. constructs the same validation `PortError` on failure;
+3. records the UUID parse cause and complete available owner context;
+4. returns that same validation error after diagnostics.
+
+Tenant validation diagnostics record:
+
+- truthful owner `rustok_payment`;
+- exact owner operation;
+- validation phase `tenant_id`;
+- correlation id and tenant id;
+- actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original validation code, message, typed kind, and retryability;
+- internal UUID parse cause;
+- boundary `payment_collection_port`.
+
+Invalid tenant identity is a caller/context validation rejection and therefore uses
+warning severity.
+
+## Preserved behavior
+
+This slice does not change:
+
+- public `PaymentCollectionPort` trait signatures;
+- write-policy or write-semantics admission;
+- read-policy admission;
+- admission ordering before tenant parsing;
+- tenant validation code `payment.tenant_id_invalid`;
+- tenant validation message
+  `PortContext.tenant_id must be a UUID for payment ports`;
+- validation kind or retryability;
+- reusable collection lookup by cart;
+- create-after-read behavior;
+- race adoption after a create error;
+- granular owner operation labels for existing lookup, race adoption, and
+  collection creation errors;
+- status collection identity or status snapshot mapping;
+- payment validation, not-found, lifecycle, provider, reconciliation,
+  configuration, or database `PortError` codes and public messages;
+- provider ids or provider operation diagnostics;
+- checkout payment execution or compensation consumer behavior;
+- FBA, FFA, or ecommerce audit status.
+
+## Static evidence
+
+`scripts/verify/verify-payment-collection-tenant-context.mjs` guards:
+
+- two operation-aware tenant parser callsites;
+- operation selection and admission before tenant parsing;
+- tenant parsing before owner storage/service work;
+- stable tenant validation code, message, kind, and retryability;
+- UUID parse cause plus complete available `PortContext` fields;
+- truthful payment owner, exact operation, validation phase, and boundary;
+- diagnostics before returning the validation error;
+- unchanged admission helpers;
+- unchanged reusable lookup, race adoption, status projection, provider,
+  reconciliation, and storage envelopes;
+- absence of the old operation-free and silent parser paths.
+
+The preceding
+`scripts/verify/verify-payment-collection-admission-context.mjs` is synchronized
+to the operation-aware parser signature while preserving all admission assertions.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- remaining payment execution and compensation consumers;
+- storefront customer read consumers;
+- remaining order, fulfillment, inventory, customer, tax, and promotion
+  adapters;
+- non-`PortError` public envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-payment-collection-tenant-context.mjs
+node scripts/verify/verify-payment-collection-admission-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-payment --lib
+```

--- a/crates/rustok-payment/src/ports.rs
+++ b/crates/rustok-payment/src/ports.rs
@@ -81,7 +81,7 @@ impl PaymentCollectionPort for crate::PaymentService {
     ) -> Result<PaymentCollectionResponse, PortError> {
         let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;
         require_payment_collection_write_admission(&context, owner_operation)?;
-        let tenant_id = parse_port_tenant_id(&context)?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
 
         if let Some(cart_id) = request.cart_id {
             if let Some(collection) = self
@@ -148,7 +148,7 @@ impl PaymentCollectionPort for crate::PaymentService {
     ) -> Result<PaymentCollectionStatusSnapshot, PortError> {
         let owner_operation = READ_COLLECTION_STATUS_OPERATION;
         require_payment_collection_read_admission(&context, owner_operation)?;
-        let tenant_id = parse_port_tenant_id(&context)?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
         let response = self
             .get_collection(tenant_id, request.collection_id)
             .await
@@ -242,12 +242,38 @@ fn log_payment_collection_admission_rejection(
     }
 }
 
-fn parse_port_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|_| {
-        PortError::validation(
+fn parse_port_tenant_id(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {
+        let error = PortError::validation(
             "payment.tenant_id_invalid",
             "PortContext.tenant_id must be a UUID for payment ports",
-        )
+        );
+        tracing::warn!(
+            parse_error = ?parse_error,
+            error = ?error,
+            owner = PAYMENT_COLLECTION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            operation = owner_operation,
+            validation = "tenant_id",
+            code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+            "payment collection tenant context was rejected"
+        );
+        error
     })
 }
 

--- a/scripts/verify/verify-payment-collection-admission-context.mjs
+++ b/scripts/verify/verify-payment-collection-admission-context.mjs
@@ -80,7 +80,7 @@ for (const [content, values, label] of [
     [
       'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
       'require_payment_collection_write_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context)?;',
+      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
     ],
     'write admission ordering',
   ],
@@ -89,7 +89,7 @@ for (const [content, values, label] of [
     [
       'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
       'require_payment_collection_read_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context)?;',
+      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
     ],
     'read admission ordering',
   ],
@@ -173,6 +173,7 @@ forbidText(readBlock, 'context.require_policy(', 'direct read policy admission')
 forbidText(source, 'context.require_policy(PortCallPolicy::write())?;', 'context-dropping write policy rejection');
 forbidText(source, 'context.require_write_semantics()?;', 'context-dropping write semantics rejection');
 forbidText(source, 'context.require_policy(PortCallPolicy::read())?;', 'context-dropping read policy rejection');
+forbidText(source, 'parse_port_tenant_id(&context)?', 'operation-free tenant parsing');
 
 if (failures.length > 0) {
   console.error('Payment collection admission context verification failed:');

--- a/scripts/verify/verify-payment-collection-tenant-context.mjs
+++ b/scripts/verify/verify-payment-collection-tenant-context.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-payment/src/ports.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const createBlock = between(
+  source,
+  '    async fn create_or_reuse_collection(',
+  '    async fn read_collection_status(',
+  'create or reuse implementation',
+);
+const readBlock = between(
+  source,
+  '    async fn read_collection_status(',
+  '\n}\n\nfn require_payment_collection_read_admission(',
+  'status read implementation',
+);
+const admissionBlock = between(
+  source,
+  'fn require_payment_collection_read_admission(',
+  'fn parse_port_tenant_id(',
+  'payment collection admission block',
+);
+const tenantParser = between(
+  source,
+  'fn parse_port_tenant_id(',
+  'fn payment_error_to_port_error(',
+  'tenant parser and diagnostics',
+);
+const ownerMapperStart = source.indexOf('fn payment_error_to_port_error(');
+if (ownerMapperStart < 0) failures.push('payment owner mapper: unable to isolate source block');
+const ownerMapper = ownerMapperStart >= 0 ? source.slice(ownerMapperStart) : '';
+
+for (const [value, label] of [
+  ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
+  ['const PAYMENT_COLLECTION_OWNER: &str = "rustok_payment";', 'truthful owner identity'],
+  ['const CREATE_OR_REUSE_COLLECTION_OPERATION: &str = "create_or_reuse_collection";', 'create owner operation'],
+  ['const READ_COLLECTION_STATUS_OPERATION: &str = "read_collection_status";', 'status owner operation'],
+]) requireText(source, value, label);
+
+for (const [content, values, label] of [
+  [
+    createBlock,
+    [
+      'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
+      'require_payment_collection_write_admission(&context, owner_operation)?;',
+      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+      'find_reusable_collection_by_cart(tenant_id, cart_id)',
+    ],
+    'create tenant parsing order',
+  ],
+  [
+    readBlock,
+    [
+      'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
+      'require_payment_collection_read_admission(&context, owner_operation)?;',
+      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+      'get_collection(tenant_id, request.collection_id)',
+    ],
+    'read tenant parsing order',
+  ],
+]) {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value);
+    if (index < 0) failures.push(`${label}: missing ${value}`);
+    if (index >= 0 && index <= previous) failures.push(`${label}: ${value} is out of order`);
+    previous = index;
+  }
+}
+
+const parserCalls = source.match(/parse_port_tenant_id\(&context, owner_operation\)\?/g) ?? [];
+if (parserCalls.length !== 2) {
+  failures.push(`expected two operation-aware tenant parser calls, found ${parserCalls.length}`);
+}
+
+for (const [value, label] of [
+  ['context: &PortContext', 'retained context input'],
+  ["owner_operation: &'static str", 'exact owner operation input'],
+  ['Uuid::parse_str(&context.tenant_id)', 'tenant UUID parsing'],
+  ['map_err(|parse_error|', 'parse failure mapping'],
+  ['let error = PortError::validation(', 'stable validation construction'],
+  ['"payment.tenant_id_invalid"', 'stable validation code'],
+  ['"PortContext.tenant_id must be a UUID for payment ports"', 'stable validation message'],
+  ['parse_error = ?parse_error', 'internal parse cause'],
+  ['error = ?error', 'mapped public error'],
+  ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['operation = owner_operation', 'exact operation field'],
+  ['validation = "tenant_id"', 'validation phase'],
+  ['code = %error.code', 'mapped code'],
+  ['internal_message = %error.message', 'mapped message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
+  ['tracing::warn!(', 'validation rejection severity'],
+  ['"payment collection tenant context was rejected"', 'tenant rejection event'],
+]) requireText(tenantParser, value, label);
+
+const validationIndex = tenantParser.indexOf('let error = PortError::validation(');
+const diagnosticsIndex = tenantParser.indexOf('tracing::warn!(');
+const returnIndex = tenantParser.lastIndexOf('\n        error');
+if (!(validationIndex >= 0 && validationIndex < diagnosticsIndex && diagnosticsIndex < returnIndex)) {
+  failures.push('tenant validation must be constructed, diagnosed, and then returned in order');
+}
+
+for (const [value, label] of [
+  ['log_payment_collection_admission_rejection(', 'admission diagnostics remain mounted'],
+  ['context.require_policy(PortCallPolicy::read())', 'read policy remains unchanged'],
+  ['context.require_policy(PortCallPolicy::write())', 'write policy remains unchanged'],
+  ['context.require_write_semantics()', 'write semantics remain unchanged'],
+]) requireText(admissionBlock, value, label);
+
+for (const [value, label] of [
+  ['"create_or_reuse_collection.read_existing"', 'existing lookup operation'],
+  ['"create_or_reuse_collection.adopt_race"', 'race adoption operation'],
+  ['"create_or_reuse_collection.create"', 'create operation'],
+  ['"payment provider outcome requires reconciliation"', 'stable reconciliation envelope'],
+  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
+]) requireText(ownerMapper, value, label);
+
+forbidText(source, 'parse_port_tenant_id(&context)?', 'operation-free tenant parser call');
+forbidText(
+  tenantParser,
+  'Uuid::parse_str(&context.tenant_id).map_err(|_|',
+  'silent tenant parse rejection',
+);
+forbidText(
+  tenantParser,
+  `PortError::validation(
+            "payment.tenant_id_invalid",
+            "PortContext.tenant_id must be a UUID for payment ports",
+        )
+    })`,
+  'undiagnosed tenant validation return',
+);
+
+if (failures.length > 0) {
+  console.error('Payment collection tenant context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Payment collection tenant UUID rejection retains exact owner context without changing admission, lifecycle, or public PortError behavior',
+);


### PR DESCRIPTION
## Summary

- pass the already-selected canonical payment owner operation into tenant UUID parsing for both `create_or_reuse_collection` and `read_collection_status`;
- construct the same `payment.tenant_id_invalid` validation `PortError` on UUID failure;
- record the UUID parse cause, truthful owner `rustok_payment`, exact owner operation, validation phase `tenant_id`, correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, mapped code/message/kind/retryability, and boundary `payment_collection_port` before returning that error;
- preserve warning severity for invalid caller/context identity;
- preserve admission ordering, policy/write-semantics requirements, tenant validation envelope, reusable lookup, create/race adoption, status projection, provider/lifecycle/reconciliation/storage mappings, public codes/messages, and retryability;
- synchronize the preceding admission verifier to the operation-aware parser signature;
- add a focused tenant-context verifier and source-ready/unvalidated evidence note.

## Scope

Four files only:

- `crates/rustok-payment/src/ports.rs`
- `scripts/verify/verify-payment-collection-admission-context.mjs`
- `scripts/verify/verify-payment-collection-tenant-context.mjs`
- `crates/rustok-payment/docs/payment-collection-tenant-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe payment mapper cleanup. It closes only `PaymentCollectionPort` tenant UUID rejection context. Remaining payment execution/compensation consumers, storefront customer reads, other owner adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or audit status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- diff contains exactly the four scoped files;
- both public operations pass their exact owner operation into tenant parsing after unchanged admission;
- the original tenant validation code, message, kind, and retryability remain statically guarded;
- full available `PortContext`, UUID parse cause, and explicit validation phase are guarded;
- diagnostics are required before returning the validation error;
- the preceding admission guard is synchronized without weakening admission assertions;
- existing collection lifecycle and provider/storage public envelopes remain intact;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-payment-collection-tenant-context.mjs
node scripts/verify/verify-payment-collection-admission-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment --lib
```