### PR TITLE
Retain cart checkout owner admission context

### DIFF
--- a/crates/rustok-cart/docs/checkout-admission-context.md
+++ b/crates/rustok-cart/docs/checkout-admission-context.md
@@ -1,0 +1,125 @@
+# Cart checkout owner admission context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the owner-admission diagnostic gap for the four operations
+published by `CartCheckoutPort` in
+`crates/rustok-cart/src/checkout_snapshot.rs`:
+
+- `prepare_checkout`;
+- `read_checkout_snapshot`;
+- `complete_checkout`;
+- `release_checkout`.
+
+Before this slice, each operation called `PortContext::require_policy` directly and
+returned admission rejection through `?`. The three write operations also called
+`require_write_semantics` directly. Those failures preserved the typed `PortError`
+but crossed the cart owner boundary without cart-specific owner, operation, phase,
+or delegated-context diagnostics.
+
+Consumer-side checkout inventory, payment, fulfillment, order, and compensation
+context retention remains separate. This slice changes only the cart owner admission
+boundary.
+
+## Delivered source contract
+
+The port now declares stable owner operations for all four methods and routes
+admission through two cart-owned helpers:
+
+- read admission requires `PortCallPolicy::read`;
+- write admission requires `PortCallPolicy::write` and then write semantics;
+- policy and write-semantics failures carry distinct admission phases;
+- the original `PortError` is logged and returned unchanged.
+
+The shared admission mapper attributes every rejection to:
+
+- truthful owner `rustok_cart`;
+- exact owner operation;
+- phase `policy` or `write_semantics`;
+- boundary `cart_checkout_port`.
+
+Diagnostics retain:
+
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- original internal code and message;
+- typed error kind and original retryability.
+
+Unavailable, timeout, and invariant failures use error severity. Validation,
+not-found, conflict, forbidden, and other ordinary admission rejections use warning
+severity.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `CartCheckoutPort` method signatures or request/response DTOs;
+- admission ordering before tenant parsing and owner service access;
+- the read/write policy selected by each operation;
+- write-semantics requirements for prepare, complete, and release;
+- tenant parsing or its current public validation envelope;
+- cart lookup, begin-checkout, context update, completion, or abandonment calls;
+- active/checking-out lifecycle routing;
+- checkout order metadata merge behavior;
+- snapshot projection, normalization, canonical JSON, snapshot hash, or projection
+  hash behavior;
+- delivery-group normalization;
+- cart service error classification or public codes/messages/retryability;
+- tax-boundary propagation;
+- existing source tests;
+- FBA, FFA, or ecommerce audit status.
+
+No owner cause is copied into a new public envelope. Admission returns the same
+`PortError` value produced by the shared `PortContext` policy helpers.
+
+## Static evidence
+
+`scripts/verify/verify-cart-checkout-admission-context.mjs` guards:
+
+- stable owner, boundary, and four exact operation constants;
+- one read admission helper and one write admission helper;
+- policy-before-write-semantics ordering;
+- explicit `policy` and `write_semantics` phases;
+- mapper inputs for retained context, operation, phase, and original error;
+- complete available `PortContext` and original `PortError` fields;
+- technical versus ordinary rejection severity;
+- exactly one read helper use and three write helper uses;
+- admission before tenant parsing in every public operation;
+- absence of direct context-dropping `require_policy(...)?` and
+  `require_write_semantics()?` forms inside the port implementation;
+- preservation of cart service calls, snapshot/hash helpers, metadata merge, public
+  mapper, and existing test-source markers.
+
+The broad ecommerce public-port-error verifier remains compatible because this slice
+preserves every existing cart public error mapping and adds only internal structured
+diagnostics.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- cart checkout tenant-context rejection diagnostics;
+- cart service error diagnostics that do not yet retain the delegated `PortContext`;
+- fulfillment execution owner admission;
+- order settlement and compensation owner admission;
+- inventory reservation owner admission;
+- remaining payment execution and compensation consumers;
+- GraphQL query customer reads and the shared storefront customer lookup;
+- remaining customer, tax, promotion, ecommerce, and non-`PortError` envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source inspection alone.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-cart-checkout-admission-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-cart --lib
+```

--- a/crates/rustok-cart/src/checkout_snapshot.rs
+++ b/crates/rustok-cart/src/checkout_snapshot.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rust_decimal::Decimal;
-use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -11,6 +11,13 @@ use validator::Validate;
 
 use crate::dto::{CartDeliveryGroupResponse, CartResponse, UpdateCartContextInput};
 use crate::{CartError, CartService, CartStatus};
+
+const CART_CHECKOUT_OWNER: &str = "rustok_cart";
+const CART_CHECKOUT_BOUNDARY: &str = "cart_checkout_port";
+const PREPARE_CHECKOUT_OPERATION: &str = "prepare_checkout";
+const READ_CHECKOUT_SNAPSHOT_OPERATION: &str = "read_checkout_snapshot";
+const COMPLETE_CHECKOUT_OPERATION: &str = "complete_checkout";
+const RELEASE_CHECKOUT_OPERATION: &str = "release_checkout";
 
 /// Immutable, transport-neutral checkout snapshot owned by the cart module.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +93,91 @@ pub fn in_process_cart_checkout_port(service: CartService) -> Arc<dyn CartChecko
     Arc::new(InProcessCartCheckoutPort::new(service))
 }
 
+fn require_cart_checkout_read_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::read()).map_err(|error| {
+        log_cart_checkout_admission_rejection(context, owner_operation, "policy", &error);
+        error
+    })
+}
+
+fn require_cart_checkout_write_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).map_err(|error| {
+        log_cart_checkout_admission_rejection(context, owner_operation, "policy", &error);
+        error
+    })?;
+    context.require_write_semantics().map_err(|error| {
+        log_cart_checkout_admission_rejection(
+            context,
+            owner_operation,
+            "write_semantics",
+            &error,
+        );
+        error
+    })
+}
+
+fn log_cart_checkout_admission_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    admission_phase: &'static str,
+    error: &PortError,
+) {
+    match &error.kind {
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
+            tracing::error!(
+                error = ?error,
+                owner = CART_CHECKOUT_OWNER,
+                owner_operation,
+                admission_phase,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = CART_CHECKOUT_BOUNDARY,
+                "cart checkout owner admission failed"
+            );
+        }
+        _ => {
+            tracing::warn!(
+                error = ?error,
+                owner = CART_CHECKOUT_OWNER,
+                owner_operation,
+                admission_phase,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                actor = ?context.actor,
+                channel = ?context.channel,
+                locale = %context.locale,
+                causation_id = ?context.causation_id,
+                traceparent = ?context.traceparent,
+                idempotency_key = ?context.idempotency_key,
+                deadline_ms = ?context.deadline_ms,
+                internal_code = %error.code,
+                internal_message = %error.message,
+                error_kind = ?error.kind,
+                retryable = error.retryable,
+                boundary = CART_CHECKOUT_BOUNDARY,
+                "cart checkout owner admission was rejected"
+            );
+        }
+    }
+}
+
 #[async_trait]
 impl CartCheckoutPort for InProcessCartCheckoutPort {
     async fn prepare_checkout(
@@ -93,8 +185,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         context: PortContext,
         request: PrepareCartCheckoutSnapshotRequest,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_cart_checkout_write_admission(&context, PREPARE_CHECKOUT_OPERATION)?;
         let tenant_id = parse_tenant_id(&context)?;
         validate_prepare_input(&request.input).map_err(cart_error_to_port_error)?;
 
@@ -139,7 +230,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         context: PortContext,
         cart_id: Uuid,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
+        require_cart_checkout_read_admission(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;
         let tenant_id = parse_tenant_id(&context)?;
         self.service
             .get_cart(tenant_id, cart_id)
@@ -153,8 +244,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         context: PortContext,
         request: CompleteCartCheckoutRequest,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_cart_checkout_write_admission(&context, COMPLETE_CHECKOUT_OPERATION)?;
         let tenant_id = parse_tenant_id(&context)?;
         let cart = self
             .service
@@ -171,8 +261,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         context: PortContext,
         cart_id: Uuid,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_cart_checkout_write_admission(&context, RELEASE_CHECKOUT_OPERATION)?;
         let tenant_id = parse_tenant_id(&context)?;
         let cart = self
             .service

--- a/scripts/verify/verify-cart-checkout-admission-context.mjs
+++ b/scripts/verify/verify-cart-checkout-admission-context.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-cart/src/checkout_snapshot.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const admission = between(
+  source,
+  'fn require_cart_checkout_read_admission(',
+  '#[async_trait]\nimpl CartCheckoutPort for InProcessCartCheckoutPort',
+  'cart checkout admission helpers',
+);
+const portImpl = between(
+  source,
+  '#[async_trait]\nimpl CartCheckoutPort for InProcessCartCheckoutPort',
+  'fn validate_prepare_input(',
+  'cart checkout port implementation',
+);
+const prepare = between(
+  portImpl,
+  'async fn prepare_checkout(',
+  'async fn read_checkout_snapshot(',
+  'prepare checkout operation',
+);
+const readSnapshot = between(
+  portImpl,
+  'async fn read_checkout_snapshot(',
+  'async fn complete_checkout(',
+  'read checkout snapshot operation',
+);
+const complete = between(
+  portImpl,
+  'async fn complete_checkout(',
+  'async fn release_checkout(',
+  'complete checkout operation',
+);
+const release = from(
+  portImpl,
+  'async fn release_checkout(',
+  'release checkout operation',
+);
+
+for (const [value, label] of [
+  ['use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};', 'typed admission imports'],
+  ['const CART_CHECKOUT_OWNER: &str = "rustok_cart";', 'truthful cart owner'],
+  ['const CART_CHECKOUT_BOUNDARY: &str = "cart_checkout_port";', 'stable cart checkout boundary'],
+  ['const PREPARE_CHECKOUT_OPERATION: &str = "prepare_checkout";', 'prepare operation'],
+  [
+    'const READ_CHECKOUT_SNAPSHOT_OPERATION: &str = "read_checkout_snapshot";',
+    'read snapshot operation',
+  ],
+  ['const COMPLETE_CHECKOUT_OPERATION: &str = "complete_checkout";', 'complete operation'],
+  ['const RELEASE_CHECKOUT_OPERATION: &str = "release_checkout";', 'release operation'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['fn require_cart_checkout_read_admission(', 'read admission helper'],
+  ['context.require_policy(PortCallPolicy::read()).map_err(|error| {', 'read policy interception'],
+  [
+    'log_cart_checkout_admission_rejection(context, owner_operation, "policy", &error);',
+    'read policy diagnostics',
+  ],
+  ['fn require_cart_checkout_write_admission(', 'write admission helper'],
+  ['context.require_policy(PortCallPolicy::write()).map_err(|error| {', 'write policy interception'],
+  ['context.require_write_semantics().map_err(|error| {', 'write semantics interception'],
+  ['"write_semantics",', 'write semantics phase'],
+  ['fn log_cart_checkout_admission_rejection(', 'shared rejection diagnostics'],
+  ['context: &PortContext', 'retained context input'],
+  ["owner_operation: &'static str", 'exact owner operation input'],
+  ["admission_phase: &'static str", 'admission phase input'],
+  ['error: &PortError', 'original port error input'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'technical severity classification',
+  ],
+  ['tracing::error!(', 'technical rejection severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
+  ['error = ?error', 'original error evidence'],
+  ['owner = CART_CHECKOUT_OWNER', 'truthful owner field'],
+  ['owner_operation,', 'exact operation field'],
+  ['admission_phase,', 'admission phase field'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['internal_code = %error.code', 'original internal code'],
+  ['internal_message = %error.message', 'original internal message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'original retryability'],
+  ['boundary = CART_CHECKOUT_BOUNDARY', 'cart checkout boundary field'],
+  ['"cart checkout owner admission failed"', 'technical event'],
+  ['"cart checkout owner admission was rejected"', 'ordinary event'],
+]) requireText(admission, value, label);
+
+for (const [block, values, label] of [
+  [
+    prepare,
+    [
+      'require_cart_checkout_write_admission(&context, PREPARE_CHECKOUT_OPERATION)?;',
+      'let tenant_id = parse_tenant_id(&context)?;',
+      '.get_cart(tenant_id, request.cart_id)',
+      '.begin_checkout(tenant_id, request.cart_id)',
+      '.update_context(tenant_id, request.cart_id, request.input)',
+      'snapshot_from_cart(cart)',
+    ],
+    'prepare checkout behavior',
+  ],
+  [
+    readSnapshot,
+    [
+      'require_cart_checkout_read_admission(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;',
+      'let tenant_id = parse_tenant_id(&context)?;',
+      '.get_cart(tenant_id, cart_id)',
+      '.and_then(snapshot_from_cart)',
+    ],
+    'read snapshot behavior',
+  ],
+  [
+    complete,
+    [
+      'require_cart_checkout_write_admission(&context, COMPLETE_CHECKOUT_OPERATION)?;',
+      'let tenant_id = parse_tenant_id(&context)?;',
+      '.complete_cart(tenant_id, request.cart_id)',
+      'merge_checkout_order_metadata(cart.metadata, request.order_id)',
+      'snapshot_from_cart(cart)',
+    ],
+    'complete checkout behavior',
+  ],
+  [
+    release,
+    [
+      'require_cart_checkout_write_admission(&context, RELEASE_CHECKOUT_OPERATION)?;',
+      'let tenant_id = parse_tenant_id(&context)?;',
+      '.abandon_cart(tenant_id, cart_id)',
+      'snapshot_from_cart(cart)',
+    ],
+    'release checkout behavior',
+  ],
+]) {
+  for (const value of values) requireText(block, value, label);
+  const admissionIndex = block.indexOf('require_cart_checkout_');
+  const tenantIndex = block.indexOf('let tenant_id = parse_tenant_id(&context)?;');
+  if (!(admissionIndex >= 0 && admissionIndex < tenantIndex)) {
+    failures.push(`${label}: admission must precede tenant parsing`);
+  }
+}
+
+for (const value of [
+  'context.require_policy(PortCallPolicy::read())?;',
+  'context.require_policy(PortCallPolicy::write())?;',
+  'context.require_write_semantics()?;',
+]) forbidText(portImpl, value, 'context-dropping direct admission');
+
+for (const [pattern, expected, label] of [
+  [/require_cart_checkout_read_admission\(/g, 2, 'read helper definition/use count'],
+  [/require_cart_checkout_write_admission\(/g, 4, 'write helper definition/use count'],
+  [/log_cart_checkout_admission_rejection\(/g, 4, 'diagnostic helper definition/use count'],
+  [/owner = CART_CHECKOUT_OWNER/g, 2, 'owner diagnostic count'],
+  [/boundary = CART_CHECKOUT_BOUNDARY/g, 2, 'boundary diagnostic count'],
+  [/"policy"/g, 2, 'policy phase count'],
+  [/"write_semantics"/g, 1, 'write semantics phase count'],
+]) {
+  const count = source.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [value, label] of [
+  ['fn snapshot_from_cart(', 'snapshot projection'],
+  ['fn cart_snapshot_hash(', 'snapshot hash'],
+  ['fn projection_hash(', 'projection hash'],
+  ['fn normalize_snapshot_value(', 'snapshot normalization'],
+  ['fn canonicalize_json(', 'canonical JSON'],
+  ['fn merge_checkout_order_metadata(', 'checkout order metadata merge'],
+  ['fn cart_error_to_port_error(', 'stable public cart mapping'],
+  ['fn canonical_json_is_independent_of_object_key_order()', 'canonical hash test source'],
+  [
+    'fn snapshot_normalization_removes_volatile_projection_fields()',
+    'snapshot normalization test source',
+  ],
+]) requireText(source, value, label);
+
+if (failures.length > 0) {
+  console.error('Cart checkout admission context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Cart checkout owner admission retains full PortContext, exact operation and phase, original PortError, stable behavior, and technical-versus-ordinary severity',
+);


### PR DESCRIPTION
## Summary

- route `CartCheckoutPort` admission through cart-owned read/write helpers for `prepare_checkout`, `read_checkout_snapshot`, `complete_checkout`, and `release_checkout`;
- retain the complete delegated `PortContext` when read/write policy or write-semantics admission is rejected;
- attribute rejection to truthful owner `rustok_cart`, exact owner operation, explicit phase `policy` or `write_semantics`, and boundary `cart_checkout_port`;
- record correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, original internal code/message, typed kind, and retryability;
- use error severity for unavailable, timeout, and invariant failures and warning severity for ordinary admission rejection;
- return the original `PortError` unchanged after diagnostics;
- preserve admission ordering, tenant parsing, cart service calls, lifecycle routing, checkout metadata, snapshot normalization, canonical hashing, public cart error mapping, tax-boundary propagation, and existing source tests;
- add a focused static verifier and source-ready/unvalidated evidence note.

## Scope

Three files only:

- `crates/rustok-cart/src/checkout_snapshot.rs`
- `scripts/verify/verify-cart-checkout-admission-context.mjs`
- `crates/rustok-cart/docs/checkout-admission-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper cleanup. It closes only cart checkout owner policy/write-semantics admission diagnostics. Cart tenant parsing, context-aware cart service mappings, fulfillment/order/inventory owner admission, remaining payment execution/compensation consumers, GraphQL query customer reads, other adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or ecommerce audit status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- final diff contains exactly the three scoped files;
- one read admission helper use and three write admission helper uses are statically guarded;
- policy-before-write-semantics ordering and admission-before-tenant-parsing ordering are guarded;
- the original `PortError`, full available context, exact operation, phase, boundary, and severity split are guarded;
- direct context-dropping admission forms are forbidden inside the port implementation;
- snapshot, lifecycle, metadata, hashing, public mapper, tax-boundary, and existing test-source markers remain guarded;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-cart-checkout-admission-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-cart --lib
```