### PR TITLE
Retain storefront order customer read context

### DIFF
--- a/crates/rustok-commerce/docs/storefront-order-customer-read-context.md
+++ b/crates/rustok-commerce/docs/storefront-order-customer-read-context.md
@@ -1,0 +1,120 @@
+# Storefront order customer read context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the retained-context gap for customer projection reads in
+`crates/rustok-commerce/src/controllers/store/orders.rs`:
+
+- customer lookup used by storefront order-access and ownership helpers;
+- the `/store/customers/me` route.
+
+Both paths already delegated to the typed `CustomerReadPort` and mapped failures
+through `port_error_to_http_error`. Before this slice, they constructed
+`PortContext` inline and moved it into the customer owner call. The HTTP mapper
+therefore retained only the returned `PortError`, a consumer operation label, and
+an independently passed tenant UUID.
+
+The shared customer lookup in `controllers/store/mod.rs`, GraphQL customer helpers,
+checkout runtime consumers, and other adapters are deliberately outside this
+slice.
+
+## Delivered source contract
+
+Each order-surface customer read now:
+
+1. constructs one `customer_context` with the existing
+   `storefront_customer_port_context` helper;
+2. clones that context into
+   `CustomerReadPort::read_customer_projection_by_user`;
+3. retains the original context for failure diagnostics;
+4. maps the same `PortError` through the unchanged shared HTTP policy.
+
+The mapper attributes failures to:
+
+- truthful owner `rustok_customer`;
+- exact owner operation `read_customer_projection_by_user`;
+- the existing storefront consumer operation such as `get_me`, `get_order`, or an
+  order-access operation;
+- boundary `commerce_storefront_order_http`.
+
+Diagnostics retain:
+
+- correlation id and tenant id;
+- authenticated user id and typed actor;
+- channel and locale from the delegated context;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original owner code, internal message, typed kind, and retryability;
+- mapped public code and HTTP status.
+
+Unavailable, timeout, and invariant failures use error severity. Ordinary owner
+rejections use warning severity.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `CustomerReadPort` requests or response DTOs;
+- the existing customer context constructor, correlation format, actor, locale,
+  or two-second deadline;
+- `customer.customer_by_user_not_found -> Ok(None)` behavior in order-access
+  lookup;
+- `/store/customers/me` success response;
+- channel-enabled admission before the current-customer route;
+- customer-required and order-access-denied HTTP envelopes;
+- order ownership lookup and comparison;
+- verified customer ID reuse by the refund route;
+- order, return, refund, and order-change service calls;
+- pagination and filter forwarding;
+- payment refund diagnostics added by the preceding storefront refund slice;
+- `port_error_to_http_error` status, code, message, and retryability policy;
+- FBA, FFA, or ecommerce audit status.
+
+Raw owner evidence remains internal to structured diagnostics. The public HTTP
+response is still produced by `port_error_to_http_error` before being returned.
+
+## Static evidence
+
+`scripts/verify/verify-commerce-storefront-order-customer-context.mjs` guards:
+
+- stable customer owner, exact owner operation, and order HTTP boundary;
+- mapper inputs for the original `PortError`, retained `PortContext`, user ID, and
+  consumer operation;
+- technical versus ordinary rejection severity;
+- complete available context and original owner error fields;
+- mapped public code/status and mapper-before-diagnostics-before-return ordering;
+- exactly two retained customer contexts and two delegation clones;
+- operation-aware mapper use in order-access lookup and `/customers/me`;
+- unchanged customer-not-found fallback, channel guard, order ownership, and safe
+  public HTTP policy;
+- absence of the two old inline/context-dropping call forms.
+
+The existing broad storefront order HTTP and refund-context verifiers remain
+unchanged because their route, mapper-count, ownership, payment, and public-envelope
+contracts are preserved.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- the shared storefront customer lookup in `controllers/store/mod.rs`;
+- remaining payment execution and compensation consumers;
+- remaining order, fulfillment, inventory, customer, tax, and promotion adapters;
+- non-`PortError` public envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-order-customer-context.mjs
+node scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -4,6 +4,7 @@ use axum::{
     http::StatusCode,
 };
 use rustok_api::{PortError, RequestContext, TenantContext};
