### PR TITLE
Retain GraphQL cart helper customer context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-cart-helper-customer-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-helper-customer-context.md
@@ -86,7 +86,7 @@ the public GraphQL envelope.
 ## Static evidence
 
 The existing
-` scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs` guard was
+`scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs` guard was
 strengthened rather than adding a duplicate verifier. It now guards:
 
 - stable GraphQL boundary plus truthful customer owner and exact owner operation;

--- a/crates/rustok-commerce/docs/graphql-cart-helper-customer-context.md
+++ b/crates/rustok-commerce/docs/graphql-cart-helper-customer-context.md
@@ -1,0 +1,134 @@
+# GraphQL cart-helper customer context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the retained-context and diagnostic-severity gap for the
+optional customer projection read in
+`crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs`:
+
+- `resolve_optional_storefront_customer_id`;
+- `CustomerReadPort::read_customer_projection_by_user`;
+- the customer-specific `PortError -> async_graphql::Error` mapper used by that
+  helper.
+
+The preceding GraphQL cart-helper hardening established stable public customer,
+cart, pricing, and intercepted legacy-helper envelopes. Before this follow-up, the
+customer path created one `PortContext`, cloned it into a separate `error_context`,
+and moved the original into the owner call. Its mapper recorded correlation and
+tenant identity but omitted the rest of the delegated context, did not identify the
+exact owner operation separately from the consumer helper operation, and used error
+severity for every owner rejection.
+
+GraphQL query resolvers, the shared HTTP storefront helper in
+`controllers/store/mod.rs`, order/shipping helpers, cart/pricing mapper context, and
+legacy helper internals remain outside this slice.
+
+## Delivered source contract
+
+The optional customer helper now:
+
+1. creates one `customer_context` with the existing context constructor;
+2. clones that context into
+   `CustomerReadPort::read_customer_projection_by_user`;
+3. retains the original context for the GraphQL boundary mapper;
+4. preserves the existing optional-customer not-found behavior;
+5. passes the existing consumer operation
+   `resolve_optional_storefront_customer_id` to diagnostics.
+
+The customer mapper attributes failures to:
+
+- truthful owner `rustok_customer`;
+- exact owner operation `read_customer_projection_by_user`;
+- consumer operation `resolve_optional_storefront_customer_id`;
+- boundary `commerce_graphql_storefront_cart_helper`.
+
+Diagnostics retain:
+
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original owner code, internal message, typed kind, and retryability;
+- the already selected public GraphQL code and retryability.
+
+Unavailable, timeout, and invariant failures use error severity. Validation,
+not-found, conflict, and forbidden owner rejections use warning severity.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the external signature of `resolve_optional_storefront_customer_id`;
+- anonymous-authentication behavior (`None -> Ok(None)`);
+- `customer.customer_by_user_not_found -> Ok(None)` behavior;
+- the customer projection request or authenticated user identity;
+- the existing customer context correlation format, actor, fallback locale, or
+  two-second deadline;
+- public customer GraphQL messages, codes, or retryability:
+  - `CUSTOMER_REQUEST_INVALID`;
+  - `CUSTOMER_NOT_FOUND`;
+  - `CUSTOMER_STATE_CONFLICT`;
+  - `CUSTOMER_ACCESS_DENIED`;
+  - `CUSTOMER_TEMPORARILY_UNAVAILABLE`;
+  - `CUSTOMER_OPERATION_FAILED`;
+- the shared `public_graphql_error` extension shape;
+- cart/pricing source-owner classification and cart public envelopes;
+- intercepted shipping, line-item, inventory, enrichment, and repricing helper
+  envelopes;
+- private module routing and the crate-private legacy-helper facade;
+- FBA, FFA, or ecommerce audit status.
+
+Raw owner messages remain internal to structured diagnostics and are not copied into
+the public GraphQL envelope.
+
+## Static evidence
+
+The existing
+` scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs` guard was
+strengthened rather than adding a duplicate verifier. It now guards:
+
+- stable GraphQL boundary plus truthful customer owner and exact owner operation;
+- one retained customer context and one delegation clone;
+- operation-aware customer mapper use;
+- complete available `PortContext` and original owner error fields;
+- technical versus ordinary rejection severity;
+- unchanged customer message/code/retryability policy before diagnostics and return;
+- unchanged anonymous and customer-not-found behavior;
+- unchanged cart/pricing and intercepted legacy-helper contracts;
+- absence of the old `port_context` / `error_context` split and owner-free log form.
+
+The verifier was also synchronized with the current source by replacing three stale
+assertions that contradicted the facade:
+
+- the crate-private legacy re-export is now required rather than forbidden;
+- the operation list no longer requires a helper that is not implemented in this
+  facade;
+- the intercepted legacy-call count now reflects the five actual calls.
+
+These verifier corrections do not change production behavior.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- optional and authenticated customer reads in `graphql/query.rs`;
+- the shared storefront customer lookup in `controllers/store/mod.rs`;
+- remaining payment execution and compensation consumers;
+- remaining order, fulfillment, inventory, customer, tax, promotion, and ecommerce
+  adapters;
+- remaining cart/pricing and non-`PortError` public envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -9,6 +9,8 @@ use super::super::types::AddStorefrontCartLineItemInput;
 pub(crate) use super::legacy_helpers::*;
 
 const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";
