### PR TITLE
Retain cart checkout tenant context

### DIFF
--- a/crates/rustok-cart/docs/checkout-tenant-context.md
+++ b/crates/rustok-cart/docs/checkout-tenant-context.md
@@ -1,0 +1,128 @@
+# Cart checkout owner tenant context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice closes the tenant UUID rejection diagnostic gap for the four operations
+published by `CartCheckoutPort` in `crates/rustok-cart/src/checkout_snapshot.rs`:
+
+- `prepare_checkout`;
+- `read_checkout_snapshot`;
+- `complete_checkout`;
+- `release_checkout`.
+
+The preceding owner-admission slice retained policy and write-semantics rejection context.
+After admission succeeded, all four methods still delegated to `parse_tenant_id(&context)`.
+An invalid `PortContext.tenant_id` returned the stable typed validation error, but the
+parser discarded the UUID cause and had no exact owner operation or cart-owned structured
+diagnostics.
+
+This slice changes only that validation boundary.
+
+## Delivered source contract
+
+Each public operation now passes its already selected canonical owner operation to tenant
+parsing after unchanged admission:
+
+- `PREPARE_CHECKOUT_OPERATION` for `prepare_checkout`;
+- `READ_CHECKOUT_SNAPSHOT_OPERATION` for `read_checkout_snapshot`;
+- `COMPLETE_CHECKOUT_OPERATION` for `complete_checkout`;
+- `RELEASE_CHECKOUT_OPERATION` for `release_checkout`.
+
+`parse_tenant_id` now accepts the retained `PortContext` and exact owner operation. When
+UUID parsing fails, it:
+
+1. captures the original UUID parse cause;
+2. constructs the same `PortError::validation` value as before;
+3. emits cart-owned structured warning diagnostics;
+4. returns that same validation error.
+
+Diagnostics attribute the rejection to:
+
+- truthful owner `rustok_cart`;
+- exact owner operation;
+- validation phase `tenant_id`;
+- boundary `cart_checkout_port`.
+
+They retain:
+
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- UUID parse cause;
+- mapped validation error;
+- stable internal code and message;
+- typed error kind and retryability.
+
+Tenant identity rejection uses warning severity because it is caller/context validation,
+not an owner availability or invariant failure.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `CartCheckoutPort` method signatures or request/response DTOs;
+- read/write admission policy or write-semantics requirements;
+- admission-before-tenant-parsing ordering;
+- public tenant validation code `cart.tenant_id_invalid`;
+- public tenant validation message
+  `PortContext.tenant_id must be a UUID for cart checkout`;
+- validation kind or retryability;
+- cart lookup, begin-checkout, context update, completion, or abandonment calls;
+- active/checking-out lifecycle routing;
+- checkout order metadata merge behavior;
+- snapshot projection, normalization, canonical JSON, snapshot hash, or projection hash;
+- delivery-group normalization;
+- cart service error mapping or tax-boundary propagation;
+- existing source tests;
+- FBA, FFA, or ecommerce audit status.
+
+No UUID parse cause or delegated context value is copied into the public error envelope.
+
+## Static evidence
+
+`scripts/verify/verify-cart-checkout-tenant-context.mjs` guards:
+
+- four exact operation-aware parser callsites;
+- admission before tenant parsing in every operation;
+- one parser definition and four uses;
+- retained context and exact operation parser inputs;
+- UUID cause capture;
+- stable validation code, message, kind, and retryability evidence;
+- truthful owner, phase, boundary, and complete available context diagnostics;
+- warning severity and diagnostics-before-return ordering;
+- return of the same constructed validation error;
+- absence of the old context-only parser signature and callsites;
+- preservation of admission helpers, cart service behavior, snapshot/hash helpers,
+  metadata merge, and stable public cart mapper.
+
+The preceding `verify-cart-checkout-admission-context.mjs` guard is synchronized only to
+the operation-aware tenant parser signature and retains its existing admission assertions.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- cart service error diagnostics that do not yet retain the delegated `PortContext`;
+- fulfillment execution owner admission and validation;
+- order settlement and compensation owner admission and validation;
+- inventory reservation owner admission and validation;
+- remaining payment execution and compensation consumers;
+- GraphQL query customer reads and the shared storefront customer lookup;
+- remaining customer, tax, promotion, ecommerce, and non-`PortError` envelopes;
+- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+
+No architecture status is promoted from source inspection alone.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-cart-checkout-tenant-context.mjs
+node scripts/verify/verify-cart-checkout-admission-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-cart --lib
+```

--- a/crates/rustok-cart/src/checkout_snapshot.rs
+++ b/crates/rustok-cart/src/checkout_snapshot.rs
@@ -186,7 +186,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         request: PrepareCartCheckoutSnapshotRequest,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
         require_cart_checkout_write_admission(&context, PREPARE_CHECKOUT_OPERATION)?;
-        let tenant_id = parse_tenant_id(&context)?;
+        let tenant_id = parse_tenant_id(&context, PREPARE_CHECKOUT_OPERATION)?;
         validate_prepare_input(&request.input).map_err(cart_error_to_port_error)?;
 
         let cart = self
@@ -231,7 +231,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         cart_id: Uuid,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
         require_cart_checkout_read_admission(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;
-        let tenant_id = parse_tenant_id(&context)?;
+        let tenant_id = parse_tenant_id(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;
         self.service
             .get_cart(tenant_id, cart_id)
             .await
@@ -245,7 +245,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         request: CompleteCartCheckoutRequest,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
         require_cart_checkout_write_admission(&context, COMPLETE_CHECKOUT_OPERATION)?;
-        let tenant_id = parse_tenant_id(&context)?;
+        let tenant_id = parse_tenant_id(&context, COMPLETE_CHECKOUT_OPERATION)?;
         let cart = self
             .service
             .complete_cart(tenant_id, request.cart_id)
@@ -262,7 +262,7 @@ impl CartCheckoutPort for InProcessCartCheckoutPort {
         cart_id: Uuid,
     ) -> Result<PreparedCartCheckoutSnapshot, PortError> {
         require_cart_checkout_write_admission(&context, RELEASE_CHECKOUT_OPERATION)?;
-        let tenant_id = parse_tenant_id(&context)?;
+        let tenant_id = parse_tenant_id(&context, RELEASE_CHECKOUT_OPERATION)?;
         let cart = self
             .service
             .abandon_cart(tenant_id, cart_id)
@@ -280,12 +280,38 @@ fn validate_prepare_input(input: &UpdateCartContextInput) -> Result<(), CartErro
     Ok(())
 }
 
-fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
-    Uuid::parse_str(context.tenant_id.as_str()).map_err(|_| {
-        PortError::validation(
+fn parse_tenant_id(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<Uuid, PortError> {
+    Uuid::parse_str(context.tenant_id.as_str()).map_err(|cause| {
+        let error = PortError::validation(
             "cart.tenant_id_invalid",
             "PortContext.tenant_id must be a UUID for cart checkout",
-        )
+        );
+        tracing::warn!(
+            cause = ?cause,
+            error = ?error,
+            owner = CART_CHECKOUT_OWNER,
+            owner_operation,
+            validation_phase = "tenant_id",
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = CART_CHECKOUT_BOUNDARY,
+            "cart checkout owner tenant context was rejected"
+        );
+        error
     })
 }
 

--- a/scripts/verify/verify-cart-checkout-admission-context.mjs
+++ b/scripts/verify/verify-cart-checkout-admission-context.mjs
@@ -136,7 +136,7 @@ for (const [block, values, label] of [
     prepare,
     [
       'require_cart_checkout_write_admission(&context, PREPARE_CHECKOUT_OPERATION)?;',
-      'let tenant_id = parse_tenant_id(&context)?;',
+      'let tenant_id = parse_tenant_id(&context, PREPARE_CHECKOUT_OPERATION)?;',
       '.get_cart(tenant_id, request.cart_id)',
       '.begin_checkout(tenant_id, request.cart_id)',
       '.update_context(tenant_id, request.cart_id, request.input)',
@@ -148,7 +148,7 @@ for (const [block, values, label] of [
     readSnapshot,
     [
       'require_cart_checkout_read_admission(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;',
-      'let tenant_id = parse_tenant_id(&context)?;',
+      'let tenant_id = parse_tenant_id(&context, READ_CHECKOUT_SNAPSHOT_OPERATION)?;',
       '.get_cart(tenant_id, cart_id)',
       '.and_then(snapshot_from_cart)',
     ],
@@ -158,7 +158,7 @@ for (const [block, values, label] of [
     complete,
     [
       'require_cart_checkout_write_admission(&context, COMPLETE_CHECKOUT_OPERATION)?;',
-      'let tenant_id = parse_tenant_id(&context)?;',
+      'let tenant_id = parse_tenant_id(&context, COMPLETE_CHECKOUT_OPERATION)?;',
       '.complete_cart(tenant_id, request.cart_id)',
       'merge_checkout_order_metadata(cart.metadata, request.order_id)',
       'snapshot_from_cart(cart)',
@@ -169,7 +169,7 @@ for (const [block, values, label] of [
     release,
     [
       'require_cart_checkout_write_admission(&context, RELEASE_CHECKOUT_OPERATION)?;',
-      'let tenant_id = parse_tenant_id(&context)?;',
+      'let tenant_id = parse_tenant_id(&context, RELEASE_CHECKOUT_OPERATION)?;',
       '.abandon_cart(tenant_id, cart_id)',
       'snapshot_from_cart(cart)',
     ],
@@ -178,7 +178,7 @@ for (const [block, values, label] of [
 ]) {
   for (const value of values) requireText(block, value, label);
   const admissionIndex = block.indexOf('require_cart_checkout_');
-  const tenantIndex = block.indexOf('let tenant_id = parse_tenant_id(&context)?;');
+  const tenantIndex = block.indexOf('let tenant_id = parse_tenant_id(&context,');
   if (!(admissionIndex >= 0 && admissionIndex < tenantIndex)) {
     failures.push(`${label}: admission must precede tenant parsing`);
   }
@@ -194,8 +194,8 @@ for (const [pattern, expected, label] of [
   [/require_cart_checkout_read_admission\(/g, 2, 'read helper definition/use count'],
   [/require_cart_checkout_write_admission\(/g, 4, 'write helper definition/use count'],
   [/log_cart_checkout_admission_rejection\(/g, 4, 'diagnostic helper definition/use count'],
-  [/owner = CART_CHECKOUT_OWNER/g, 2, 'owner diagnostic count'],
-  [/boundary = CART_CHECKOUT_BOUNDARY/g, 2, 'boundary diagnostic count'],
+  [/owner = CART_CHECKOUT_OWNER/g, 3, 'owner diagnostic count'],
+  [/boundary = CART_CHECKOUT_BOUNDARY/g, 3, 'boundary diagnostic count'],
   [/"policy"/g, 2, 'policy phase count'],
   [/"write_semantics"/g, 1, 'write semantics phase count'],
 ]) {

--- a/scripts/verify/verify-cart-checkout-tenant-context.mjs
+++ b/scripts/verify/verify-cart-checkout-tenant-context.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-cart/src/checkout_snapshot.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const from = (content, start, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex);
+};
+
+const portImpl = between(
+  source,
+  '#[async_trait]\nimpl CartCheckoutPort for InProcessCartCheckoutPort',
+  'fn validate_prepare_input(',
+  'cart checkout port implementation',
+);
+const prepare = between(
+  portImpl,
+  'async fn prepare_checkout(',
+  'async fn read_checkout_snapshot(',
+  'prepare checkout operation',
+);
+const readSnapshot = between(
+  portImpl,
+  'async fn read_checkout_snapshot(',
+  'async fn complete_checkout(',
+  'read checkout snapshot operation',
+);
+const complete = between(
+  portImpl,
+  'async fn complete_checkout(',
+  'async fn release_checkout(',
+  'complete checkout operation',
+);
+const release = from(
+  portImpl,
+  'async fn release_checkout(',
+  'release checkout operation',
+);
+const parser = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn snapshot_from_cart(',
+  'cart checkout tenant parser',
+);
+
+for (const [block, operation, label] of [
+  [prepare, 'PREPARE_CHECKOUT_OPERATION', 'prepare tenant context'],
+  [readSnapshot, 'READ_CHECKOUT_SNAPSHOT_OPERATION', 'read tenant context'],
+  [complete, 'COMPLETE_CHECKOUT_OPERATION', 'complete tenant context'],
+  [release, 'RELEASE_CHECKOUT_OPERATION', 'release tenant context'],
+]) {
+  const admissionIndex = block.indexOf('require_cart_checkout_');
+  const parserCall = `let tenant_id = parse_tenant_id(&context, ${operation})?;`;
+  const parserIndex = block.indexOf(parserCall);
+  requireText(block, parserCall, label);
+  if (!(admissionIndex >= 0 && admissionIndex < parserIndex)) {
+    failures.push(`${label}: admission must precede operation-aware tenant parsing`);
+  }
+}
+
+for (const [value, label] of [
+  ['fn parse_tenant_id(', 'tenant parser'],
+  ['context: &PortContext', 'retained context input'],
+  ["owner_operation: &'static str", 'exact owner operation input'],
+  ['Uuid::parse_str(context.tenant_id.as_str()).map_err(|cause| {', 'UUID parse cause capture'],
+  ['let error = PortError::validation(', 'stable validation construction'],
+  ['"cart.tenant_id_invalid"', 'stable tenant code'],
+  ['"PortContext.tenant_id must be a UUID for cart checkout"', 'stable tenant message'],
+  ['tracing::warn!(', 'validation warning severity'],
+  ['cause = ?cause', 'UUID parse cause evidence'],
+  ['error = ?error', 'mapped error evidence'],
+  ['owner = CART_CHECKOUT_OWNER', 'truthful owner'],
+  ['owner_operation,', 'exact owner operation'],
+  ['validation_phase = "tenant_id"', 'tenant validation phase'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['internal_code = %error.code', 'stable internal code evidence'],
+  ['internal_message = %error.message', 'stable internal message evidence'],
+  ['error_kind = ?error.kind', 'validation kind evidence'],
+  ['retryable = error.retryable', 'stable retryability evidence'],
+  ['boundary = CART_CHECKOUT_BOUNDARY', 'cart checkout boundary'],
+  ['"cart checkout owner tenant context was rejected"', 'tenant rejection event'],
+  ['error\n    })', 'same error returned'],
+]) requireText(parser, value, label);
+
+const warningIndex = parser.indexOf('tracing::warn!(');
+const returnIndex = parser.lastIndexOf('error\n    })');
+if (!(warningIndex >= 0 && warningIndex < returnIndex)) {
+  failures.push('tenant parser: diagnostics must precede returning the stable validation error');
+}
+
+for (const value of [
+  'fn parse_tenant_id(context: &PortContext)',
+  'let tenant_id = parse_tenant_id(&context)?;',
+  'Uuid::parse_str(context.tenant_id.as_str()).map_err(|_| {',
+]) forbidText(source, value, 'context-dropping tenant parser');
+
+for (const [pattern, expected, label] of [
+  [/parse_tenant_id\(/g, 5, 'tenant parser definition/use count'],
+  [/validation_phase = "tenant_id"/g, 1, 'tenant validation phase count'],
+  [/"cart\.tenant_id_invalid"/g, 1, 'stable tenant code count'],
+  [/"PortContext\.tenant_id must be a UUID for cart checkout"/g, 1, 'stable tenant message count'],
+  [/"cart checkout owner tenant context was rejected"/g, 1, 'tenant rejection event count'],
+]) {
+  const count = source.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [value, label] of [
+  ['fn require_cart_checkout_read_admission(', 'read admission helper'],
+  ['fn require_cart_checkout_write_admission(', 'write admission helper'],
+  ['fn log_cart_checkout_admission_rejection(', 'admission diagnostics'],
+  ['fn snapshot_from_cart(', 'snapshot projection'],
+  ['fn cart_snapshot_hash(', 'snapshot hash'],
+  ['fn projection_hash(', 'projection hash'],
+  ['fn normalize_snapshot_value(', 'snapshot normalization'],
+  ['fn canonicalize_json(', 'canonical JSON'],
+  ['fn merge_checkout_order_metadata(', 'checkout metadata merge'],
+  ['fn cart_error_to_port_error(', 'stable public cart mapper'],
+]) requireText(source, value, label);
+
+if (failures.length > 0) {
+  console.error('Cart checkout tenant context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Cart checkout tenant validation retains UUID cause, full PortContext, exact owner operation, stable validation envelope, and warning severity',
+);


### PR DESCRIPTION
## Summary

- pass the already selected canonical cart checkout owner operation into tenant UUID parsing for `prepare_checkout`, `read_checkout_snapshot`, `complete_checkout`, and `release_checkout`;
- retain the delegated `PortContext` and exact operation when `PortContext.tenant_id` is not a UUID;
- capture the original UUID parse cause and construct the same stable `cart.tenant_id_invalid` validation `PortError` as before;
- attribute rejection to truthful owner `rustok_cart`, validation phase `tenant_id`, exact owner operation, and boundary `cart_checkout_port`;
- record correlation id, tenant, actor, channel, locale, causation id, traceparent, idempotency key, deadline, mapped code/message, typed kind, and retryability;
- use warning severity for invalid caller/context identity and return the same constructed validation error after diagnostics;
- preserve admission ordering, read/write policies, write-semantics requirements, cart service calls, lifecycle behavior, metadata merge, snapshot normalization, canonical hashing, public cart mappings, tax-boundary propagation, and existing source tests;
- synchronize the preceding admission verifier to the operation-aware parser signature;
- add a focused tenant-context verifier and source-ready/unvalidated evidence note.

## Scope

Four files only:

- `crates/rustok-cart/src/checkout_snapshot.rs`
- `scripts/verify/verify-cart-checkout-admission-context.mjs`
- `scripts/verify/verify-cart-checkout-tenant-context.mjs`
- `crates/rustok-cart/docs/checkout-tenant-context.md`

## Plan alignment

This advances the still-open ecommerce P0 correlation-safe mapper cleanup. It closes only `CartCheckoutPort` tenant UUID rejection context. Context-aware cart service mappings, fulfillment/order/inventory owner admission and validation, remaining payment execution/compensation consumers, GraphQL query customer reads, other adapters, non-`PortError` envelopes, and runtime evidence remain open. No FBA/FFA or ecommerce audit status is promoted.

## Validation

- branch is one clean commit ahead of current `main` and zero commits behind;
- final diff contains exactly the four scoped files;
- all four operations pass their exact owner operation into tenant parsing after unchanged admission;
- the original tenant validation code, message, kind, and retryability remain statically guarded;
- full available `PortContext`, UUID parse cause, exact operation, validation phase, and boundary are guarded;
- diagnostics are required before returning the same constructed validation error;
- the preceding admission guard is synchronized without weakening admission assertions;
- snapshot, lifecycle, metadata, hashing, public mapper, tax-boundary, and existing test-source markers remain guarded;
- tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-cart-checkout-tenant-context.mjs
node scripts/verify/verify-cart-checkout-admission-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-cart --lib
```