### PR TITLE
feat(index): add partition evidence assembly

### DIFF
--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -31,9 +31,12 @@ on:
       - "scripts/verify/index-storage-tooling.mjs"
       - "scripts/verify/index-storage-tooling.test.mjs"
       - "scripts/verify/index-partition-evidence-core.mjs"
+      - "scripts/verify/index-partition-evidence-assembly-core.mjs"
       - "scripts/verify/prepare-index-partition-evidence.mjs"
+      - "scripts/verify/assemble-index-partition-evidence.mjs"
       - "scripts/verify/validate-index-partition-evidence.mjs"
       - "scripts/verify/index-partition-evidence.test.mjs"
+      - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
@@ -70,9 +73,12 @@ on:
       - "scripts/verify/index-storage-tooling.mjs"
       - "scripts/verify/index-storage-tooling.test.mjs"
       - "scripts/verify/index-partition-evidence-core.mjs"
+      - "scripts/verify/index-partition-evidence-assembly-core.mjs"
       - "scripts/verify/prepare-index-partition-evidence.mjs"
+      - "scripts/verify/assemble-index-partition-evidence.mjs"
       - "scripts/verify/validate-index-partition-evidence.mjs"
       - "scripts/verify/index-partition-evidence.test.mjs"
+      - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
@@ -132,9 +138,12 @@ jobs:
             node --check scripts/verify/verify-index-storage-adr-integrity.mjs
             node --check scripts/verify/index-storage-decision-tooling.test.mjs
             node --check scripts/verify/index-partition-evidence-core.mjs
+            node --check scripts/verify/index-partition-evidence-assembly-core.mjs
             node --check scripts/verify/prepare-index-partition-evidence.mjs
+            node --check scripts/verify/assemble-index-partition-evidence.mjs
             node --check scripts/verify/validate-index-partition-evidence.mjs
             node --check scripts/verify/index-partition-evidence.test.mjs
+            node --check scripts/verify/index-partition-evidence-assembly.test.mjs
             node --check scripts/verify/verify-index-partition-evidence.mjs
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
@@ -143,6 +152,7 @@ jobs:
             node --test scripts/verify/index-storage-standalone-tools.test.mjs
             node --test scripts/verify/index-storage-decision-tooling.test.mjs
             node --test scripts/verify/index-partition-evidence.test.mjs
+            node --test scripts/verify/index-partition-evidence-assembly.test.mjs
           } 2>&1 | tee evidence/index-storage/contract/verify.log
       - name: Archive contract diagnostic
         if: always()

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,7 +26,7 @@ without runtime fan-out.
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
-- retained partition evidence contracts and validation;
+- retained partition evidence preparation, capture assembly, and validation;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -156,13 +156,16 @@ relations. Copy, constraint/index attachment, replay or dual-write, durable glob
 operation ownership, cutover, rollback, and retained PostgreSQL evidence remain
 open M3 work.
 
-Partition evidence tooling now binds one immutable manifest to a SHA-256
-`evidence_id`, emits deterministic shadow-only bootstrap SQL, validates exact
-query/mutation/maintenance/cutover repetition groups, and calculates tenant
-coverage, digest parity, latency regression, WAL amplification, partition skew,
-lock duration, rollback state, and typed rejection reasons. It cannot accept
-precomputed pass flags or authorize cutover. The repository owner still executes
-and retains the PostgreSQL packet.
+Partition evidence tooling binds one immutable manifest to a SHA-256 `evidence_id`,
+emits deterministic shadow-only bootstrap SQL, and validates exact
+query/mutation/maintenance/cutover repetition groups. The capture/assembly layer
+reads six retained raw JSON artifacts once, confines unique relative paths to one
+bundle, rejects symbolic links and aliases, calculates exact-byte SHA-256 hashes,
+and publishes a structurally validated packet without accepting precomputed packet
+fields or pass flags. Final validation calculates tenant coverage, digest parity,
+latency regression, WAL amplification, partition skew, lock duration, rollback
+state, and typed rejection reasons. The repository owner still executes and
+retains the PostgreSQL packet.
 
 PostgreSQL Testcontainers/concurrency evidence, query execution, and batch
 ingestion remain later M3/M4/M5 slices.
@@ -184,9 +187,11 @@ ingestion remain later M3/M4/M5 slices.
 - M3 secondary-index lifecycle: `complete`
 - M3 partition admission and shadow planning: `complete`
 - M3 partition evidence packet tooling: `complete`
+- M3 partition evidence capture/assembly: `complete`
 - Production persistence: mutation writes, schema/index coordination, partition
-  admission, and evidence validation implemented; query adapter, retained
-  PostgreSQL partition run, and partition cutover lifecycle not yet implemented
+  admission, evidence assembly, and evidence validation implemented; query adapter,
+  retained PostgreSQL partition run, and partition cutover lifecycle not yet
+  implemented
 
 ## Verification
 
