### PR TITLE
feat(index): add schema application leases

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -8,9 +8,9 @@
 - `migrations`
 
 The domain/application contract remains database independent. M3 adds module-owned
-production migrations and an Index-owned PostgreSQL mutation adapter;
-source-specific Content, Product, Flex, search, legacy migration, runtime, and
-scheduler modules remain deleted.
+production migrations, an Index-owned PostgreSQL mutation adapter, and durable
+schema-application leases; source-specific Content, Product, Flex, search, legacy
+migration, runtime, and scheduler modules remain deleted.
 
 ## Primary Public Types
 
@@ -40,6 +40,11 @@ scheduler modules remain deleted.
 - `MutationDelivery`
 - `MutationApplyOutcome`
 - `MutationStorageError`
+- `PostgresSchemaLeaseStore`
+- `SchemaApplicationLeaseRequest`
+- `SchemaApplicationLease`
+- `SchemaLeaseAcquireOutcome`
+- `SchemaLeaseError`
 
 ## Contract Status
 
@@ -50,10 +55,13 @@ and query-scoped keyset cursors.
 
 The accepted M2 ADR selects JSONB, and M3 now registers the canonical schema for
 `index_schemas`, `index_entities`, `index_links`, `index_inbox`, `index_jobs`,
-`index_checkpoints`, and `index_consistency_findings`. The first runtime contract is
-`PostgresMutationStore`, which atomically applies validated entity/link upserts and
-deletes through the durable inbox. Source registries, batch ingestion, rebuild,
-query-port, and operator APIs are published by later milestones.
+`index_checkpoints`, and `index_consistency_findings`. `PostgresMutationStore`
+atomically applies validated entity/link upserts and deletes through the durable
+inbox. `PostgresSchemaLeaseStore` serializes exact tenant/schema application,
+reclaims expired jobs with attempt fencing, and requires current ownership for
+heartbeat and terminal completion. Source registries, batch ingestion, rebuild,
+query-port, secondary-index lifecycle, and operator APIs are published by later
+milestones.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -77,6 +85,8 @@ to owner modules or explicit integration crates.
 - Accepting a cursor without checking tenant, schema, fingerprint, locale, and
   order arity.
 - Sorting through a `many` link without an explicit aggregate policy.
+- Completing or heartbeating schema work without exact worker and attempt
+  fencing.
 - Restoring deleted v1 or source-specific code as a compatibility layer.
 
 ## Minimum Contract Set
@@ -86,6 +96,8 @@ to owner modules or explicit integration crates.
 - `IndexSchema`, `IndexRecord`, `IndexMutation`, and `IndexQuery` are the current
   input contracts.
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
+- `SchemaApplicationLeaseRequest` binds one tenant, exact schema reference,
+  computed fingerprint, worker identity, and bounded whole-second lease duration.
 - Construction and validation preserve tenant, schema, entity, locale, and
   source-version identity.
 - Identifiers use bounded lowercase ASCII grammar; locales use ICU4X
@@ -116,6 +128,19 @@ to owner modules or explicit integration crates.
 - Link paths resolve deterministically through the registered graph.
 - Schema fingerprints ignore declaration order but include all semantic field,
   link, locale, and version metadata.
+
+### Schema Application Lease
+
+- Acquisition is scoped by tenant, module, entity, and schema version.
+- PostgreSQL acquisition takes a transaction-scoped advisory lock before reading
+  persisted schema and job state.
+- The persisted schema must be active and match the request fingerprint.
+- A non-expired running owner returns `Busy`; a succeeded application returns
+  `AlreadyApplied`.
+- Expired work is reclaimed by increasing `attempt_count` on the same job.
+- Heartbeat, success, and failure require the exact job, worker, attempt, running
+  state, and an unexpired lease.
+- Failed terminal jobs permit a new job; succeeded jobs remain terminal.
 
 ### Cursor Contract
 
@@ -152,4 +177,6 @@ to owner modules or explicit integration crates.
   in-progress/rejected replay, stored-version corruption, backend limits, and
   database failure. Its public display is generic; transport adapters must still
   map owner errors rather than returning storage details directly.
+- `SchemaLeaseError` separates request validation, missing/retired/conflicting
+  schema state, malformed durable jobs, lost ownership, and database failure.
 - Later milestones add source, retry, cancellation, and rebuild errors.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -47,12 +47,13 @@ a rewrite goal.
 - M2 rejected prototype cleanup: complete
 - M3 storage-schema foundation: complete
 - M3 atomic mutation persistence: complete
+- M3 schema-application leases: complete
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
 configuration, scheduler, errors, and server composition have been deleted. M3
-registers the canonical production schema and now publishes one Index-owned
-transactional mutation adapter; query execution, schema leases, and secondary-index
-management remain absent.
+registers the canonical production schema, publishes an Index-owned transactional
+mutation adapter, and now owns durable schema-application leases. Query execution
+and partition/secondary-index management remain absent.
 
 The module-owned migration source creates:
 
@@ -76,6 +77,15 @@ rolls back the inbox claim. SQLite support exists only for contract fixtures and
 rejects source versions above its signed integer range; PostgreSQL preserves the
 full domain `u64` range through `DECIMAL(20,0)`.
 
+The `PostgresSchemaLeaseStore` coordinates one `schema_apply` job per exact
+tenant/module/entity/schema-version scope. Acquisition is serialized with a
+transaction-scoped PostgreSQL advisory lock, verifies the persisted schema and
+fingerprint, returns `Busy` while another non-expired owner holds the lease, and
+returns `AlreadyApplied` after terminal success. Expired work is reclaimed with an
+incremented attempt fence; heartbeat, success, and failure require the exact job,
+worker, attempt, running state, and unexpired lease so an old owner cannot commit
+after takeover. SQLite support remains contract-test-only.
+
 ## Current entry points
 
 - `IndexModule`
@@ -83,6 +93,8 @@ full domain `u64` range through `DECIMAL(20,0)`.
 - `rustok_index::application::*`
 - `rustok_index::migrations::*`
 - `PostgresMutationStore`, `MutationDelivery`, and `MutationApplyOutcome`
+- `PostgresSchemaLeaseStore`, `SchemaApplicationLeaseRequest`,
+  `SchemaApplicationLease`, and `SchemaLeaseAcquireOutcome`
 - `SchemaRegistry`, `IndexSchema`, `IndexRecord`, and `IndexMutation`
 - `IndexQuery`, `IndexQueryScope`, `FilterExpr`, and typed `FieldPath`
 - `CursorCodec`, `IndexCursor`, and query-scope cursor validation
@@ -103,7 +115,9 @@ full domain `u64` range through `DECIMAL(20,0)`.
 - reference mutation/query engine and property-based invariants for future
   PostgreSQL equivalence tests;
 - atomic tenant-scoped inbox/entity/link mutation persistence with monotonic
-  source-version and tombstone admission.
+  source-version and tombstone admission;
+- durable schema-application exclusion, expiry reclaim, heartbeat, terminal
+  completion, and attempt fencing.
 
 ## M2 benchmark
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -3,9 +3,8 @@
 ## Mission
 
 `rustok-index` is the platform-owned cross-module relational index and query
-engine. It solves the same problem class as the Medusa Index Module: source
-modules publish generic schemas, records, mutations, and links; Index
-materializes them into optimized relational storage and executes filtering,
+engine. Source modules publish generic schemas, records, mutations, and links;
+Index materializes them into optimized relational storage and executes filtering,
 projection, sorting, counting, and pagination without runtime fan-out to source
 modules.
 
