### PR TITLE
feat(index): add partition admission planning

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -9,9 +9,10 @@
 
 The domain/application contract remains database independent. M3 adds module-owned
 production migrations, an Index-owned PostgreSQL mutation adapter, durable
-schema-application leases, and schema-derived secondary-index lifecycle;
-source-specific Content, Product, Flex, search, legacy migration, runtime, and
-scheduler modules remain deleted.
+schema-application leases, schema-derived secondary-index lifecycle, and a
+fail-closed measured partition-admission contract; source-specific Content,
+Product, Flex, search, legacy migration, runtime, and scheduler modules remain
+deleted.
 
 ## Primary Public Types
 
@@ -56,6 +57,18 @@ scheduler modules remain deleted.
 - `SecondaryIndexExecutionOutcome`
 - `SecondaryIndexError`
 - `PostgresSecondaryIndexManager`
+- `PartitionStrategy`
+- `PartitionAdmissionPolicy`
+- `PartitionBaselineEvidence`
+- `PartitionMeasurementCoverage`
+- `PartitionShadowEvidence`
+- `PartitionEvidence`
+- `PartitionAdmissionReason`
+- `PartitionAdmissionOutcome`
+- `PartitionRelationPlan`
+- `PartitionShadowPlan`
+- `PartitionAdmissionError`
+- `evaluate_partition_admission`
 
 ## Contract Status
 
@@ -73,8 +86,13 @@ reclaims expired jobs with attempt fencing, and requires current ownership for
 heartbeat and terminal completion. `SecondaryIndexPlan` derives stable indexes
 from filterable/sortable schema fields, and `PostgresSecondaryIndexManager`
 coordinates concurrent ensure/reindex/retire execution through durable fenced
-jobs and PostgreSQL catalog readiness checks. Source registries, batch ingestion,
-rebuild, query-port, partition lifecycle, and operator APIs remain later work.
+jobs and PostgreSQL catalog readiness checks. Partition admission now requires an
+exact retained evidence identifier, complete query/mutation/maintenance/cutover
+measurement coverage, and an explicit policy before producing deterministic
+tenant-hash shadow relation names and bootstrap SQL. It does not execute copy,
+constraint/index attachment, dual-write/replay, cutover, or rollback. Source
+registries, batch ingestion, rebuild, query-port, partition cutover, and operator
+APIs remain later work.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -104,6 +122,12 @@ to owner modules or explicit integration crates.
   payloads are tagged and scalar/list values live under each field's `value` key.
 - Creating bespoke Product or other owner-specific indexes instead of deriving
   them from the generic schema contract.
+- Enabling partitioning because a relation is merely large, without retained
+  tenant-scoped baseline and shadow evidence.
+- Treating zero measured runs or less than 100% tenant-predicate coverage as
+  acceptable partition evidence.
+- Treating `PartitionShadowPlan::bootstrap_statements` as cutover-ready DDL; it
+  intentionally contains no production rename/drop or constraint/index attachment.
 - Restoring deleted v1 or source-specific code as a compatibility layer.
 
 ## Minimum Contract Set
@@ -119,6 +143,13 @@ to owner modules or explicit integration crates.
   filterable/sortable field indexes.
 - `SecondaryIndexRequest` binds one immutable index spec, operation, worker, and
   bounded whole-second lease duration.
+- `PartitionEvidence` binds measured unpartitioned baseline facts to one exact
+  SHA-256 identified tenant-hash shadow packet.
+- `PartitionMeasurementCoverage` records non-zero query, mutation, maintenance,
+  and cutover-rehearsal run counts. A missing group is a typed rejection reason.
+- `PartitionAdmissionPolicy` supplies explicit minimum scale and maximum
+  regression/skew/lock thresholds; no production default silently admits rollout,
+  and tenant-predicate coverage is fixed at 10000 basis points.
 - Construction and validation preserve tenant, schema, entity, locale, and
   source-version identity.
 - Identifiers use bounded lowercase ASCII grammar; locales use ICU4X
@@ -182,6 +213,27 @@ to owner modules or explicit integration crates.
 - Completion requires catalog `indisready` and `indisvalid`; retirement remains
   available after a schema is retired.
 
+### Partition Admission and Shadow Planning
+
+- The canonical `index_entities` and `index_links` tables remain unpartitioned by
+  default because M2 did not measure partitioning.
+- Tenant-hash modulus must be a power of two between 2 and 128.
+- Evidence identity is a lowercase 64-character SHA-256 digest.
+- Admission requires exactly 10000 basis points of tenant-predicate coverage.
+- Query, mutation, maintenance, and cutover-rehearsal measurement counts must each
+  be non-zero.
+- Admission also checks measured total rows/bytes, distinct tenants, entity/link
+  digest parity, catch-up, foreign keys, orphan links, query-plan regressions, p95
+  query/mutation regressions, WAL amplification, partition-size skew, and
+  cutover-lock duration.
+- Any failed gate returns `KeepUnpartitioned` with typed reasons.
+- An admitted plan derives deterministic shadow parent/partition names from the
+  evidence identity, strategy, modulus, and plan-contract version.
+- Bootstrap SQL creates only shadow hash-partition parents and children. It never
+  renames, drops, or alters the production entity/link relations.
+- Copy, constraints, indexes, replay/dual-write, cutover, rollback, durable global
+  ownership, and PostgreSQL evidence remain mandatory future work.
+
 ### Cursor Contract
 
 - Cursor format is explicitly versioned.
@@ -222,4 +274,7 @@ to owner modules or explicit integration crates.
 - `SecondaryIndexError` separates plan/request validation, schema conflicts,
   malformed jobs, lease loss, ownership conflicts, missing/not-ready indexes,
   unsupported backends, and storage failures.
+- `PartitionAdmissionError` separates invalid policy, invalid evidence, metric
+  overflow, and unsupported hash modulus. Typed admission reasons explain every
+  rejected evidence gate without exposing storage internals.
 - Later milestones add source, retry, cancellation, and rebuild errors.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -49,13 +49,15 @@ a rewrite goal.
 - M3 atomic mutation persistence: complete
 - M3 schema-application leases: complete
 - M3 secondary-index lifecycle: complete
+- M3 partition admission and shadow planning: complete
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
 configuration, scheduler, errors, and server composition have been deleted. M3
 registers the canonical production schema, publishes an Index-owned transactional
-mutation adapter, owns durable schema-application leases, and now manages
-deterministic schema-derived secondary indexes. Query execution and partition
-management remain absent.
+mutation adapter, owns durable schema-application leases, manages deterministic
+schema-derived secondary indexes, and now rejects partition rollout until measured
+shadow evidence passes an explicit policy. Query execution and partition cutover
+remain absent.
 
 The module-owned migration source creates:
 
@@ -99,6 +101,19 @@ reindex, and retirement through fenced `secondary_index` jobs, executes PostgreS
 and `indisvalid` before completion. Retire remains available for retired schemas;
 SQLite is contract-test-only.
 