+const STOREFRONT_CUSTOMER_OWNER: &str = "rustok_customer";
+const STOREFRONT_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";
 
 fn public_graphql_error(
     message: &'static str,
@@ -33,7 +35,7 @@ fn storefront_customer_port_context(tenant_id: Uuid, user_id: Uuid) -> PortConte
 
 fn customer_port_graphql_error(
     context: &PortContext,
-    operation: &'static str,
+    consumer_operation: &'static str,
     error: PortError,
 ) -> async_graphql::Error {
     let (message, code, retryable) = match &error.kind {
@@ -65,20 +67,58 @@ fn customer_port_graphql_error(
         ),
     };
 
-    tracing::error!(
-        error = ?error,
-        owner = "rustok_customer",
-        correlation_id = %context.correlation_id,
-        tenant_id = %context.tenant_id,
-        operation,
-        owner_code = %error.code,
-        owner_kind = ?error.kind,
-        owner_retryable = error.retryable,
-        public_code = code,
-        public_retryable = retryable,
-        boundary = STOREFRONT_CART_HELPER_BOUNDARY,
-        "commerce GraphQL storefront customer owner port failed"
-    );
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner = STOREFRONT_CUSTOMER_OWNER,
+                owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
+                consumer_operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                public_code = code,
+                public_retryable = retryable,
+                boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+                "commerce GraphQL storefront customer owner port failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner = STOREFRONT_CUSTOMER_OWNER,
+                owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
+                consumer_operation,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                owner_retryable = error.retryable,
+                public_code = code,
+                public_retryable = retryable,
+                boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+                "commerce GraphQL storefront customer owner port was rejected"
+            );
+        }
+    }
 
     public_graphql_error(message, code, retryable)
 }
@@ -147,11 +187,10 @@ pub(crate) async fn resolve_optional_storefront_customer_id(
         return Ok(None);
     };
 