@@ -20,6 +19,10 @@ mutations, PostgreSQL persistence, query planning/execution, incremental
 ingestion, rebuild/reconciliation, operator controls, and the first owner-published
 vertical slices. It excludes text relevance, ranking, autocomplete, external
 search engines, source-table reads, and source-domain semantics in Index core.
+
+Detailed completed-work evidence belongs in the accepted ADRs, committed evidence
+packets, and Git history. This document remains the live roadmap and verification
+contract.
 
 ## Rewrite policy
 
@@ -43,7 +46,7 @@ replaced whenever they conflict with the target architecture.
    `rustok-index` migrations or runtime composition.
 
 The repository owner performs test and benchmark execution during this rewrite.
-Commits record which checks and evidence runs were not executed.
+Commits and pull requests record which checks and evidence runs were not executed.
 
 ## Current state
 
@@ -53,25 +56,19 @@ Commits record which checks and evidence runs were not executed.
 - FBA status: `in_progress`
 - M0 code reset: `complete`
 - M1 domain/application core: `complete`
-- M2 read/query harness: `replacement 100k/1m archived from run 30222913450`
-- M2 transactional mutation/WAL harness: `replacement 100k/1m archived from run 30222913450`
-- M2 persistent churn/VACUUM harness: `replacement 100k/1m archived from run 30222913450`
-- M2 deterministic PostgreSQL session contract: `complete`
-- M2 observed cross-report database metadata contract: `complete`
-- M2 comparison provenance contract: `complete`
-- M2 storage benchmark: `complete`
-- M2 storage decision: `JSONB accepted; rejected prototypes removed`
+- M2 storage benchmark and accepted JSONB decision: `complete`
 - M3 storage-schema foundation: `complete`
 - M3 atomic mutation persistence: `complete`
-- Production persistence: atomic mutation writes implemented; query adapter not yet implemented
+- M3 schema-application leases: `complete`
+- Production persistence: mutation writes and schema coordination implemented;
+  query adapter and secondary-index lifecycle not yet implemented
 
 The active production crate contains the generic domain/application core, the M3
-production migrations, and an Index-owned transactional mutation adapter. The
-adapter validates each delivery, provides tenant-scoped inbox deduplication,
-monotonic source-version admission, atomic JSONB entity/tombstone plus ordered-link
-replacement, and rollback-safe terminal inbox completion. Query adapters, schema
-leases, partition/index lifecycle, and batch ingestion remain absent. Benchmark
-DDL and generated evidence stay under `ops/benches`, outside the production module.
+production migrations, an Index-owned transactional mutation adapter, and a
+durable schema-application lease store. Query adapters, partition/secondary-index
+lifecycle, batch ingestion, and PostgreSQL Testcontainers evidence remain open.
+Benchmark DDL and generated evidence stay under `ops/benches`, outside the
+production module.
 
 ## Ownership
 
@@ -107,11 +104,10 @@ crates/rustok-index/src/
   domain/
   application/
   migrations/
-    m20260727_000001_create_index_records.rs
-    m20260727_000002_create_index_delivery_state.rs
-    m20260727_000003_create_index_operations.rs
   infrastructure/
     postgres/
+      mutation_store.rs
+      schema_lease.rs
     events/
     telemetry.rs
   api/
@@ -124,11 +120,6 @@ ops/benches/src/index_storage/
   mutation_runner.rs
   maintenance_runner.rs
   sql/