+`evaluate_partition_admission` keeps the canonical tables unpartitioned unless one
+explicit policy is satisfied by one exact SHA-256 evidence packet. Admission checks
+minimum measured size/row/tenant scale, tenant-predicate coverage, entity and link
+digest parity, shadow catch-up, foreign-key validation, orphan-link absence, query
+plan stability, p95 query/mutation regressions, WAL amplification, partition-size
+skew, and cutover-lock duration. An admitted `PartitionShadowPlan` derives stable
+hash-partition parent/child names and PostgreSQL bootstrap statements for shadow
+relations only. It never emits production table rename, drop, or cutover SQL.
+Tenant-hash modulus must be a power of two from 2 through 128. Actual copy,
+constraint/index attachment, dual-write/replay, cutover, rollback, and durable
+global operation ownership remain later work and require retained PostgreSQL
+evidence.
+
 ## Current entry points
 
 - `IndexModule`
@@ -110,6 +125,8 @@ SQLite is contract-test-only.
   `SchemaApplicationLease`, and `SchemaLeaseAcquireOutcome`
 - `SecondaryIndexPlan`, `SecondaryIndexSpec`, `SecondaryIndexRequest`,
   `SecondaryIndexLease`, and `PostgresSecondaryIndexManager`
+- `PartitionAdmissionPolicy`, `PartitionEvidence`, `PartitionAdmissionOutcome`,
+  `PartitionShadowPlan`, and `evaluate_partition_admission`
 - `SchemaRegistry`, `IndexSchema`, `IndexRecord`, and `IndexMutation`
 - `IndexQuery`, `IndexQueryScope`, `FilterExpr`, and typed `FieldPath`
 - `CursorCodec`, `IndexCursor`, and query-scope cursor validation
@@ -135,7 +152,9 @@ SQLite is contract-test-only.
   completion, and attempt fencing;
 - deterministic tenant/schema/fingerprint-bound secondary-index names,
   tagged-payload expressions, concurrent lifecycle, owner verification, catalog
-  readiness checks, and operation fencing.
+  readiness checks, and operation fencing;
+- fail-closed partition admission, exact evidence identity, explicit regression
+  limits, deterministic tenant-hash shadow names, and no destructive cutover SQL.
 
 ## M2 benchmark
 
@@ -157,4 +176,5 @@ DDL remains benchmark-only and must not be copied into production migrations.
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)
 - [M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)
 - [Index Engine rewrite ADR](../../DECISIONS/2026-07-23-index-engine-rewrite.md)
