### PR TITLE
Retain storefront staged owner port context

### DIFF
--- a/crates/rustok-commerce/docs/storefront-staged-owner-port-context.md
+++ b/crates/rustok-commerce/docs/storefront-staged-owner-port-context.md
@@ -1,0 +1,133 @@
+# Storefront staged checkout owner-port context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the owner-attribution and retained-context gap for the two
+owner-port reads mounted directly in
+`crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs`:
+
+- `CartStorefrontPort::read_storefront_cart`;
+- `CustomerReadPort::read_customer_projection_by_user`.
+
+Both callsites already retained and cloned a `PortContext`. Before this slice, the
+shared runtime mapper received that context and the exact operation, but did not
+receive truthful owner identity. Its diagnostics recorded only correlation id,
+tenant id, owner code, and typed kind, used error severity for every failure, and
+did not record actor, channel, locale, deadline, internal message, retryability, or
+the selected public runtime outcome.
+
+The shared storefront lookup in `controllers/store/mod.rs`, HTTP transport mappers,
+checkout stage internals, payment execution/compensation consumers, and other owner
+adapters remain separate concerns.
+
+## Delivered source contract
+
+The cart read now passes:
+
+- truthful owner `rustok_cart`;
+- exact operation `read_storefront_cart`;
+- the existing retained cart `PortContext`;
+- the existing `CartAccess` fallback.
+
+The authenticated customer read now passes:
+
+- truthful owner `rustok_customer`;
+- exact operation `read_customer_projection_by_user`;
+- the existing retained customer `PortContext`;
+- the existing `CartAccess` fallback.
+
+The shared owner-port mapper now:
+
+1. selects the same public runtime outcome before diagnostics;
+2. maps only `Unavailable` and `Timeout` to `TemporarilyUnavailable`;
+3. preserves the supplied fallback for every other owner error kind;
+4. records the complete available owner and delegated context;
+5. returns the already selected public runtime outcome after diagnostics.
+
+Diagnostics record:
+
+- truthful owner and exact owner operation;
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original owner code, internal message, typed kind, and retryability;
+- mapped public runtime code and retryability;
+- boundary `commerce_storefront_staged_checkout_runtime`.
+
+Unavailable, timeout, and invariant failures use error severity. Ordinary owner
+rejections use warning severity. Invariant failures retain their pre-existing
+fallback outcome; severity classification does not change public behavior.
+
+## Preserved behavior
+
+This slice does not change:
+
+- public `StorefrontStagedCheckoutRuntimeError` variants;
+- public codes, messages, or retryability;
+- idempotency-key validation;
+- cart request identity or retained cart context construction;
+- cart locale, country, and region fallback;
+- customer context construction or two-second deadline;
+- anonymous-customer behavior;
+- `customer.customer_by_user_not_found -> Ok(None)` behavior;
+- customer-owned cart access checks;
+- actor-id resolution;
+- pricing resolver or atomic-cart composition;
+- inventory reservation identity wiring;
+- checkout plan, marketplace, payment-provider, staged, compensation, or recovery
+  composition;
+- recovery error mapping for reconciliation, compensation pending, journal, or
+  staged failures;
+- REST, GraphQL, native, or mounted facade delegation;
+- FBA, FFA, or ecommerce audit status.
+
+## Static evidence
+
+`scripts/verify/verify-commerce-storefront-staged-owner-context.mjs` guards:
+
+- stable cart/customer owner constants and runtime boundary;
+- one truthful cart owner callsite and one truthful customer owner callsite;
+- retained context clones and exact operations;
+- unchanged cart/customer fallback inputs;
+- mapper inputs for context, owner, operation, original error, and fallback;
+- unchanged `Unavailable | Timeout -> TemporarilyUnavailable` classification;
+- unchanged fallback behavior for all other kinds;
+- technical versus ordinary rejection severity;
+- complete available context and owner error fields;
+- mapped public code/retryability before returning the selected outcome;
+- unchanged customer-not-found behavior;
+- unchanged checkout composition and recovery mapper;
+- absence of the two old owner-free mapper call forms.
+
+The existing
+`scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs` remains
+structurally compatible because mounted delegation, checkout composition, public
+runtime error contracts, and recovery diagnostics are unchanged.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- the shared storefront customer lookup in `controllers/store/mod.rs`;
+- remaining payment execution and compensation consumers;
+- remaining order, fulfillment, inventory, customer, tax, promotion, and ecommerce
+  adapters;
+- non-`PortError` public envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-staged-owner-context.mjs
+node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
+node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
+++ b/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
@@ -18,6 +18,8 @@ use crate::storefront_checkout_runtime::{
 };
 
 const STOREFRONT_STAGED_CHECKOUT_OWNER: &str = "rustok_commerce.recovering_staged_checkout";