-    mod.rs
-    source.rs
-    common.rs
-    maintenance.rs
-    jsonb.rs
 ```
 
 ## Library decisions
@@ -140,7 +131,6 @@ Use existing workspace libraries where possible:
 - `tokio` and `futures-util` for bounded async work;
 - `serde` and `postcard` for DTO/cursor serialization;
 - `thiserror` for typed errors;
-- `validator` for external DTO/config validation only;
 - `tracing`, `rustok-telemetry`, and `prometheus` for observability;
 - `proptest` and `criterion` for invariants and benchmarks;
 - `moka` only for immutable schema/compiled-plan local caching.
@@ -177,162 +167,76 @@ Forbidden in Index core:
 - [x] Replace the implementation plan with the Index Engine roadmap.
 - [x] Record rewrite policy and target ownership in an ADR.
 - [x] Reset local FBA readiness to `in_progress`.
-- [x] Update crate/module documentation.
-- [x] Inventory the active legacy surface.
-- [x] Remove empty Content/Product query services.
-- [x] Remove duplicate read adapters.
-- [x] Remove `DocumentType` and `IndexDocument`.
-- [x] Delete legacy v1 ports, registry, and evidence.
-- [x] Delete the search-specific FTS helper.
-- [x] Detach Index admin from legacy index/search tables.
-- [x] Delete Content/Product/Flex indexers and projection models.
-- [x] Remove all direct source-table SQL from Index.
-- [x] Delete all legacy Index migrations, including the misplaced search table.
-- [x] Remove source-domain Cargo dependencies.
-- [x] Delete the legacy runtime config, scheduler, and operational errors.
-- [x] Remove legacy server dispatcher config and metrics.
-- [x] Add repository guards preventing legacy/source-domain artifacts returning.
-- [x] Synchronize the central module registry and historical FBA overview.
+- [x] Remove legacy v1 ports, adapters, source-specific indexers, projections,
+      migrations, runtime configuration, scheduler, server composition, and direct
+      source-table reads.
+- [x] Remove source-domain dependencies and add guards preventing their return.
+- [x] Synchronize local and central module documentation.
 
-M0 is complete. The central module registry and historical FBA overview now
-record the full removal of Index v1 and keep replacement FBA readiness at
-`in_progress` until new contracts and runtime evidence exist.
+M0 is complete. No compatibility contract exists for deleted Index v1 behavior.
 
 ### M1 - Domain core and schema registry
 
-- [x] Add bounded lowercase identifiers for modules, schemas, entities, fields,
-      links, locales, and versions.
-- [x] Add `IndexValue`, `IndexRecord`, and `IndexMutation`.
-- [x] Add `IndexSchema`, field/link metadata, and contract validation.
-- [x] Add explicit tenant/locale query scope.
-- [x] Add typed link-aware field paths, filter AST, ordering, and pagination.
-- [x] Add ICU4X locale syntax and CLDR alias canonicalization.
+- [x] Add bounded identifiers, canonical locales, schema identities, and versions.
+- [x] Add `IndexValue`, `IndexRecord`, `IndexMutation`, `IndexSchema`, and link
+      metadata.
 - [x] Add stable order-independent SHA-256 schema fingerprints.
-- [x] Add atomic versioned schema registration and conflict rules.
-- [x] Validate link targets, target fields, join-field types, and cardinality.
-- [x] Add deterministic shortest-path resolution through `petgraph`.
-- [x] Validate records against registered schemas and locale/cardinality rules.
-- [x] Validate query selectability, filterability, sortability, operators, types,
-      scope, and complexity limits.
-- [x] Reject ambiguous sorting through `many` links until aggregation is explicit.
-- [x] Add versioned, checksummed, query-scoped keyset cursor encoding.
-- [x] Add a test-only in-memory reference mutation/query engine.
-- [x] Add property tests for tenant isolation, redelivery idempotency, stale
-      tombstones, locale normalization, cursor round-trip, and deterministic
-      planning.
+- [x] Add atomic versioned schema registration and deterministic link-path
+      resolution.
+- [x] Validate records, mutations, query paths, operators, types, cardinality,
+      tenant/locale scope, and complexity bounds.
+- [x] Add versioned checksummed query-scoped keyset cursors.
+- [x] Add a test-only reference mutation/query engine and property invariants.
 
-Acceptance criterion is complete: Product and SalesChannel are representable by
-ordinary generic schemas and links with no Product-specific engine code.
+M1 is complete. Product and SalesChannel are representable by ordinary generic
+schemas and links without Product-specific Index code.
 
 ### M2 - PostgreSQL storage benchmark
 
-Goal: select physical storage from evidence before creating production
-migrations.
+- [x] Define the benchmark contract and keep candidate DDL outside production
+      migrations.
+- [x] Add deterministic smoke, 100k, and 1m datasets and identical read, mutation,
+      and maintenance workloads.
+- [x] Compare JSONB, typed EAV, and specialized hot projection using equal result
+      digests, cardinality, planner/session metadata, WAL, buffers, relation size,
+      churn, and VACUUM evidence.
+- [x] Archive same-commit replacement 100k/1m PostgreSQL evidence.
+- [x] Accept JSONB in the storage ADR and remove rejected prototype implementations.
 
-- [x] Define the benchmark contract and decision rules in
-      `docs/storage-benchmark.md`.
-- [x] Keep all candidate DDL outside production migrations in `ops/benches`.
-- [x] Add deterministic `smoke`, `100k`, and `1m` dataset presets.
-- [x] Canonicalize configured locales through `LocaleKey` before SQL generation.
-- [x] Pin every single-session PostgreSQL benchmark connection to
-      `standard_conforming_strings = on`, UTC, `DateStyle = 'ISO, YMD'`, and
-      `extra_float_digits = 3` before generated benchmark SQL runs.
-- [x] Archive one exact eleven-field observed PostgreSQL `database` object in
-      every read, mutation, and maintenance report through one shared Rust type
-      and metadata query.
-- [x] Re-read the observed database/session metadata after every report's
-      workloads and fail before serialization when any field drifts.
-- [x] Require exact metadata shape and equality across read, mutation, and
-      maintenance reports before importing the byte-preserved validator or
-      comparator core.
-- [x] Compare the canonical ten planner/session fields across same-commit scales
-      and bind the recorded methodology through shared ADR preparation,
-      rendering, and finalization gates.
-- [x] Generate Product, Variant, SalesChannel, tags, prices, timestamps, and links
-      without random or wall-clock inputs.
-- [x] Prototype JSONB entity rows plus typed expression/GIN indexes.
-- [x] Prototype normalized typed field-value rows.
-- [x] Preserve complete module/entity/schema-version identity in typed EAV field
-      keys, joins, mutations, and maintenance, with an entity-envelope foreign key.
-- [x] Scope JSONB and typed EAV maintenance entity mutations by the complete schema
-      identity.
-- [x] Add static guards for full-identity EAV and maintenance SQL.
-- [x] Prototype a specialized hot typed projection as the comparison baseline.
-- [x] Represent links independently from entity payload storage in every model.
-- [x] Split source, common-link, JSONB, EAV, hot, and maintenance SQL into
-      independent modules.
-- [x] Run the same equality, range, multi-value, two-hop link, keyset, and count
-      workload definitions against every model.
-- [x] Verify source/candidate entity and link cardinality before timing.
-- [x] Verify identical workload result digests across all candidates.
-- [x] Capture prototype load time, schema bytes, PostgreSQL settings, full SQL,
-      and repeated `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` output.
-- [x] Add a release-mode executable that writes machine-readable JSON evidence.
-- [x] Add deterministic Product batch update and delete workloads for all models.
-- [x] Validate equal affected entity/link counts before mutation timing.
-- [x] Isolate every measured mutation in its own rolled-back transaction.
-- [x] Capture mutation planning/execution time, buffers, full JSON plan, and
-      maximum per-node WAL records, FPI, and bytes.
-- [x] Add a separate release-mode mutation evidence executable/report.
-- [x] Add committed update plus delete/reinsert churn cycles for every candidate.
-- [x] Preserve exact entity/link cardinality through every maintenance phase.
-- [x] Capture baseline, after-churn, and after-VACUUM schema sizes and
-      `pg_stat_user_tables` live/dead/insert/update/delete/HOT counters.
-- [x] Execute `VACUUM (ANALYZE)` outside transactions and record its duration.
-- [x] Add a separate release-mode maintenance evidence executable/report with
-      configurable churn-cycle count.
-- [x] Run and archive the `smoke` read, mutation, and maintenance evidence as a
-      harness sanity check; retain it as historical evidence after later SQL fixes.
-- [x] Record the candidate operational review and ADR completion checklist.
-- [x] Require matching repository, commit, PostgreSQL settings, repetitions,
-      churn cycles, candidate order, and workload shape before `decision_ready`.
-- [x] Add fixture coverage that rejects mixed or incomplete cross-scale provenance.
-- [x] Run and archive replacement 100k Product-locale row read, mutation, and
-      maintenance evidence after the full-identity corrections.
-- [x] Run and archive replacement 1m Product-locale row read, mutation, and
-      maintenance evidence from the same commit as replacement 100k.
-- [x] Compare warm/cold buffers, planner stability, execution latency, ingestion
-      throughput, relation size, WAL, dead tuples, vacuum behavior, and operational
-      complexity.
-- [x] Record the selected model and rejected alternatives in an ADR.
-- [x] Delete benchmark prototypes that are not selected.
-
-Replacement same-commit PostgreSQL evidence is archived, the accepted ADR
-selects JSONB as canonical generic storage, and the rejected typed-EAV and
-hot-projection benchmark implementations are removed. M2 is complete. The
-remaining JSONB benchmark path is a selected-layout regression harness; it is not
-production persistence and does not reopen the accepted storage decision.
+M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
+harness; it is not production persistence and does not reopen the accepted storage
+decision.
 
 ### M3 - PostgreSQL storage engine
 
 - [x] Add canonical schema/entity/link/inbox/job/checkpoint/consistency migrations.
 - [x] Add tenant/schema/entity/locale keys and source-version guards.
 - [x] Add atomic entity/link upsert and delete transactions.
-- [ ] Add locking/leases for schema application.
+- [x] Add locking/leases for schema application.
 - [ ] Add partition and secondary-index management.
 - [ ] Add PostgreSQL Testcontainers fixtures.
 - [ ] Cover migration-from-zero, stale mutation, redelivery, rollback,
-      concurrency, and tenant/locale isolation.
+      concurrency, and tenant/locale isolation in PostgreSQL.
 
-The first M3 slice registers three fail-closed module-owned migrations that create
-`index_schemas`, `index_entities`, `index_links`, `index_inbox`,
-`index_checkpoints`, `index_jobs`, and `index_consistency_findings`. Their keys
-lead with tenant identity, preserve the complete generic schema/entity/locale
-shape, bind entities and outgoing links to an exact non-negative `DECIMAL(20,0)` source
-version that preserves the domain `u64` range,
-and use the empty locale sentinel for locale-neutral records. Schema fingerprints
-remain explicit in the entity foreign key.
+The first M3 slice registers the seven module-owned tables. Their keys lead with
+tenant identity, preserve the complete schema/entity/locale shape, bind entities
+and links to exact non-negative `DECIMAL(20,0)` source versions, and retain schema
+fingerprints in entity foreign keys.
 
 The second M3 slice publishes `PostgresMutationStore`. Every delivery is validated
-through `SchemaRegistry`, bound to a SHA-256 payload identity, claimed by the
-composite inbox key, and applied in one database transaction. The store takes a transaction-scoped PostgreSQL advisory lock on the complete
-entity key, retains a conditional monotonic upsert for the
-concurrent-create race, deletes old links before replacing the source version,
-rebuilds ordered links for live rows, writes payload-free tombstones for deletes,
-and completes the inbox only after all writes succeed. Exact redelivery returns a
-duplicate outcome; stale versions are terminally ignored. SQLite remains a
-contract-test backend with signed source-version limits. PostgreSQL concurrency
-and Testcontainers evidence remain open.
+through `SchemaRegistry`, bound to a SHA-256 payload identity, claimed through the
+composite inbox key, serialized by a transaction-scoped entity advisory lock, and
+applied atomically. Exact redelivery is a duplicate; stale versions are terminally
+ignored; deletes write payload-free tombstones.
+
+The third M3 slice publishes `PostgresSchemaLeaseStore`. It serializes exact
+tenant/module/entity/schema-version application with a transaction-scoped advisory
+lock, verifies the persisted active schema and fingerprint, records durable
+`schema_apply` work in `index_jobs`, and returns `Busy` or `AlreadyApplied` when
+appropriate. Expired work is reclaimed with incremented attempt fencing. Heartbeat,
+success, and failure require the exact job, worker, attempt, running state, and an
+unexpired lease. SQLite remains contract-test-only; PostgreSQL concurrency and
+Testcontainers evidence remain open.
 
 ### M4 - Query engine v1
 
@@ -416,108 +320,28 @@ cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
 npm run verify:index:runtime-fallback-smoke
+node scripts/verify/index-storage-tooling.mjs contract
+node scripts/verify/index-storage-tooling.mjs fixtures
 node --test scripts/verify/compare-index-storage-evidence.test.mjs
 ```
 