-    let port_context = storefront_customer_port_context(tenant_id, auth.user_id);
-    let error_context = port_context.clone();
+    let customer_context = storefront_customer_port_context(tenant_id, auth.user_id);
     match in_process_customer_read_port(db.clone())
         .read_customer_projection_by_user(
-            port_context,
+            customer_context.clone(),
             CustomerUserProjectionRequest {
                 user_id: auth.user_id,
             },
@@ -161,7 +200,7 @@ pub(crate) async fn resolve_optional_storefront_customer_id(
         Ok(customer) => Ok(Some(customer.id)),
         Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None),
         Err(error) => Err(customer_port_graphql_error(
-            &error_context,
+            &customer_context,
             "resolve_optional_storefront_customer_id",
             error,
         )),

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -46,15 +46,16 @@ for (const [value, label] of [
   ['#[path = "helpers.rs"]\nmod legacy_helpers;', 'private legacy helper routing'],
   ['#[path = "safe_helpers.rs"]\nmod cart_safe_helpers;', 'private cart safe helper routing'],
   ['#[path = "safe_order_helpers.rs"]\npub mod helpers;', 'public layered safe helper routing'],
+  ['pub(crate) use super::legacy_helpers::*;', 'crate-private legacy helper facade'],
 ]) {
-  requireText(moduleSource, value, label);
+  requireText(`${moduleSource}\n${facadeSource}`, value, label);
 }
 
 for (const value of [
   'async_graphql::Error::new(error.message)',
   'async_graphql::Error::new(error.to_string())',
   'async_graphql::Error::new(format!("{error}"))',
-  'pub(crate) use super::legacy_helpers::*',
+  'pub use super::legacy_helpers::*;',
 ]) {
   forbidText(facadeSource, value, 'storefront cart safe helper facade');
 }

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -19,6 +19,28 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const customerMapper = between(
+  facadeSource,
+  'fn customer_port_graphql_error(',
+  'fn cart_port_source_owner(',
+  'customer GraphQL mapper',
+);
+const customerLookup = between(
+  facadeSource,
+  'pub(crate) async fn resolve_optional_storefront_customer_id(',
+  'fn legacy_graphql_error(',
+  'optional storefront customer lookup',
+);
 
 for (const [value, label] of [
   ['#[path = "helpers.rs"]\nmod legacy_helpers;', 'private legacy helper routing'],
@@ -39,39 +61,26 @@ for (const value of [
 
 for (const [value, label] of [
   ['PortError, PortErrorKind', 'port error imports'],
-  ['const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";', 'shared GraphQL boundary'],
+  [
+    'const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";',
+    'shared GraphQL boundary',
+  ],
+  ['const STOREFRONT_CUSTOMER_OWNER: &str = "rustok_customer";', 'truthful customer owner'],
+  [
+    'const STOREFRONT_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";',
+    'exact customer owner operation',
+  ],
   ['fn customer_port_graphql_error(', 'customer mapper'],
   ['fn cart_port_source_owner(', 'cart source-owner classifier'],
   ['pub(crate) fn cart_port_error(', 'cart mapper'],
   ['Some(("cart", _)) => "rustok_cart"', 'cart owner classification'],
   ['Some(("pricing", _)) => "rustok_pricing"', 'pricing owner classification'],
   ['_ => "unknown"', 'unknown owner classification'],
-  ['owner = "rustok_customer"', 'customer owner logging'],
   ['owner = "rustok_commerce.graphql_cart_helper"', 'commerce boundary owner logging'],
   ['source_owner = cart_port_source_owner(&error)', 'typed source owner logging'],
-  ['correlation_id = %context.correlation_id', 'customer correlation logging'],
-  ['tenant_id = %context.tenant_id', 'customer tenant logging'],
-  ['owner_code = %error.code', 'owner code logging'],
-  ['owner_kind = ?error.kind', 'owner kind logging'],
-  ['owner_retryable = error.retryable', 'owner retryability logging'],
+  ['owner_code = %error.code', 'cart owner code logging'],
+  ['owner_kind = ?error.kind', 'cart owner kind logging'],
   ['error_kind = "legacy_graphql_error"', 'legacy error kind logging'],
-  ['public_code = code', 'public code logging'],
-  ['public_retryable = retryable', 'public retryability logging'],
-  ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'transport boundary logging'],
-  ['PortErrorKind::Validation', 'validation mapping'],
-  ['PortErrorKind::NotFound', 'not-found mapping'],
-  ['PortErrorKind::Conflict', 'conflict mapping'],
-  ['PortErrorKind::Forbidden', 'forbidden mapping'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'availability mapping'],
-  ['PortErrorKind::InvariantViolation', 'invariant mapping'],
-  ['"CART_REQUEST_INVALID"', 'cart validation code'],
-  ['"CART_RESOURCE_NOT_FOUND"', 'cart not-found code'],
-  ['"CART_STATE_CONFLICT"', 'cart conflict code'],
-  ['"CART_ACCESS_DENIED"', 'cart forbidden code'],
-  ['"CART_TEMPORARILY_UNAVAILABLE"', 'cart availability code'],
-  ['"CART_OPERATION_FAILED"', 'cart invariant code'],
-  ['"CUSTOMER_TEMPORARILY_UNAVAILABLE"', 'customer availability code'],
-  ['fn legacy_graphql_error(', 'legacy envelope interceptor'],
   ['resource_id = ?resource_id', 'resource logging'],
   ['"Cart shipping details are temporarily unavailable"', 'cart enrichment message'],
   ['"Selected shipping option is invalid"', 'shipping selection message'],
@@ -85,15 +94,113 @@ for (const [value, label] of [
   requireText(facadeSource, value, label);
 }
 
+for (const [value, label] of [
+  ['context: &PortContext', 'retained customer context input'],
+  ["consumer_operation: &'static str", 'consumer operation input'],
+  ['error: PortError', 'original customer error input'],
+  ['PortErrorKind::Validation', 'customer validation mapping'],
+  ['PortErrorKind::NotFound', 'customer not-found mapping'],
+  ['PortErrorKind::Conflict', 'customer conflict mapping'],
+  ['PortErrorKind::Forbidden', 'customer forbidden mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'customer availability mapping'],
+  ['PortErrorKind::InvariantViolation', 'customer invariant mapping'],
+  ['"CUSTOMER_REQUEST_INVALID"', 'customer validation code'],
+  ['"CUSTOMER_NOT_FOUND"', 'customer not-found code'],
+  ['"CUSTOMER_STATE_CONFLICT"', 'customer conflict code'],
+  ['"CUSTOMER_ACCESS_DENIED"', 'customer forbidden code'],
+  ['"CUSTOMER_TEMPORARILY_UNAVAILABLE"', 'customer availability code'],
+  ['"CUSTOMER_OPERATION_FAILED"', 'customer invariant code'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'technical customer severity classification',
+  ],
+  ['tracing::error!(', 'technical customer error severity'],
+  ['tracing::warn!(', 'ordinary customer rejection severity'],
+  ['error = ?error', 'original customer error evidence'],
+  ['owner = STOREFRONT_CUSTOMER_OWNER', 'truthful customer owner field'],
+  ['owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION', 'exact owner operation field'],
+  ['consumer_operation,', 'consumer operation field'],
+  ['correlation_id = %context.correlation_id', 'customer correlation context'],
+  ['tenant_id = %context.tenant_id', 'customer tenant context'],
+  ['actor = ?context.actor', 'customer actor context'],
+  ['channel = ?context.channel', 'customer channel context'],
+  ['locale = %context.locale', 'customer locale context'],
+  ['causation_id = ?context.causation_id', 'customer causation context'],
+  ['traceparent = ?context.traceparent', 'customer trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'customer idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'customer deadline context'],
+  ['internal_code = %error.code', 'customer internal code'],
+  ['internal_message = %error.message', 'customer internal message'],
+  ['error_kind = ?error.kind', 'customer typed error kind'],
+  ['owner_retryable = error.retryable', 'customer owner retryability'],
+  ['public_code = code', 'customer public code'],
+  ['public_retryable = retryable', 'customer public retryability'],
+  ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'customer GraphQL boundary'],
+  ['"commerce GraphQL storefront customer owner port failed"', 'technical customer event'],
+  [
+    '"commerce GraphQL storefront customer owner port was rejected"',
+    'ordinary customer rejection event',
+  ],
+  ['public_graphql_error(message, code, retryable)', 'unchanged safe customer envelope'],
+]) {
+  requireText(customerMapper, value, label);
+}
+
+const policyIndex = customerMapper.indexOf('let (message, code, retryable) = match &error.kind');
+const diagnosticsIndex = customerMapper.indexOf('match &error.kind', policyIndex + 1);
+const returnIndex = customerMapper.lastIndexOf('public_graphql_error(message, code, retryable)');
+if (!(policyIndex >= 0 && policyIndex < diagnosticsIndex && diagnosticsIndex < returnIndex)) {
+  failures.push('customer error must be mapped, diagnosed, and then returned in order');
+}
+
+for (const [value, label] of [
+  [
+    'let customer_context = storefront_customer_port_context(tenant_id, auth.user_id);',
+    'single retained customer context',
+  ],
+  ['read_customer_projection_by_user(', 'customer owner call'],
+  ['customer_context.clone(),', 'customer context delegation clone'],
+  ['CustomerUserProjectionRequest {', 'customer projection request'],
+  ['user_id: auth.user_id,', 'customer user identity'],
+  [
+    'Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)',
+    'unchanged optional-customer fallback',
+  ],
+  ['&customer_context,', 'retained customer mapper context'],
+  ['"resolve_optional_storefront_customer_id"', 'consumer operation value'],
+]) {
+  requireText(customerLookup, value, label);
+}
+
+for (const value of [
+  'let port_context = storefront_customer_port_context(',
+  'let error_context = port_context.clone();',
+  'read_customer_projection_by_user(\n            port_context,',
+  '&error_context,',
+  'owner = "rustok_customer"',
+]) {
+  forbidText(facadeSource, value, 'context-dropping or legacy customer mapping');
+}
+
 for (const [pattern, expected, label] of [
-  [/public_code = code/g, 3, 'public code log count'],
-  [/public_retryable = retryable/g, 3, 'public retryability log count'],
-  [/boundary = STOREFRONT_CART_HELPER_BOUNDARY/g, 3, 'boundary log count'],
+  [/public_code = code/g, 4, 'public code log count'],
+  [/public_retryable = retryable/g, 4, 'public retryability log count'],
+  [/boundary = STOREFRONT_CART_HELPER_BOUNDARY/g, 4, 'boundary log count'],
   [/owner = "rustok_commerce\.graphql_cart_helper"/g, 2, 'commerce boundary owner count'],
   [/source_owner = cart_port_source_owner\(&error\)/g, 1, 'source owner log count'],
+  [/owner = STOREFRONT_CUSTOMER_OWNER/g, 2, 'customer owner log count'],
+  [/owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION/g, 2, 'customer operation log count'],
+  [/customer_context\.clone\(\),/g, 1, 'customer context clone count'],
 ]) {
   const count = facadeSource.match(pattern)?.length ?? 0;
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+const customerMapperUses = facadeSource.match(/customer_port_graphql_error\(/g) ?? [];
+if (customerMapperUses.length !== 2) {
+  failures.push(
+    `expected customer mapper definition plus one use, found ${customerMapperUses.length}`,
+  );
 }
 
 for (const operation of [
@@ -103,15 +210,13 @@ for (const operation of [
   'resolve_storefront_line_item_input',
   'reprice_storefront_cart_line_items',
   'validate_storefront_line_item_quantity',
-  'validate_storefront_variant_inventory',
 ]) {
   requireText(facadeSource, `"${operation}"`, `${operation} operation mapping`);
 }
 
-const legacyCalls =
-  facadeSource.match(/super::legacy_helpers::[a-z_]+\(/g) ?? [];
-if (legacyCalls.length !== 6) {
-  failures.push(`expected 6 intercepted legacy helper calls, found ${legacyCalls.length}`);
+const legacyCalls = facadeSource.match(/super::legacy_helpers::[a-z_]+\(/g) ?? [];
+if (legacyCalls.length !== 5) {
+  failures.push(`expected 5 intercepted legacy helper calls, found ${legacyCalls.length}`);
 }
 
 if (failures.length > 0) {
@@ -121,5 +226,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers retain truthful cart/pricing source ownership, stable public diagnostics, and one transport boundary while layered helper routing stays private',
+  '✔ Commerce GraphQL storefront cart helpers retain full customer PortContext, truthful cart/pricing ownership, stable public envelopes, and private layered routing',
 );


### PR DESCRIPTION
## Summary

- retain one `customer_context` for the optional GraphQL storefront customer lookup;
- clone it into `CustomerReadPort::read_customer_projection_by_user` while retaining the original for diagnostics;
- attribute failures to truthful owner `rustok_customer`, exact owner operation `read_customer_projection_by_user`, and consumer operation `resolve_optional_storefront_customer_id`;
- record actor, channel, locale, causation id, traceparent, idempotency key, deadline, internal owner code/message/kind/retryability, and selected public GraphQL code/retryability;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary owner rejection;
- preserve all existing customer GraphQL messages, codes, retryability, anonymous behavior, customer-not-found fallback, helper signatures, cart/pricing mappings, legacy helper envelopes, and private routing;
- strengthen the existing cart-helper verifier and synchronize three stale assertions with the actual facade;
- add a source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs`
- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
- `crates/rustok-commerce/docs/graphql-cart-helper-customer-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe customer/adapter mapper cleanup. GraphQL query resolvers, the shared storefront lookup in `controllers/store/mod.rs`, payment execution/compensation consumers, other adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or audit status is promoted.

## Validation

- branch is seven scoped commits ahead of current `main` and zero commits behind;
- final diff contains exactly the three scoped files;
- the temporary empty placeholder created during tooling was removed and is absent from the final diff;
- retained context, exact owner operation, severity split, public-envelope preservation, helper routing, cart/pricing mappings, and five actual legacy calls are statically guarded;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce --lib
```