+use rustok_api::{PortContext, PortErrorKind};
 use rustok_customer::dto::CustomerResponse;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
 use rustok_order::{OrderService, error::OrderError};
@@ -23,6 +24,9 @@ use crate::dto::{
     OrderChangeResponse, OrderResponse, OrderReturnResponse, RefundResponse,
 };
 
+const STOREFRONT_ORDER_CUSTOMER_OWNER: &str = "rustok_customer";
+const STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";
+const STOREFRONT_ORDER_CUSTOMER_BOUNDARY: &str = "commerce_storefront_order_http";
 const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
 const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
 
@@ -68,17 +72,66 @@ impl<'a> StorefrontOrderPaymentErrorContext<'a> {
 
 fn map_storefront_customer_port_error(
     error: PortError,
-    operation: &'static str,
-    tenant_id: Uuid,
+    context: &PortContext,
+    user_id: Uuid,
+    consumer_operation: &'static str,
 ) -> HttpError {
-    tracing::error!(
-        error = ?error,
-        operation,
-        tenant_id = %tenant_id,
-        boundary = "commerce_storefront_order_http",
-        "storefront customer read failed"
-    );
-    port_error_to_http_error(error)
+    let public = port_error_to_http_error(error.clone());
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner = STOREFRONT_ORDER_CUSTOMER_OWNER,
+                owner_operation = STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION,
+                consumer_operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                user_id = %user_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                public_code = %public.code,
+                status = %public.status,
+                boundary = STOREFRONT_ORDER_CUSTOMER_BOUNDARY,
+                "storefront customer read failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner = STOREFRONT_ORDER_CUSTOMER_OWNER,
+                owner_operation = STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION,
+                consumer_operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                user_id = %user_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                public_code = %public.code,
+                status = %public.status,
+                boundary = STOREFRONT_ORDER_CUSTOMER_BOUNDARY,
+                "storefront customer read was rejected"
+            );
+        }
+    }
+    public
 }
 
 fn map_storefront_order_error(
@@ -252,9 +305,10 @@ async fn current_storefront_customer_id(
     auth: &rustok_api::AuthContext,
     operation: &'static str,
 ) -> HttpResult<Option<Uuid>> {
+    let customer_context = super::storefront_customer_port_context(tenant_id, auth.user_id);
     match in_process_customer_read_port(runtime.db_clone())
         .read_customer_projection_by_user(
-            super::storefront_customer_port_context(tenant_id, auth.user_id),
+            customer_context.clone(),
             CustomerUserProjectionRequest {
                 user_id: auth.user_id,
             },
@@ -264,7 +318,10 @@ async fn current_storefront_customer_id(
         Ok(customer) => Ok(Some(customer.id)),
         Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None),
         Err(error) => Err(map_storefront_customer_port_error(
-            error, operation, tenant_id,
+            error,
+            &customer_context,
+            auth.user_id,
+            operation,
         )),
     }
 }
@@ -317,15 +374,18 @@ pub async fn get_me(
 ) -> HttpResult<Json<CustomerResponse>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
+    let customer_context = super::storefront_customer_port_context(tenant.id, auth.user_id);
     let customer = in_process_customer_read_port(runtime.db_clone())
         .read_customer_projection_by_user(
-            super::storefront_customer_port_context(tenant.id, auth.user_id),
+            customer_context.clone(),
             CustomerUserProjectionRequest {
                 user_id: auth.user_id,
             },
         )
         .await
-        .map_err(|error| map_storefront_customer_port_error(error, "get_me", tenant.id))?;
+        .map_err(|error| {
+            map_storefront_customer_port_error(error, &customer_context, auth.user_id, "get_me")
+        })?;
     Ok(Json(customer))
 }
 