-M2 operational commands:
+Targeted M3 maintainer checks:
 
 ```bash
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=smoke \
-  cargo run -p rustok-benchmarks --bin index-storage-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=smoke \
-  cargo run -p rustok-benchmarks --bin index-storage-mutation-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=smoke INDEX_BENCH_CHURN_CYCLES=5 \
-  cargo run -p rustok-benchmarks --bin index-storage-maintenance-benchmark --release
-
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=100k \
-  cargo run -p rustok-benchmarks --bin index-storage-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=100k \
-  cargo run -p rustok-benchmarks --bin index-storage-mutation-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=100k INDEX_BENCH_CHURN_CYCLES=5 \
-  cargo run -p rustok-benchmarks --bin index-storage-maintenance-benchmark --release
-
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=1m \
-  cargo run -p rustok-benchmarks --bin index-storage-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=1m \
-  cargo run -p rustok-benchmarks --bin index-storage-mutation-benchmark --release
-DATABASE_URL=postgres://... INDEX_BENCH_SCALE=1m INDEX_BENCH_CHURN_CYCLES=5 \
-  cargo run -p rustok-benchmarks --bin index-storage-maintenance-benchmark --release
+cargo check -p rustok-index --all-targets
+cargo test -p rustok-index --lib
+node scripts/verify/verify-index-mutation-storage.mjs
+node scripts/verify/verify-index-schema-leases.mjs
 ```
 
 ## Progress log
 
-- 2026-07-23: accepted the destructive rewrite and added the initial generic
-  domain core.
-- 2026-07-23: deleted every legacy query, projection, indexer, migration, port,
-  adapter, scheduler, runtime config, error type, and server composition path.
-- 2026-07-23: completed M1 with canonical identifiers/locales, schema
-  fingerprints, atomic registry, deterministic link graph, scoped validation,
-  bounded queries, keyset cursors, reference evaluator, and property invariants.
-- 2026-07-23: moved the active milestone to the PostgreSQL storage benchmark;
-  no production persistence will be added before the benchmark ADR.
-- 2026-07-23: implemented deterministic M2 datasets, JSONB/EAV/hot candidates,
-  independent link storage, shared workloads, PostgreSQL execution, and JSON
-  EXPLAIN evidence output.
-- 2026-07-23: modularized candidate SQL and added fail-fast entity/link cardinality
-  plus semantic result-digest parity before any plan comparison.
-- 2026-07-23: added isolated update/delete write-amplification workloads with
-  affected-row/link validation, rollback isolation, WAL/BUFFERS evidence, and a
-  separate machine-readable mutation report.
-- 2026-07-23: added persistent committed churn with delete/reinsert restoration,
-  baseline/after-churn/after-VACUUM size and table-stat snapshots, cardinality
-  guards, and a dedicated maintenance report.
-- 2026-07-23: archived PostgreSQL 16 smoke evidence from Actions run `30041091121`
-  as artifact `index-storage-smoke-8efd318091098bb5bce0d5f83b8b51653dc4934c`.
-  All candidates preserved 1,216 entities and 2,400 links, produced identical
-  read-workload digests, validated equal mutation effects, and preserved exact
-  cardinality through five committed churn cycles and VACUUM. This packet remains
-  historical harness-sanity evidence after later SQL corrections.
-- 2026-07-24: synchronized the central module registry and FBA overview with
-  complete Index v1 removal, removed references to deleted registry/evidence
-  and read-model contracts, and reset central FBA readiness to `in_progress`.
-- 2026-07-24: inspected Actions run `30051321255` and artifact
-  `index-storage-100k-84a11b147689b226ca161f5a0287990c1e8489d4`.
-  PostgreSQL 16 preserved 300,080 entities and 600,000 links across JSONB,
-  typed EAV, and hot projection candidates; all read digests, mutation effects,
-  five churn cycles, and post-VACUUM cardinalities matched. That run's 1m stage
-  failed closed because `INDEX_BENCH_LARGE_RUNNER` was unset. The workflow now
-  prefers that explicit runner when configured and otherwise uses `ubuntu-latest`,
-  while the reusable job still rejects any runner below 35 GB free disk.
-- 2026-07-24: runner evidence showed 93,030,404,096 free bytes before the 100k
-  packet and 88,893,792,256 after it. Enabled a guarded `ubuntu-latest` fallback
-  for the 1m stage while preserving `INDEX_BENCH_LARGE_RUNNER` as an override
-  and the existing 35 GB fail-closed disk check.
-- 2026-07-24: inspected the 100k `two_hop_channel_filter` EXPLAIN tree. The
-  Product-to-Variant reverse lookup performed about 1.64 million shared-hit
-  buffer accesses because both link hops omitted their known `target_entity`
-  discriminators. Added `variant` and `sales_channel` target predicates to all
-  three candidate queries and locked them in `verify-index-fba.mjs`; the prior
-  two-hop latency is retained only as pre-fix diagnostic evidence.
-- 2026-07-24: re-audited the M2 physical identity contract. Typed EAV field rows
-  omitted module and schema version, and JSONB/EAV maintenance entity mutations
-  still relied on `entity_name` alone. Added complete field identity, an entity
-  foreign key, full-identity query/mutation/maintenance predicates, static guards,
-  and the canonical operational review. The original 100k packet is now historical
-  diagnostic evidence; replacement same-commit 100k/1m evidence remains the next
-  open M2 action.
-- 2026-07-24: made `decision_ready` fail closed unless replacement 100k/1m packets
-  share repository, commit, PostgreSQL settings, repetitions, churn contract, and
-  candidate/workload shape. Added fixture coverage for valid same-commit input and
-  mixed or incomplete provenance; tests were not run by the assistant.
-- 2026-07-24: pinned every M2 benchmark connection to
-  `standard_conforming_strings = on` before source or candidate SQL runs, and
-  added a permanent source guard so server, database, or role defaults cannot
-  change archived SQL semantics. Tests were not run by the assistant.
-- 2026-07-25: expanded the deterministic session contract to UTC,
-  `DateStyle = 'ISO, YMD'`, and `extra_float_digits = 3`, captured the exact
-  observed PostgreSQL metadata from each active read, mutation, and maintenance
-  session, and re-checked it after all workloads before writing reports.
-- 2026-07-25: made packet preflight fail closed on missing, extra, or unequal
-  eleven-field database metadata across the three reports before byte-preserved
-  validation or comparison, and unified all runners on one shared Rust metadata
-  owner.
-- 2026-07-25: bound the official ten-field cross-scale methodology to comparison,
-  decision preparation, direct ADR rendering, finalization, integrity guards, and
-  documentation. Core-only output remains incomplete, while replacement same-
-  commit 100k/1m evidence and the accepted storage ADR remain open. Tests,
-  verifiers, workflows, and benchmarks were not run by the assistant.
+- 2026-07-23: completed the destructive reset and generic M1 core.
+- 2026-07-24 through 2026-07-27: completed the deterministic M2 PostgreSQL
+  comparison, archived same-commit replacement evidence, accepted JSONB, and
+  removed rejected prototypes.
+- 2026-07-27: registered the canonical M3 storage schema and added atomic
+  mutation/inbox/entity/link persistence.
+- 2026-07-27: added durable schema-application exclusion, expiry reclaim,
+  heartbeat, terminal completion, and attempt fencing. Tests and verifiers were
+  left for the repository owner to execute.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,8 +1,15 @@
 mod mutation_store;