+- [Accepted storage ADR](../../DECISIONS/2026-07-24-index-storage-layout.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -25,6 +25,7 @@ without runtime fan-out.
 - incremental ingestion and inbox deduplication;
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
+- measured partition admission and shadow planning;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -35,7 +36,8 @@ without runtime fan-out.
 - typo tolerance, synonyms, autocomplete, and search UX;
 - external search-engine connectors;
 - source-module table reads from Index core;
-- source-specific Product, Content, or Flex logic in the engine.
+- source-specific Product, Content, or Flex logic in the engine;
+- destructive partition cutover without retained PostgreSQL evidence.
 
 ## Integration
 
@@ -91,7 +93,9 @@ and ordinary `VACUUM (ANALYZE)` duration.
 
 Replacement same-commit evidence selected JSONB over typed EAV and hot projection.
 Rejected candidate implementations were deleted. The remaining JSONB path is a
-selected-layout regression harness, not production persistence.
+selected-layout regression harness, not production persistence. Partitioning was
+not part of M2 evidence, so the canonical relations remain unpartitioned by
+default.
 
 ## M3 PostgreSQL storage engine
 
@@ -137,8 +141,22 @@ each index to its full definition hash, and completion checks `indisready` plus
 `indisvalid`. Retirement remains available after schema retirement. SQLite is
 contract-test-only.
 
-Partition lifecycle, PostgreSQL Testcontainers/concurrency evidence, query
-execution, and batch ingestion remain later M3/M4/M5 slices.
+`evaluate_partition_admission` compares one unpartitioned baseline with one exact
+SHA-256 identified tenant-hash shadow packet under an explicit policy. It checks
+measured rows, bytes, tenants, tenant-predicate coverage, entity/link digests,
+catch-up, foreign keys, orphan links, query-plan regressions, p95 query/mutation
+regressions, WAL amplification, partition-size skew, and cutover-lock duration.
+Any failed gate returns `KeepUnpartitioned` with typed reasons.
+
+An admitted `PartitionShadowPlan` derives stable names and bootstrap SQL only for
+shadow hash-partition parents and children. Hash modulus must be a power of two
+from 2 through 128. The plan cannot rename, drop, or alter production entity/link
+relations. Copy, constraint/index attachment, replay or dual-write, durable global
+operation ownership, cutover, rollback, and retained PostgreSQL evidence remain
+open M3 work.
+
+PostgreSQL Testcontainers/concurrency evidence, query execution, and batch
+ingestion remain later M3/M4/M5 slices.
 
 ## Status
 
@@ -155,8 +173,10 @@ execution, and batch ingestion remain later M3/M4/M5 slices.
 - M3 atomic mutation persistence: `complete`
 - M3 schema-application leases: `complete`
 - M3 secondary-index lifecycle: `complete`
-- Production persistence: mutation writes and schema/index coordination implemented;
-  query adapter and partition lifecycle not yet implemented
+- M3 partition admission and shadow planning: `complete`
+- Production persistence: mutation writes, schema/index coordination, and
+  partition admission implemented; query adapter and partition cutover lifecycle
+  not yet implemented
 
 ## Verification
 
@@ -169,6 +189,7 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo xtask module test index`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/verify-index-secondary-index-lifecycle.mjs`
+- `node scripts/verify/verify-index-partition-admission.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -20,7 +20,7 @@ ingestion, rebuild/reconciliation, operator controls, and the first owner-publis
 vertical slices. It excludes text relevance, ranking, autocomplete, external
 search engines, source-table reads, and source-domain semantics in Index core.
 
-Detailed completed-work evidence belongs in the accepted ADRs, committed evidence
+Detailed completed-work evidence belongs in accepted ADRs, committed evidence
 packets, and Git history. This document remains the live roadmap and verification
 contract.
 
@@ -44,6 +44,8 @@ replaced whenever they conflict with the target architecture.
 7. A milestone is complete only when its acceptance criteria are satisfied.
 8. Benchmark scaffolding is not production persistence and must not leak into
    `rustok-index` migrations or runtime composition.
+9. Partition cutover remains forbidden until retained PostgreSQL shadow evidence
+   satisfies an explicit admission policy.
 
 The repository owner performs test and benchmark execution during this rewrite.
 Commits and pull requests record which checks and evidence runs were not executed.
@@ -62,16 +64,19 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 atomic mutation persistence: `complete`
 - M3 schema-application leases: `complete`
 - M3 secondary-index lifecycle: `complete`
-- Production persistence: mutation writes, schema coordination, and schema-derived
-  secondary-index lifecycle implemented; query adapter and partition lifecycle not
-  yet implemented
+- M3 partition admission and shadow planning: `complete`
+- Production persistence: mutation writes, schema coordination, secondary-index
+  lifecycle, and fail-closed partition admission implemented; query adapter and
+  partition copy/cutover lifecycle not yet implemented
 
 The active production crate contains the generic domain/application core, the M3
 production migrations, an Index-owned transactional mutation adapter, a durable
-schema-application lease store, and a schema-derived secondary-index manager.
-Query adapters, partition lifecycle, batch ingestion, and PostgreSQL Testcontainers
-evidence remain open. Benchmark DDL and generated evidence stay under
-`ops/benches`, outside the production module.
+schema-application lease store, a schema-derived secondary-index manager, and a
+measured partition-admission contract that emits shadow bootstrap plans only.
+Query adapters, partition copy/constraint/index attachment, replay/cutover,
+batch ingestion, and PostgreSQL Testcontainers evidence remain open. Benchmark
+DDL and generated evidence stay under `ops/benches`, outside the production
+module.
 
 ## Ownership
 
@@ -112,6 +117,7 @@ crates/rustok-index/src/
       mutation_store.rs
       schema_lease.rs
       secondary_index.rs
+      partition_admission.rs
     events/
     telemetry.rs
   api/
@@ -144,7 +150,8 @@ Selected additions:
 - `petgraph` for deterministic schema/link graph traversal;
 - `icu_locale` with compiled ICU4X data for UTS #35/CLDR locale alias
   canonicalization;
-- `sha2` for stable schema fingerprints and cursor checksums;
+- `sha2` for stable schema fingerprints, cursor checksums, secondary-index
+  definitions, and partition shadow-plan identities;
 - `postcard` plus URL-safe Base64 for versioned keyset cursors.
 
 Add when required:
@@ -162,7 +169,8 @@ Forbidden in Index core:
 - collecting all rebuild IDs in memory;
 - source-table reads;
 - source-domain crate dependencies;
-- unvalidated JSON-only public queries.
+- unvalidated JSON-only public queries;
+- destructive partition cutover without retained evidence and rollback proof.
 
 ## Milestones
 
@@ -216,7 +224,8 @@ schemas and links without Product-specific Index code.
 
 M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
 harness; it is not production persistence and does not reopen the accepted storage
-decision.
+decision. Partitioning was not measured by M2, so the canonical tables remain
+unpartitioned until a separate shadow packet passes admission.
 
 ### M3 - PostgreSQL storage engine
 
@@ -225,7 +234,11 @@ decision.
 - [x] Add atomic entity/link upsert and delete transactions.
 - [x] Add locking/leases for schema application.
 - [x] Add secondary-index planning and lifecycle management.
-- [ ] Add partition management after measured design evidence.
+- [x] Add fail-closed partition admission and deterministic tenant-hash shadow
+      planning.
+- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
+- [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
+      rollback, and durable global operation ownership.
 - [ ] Add PostgreSQL Testcontainers fixtures.
 - [ ] Cover migration-from-zero, stale mutation, redelivery, rollback,
       concurrency, and tenant/locale isolation in PostgreSQL.
@@ -260,6 +273,17 @@ heartbeats, attempt fencing, persisted schema validation, owner comments, and
 PostgreSQL readiness/validity inspection. Expressions follow the production tagged
 `IndexValue` payload through each field's `value` member. SQLite remains
 contract-test-only; PostgreSQL concurrency and Testcontainers evidence remain open.
+
+The fifth M3 slice publishes `PartitionAdmissionPolicy`, measured baseline/shadow
+evidence types, typed rejection reasons, and `PartitionShadowPlan`. Admission is
+fail-closed unless the packet passes minimum row/byte/tenant scale, tenant-predicate
+coverage, entity/link digest parity, catch-up, foreign-key/orphan checks, query-plan
+stability, p95 query/mutation regression, WAL amplification, partition-size skew,
+and cutover-lock limits. Tenant-hash modulus is restricted to powers of two from 2
+through 128. Admitted plans derive stable SHA-256-bound shadow parent/child names
+and emit only shadow bootstrap DDL. They never rename, drop, or alter production
+relations. Copy, constraints, indexes, replay, cutover, rollback, and global
+operation fencing remain open until retained PostgreSQL evidence exists.
 
 ### M4 - Query engine v1
 
@@ -356,6 +380,7 @@ cargo test -p rustok-index --lib
 node scripts/verify/verify-index-mutation-storage.mjs
 node scripts/verify/verify-index-schema-leases.mjs
 node scripts/verify/verify-index-secondary-index-lifecycle.mjs
+node scripts/verify/verify-index-partition-admission.mjs
 ```
 
 ## Progress log
@@ -370,5 +395,7 @@ node scripts/verify/verify-index-secondary-index-lifecycle.mjs
   heartbeat, terminal completion, and attempt fencing.
 - 2026-07-27: added schema-derived typed/containment secondary-index planning,
   concurrent ensure/reindex/retire execution, catalog readiness checks, durable
-  jobs, owner fingerprints, and operation fencing. Tests and verifiers were left
-  for the repository owner to execute.
+  jobs, owner fingerprints, and operation fencing.
+- 2026-07-27: added fail-closed measured partition admission and deterministic
+  tenant-hash shadow planning without destructive production cutover SQL. Tests,
+  verifiers, and PostgreSQL evidence were left for the repository owner to execute.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,9 +1,12 @@
 mod mutation_store;
+mod partition_admission;
 mod schema_lease;
 mod secondary_index;
 
 #[cfg(test)]
 mod mutation_store_tests;
+#[cfg(test)]
+mod partition_admission_tests;
 #[cfg(test)]
 mod schema_lease_tests;
 #[cfg(test)]
@@ -11,6 +14,12 @@ mod secondary_index_tests;
 
 pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+};
