### PR TITLE
feat(index): add partition evidence tooling

### DIFF
--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -30,6 +30,11 @@ on:
       - "scripts/verify/index-storage-decision-tooling.test.mjs"
       - "scripts/verify/index-storage-tooling.mjs"
       - "scripts/verify/index-storage-tooling.test.mjs"
+      - "scripts/verify/index-partition-evidence-core.mjs"
+      - "scripts/verify/prepare-index-partition-evidence.mjs"
+      - "scripts/verify/validate-index-partition-evidence.mjs"
+      - "scripts/verify/index-partition-evidence.test.mjs"
+      - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -64,6 +69,11 @@ on:
       - "scripts/verify/index-storage-decision-tooling.test.mjs"
       - "scripts/verify/index-storage-tooling.mjs"
       - "scripts/verify/index-storage-tooling.test.mjs"
+      - "scripts/verify/index-partition-evidence-core.mjs"
+      - "scripts/verify/prepare-index-partition-evidence.mjs"
+      - "scripts/verify/validate-index-partition-evidence.mjs"
+      - "scripts/verify/index-partition-evidence.test.mjs"
+      - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -121,12 +131,18 @@ jobs:
             node --check scripts/verify/verify-index-storage-adr.mjs
             node --check scripts/verify/verify-index-storage-adr-integrity.mjs
             node --check scripts/verify/index-storage-decision-tooling.test.mjs
+            node --check scripts/verify/index-partition-evidence-core.mjs
+            node --check scripts/verify/prepare-index-partition-evidence.mjs
+            node --check scripts/verify/validate-index-partition-evidence.mjs
+            node --check scripts/verify/index-partition-evidence.test.mjs
+            node --check scripts/verify/verify-index-partition-evidence.mjs
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
             node --test scripts/verify/check-index-storage-read-ordering.test.mjs
             node --test scripts/verify/index-storage-validator-arguments.test.mjs
             node --test scripts/verify/index-storage-standalone-tools.test.mjs
             node --test scripts/verify/index-storage-decision-tooling.test.mjs
+            node --test scripts/verify/index-partition-evidence.test.mjs
           } 2>&1 | tee evidence/index-storage/contract/verify.log
       - name: Archive contract diagnostic
         if: always()

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,6 +26,7 @@ without runtime fan-out.
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
+- retained partition evidence contracts and validation;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -155,6 +156,14 @@ relations. Copy, constraint/index attachment, replay or dual-write, durable glob
 operation ownership, cutover, rollback, and retained PostgreSQL evidence remain
 open M3 work.
 
+Partition evidence tooling now binds one immutable manifest to a SHA-256
+`evidence_id`, emits deterministic shadow-only bootstrap SQL, validates exact
+query/mutation/maintenance/cutover repetition groups, and calculates tenant
+coverage, digest parity, latency regression, WAL amplification, partition skew,
+lock duration, rollback state, and typed rejection reasons. It cannot accept
+precomputed pass flags or authorize cutover. The repository owner still executes
+and retains the PostgreSQL packet.
+
 PostgreSQL Testcontainers/concurrency evidence, query execution, and batch
 ingestion remain later M3/M4/M5 slices.
 
@@ -174,9 +183,10 @@ ingestion remain later M3/M4/M5 slices.
 - M3 schema-application leases: `complete`
 - M3 secondary-index lifecycle: `complete`
 - M3 partition admission and shadow planning: `complete`
-- Production persistence: mutation writes, schema/index coordination, and
-  partition admission implemented; query adapter and partition cutover lifecycle
-  not yet implemented
+- M3 partition evidence packet tooling: `complete`
+- Production persistence: mutation writes, schema/index coordination, partition
+  admission, and evidence validation implemented; query adapter, retained
+  PostgreSQL partition run, and partition cutover lifecycle not yet implemented
 
 ## Verification
 
@@ -188,8 +198,10 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo xtask module validate index`
 - `cargo xtask module test index`
 - `node scripts/verify/index-storage-tooling.mjs contract`
+- `node scripts/verify/index-storage-tooling.mjs fixtures`
 - `node scripts/verify/verify-index-secondary-index-lifecycle.mjs`
 - `node scripts/verify/verify-index-partition-admission.mjs`
+- `node scripts/verify/verify-index-partition-evidence.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 
@@ -200,6 +212,7 @@ The repository owner runs the checks and database evidence during this rewrite:
 - [M2 storage benchmark contract](./storage-benchmark.md)
 - [M2 storage evidence comparison](./storage-comparison.md)
 - [M2 storage operational review](./storage-operational-review.md)