@@ -199,6 +204,7 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo xtask module test index`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
+- `node --test scripts/verify/index-partition-evidence-assembly.test.mjs`
 - `node scripts/verify/verify-index-secondary-index-lifecycle.mjs`
 - `node scripts/verify/verify-index-partition-admission.mjs`
 - `node scripts/verify/verify-index-partition-evidence.mjs`

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -66,20 +66,22 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 secondary-index lifecycle: `complete`
 - M3 partition admission and shadow planning: `complete`
 - M3 partition evidence packet tooling: `complete`
+- M3 partition evidence capture/assembly: `complete`
 - Production persistence: mutation writes, schema coordination, secondary-index
-  lifecycle, fail-closed partition admission, and evidence validation implemented;
-  the retained PostgreSQL partition run, query adapter, and partition copy/cutover
-  lifecycle are not yet implemented
+  lifecycle, fail-closed partition admission, evidence assembly, and evidence
+  validation implemented; the retained PostgreSQL partition run, query adapter,
+  and partition copy/cutover lifecycle are not yet implemented
 
 The active production crate contains the generic domain/application core, the M3
 production migrations, an Index-owned transactional mutation adapter, a durable
 schema-application lease store, a schema-derived secondary-index manager, and a
 measured partition-admission contract that emits shadow bootstrap plans only. The
-repository also contains immutable partition-manifest preparation and measured
-packet validation tooling. Query adapters, retained partition evidence,
-partition copy/constraint/index attachment, replay/cutover, batch ingestion, and
-PostgreSQL Testcontainers evidence remain open. Benchmark DDL and generated
-evidence stay under `ops/benches`, outside the production module.
+repository also contains immutable partition-manifest preparation, exact-byte raw
+artifact assembly, and measured packet validation tooling. Query adapters,
+retained partition evidence, partition copy/constraint/index attachment,
+replay/cutover, batch ingestion, and PostgreSQL Testcontainers evidence remain
+open. Benchmark DDL and generated evidence stay under `ops/benches`, outside the
+production module.
 
 ## Ownership
 
@@ -241,6 +243,8 @@ unpartitioned until a separate shadow packet passes admission.
       planning.
 - [x] Add immutable partition evidence manifest, measured packet validator, and
       owner-operated runbook.
+- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
+      no-clobber packet publication.
 - [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
 - [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
       rollback, and durable global operation ownership.
@@ -300,6 +304,15 @@ amplification, child-size skew, lock duration, rollback facts, and typed admissi
 reasons before atomically publishing an outcome. The repository owner still must
 execute and retain the PostgreSQL packet. This slice also removes the stale
 integration-test assumption that `IndexModule` has no production migrations.
+
+The seventh M3 slice adds fail-closed raw-artifact packet assembly. A strict
+`index_partition_capture_v1` descriptor points to exactly six unique relative JSON
+files inside one bundle. The assembler rejects absolute paths, traversal,
+directories, symbolic links, duplicate role paths, output aliases, and overwrite
+attempts. It reads each artifact once, hashes exact bytes, maps only the required
+baseline/shadow/query/mutation/maintenance/cutover shapes, and runs the canonical
+packet validator before no-clobber publication. It still does not execute
+PostgreSQL measurements or authorize production partitioning.
 
 ### M4 - Query engine v1
 
@@ -387,6 +400,7 @@ node scripts/verify/index-storage-tooling.mjs contract
 node scripts/verify/index-storage-tooling.mjs fixtures
 node --test scripts/verify/compare-index-storage-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence.test.mjs
+node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 ```
 
 Targeted M3 maintainer checks:
@@ -419,5 +433,8 @@ node scripts/verify/verify-index-partition-evidence.mjs
   tenant-hash shadow planning without destructive production cutover SQL.
 - 2026-07-27: added immutable partition evidence manifests, calculated packet
   admission, non-clobbering shadow bootstrap publication, owner runbook, lightweight
-  CI guards, and corrected the stale integration migration contract. Repository
-  tests, verifiers, and PostgreSQL evidence remain for the owner to execute.
+  CI guards, and corrected the stale integration migration contract.
+- 2026-07-27: added exact-byte raw-artifact capture assembly, bundle confinement,
+  no-symlink/no-alias/no-overwrite publication, fixture coverage, and tooling
+  routing. Repository tests, verifiers, and PostgreSQL evidence remain for the
+  owner to execute.

--- a/crates/rustok-index/docs/partition-evidence-runbook.md
+++ b/crates/rustok-index/docs/partition-evidence-runbook.md
@@ -7,20 +7,22 @@ relations remain unpartitioned unless one retained packet validates to `admitted
 
 ## Tooling boundary
 
-The tooling is intentionally split into two phases:
+The tooling is intentionally split into three phases:
 
 1. `partition-prepare` binds an immutable run manifest to one SHA-256
    `evidence_id` and emits deterministic shadow-only bootstrap SQL.
-2. `partition-validate` validates a completed measured packet, calculates all
-   admission metrics, and atomically publishes `admission.json`.
+2. The owner executes PostgreSQL measurements and retains six raw JSON artifacts.
+   `partition-assemble` reads those exact files, calculates their exact-byte
+   SHA-256 identities, and publishes one structurally validated packet.
+3. `partition-validate` recalculates admission metrics and atomically publishes
+   `admission.json`.
 
-The preparer refuses to overwrite either manifest or bootstrap output. The
-validator removes stale admission output before validation and writes a new file
-only after the complete packet is accepted structurally.
+The preparer and assembler refuse to overwrite retained outputs. The validator
+removes stale admission output before validation and writes a new file only after
+the complete packet is accepted structurally.
 
-Neither command copies rows, installs production constraints or indexes, starts
-replay or dual-write, renames production relations, drops production relations,
-or performs cutover.
+None of these commands installs production constraints or indexes, starts replay
+or dual-write, renames or drops production relations, or performs cutover.
 
 ## Prepare an immutable run
 
@@ -56,8 +58,8 @@ Create a configuration file such as `evidence/index-partition/config.json`:
 }
 ```
 
-Use an immutable reviewed commit. `run_key` must identify one run attempt and must
-not be reused for a rerun. Modulus must be a power of two from 2 through 128.
+Use an immutable reviewed commit. `run_key` identifies exactly one run attempt and
+must not be reused for a rerun. Modulus must be a power of two from 2 through 128.
 PostgreSQL image is pinned to `postgres:16`. Repetition counts are exact and must
 all be positive.
 