+pub use partition_admission::{
+    evaluate_partition_admission, PartitionAdmissionError, PartitionAdmissionOutcome,
+    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
+    PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
+    PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
 };
 pub use schema_lease::{
     PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,

--- a/crates/rustok-index/src/infrastructure/postgres/partition_admission.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/partition_admission.rs
@@ -1,0 +1,637 @@
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const BASIS_POINTS: u32 = 10_000;
+const MAX_PARTITION_MODULUS: u16 = 128;
+const EVIDENCE_ID_HEX_BYTES: usize = 64;
+const SHADOW_PLAN_VERSION: &str = "tenant_hash_shadow_v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartitionStrategy {
+    TenantHash { modulus: u16 },
+}
+
+impl PartitionStrategy {
+    pub fn tenant_hash(modulus: u16) -> Result<Self, PartitionAdmissionError> {
+        validate_modulus(modulus)?;
+        Ok(Self::TenantHash { modulus })
+    }
+
+    pub const fn modulus(self) -> u16 {
+        match self {
+            Self::TenantHash { modulus } => modulus,
+        }
+    }
+
+    const fn tag(self) -> &'static str {
+        match self {
+            Self::TenantHash { .. } => "tenant_hash",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionAdmissionPolicy {
+    minimum_total_rows: u64,
+    minimum_total_bytes: u64,
+    minimum_distinct_tenants: u64,
+    required_tenant_predicate_coverage_bps: u32,
+    maximum_query_p95_regression_bps: u32,
+    maximum_mutation_p95_regression_bps: u32,
+    maximum_wal_amplification_bps: u32,
+    maximum_partition_size_to_mean_bps: u32,
+    maximum_cutover_lock_ms: u64,
+}
+
+impl PartitionAdmissionPolicy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        minimum_total_rows: u64,
+        minimum_total_bytes: u64,
+        minimum_distinct_tenants: u64,
+        required_tenant_predicate_coverage_bps: u32,
+        maximum_query_p95_regression_bps: u32,
+        maximum_mutation_p95_regression_bps: u32,
+        maximum_wal_amplification_bps: u32,
+        maximum_partition_size_to_mean_bps: u32,
+        maximum_cutover_lock_ms: u64,
+    ) -> Result<Self, PartitionAdmissionError> {
+        if minimum_total_rows == 0 {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "minimum_total_rows must be positive",
+            ));
+        }
+        if minimum_total_bytes == 0 {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "minimum_total_bytes must be positive",
+            ));
+        }
+        if minimum_distinct_tenants < 2 {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "minimum_distinct_tenants must be at least two",
+            ));
+        }
+        if required_tenant_predicate_coverage_bps != BASIS_POINTS {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "partition admission requires 10000 basis points of tenant predicate coverage",
+            ));
+        }
+        if maximum_wal_amplification_bps < BASIS_POINTS {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "maximum WAL amplification must allow the 10000 basis-point parity value",
+            ));
+        }
+        if maximum_partition_size_to_mean_bps < BASIS_POINTS {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "maximum partition skew must allow the 10000 basis-point parity value",
+            ));
+        }
+        if maximum_cutover_lock_ms == 0 {
+            return Err(PartitionAdmissionError::InvalidPolicy(
+                "maximum_cutover_lock_ms must be positive",
+            ));
+        }
+        Ok(Self {
+            minimum_total_rows,
+            minimum_total_bytes,
+            minimum_distinct_tenants,
+            required_tenant_predicate_coverage_bps,
+            maximum_query_p95_regression_bps,
+            maximum_mutation_p95_regression_bps,
+            maximum_wal_amplification_bps,
+            maximum_partition_size_to_mean_bps,
+            maximum_cutover_lock_ms,
+        })
+    }
+
+    pub const fn minimum_total_rows(&self) -> u64 {
+        self.minimum_total_rows
+    }
+
+    pub const fn minimum_total_bytes(&self) -> u64 {
+        self.minimum_total_bytes
+    }
+
+    pub const fn minimum_distinct_tenants(&self) -> u64 {
+        self.minimum_distinct_tenants
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionBaselineEvidence {
+    entity_rows: u64,
+    link_rows: u64,
+    entity_bytes: u64,
+    link_bytes: u64,
+    distinct_tenants: u64,
+    tenant_predicate_coverage_bps: u32,
+}
+
+impl PartitionBaselineEvidence {
+    pub fn new(
+        entity_rows: u64,
+        link_rows: u64,
+        entity_bytes: u64,
+        link_bytes: u64,
+        distinct_tenants: u64,
+        tenant_predicate_coverage_bps: u32,
+    ) -> Result<Self, PartitionAdmissionError> {
+        if entity_rows == 0 {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "entity_rows must be positive",
+            ));
+        }
+        if entity_bytes == 0 {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "entity_bytes must be positive",
+            ));
+        }
+        if distinct_tenants == 0 {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "distinct_tenants must be positive",
+            ));
+        }
+        if tenant_predicate_coverage_bps > BASIS_POINTS {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "tenant predicate coverage must not exceed 10000 basis points",
+            ));
+        }
+        Ok(Self {
+            entity_rows,
+            link_rows,
+            entity_bytes,
+            link_bytes,
+            distinct_tenants,
+            tenant_predicate_coverage_bps,
+        })
+    }
+
+    pub fn total_rows(&self) -> Result<u64, PartitionAdmissionError> {
+        self.entity_rows
+            .checked_add(self.link_rows)
+            .ok_or(PartitionAdmissionError::MetricOverflow("total rows"))
+    }
+
+    pub fn total_bytes(&self) -> Result<u64, PartitionAdmissionError> {
+        self.entity_bytes
+            .checked_add(self.link_bytes)
+            .ok_or(PartitionAdmissionError::MetricOverflow("total bytes"))
+    }
+
+    pub const fn distinct_tenants(&self) -> u64 {
+        self.distinct_tenants
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartitionMeasurementCoverage {
+    query_runs: u32,
+    mutation_runs: u32,
+    maintenance_runs: u32,
+    cutover_rehearsals: u32,
+}
+
+impl PartitionMeasurementCoverage {
+    pub const fn new(
+        query_runs: u32,
+        mutation_runs: u32,
+        maintenance_runs: u32,
+        cutover_rehearsals: u32,
+    ) -> Self {
+        Self {
+            query_runs,
+            mutation_runs,
+            maintenance_runs,
+            cutover_rehearsals,
+        }
+    }
+
+    pub const fn query_runs(self) -> u32 {
+        self.query_runs
+    }
+
+    pub const fn mutation_runs(self) -> u32 {
+        self.mutation_runs
+    }
+
+    pub const fn maintenance_runs(self) -> u32 {
+        self.maintenance_runs
+    }
+
+    pub const fn cutover_rehearsals(self) -> u32 {
+        self.cutover_rehearsals
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionShadowEvidence {
+    evidence_id: String,
+    strategy: PartitionStrategy,
+    measurement_coverage: PartitionMeasurementCoverage,
+    entity_digest_matches: bool,
+    link_digest_matches: bool,
+    shadow_caught_up: bool,
+    foreign_keys_validated: bool,
+    orphan_links: u64,
+    query_plan_regressions: u32,
+    query_p95_regression_bps: u32,
+    mutation_p95_regression_bps: u32,
+    wal_amplification_bps: u32,
+    maximum_partition_size_to_mean_bps: u32,
+    cutover_lock_ms: u64,
+}
+
+impl PartitionShadowEvidence {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        evidence_id: impl Into<String>,
+        strategy: PartitionStrategy,
+        measurement_coverage: PartitionMeasurementCoverage,
+        entity_digest_matches: bool,
+        link_digest_matches: bool,
+        shadow_caught_up: bool,
+        foreign_keys_validated: bool,
+        orphan_links: u64,
+        query_plan_regressions: u32,
+        query_p95_regression_bps: u32,
+        mutation_p95_regression_bps: u32,
+        wal_amplification_bps: u32,
+        maximum_partition_size_to_mean_bps: u32,
+        cutover_lock_ms: u64,
+    ) -> Result<Self, PartitionAdmissionError> {
+        let evidence_id = evidence_id.into();
+        validate_evidence_id(&evidence_id)?;
+        if wal_amplification_bps == 0 {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "WAL amplification must use 10000 basis points as parity",
+            ));
+        }
+        if maximum_partition_size_to_mean_bps == 0 {
+            return Err(PartitionAdmissionError::InvalidEvidence(
+                "partition size skew must use 10000 basis points as parity",
+            ));
+        }
+        Ok(Self {
+            evidence_id,
+            strategy,
+            measurement_coverage,
+            entity_digest_matches,
+            link_digest_matches,
+            shadow_caught_up,
+            foreign_keys_validated,
+            orphan_links,
+            query_plan_regressions,
+            query_p95_regression_bps,
+            mutation_p95_regression_bps,
+            wal_amplification_bps,
+            maximum_partition_size_to_mean_bps,
+            cutover_lock_ms,
+        })
+    }
+
+    pub fn evidence_id(&self) -> &str {
+        &self.evidence_id
+    }
+
+    pub const fn strategy(&self) -> PartitionStrategy {
+        self.strategy
+    }
+
+    pub const fn measurement_coverage(&self) -> PartitionMeasurementCoverage {
+        self.measurement_coverage
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionEvidence {
+    baseline: PartitionBaselineEvidence,
+    shadow: PartitionShadowEvidence,
+}
+
+impl PartitionEvidence {
+    pub const fn new(
+        baseline: PartitionBaselineEvidence,
+        shadow: PartitionShadowEvidence,
+    ) -> Self {
+        Self { baseline, shadow }
+    }
+
+    pub const fn baseline(&self) -> &PartitionBaselineEvidence {
+        &self.baseline
+    }
+
+    pub const fn shadow(&self) -> &PartitionShadowEvidence {
+        &self.shadow
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartitionAdmissionReason {
+    BelowMinimumRows { actual: u64, minimum: u64 },
+    BelowMinimumBytes { actual: u64, minimum: u64 },
+    InsufficientDistinctTenants { actual: u64, minimum: u64 },
+    InsufficientTenantsForModulus { actual: u64, modulus: u16 },
+    TenantPredicateCoverage { actual_bps: u32, required_bps: u32 },
+    MissingQueryMeasurements,
+    MissingMutationMeasurements,
+    MissingMaintenanceMeasurements,
+    MissingCutoverRehearsal,
+    EntityDigestMismatch,
+    LinkDigestMismatch,
+    ShadowNotCaughtUp,
+    ForeignKeysNotValidated,
+    OrphanLinks { count: u64 },
+    QueryPlanRegressions { count: u32 },
+    QueryLatencyRegression { actual_bps: u32, maximum_bps: u32 },
+    MutationLatencyRegression { actual_bps: u32, maximum_bps: u32 },
+    WalAmplification { actual_bps: u32, maximum_bps: u32 },
+    PartitionSizeSkew { actual_bps: u32, maximum_bps: u32 },
+    CutoverLockExceeded { actual_ms: u64, maximum_ms: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartitionAdmissionOutcome {
+    KeepUnpartitioned { reasons: Vec<PartitionAdmissionReason> },
+    Admitted(PartitionShadowPlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionRelationPlan {
+    parent_name: String,
+    partition_names: Vec<String>,
+}
+
+impl PartitionRelationPlan {
+    pub fn parent_name(&self) -> &str {
+        &self.parent_name
+    }
+
+    pub fn partition_names(&self) -> &[String] {
+        &self.partition_names
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionShadowPlan {
+    evidence_id: String,
+    strategy: PartitionStrategy,
+    definition_hash: String,
+    entities: PartitionRelationPlan,
+    links: PartitionRelationPlan,
+}
+
+impl PartitionShadowPlan {
+    fn new(shadow: &PartitionShadowEvidence) -> Self {
+        let definition = format!(
+            "rustok-index-partition\u{1f}{SHADOW_PLAN_VERSION}\u{1f}{}\u{1f}{}\u{1f}{}",
+            shadow.evidence_id,
+            shadow.strategy.tag(),
+            shadow.strategy.modulus(),
+        );
+        let definition_hash = hex::encode(Sha256::digest(definition.as_bytes()));
+        let suffix = &definition_hash[..24];
+        let modulus = shadow.strategy.modulus();
+        let entities_parent = format!("index_entities_shadow_{suffix}");
+        let links_parent = format!("index_links_shadow_{suffix}");
+        Self {
+            evidence_id: shadow.evidence_id.clone(),
+            strategy: shadow.strategy,
+            definition_hash,
+            entities: relation_plan(entities_parent, modulus),
+            links: relation_plan(links_parent, modulus),
+        }
+    }
+
+    pub fn evidence_id(&self) -> &str {
+        &self.evidence_id
+    }
+
+    pub const fn strategy(&self) -> PartitionStrategy {
+        self.strategy
+    }
+
+    pub fn definition_hash(&self) -> &str {
+        &self.definition_hash
+    }
+
+    pub const fn entities(&self) -> &PartitionRelationPlan {
+        &self.entities
+    }
+
+    pub const fn links(&self) -> &PartitionRelationPlan {
+        &self.links
+    }
+
+    pub fn bootstrap_statements(&self) -> Vec<String> {
+        let mut statements = Vec::with_capacity(2 + usize::from(self.strategy.modulus()) * 2);
+        statements.push(shadow_parent_statement(
+            "index_entities",
+            self.entities.parent_name(),
+        ));
+        statements.push(shadow_parent_statement(
+            "index_links",
+            self.links.parent_name(),
+        ));
+        for (remainder, name) in self.entities.partition_names().iter().enumerate() {
+            statements.push(shadow_partition_statement(
+                self.entities.parent_name(),
+                name,
+                self.strategy.modulus(),
+                remainder,
+            ));
+        }
+        for (remainder, name) in self.links.partition_names().iter().enumerate() {
+            statements.push(shadow_partition_statement(
+                self.links.parent_name(),
+                name,
+                self.strategy.modulus(),
+                remainder,
+            ));
+        }
+        statements
+    }
+}
+
+pub fn evaluate_partition_admission(
+    policy: &PartitionAdmissionPolicy,
+    evidence: &PartitionEvidence,
+) -> Result<PartitionAdmissionOutcome, PartitionAdmissionError> {
+    let total_rows = evidence.baseline.total_rows()?;
+    let total_bytes = evidence.baseline.total_bytes()?;
+    let coverage = evidence.shadow.measurement_coverage;
+    let mut reasons = Vec::new();
+
+    if total_rows < policy.minimum_total_rows {
+        reasons.push(PartitionAdmissionReason::BelowMinimumRows {
+            actual: total_rows,
+            minimum: policy.minimum_total_rows,
+        });
+    }
+    if total_bytes < policy.minimum_total_bytes {
+        reasons.push(PartitionAdmissionReason::BelowMinimumBytes {
+            actual: total_bytes,
+            minimum: policy.minimum_total_bytes,
+        });
+    }
+    if evidence.baseline.distinct_tenants < policy.minimum_distinct_tenants {
+        reasons.push(PartitionAdmissionReason::InsufficientDistinctTenants {
+            actual: evidence.baseline.distinct_tenants,
+            minimum: policy.minimum_distinct_tenants,
+        });
+    }
+    if evidence.baseline.distinct_tenants < u64::from(evidence.shadow.strategy.modulus()) {
+        reasons.push(PartitionAdmissionReason::InsufficientTenantsForModulus {
+            actual: evidence.baseline.distinct_tenants,
+            modulus: evidence.shadow.strategy.modulus(),
+        });
+    }
+    if evidence.baseline.tenant_predicate_coverage_bps
+        < policy.required_tenant_predicate_coverage_bps
+    {
+        reasons.push(PartitionAdmissionReason::TenantPredicateCoverage {
+            actual_bps: evidence.baseline.tenant_predicate_coverage_bps,
+            required_bps: policy.required_tenant_predicate_coverage_bps,
+        });
+    }
+    if coverage.query_runs == 0 {
+        reasons.push(PartitionAdmissionReason::MissingQueryMeasurements);
+    }
+    if coverage.mutation_runs == 0 {
+        reasons.push(PartitionAdmissionReason::MissingMutationMeasurements);
+    }
+    if coverage.maintenance_runs == 0 {
+        reasons.push(PartitionAdmissionReason::MissingMaintenanceMeasurements);
+    }
+    if coverage.cutover_rehearsals == 0 {
+        reasons.push(PartitionAdmissionReason::MissingCutoverRehearsal);
+    }
+    if !evidence.shadow.entity_digest_matches {
+        reasons.push(PartitionAdmissionReason::EntityDigestMismatch);
+    }
+    if !evidence.shadow.link_digest_matches {
+        reasons.push(PartitionAdmissionReason::LinkDigestMismatch);
+    }
+    if !evidence.shadow.shadow_caught_up {
+        reasons.push(PartitionAdmissionReason::ShadowNotCaughtUp);
+    }
+    if !evidence.shadow.foreign_keys_validated {
+        reasons.push(PartitionAdmissionReason::ForeignKeysNotValidated);
+    }
+    if evidence.shadow.orphan_links != 0 {
+        reasons.push(PartitionAdmissionReason::OrphanLinks {
+            count: evidence.shadow.orphan_links,
+        });
+    }
+    if evidence.shadow.query_plan_regressions != 0 {
+        reasons.push(PartitionAdmissionReason::QueryPlanRegressions {
+            count: evidence.shadow.query_plan_regressions,
+        });
+    }
+    if evidence.shadow.query_p95_regression_bps > policy.maximum_query_p95_regression_bps {
+        reasons.push(PartitionAdmissionReason::QueryLatencyRegression {
+            actual_bps: evidence.shadow.query_p95_regression_bps,
+            maximum_bps: policy.maximum_query_p95_regression_bps,
+        });
+    }
+    if evidence.shadow.mutation_p95_regression_bps > policy.maximum_mutation_p95_regression_bps {
+        reasons.push(PartitionAdmissionReason::MutationLatencyRegression {
+            actual_bps: evidence.shadow.mutation_p95_regression_bps,
+            maximum_bps: policy.maximum_mutation_p95_regression_bps,
+        });
+    }
+    if evidence.shadow.wal_amplification_bps > policy.maximum_wal_amplification_bps {
+        reasons.push(PartitionAdmissionReason::WalAmplification {
+            actual_bps: evidence.shadow.wal_amplification_bps,
+            maximum_bps: policy.maximum_wal_amplification_bps,
+        });
+    }
+    if evidence.shadow.maximum_partition_size_to_mean_bps
+        > policy.maximum_partition_size_to_mean_bps
+    {
+        reasons.push(PartitionAdmissionReason::PartitionSizeSkew {
+            actual_bps: evidence.shadow.maximum_partition_size_to_mean_bps,
+            maximum_bps: policy.maximum_partition_size_to_mean_bps,
+        });
+    }
+    if evidence.shadow.cutover_lock_ms > policy.maximum_cutover_lock_ms {
+        reasons.push(PartitionAdmissionReason::CutoverLockExceeded {
+            actual_ms: evidence.shadow.cutover_lock_ms,
+            maximum_ms: policy.maximum_cutover_lock_ms,
+        });
+    }
+
+    if reasons.is_empty() {
+        Ok(PartitionAdmissionOutcome::Admitted(PartitionShadowPlan::new(
+            &evidence.shadow,
+        )))
+    } else {
+        Ok(PartitionAdmissionOutcome::KeepUnpartitioned { reasons })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PartitionAdmissionError {
+    #[error("invalid partition admission policy: {0}")]
+    InvalidPolicy(&'static str),
+    #[error("invalid partition evidence: {0}")]
+    InvalidEvidence(&'static str),
+    #[error("partition metric overflow: {0}")]
+    MetricOverflow(&'static str),
+    #[error("partition modulus must be a power of two between 2 and 128")]
+    InvalidModulus,
+}
+
+fn validate_modulus(modulus: u16) -> Result<(), PartitionAdmissionError> {
+    if !(2..=MAX_PARTITION_MODULUS).contains(&modulus) || !modulus.is_power_of_two() {
+        return Err(PartitionAdmissionError::InvalidModulus);
+    }
+    Ok(())
+}
+
+fn validate_evidence_id(evidence_id: &str) -> Result<(), PartitionAdmissionError> {
+    if evidence_id.len() != EVIDENCE_ID_HEX_BYTES
+        || !evidence_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(PartitionAdmissionError::InvalidEvidence(
+            "evidence_id must be a lowercase 64-character SHA-256 hex digest",
+        ));
+    }
+    Ok(())
+}
+
+fn relation_plan(parent_name: String, modulus: u16) -> PartitionRelationPlan {
+    let partition_names = (0..modulus)
+        .map(|remainder| format!("{parent_name}_p{remainder:03}"))
+        .collect();
+    PartitionRelationPlan {
+        parent_name,
+        partition_names,
+    }
+}
+
+fn shadow_parent_statement(source: &str, shadow: &str) -> String {
+    format!(
+        "CREATE TABLE {} (LIKE {} INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING IDENTITY INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY HASH (tenant_id)",
+        quote_identifier(shadow),
+        quote_identifier(source),
+    )
+}
+
+fn shadow_partition_statement(
+    parent: &str,
+    partition: &str,
+    modulus: u16,
+    remainder: usize,
+) -> String {
+    format!(
+        "CREATE TABLE {} PARTITION OF {} FOR VALUES WITH (MODULUS {modulus}, REMAINDER {remainder})",
+        quote_identifier(partition),
+        quote_identifier(parent),
+    )
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}

--- a/crates/rustok-index/src/infrastructure/postgres/partition_admission_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/partition_admission_tests.rs
@@ -1,0 +1,220 @@
+use super::{
+    evaluate_partition_admission, PartitionAdmissionError, PartitionAdmissionOutcome,
+    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
+    PartitionEvidence, PartitionMeasurementCoverage, PartitionShadowEvidence, PartitionStrategy,
+};
+
+const EVIDENCE_ID: &str =
+    "1111111111111111111111111111111111111111111111111111111111111111";
+
+fn policy() -> PartitionAdmissionPolicy {
+    PartitionAdmissionPolicy::new(
+        1_000_000,
+        4 * 1024 * 1024 * 1024,
+        16,
+        10_000,
+        500,
+        500,
+        11_000,
+        15_000,
+        250,
+    )
+    .unwrap()
+}
+
+fn baseline() -> PartitionBaselineEvidence {
+    PartitionBaselineEvidence::new(
+        1_000_000,
+        3_000_000,
+        4 * 1024 * 1024 * 1024,
+        2 * 1024 * 1024 * 1024,
+        64,
+        10_000,
+    )
+    .unwrap()
+}
+
+fn shadow() -> PartitionShadowEvidence {
+    PartitionShadowEvidence::new(
+        EVIDENCE_ID,
+        PartitionStrategy::tenant_hash(16).unwrap(),
+        PartitionMeasurementCoverage::new(3, 3, 3, 1),
+        true,
+        true,
+        true,
+        true,
+        0,
+        0,
+        100,
+        200,
+        10_500,
+        12_000,
+        100,
+    )
+    .unwrap()
+}
+
+#[test]
+fn admitted_plan_is_stable_and_shadow_only() {
+    let evidence = PartitionEvidence::new(baseline(), shadow());
+    let first = evaluate_partition_admission(&policy(), &evidence).unwrap();
+    let second = evaluate_partition_admission(&policy(), &evidence).unwrap();
+    assert_eq!(first, second);
+
+    let PartitionAdmissionOutcome::Admitted(plan) = first else {
+        panic!("complete evidence should admit a shadow plan");
+    };
+    assert_eq!(plan.evidence_id(), EVIDENCE_ID);
+    assert_eq!(plan.strategy().modulus(), 16);
+    assert_eq!(plan.definition_hash().len(), 64);
+    assert!(plan.entities().parent_name().starts_with("index_entities_shadow_"));
+    assert!(plan.links().parent_name().starts_with("index_links_shadow_"));
+    assert_eq!(plan.entities().partition_names().len(), 16);
+    assert_eq!(plan.links().partition_names().len(), 16);
+
+    let statements = plan.bootstrap_statements();
+    assert_eq!(statements.len(), 34);
+    assert!(statements[0].contains("PARTITION BY HASH (tenant_id)"));
+    assert!(statements[1].contains("PARTITION BY HASH (tenant_id)"));
+    assert!(statements
+        .iter()
+        .any(|sql| sql.contains("FOR VALUES WITH (MODULUS 16, REMAINDER 15)")));
+    assert!(statements.iter().all(|sql| !sql.contains("DROP TABLE")));
+    assert!(statements.iter().all(|sql| !sql.contains("RENAME TO")));
+    assert!(statements
+        .iter()
+        .all(|sql| !sql.starts_with("ALTER TABLE \"index_entities\"")));
+    assert!(statements
+        .iter()
+        .all(|sql| !sql.starts_with("ALTER TABLE \"index_links\"")));
+}
+
+#[test]
+fn incomplete_or_regressed_evidence_keeps_storage_unpartitioned() {
+    let baseline = PartitionBaselineEvidence::new(100, 50, 1024, 512, 4, 9_500).unwrap();
+    let shadow = PartitionShadowEvidence::new(
+        EVIDENCE_ID,
+        PartitionStrategy::tenant_hash(16).unwrap(),
+        PartitionMeasurementCoverage::new(0, 0, 0, 0),
+        false,
+        false,
+        false,
+        false,
+        7,
+        2,
+        800,
+        900,
+        12_000,
+        20_000,
+        500,
+    )
+    .unwrap();
+    let outcome = evaluate_partition_admission(
+        &policy(),
+        &PartitionEvidence::new(baseline, shadow),
+    )
+    .unwrap();
+    let PartitionAdmissionOutcome::KeepUnpartitioned { reasons } = outcome else {
+        panic!("incomplete evidence must fail closed");
+    };
+
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::BelowMinimumRows { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::BelowMinimumBytes { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::InsufficientDistinctTenants { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::InsufficientTenantsForModulus { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::TenantPredicateCoverage { .. }
+    )));
+    assert!(reasons.contains(&PartitionAdmissionReason::MissingQueryMeasurements));
+    assert!(reasons.contains(&PartitionAdmissionReason::MissingMutationMeasurements));
+    assert!(reasons.contains(&PartitionAdmissionReason::MissingMaintenanceMeasurements));
+    assert!(reasons.contains(&PartitionAdmissionReason::MissingCutoverRehearsal));
+    assert!(reasons.contains(&PartitionAdmissionReason::EntityDigestMismatch));
+    assert!(reasons.contains(&PartitionAdmissionReason::LinkDigestMismatch));
+    assert!(reasons.contains(&PartitionAdmissionReason::ShadowNotCaughtUp));
+    assert!(reasons.contains(&PartitionAdmissionReason::ForeignKeysNotValidated));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::OrphanLinks { count: 7 }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::QueryPlanRegressions { count: 2 }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::QueryLatencyRegression { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::MutationLatencyRegression { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::WalAmplification { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::PartitionSizeSkew { .. }
+    )));
+    assert!(reasons.iter().any(|reason| matches!(
+        reason,
+        PartitionAdmissionReason::CutoverLockExceeded { .. }
+    )));
+}
+
+#[test]
+fn policy_strategy_and_evidence_validation_fail_closed() {
+    assert_eq!(
+        PartitionStrategy::tenant_hash(3),
+        Err(PartitionAdmissionError::InvalidModulus)
+    );
+    assert_eq!(
+        PartitionStrategy::tenant_hash(256),
+        Err(PartitionAdmissionError::InvalidModulus)
+    );
+    assert!(matches!(
+        PartitionAdmissionPolicy::new(0, 1, 2, 10_000, 0, 0, 10_000, 10_000, 1),
+        Err(PartitionAdmissionError::InvalidPolicy(_))
+    ));
+    assert!(matches!(
+        PartitionAdmissionPolicy::new(1, 1, 2, 9_999, 0, 0, 10_000, 10_000, 1),
+        Err(PartitionAdmissionError::InvalidPolicy(_))
+    ));
+    assert!(matches!(
+        PartitionBaselineEvidence::new(1, 0, 1, 0, 1, 10_001),
+        Err(PartitionAdmissionError::InvalidEvidence(_))
+    ));
+    assert!(matches!(
+        PartitionShadowEvidence::new(
+            "not-a-sha256",
+            PartitionStrategy::tenant_hash(2).unwrap(),
+            PartitionMeasurementCoverage::new(1, 1, 1, 1),
+            true,
+            true,
+            true,
+            true,
+            0,
+            0,
+            0,
+            0,
+            10_000,
+            10_000,
+            1,
+        ),
+        Err(PartitionAdmissionError::InvalidEvidence(_))
+    ));
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -3,7 +3,8 @@
 //! The active implementation contains the database-independent generic engine
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, durable
-//! schema-application leases, and schema-derived secondary-index lifecycle.
+//! schema-application leases, schema-derived secondary-index lifecycle, and a
+//! fail-closed measured partition-admission contract.
 
 use async_trait::async_trait;
 use rustok_core::{MigrationDependencyDescriptor, MigrationSource, ModuleKind, RusToKModule};
@@ -17,12 +18,16 @@ pub mod migrations;
 pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
-    MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
-    PostgresSchemaLeaseStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
-    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
-    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
-    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
-    SecondaryIndexRequest, SecondaryIndexSpec,
+    evaluate_partition_admission, MutationApplyOutcome, MutationDelivery, MutationStorageError,
+    PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
+    PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
+    PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
+    PartitionShadowPlan, PartitionStrategy, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
+    SchemaLeaseAcquireOutcome, SchemaLeaseError, SecondaryIndexClaimOutcome,
+    SecondaryIndexError, SecondaryIndexExecutionOutcome, SecondaryIndexKind,
+    SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest,
+    SecondaryIndexSpec,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -57,6 +57,7 @@ const runContract = (args) => {
     'verify-index-mutation-storage.mjs',
     'verify-index-schema-leases.mjs',
     'verify-index-secondary-index-lifecycle.mjs',
+    'verify-index-partition-admission.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',

--- a/scripts/verify/verify-index-partition-admission.mjs
+++ b/scripts/verify/verify-index-partition-admission.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-partition-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const admissionPath = 'crates/rustok-index/src/infrastructure/postgres/partition_admission.rs';
+const admission = requireMarkers(admissionPath, [
+  'pub enum PartitionStrategy',
+  'TenantHash { modulus: u16 }',
+  'pub struct PartitionAdmissionPolicy',
+  'pub struct PartitionBaselineEvidence',
+  'pub struct PartitionMeasurementCoverage',
+  'pub struct PartitionShadowEvidence',
+  'pub struct PartitionEvidence',
+  'pub enum PartitionAdmissionReason',
+  'MissingQueryMeasurements',
+  'MissingMutationMeasurements',
+  'MissingMaintenanceMeasurements',
+  'MissingCutoverRehearsal',
+  'pub enum PartitionAdmissionOutcome',
+  'KeepUnpartitioned',
+  'Admitted(PartitionShadowPlan)',
+  'pub struct PartitionShadowPlan',
+  'pub fn evaluate_partition_admission',
+  'minimum_total_rows',
+  'minimum_total_bytes',
+  'minimum_distinct_tenants',
+  'required_tenant_predicate_coverage_bps != BASIS_POINTS',
+  'partition admission requires 10000 basis points of tenant predicate coverage',
+  'query_runs',
+  'mutation_runs',
+  'maintenance_runs',
+  'cutover_rehearsals',
+  'entity_digest_matches',
+  'link_digest_matches',
+  'shadow_caught_up',
+  'foreign_keys_validated',
+  'orphan_links',
+  'query_plan_regressions',
+  'query_p95_regression_bps',
+  'mutation_p95_regression_bps',
+  'wal_amplification_bps',
+  'maximum_partition_size_to_mean_bps',
+  'cutover_lock_ms',
+  'evidence_id must be a lowercase 64-character SHA-256 hex digest',
+  'partition modulus must be a power of two between 2 and 128',
+  'rustok-index-partition',
+  'tenant_hash_shadow_v1',
+  'PARTITION BY HASH (tenant_id)',
+  'FOR VALUES WITH (MODULUS',
+  'index_entities_shadow_',
+  'index_links_shadow_',
+]);
+
+for (const forbidden of [
+  'ALTER TABLE "index_entities"',
+  'ALTER TABLE "index_links"',
+  'DROP TABLE "index_entities"',
+  'DROP TABLE "index_links"',
+  'RENAME TO index_entities',
+  'RENAME TO index_links',
+  'VACUUM FULL',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+  'rustok_pricing',
+  'rustok_inventory',
+]) {
+  if (admission.includes(forbidden)) fail(`${admissionPath} contains forbidden marker ${forbidden}`);
+}
+
+const admissionPosition = admission.indexOf('pub fn evaluate_partition_admission');
+const planPosition = admission.indexOf('PartitionShadowPlan::new');
+if (admissionPosition < 0 || planPosition < 0 || admissionPosition > planPosition) {
+  fail('partition admission must run before a shadow plan is constructed');
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/partition_admission_tests.rs', [
+  'admitted_plan_is_stable_and_shadow_only',
+  'incomplete_or_regressed_evidence_keeps_storage_unpartitioned',
+  'policy_strategy_and_evidence_validation_fail_closed',
+  'PartitionMeasurementCoverage::new(3, 3, 3, 1)',
+  'PartitionMeasurementCoverage::new(0, 0, 0, 0)',
+  'PartitionAdmissionOutcome::KeepUnpartitioned',
+  'PartitionAdmissionReason::MissingQueryMeasurements',
+  'PartitionAdmissionReason::MissingMutationMeasurements',
+  'PartitionAdmissionReason::MissingMaintenanceMeasurements',
+  'PartitionAdmissionReason::MissingCutoverRehearsal',
+  'PartitionAdmissionReason::EntityDigestMismatch',
+  'PartitionAdmissionReason::ForeignKeysNotValidated',
+  'PartitionAdmissionReason::QueryPlanRegressions',
+  'PartitionAdmissionReason::WalAmplification',
+  'PartitionAdmissionReason::CutoverLockExceeded',
+  'PartitionAdmissionPolicy::new(1, 1, 2, 9_999',
+  '!sql.contains("DROP TABLE")',
+  '!sql.contains("RENAME TO")',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod partition_admission;',
+  'mod partition_admission_tests;',
+  'evaluate_partition_admission',
+  'PartitionMeasurementCoverage',
+  'PartitionShadowPlan',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'evaluate_partition_admission',
+  'PartitionAdmissionOutcome',
+  'PartitionMeasurementCoverage',
+  'PartitionShadowPlan',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M3 partition admission and shadow planning: `complete`',
+  '- [x] Add fail-closed partition admission and deterministic tenant-hash shadow',
+  '- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.',
+  'tenant-predicate',
+  'query/mutation',
+  'They never rename, drop, or alter production',
+]);
+requireMarkers('DECISIONS/2026-07-24-index-storage-layout.md', [
+  'The initial canonical tables remain unpartitioned because partitioning was not part of the M2 evidence',
+  'a later measured shadow migration may introduce tenant-hash partitioning',
+]);
+
+console.log('[verify-index-partition-admission] OK');


### PR DESCRIPTION
## Summary

- continue M3 with fail-closed measured partition admission and deterministic tenant-hash shadow planning;
- keep canonical `index_entities` and `index_links` unpartitioned because M2 did not measure partitioning;
- require an explicit policy with minimum rows, bytes, and tenant scale plus bounded latency, WAL, skew, and lock regressions;
- require exactly 100% tenant-predicate coverage;
- require non-zero query, mutation, maintenance, and cutover-rehearsal measurement counts;
- require entity/link digest parity, shadow catch-up, validated foreign keys, zero orphan links, and zero query-plan regressions;
- return `KeepUnpartitioned` with typed reasons for every failed gate;
- derive stable SHA-256-bound shadow parent and child names for power-of-two tenant-hash moduli from 2 through 128;
- emit PostgreSQL bootstrap DDL for shadow parent/partition relations only;
- forbid production table rename, drop, alter, copy, replay, dual-write, cutover, or rollback behavior in this slice;
- add unit fixtures, a compile-free source guard, public exports, and synchronized Index documentation.

## Previous slice recheck

- PR #2302 was rechecked with no comments or review threads and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Order, Forum, and Notifications changes.

## Important behavior

- no policy default can silently enable partitioning;
- tenant-predicate coverage below 10000 basis points is rejected at policy construction;
- missing measurement groups are typed admission failures rather than implicit zero regressions;
- insufficient tenant count for the selected modulus fails closed;
- shadow relation names are deterministic and remain below PostgreSQL identifier limits;
- admitted plans contain no `ALTER TABLE` against production relations, no production `DROP TABLE`, and no `RENAME TO` cutover;
- actual copy, constraints/index attachment, replay or dual-write, cutover, rollback, durable global operation fencing, and retained PostgreSQL evidence remain open.

## Validation

Not run, per repository-owner instruction. Suggested checks:

```bash
cargo check -p rustok-index --all-targets
cargo test -p rustok-index --lib
node scripts/verify/verify-index-partition-admission.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

## Next M3 slice

Execute and retain PostgreSQL baseline/shadow evidence, then add durable global partition-operation ownership and the bounded copy, constraint/index attachment, catch-up/replay, cutover, and rollback lifecycle only after admission passes.