+- [M3 partition evidence runbook](./partition-evidence-runbook.md)
 - [Index Engine rewrite ADR](../../../DECISIONS/2026-07-23-index-engine-rewrite.md)
 - [Accepted storage ADR](../../../DECISIONS/2026-07-24-index-storage-layout.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -65,18 +65,21 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 schema-application leases: `complete`
 - M3 secondary-index lifecycle: `complete`
 - M3 partition admission and shadow planning: `complete`
+- M3 partition evidence packet tooling: `complete`
 - Production persistence: mutation writes, schema coordination, secondary-index
-  lifecycle, and fail-closed partition admission implemented; query adapter and
-  partition copy/cutover lifecycle not yet implemented
+  lifecycle, fail-closed partition admission, and evidence validation implemented;
+  the retained PostgreSQL partition run, query adapter, and partition copy/cutover
+  lifecycle are not yet implemented
 
 The active production crate contains the generic domain/application core, the M3
 production migrations, an Index-owned transactional mutation adapter, a durable
 schema-application lease store, a schema-derived secondary-index manager, and a
-measured partition-admission contract that emits shadow bootstrap plans only.
-Query adapters, partition copy/constraint/index attachment, replay/cutover,
-batch ingestion, and PostgreSQL Testcontainers evidence remain open. Benchmark
-DDL and generated evidence stay under `ops/benches`, outside the production
-module.
+measured partition-admission contract that emits shadow bootstrap plans only. The
+repository also contains immutable partition-manifest preparation and measured
+packet validation tooling. Query adapters, retained partition evidence,
+partition copy/constraint/index attachment, replay/cutover, batch ingestion, and
+PostgreSQL Testcontainers evidence remain open. Benchmark DDL and generated
+evidence stay under `ops/benches`, outside the production module.
 
 ## Ownership
 
@@ -236,6 +239,8 @@ unpartitioned until a separate shadow packet passes admission.
 - [x] Add secondary-index planning and lifecycle management.
 - [x] Add fail-closed partition admission and deterministic tenant-hash shadow
       planning.
+- [x] Add immutable partition evidence manifest, measured packet validator, and
+      owner-operated runbook.
 - [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
 - [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
       rollback, and durable global operation ownership.
@@ -284,6 +289,17 @@ through 128. Admitted plans derive stable SHA-256-bound shadow parent/child name
 and emit only shadow bootstrap DDL. They never rename, drop, or alter production
 relations. Copy, constraints, indexes, replay, cutover, rollback, and global
 operation fencing remain open until retained PostgreSQL evidence exists.
+
+The sixth M3 slice adds immutable partition evidence preparation and validation.
+The preparer binds repository, commit, PostgreSQL image, strategy, modulus,
+locales, repetitions, and explicit thresholds to one SHA-256 `evidence_id`, then
+emits deterministic shadow-only bootstrap SQL without clobbering an existing
+manifest. The validator rejects incomplete packets and calculates tenant-predicate
+coverage, cardinality/digest parity, normalized plan changes, p95 regressions, WAL
+amplification, child-size skew, lock duration, rollback facts, and typed admission
+reasons before atomically publishing an outcome. The repository owner still must
+execute and retain the PostgreSQL packet. This slice also removes the stale
+integration-test assumption that `IndexModule` has no production migrations.
 
 ### M4 - Query engine v1
 
@@ -370,6 +386,7 @@ npm run verify:index:runtime-fallback-smoke
 node scripts/verify/index-storage-tooling.mjs contract
 node scripts/verify/index-storage-tooling.mjs fixtures
 node --test scripts/verify/compare-index-storage-evidence.test.mjs
+node --test scripts/verify/index-partition-evidence.test.mjs
 ```
 
 Targeted M3 maintainer checks:
@@ -377,10 +394,12 @@ Targeted M3 maintainer checks:
 ```bash
 cargo check -p rustok-index --all-targets
 cargo test -p rustok-index --lib
+cargo test -p rustok-index --test module
 node scripts/verify/verify-index-mutation-storage.mjs
 node scripts/verify/verify-index-schema-leases.mjs
 node scripts/verify/verify-index-secondary-index-lifecycle.mjs
 node scripts/verify/verify-index-partition-admission.mjs
+node scripts/verify/verify-index-partition-evidence.mjs
 ```
 
 ## Progress log
@@ -397,5 +416,8 @@ node scripts/verify/verify-index-partition-admission.mjs
   concurrent ensure/reindex/retire execution, catalog readiness checks, durable
   jobs, owner fingerprints, and operation fencing.
 - 2026-07-27: added fail-closed measured partition admission and deterministic
-  tenant-hash shadow planning without destructive production cutover SQL. Tests,
-  verifiers, and PostgreSQL evidence were left for the repository owner to execute.
+  tenant-hash shadow planning without destructive production cutover SQL.
+- 2026-07-27: added immutable partition evidence manifests, calculated packet
+  admission, non-clobbering shadow bootstrap publication, owner runbook, lightweight
+  CI guards, and corrected the stale integration migration contract. Repository
+  tests, verifiers, and PostgreSQL evidence remain for the owner to execute.

--- a/crates/rustok-index/docs/partition-evidence-runbook.md
+++ b/crates/rustok-index/docs/partition-evidence-runbook.md
@@ -1,0 +1,218 @@
+# Index M3 partition evidence runbook
+
+This runbook defines the owner-operated PostgreSQL evidence procedure required
+before tenant-hash partition copy or cutover can be implemented. It does not grant
+cutover permission by itself. The canonical `index_entities` and `index_links`
+relations remain unpartitioned unless one retained packet validates to `admitted`.
+
+## Tooling boundary
+
+The tooling is intentionally split into two phases:
+
+1. `partition-prepare` binds an immutable run manifest to one SHA-256
+   `evidence_id` and emits deterministic shadow-only bootstrap SQL.
+2. `partition-validate` validates a completed measured packet, calculates all
+   admission metrics, and atomically publishes `admission.json`.
+
+The preparer refuses to overwrite either manifest or bootstrap output. The
+validator removes stale admission output before validation and writes a new file
+only after the complete packet is accepted structurally.
+
+Neither command copies rows, installs production constraints or indexes, starts
+replay or dual-write, renames production relations, drops production relations,
+or performs cutover.
+
+## Prepare an immutable run
+
+Create a configuration file such as `evidence/index-partition/config.json`:
+
+```json
+{
+  "contract": "index_partition_evidence_manifest_v1",
+  "repository": "RusTokRs/RusTok",
+  "commit": "<full lowercase 40-character commit SHA>",
+  "run_key": "<stable workflow-run or UUID-like identifier>",
+  "postgres_image": "postgres:16",
+  "strategy": "tenant_hash",
+  "plan_digest_contract": "normalized_partition_plan_v1",
+  "modulus": 16,
+  "locales": ["en-US", "ru-RU"],
+  "repetitions": {
+    "query": 3,
+    "mutation": 3,
+    "maintenance": 3,
+    "cutover": 1
+  },
+  "thresholds": {
+    "minimum_total_rows": 1000000,
+    "minimum_total_bytes": 4294967296,
+    "minimum_distinct_tenants": 16,
+    "maximum_query_p95_regression_bps": 500,
+    "maximum_mutation_p95_regression_bps": 500,
+    "maximum_wal_amplification_bps": 11000,
+    "maximum_partition_size_to_mean_bps": 15000,
+    "maximum_cutover_lock_ms": 250
+  }
+}
+```
+
+Use an immutable reviewed commit. `run_key` must identify one run attempt and must
+not be reused for a rerun. Modulus must be a power of two from 2 through 128.
+PostgreSQL image is pinned to `postgres:16`. Repetition counts are exact and must
+all be positive.
+
+Prepare the manifest and bootstrap SQL:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-prepare \
+  --input evidence/index-partition/config.json \
+  --manifest evidence/index-partition/manifest.json \
+  --bootstrap evidence/index-partition/bootstrap.sql
+```
+
+`evidence_id` is the SHA-256 digest of canonical manifest input, including the
+commit and unique run key. Shadow relation names use the same
+`tenant_hash_shadow_v1` definition contract as `PartitionShadowPlan`: the
+definition hash binds evidence identity, strategy, and modulus, and the first 24
+hexadecimal characters form the relation suffix.
+
+Review `bootstrap.sql` before execution. It may contain only:
+
+- `CREATE TABLE ... LIKE index_entities ... PARTITION BY HASH (tenant_id)`;
+- `CREATE TABLE ... LIKE index_links ... PARTITION BY HASH (tenant_id)`;
+- child `PARTITION OF` statements for every remainder;
+- owner comments bound to the evidence identity.
+
+It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`, copy,
+replay, dual-write, or cutover statements.
+
+## Required measured packet
+
+The owner-run harness produces one `partition-packet.json` with contract
+`index_partition_evidence_packet_v1`. The packet embeds the prepared manifest and
+records PostgreSQL 16 metadata with JIT disabled.
+
+The packet also records:
+
+- runner repository, commit, run key, job, operating system, and architecture;
+- PostgreSQL system identifier and database name, so all sections remain bound to
+  one database instance;
+- SHA-256 digests for the retained raw baseline, shadow, query, mutation,
+  maintenance, and cutover artifacts.
+
+The repository, commit, and run key in runner provenance must exactly match the
+manifest. Raw-artifact roles are exact; missing or additional roles fail
+validation.
+
+### Baseline
+
+The unpartitioned baseline records:
+
+- generation timestamp;
+- distinct tenant count;
+- audited query-template count and tenant-scoped template count;
+- exact entity rows, bytes, and SHA-256 logical digest;
+- exact link rows, bytes, and SHA-256 logical digest.
+
+Tenant-predicate coverage is calculated by the validator. Admission requires
+exactly 10,000 basis points.
+
+### Shadow
+
+The shadow section records:
+
+- generation timestamp and caught-up state;
+- validated foreign-key state and orphan-link count;
+- exact entity/link rows, bytes, and logical digests;
+- one positive byte size for every entity partition;
+- one positive byte size for every link partition.
+
+Partition-size skew is calculated from the largest child divided by the mean child
+size. The packet cannot supply a precomputed pass/fail value. Timestamps must
+satisfy baseline generation before shadow generation before packet completion.
+
+### Query measurements
+
+Each query run records a unique name, baseline and shadow p95 latency, and
+SHA-256 plan digests. Both digests must follow
+`normalized_partition_plan_v1` and be produced by the same reviewed logical plan
+normalization: runtime timing/buffer/WAL counters and physical relation, alias, and
+index names are excluded, while operator, join, predicate, ordering, grouping, and
+partition-pruning semantics are retained. Raw baseline and shadow
+`EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` artifacts remain mandatory retained
+inputs for reviewer verification. The validator calculates the maximum
+non-negative latency regression and counts normalized plan-digest changes.
+
+### Mutation and WAL measurements
+
+Each mutation run records a unique name, baseline and shadow p95 latency, and
+baseline/shadow WAL bytes. The validator calculates maximum latency regression and
+maximum WAL amplification.
+
+### Maintenance measurements
+
+Each maintenance run records baseline/shadow ordinary VACUUM duration and dead
+tuple counts. `VACUUM FULL` is not valid evidence and production health must not
+depend on exclusive rewrites.
+
+### Cutover rehearsals
+
+Each rehearsal records measured lock duration plus two independent facts:
+rollback was verified and production relations remained unchanged. This evidence
+is a rehearsal boundary only; the current implementation still contains no
+production cutover operation.
+
+## Validate and publish admission
+
+Run:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-validate \
+  --input evidence/index-partition/partition-packet.json \
+  --output evidence/index-partition/admission.json
+```
+
+The validator recomputes manifest identity and deterministic relation names,
+checks provenance, raw-artifact hashes, timestamp order, exact repetition counts,
+and calculates tenant coverage, latency regression, WAL amplification, partition
+skew, lock duration, cardinality/digest parity, and all typed rejection reasons.
+
+`admission.json` uses contract `index_partition_admission_v1` and contains both the
+manifest `evidence_id` and a SHA-256 `packet_digest` calculated from the complete
+canonical packet. It returns either:
+
+- `admitted` with an empty reasons list; or
+- `keep_unpartitioned` with calculated typed reasons.
+
+A structurally invalid or incomplete packet produces no admission output.
+
+## Retention and review
+
+Retain together:
+
+- `config.json`;
+- `manifest.json`;
+- `bootstrap.sql`;
+- raw query, mutation, maintenance, and cutover artifacts used to assemble the
+  packet;
+- `partition-packet.json`;
+- `admission.json`;
+- PostgreSQL logs and runner metadata.
+
+Recalculate every raw-artifact SHA-256 before assembling the packet. Do not combine
+files from different commits, PostgreSQL instances, manifests, run keys, or run
+attempts. A validated packet is necessary but not sufficient for production
+partitioning. Reviewers must still approve durable global operation ownership,
+copy/checkpoint semantics, constraint and index attachment, catch-up or replay,
+cutover, rollback, and failure recovery in later changes.
+
+## Suggested repository checks
+
+The repository owner runs:
+
+```bash
+node --test scripts/verify/index-partition-evidence.test.mjs
+node scripts/verify/verify-index-partition-evidence.mjs
+node scripts/verify/index-storage-tooling.mjs contract
+cargo test -p rustok-index --test module
+```

--- a/crates/rustok-index/tests/module.rs
+++ b/crates/rustok-index/tests/module.rs
@@ -14,10 +14,34 @@ fn module_metadata() {
 }
 
 #[test]
-fn module_has_no_legacy_migrations_during_storage_rewrite() {
+fn module_registers_canonical_storage_migrations() {
     let module = IndexModule;
-    assert!(
-        module.migrations().is_empty(),
-        "IndexModule production persistence remains absent until the storage ADR is accepted"
+    let migrations = module.migrations();
+    let names = migrations
+        .iter()
+        .map(|migration| migration.name())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        [
+            "m20260727_000001_create_index_records",
+            "m20260727_000002_create_index_delivery_state",
+            "m20260727_000003_create_index_operations",
+        ]
+    );
+
+    let dependencies = module.migration_dependencies();
+    assert_eq!(dependencies.len(), 3);
+    assert_eq!(
+        dependencies[0].migration,
+        "m20260727_000001_create_index_records"
+    );
+    assert_eq!(
+        dependencies[1].migration,
+        "m20260727_000002_create_index_delivery_state"
+    );
+    assert_eq!(
+        dependencies[2].migration,
+        "m20260727_000003_create_index_operations"
     );
 }

--- a/scripts/verify/index-partition-evidence-core.mjs
+++ b/scripts/verify/index-partition-evidence-core.mjs
@@ -1,0 +1,579 @@
+import { createHash } from 'node:crypto';
+
+export const MANIFEST_CONTRACT = 'index_partition_evidence_manifest_v1';
+export const PACKET_CONTRACT = 'index_partition_evidence_packet_v1';
+export const ADMISSION_CONTRACT = 'index_partition_admission_v1';
+export const SHADOW_PLAN_VERSION = 'tenant_hash_shadow_v1';
+export const PLAN_DIGEST_CONTRACT = 'normalized_partition_plan_v1';
+export const TENANT_COVERAGE_BPS = 10_000;
+
+const RAW_ARTIFACT_ROLES = [
+  'baseline',
+  'shadow',
+  'query',
+  'mutation',
+  'maintenance',
+  'cutover',
+];
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const requireObject = (value, label) => {
+  if (!isObject(value)) throw new Error(`${label} must be an object`);
+  return value;
+};
+
+const requireArray = (value, label) => {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+};
+
+const requireNonEmptyString = (value, label) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+const requireInteger = (value, label, minimum = 0) => {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`${label} must be an integer >= ${minimum}`);
+  }
+  return value;
+};
+
+const requireNumber = (value, label, minimum = 0) => {
+  if (!Number.isFinite(value) || value < minimum) {
+    throw new Error(`${label} must be a finite number >= ${minimum}`);
+  }
+  return value;
+};
+
+const requireBoolean = (value, label) => {
+  if (typeof value !== 'boolean') throw new Error(`${label} must be a boolean`);
+  return value;
+};
+
+const requireDigest = (value, label) => {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/u.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`);
+  }
+  return value;
+};
+
+const requireTimestamp = (value, label) => {
+  requireNonEmptyString(value, label);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u.test(value)
+      || !Number.isFinite(Date.parse(value))) {
+    throw new Error(`${label} must be an RFC 3339 UTC timestamp`);
+  }
+  return value;
+};
+
+const canonicalValue = (value) => {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalValue(value[key])]),
+  );
+};
+
+export const canonicalJson = (value) => JSON.stringify(canonicalValue(value));
+export const sha256Hex = (value) => createHash('sha256').update(value).digest('hex');
+
+const validateModulus = (modulus) => {
+  requireInteger(modulus, 'manifest.modulus', 2);
+  if (modulus > 128 || (modulus & (modulus - 1)) !== 0) {
+    throw new Error('manifest.modulus must be a power of two between 2 and 128');
+  }
+};
+
+const requireThresholds = (thresholds) => {
+  requireObject(thresholds, 'manifest.thresholds');
+  requireInteger(thresholds.minimum_total_rows, 'manifest.thresholds.minimum_total_rows', 1);
+  requireInteger(thresholds.minimum_total_bytes, 'manifest.thresholds.minimum_total_bytes', 1);
+  requireInteger(
+    thresholds.minimum_distinct_tenants,
+    'manifest.thresholds.minimum_distinct_tenants',
+    2,
+  );
+  requireInteger(
+    thresholds.maximum_query_p95_regression_bps,
+    'manifest.thresholds.maximum_query_p95_regression_bps',
+  );
+  requireInteger(
+    thresholds.maximum_mutation_p95_regression_bps,
+    'manifest.thresholds.maximum_mutation_p95_regression_bps',
+  );
+  requireInteger(
+    thresholds.maximum_wal_amplification_bps,
+    'manifest.thresholds.maximum_wal_amplification_bps',
+    TENANT_COVERAGE_BPS,
+  );
+  requireInteger(
+    thresholds.maximum_partition_size_to_mean_bps,
+    'manifest.thresholds.maximum_partition_size_to_mean_bps',
+    TENANT_COVERAGE_BPS,
+  );
+  requireInteger(
+    thresholds.maximum_cutover_lock_ms,
+    'manifest.thresholds.maximum_cutover_lock_ms',
+    1,
+  );
+};
+
+const requireRepetitions = (repetitions) => {
+  requireObject(repetitions, 'manifest.repetitions');
+  for (const key of ['query', 'mutation', 'maintenance', 'cutover']) {
+    requireInteger(repetitions[key], `manifest.repetitions.${key}`, 1);
+  }
+};
+
+const requireLocales = (locales) => {
+  requireArray(locales, 'manifest.locales');
+  if (locales.length === 0) throw new Error('manifest.locales must not be empty');
+  if (new Set(locales).size !== locales.length) {
+    throw new Error('manifest.locales must not contain duplicates');
+  }
+  for (const [index, locale] of locales.entries()) {
+    requireNonEmptyString(locale, `manifest.locales[${index}]`);
+  }
+};
+
+export const validateManifestInput = (manifest) => {
+  requireObject(manifest, 'manifest');
+  if (manifest.contract !== MANIFEST_CONTRACT) {
+    throw new Error(`manifest.contract must be ${MANIFEST_CONTRACT}`);
+  }
+  if (manifest.repository !== 'RusTokRs/RusTok') {
+    throw new Error('manifest.repository must be RusTokRs/RusTok');
+  }
+  if (typeof manifest.commit !== 'string' || !/^[0-9a-f]{40}$/u.test(manifest.commit)) {
+    throw new Error('manifest.commit must be a full lowercase Git commit SHA');
+  }
+  if (typeof manifest.run_key !== 'string'
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(manifest.run_key)) {
+    throw new Error('manifest.run_key must be a bounded stable run identifier');
+  }
+  if (manifest.postgres_image !== 'postgres:16') {
+    throw new Error('manifest.postgres_image must be postgres:16');
+  }
+  if (manifest.strategy !== 'tenant_hash') {
+    throw new Error('manifest.strategy must be tenant_hash');
+  }
+  if (manifest.plan_digest_contract !== PLAN_DIGEST_CONTRACT) {
+    throw new Error(`manifest.plan_digest_contract must be ${PLAN_DIGEST_CONTRACT}`);
+  }
+  validateModulus(manifest.modulus);
+  requireLocales(manifest.locales);
+  requireRepetitions(manifest.repetitions);
+  requireThresholds(manifest.thresholds);
+  return manifest;
+};
+
+export const computeEvidenceId = (manifestInput) => {
+  validateManifestInput(manifestInput);
+  return sha256Hex(canonicalJson(manifestInput));
+};
+
+export const deriveShadowRelations = (evidenceId, modulus) => {
+  requireDigest(evidenceId, 'evidence_id');
+  validateModulus(modulus);
+  const definition = [
+    'rustok-index-partition',
+    SHADOW_PLAN_VERSION,
+    evidenceId,
+    'tenant_hash',
+    String(modulus),
+  ].join('\u001f');
+  const definitionHash = sha256Hex(definition);
+  const suffix = definitionHash.slice(0, 24);
+  const relation = (source) => {
+    const parent = `${source}_shadow_${suffix}`;
+    const partitions = Array.from(
+      { length: modulus },
+      (_, remainder) => `${parent}_p${String(remainder).padStart(3, '0')}`,
+    );
+    return { source, parent, partitions };
+  };
+  return {
+    definition_hash: definitionHash,
+    entities: relation('index_entities'),
+    links: relation('index_links'),
+  };
+};
+
+const quoteIdentifier = (value) => `"${value.replaceAll('"', '""')}"`;
+
+export const renderShadowBootstrapSql = (preparedManifest) => {
+  validatePreparedManifest(preparedManifest);
+  const lines = [
+    '-- Generated by prepare-index-partition-evidence.mjs.',
+    '-- Shadow bootstrap only: no production ALTER, DROP, RENAME, copy, or cutover.',
+    'BEGIN;',
+  ];
+  for (const relation of [
+    preparedManifest.shadow_relations.entities,
+    preparedManifest.shadow_relations.links,
+  ]) {
+    lines.push(
+      `CREATE TABLE ${quoteIdentifier(relation.parent)} (LIKE ${quoteIdentifier(relation.source)} INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING IDENTITY INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY HASH (tenant_id);`,
+      `COMMENT ON TABLE ${quoteIdentifier(relation.parent)} IS 'rustok-index-partition:${preparedManifest.evidence_id}';`,
+    );
+    relation.partitions.forEach((partition, remainder) => {
+      lines.push(
+        `CREATE TABLE ${quoteIdentifier(partition)} PARTITION OF ${quoteIdentifier(relation.parent)} FOR VALUES WITH (MODULUS ${preparedManifest.modulus}, REMAINDER ${remainder});`,
+      );
+    });
+  }
+  lines.push('COMMIT;', '');
+  return lines.join('\n');
+};
+
+export const prepareManifest = (manifestInput) => {
+  const input = structuredClone(validateManifestInput(manifestInput));
+  const evidenceId = computeEvidenceId(input);
+  return {
+    ...input,
+    evidence_id: evidenceId,
+    shadow_plan_version: SHADOW_PLAN_VERSION,
+    shadow_relations: deriveShadowRelations(evidenceId, input.modulus),
+  };
+};
+
+export const validatePreparedManifest = (manifest) => {
+  requireObject(manifest, 'packet.manifest');
+  const {
+    evidence_id: evidenceId,
+    shadow_plan_version: shadowPlanVersion,
+    shadow_relations: shadowRelations,
+    ...input
+  } = manifest;
+  validateManifestInput(input);
+  requireDigest(evidenceId, 'packet.manifest.evidence_id');
+  if (computeEvidenceId(input) !== evidenceId) {
+    throw new Error('packet.manifest.evidence_id does not match canonical manifest bytes');
+  }
+  if (shadowPlanVersion !== SHADOW_PLAN_VERSION) {
+    throw new Error(`packet.manifest.shadow_plan_version must be ${SHADOW_PLAN_VERSION}`);
+  }
+  const expected = deriveShadowRelations(evidenceId, input.modulus);
+  if (canonicalJson(shadowRelations) !== canonicalJson(expected)) {
+    throw new Error('packet.manifest.shadow_relations do not match the deterministic plan');
+  }
+  return manifest;
+};
+
+const validateRelationEvidence = (relation, label) => {
+  requireObject(relation, label);
+  requireInteger(relation.rows, `${label}.rows`);
+  requireInteger(relation.bytes, `${label}.bytes`, 1);
+  requireDigest(relation.digest, `${label}.digest`);
+};
+
+const regressionBps = (baseline, shadow, label) => {
+  requireNumber(baseline, `${label}.baseline`, Number.EPSILON);
+  requireNumber(shadow, `${label}.shadow`);
+  return Math.max(0, Math.round(((shadow - baseline) / baseline) * TENANT_COVERAGE_BPS));
+};
+
+const amplificationBps = (baseline, shadow, label) => {
+  requireInteger(baseline, `${label}.baseline`, 1);
+  requireInteger(shadow, `${label}.shadow`);
+  return Math.round((shadow / baseline) * TENANT_COVERAGE_BPS);
+};
+
+const maximumSkewBps = (partitionBytes, modulus, label) => {
+  requireArray(partitionBytes, label);
+  if (partitionBytes.length !== modulus) {
+    throw new Error(`${label} must contain exactly ${modulus} partition sizes`);
+  }
+  partitionBytes.forEach((value, index) => requireInteger(value, `${label}[${index}]`, 1));
+  const mean = partitionBytes.reduce((sum, value) => sum + value, 0) / modulus;
+  return Math.round((Math.max(...partitionBytes) / mean) * TENANT_COVERAGE_BPS);
+};
+
+const validateNamedRuns = (runs, label, expectedCount) => {
+  requireArray(runs, label);
+  if (runs.length !== expectedCount) {
+    throw new Error(`${label} must contain exactly ${expectedCount} runs`);
+  }
+  const names = runs.map((run, index) => {
+    requireObject(run, `${label}[${index}]`);
+    return requireNonEmptyString(run.name, `${label}[${index}].name`);
+  });
+  if (new Set(names).size !== names.length) throw new Error(`${label} contains duplicate names`);
+};
+
+const pushThresholdReason = (reasons, condition, code, actual, maximum) => {
+  if (condition) reasons.push({ code, actual, maximum });
+};
+
+const validateRunProvenance = (provenance, manifest) => {
+  requireObject(provenance, 'packet.run_provenance');
+  for (const field of ['repository', 'commit', 'run_key', 'job', 'runner_os', 'runner_arch']) {
+    requireNonEmptyString(provenance[field], `packet.run_provenance.${field}`);
+  }
+  if (provenance.repository !== manifest.repository) {
+    throw new Error('packet.run_provenance.repository must match the manifest');
+  }
+  if (provenance.commit !== manifest.commit) {
+    throw new Error('packet.run_provenance.commit must match the manifest');
+  }
+  if (provenance.run_key !== manifest.run_key) {
+    throw new Error('packet.run_provenance.run_key must match the manifest');
+  }
+};
+
+const validateRawArtifacts = (artifacts) => {
+  requireObject(artifacts, 'packet.raw_artifacts');
+  const keys = Object.keys(artifacts).sort();
+  if (canonicalJson(keys) !== canonicalJson([...RAW_ARTIFACT_ROLES].sort())) {
+    throw new Error(`packet.raw_artifacts must contain exactly: ${RAW_ARTIFACT_ROLES.join(', ')}`);
+  }
+  for (const role of RAW_ARTIFACT_ROLES) {
+    requireDigest(artifacts[role], `packet.raw_artifacts.${role}`);
+  }
+};
+
+export const validatePartitionPacket = (packet) => {
+  requireObject(packet, 'packet');
+  if (packet.contract !== PACKET_CONTRACT) {
+    throw new Error(`packet.contract must be ${PACKET_CONTRACT}`);
+  }
+  validatePreparedManifest(packet.manifest);
+  const completedAt = Date.parse(requireTimestamp(packet.completed_at, 'packet.completed_at'));
+  validateRunProvenance(packet.run_provenance, packet.manifest);
+  validateRawArtifacts(packet.raw_artifacts);
+
+  const database = requireObject(packet.database, 'packet.database');
+  requireNonEmptyString(database.version, 'packet.database.version');
+  if (typeof database.server_version_num !== 'string'
+      || !/^16\d{4}$/u.test(database.server_version_num)) {
+    throw new Error('packet.database.server_version_num must describe PostgreSQL 16');
+  }
+  if (database.jit !== 'off') throw new Error('packet.database.jit must be off');
+  requireNonEmptyString(database.system_identifier, 'packet.database.system_identifier');
+  if (!/^\d+$/u.test(database.system_identifier)) {
+    throw new Error('packet.database.system_identifier must contain only digits');
+  }
+  requireNonEmptyString(database.database_name, 'packet.database.database_name');
+
+  const baseline = requireObject(packet.baseline, 'packet.baseline');
+  const baselineAt = Date.parse(requireTimestamp(baseline.generated_at, 'packet.baseline.generated_at'));
+  requireInteger(baseline.distinct_tenants, 'packet.baseline.distinct_tenants', 1);
+  const audit = requireObject(baseline.tenant_predicate_audit, 'packet.baseline.tenant_predicate_audit');
+  requireInteger(audit.total_templates, 'packet.baseline.tenant_predicate_audit.total_templates', 1);
+  requireInteger(audit.tenant_scoped_templates, 'packet.baseline.tenant_predicate_audit.tenant_scoped_templates');
+  if (audit.tenant_scoped_templates > audit.total_templates) {
+    throw new Error('tenant-scoped template count cannot exceed total templates');
+  }
+  validateRelationEvidence(baseline.entities, 'packet.baseline.entities');
+  validateRelationEvidence(baseline.links, 'packet.baseline.links');
+
+  const shadow = requireObject(packet.shadow, 'packet.shadow');
+  const shadowAt = Date.parse(requireTimestamp(shadow.generated_at, 'packet.shadow.generated_at'));
+  if (baselineAt > shadowAt || shadowAt > completedAt) {
+    throw new Error('packet timestamps must satisfy baseline <= shadow <= completed');
+  }
+  requireBoolean(shadow.caught_up, 'packet.shadow.caught_up');
+  requireBoolean(shadow.foreign_keys_validated, 'packet.shadow.foreign_keys_validated');
+  requireInteger(shadow.orphan_links, 'packet.shadow.orphan_links');
+  validateRelationEvidence(shadow.entities, 'packet.shadow.entities');
+  validateRelationEvidence(shadow.links, 'packet.shadow.links');
+
+  const repetitions = packet.manifest.repetitions;
+  validateNamedRuns(packet.query_runs, 'packet.query_runs', repetitions.query);
+  validateNamedRuns(packet.mutation_runs, 'packet.mutation_runs', repetitions.mutation);
+  validateNamedRuns(packet.maintenance_runs, 'packet.maintenance_runs', repetitions.maintenance);
+  requireArray(packet.cutover_rehearsals, 'packet.cutover_rehearsals');
+  if (packet.cutover_rehearsals.length !== repetitions.cutover) {
+    throw new Error(`packet.cutover_rehearsals must contain exactly ${repetitions.cutover} runs`);
+  }
+
+  let maximumQueryRegressionBps = 0;
+  let queryPlanRegressions = 0;
+  for (const [index, run] of packet.query_runs.entries()) {
+    maximumQueryRegressionBps = Math.max(
+      maximumQueryRegressionBps,
+      regressionBps(run.baseline_p95_ms, run.shadow_p95_ms, `packet.query_runs[${index}]`),
+    );
+    requireDigest(run.baseline_plan_digest, `packet.query_runs[${index}].baseline_plan_digest`);
+    requireDigest(run.shadow_plan_digest, `packet.query_runs[${index}].shadow_plan_digest`);
+    if (run.baseline_plan_digest !== run.shadow_plan_digest) queryPlanRegressions += 1;
+  }
+
+  let maximumMutationRegressionBps = 0;
+  let maximumWalAmplificationBps = 0;
+  for (const [index, run] of packet.mutation_runs.entries()) {
+    maximumMutationRegressionBps = Math.max(
+      maximumMutationRegressionBps,
+      regressionBps(run.baseline_p95_ms, run.shadow_p95_ms, `packet.mutation_runs[${index}]`),
+    );
+    maximumWalAmplificationBps = Math.max(
+      maximumWalAmplificationBps,
+      amplificationBps(
+        run.baseline_wal_bytes,
+        run.shadow_wal_bytes,
+        `packet.mutation_runs[${index}].wal`,
+      ),
+    );
+  }
+
+  for (const [index, run] of packet.maintenance_runs.entries()) {
+    requireNumber(run.baseline_vacuum_ms, `packet.maintenance_runs[${index}].baseline_vacuum_ms`);
+    requireNumber(run.shadow_vacuum_ms, `packet.maintenance_runs[${index}].shadow_vacuum_ms`);
+    requireInteger(run.baseline_dead_tuples, `packet.maintenance_runs[${index}].baseline_dead_tuples`);
+    requireInteger(run.shadow_dead_tuples, `packet.maintenance_runs[${index}].shadow_dead_tuples`);
+  }
+
+  let maximumCutoverLockMs = 0;
+  for (const [index, run] of packet.cutover_rehearsals.entries()) {
+    requireObject(run, `packet.cutover_rehearsals[${index}]`);
+    maximumCutoverLockMs = Math.max(
+      maximumCutoverLockMs,
+      requireInteger(run.lock_ms, `packet.cutover_rehearsals[${index}].lock_ms`),
+    );
+    requireBoolean(run.rollback_verified, `packet.cutover_rehearsals[${index}].rollback_verified`);
+    requireBoolean(
+      run.production_relations_unchanged,
+      `packet.cutover_rehearsals[${index}].production_relations_unchanged`,
+    );
+  }
+
+  const entitySkewBps = maximumSkewBps(
+    shadow.entities.partition_bytes,
+    packet.manifest.modulus,
+    'packet.shadow.entities.partition_bytes',
+  );
+  const linkSkewBps = maximumSkewBps(
+    shadow.links.partition_bytes,
+    packet.manifest.modulus,
+    'packet.shadow.links.partition_bytes',
+  );
+  const maximumPartitionSizeToMeanBps = Math.max(entitySkewBps, linkSkewBps);
+  const tenantPredicateCoverageBps = Math.floor(
+    (audit.tenant_scoped_templates * TENANT_COVERAGE_BPS) / audit.total_templates,
+  );
+  const totalRows = baseline.entities.rows + baseline.links.rows;
+  const totalBytes = baseline.entities.bytes + baseline.links.bytes;
+  const thresholds = packet.manifest.thresholds;
+  const reasons = [];
+
+  if (totalRows < thresholds.minimum_total_rows) {
+    reasons.push({ code: 'below_minimum_rows', actual: totalRows, minimum: thresholds.minimum_total_rows });
+  }
+  if (totalBytes < thresholds.minimum_total_bytes) {
+    reasons.push({ code: 'below_minimum_bytes', actual: totalBytes, minimum: thresholds.minimum_total_bytes });
+  }
+  if (baseline.distinct_tenants < thresholds.minimum_distinct_tenants) {
+    reasons.push({
+      code: 'insufficient_distinct_tenants',
+      actual: baseline.distinct_tenants,
+      minimum: thresholds.minimum_distinct_tenants,
+    });
+  }
+  if (baseline.distinct_tenants < packet.manifest.modulus) {
+    reasons.push({
+      code: 'insufficient_tenants_for_modulus',
+      actual: baseline.distinct_tenants,
+      modulus: packet.manifest.modulus,
+    });
+  }
+  if (tenantPredicateCoverageBps !== TENANT_COVERAGE_BPS) {
+    reasons.push({
+      code: 'tenant_predicate_coverage',
+      actual_bps: tenantPredicateCoverageBps,
+      required_bps: TENANT_COVERAGE_BPS,
+    });
+  }
+  if (baseline.entities.rows !== shadow.entities.rows
+      || baseline.entities.digest !== shadow.entities.digest) {
+    reasons.push({ code: 'entity_digest_mismatch' });
+  }
+  if (baseline.links.rows !== shadow.links.rows || baseline.links.digest !== shadow.links.digest) {
+    reasons.push({ code: 'link_digest_mismatch' });
+  }
+  if (!shadow.caught_up) reasons.push({ code: 'shadow_not_caught_up' });
+  if (!shadow.foreign_keys_validated) reasons.push({ code: 'foreign_keys_not_validated' });
+  if (shadow.orphan_links !== 0) reasons.push({ code: 'orphan_links', count: shadow.orphan_links });
+  if (queryPlanRegressions !== 0) {
+    reasons.push({ code: 'query_plan_regressions', count: queryPlanRegressions });
+  }
+  pushThresholdReason(
+    reasons,
+    maximumQueryRegressionBps > thresholds.maximum_query_p95_regression_bps,
+    'query_latency_regression',
+    maximumQueryRegressionBps,
+    thresholds.maximum_query_p95_regression_bps,
+  );
+  pushThresholdReason(
+    reasons,
+    maximumMutationRegressionBps > thresholds.maximum_mutation_p95_regression_bps,
+    'mutation_latency_regression',
+    maximumMutationRegressionBps,
+    thresholds.maximum_mutation_p95_regression_bps,
+  );
+  pushThresholdReason(
+    reasons,
+    maximumWalAmplificationBps > thresholds.maximum_wal_amplification_bps,
+    'wal_amplification',
+    maximumWalAmplificationBps,
+    thresholds.maximum_wal_amplification_bps,
+  );
+  pushThresholdReason(
+    reasons,
+    maximumPartitionSizeToMeanBps > thresholds.maximum_partition_size_to_mean_bps,
+    'partition_size_skew',
+    maximumPartitionSizeToMeanBps,
+    thresholds.maximum_partition_size_to_mean_bps,
+  );
+  pushThresholdReason(
+    reasons,
+    maximumCutoverLockMs > thresholds.maximum_cutover_lock_ms,
+    'cutover_lock_exceeded',
+    maximumCutoverLockMs,
+    thresholds.maximum_cutover_lock_ms,
+  );
+  if (packet.cutover_rehearsals.some((run) => !run.rollback_verified)) {
+    reasons.push({ code: 'rollback_not_verified' });
+  }
+  if (packet.cutover_rehearsals.some((run) => !run.production_relations_unchanged)) {
+    reasons.push({ code: 'production_relations_changed' });
+  }
+
+  return {
+    contract: ADMISSION_CONTRACT,
+    evidence_id: packet.manifest.evidence_id,
+    packet_digest: sha256Hex(canonicalJson(packet)),
+    completed_at: packet.completed_at,
+    run_provenance: structuredClone(packet.run_provenance),
+    measurements: {
+      total_rows: totalRows,
+      total_bytes: totalBytes,
+      distinct_tenants: baseline.distinct_tenants,
+      tenant_predicate_coverage_bps: tenantPredicateCoverageBps,
+      query_runs: packet.query_runs.length,
+      mutation_runs: packet.mutation_runs.length,
+      maintenance_runs: packet.maintenance_runs.length,
+      cutover_rehearsals: packet.cutover_rehearsals.length,
+      query_plan_regressions: queryPlanRegressions,
+      maximum_query_p95_regression_bps: maximumQueryRegressionBps,
+      maximum_mutation_p95_regression_bps: maximumMutationRegressionBps,
+      maximum_wal_amplification_bps: maximumWalAmplificationBps,
+      maximum_partition_size_to_mean_bps: maximumPartitionSizeToMeanBps,
+      maximum_cutover_lock_ms: maximumCutoverLockMs,
+      entity_digest_matches:
+        baseline.entities.rows === shadow.entities.rows
+        && baseline.entities.digest === shadow.entities.digest,
+      link_digest_matches:
+        baseline.links.rows === shadow.links.rows
+        && baseline.links.digest === shadow.links.digest,
+      shadow_caught_up: shadow.caught_up,
+      foreign_keys_validated: shadow.foreign_keys_validated,
+      orphan_links: shadow.orphan_links,
+    },
+    outcome: reasons.length === 0 ? 'admitted' : 'keep_unpartitioned',
+    reasons,
+  };
+};

--- a/scripts/verify/index-partition-evidence.test.mjs
+++ b/scripts/verify/index-partition-evidence.test.mjs
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PACKET_CONTRACT,
+  computeEvidenceId,
+  prepareManifest,
+  renderShadowBootstrapSql,
+  validatePartitionPacket,
+} from './index-partition-evidence-core.mjs';
+
+const digest = (character) => character.repeat(64);
+
+const config = () => ({
+  contract: 'index_partition_evidence_manifest_v1',
+  repository: 'RusTokRs/RusTok',
+  commit: '1'.repeat(40),
+  run_key: 'fixture-run-1',
+  postgres_image: 'postgres:16',
+  strategy: 'tenant_hash',
+  plan_digest_contract: 'normalized_partition_plan_v1',
+  modulus: 4,
+  locales: ['en-US', 'ru-RU'],
+  repetitions: { query: 2, mutation: 2, maintenance: 2, cutover: 1 },
+  thresholds: {
+    minimum_total_rows: 100,
+    minimum_total_bytes: 1_000,
+    minimum_distinct_tenants: 4,
+    maximum_query_p95_regression_bps: 500,
+    maximum_mutation_p95_regression_bps: 500,
+    maximum_wal_amplification_bps: 11_000,
+    maximum_partition_size_to_mean_bps: 13_000,
+    maximum_cutover_lock_ms: 250,
+  },
+});
+
+const packet = () => {
+  const manifest = prepareManifest(config());
+  return {
+    contract: PACKET_CONTRACT,
+    completed_at: '2026-07-27T14:00:00Z',
+    manifest,
+    run_provenance: {
+      repository: manifest.repository,
+      commit: manifest.commit,
+      run_key: manifest.run_key,
+      job: 'partition-evidence-fixture',
+      runner_os: 'Linux',
+      runner_arch: 'X64',
+    },
+    raw_artifacts: {
+      baseline: digest('1'),
+      shadow: digest('2'),
+      query: digest('3'),
+      mutation: digest('4'),
+      maintenance: digest('5'),
+      cutover: digest('6'),
+    },
+    database: {
+      version: 'PostgreSQL 16.4',
+      server_version_num: '160004',
+      jit: 'off',
+      system_identifier: '7432859712345678901',
+      database_name: 'rustok_index_partition_fixture',
+    },
+    baseline: {
+      generated_at: '2026-07-27T13:00:00Z',
+      distinct_tenants: 8,
+      tenant_predicate_audit: { total_templates: 12, tenant_scoped_templates: 12 },
+      entities: { rows: 1_000, bytes: 80_000, digest: digest('a') },
+      links: { rows: 2_000, bytes: 120_000, digest: digest('b') },
+    },
+    shadow: {
+      generated_at: '2026-07-27T13:30:00Z',
+      caught_up: true,
+      foreign_keys_validated: true,
+      orphan_links: 0,
+      entities: {
+        rows: 1_000,
+        bytes: 82_000,
+        digest: digest('a'),
+        partition_bytes: [20_000, 20_500, 20_500, 21_000],
+      },
+      links: {
+        rows: 2_000,
+        bytes: 123_000,
+        digest: digest('b'),
+        partition_bytes: [30_000, 30_500, 31_000, 31_500],
+      },
+    },
+    query_runs: [
+      {
+        name: 'filter-sort-1',
+        baseline_p95_ms: 10,
+        shadow_p95_ms: 10.2,
+        baseline_plan_digest: digest('c'),
+        shadow_plan_digest: digest('c'),
+      },
+      {
+        name: 'keyset-1',
+        baseline_p95_ms: 5,
+        shadow_p95_ms: 5.1,
+        baseline_plan_digest: digest('d'),
+        shadow_plan_digest: digest('d'),
+      },
+    ],
+    mutation_runs: [
+      {
+        name: 'upsert-1',
+        baseline_p95_ms: 20,
+        shadow_p95_ms: 20.4,
+        baseline_wal_bytes: 1_000,
+        shadow_wal_bytes: 1_040,
+      },
+      {
+        name: 'delete-1',
+        baseline_p95_ms: 10,
+        shadow_p95_ms: 10.2,
+        baseline_wal_bytes: 500,
+        shadow_wal_bytes: 520,
+      },
+    ],
+    maintenance_runs: [
+      {
+        name: 'vacuum-1',
+        baseline_vacuum_ms: 100,
+        shadow_vacuum_ms: 104,
+        baseline_dead_tuples: 20,
+        shadow_dead_tuples: 18,
+      },
+      {
+        name: 'vacuum-2',
+        baseline_vacuum_ms: 101,
+        shadow_vacuum_ms: 105,
+        baseline_dead_tuples: 21,
+        shadow_dead_tuples: 19,
+      },
+    ],
+    cutover_rehearsals: [
+      { lock_ms: 50, rollback_verified: true, production_relations_unchanged: true },
+    ],
+  };
+};
+
+test('manifest identity and shadow bootstrap are deterministic and non-destructive', () => {
+  const first = prepareManifest(config());
+  const second = prepareManifest(config());
+  assert.deepEqual(first, second);
+  assert.equal(first.evidence_id, computeEvidenceId(config()));
+  assert.equal(first.shadow_relations.entities.partitions.length, 4);
+  assert.equal(first.shadow_relations.links.partitions.length, 4);
+
+  const sql = renderShadowBootstrapSql(first);
+  assert.match(sql, /PARTITION BY HASH \(tenant_id\)/u);
+  assert.match(sql, /MODULUS 4, REMAINDER 3/u);
+  assert.doesNotMatch(sql, /ALTER TABLE "index_entities"/u);
+  assert.doesNotMatch(sql, /ALTER TABLE "index_links"/u);
+  assert.doesNotMatch(sql, /DROP TABLE/u);
+  assert.doesNotMatch(sql, /RENAME TO/u);
+});
+
+test('complete measured packet is admitted with calculated metrics', () => {
+  const admission = validatePartitionPacket(packet());
+  assert.equal(admission.outcome, 'admitted');
+  assert.deepEqual(admission.reasons, []);
+  assert.equal(admission.packet_digest.length, 64);
+  assert.equal(admission.run_provenance.run_key, 'fixture-run-1');
+  assert.equal(admission.measurements.tenant_predicate_coverage_bps, 10_000);
+  assert.equal(admission.measurements.query_runs, 2);
+  assert.equal(admission.measurements.mutation_runs, 2);
+  assert.equal(admission.measurements.maintenance_runs, 2);
+  assert.equal(admission.measurements.cutover_rehearsals, 1);
+  assert.equal(admission.measurements.query_plan_regressions, 0);
+  assert.equal(admission.measurements.entity_digest_matches, true);
+  assert.equal(admission.measurements.link_digest_matches, true);
+});
+
+test('regressed packet stays unpartitioned with typed calculated reasons', () => {
+  const value = packet();
+  value.baseline.tenant_predicate_audit.tenant_scoped_templates = 11;
+  value.shadow.links.digest = digest('e');
+  value.shadow.orphan_links = 2;
+  value.query_runs[0].shadow_plan_digest = digest('f');
+  value.query_runs[0].shadow_p95_ms = 12;
+  value.mutation_runs[0].shadow_wal_bytes = 1_500;
+  value.shadow.entities.partition_bytes = [10_000, 10_000, 10_000, 52_000];
+  value.cutover_rehearsals[0] = {
+    lock_ms: 500,
+    rollback_verified: false,
+    production_relations_unchanged: false,
+  };
+
+  const admission = validatePartitionPacket(value);
+  assert.equal(admission.outcome, 'keep_unpartitioned');
+  const codes = new Set(admission.reasons.map((reason) => reason.code));
+  for (const code of [
+    'tenant_predicate_coverage',
+    'link_digest_mismatch',
+    'orphan_links',
+    'query_plan_regressions',
+    'query_latency_regression',
+    'wal_amplification',
+    'partition_size_skew',
+    'cutover_lock_exceeded',
+    'rollback_not_verified',
+    'production_relations_changed',
+  ]) {
+    assert.equal(codes.has(code), true, `missing reason ${code}`);
+  }
+});
+
+test('manifest tampering, provenance drift, and incomplete groups fail validation', () => {
+  const tampered = packet();
+  tampered.manifest.modulus = 8;
+  assert.throws(
+    () => validatePartitionPacket(tampered),
+    /evidence_id does not match canonical manifest bytes/u,
+  );
+
+  const provenanceDrift = packet();
+  provenanceDrift.run_provenance.commit = '2'.repeat(40);
+  assert.throws(
+    () => validatePartitionPacket(provenanceDrift),
+    /run_provenance.commit must match the manifest/u,
+  );
+
+  const incomplete = packet();
+  incomplete.query_runs.pop();
+  assert.throws(
+    () => validatePartitionPacket(incomplete),
+    /packet.query_runs must contain exactly 2 runs/u,
+  );
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -18,20 +18,24 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs fixtures
   node scripts/verify/index-storage-tooling.mjs packet --scale <smoke|100k|1m> [--root <directory>]
   node scripts/verify/index-storage-tooling.mjs compare --input <directory> [--input <directory>] [--output <directory>]
+  node scripts/verify/index-storage-tooling.mjs partition-prepare --input <config.json> --manifest <manifest.json> --bootstrap <bootstrap.sql>
+  node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
   node scripts/verify/index-storage-tooling.mjs render --comparison <comparison.json> --decision <decision.json> --output <adr.md>
   node scripts/verify/index-storage-tooling.mjs verify-adr --comparison <comparison.json> --decision <decision.json> --adr <adr.md>
 
 Commands:
-  contract  Run static Index boundary, source-oracle/evidence, standalone-tool, and ADR guards.
-  fixtures  Run standalone, comparator, read-ordering, decision preparation/finalization, and ADR renderer fixture suites.
-  packet    Validate one smoke, 100k, or 1m evidence packet through terminal-ordering preflight and the canonical validator.
-  compare   Generate a cross-scale comparison after terminal-ordering preflight for every input packet.
-  hash      Print the SHA-256 digest of the exact comparison.json bytes.
-  prepare   Create a non-overwriting manual decision draft bound to the exact comparison bytes.
-  render    Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
-  verify-adr Verify a saved ADR against exact comparison and decision bytes and deterministic re-rendering.`);
+  contract           Run static Index boundary, evidence, partition, standalone-tool, and ADR guards.
+  fixtures           Run standalone, evidence, comparator, decision, partition, and ADR fixture suites.
+  packet             Validate one smoke, 100k, or 1m storage evidence packet.
+  compare            Generate a cross-scale storage comparison.
+  partition-prepare  Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
+  partition-validate Validate a measured partition packet and publish calculated admission output.
+  hash               Print the SHA-256 digest of the exact comparison.json bytes.
+  prepare            Create a non-overwriting manual decision draft bound to exact comparison bytes.
+  render             Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
+  verify-adr         Verify a saved ADR against exact comparison and decision bytes.`);
 };
 
 const runNode = (args, label, environment = process.env) => {
@@ -58,6 +62,7 @@ const runContract = (args) => {
     'verify-index-schema-leases.mjs',
     'verify-index-secondary-index-lifecycle.mjs',
     'verify-index-partition-admission.mjs',
+    'verify-index-partition-evidence.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',
@@ -95,6 +100,7 @@ const runFixtures = (args) => {
     scriptPath('index-storage-decision-tooling.test.mjs'),
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),
     scriptPath('storage-decision-schema-text.test.mjs'),
+    scriptPath('index-partition-evidence.test.mjs'),
   ], 'Index storage fixture suites');
 };
 
@@ -180,6 +186,12 @@ switch (command) {
     break;
   case 'compare':
     runCompare(args);
+    break;
+  case 'partition-prepare':
+    runScript('prepare-index-partition-evidence.mjs', args);
+    break;
+  case 'partition-validate':
+    runScript('validate-index-partition-evidence.mjs', args);
     break;
   case 'hash':
     runScript('hash-index-storage-comparison.mjs', args);

--- a/scripts/verify/prepare-index-partition-evidence.mjs
+++ b/scripts/verify/prepare-index-partition-evidence.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { prepareManifest, renderShadowBootstrapSql } from './index-partition-evidence-core.mjs';
+
+const prefix = '[prepare-index-partition-evidence]';
+
+const parseArgs = (args) => {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--input', '--manifest', '--bootstrap'].includes(flag) || !value || value.startsWith('--')) {
+      throw new Error('usage: --input <config.json> --manifest <manifest.json> --bootstrap <bootstrap.sql>');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  for (const flag of ['--input', '--manifest', '--bootstrap']) {
+    if (!values.has(flag)) throw new Error(`${flag} is required`);
+  }
+  const options = {
+    input: values.get('--input'),
+    manifest: values.get('--manifest'),
+    bootstrap: values.get('--bootstrap'),
+  };
+  const resolved = [options.input, options.manifest, options.bootstrap].map((value) => path.resolve(value));
+  if (new Set(resolved).size !== resolved.length) {
+    throw new Error('--input, --manifest, and --bootstrap must reference distinct paths');
+  }
+  return options;
+};
+
+const writeAtomicNew = (filename, content) => {
+  if (existsSync(filename)) throw new Error(`refusing to overwrite existing file: ${filename}`);
+  mkdirSync(path.dirname(filename), { recursive: true });
+  const temporary = `${filename}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporary, content, { encoding: 'utf8', flag: 'wx' });
+    linkSync(temporary, filename);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const config = JSON.parse(readFileSync(options.input, 'utf8'));
+  const manifest = prepareManifest(config);
+  const bootstrap = renderShadowBootstrapSql(manifest);
+  writeAtomicNew(options.manifest, `${JSON.stringify(manifest, null, 2)}\n`);
+  try {
+    writeAtomicNew(options.bootstrap, bootstrap);
+  } catch (error) {
+    rmSync(options.manifest, { force: true });
+    throw error;
+  }
+  console.log(`${prefix} prepared ${manifest.evidence_id}`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/validate-index-partition-evidence.mjs
+++ b/scripts/verify/validate-index-partition-evidence.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { validatePartitionPacket } from './index-partition-evidence-core.mjs';
+
+const prefix = '[validate-index-partition-evidence]';
+
+const parseArgs = (args) => {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--input', '--output'].includes(flag) || !value || value.startsWith('--')) {
+      throw new Error('usage: --input <packet.json> --output <admission.json>');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  for (const flag of ['--input', '--output']) {
+    if (!values.has(flag)) throw new Error(`${flag} is required`);
+  }
+  const options = { input: values.get('--input'), output: values.get('--output') };
+  if (path.resolve(options.input) === path.resolve(options.output)) {
+    throw new Error('--input and --output must reference distinct paths');
+  }
+  return options;
+};
+
+const writeAtomic = (filename, content) => {
+  mkdirSync(path.dirname(filename), { recursive: true });
+  const temporary = `${filename}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporary, content, 'utf8');
+    renameSync(temporary, filename);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (!existsSync(options.input)) throw new Error(`missing packet: ${options.input}`);
+  rmSync(options.output, { force: true });
+  const packet = JSON.parse(readFileSync(options.input, 'utf8'));
+  const admission = validatePartitionPacket(packet);
+  writeAtomic(options.output, `${JSON.stringify(admission, null, 2)}\n`);
+  console.log(`${prefix} ${admission.outcome} ${admission.evidence_id}`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-evidence.mjs
+++ b/scripts/verify/verify-index-partition-evidence.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-partition-evidence] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const corePath = 'scripts/verify/index-partition-evidence-core.mjs';
+const core = requireMarkers(corePath, [
+  "MANIFEST_CONTRACT = 'index_partition_evidence_manifest_v1'",
+  "PACKET_CONTRACT = 'index_partition_evidence_packet_v1'",
+  "ADMISSION_CONTRACT = 'index_partition_admission_v1'",
+  "SHADOW_PLAN_VERSION = 'tenant_hash_shadow_v1'",
+  "PLAN_DIGEST_CONTRACT = 'normalized_partition_plan_v1'",
+  'export const computeEvidenceId',
+  'export const deriveShadowRelations',
+  'export const renderShadowBootstrapSql',
+  'export const prepareManifest',
+  'export const validatePreparedManifest',
+  'export const validatePartitionPacket',
+  "manifest.repository must be RusTokRs/RusTok",
+  'manifest.run_key must be a bounded stable run identifier',
+  "manifest.postgres_image must be postgres:16",
+  "manifest.strategy must be tenant_hash",
+  'manifest.modulus must be a power of two between 2 and 128',
+  'packet.manifest.evidence_id does not match canonical manifest bytes',
+  'packet.run_provenance.commit must match the manifest',
+  'packet.raw_artifacts must contain exactly',
+  'packet.database.system_identifier must contain only digits',
+  'packet timestamps must satisfy baseline <= shadow <= completed',
+  'packet_digest: sha256Hex(canonicalJson(packet))',
+  'tenant_predicate_coverage_bps',
+  'query_plan_regressions',
+  'maximum_query_p95_regression_bps',
+  'maximum_mutation_p95_regression_bps',
+  'maximum_wal_amplification_bps',
+  'maximum_partition_size_to_mean_bps',
+  'maximum_cutover_lock_ms',
+  "outcome: reasons.length === 0 ? 'admitted' : 'keep_unpartitioned'",
+  "code: 'rollback_not_verified'",
+  "code: 'production_relations_changed'",
+]);
+
+for (const forbidden of [
+  'ALTER TABLE "index_entities"',
+  'ALTER TABLE "index_links"',
+  'DROP TABLE "index_entities"',
+  'DROP TABLE "index_links"',
+  'RENAME TO index_entities',
+  'RENAME TO index_links',
+  'VACUUM FULL',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (core.includes(forbidden)) fail(`${corePath} contains forbidden marker ${forbidden}`);
+}
+
+const prepare = requireMarkers('scripts/verify/prepare-index-partition-evidence.mjs', [
+  '--input, --manifest, and --bootstrap must reference distinct paths',
+  'refusing to overwrite existing file',
+  'writeFileSync(temporary, content',
+  'linkSync(temporary, filename)',
+  'writeAtomicNew(options.manifest',
+  'writeAtomicNew(options.bootstrap',
+  'rmSync(options.manifest, { force: true })',
+]);
+if (prepare.includes("writeFileSync(options.manifest")) {
+  fail('manifest preparer must publish through the atomic new-file helper');
+}
+
+requireMarkers('scripts/verify/validate-index-partition-evidence.mjs', [
+  '--input and --output must reference distinct paths',
+  'rmSync(options.output, { force: true })',
+  'validatePartitionPacket(packet)',
+  'writeAtomic(options.output',
+]);
+
+requireMarkers('scripts/verify/index-partition-evidence.test.mjs', [
+  'manifest identity and shadow bootstrap are deterministic and non-destructive',
+  'complete measured packet is admitted with calculated metrics',
+  'regressed packet stays unpartitioned with typed calculated reasons',
+  'manifest tampering, provenance drift, and incomplete groups fail validation',
+  "run_key: 'fixture-run-1'",
+  "plan_digest_contract: 'normalized_partition_plan_v1'",
+  'raw_artifacts',
+  'system_identifier',
+  'admission.packet_digest.length',
+  'run_provenance.commit must match the manifest',
+  'tenant_predicate_coverage',
+  'link_digest_mismatch',
+  'query_plan_regressions',
+  'wal_amplification',
+  'partition_size_skew',
+  'rollback_not_verified',
+  'production_relations_changed',
+  'assert.doesNotMatch(sql, /DROP TABLE/u)',
+  'assert.doesNotMatch(sql, /RENAME TO/u)',
+]);
+
+requireMarkers('scripts/verify/index-storage-tooling.mjs', [
+  'partition-prepare',
+  'partition-validate',
+  "'verify-index-partition-evidence.mjs'",
+  "scriptPath('index-partition-evidence.test.mjs')",
+  "runScript('prepare-index-partition-evidence.mjs', args)",
+  "runScript('validate-index-partition-evidence.mjs', args)",
+]);
+
+requireMarkers('crates/rustok-index/tests/module.rs', [
+  'module_registers_canonical_storage_migrations',
+  'let migrations = module.migrations();',
+  'm20260727_000001_create_index_records',
+  'm20260727_000002_create_index_delivery_state',
+  'm20260727_000003_create_index_operations',
+  'migration_dependencies',
+]);
+
+requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
+  'index_partition_evidence_manifest_v1',
+  'index_partition_evidence_packet_v1',
+  'index_partition_admission_v1',
+  'normalized_partition_plan_v1',
+  'run_key',
+  'partition-prepare',
+  'partition-validate',
+  'PostgreSQL system identifier',
+  'SHA-256 digests for the retained raw baseline',
+  'Tenant-predicate coverage is calculated by the validator',
+  'The packet cannot supply a precomputed pass/fail value',
+  'packet_digest',
+  'It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`',
+]);
+
+requireMarkers('crates/rustok-index/docs/README.md', [
+  'M3 partition evidence packet tooling: `complete`',
+  'The repository owner still executes',
+  'and retains the PostgreSQL packet.',
+  '[M3 partition evidence runbook](./partition-evidence-runbook.md)',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M3 partition evidence packet tooling: `complete`',
+  '- [x] Add immutable partition evidence manifest, measured packet validator, and',
+  '- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.',
+  'The sixth M3 slice adds immutable partition evidence preparation and validation.',
+  'cargo test -p rustok-index --test module',
+  'node scripts/verify/verify-index-partition-evidence.mjs',
+]);
+
+console.log('[verify-index-partition-evidence] OK');


### PR DESCRIPTION
## Summary

- continue M3 with immutable PostgreSQL partition-evidence preparation and fail-closed packet validation;
- bind repository, exact commit, unique run key, PostgreSQL image, tenant-hash strategy/modulus, locales, normalized plan-digest contract, exact repetition counts, and explicit thresholds to one canonical SHA-256 `evidence_id`;
- derive the same deterministic shadow parent/child names as `PartitionShadowPlan` and emit shadow-only hash-partition bootstrap SQL;
- publish manifest/bootstrap files with no-clobber atomic hard-link semantics and reject aliased input/output paths;
- validate one measured packet against exact manifest identity, runner repository/commit/run provenance, PostgreSQL 16 system identity, raw-artifact SHA-256 roles, timestamp ordering, and exact measurement-group cardinality;
- calculate tenant-predicate coverage, entity/link cardinality and digest parity, normalized plan changes, p95 query/mutation regression, WAL amplification, partition-size skew, lock duration, catch-up/FK/orphan state, rollback evidence, and production-relation invariance;
- atomically publish `admission.json` only after structural validation, with a digest of the complete canonical packet and either `admitted` or typed `keep_unpartitioned` reasons;
- keep all copy, constraint/index attachment, replay/dual-write, production rename/drop, cutover, rollback execution, and durable global operation ownership outside this slice;
- add fixture contracts, a compile-free guard, lightweight Index workflow coverage, the owner-operated runbook, and roadmap synchronization;
- correct the stale integration test that still required `IndexModule` to expose no migrations; it now checks the three canonical M3 migrations and dependency descriptors.

## Previous slice recheck

- PR #2306 was rechecked with no comments, reviews, review threads, or status checks and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Commerce, Forum, Inventory, and Notifications changes.

## Important behavior

- `run_key` makes every retained attempt distinct even when commit and thresholds are unchanged;
- `normalized_partition_plan_v1` excludes runtime counters and physical relation/index names while retaining logical operator, predicate, ordering, join, grouping, and pruning semantics;
- raw baseline, shadow, query, mutation, maintenance, and cutover artifact hashes are mandatory and exact;
- manifest `evidence_id` identifies the prepared run; admission also records `packet_digest` for the completed measured packet;
- runner repository, commit, and run key must match the manifest;
- PostgreSQL system identifier and database name bind all measurements to one instance;
- timestamps must satisfy baseline <= shadow <= packet completion;
- invalid or incomplete packets leave no admission output;
- an `admitted` packet is necessary but not sufficient permission for production partitioning.

## Validation

Authoritative repository checks were not run, per repository-owner instruction. An earlier isolated temporary JavaScript fixture sanity check was used during drafting before the final provenance hardening; it is not validation of this branch.

Suggested owner checks:

```bash
cargo test -p rustok-index --test module
node --test scripts/verify/index-partition-evidence.test.mjs
node scripts/verify/verify-index-partition-evidence.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

The actual PostgreSQL partition evidence run was not executed.

## Next M3 slice

Execute and retain one real PostgreSQL baseline/shadow packet. Only after it validates to `admitted`, add durable global partition-operation ownership and bounded copy/checkpoint, constraint/index attachment, catch-up/replay, cutover, rollback, and failure-recovery lifecycle.