@@ -86,23 +88,92 @@ Review `bootstrap.sql` before execution. It may contain only:
 It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`, copy,
 replay, dual-write, or cutover statements.
 
-## Required measured packet
+## Capture retained raw artifacts
 
-The owner-run harness produces one `partition-packet.json` with contract
-`index_partition_evidence_packet_v1`. The packet embeds the prepared manifest and
-records PostgreSQL 16 metadata with JIT disabled.
+The owner-operated PostgreSQL harness writes six raw JSON artifacts in one bundle
+directory. They are regular files, never symbolic links:
 
-The packet also records:
+- `baseline.json` — unpartitioned relation evidence and tenant-predicate audit;
+- `shadow.json` — shadow relation evidence, child sizes, catch-up, FK, and orphan
+  state;
+- `query.json` — an array of baseline/shadow query p95 and normalized plan digests;
+- `mutation.json` — an array of mutation p95 and WAL measurements;
+- `maintenance.json` — an array of ordinary VACUUM/dead-tuple measurements;
+- `cutover.json` — an array of lock rehearsals and rollback/invariance facts.
+
+The artifact producer must write final files once. Do not edit measurements after
+the run. A formatting-only byte change intentionally creates a different raw
+artifact digest even when parsed JSON values are equal.
+
+Create `capture.json` beside those six artifacts:
+
+```json
+{
+  "contract": "index_partition_capture_v1",
+  "completed_at": "2026-07-27T14:00:00Z",
+  "run_provenance": {
+    "repository": "RusTokRs/RusTok",
+    "commit": "<same full commit SHA as manifest>",
+    "run_key": "<same run key as manifest>",
+    "job": "index-partition-evidence",
+    "runner_os": "Linux",
+    "runner_arch": "X64"
+  },
+  "database": {
+    "version": "PostgreSQL 16.x",
+    "server_version_num": "160000",
+    "jit": "off",
+    "system_identifier": "<pg_control_system system_identifier>",
+    "database_name": "rustok_index_partition_evidence"
+  },
+  "artifacts": {
+    "baseline": "baseline.json",
+    "shadow": "shadow.json",
+    "query": "query.json",
+    "mutation": "mutation.json",
+    "maintenance": "maintenance.json",
+    "cutover": "cutover.json"
+  }
+}
+```
+
+Artifact paths are relative to `capture.json` and must remain inside the canonical
+bundle. Paths and underlying file identities must be unique: absolute paths, `..`
+traversal, duplicate roles, directories, symbolic links, and hard-link aliases fail
+closed. The manifest, capture descriptor, raw artifacts, and output packet must not
+alias each other.
+
+## Assemble the measured packet
+
+Run:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-assemble \
+  --manifest evidence/index-partition/manifest.json \
+  --capture evidence/index-partition/capture.json \
+  --output evidence/index-partition/partition-packet.json
+```
+
+The assembler reads every raw artifact exactly once, hashes its exact bytes, parses
+the required object or array shape, constructs contract
+`index_partition_evidence_packet_v1`, and runs the canonical structural validator.
+It refuses to overwrite an existing packet and does not accept precomputed raw
+hashes, packet fields, admission reasons, or pass/fail flags from `capture.json`.
+
+The packet records:
 
 - runner repository, commit, run key, job, operating system, and architecture;
 - PostgreSQL system identifier and database name, so all sections remain bound to
   one database instance;
 - SHA-256 digests for the retained raw baseline, shadow, query, mutation,
-  maintenance, and cutover artifacts.
+  maintenance, and cutover artifacts;
+- parsed baseline, shadow, query, mutation, maintenance, and cutover evidence.
 
 The repository, commit, and run key in runner provenance must exactly match the
 manifest. Raw-artifact roles are exact; missing or additional roles fail
 validation.
+
+## Required measured evidence
 
 ### Baseline
 
@@ -133,15 +204,15 @@ satisfy baseline generation before shadow generation before packet completion.
 
 ### Query measurements
 
-Each query run records a unique name, baseline and shadow p95 latency, and
-SHA-256 plan digests. Both digests must follow
-`normalized_partition_plan_v1` and be produced by the same reviewed logical plan
-normalization: runtime timing/buffer/WAL counters and physical relation, alias, and
-index names are excluded, while operator, join, predicate, ordering, grouping, and
-partition-pruning semantics are retained. Raw baseline and shadow
+Each query run records a unique name, baseline and shadow p95 latency, and SHA-256
+plan digests. Both digests follow `normalized_partition_plan_v1` and must be
+produced by the same reviewed logical plan normalization. Runtime timing,
+buffer/WAL counters, and physical relation, alias, and index names are excluded;
+operator, join, predicate, ordering, grouping, and partition-pruning semantics are
+retained. Raw baseline and shadow
 `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` artifacts remain mandatory retained
-inputs for reviewer verification. The validator calculates the maximum
-non-negative latency regression and counts normalized plan-digest changes.
+inputs for reviewer verification. The validator calculates maximum non-negative
+latency regression and counts normalized plan-digest changes.
 
 ### Mutation and WAL measurements
 
@@ -157,10 +228,10 @@ depend on exclusive rewrites.
 
 ### Cutover rehearsals
 
-Each rehearsal records measured lock duration plus two independent facts:
-rollback was verified and production relations remained unchanged. This evidence
-is a rehearsal boundary only; the current implementation still contains no
-production cutover operation.
+Each rehearsal records measured lock duration plus two independent facts: rollback
+was verified and production relations remained unchanged. This evidence is a
+rehearsal boundary only; the implementation still contains no production cutover
+operation.
 
 ## Validate and publish admission
 
@@ -193,18 +264,18 @@ Retain together:
 - `config.json`;
 - `manifest.json`;
 - `bootstrap.sql`;
-- raw query, mutation, maintenance, and cutover artifacts used to assemble the
-  packet;
+- `capture.json`;
+- all six raw JSON artifacts and deeper PostgreSQL logs/EXPLAIN inputs from which
+  they were derived;
 - `partition-packet.json`;
 - `admission.json`;
 - PostgreSQL logs and runner metadata.
 
-Recalculate every raw-artifact SHA-256 before assembling the packet. Do not combine
-files from different commits, PostgreSQL instances, manifests, run keys, or run
-attempts. A validated packet is necessary but not sufficient for production
-partitioning. Reviewers must still approve durable global operation ownership,
-copy/checkpoint semantics, constraint and index attachment, catch-up or replay,
-cutover, rollback, and failure recovery in later changes.
+Do not combine files from different commits, PostgreSQL instances, manifests, run
+keys, or run attempts. A validated packet is necessary but not sufficient for
+production partitioning. Reviewers must still approve durable global operation
+ownership, copy/checkpoint semantics, constraint and index attachment, catch-up or
+replay, cutover, rollback, and failure recovery in later changes.
 
 ## Suggested repository checks
 