--- a/scripts/verify/verify-commerce-storefront-order-customer-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-customer-context.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const webErrors = read('crates/rustok-web/src/lib.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const customerMapper = between(
+  controller,
+  'fn map_storefront_customer_port_error(',
+  'fn map_storefront_order_error(',
+  'storefront order customer mapper',
+);
+const customerLookup = between(
+  controller,
+  'async fn current_storefront_customer_id(',
+  'async fn ensure_customer_owns_order(',
+  'storefront order customer lookup',
+);
+const ownership = between(
+  controller,
+  'async fn ensure_customer_owns_order(',
+  '/// Get current storefront customer',
+  'storefront order ownership helper',
+);
+const getMe = between(
+  controller,
+  'pub async fn get_me(',
+  '/// Get customer-owned storefront order',
+  'storefront current-customer route',
+);
+
+for (const [value, label] of [
+  ['use rustok_api::{PortContext, PortErrorKind};', 'retained context imports'],
+  ['const STOREFRONT_ORDER_CUSTOMER_OWNER: &str = "rustok_customer";', 'truthful customer owner'],
+  [
+    'const STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";',
+    'exact customer owner operation',
+  ],
+  [
+    'const STOREFRONT_ORDER_CUSTOMER_BOUNDARY: &str = "commerce_storefront_order_http";',
+    'order customer boundary',
+  ],
+]) requireText(controller, value, label);
+
+for (const [value, label] of [
+  ['error: PortError', 'original port error input'],
+  ['context: &PortContext', 'retained context input'],
+  ['user_id: Uuid', 'user identity input'],
+  ["consumer_operation: &'static str", 'consumer operation input'],
+  ['let public = port_error_to_http_error(error.clone());', 'unchanged safe HTTP mapping'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'technical severity classification',
+  ],
+  ['tracing::error!(', 'technical error severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
+  ['error = ?error', 'original error evidence'],
+  ['owner = STOREFRONT_ORDER_CUSTOMER_OWNER', 'owner field'],
+  ['owner_operation = STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION', 'owner operation field'],
+  ['consumer_operation,', 'consumer operation field'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['user_id = %user_id', 'user context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['internal_code = %error.code', 'internal owner code'],
+  ['internal_message = %error.message', 'internal owner message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['public_code = %public.code', 'public code'],
+  ['status = %public.status', 'public status'],
+  ['boundary = STOREFRONT_ORDER_CUSTOMER_BOUNDARY', 'boundary field'],
+  ['"storefront customer read failed"', 'technical event'],
+  ['"storefront customer read was rejected"', 'ordinary rejection event'],
+  ['\n    public\n}', 'mapped HTTP return'],
+]) requireText(customerMapper, value, label);
+
+const publicIndex = customerMapper.indexOf('let public = port_error_to_http_error(error.clone());');
+const diagnosticIndex = customerMapper.indexOf('match &error.kind');
+const returnIndex = customerMapper.lastIndexOf('\n    public');
+if (!(publicIndex >= 0 && publicIndex < diagnosticIndex && diagnosticIndex < returnIndex)) {
+  failures.push('customer error must be mapped, diagnosed, and then returned in order');
+}
+
+for (const [content, values, label] of [
+  [
+    customerLookup,
+    [
+      'let customer_context = super::storefront_customer_port_context(tenant_id, auth.user_id);',
+      'read_customer_projection_by_user(',
+      'customer_context.clone(),',
+      'CustomerUserProjectionRequest {',
+      'user_id: auth.user_id,',
+      'Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)',
+      '&customer_context,',
+      'auth.user_id,',
+      'operation,',
+    ],
+    'order-access customer lookup',
+  ],
+  [
+    getMe,
+    [
+      'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
+      'let customer_context = super::storefront_customer_port_context(tenant.id, auth.user_id);',
+      'read_customer_projection_by_user(',
+      'customer_context.clone(),',
+      'CustomerUserProjectionRequest {',
+      'user_id: auth.user_id,',
+      'map_storefront_customer_port_error(error, &customer_context, auth.user_id, "get_me")',
+      'Ok(Json(customer))',
+    ],
+    'current-customer route',
+  ],
+]) {
+  for (const value of values) requireText(content, value, label);
+}
+
+for (const [value, label] of [
+  ['current_storefront_customer_id(runtime, tenant_id, auth, operation)', 'ownership lookup reuse'],
+  ['.get_order(tenant_id, order_id)', 'order ownership read'],
+  ['order.customer_id != Some(customer_id)', 'ownership comparison'],
+  ['"commerce_store_customer_required"', 'customer-required envelope'],
+  ['"commerce_store_order_access_denied"', 'access-denied envelope'],
+  ['Ok(customer_id)', 'verified customer identity return'],
+]) requireText(ownership, value, label);
+
+const contextBindings = controller.match(/let customer_context = super::storefront_customer_port_context\(/g) ?? [];
+if (contextBindings.length !== 2) {
+  failures.push(`expected two retained customer contexts, found ${contextBindings.length}`);
+}
+const contextClones = controller.match(/customer_context\.clone\(\),/g) ?? [];
+if (contextClones.length !== 2) {
+  failures.push(`expected two customer context delegation clones, found ${contextClones.length}`);
+}
+const mapperUses = controller.match(/map_storefront_customer_port_error\(/g) ?? [];
+if (mapperUses.length !== 3) {
+  failures.push(`expected customer mapper definition plus two uses, found ${mapperUses.length}`);
+}
+
+for (const value of [
+  'read_customer_projection_by_user(\n            super::storefront_customer_port_context(',
+  'map_storefront_customer_port_error(\n            error, operation, tenant_id',
+  'map_storefront_customer_port_error(error, "get_me", tenant.id)',
+]) forbidText(controller, value, 'context-dropping customer mapping');
+
+for (const value of [
+  'PortErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE',
+  'PortErrorKind::Timeout => StatusCode::GATEWAY_TIMEOUT',
+  'PortErrorKind::InvariantViolation => StatusCode::INTERNAL_SERVER_ERROR',
+  '"The requested service is temporarily unavailable"',
+  '"The requested operation could not be completed"',
+]) requireText(webErrors, value, 'shared safe HTTP contract');
+
+if (failures.length > 0) {
+  console.error('Commerce storefront order customer-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront order customer reads retain the delegated PortContext and preserve safe HTTP envelopes and ownership behavior',
+);


### PR DESCRIPTION
## Summary

- retain one `PortContext` for the storefront order-access customer projection lookup;
- retain one separate `PortContext` for `/store/customers/me`;
- clone each retained context into `CustomerReadPort::read_customer_projection_by_user` while keeping the original available for HTTP-boundary diagnostics;
- attribute failures to truthful owner `rustok_customer`, exact owner operation `read_customer_projection_by_user`, the existing consumer operation, and boundary `commerce_storefront_order_http`;
- record correlation id, tenant, authenticated user, actor, channel, locale, causation id, traceparent, idempotency key, deadline, original owner code/message/kind/retryability, mapped public code, and HTTP status;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary owner rejection;
- preserve `port_error_to_http_error` as the public mapping policy;
- preserve customer-not-found fallback, current-customer success behavior, channel admission, order ownership checks, verified customer reuse, order/refund routes, pagination, and existing payment diagnostics;
- add a focused static verifier and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/controllers/store/orders.rs`
- `scripts/verify/verify-commerce-storefront-order-customer-context.mjs`
- `crates/rustok-commerce/docs/storefront-order-customer-read-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe customer/ecommerce mapper cleanup. It closes only storefront order-surface customer read context retention. The shared customer lookup in `controllers/store/mod.rs`, remaining payment execution/compensation consumers, other owner adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or audit status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- diff contains exactly the three scoped files;
- exactly two retained customer contexts, two delegation clones, and two context-aware mapper uses are statically guarded;
- diagnostics execute after unchanged safe HTTP mapping and before returning the mapped error;
- the `customer.customer_by_user_not_found -> Ok(None)` fallback and ownership behavior remain guarded;
- existing broad storefront order and refund verifiers remain structurally compatible;
- concurrent Notifications and toolchain commits do not overlap this slice;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-storefront-order-customer-context.mjs
node scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
node scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce --lib
```