+const STOREFRONT_STAGED_CHECKOUT_CART_OWNER: &str = "rustok_cart";
+const STOREFRONT_STAGED_CHECKOUT_CUSTOMER_OWNER: &str = "rustok_customer";
 const STOREFRONT_STAGED_CHECKOUT_BOUNDARY: &str = "commerce_storefront_staged_checkout_runtime";
 
 #[derive(Debug, Error)]
@@ -148,6 +150,7 @@ pub async fn complete_storefront_checkout_input(
         .map_err(|error| {
             map_owner_port_error(
                 &cart_port_context,
+                STOREFRONT_STAGED_CHECKOUT_CART_OWNER,
                 "read_storefront_cart",
                 error,
                 StorefrontStagedCheckoutRuntimeError::CartAccess,
@@ -292,6 +295,7 @@ async fn resolve_customer_id(
         Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None),
         Err(error) => Err(map_owner_port_error(
             &context,
+            STOREFRONT_STAGED_CHECKOUT_CUSTOMER_OWNER,
             "read_customer_projection_by_user",
             error,
             StorefrontStagedCheckoutRuntimeError::CartAccess,
@@ -325,25 +329,68 @@ fn cart_context(
 
 fn map_owner_port_error(
     context: &PortContext,
+    owner: &'static str,
     operation: &'static str,
     error: PortError,
     fallback: StorefrontStagedCheckoutRuntimeError,
 ) -> StorefrontStagedCheckoutRuntimeError {
-    tracing::error!(
-        error = ?error,
-        correlation_id = %context.correlation_id,
-        tenant_id = %context.tenant_id,
-        operation,
-        owner_code = %error.code,
-        owner_kind = ?error.kind,
-        "storefront checkout owner port failed"
-    );
-    match error.kind {
+    let public = match &error.kind {
         PortErrorKind::Unavailable | PortErrorKind::Timeout => {
             StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable
         }
         _ => fallback,
+    };
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner,
+                operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                public_code = public.public_code(),
+                public_retryable = public.retryable(),
+                boundary = STOREFRONT_STAGED_CHECKOUT_BOUNDARY,
+                "storefront checkout owner port failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner,
+                operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                public_code = public.public_code(),
+                public_retryable = public.retryable(),
+                boundary = STOREFRONT_STAGED_CHECKOUT_BOUNDARY,
+                "storefront checkout owner port was rejected"
+            );
+        }
     }
+    public
 }
 
 fn map_checkout_error(

--- a/scripts/verify/verify-commerce-storefront-staged-owner-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-staged-owner-context.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const completion = between(
+  source,
+  'pub async fn complete_storefront_checkout_input(',
+  'async fn resolve_customer_id(',
+  'staged checkout completion',
+);
+const customerLookup = between(
+  source,
+  'async fn resolve_customer_id(',
+  'fn cart_context(',
+  'staged customer lookup',
+);
+const ownerMapper = between(
+  source,
+  'fn map_owner_port_error(',
+  'fn map_checkout_error(',
+  'staged owner-port mapper',
+);
+const recoveryMapper = source.slice(source.indexOf('fn map_checkout_error('));
+
+for (const [value, label] of [
+  [
+    'const STOREFRONT_STAGED_CHECKOUT_CART_OWNER: &str = "rustok_cart";',
+    'truthful cart owner',
+  ],
+  [
+    'const STOREFRONT_STAGED_CHECKOUT_CUSTOMER_OWNER: &str = "rustok_customer";',
+    'truthful customer owner',
+  ],
+  [
+    'const STOREFRONT_STAGED_CHECKOUT_BOUNDARY: &str = "commerce_storefront_staged_checkout_runtime";',
+    'stable runtime boundary',
+  ],
+]) requireText(source, value, label);
+
+for (const [content, values, label] of [
+  [
+    completion,
+    [
+      'let cart_port_context = cart_context(',
+      'read_storefront_cart(',
+      'cart_port_context.clone(),',
+      '&cart_port_context,',
+      'STOREFRONT_STAGED_CHECKOUT_CART_OWNER,',
+      '"read_storefront_cart",',
+      'StorefrontStagedCheckoutRuntimeError::CartAccess,',
+    ],
+    'cart owner delegation',
+  ],
+  [
+    customerLookup,
+    [
+      'let context = PortContext::new(',
+      'read_customer_projection_by_user(',
+      'context.clone(),',
+      'Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)',
+      '&context,',
+      'STOREFRONT_STAGED_CHECKOUT_CUSTOMER_OWNER,',
+      '"read_customer_projection_by_user",',
+      'StorefrontStagedCheckoutRuntimeError::CartAccess,',
+    ],
+    'customer owner delegation',
+  ],
+]) {
+  for (const value of values) requireText(content, value, label);
+}
+
+for (const [value, label] of [
+  ['context: &PortContext', 'retained context input'],
+  ["owner: &'static str", 'truthful owner input'],
+  ["operation: &'static str", 'exact operation input'],
+  ['error: PortError', 'original port error input'],
+  ['fallback: StorefrontStagedCheckoutRuntimeError', 'preserved fallback input'],
+  ['let public = match &error.kind', 'public classification before diagnostics'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout =>',
+    'unchanged temporary classification',
+  ],
+  ['StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable', 'temporary public outcome'],
+  ['_ => fallback,', 'unchanged non-temporary fallback'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'technical severity classification',
+  ],
+  ['tracing::error!(', 'technical severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
+  ['error = ?error', 'original error evidence'],
+  ['owner,', 'truthful owner field'],
+  ['operation,', 'exact operation field'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['internal_code = %error.code', 'owner error code'],
+  ['internal_message = %error.message', 'owner internal message'],
+  ['error_kind = ?error.kind', 'typed owner kind'],
+  ['owner_retryable = error.retryable', 'owner retryability'],
+  ['public_code = public.public_code()', 'mapped public code'],
+  ['public_retryable = public.retryable()', 'mapped public retryability'],
+  ['boundary = STOREFRONT_STAGED_CHECKOUT_BOUNDARY', 'runtime boundary field'],
+  ['"storefront checkout owner port failed"', 'technical event'],
+  ['"storefront checkout owner port was rejected"', 'rejection event'],
+  ['\n    public\n}', 'mapped public return'],
+]) requireText(ownerMapper, value, label);
+
+const publicIndex = ownerMapper.indexOf('let public = match &error.kind');
+const diagnosticsIndex = ownerMapper.indexOf('match &error.kind', publicIndex + 1);
+const returnIndex = ownerMapper.lastIndexOf('\n    public');
+if (!(publicIndex >= 0 && publicIndex < diagnosticsIndex && diagnosticsIndex < returnIndex)) {
+  failures.push('owner error must be classified, diagnosed, and then returned in order');
+}
+
+const mapperCalls = source.match(/map_owner_port_error\(/g) ?? [];
+if (mapperCalls.length !== 3) {
+  failures.push(`expected owner mapper definition plus two uses, found ${mapperCalls.length}`);
+}
+const cartOwnerUses = source.match(/STOREFRONT_STAGED_CHECKOUT_CART_OWNER/g) ?? [];
+if (cartOwnerUses.length !== 2) {
+  failures.push(`expected cart owner constant plus one use, found ${cartOwnerUses.length}`);
+}
+const customerOwnerUses = source.match(/STOREFRONT_STAGED_CHECKOUT_CUSTOMER_OWNER/g) ?? [];
+if (customerOwnerUses.length !== 2) {
+  failures.push(`expected customer owner constant plus one use, found ${customerOwnerUses.length}`);
+}
+
+for (const [value, label] of [
+  ['checkout_input.shipping_selections.clone()', 'shipping selection preservation'],
+  ['with_payment_provider_registry(payment_provider_registry.clone())', 'provider registry composition'],
+  ['RecoveringStagedCheckoutService::new(staged, compensation)', 'recovery composition'],
+  ['map_checkout_error(&cart_port_context, cart_id, actor_id, error)', 'recovery mapper use'],
+]) requireText(completion, value, label);
+
+for (const [value, label] of [
+  ['owner = STOREFRONT_STAGED_CHECKOUT_OWNER', 'recovery owner identity'],
+  ['operation = "complete_storefront_checkout"', 'recovery operation'],
+  ['StorefrontStagedCheckoutRuntimeError::ReconciliationRequired', 'reconciliation outcome'],
+  ['StorefrontStagedCheckoutRuntimeError::CompensationPending', 'compensation outcome'],
+  ['StorefrontStagedCheckoutRuntimeError::CheckoutFailed', 'checkout failure outcome'],
+]) requireText(recoveryMapper, value, label);
+
+forbidText(
+  source,
+  `map_owner_port_error(
+                &cart_port_context,
+                "read_storefront_cart",`,
+  'owner-free cart mapper call',
+);
+forbidText(
+  source,
+  `map_owner_port_error(
+            &context,
+            "read_customer_projection_by_user",`,
+  'owner-free customer mapper call',
+);
+forbidText(ownerMapper, 'tracing::error!(\n        error = ?error,', 'single-severity legacy mapper');
+forbidText(ownerMapper, 'match error.kind {', 'post-diagnostic legacy classification');
+
+if (failures.length > 0) {
+  console.error('Commerce storefront staged owner-context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Mounted storefront staged cart/customer owner-port failures retain truthful owner context and preserve runtime outcomes',
+);


### PR DESCRIPTION
## Summary

- pass truthful owner `rustok_cart` for `read_storefront_cart` and `rustok_customer` for `read_customer_projection_by_user` into the shared staged-runtime owner mapper;
- retain the existing cart/customer `PortContext` and exact owner operation;
- classify the same public runtime outcome before diagnostics: only `Unavailable` and `Timeout` become `TemporarilyUnavailable`, while every other kind keeps the existing fallback;
- record correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, internal code/message, typed kind, owner retryability, mapped public code/retryability, truthful owner, exact operation, and runtime boundary;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary owner rejection;
- preserve cart/customer requests, not-found behavior, cart-access fallback, checkout composition, recovery mapping, mounted transport convergence, and all public runtime codes/messages/retryability;
- add a focused static verifier and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs`
- `scripts/verify/verify-commerce-storefront-staged-owner-context.mjs`
- `crates/rustok-commerce/docs/storefront-staged-owner-port-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe customer/cart consumer cleanup. It closes only the two owner-port reads mounted directly in the storefront staged checkout runtime. The shared storefront customer lookup in `controllers/store/mod.rs`, payment execution/compensation consumers, other adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or audit status is promoted.

## Validation

- branch is three scoped commits ahead of current `main` and zero commits behind;
- diff contains exactly the three scoped files;
- one truthful cart owner callsite and one truthful customer owner callsite are guarded;
- unchanged public classification and fallback behavior are guarded;
- full available retained context, internal owner evidence, mapped public outcome, severity, and diagnostic ordering are guarded;
- checkout composition and recovery mapper remain guarded;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-storefront-staged-owner-context.mjs
node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce --lib
```