@@ -212,6 +283,7 @@ The repository owner runs:
 
 ```bash
 node --test scripts/verify/index-partition-evidence.test.mjs
+node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
 node scripts/verify/index-storage-tooling.mjs contract
 cargo test -p rustok-index --test module

--- a/scripts/verify/assemble-index-partition-evidence.mjs
+++ b/scripts/verify/assemble-index-partition-evidence.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import { assemblePartitionPacket } from './index-partition-evidence-assembly-core.mjs';
+
+const prefix = '[assemble-index-partition-evidence]';
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+
+const parseArgs = (args) => {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--manifest', '--capture', '--output'].includes(flag)
+        || !value || value.startsWith('--')) {
+      throw new Error('usage: --manifest <manifest.json> --capture <capture.json> --output <packet.json>');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  for (const flag of ['--manifest', '--capture', '--output']) {
+    if (!values.has(flag)) throw new Error(`${flag} is required`);
+  }
+  const options = {
+    manifest: path.resolve(values.get('--manifest')),
+    capture: path.resolve(values.get('--capture')),
+    output: path.resolve(values.get('--output')),
+  };
+  if (new Set(Object.values(options)).size !== 3) {
+    throw new Error('--manifest, --capture, and --output must reference distinct paths');
+  }
+  return options;
+};
+
+const readRegularJson = (filename, label) => {
+  const stat = lstatSync(filename);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`${label} must be a regular non-symlink file`);
+  }
+  try {
+    return {
+      value: JSON.parse(readFileSync(filename, 'utf8')),
+      identity: identityOf(stat),
+    };
+  } catch (error) {
+    throw new Error(`${label} must contain valid UTF-8 JSON: ${error.message}`);
+  }
+};
+
+const writeAtomicNew = (filename, content) => {
+  if (existsSync(filename)) throw new Error(`refusing to overwrite existing file: ${filename}`);
+  mkdirSync(path.dirname(filename), { recursive: true });
+  const temporary = `${filename}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporary, content, { encoding: 'utf8', flag: 'wx' });
+    linkSync(temporary, filename);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const manifestFile = readRegularJson(options.manifest, 'manifest');
+  const captureFile = readRegularJson(options.capture, 'capture');
+  if (manifestFile.identity === captureFile.identity) {
+    throw new Error('--manifest and --capture must not alias the same file');
+  }
+  const { packet, resolvedPaths, identities } = assemblePartitionPacket({
+    manifest: manifestFile.value,
+    capturePath: options.capture,
+    capture: captureFile.value,
+  });
+  if ([...resolvedPaths.values()].includes(options.output)) {
+    throw new Error('--output must not alias a raw artifact path');
+  }
+  const retainedInputIdentities = new Set([
+    manifestFile.identity,
+    captureFile.identity,
+    ...identities.values(),
+  ]);
+  if (retainedInputIdentities.size !== identities.size + 2) {
+    throw new Error('manifest, capture, and raw artifacts must be distinct files');
+  }
+  writeAtomicNew(options.output, `${JSON.stringify(packet, null, 2)}\n`);
+  console.log(`${prefix} assembled ${packet.manifest.evidence_id}`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/index-partition-evidence-assembly-core.mjs
+++ b/scripts/verify/index-partition-evidence-assembly-core.mjs
@@ -1,0 +1,165 @@
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  PACKET_CONTRACT,
+  sha256Hex,
+  validatePartitionPacket,
+  validatePreparedManifest,
+} from './index-partition-evidence-core.mjs';
+
+export const CAPTURE_CONTRACT = 'index_partition_capture_v1';
+export const RAW_ARTIFACT_ROLES = Object.freeze([
+  'baseline',
+  'shadow',
+  'query',
+  'mutation',
+  'maintenance',
+  'cutover',
+]);
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const requireObject = (value, label) => {
+  if (!isObject(value)) throw new Error(`${label} must be an object`);
+  return value;
+};
+
+const requireArray = (value, label) => {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+};
+
+const requireNonEmptyString = (value, label) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+const requireExactKeys = (value, expected, label) => {
+  const actual = Object.keys(requireObject(value, label)).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    throw new Error(`${label} must contain exactly: ${wanted.join(', ')}`);
+  }
+};
+
+const parseJsonBytes = (bytes, label) => {
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${label} must contain valid UTF-8 JSON: ${error.message}`);
+  }
+};
+
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+
+const resolveArtifactPath = (bundleRoot, canonicalBundleRoot, relative, label) => {
+  requireNonEmptyString(relative, label);
+  if (path.isAbsolute(relative)) throw new Error(`${label} must be relative to the capture file`);
+  const normalized = path.normalize(relative);
+  if (normalized === '.' || normalized === '..' || normalized.startsWith(`..${path.sep}`)) {
+    throw new Error(`${label} must stay inside the capture bundle`);
+  }
+  const resolved = path.resolve(bundleRoot, normalized);
+  const relativeToRoot = path.relative(bundleRoot, resolved);
+  if (relativeToRoot === '..' || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToRoot)) {
+    throw new Error(`${label} must stay inside the capture bundle`);
+  }
+  const canonical = realpathSync.native(resolved);
+  const canonicalRelative = path.relative(canonicalBundleRoot, canonical);
+  if (canonicalRelative === '..'
+      || canonicalRelative.startsWith(`..${path.sep}`)
+      || path.isAbsolute(canonicalRelative)) {
+    throw new Error(`${label} must stay inside the canonical capture bundle`);
+  }
+  return { resolved, canonical };
+};
+
+export const validateCaptureDescriptor = (capture) => {
+  requireExactKeys(
+    capture,
+    ['contract', 'completed_at', 'run_provenance', 'database', 'artifacts'],
+    'capture',
+  );
+  if (capture.contract !== CAPTURE_CONTRACT) {
+    throw new Error(`capture.contract must be ${CAPTURE_CONTRACT}`);
+  }
+  requireNonEmptyString(capture.completed_at, 'capture.completed_at');
+  requireObject(capture.run_provenance, 'capture.run_provenance');
+  requireObject(capture.database, 'capture.database');
+  requireExactKeys(capture.artifacts, RAW_ARTIFACT_ROLES, 'capture.artifacts');
+  for (const role of RAW_ARTIFACT_ROLES) {
+    requireNonEmptyString(capture.artifacts[role], `capture.artifacts.${role}`);
+  }
+  return capture;
+};
+
+export const readCaptureArtifacts = ({ capturePath, capture }) => {
+  validateCaptureDescriptor(capture);
+  const bundleRoot = path.dirname(path.resolve(capturePath));
+  const canonicalBundleRoot = realpathSync.native(bundleRoot);
+  const resolvedPaths = new Map();
+  const identities = new Map();
+  const seenIdentities = new Set();
+  const rawArtifacts = {};
+  const parsed = {};
+
+  for (const role of RAW_ARTIFACT_ROLES) {
+    const { resolved, canonical } = resolveArtifactPath(
+      bundleRoot,
+      canonicalBundleRoot,
+      capture.artifacts[role],
+      `capture.artifacts.${role}`,
+    );
+    const stat = lstatSync(resolved);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`capture artifact ${role} must be a regular non-symlink file`);
+    }
+    const identity = identityOf(stat);
+    if (seenIdentities.has(identity)) {
+      throw new Error(`capture artifact files must be unique; ${role} aliases another role`);
+    }
+    seenIdentities.add(identity);
+    const bytes = readFileSync(resolved);
+    if (bytes.length === 0) throw new Error(`capture artifact ${role} must not be empty`);
+    resolvedPaths.set(role, canonical);
+    identities.set(role, identity);
+    rawArtifacts[role] = sha256Hex(bytes);
+    parsed[role] = parseJsonBytes(bytes, `capture artifact ${role}`);
+  }
+
+  requireObject(parsed.baseline, 'baseline artifact');
+  requireObject(parsed.shadow, 'shadow artifact');
+  requireArray(parsed.query, 'query artifact');
+  requireArray(parsed.mutation, 'mutation artifact');
+  requireArray(parsed.maintenance, 'maintenance artifact');
+  requireArray(parsed.cutover, 'cutover artifact');
+
+  return { rawArtifacts, parsed, resolvedPaths, identities };
+};
+
+export const assemblePartitionPacket = ({ manifest, capturePath, capture }) => {
+  validatePreparedManifest(manifest);
+  const { rawArtifacts, parsed, resolvedPaths, identities } = readCaptureArtifacts({
+    capturePath,
+    capture,
+  });
+  const packet = {
+    contract: PACKET_CONTRACT,
+    completed_at: capture.completed_at,
+    manifest: structuredClone(manifest),
+    run_provenance: structuredClone(capture.run_provenance),
+    raw_artifacts: rawArtifacts,
+    database: structuredClone(capture.database),
+    baseline: parsed.baseline,
+    shadow: parsed.shadow,
+    query_runs: parsed.query,
+    mutation_runs: parsed.mutation,
+    maintenance_runs: parsed.maintenance,
+    cutover_rehearsals: parsed.cutover,
+  };
+  validatePartitionPacket(packet);
+  return { packet, resolvedPaths, identities };
+};

--- a/scripts/verify/index-partition-evidence-assembly.test.mjs
+++ b/scripts/verify/index-partition-evidence-assembly.test.mjs
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  CAPTURE_CONTRACT,
+  assemblePartitionPacket,
+  readCaptureArtifacts,
+} from './index-partition-evidence-assembly-core.mjs';
+import {
+  PLAN_DIGEST_CONTRACT,
+  prepareManifest,
+  sha256Hex,
+} from './index-partition-evidence-core.mjs';
+
+const digest = (character) => character.repeat(64);
+
+const manifestInput = () => ({
+  contract: 'index_partition_evidence_manifest_v1',
+  repository: 'RusTokRs/RusTok',
+  commit: '1'.repeat(40),
+  run_key: 'fixture-run-1',
+  postgres_image: 'postgres:16',
+  strategy: 'tenant_hash',
+  plan_digest_contract: PLAN_DIGEST_CONTRACT,
+  modulus: 4,
+  locales: ['en-US', 'ru-RU'],
+  repetitions: { query: 2, mutation: 2, maintenance: 2, cutover: 1 },
+  thresholds: {
+    minimum_total_rows: 100,
+    minimum_total_bytes: 1_000,
+    minimum_distinct_tenants: 4,
+    maximum_query_p95_regression_bps: 500,
+    maximum_mutation_p95_regression_bps: 500,
+    maximum_wal_amplification_bps: 11_000,
+    maximum_partition_size_to_mean_bps: 13_000,
+    maximum_cutover_lock_ms: 250,
+  },
+});
+
+const rawValues = () => ({
+  baseline: {
+    generated_at: '2026-07-27T13:00:00Z',
+    distinct_tenants: 8,
+    tenant_predicate_audit: { total_templates: 12, tenant_scoped_templates: 12 },
+    entities: { rows: 1_000, bytes: 80_000, digest: digest('a') },
+    links: { rows: 2_000, bytes: 120_000, digest: digest('b') },
+  },
+  shadow: {
+    generated_at: '2026-07-27T13:30:00Z',
+    caught_up: true,
+    foreign_keys_validated: true,
+    orphan_links: 0,
+    entities: {
+      rows: 1_000,
+      bytes: 82_000,
+      digest: digest('a'),
+      partition_bytes: [20_000, 20_500, 20_500, 21_000],
+    },
+    links: {
+      rows: 2_000,
+      bytes: 123_000,
+      digest: digest('b'),
+      partition_bytes: [30_000, 30_500, 31_000, 31_500],
+    },
+  },
+  query: [
+    {
+      name: 'filter-sort-1',
+      baseline_p95_ms: 10,
+      shadow_p95_ms: 10.2,
+      baseline_plan_digest: digest('c'),
+      shadow_plan_digest: digest('c'),
+    },
+    {
+      name: 'keyset-1',
+      baseline_p95_ms: 5,
+      shadow_p95_ms: 5.1,
+      baseline_plan_digest: digest('d'),
+      shadow_plan_digest: digest('d'),
+    },
+  ],
+  mutation: [
+    {
+      name: 'upsert-1',
+      baseline_p95_ms: 20,
+      shadow_p95_ms: 20.4,
+      baseline_wal_bytes: 1_000,
+      shadow_wal_bytes: 1_040,
+    },
+    {
+      name: 'delete-1',
+      baseline_p95_ms: 10,
+      shadow_p95_ms: 10.2,
+      baseline_wal_bytes: 500,
+      shadow_wal_bytes: 520,
+    },
+  ],
+  maintenance: [
+    {
+      name: 'vacuum-1',
+      baseline_vacuum_ms: 100,
+      shadow_vacuum_ms: 104,
+      baseline_dead_tuples: 20,
+      shadow_dead_tuples: 18,
+    },
+    {
+      name: 'vacuum-2',
+      baseline_vacuum_ms: 101,
+      shadow_vacuum_ms: 105,
+      baseline_dead_tuples: 21,
+      shadow_dead_tuples: 19,
+    },
+  ],
+  cutover: [
+    { lock_ms: 50, rollback_verified: true, production_relations_unchanged: true },
+  ],
+});
+
+const createBundle = () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-index-partition-assembly-'));
+  const manifest = prepareManifest(manifestInput());
+  const manifestPath = path.join(root, 'manifest.json');
+  const capturePath = path.join(root, 'capture.json');
+  const raw = rawValues();
+  const artifacts = {};
+  for (const [role, value] of Object.entries(raw)) {
+    const filename = `raw-${role}.json`;
+    writeFileSync(path.join(root, filename), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    artifacts[role] = filename;
+  }
+  const capture = {
+    contract: CAPTURE_CONTRACT,
+    completed_at: '2026-07-27T14:00:00Z',
+    run_provenance: {
+      repository: manifest.repository,
+      commit: manifest.commit,
+      run_key: manifest.run_key,
+      job: 'partition-evidence-fixture',
+      runner_os: 'Linux',
+      runner_arch: 'X64',
+    },
+    database: {
+      version: 'PostgreSQL 16.4',
+      server_version_num: '160004',
+      jit: 'off',
+      system_identifier: '1234567890123456789',
+      database_name: 'rustok_index_partition_evidence_fixture',
+    },
+    artifacts,
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  writeFileSync(capturePath, `${JSON.stringify(capture, null, 2)}\n`, 'utf8');
+  return { root, manifest, manifestPath, capture, capturePath };
+};
+
+const withBundle = (callback) => {
+  const bundle = createBundle();
+  try {
+    callback(bundle);
+  } finally {
+    rmSync(bundle.root, { recursive: true, force: true });
+  }
+};
+
+test('assembly hashes exact raw bytes and emits a structurally validated packet', () => {
+  withBundle(({ manifest, capture, capturePath, root }) => {
+    const { packet } = assemblePartitionPacket({ manifest, capturePath, capture });
+    assert.equal(packet.manifest.evidence_id, manifest.evidence_id);
+    assert.equal(packet.baseline.entities.rows, 1_000);
+    assert.equal(packet.query_runs.length, 2);
+    for (const [role, filename] of Object.entries(capture.artifacts)) {
+      assert.equal(packet.raw_artifacts[role], sha256Hex(readFileSync(path.join(root, filename))));
+    }
+
+    const queryPath = path.join(root, capture.artifacts.query);
+    const before = packet.raw_artifacts.query;
+    writeFileSync(queryPath, `${readFileSync(queryPath, 'utf8')}\n`, 'utf8');
+    const { packet: after } = assemblePartitionPacket({ manifest, capturePath, capture });
+    assert.notEqual(after.raw_artifacts.query, before, 'whitespace changes exact-byte identity');
+    assert.deepEqual(after.query_runs, packet.query_runs, 'parsed measurements remain unchanged');
+  });
+});
+
+test('capture artifact paths fail closed on traversal and duplicate file identity', () => {
+  withBundle(({ root, capture, capturePath }) => {
+    const traversal = structuredClone(capture);
+    traversal.artifacts.baseline = '../outside.json';
+    assert.throws(
+      () => readCaptureArtifacts({ capturePath, capture: traversal }),
+      /must stay inside the capture bundle/u,
+    );
+
+    const duplicate = structuredClone(capture);
+    duplicate.artifacts.shadow = duplicate.artifacts.baseline;
+    assert.throws(
+      () => readCaptureArtifacts({ capturePath, capture: duplicate }),
+      /artifact files must be unique/u,
+    );
+
+    const hardlinkName = 'raw-shadow-hardlink.json';
+    linkSync(
+      path.join(root, capture.artifacts.baseline),
+      path.join(root, hardlinkName),
+    );
+    const hardlink = structuredClone(capture);
+    hardlink.artifacts.shadow = hardlinkName;
+    assert.throws(
+      () => readCaptureArtifacts({ capturePath, capture: hardlink }),
+      /artifact files must be unique/u,
+    );
+  });
+});
+
+test('assembler CLI publishes once and never aliases or overwrites retained inputs', () => {
+  withBundle(({ root, manifestPath, capturePath, capture }) => {
+    const script = path.resolve('scripts/verify/assemble-index-partition-evidence.mjs');
+    const output = path.join(root, 'partition-packet.json');
+    const run = (...args) => spawnSync(process.execPath, [script, ...args], { encoding: 'utf8' });
+
+    const first = run('--manifest', manifestPath, '--capture', capturePath, '--output', output);
+    assert.equal(first.status, 0, first.stderr);
+    assert.match(first.stdout, /assembled [0-9a-f]{64}/u);
+
+    const second = run('--manifest', manifestPath, '--capture', capturePath, '--output', output);
+    assert.notEqual(second.status, 0);
+    assert.match(second.stderr, /refusing to overwrite existing file/u);
+
+    const aliased = run(
+      '--manifest', manifestPath,
+      '--capture', capturePath,
+      '--output', path.join(root, capture.artifacts.baseline),
+    );
+    assert.notEqual(aliased.status, 0);
+    assert.match(aliased.stderr, /must not alias a raw artifact path/u);
+
+    const captureAlias = path.join(root, 'capture-hardlink.json');
+    linkSync(manifestPath, captureAlias);
+    const retainedAlias = run(
+      '--manifest', manifestPath,
+      '--capture', captureAlias,
+      '--output', path.join(root, 'alias-packet.json'),
+    );
+    assert.notEqual(retainedAlias.status, 0);
+    assert.match(retainedAlias.stderr, /must not alias the same file/u);
+  });
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -19,6 +19,7 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs packet --scale <smoke|100k|1m> [--root <directory>]
   node scripts/verify/index-storage-tooling.mjs compare --input <directory> [--input <directory>] [--output <directory>]
   node scripts/verify/index-storage-tooling.mjs partition-prepare --input <config.json> --manifest <manifest.json> --bootstrap <bootstrap.sql>
+  node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
@@ -26,16 +27,17 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs verify-adr --comparison <comparison.json> --decision <decision.json> --adr <adr.md>
 
 Commands:
-  contract           Run static Index boundary, evidence, partition, standalone-tool, and ADR guards.
-  fixtures           Run standalone, evidence, comparator, decision, partition, and ADR fixture suites.
-  packet             Validate one smoke, 100k, or 1m storage evidence packet.
-  compare            Generate a cross-scale storage comparison.
-  partition-prepare  Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
-  partition-validate Validate a measured partition packet and publish calculated admission output.
-  hash               Print the SHA-256 digest of the exact comparison.json bytes.
-  prepare            Create a non-overwriting manual decision draft bound to exact comparison bytes.
-  render             Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
-  verify-adr         Verify a saved ADR against exact comparison and decision bytes.`);
+  contract            Run static Index boundary, evidence, partition, standalone-tool, and ADR guards.
+  fixtures            Run standalone, evidence, comparator, decision, partition, and ADR fixture suites.
+  packet              Validate one smoke, 100k, or 1m storage evidence packet.
+  compare             Generate a cross-scale storage comparison.
+  partition-prepare   Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
+  partition-assemble  Build one packet from six retained raw JSON artifacts and exact-byte hashes.
+  partition-validate  Validate a measured partition packet and publish calculated admission output.
+  hash                Print the SHA-256 digest of the exact comparison.json bytes.
+  prepare             Create a non-overwriting manual decision draft bound to exact comparison bytes.
+  render              Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
+  verify-adr          Verify a saved ADR against exact comparison and decision bytes.`);
 };
 
 const runNode = (args, label, environment = process.env) => {
@@ -101,6 +103,7 @@ const runFixtures = (args) => {
     scriptPath('prepare-index-storage-decision-lifecycle.test.mjs'),
     scriptPath('storage-decision-schema-text.test.mjs'),
     scriptPath('index-partition-evidence.test.mjs'),
+    scriptPath('index-partition-evidence-assembly.test.mjs'),
   ], 'Index storage fixture suites');
 };
 
@@ -189,6 +192,9 @@ switch (command) {
     break;
   case 'partition-prepare':
     runScript('prepare-index-partition-evidence.mjs', args);
+    break;
+  case 'partition-assemble':
+    runScript('assemble-index-partition-evidence.mjs', args);
     break;
   case 'partition-validate':
     runScript('validate-index-partition-evidence.mjs', args);

--- a/scripts/verify/verify-index-partition-evidence.mjs
+++ b/scripts/verify/verify-index-partition-evidence.mjs
@@ -82,6 +82,40 @@ if (prepare.includes("writeFileSync(options.manifest")) {
   fail('manifest preparer must publish through the atomic new-file helper');
 }
 
+const assemblyCore = requireMarkers('scripts/verify/index-partition-evidence-assembly-core.mjs', [
+  "CAPTURE_CONTRACT = 'index_partition_capture_v1'",
+  'RAW_ARTIFACT_ROLES = Object.freeze',
+  "['contract', 'completed_at', 'run_provenance', 'database', 'artifacts']",
+  "requireExactKeys(capture.artifacts, RAW_ARTIFACT_ROLES, 'capture.artifacts')",
+  'realpathSync.native(bundleRoot)',
+  'must stay inside the canonical capture bundle',
+  'must be a regular non-symlink file',
+  'const identityOf = (stat) => `${stat.dev}:${stat.ino}`',
+  'capture artifact files must be unique',
+  'rawArtifacts[role] = sha256Hex(bytes)',
+  'export const readCaptureArtifacts',
+  'export const assemblePartitionPacket',
+  'const { rawArtifacts, parsed, resolvedPaths, identities } = readCaptureArtifacts',
+  'validatePartitionPacket(packet)',
+  'return { packet, resolvedPaths, identities }',
+]);
+for (const forbidden of ['readlinkSync(', 'followSymlink', 'artifactBundle =']) {
+  if (assemblyCore.includes(forbidden)) {
+    fail(`partition assembly core contains forbidden bypass behavior: ${forbidden}`);
+  }
+}
+
+requireMarkers('scripts/verify/assemble-index-partition-evidence.mjs', [
+  '--manifest, --capture, and --output must reference distinct paths',
+  '--manifest and --capture must not alias the same file',
+  '--output must not alias a raw artifact path',
+  'manifest, capture, and raw artifacts must be distinct files',
+  'refusing to overwrite existing file',
+  'writeFileSync(temporary, content',
+  'linkSync(temporary, filename)',
+  'const { packet, resolvedPaths, identities } = assemblePartitionPacket({',
+]);
+
 requireMarkers('scripts/verify/validate-index-partition-evidence.mjs', [
   '--input and --output must reference distinct paths',
   'rmSync(options.output, { force: true })',
@@ -111,13 +145,38 @@ requireMarkers('scripts/verify/index-partition-evidence.test.mjs', [
   'assert.doesNotMatch(sql, /RENAME TO/u)',
 ]);
 
+requireMarkers('scripts/verify/index-partition-evidence-assembly.test.mjs', [
+  'assembly hashes exact raw bytes and emits a structurally validated packet',
+  'capture artifact paths fail closed on traversal and duplicate file identity',
+  'assembler CLI publishes once and never aliases or overwrites retained inputs',
+  'whitespace changes exact-byte identity',
+  'must stay inside the capture bundle',
+  'artifact files must be unique',
+  'raw-shadow-hardlink.json',
+  'refusing to overwrite existing file',
+  'must not alias a raw artifact path',
+  'must not alias the same file',
+]);
+
 requireMarkers('scripts/verify/index-storage-tooling.mjs', [
   'partition-prepare',
+  'partition-assemble',
   'partition-validate',
   "'verify-index-partition-evidence.mjs'",
   "scriptPath('index-partition-evidence.test.mjs')",
+  "scriptPath('index-partition-evidence-assembly.test.mjs')",
   "runScript('prepare-index-partition-evidence.mjs', args)",
+  "runScript('assemble-index-partition-evidence.mjs', args)",
   "runScript('validate-index-partition-evidence.mjs', args)",
+]);
+
+requireMarkers('.github/workflows/index-storage-smoke.yml', [
+  'scripts/verify/index-partition-evidence-assembly-core.mjs',
+  'scripts/verify/assemble-index-partition-evidence.mjs',
+  'scripts/verify/index-partition-evidence-assembly.test.mjs',
+  'node --check scripts/verify/index-partition-evidence-assembly-core.mjs',
+  'node --check scripts/verify/assemble-index-partition-evidence.mjs',
+  'node --test scripts/verify/index-partition-evidence-assembly.test.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/tests/module.rs', [
@@ -131,12 +190,17 @@ requireMarkers('crates/rustok-index/tests/module.rs', [
 
 requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
   'index_partition_evidence_manifest_v1',
+  'index_partition_capture_v1',
   'index_partition_evidence_packet_v1',
   'index_partition_admission_v1',
   'normalized_partition_plan_v1',
   'run_key',
   'partition-prepare',
+  'partition-assemble',
   'partition-validate',
+  'six raw JSON artifacts',
+  'regular files, never symbolic links',
+  'hard-link aliases',
   'PostgreSQL system identifier',
   'SHA-256 digests for the retained raw baseline',
   'Tenant-predicate coverage is calculated by the validator',
@@ -147,17 +211,20 @@ requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
 
 requireMarkers('crates/rustok-index/docs/README.md', [
   'M3 partition evidence packet tooling: `complete`',
-  'The repository owner still executes',
-  'and retains the PostgreSQL packet.',
+  'M3 partition evidence capture/assembly: `complete`',
+  'The repository owner still executes and',
+  'retains the PostgreSQL packet.',
   '[M3 partition evidence runbook](./partition-evidence-runbook.md)',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M3 partition evidence packet tooling: `complete`',
+  '- M3 partition evidence capture/assembly: `complete`',
   '- [x] Add immutable partition evidence manifest, measured packet validator, and',
+  '- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and',
   '- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.',
-  'The sixth M3 slice adds immutable partition evidence preparation and validation.',
-  'cargo test -p rustok-index --test module',
+  'The seventh M3 slice adds fail-closed raw-artifact packet assembly.',
+  'node --test scripts/verify/index-partition-evidence-assembly.test.mjs',
   'node scripts/verify/verify-index-partition-evidence.mjs',
 ]);
 


### PR DESCRIPTION
## Summary

- continue M3 with an owner-operated raw capture and packet assembly boundary for PostgreSQL partition evidence;
- add strict `index_partition_capture_v1` descriptors containing only completion time, run/database provenance, and six raw-artifact paths;
- require exactly `baseline`, `shadow`, `query`, `mutation`, `maintenance`, and `cutover` JSON artifacts;
- confine relative artifact paths to the canonical capture bundle and reject absolute paths, traversal, directories, final symlinks, symlink-directory escapes, duplicate roles, and hard-link aliases;
- keep exact-byte hashing inside the assembly core so callers cannot inject precomputed hashes or a preassembled artifact bundle;
- read each raw artifact once, calculate its SHA-256 identity, parse only the required object/array shape, and construct `index_partition_evidence_packet_v1`;
- run the canonical structural packet validator before publication;
- reject aliases among manifest, capture descriptor, raw artifacts, and output packet;
- publish the packet with no-clobber atomic hard-link semantics;
- route `partition-assemble` through the canonical Index storage tooling and add lightweight workflow syntax/fixture coverage;
- synchronize the owner runbook and local M3 roadmap while keeping the real PostgreSQL run open;
- keep production copy, constraint/index attachment, replay/dual-write, rename/drop, cutover, rollback execution, and durable global operation ownership outside this slice.

## Previous slice recheck

- PR #2312 was rechecked with no comments, reviews, review threads, or status checks and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Commerce, Forum, and Inventory changes.

## Important behavior

- `capture.json` cannot supply packet fields, admission reasons, pass/fail flags, or raw-artifact hashes;
- exact bytes are authoritative: a formatting-only change produces a different artifact digest even when parsed JSON values are equal;
- canonical-path confinement prevents a symlinked parent directory from escaping the retained bundle;
- device/inode identity prevents two roles or retained inputs from using the same file through hard links;
- invalid or incomplete artifacts produce no packet output;
- an assembled and validated packet still does not authorize production partitioning.

## Validation

Not run, per repository-owner instruction. Suggested owner checks:

```bash
node --test scripts/verify/index-partition-evidence-assembly.test.mjs
node scripts/verify/verify-index-partition-evidence.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

The actual PostgreSQL partition evidence run was not executed.

## Next M3 slice

Execute and retain one real PostgreSQL baseline/shadow capture bundle, assemble and validate its packet, and review the calculated admission result. Only after an `admitted` packet should durable global partition-operation ownership and bounded copy/checkpoint, constraint/index attachment, catch-up/replay, cutover, rollback, and failure-recovery lifecycle be implemented.