+mod schema_lease;
 
 #[cfg(test)]
 mod mutation_store_tests;
+#[cfg(test)]
+mod schema_lease_tests;
 
 pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+};
+pub use schema_lease::{
+    PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,
+    SchemaLeaseAcquireOutcome, SchemaLeaseError,
 };

--- a/crates/rustok-index/src/infrastructure/postgres/schema_lease.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/schema_lease.rs
@@ -1,0 +1,646 @@
+use std::time::Duration;
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{IndexSchema, SchemaFingerprint, SchemaRef};
+
+const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_ERROR_CODE_BYTES: usize = 128;
+const MAX_LEASE_SECONDS: u64 = 86_400;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaApplicationLeaseRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    schema_fingerprint: SchemaFingerprint,
+    worker_id: String,
+    lease_seconds: u64,
+}
+
+impl SchemaApplicationLeaseRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: &IndexSchema,
+        worker_id: impl Into<String>,
+        lease_duration: Duration,
+    ) -> Result<Self, SchemaLeaseError> {
+        if tenant_id.is_nil() {
+            return Err(SchemaLeaseError::NilTenantId);
+        }
+        let worker_id = worker_id.into();
+        validate_worker_id(&worker_id)?;
+        let lease_seconds = validate_lease_duration(lease_duration)?;
+        let schema_fingerprint = schema
+            .fingerprint()
+            .map_err(|error| SchemaLeaseError::InvalidSchema(error.to_string()))?;
+        Ok(Self {
+            tenant_id,
+            schema: schema.reference.clone(),
+            schema_fingerprint,
+            worker_id,
+            lease_seconds,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn schema_fingerprint(&self) -> SchemaFingerprint {
+        self.schema_fingerprint
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn lease_duration(&self) -> Duration {
+        Duration::from_secs(self.lease_seconds)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaApplicationLease {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    schema: SchemaRef,
+    schema_fingerprint: SchemaFingerprint,
+    worker_id: String,
+    attempt_count: u32,
+}
+
+impl SchemaApplicationLease {
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn schema_fingerprint(&self) -> SchemaFingerprint {
+        self.schema_fingerprint
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaLeaseAcquireOutcome {
+    Acquired(SchemaApplicationLease),
+    Busy,
+    AlreadyApplied { job_id: Uuid },
+}
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum SchemaLeaseError {
+    #[error("schema application tenant id must not be nil")]
+    NilTenantId,
+    #[error("invalid schema application worker id: {reason}")]
+    InvalidWorkerId { reason: &'static str },
+    #[error("schema application lease duration must be a whole number of seconds between 1 and 86400")]
+    InvalidLeaseDuration,
+    #[error("invalid schema application error code: {reason}")]
+    InvalidErrorCode { reason: &'static str },
+    #[error("invalid schema application contract: {0}")]
+    InvalidSchema(String),
+    #[error("schema is not persisted for this tenant: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("schema is retired and cannot be applied: {0}")]
+    SchemaRetired(SchemaRef),
+    #[error("persisted schema fingerprint does not match the requested schema")]
+    SchemaFingerprintConflict,
+    #[error("stored schema application job is invalid: {0}")]
+    InvalidStoredJob(String),
+    #[error("schema application lease ownership was lost")]
+    LeaseLost,
+    #[error("schema application storage operation failed")]
+    Storage(String),
+}
+
+#[derive(Clone)]
+pub struct PostgresSchemaLeaseStore {
+    db: DatabaseConnection,
+}
+
+impl PostgresSchemaLeaseStore {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn acquire(
+        &self,
+        request: &SchemaApplicationLeaseRequest,
+    ) -> Result<SchemaLeaseAcquireOutcome, SchemaLeaseError> {
+        let transaction = self.db.begin().await.map_err(storage_error)?;
+        let result = self.acquire_in_transaction(&transaction, request).await;
+        match result {
+            Ok(outcome) => {
+                transaction.commit().await.map_err(storage_error)?;
+                Ok(outcome)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(storage_error)?;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn heartbeat(
+        &self,
+        lease: &SchemaApplicationLease,
+        lease_duration: Duration,
+    ) -> Result<(), SchemaLeaseError> {
+        let lease_seconds = validate_lease_duration(lease_duration)?;
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let updated = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                heartbeat_sql(backend),
+                vec![
+                    uuid_value(lease.tenant_id, backend),
+                    uuid_value(lease.job_id, backend),
+                    lease.worker_id.clone().into(),
+                    i64::from(lease.attempt_count).into(),
+                    i64::try_from(lease_seconds)
+                        .map_err(|_| SchemaLeaseError::InvalidLeaseDuration)?
+                        .into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        if updated.rows_affected() != 1 {
+            return Err(SchemaLeaseError::LeaseLost);
+        }
+        Ok(())
+    }
+
+    pub async fn succeed(&self, lease: &SchemaApplicationLease) -> Result<(), SchemaLeaseError> {
+        self.finish(lease, "succeeded", None, None).await
+    }
+
+    pub async fn fail(
+        &self,
+        lease: &SchemaApplicationLease,
+        error_code: impl Into<String>,
+        error_details: JsonValue,
+    ) -> Result<(), SchemaLeaseError> {
+        let error_code = error_code.into();
+        validate_error_code(&error_code)?;
+        self.finish(
+            lease,
+            "failed",
+            Some(error_code),
+            Some(error_details),
+        )
+        .await
+    }
+
+    async fn acquire_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        request: &SchemaApplicationLeaseRequest,
+    ) -> Result<SchemaLeaseAcquireOutcome, SchemaLeaseError> {
+        let backend = transaction.get_database_backend();
+        ensure_supported_backend(backend)?;
+        self.lock_schema(transaction, request, backend).await?;
+        self.verify_schema_registration(transaction, request, backend)
+            .await?;
+
+        let rows = transaction
+            .query_all(Statement::from_sql_and_values(
+                backend,
+                select_schema_jobs_sql(backend),
+                schema_scope_values(request, backend),
+            ))
+            .await
+            .map_err(storage_error)?;
+
+        let mut claimable = None;
+        for row in rows {
+            let stored = stored_job(&row, backend)?;
+            if stored.schema_fingerprint != request.schema_fingerprint.to_string() {
+                return Err(SchemaLeaseError::InvalidStoredJob(
+                    "job fingerprint does not match the persisted schema version".to_owned(),
+                ));
+            }
+            match stored.state.as_str() {
+                "succeeded" => {
+                    return Ok(SchemaLeaseAcquireOutcome::AlreadyApplied {
+                        job_id: stored.job_id,
+                    });
+                }
+                "running" if !stored.claimable => {
+                    return Ok(SchemaLeaseAcquireOutcome::Busy);
+                }
+                "pending" if !stored.claimable => {
+                    return Ok(SchemaLeaseAcquireOutcome::Busy);
+                }
+                "pending" | "running" => {
+                    claimable = Some(stored);
+                    break;
+                }
+                state => {
+                    return Err(SchemaLeaseError::InvalidStoredJob(format!(
+                        "unexpected active state {state}"
+                    )));
+                }
+            }
+        }
+
+        let job_id;
+        let attempt_count;
+        if let Some(stored) = claimable {
+            job_id = stored.job_id;
+            attempt_count = stored.attempt_count.checked_add(1).ok_or_else(|| {
+                SchemaLeaseError::InvalidStoredJob("attempt count overflow".to_owned())
+            })?;
+            let claimed = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    claim_job_sql(backend),
+                    vec![
+                        uuid_value(request.tenant_id, backend),
+                        uuid_value(job_id, backend),
+                        request.worker_id.clone().into(),
+                        i64::from(attempt_count).into(),
+                        i64::try_from(request.lease_seconds)
+                            .map_err(|_| SchemaLeaseError::InvalidLeaseDuration)?
+                            .into(),
+                    ],
+                ))
+                .await
+                .map_err(storage_error)?;
+            if claimed.rows_affected() != 1 {
+                return Err(SchemaLeaseError::LeaseLost);
+            }
+        } else {
+            job_id = Uuid::new_v4();
+            attempt_count = 1;
+            let job_request = json!({
+                "schema_fingerprint": request.schema_fingerprint.to_string(),
+            });
+            transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    insert_job_sql(backend),
+                    vec![
+                        uuid_value(request.tenant_id, backend),
+                        uuid_value(job_id, backend),
+                        request.schema.module.as_str().to_owned().into(),
+                        request.schema.entity.as_str().to_owned().into(),
+                        i64::from(request.schema.version.get()).into(),
+                        SqlValue::Json(Some(Box::new(job_request))),
+                        request.worker_id.clone().into(),
+                        i64::try_from(request.lease_seconds)
+                            .map_err(|_| SchemaLeaseError::InvalidLeaseDuration)?
+                            .into(),
+                    ],
+                ))
+                .await
+                .map_err(storage_error)?;
+        }
+
+        Ok(SchemaLeaseAcquireOutcome::Acquired(
+            SchemaApplicationLease {
+                tenant_id: request.tenant_id,
+                job_id,
+                schema: request.schema.clone(),
+                schema_fingerprint: request.schema_fingerprint,
+                worker_id: request.worker_id.clone(),
+                attempt_count,
+            },
+        ))
+    }
+
+    async fn lock_schema(
+        &self,
+        transaction: &DatabaseTransaction,
+        request: &SchemaApplicationLeaseRequest,
+        backend: DbBackend,
+    ) -> Result<(), SchemaLeaseError> {
+        if backend == DbBackend::Sqlite {
+            return Ok(());
+        }
+        let lock_key = format!(
+            "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+            request.tenant_id,
+            request.schema.module.as_str(),
+            request.schema.entity.as_str(),
+            request.schema.version.get(),
+        );
+        transaction
+            .execute(Statement::from_sql_and_values(
+                backend,
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                vec![lock_key.into()],
+            ))
+            .await
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
+    async fn verify_schema_registration(
+        &self,
+        transaction: &DatabaseTransaction,
+        request: &SchemaApplicationLeaseRequest,
+        backend: DbBackend,
+    ) -> Result<(), SchemaLeaseError> {
+        let row = transaction
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_schema_sql(backend),
+                schema_scope_values(request, backend),
+            ))
+            .await
+            .map_err(storage_error)?
+            .ok_or_else(|| SchemaLeaseError::SchemaNotRegistered(request.schema.clone()))?;
+        let fingerprint: String = row
+            .try_get("", "schema_fingerprint")
+            .map_err(storage_error)?;
+        let status: String = row.try_get("", "status").map_err(storage_error)?;
+        if fingerprint != request.schema_fingerprint.to_string() {
+            return Err(SchemaLeaseError::SchemaFingerprintConflict);
+        }
+        if status != "active" {
+            return Err(SchemaLeaseError::SchemaRetired(request.schema.clone()));
+        }
+        Ok(())
+    }
+
+    async fn finish(
+        &self,
+        lease: &SchemaApplicationLease,
+        state: &'static str,
+        error_code: Option<String>,
+        error_details: Option<JsonValue>,
+    ) -> Result<(), SchemaLeaseError> {
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let updated = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                finish_job_sql(backend),
+                vec![
+                    state.into(),
+                    error_code.into(),
+                    SqlValue::Json(error_details.map(Box::new)),
+                    uuid_value(lease.tenant_id, backend),
+                    uuid_value(lease.job_id, backend),
+                    lease.worker_id.clone().into(),
+                    i64::from(lease.attempt_count).into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        if updated.rows_affected() != 1 {
+            return Err(SchemaLeaseError::LeaseLost);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct StoredJob {
+    job_id: Uuid,
+    state: String,
+    schema_fingerprint: String,
+    attempt_count: u32,
+    claimable: bool,
+}
+
+fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, SchemaLeaseError> {
+    let request: JsonValue = row.try_get("", "request").map_err(storage_error)?;
+    let schema_fingerprint = request
+        .get("schema_fingerprint")
+        .and_then(JsonValue::as_str)
+        .filter(|value| value.len() == 64)
+        .ok_or_else(|| {
+            SchemaLeaseError::InvalidStoredJob(
+                "request.schema_fingerprint must be a 64-character string".to_owned(),
+            )
+        })?
+        .to_owned();
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(storage_error)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        SchemaLeaseError::InvalidStoredJob("attempt count is outside the u32 range".to_owned())
+    })?;
+    let claimable: bool = row.try_get("", "claimable").map_err(storage_error)?;
+    Ok(StoredJob {
+        job_id: stored_uuid(row, "job_id", backend)?,
+        state: row.try_get("", "state").map_err(storage_error)?,
+        schema_fingerprint,
+        attempt_count,
+        claimable,
+    })
+}
+
+fn validate_worker_id(worker_id: &str) -> Result<(), SchemaLeaseError> {
+    if worker_id.is_empty() {
+        return Err(SchemaLeaseError::InvalidWorkerId {
+            reason: "must not be empty",
+        });
+    }
+    if worker_id.trim() != worker_id {
+        return Err(SchemaLeaseError::InvalidWorkerId {
+            reason: "must not contain leading or trailing whitespace",
+        });
+    }
+    if worker_id.len() > MAX_WORKER_ID_BYTES {
+        return Err(SchemaLeaseError::InvalidWorkerId {
+            reason: "exceeds the storage limit",
+        });
+    }
+    if worker_id.chars().any(char::is_control) {
+        return Err(SchemaLeaseError::InvalidWorkerId {
+            reason: "must not contain control characters",
+        });
+    }
+    Ok(())
+}
+
+fn validate_error_code(error_code: &str) -> Result<(), SchemaLeaseError> {
+    if error_code.is_empty() {
+        return Err(SchemaLeaseError::InvalidErrorCode {
+            reason: "must not be empty",
+        });
+    }
+    if error_code.trim() != error_code {
+        return Err(SchemaLeaseError::InvalidErrorCode {
+            reason: "must not contain leading or trailing whitespace",
+        });
+    }
+    if error_code.len() > MAX_ERROR_CODE_BYTES {
+        return Err(SchemaLeaseError::InvalidErrorCode {
+            reason: "exceeds the storage limit",
+        });
+    }
+    if error_code.chars().any(char::is_control) {
+        return Err(SchemaLeaseError::InvalidErrorCode {
+            reason: "must not contain control characters",
+        });
+    }
+    Ok(())
+}
+
+fn validate_lease_duration(lease_duration: Duration) -> Result<u64, SchemaLeaseError> {
+    if lease_duration.subsec_nanos() != 0 {
+        return Err(SchemaLeaseError::InvalidLeaseDuration);
+    }
+    let seconds = lease_duration.as_secs();
+    if seconds == 0 || seconds > MAX_LEASE_SECONDS {
+        return Err(SchemaLeaseError::InvalidLeaseDuration);
+    }
+    Ok(seconds)
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), SchemaLeaseError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        backend => Err(SchemaLeaseError::Storage(format!(
+            "Index schema leases do not support {backend:?}"
+        ))),
+    }
+}
+
+fn storage_error(error: impl std::fmt::Display) -> SchemaLeaseError {
+    SchemaLeaseError::Storage(error.to_string())
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn stored_uuid(
+    row: &QueryResult,
+    column: &str,
+    backend: DbBackend,
+) -> Result<Uuid, SchemaLeaseError> {
+    match backend {
+        DbBackend::Postgres => row.try_get("", column).map_err(storage_error),
+        DbBackend::Sqlite => {
+            let value: String = row.try_get("", column).map_err(storage_error)?;
+            Uuid::parse_str(&value).map_err(storage_error)
+        }
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn schema_scope_values(
+    request: &SchemaApplicationLeaseRequest,
+    backend: DbBackend,
+) -> Vec<SqlValue> {
+    vec![
+        uuid_value(request.tenant_id, backend),
+        request.schema.module.as_str().to_owned().into(),
+        request.schema.entity.as_str().to_owned().into(),
+        i64::from(request.schema.version.get()).into(),
+    ]
+}
+
+fn select_schema_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "SELECT schema_fingerprint, status FROM index_schemas WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 LIMIT 1"
+    )
+}
+
+fn select_schema_jobs_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let (attempt_count, claimable) = match backend {
+        DbBackend::Postgres => (
+            "CAST(attempt_count AS BIGINT)",
+            "((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))",
+        ),
+        DbBackend::Sqlite => (
+            "CAST(attempt_count AS INTEGER)",
+            "CASE WHEN (state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP) THEN TRUE ELSE FALSE END",
+        ),
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT job_id, state, request, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'schema_apply' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+    )
+}
+
+fn insert_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 8);
+    format!(
+        "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, request, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at) VALUES ({prefix}1, {prefix}2, 'schema_apply', 'running', 'schema', {prefix}3, {prefix}4, {prefix}5, {prefix}6, 1, CURRENT_TIMESTAMP, {prefix}7, {lease_expires}, CURRENT_TIMESTAMP)"
+    )
+}
+
+fn claim_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET state = 'running', lease_owner = {prefix}3, attempt_count = {prefix}4, lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, completed_at = NULL, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'schema_apply' AND ((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))"
+    )
+}
+
+fn heartbeat_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'schema_apply' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP"
+    )
+}
+
+fn finish_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = {prefix}1, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, last_error_code = {prefix}2, last_error_details = {prefix}3, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}4 AND job_id = {prefix}5 AND kind = 'schema_apply' AND state = 'running' AND lease_owner = {prefix}6 AND attempt_count = {prefix}7 AND lease_expires_at > CURRENT_TIMESTAMP"
+    )
+}
+
+fn lease_expires_expression(backend: DbBackend, parameter: usize) -> String {
+    let prefix = placeholder_prefix(backend);
+    match backend {
+        DbBackend::Postgres => {
+            format!("CURRENT_TIMESTAMP + ({prefix}{parameter} * INTERVAL '1 second')")
+        }
+        DbBackend::Sqlite => {
+            format!("datetime('now', '+' || {prefix}{parameter} || ' seconds')")
+        }
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/schema_lease_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/schema_lease_tests.rs
@@ -1,0 +1,251 @@
+use std::time::Duration;
+
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::{
+    PostgresSchemaLeaseStore, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
+    SchemaLeaseError,
+};
+use crate::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema,
+    IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+
+struct Fixture {
+    db: DatabaseConnection,
+    store: PostgresSchemaLeaseStore,
+    schema: IndexSchema,
+}
+
+impl Fixture {
+    async fn new(status: &str) -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema();
+        let fingerprint = schema.fingerprint().unwrap().to_string();
+        let schema_json = serde_json::to_value(&schema).unwrap();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+                status.to_owned().into(),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+        let store = PostgresSchemaLeaseStore::new(db.clone());
+        Self { db, store, schema }
+    }
+
+    fn request(&self, worker: &str) -> SchemaApplicationLeaseRequest {
+        SchemaApplicationLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            &self.schema,
+            worker,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: SchemaRef {
+            module: ModuleName::new("catalog").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::INITIAL,
+        },
+        locale_mode: LocaleMode::Required,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: false,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: &str) -> i64 {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be integer")
+}
+
+#[tokio::test]
+async fn acquire_excludes_other_workers_and_completion_is_terminal() {
+    let fixture = Fixture::new("active").await;
+    let first = match fixture.store.acquire(&fixture.request("worker-a")).await.unwrap() {
+        SchemaLeaseAcquireOutcome::Acquired(lease) => lease,
+        outcome => panic!("first acquisition should win, got {outcome:?}"),
+    };
+    assert_eq!(first.attempt_count(), 1);
+    assert_eq!(
+        fixture.store.acquire(&fixture.request("worker-b")).await.unwrap(),
+        SchemaLeaseAcquireOutcome::Busy
+    );
+    fixture
+        .store
+        .heartbeat(&first, Duration::from_secs(120))
+        .await
+        .unwrap();
+    fixture.store.succeed(&first).await.unwrap();
+    assert_eq!(
+        fixture.store.acquire(&fixture.request("worker-b")).await.unwrap(),
+        SchemaLeaseAcquireOutcome::AlreadyApplied {
+            job_id: first.job_id(),
+        }
+    );
+    assert_eq!(
+        fixture
+            .store
+            .heartbeat(&first, Duration::from_secs(60))
+            .await,
+        Err(SchemaLeaseError::LeaseLost)
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'schema_apply' AND state = 'succeeded' AND lease_owner IS NULL AND lease_expires_at IS NULL AND completed_at IS NOT NULL"
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn expired_lease_is_reclaimed_with_attempt_fencing() {
+    let fixture = Fixture::new("active").await;
+    let first = match fixture.store.acquire(&fixture.request("worker-a")).await.unwrap() {
+        SchemaLeaseAcquireOutcome::Acquired(lease) => lease,
+        outcome => panic!("first acquisition should win, got {outcome:?}"),
+    };
+    fixture
+        .db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "UPDATE index_jobs SET lease_expires_at = datetime('now', '-1 second') WHERE tenant_id = ?1 AND job_id = ?2",
+            vec![TENANT.to_owned().into(), first.job_id().to_string().into()],
+        ))
+        .await
+        .unwrap();
+
+    let second = match fixture.store.acquire(&fixture.request("worker-b")).await.unwrap() {
+        SchemaLeaseAcquireOutcome::Acquired(lease) => lease,
+        outcome => panic!("expired lease should be reclaimed, got {outcome:?}"),
+    };
+    assert_eq!(second.job_id(), first.job_id());
+    assert_eq!(second.attempt_count(), 2);
+    assert_eq!(fixture.store.succeed(&first).await, Err(SchemaLeaseError::LeaseLost));
+    fixture
+        .store
+        .fail(&second, "schema.ddl_failed", json!({"retryable": true}))
+        .await
+        .unwrap();
+
+    let third = match fixture.store.acquire(&fixture.request("worker-c")).await.unwrap() {
+        SchemaLeaseAcquireOutcome::Acquired(lease) => lease,
+        outcome => panic!("failed terminal job should permit a new attempt, got {outcome:?}"),
+    };
+    assert_ne!(third.job_id(), second.job_id());
+    assert_eq!(third.attempt_count(), 1);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'schema_apply' AND state = 'failed' AND last_error_code = 'schema.ddl_failed' AND completed_at IS NOT NULL"
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn schema_registration_and_request_identity_fail_closed() {
+    let retired = Fixture::new("retired").await;
+    assert_eq!(
+        retired.store.acquire(&retired.request("worker-a")).await,
+        Err(SchemaLeaseError::SchemaRetired(retired.schema.reference.clone()))
+    );
+
+    let active = Fixture::new("active").await;
+    active
+        .db
+        .execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "DELETE FROM index_schemas".to_owned(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        active.store.acquire(&active.request("worker-a")).await,
+        Err(SchemaLeaseError::SchemaNotRegistered(
+            active.schema.reference.clone()
+        ))
+    );
+
+    assert!(matches!(
+        SchemaApplicationLeaseRequest::new(
+            Uuid::nil(),
+            &active.schema,
+            "worker-a",
+            Duration::from_secs(60),
+        ),
+        Err(SchemaLeaseError::NilTenantId)
+    ));
+    assert!(matches!(
+        SchemaApplicationLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            &active.schema,
+            " worker-a ",
+            Duration::from_secs(60),
+        ),
+        Err(SchemaLeaseError::InvalidWorkerId { .. })
+    ));
+    assert!(matches!(
+        SchemaApplicationLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            &active.schema,
+            "worker-a",
+            Duration::ZERO,
+        ),
+        Err(SchemaLeaseError::InvalidLeaseDuration)
+    ));
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! The active implementation contains the database-independent generic engine
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
-//! storage-schema migrations, and the first transactional mutation adapter.
+//! storage-schema migrations, atomic mutation persistence, and durable
+//! schema-application leases.
 
 use async_trait::async_trait;
 use rustok_core::{MigrationDependencyDescriptor, MigrationSource, ModuleKind, RusToKModule};
@@ -17,6 +18,8 @@ pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+    PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,
+    SchemaLeaseAcquireOutcome, SchemaLeaseError,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -55,6 +55,7 @@ const runContract = (args) => {
     'verify-index-fba.mjs',
     'verify-index-storage-migrations.mjs',
     'verify-index-mutation-storage.mjs',
+    'verify-index-schema-leases.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',

--- a/scripts/verify/verify-index-schema-leases.mjs
+++ b/scripts/verify/verify-index-schema-leases.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-schema-leases] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const leasePath = 'crates/rustok-index/src/infrastructure/postgres/schema_lease.rs';
+const lease = requireMarkers(leasePath, [
+  'pub struct SchemaApplicationLeaseRequest',
+  'pub struct SchemaApplicationLease',
+  'pub enum SchemaLeaseAcquireOutcome',
+  'pub struct PostgresSchemaLeaseStore',
+  'pub async fn acquire(',
+  'pub async fn heartbeat(',
+  'pub async fn succeed(',
+  'pub async fn fail(',
+  'pg_advisory_xact_lock(hashtextextended($1, 0))',
+  "kind = 'schema_apply'",
+  "scope_kind = 'schema'",
+  "state IN ('pending', 'running', 'succeeded')",
+  "lease_expires_at <= CURRENT_TIMESTAMP",
+  "lease_expires_at > CURRENT_TIMESTAMP",
+  'attempt_count =',
+  'SchemaLeaseError::LeaseLost',
+  'SchemaLeaseAcquireOutcome::AlreadyApplied',
+  'SchemaLeaseAcquireOutcome::Busy',
+  'schema_fingerprint',
+  'DbBackend::Sqlite if cfg!(test) => Ok(())',
+]);
+
+const lockPosition = lease.indexOf('self.lock_schema(transaction, request, backend)');
+const verifyPosition = lease.indexOf('self.verify_schema_registration(transaction, request, backend)');
+const selectPosition = lease.indexOf('select_schema_jobs_sql(backend)');
+if (
+  lockPosition < 0 ||
+  verifyPosition < 0 ||
+  selectPosition < 0 ||
+  !(lockPosition < verifyPosition && verifyPosition < selectPosition)
+) {
+  fail('schema advisory lock, persisted-schema verification, and job selection must remain ordered');
+}
+
+for (const forbidden of [
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+  'rustok_pricing',
+  'rustok_inventory',
+  'CREATE INDEX CONCURRENTLY',
+]) {
+  if (lease.includes(forbidden)) fail(`${leasePath} contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_lease_tests.rs', [
+  'acquire_excludes_other_workers_and_completion_is_terminal',
+  'expired_lease_is_reclaimed_with_attempt_fencing',
+  'schema_registration_and_request_identity_fail_closed',
+  'SchemaLeaseAcquireOutcome::Busy',
+  'SchemaLeaseAcquireOutcome::AlreadyApplied',
+  'SchemaLeaseError::LeaseLost',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod schema_lease;',
+  'mod schema_lease_tests;',
+  'PostgresSchemaLeaseStore',
+  'SchemaApplicationLeaseRequest',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'PostgresSchemaLeaseStore',
+  'SchemaApplicationLease',
+  'SchemaLeaseAcquireOutcome',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [x] Add locking/leases for schema application.',
+  'M3 schema-application leases: `complete`',
+]);
+
+console.log('[verify-index-schema-leases] OK');


### PR DESCRIPTION
## Summary

- continue M3 with durable `schema_apply` coordination in `index_jobs`
- serialize exact tenant/module/entity/schema-version acquisition with a PostgreSQL transaction advisory lock
- verify the persisted active schema and fingerprint before claiming work
- support `Busy`, terminal `AlreadyApplied`, expired-lease reclaim, heartbeat, success/failure completion, and `attempt_count` fencing
- publish contract-test-only SQLite fixtures and a static repository verifier
- synchronize the public API, crate docs, and the live M0-M11 Index roadmap

## Recheck of the preceding M3 slice

Reviewed merged PR #2287 and its mutation-storage diff against the canonical migrations. Tenant/schema/entity/locale identity, inbox deduplication, advisory locking, monotonic source-version admission, tombstones, ordered-link replacement, rollback ordering, public exports, and plan state remain consistent. No unresolved review threads were found. The old branch `agent/index-m3-mutation-adapter` is already absent from the repository.

## Important behavior

- a current non-expired owner excludes other workers
- a succeeded application is terminal and returns the existing job ID
- an expired lease is reclaimed on the same job with an incremented attempt fence
- an old worker cannot heartbeat, succeed, or fail after takeover
- a failed terminal application permits a new durable job
- missing, retired, or fingerprint-conflicting schema state fails closed

## Validation

Not run, per repository-owner instruction. Suggested checks are recorded in the implementation plan:

```bash
cargo check -p rustok-index --all-targets
cargo test -p rustok-index --lib
node scripts/verify/verify-index-mutation-storage.mjs
node scripts/verify/verify-index-schema-leases.mjs
```

## Next M3 slice

Partition and secondary-index lifecycle, followed by PostgreSQL Testcontainers and concurrency/rollback/replay/tenant-locale evidence.