### PR TITLE
feat(index): add partition snapshot capture

### DIFF
--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -38,6 +38,7 @@ on:
       - "scripts/verify/index-partition-evidence.test.mjs"
       - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
+      - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -80,6 +81,7 @@ on:
       - "scripts/verify/index-partition-evidence.test.mjs"
       - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
+      - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -145,6 +147,7 @@ jobs:
             node --check scripts/verify/index-partition-evidence.test.mjs
             node --check scripts/verify/index-partition-evidence-assembly.test.mjs
             node --check scripts/verify/verify-index-partition-evidence.mjs
+            node --check scripts/verify/verify-index-partition-snapshot-capture.mjs
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
             node --test scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -198,6 +201,7 @@ jobs:
             --bin index-storage-benchmark \
             --bin index-storage-mutation-benchmark \
             --bin index-storage-maintenance-benchmark \
+            --bin index-partition-snapshot-capture \
             2>&1 | tee evidence/index-storage/build/release-build.log
 
       - name: Archive release build diagnostic

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,7 +26,7 @@ without runtime fan-out.
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
-- retained partition evidence preparation, capture assembly, and validation;
+- retained partition evidence preparation, snapshot capture, assembly, and validation;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -152,9 +152,9 @@ Any failed gate returns `KeepUnpartitioned` with typed reasons.
 An admitted `PartitionShadowPlan` derives stable names and bootstrap SQL only for
 shadow hash-partition parents and children. Hash modulus must be a power of two
 from 2 through 128. The plan cannot rename, drop, or alter production entity/link
-relations. Copy, constraint/index attachment, replay or dual-write, durable global
-operation ownership, cutover, rollback, and retained PostgreSQL evidence remain
-open M3 work.
+relations. Production copy/checkpoint, constraint/index attachment, replay or
+dual-write, durable global operation ownership, cutover, and rollback remain open
+M3 work.
 
 Partition evidence tooling binds one immutable manifest to a SHA-256 `evidence_id`,
 emits deterministic shadow-only bootstrap SQL, and validates exact
@@ -162,10 +162,22 @@ query/mutation/maintenance/cutover repetition groups. The capture/assembly layer
 reads six retained raw JSON artifacts once, confines unique relative paths to one
 bundle, rejects symbolic links and aliases, calculates exact-byte SHA-256 hashes,
 and publishes a structurally validated packet without accepting precomputed packet
-fields or pass flags. Final validation calculates tenant coverage, digest parity,
-latency regression, WAL amplification, partition skew, lock duration, rollback
-state, and typed rejection reasons. The repository owner still executes and
-retains the PostgreSQL packet.
+fields or pass flags.
+
+The owner-operated partition snapshot runner now captures `baseline.json` and
+`shadow.json` from one PostgreSQL repeatable-read snapshot. It requires an explicit
+shadow-copy opt-in, PostgreSQL 16 with JIT disabled, ordinary unpartitioned
+canonical relations, deterministic evidence-ID-bound names, and a reviewed tenant
+query audit. It creates and fills only shadow parents/children, attaches a
+shadow-only source-version uniqueness/FK contract, calculates logical SHA-256
+parity, physical child sizes, orphan state, and post-copy catch-up, and publishes
+the pair without overwriting retained evidence. The real query, mutation,
+maintenance, and cutover measurements remain open.
+
+Final validation calculates tenant coverage, digest parity, latency regression,
+WAL amplification, partition skew, lock duration, rollback state, and typed
+rejection reasons. The repository owner still executes and retains the complete
+PostgreSQL packet.
 
 PostgreSQL Testcontainers/concurrency evidence, query execution, and batch
 ingestion remain later M3/M4/M5 slices.
@@ -188,10 +200,11 @@ ingestion remain later M3/M4/M5 slices.
 - M3 partition admission and shadow planning: `complete`
 - M3 partition evidence packet tooling: `complete`
 - M3 partition evidence capture/assembly: `complete`
+- M3 partition baseline/shadow snapshot runner: `complete`
 - Production persistence: mutation writes, schema/index coordination, partition
-  admission, evidence assembly, and evidence validation implemented; query adapter,
-  retained PostgreSQL partition run, and partition cutover lifecycle not yet
-  implemented
+  admission, snapshot capture, evidence assembly, and evidence validation
+  implemented; query adapter, real query/mutation/maintenance/cutover partition
+  evidence, and production partition lifecycle not yet implemented
 
 ## Verification
 
@@ -202,12 +215,15 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo xtask module validate index`
 - `cargo xtask module test index`
+- `cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture`
+- `cargo test -p rustok-benchmarks partition_snapshot`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
 - `node --test scripts/verify/index-partition-evidence-assembly.test.mjs`
 - `node scripts/verify/verify-index-secondary-index-lifecycle.mjs`
 - `node scripts/verify/verify-index-partition-admission.mjs`
 - `node scripts/verify/verify-index-partition-evidence.mjs`
+- `node scripts/verify/verify-index-partition-snapshot-capture.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -67,18 +67,21 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 partition admission and shadow planning: `complete`
 - M3 partition evidence packet tooling: `complete`
 - M3 partition evidence capture/assembly: `complete`
+- M3 partition baseline/shadow snapshot runner: `complete`
 - Production persistence: mutation writes, schema coordination, secondary-index
-  lifecycle, fail-closed partition admission, evidence assembly, and evidence
-  validation implemented; the retained PostgreSQL partition run, query adapter,
-  and partition copy/cutover lifecycle are not yet implemented
+  lifecycle, fail-closed partition admission, snapshot capture, evidence assembly,
+  and evidence validation implemented; the real query/mutation/maintenance/cutover
+  partition evidence, query adapter, and production partition lifecycle are not yet
+  implemented
 
 The active production crate contains the generic domain/application core, the M3
 production migrations, an Index-owned transactional mutation adapter, a durable
 schema-application lease store, a schema-derived secondary-index manager, and a
 measured partition-admission contract that emits shadow bootstrap plans only. The
-repository also contains immutable partition-manifest preparation, exact-byte raw
-artifact assembly, and measured packet validation tooling. Query adapters,
-retained partition evidence, partition copy/constraint/index attachment,
+repository also contains immutable partition-manifest preparation, owner-operated
+baseline/shadow snapshot capture, exact-byte raw artifact assembly, and measured
+packet validation tooling. Query adapters, retained query/mutation/maintenance/
+cutover partition evidence, production copy/constraint/index attachment,
 replay/cutover, batch ingestion, and PostgreSQL Testcontainers evidence remain
 open. Benchmark DDL and generated evidence stay under `ops/benches`, outside the
 production module.
@@ -134,6 +137,7 @@ ops/benches/src/index_storage/
   runner.rs
   mutation_runner.rs
   maintenance_runner.rs
+  partition_snapshot.rs
   sql/
 ```
 
@@ -156,7 +160,7 @@ Selected additions:
 - `icu_locale` with compiled ICU4X data for UTS #35/CLDR locale alias
   canonicalization;
 - `sha2` for stable schema fingerprints, cursor checksums, secondary-index
-  definitions, and partition shadow-plan identities;
+  definitions, partition shadow-plan identities, and retained evidence digests;
 - `postcard` plus URL-safe Base64 for versioned keyset cursors.
 
 Add when required:
@@ -245,7 +249,8 @@ unpartitioned until a separate shadow packet passes admission.
       owner-operated runbook.
 - [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
       no-clobber packet publication.
-- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
+- [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
+- [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
 - [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
       rollback, and durable global operation ownership.
 - [ ] Add PostgreSQL Testcontainers fixtures.
@@ -308,11 +313,24 @@ integration-test assumption that `IndexModule` has no production migrations.
 The seventh M3 slice adds fail-closed raw-artifact packet assembly. A strict
 `index_partition_capture_v1` descriptor points to exactly six unique relative JSON
 files inside one bundle. The assembler rejects absolute paths, traversal,
-directories, symbolic links, duplicate role paths, output aliases, and overwrite
+directories, symbolic links, hard-link aliases, output aliases, and overwrite
 attempts. It reads each artifact once, hashes exact bytes, maps only the required
 baseline/shadow/query/mutation/maintenance/cutover shapes, and runs the canonical
 packet validator before no-clobber publication. It still does not execute
 PostgreSQL measurements or authorize production partitioning.
+
+The eighth M3 slice adds an owner-operated PostgreSQL snapshot runner. It requires
+an explicit shadow-copy opt-in, PostgreSQL 16 with JIT disabled, ordinary
+unpartitioned canonical relations, a deterministic prepared manifest, and a
+reviewed tenant-predicate audit. It serializes one evidence ID with an advisory
+lock, creates only evidence-bound tenant-hash shadow parents and children, and
+copies entities and links from one repeatable-read snapshot. A shadow-only
+source-version unique index and validated source foreign key protect link parity.
+The runner records baseline/shadow rows, physical bytes, logical SHA-256 digests,
+child sizes, orphan state, FK state, and post-copy catch-up, then publishes
+`baseline.json` and `shadow.json` together without overwriting retained evidence.
+It does not execute query, mutation, maintenance, or cutover measurements and never
+renames, drops, or alters the canonical production relations.
 
 ### M4 - Query engine v1
 
@@ -401,6 +419,8 @@ node scripts/verify/index-storage-tooling.mjs fixtures
 node --test scripts/verify/compare-index-storage-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
+cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
+cargo test -p rustok-benchmarks partition_snapshot
 ```
 
 Targeted M3 maintainer checks:
@@ -414,6 +434,7 @@ node scripts/verify/verify-index-schema-leases.mjs
 node scripts/verify/verify-index-secondary-index-lifecycle.mjs
 node scripts/verify/verify-index-partition-admission.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
+node scripts/verify/verify-index-partition-snapshot-capture.mjs
 ```
 
 ## Progress log
@@ -436,5 +457,8 @@ node scripts/verify/verify-index-partition-evidence.mjs
   CI guards, and corrected the stale integration migration contract.
 - 2026-07-27: added exact-byte raw-artifact capture assembly, bundle confinement,
   no-symlink/no-alias/no-overwrite publication, fixture coverage, and tooling
-  routing. Repository tests, verifiers, and PostgreSQL evidence remain for the
-  owner to execute.
+  routing.
+- 2026-07-27: added owner-operated PostgreSQL baseline/shadow snapshot capture,
+  repeatable-read copy, shadow integrity validation, logical SHA-256 parity, child
+  size evidence, no-clobber pair publication, and static/CI guards. Repository
+  tests, verifiers, and real PostgreSQL evidence remain for the owner to execute.

--- a/crates/rustok-index/docs/partition-evidence-runbook.md
+++ b/crates/rustok-index/docs/partition-evidence-runbook.md
@@ -7,22 +7,28 @@ relations remain unpartitioned unless one retained packet validates to `admitted
 
 ## Tooling boundary
 
-The tooling is intentionally split into three phases:
+The evidence flow has four explicit boundaries:
 
 1. `partition-prepare` binds an immutable run manifest to one SHA-256
    `evidence_id` and emits deterministic shadow-only bootstrap SQL.
-2. The owner executes PostgreSQL measurements and retains six raw JSON artifacts.
-   `partition-assemble` reads those exact files, calculates their exact-byte
-   SHA-256 identities, and publishes one structurally validated packet.
-3. `partition-validate` recalculates admission metrics and atomically publishes
+2. `index-partition-snapshot-capture` captures one repeatable-read baseline, creates
+   the evidence-ID-bound shadow tables, copies the same snapshot, validates source
+   integrity, and publishes `baseline.json` plus `shadow.json`.
+3. The owner executes the remaining query, mutation, maintenance, and cutover
+   rehearsal measurements. `partition-assemble` reads all six exact raw files,
+   calculates their exact-byte SHA-256 identities, and publishes one structurally
+   validated packet.
+4. `partition-validate` recalculates admission metrics and atomically publishes
    `admission.json`.
 
-The preparer and assembler refuse to overwrite retained outputs. The validator
-removes stale admission output before validation and writes a new file only after
-the complete packet is accepted structurally.
+The preparer, snapshot runner, and assembler refuse to overwrite retained outputs.
+The validator removes stale admission output before validation and writes a new file
+only after the complete packet is accepted structurally.
 
-None of these commands installs production constraints or indexes, starts replay
-or dual-write, renames or drops production relations, or performs cutover.
+None of these tools renames or drops production relations, performs production
+cutover, or starts runtime replay or dual-write. The snapshot runner creates and
+fills only deterministic shadow relations and adds a shadow-only source-version
+unique index and validated source foreign key.
 
 ## Prepare an immutable run
 
@@ -88,14 +94,68 @@ Review `bootstrap.sql` before execution. It may contain only:
 It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`, copy,
 replay, dual-write, or cutover statements.
 
-## Capture retained raw artifacts
+## Audit tenant-scoped query coverage
 
-The owner-operated PostgreSQL harness writes six raw JSON artifacts in one bundle
-directory. They are regular files, never symbolic links:
+Create a reviewed `query-audit.json` beside the manifest:
 
-- `baseline.json` — unpartitioned relation evidence and tenant-predicate audit;
-- `shadow.json` — shadow relation evidence, child sizes, catch-up, FK, and orphan
-  state;
+```json
+{
+  "contract": "index_partition_query_audit_v1",
+  "total_templates": 12,
+  "tenant_scoped_templates": 12
+}
+```
+
+The counts describe the exact query-template set that will later produce
+`query.json`. The snapshot runner records these values in `baseline.json`; the
+admission validator calculates coverage and requires exactly 10,000 basis points.
+The runner does not silently assume full coverage.
+
+## Capture the baseline and shadow snapshot
+
+Run the snapshot binary against an owner-approved PostgreSQL 16 evidence database
+that already contains the canonical Index migrations and representative data:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_SHADOW_COPY=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_QUERY_AUDIT=evidence/index-partition/query-audit.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+cargo run -p rustok-benchmarks --bin index-partition-snapshot-capture --release
+```
+
+The explicit copy opt-in is mandatory. The runner:
+
+- requires PostgreSQL 16 and pins JIT off;
+- rejects a canonical entity or link table that is already partitioned;
+- verifies the deterministic manifest shadow names and serializes one evidence ID
+  through a PostgreSQL advisory lock;
+- creates only the tenant-hash shadow parents and children;
+- reads baseline cardinality and logical digests and copies both canonical relations
+  from the same repeatable-read snapshot;
+- creates a shadow-only unique source-version index and validated source foreign key;
+- records exact row counts, physical bytes, one positive byte size per child,
+  SHA-256 logical digests, orphan count, FK state, and post-copy catch-up state;
+- publishes `baseline.json` and `shadow.json` together with no-clobber semantics.
+
+The relation digest contract hashes an ordered sequence of per-row PostgreSQL JSON
+identities and then binds relation kind and row count to
+`index_partition_relation_digest_v1`. It is intended for baseline/shadow parity,
+not as a replacement for the retained raw rows or database backup.
+
+The runner intentionally leaves its evidence-ID-bound shadow tables in place.
+Query, mutation, maintenance, and cutover artifacts remain separate owner-run
+measurements. A failed attempt may leave partial shadow state for inspection; use a
+new manifest and run key rather than editing or overwriting the failed evidence.
+
+## Capture all retained raw artifacts
+
+The complete bundle contains six raw JSON artifacts. They are regular files, never
+symbolic links:
+
+- `baseline.json` — produced by the snapshot runner;
+- `shadow.json` — produced by the snapshot runner;
 - `query.json` — an array of baseline/shadow query p95 and normalized plan digests;
 - `mutation.json` — an array of mutation p95 and WAL measurements;
 - `maintenance.json` — an array of ordinary VACUUM/dead-tuple measurements;
@@ -264,6 +324,7 @@ Retain together:
 - `config.json`;
 - `manifest.json`;
 - `bootstrap.sql`;
+- `query-audit.json`;
 - `capture.json`;
 - all six raw JSON artifacts and deeper PostgreSQL logs/EXPLAIN inputs from which
   they were derived;
@@ -274,17 +335,19 @@ Retain together:
 Do not combine files from different commits, PostgreSQL instances, manifests, run
 keys, or run attempts. A validated packet is necessary but not sufficient for
 production partitioning. Reviewers must still approve durable global operation
-ownership, copy/checkpoint semantics, constraint and index attachment, catch-up or
-replay, cutover, rollback, and failure recovery in later changes.
+ownership, copy/checkpoint semantics, production constraint and index attachment,
+catch-up or replay, cutover, rollback, and failure recovery in later changes.
 
 ## Suggested repository checks
 
 The repository owner runs:
 
 ```bash
+cargo test -p rustok-benchmarks partition_snapshot
+cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
 node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
+node scripts/verify/verify-index-partition-snapshot-capture.mjs
 node scripts/verify/index-storage-tooling.mjs contract
-cargo test -p rustok-index --test module
 ```

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { workspace = true }
 rust_decimal = "1.42"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 futures = "0.3"
 
 [[bin]]
@@ -39,6 +40,10 @@ path = "src/bin/index_storage_mutation_benchmark.rs"
 [[bin]]
 name = "index-storage-maintenance-benchmark"
 path = "src/bin/index_storage_maintenance_benchmark.rs"
+
+[[bin]]
+name = "index-partition-snapshot-capture"
+path = "src/bin/index_partition_snapshot_capture.rs"
 
 [[bench]]
 name = "tenant_cache"

--- a/ops/benches/README.md
+++ b/ops/benches/README.md
@@ -11,28 +11,35 @@ This is a standalone workspace crate named `rustok-benchmarks`.
   - `event_bus.rs`
   - `content_operations.rs`
   - `order_operations.rs`
-- `src/index_storage/` — the selected JSONB PostgreSQL regression harness for
-  `rustok-index`, retained after the completed M2 comparison.
-- `src/bin/index_storage_benchmark.rs` — read/query evidence runner.
-- `src/bin/index_storage_mutation_benchmark.rs` — transactional update/delete
-  WAL evidence runner.
+- `src/index_storage/` — PostgreSQL evidence tooling for `rustok-index`.
+- `src/bin/index_storage_benchmark.rs` — selected JSONB read/query evidence runner.
+- `src/bin/index_storage_mutation_benchmark.rs` — transactional update/delete WAL
+  evidence runner.
 - `src/bin/index_storage_maintenance_benchmark.rs` — committed churn and
   pre/post-VACUUM evidence runner.
+- `src/bin/index_partition_snapshot_capture.rs` — owner-operated M3 baseline/shadow
+  snapshot runner for the canonical Index relations.
 
 ## Purpose
 
 The Criterion suites detect performance regressions in established platform
-paths. The Index storage runners now exercise only the JSONB layout selected by
-the accepted storage ADR. The rejected typed-EAV and hot-projection implementations
+paths. The M2 Index storage runners exercise only the JSONB layout selected by the
+accepted storage ADR. The rejected typed-EAV and hot-projection implementations
 were removed after their exact comparison evidence was archived.
 
-The Index runners create only schemas prefixed with `idx_bench_`:
+The M2 runners create only schemas prefixed with `idx_bench_`:
 
 - `idx_bench_source`
 - `idx_bench_jsonb`
 
-Use a dedicated database because those schemas are dropped and recreated on
-every run.
+Use a dedicated database because those schemas are dropped and recreated on every
+M2 run.
+
+The M3 partition snapshot runner is different. It reads the canonical
+`index_entities` and `index_links` tables, creates deterministic evidence-ID-bound
+shadow parents and children, and copies one repeatable-read snapshot into them. It
+does not rename, drop, or alter the canonical production relations. Run it only
+against an owner-approved PostgreSQL 16 evidence database.
 
 ## Typical Criterion usage
 
@@ -59,11 +66,11 @@ INDEX_BENCH_SCALE=smoke \
 cargo run -p rustok-benchmarks --bin index-storage-mutation-benchmark --release
 ```
 
-The mutation runner validates the selected JSONB affected entity/link counts, executes every
-measured update/delete in an isolated transaction, records full JSON
+The mutation runner validates the selected JSONB affected entity/link counts,
+executes every measured update/delete in an isolated transaction, records full JSON
 `EXPLAIN (ANALYZE, BUFFERS, WAL)` output, and rolls the transaction back. The
-report exposes maximum per-plan-node WAL records, FPI, and bytes without
-claiming they are persistent bloat measurements.
+report exposes maximum per-plan-node WAL records, FPI, and bytes without claiming
+they are persistent bloat measurements.
 
 ## Index maintenance benchmark
 
@@ -74,19 +81,56 @@ INDEX_BENCH_CHURN_CYCLES=5 \
 cargo run -p rustok-benchmarks --bin index-storage-maintenance-benchmark --release
 ```
 
-The maintenance runner commits repeated update plus delete/reinsert cycles,
-checks exact entity/link cardinality, and records baseline, after-churn, and
+The maintenance runner commits repeated update plus delete/reinsert cycles, checks
+exact entity/link cardinality, and records baseline, after-churn, and
 after-`VACUUM (ANALYZE)` schema sizes and `pg_stat_user_tables` counters. Ordinary
-VACUUM is used deliberately; the benchmark does not hide an unhealthy model
-behind `VACUUM FULL`.
+VACUUM is used deliberately; the benchmark does not hide an unhealthy model behind
+`VACUUM FULL`.
 
-Scale values:
+## Index partition snapshot capture
+
+Prepare an immutable partition manifest first. Create a reviewed query audit file:
+
+```json
+{
+  "contract": "index_partition_query_audit_v1",
+  "total_templates": 12,
+  "tenant_scoped_templates": 12
+}
+```
+
+Then run:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_SHADOW_COPY=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_QUERY_AUDIT=evidence/index-partition/query-audit.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+cargo run -p rustok-benchmarks --bin index-partition-snapshot-capture --release
+```
+
+The explicit copy opt-in is mandatory. The runner requires PostgreSQL 16 with JIT
+disabled, verifies that the canonical relations remain ordinary unpartitioned
+tables, serializes one evidence ID through an advisory lock, creates only the
+deterministic shadow tables, and copies entities and links from one repeatable-read
+snapshot. It adds a shadow-only unique source-version index and validated source
+foreign key, calculates stable logical SHA-256 digests, captures child relation
+sizes, checks orphan links and post-copy catch-up, and publishes `baseline.json` and
+`shadow.json` as a no-clobber pair.
+
+The runner intentionally leaves its evidence-ID-bound shadow tables in place for
+later query, mutation, maintenance, and cutover-rehearsal measurements. A failed
+run may also leave partial shadow state for operator inspection; use a new manifest
+and run key rather than silently reusing or overwriting retained evidence.
+
+Scale values for the M2 runners:
 
 - `smoke`
 - `100k`
 - `1m`
 
-Optional environment variables:
+Optional M2 environment variables:
 
 - `INDEX_BENCH_LOCALES=en-US,ru-RU`
 - `INDEX_BENCH_REPETITIONS=3`
@@ -95,6 +139,7 @@ Optional environment variables:
 - `INDEX_BENCH_MUTATION_OUTPUT=target/index-storage-benchmark/mutation-report.json`
 - `INDEX_BENCH_MAINTENANCE_OUTPUT=target/index-storage-benchmark/maintenance-report.json`
 
-All three reports remain benchmark evidence only. JSONB is already selected by
-`DECISIONS/2026-07-24-index-storage-layout.md`; production persistence begins in
-M3 and must implement that accepted envelope rather than importing benchmark DDL.
+All reports remain evidence only. JSONB is already selected by
+`DECISIONS/2026-07-24-index-storage-layout.md`; production persistence must
+implement that accepted envelope rather than importing benchmark DDL or evidence
+shadow relations into runtime migrations.

--- a/ops/benches/src/bin/index_partition_snapshot_capture.rs
+++ b/ops/benches/src/bin/index_partition_snapshot_capture.rs
@@ -1,0 +1,18 @@
+use rustok_benchmarks::index_storage::{
+    PartitionSnapshotConfig, capture_partition_snapshot,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = PartitionSnapshotConfig::from_env()?;
+    let capture = capture_partition_snapshot(&config).await?;
+    println!(
+        "index partition snapshot capture complete: evidence_id={} baseline_rows={} shadow_rows={} baseline={} shadow={}",
+        capture.evidence_id,
+        capture.baseline_rows,
+        capture.shadow_rows,
+        capture.baseline_path.display(),
+        capture.shadow_path.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -4,6 +4,7 @@ mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
+mod partition_snapshot;
 mod report_provenance;
 mod runner;
 mod sql;
@@ -16,6 +17,10 @@ pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
+pub use partition_snapshot::{
+    BaselineSnapshot, PartitionSnapshotCapture, PartitionSnapshotConfig, RelationEvidence,
+    ShadowRelationEvidence, ShadowSnapshot, TenantPredicateAudit, capture_partition_snapshot,
+};
 pub use report_provenance::write_provenance_bound_report;
 pub use runner::{BenchmarkReport, run, write_report};
 pub(crate) use sql::read_workload_contract;

--- a/ops/benches/src/index_storage/partition_snapshot.rs
+++ b/ops/benches/src/index_storage/partition_snapshot.rs
@@ -1,0 +1,901 @@
+use std::{
+    env,
+    fs::{self, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+
+use super::{
+    connect_benchmark_database, ensure_database_metadata_stable, read_database_metadata,
+};
+
+const MANIFEST_CONTRACT: &str = "index_partition_evidence_manifest_v1";
+const SHADOW_PLAN_VERSION: &str = "tenant_hash_shadow_v1";
+const QUERY_AUDIT_CONTRACT: &str = "index_partition_query_audit_v1";
+const RELATION_DIGEST_CONTRACT: &str = "index_partition_relation_digest_v1";
+const COPY_OPT_IN: &str = "INDEX_PARTITION_ALLOW_SHADOW_COPY";
+
+#[derive(Debug, Clone)]
+pub struct PartitionSnapshotConfig {
+    pub database_url: String,
+    pub manifest_path: PathBuf,
+    pub query_audit_path: PathBuf,
+    pub output_root: PathBuf,
+}
+
+impl PartitionSnapshotConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(COPY_OPT_IN).as_deref(), Ok("1")),
+            "{COPY_OPT_IN}=1 is required because the runner creates and fills shadow tables"
+        );
+        let database_url = env::var("DATABASE_URL")
+            .context("DATABASE_URL is required for index partition snapshot capture")?;
+        let manifest_path = env::var("INDEX_PARTITION_MANIFEST")
+            .map(PathBuf::from)
+            .context("INDEX_PARTITION_MANIFEST is required")?;
+        let query_audit_path = env::var("INDEX_PARTITION_QUERY_AUDIT")
+            .map(PathBuf::from)
+            .context("INDEX_PARTITION_QUERY_AUDIT is required")?;
+        let output_root = env::var("INDEX_PARTITION_EVIDENCE_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("target/index-partition-evidence"));
+        ensure!(
+            manifest_path != query_audit_path,
+            "manifest and query-audit paths must be distinct"
+        );
+        Ok(Self {
+            database_url,
+            manifest_path,
+            query_audit_path,
+            output_root,
+        })
+    }
+
+    fn baseline_path(&self) -> PathBuf {
+        self.output_root.join("baseline.json")
+    }
+
+    fn shadow_path(&self) -> PathBuf {
+        self.output_root.join("shadow.json")
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PreparedManifest {
+    contract: String,
+    repository: String,
+    commit: String,
+    run_key: String,
+    postgres_image: String,
+    strategy: String,
+    plan_digest_contract: String,
+    modulus: u32,
+    evidence_id: String,
+    shadow_plan_version: String,
+    shadow_relations: ShadowRelations,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ShadowRelations {
+    definition_hash: String,
+    entities: RelationPlan,
+    links: RelationPlan,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelationPlan {
+    source: String,
+    parent: String,
+    partitions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TenantPredicateAudit {
+    pub contract: String,
+    pub total_templates: i64,
+    pub tenant_scoped_templates: i64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RelationEvidence {
+    pub rows: i64,
+    pub bytes: i64,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ShadowRelationEvidence {
+    pub rows: i64,
+    pub bytes: i64,
+    pub digest: String,
+    pub partition_bytes: Vec<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BaselineSnapshot {
+    pub generated_at: DateTime<Utc>,
+    pub distinct_tenants: i64,
+    pub tenant_predicate_audit: TenantPredicateAudit,
+    pub entities: RelationEvidence,
+    pub links: RelationEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ShadowSnapshot {
+    pub generated_at: DateTime<Utc>,
+    pub caught_up: bool,
+    pub foreign_keys_validated: bool,
+    pub orphan_links: i64,
+    pub entities: ShadowRelationEvidence,
+    pub links: ShadowRelationEvidence,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionSnapshotCapture {
+    pub evidence_id: String,
+    pub baseline_path: PathBuf,
+    pub shadow_path: PathBuf,
+    pub baseline_rows: i64,
+    pub shadow_rows: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RelationKind {
+    Entities,
+    Links,
+}
+
+impl RelationKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Entities => "entities",
+            Self::Links => "links",
+        }
+    }
+
+    fn digest_order(self) -> &'static str {
+        match self {
+            Self::Entities => concat!(
+                "row_data.tenant_id, row_data.module_name, row_data.entity_name, ",
+                "row_data.schema_version, row_data.entity_id, row_data.locale_key"
+            ),
+            Self::Links => concat!(
+                "row_data.tenant_id, row_data.source_module, row_data.source_entity, ",
+                "row_data.source_schema_version, row_data.source_entity_id, ",
+                "row_data.source_locale_key, row_data.source_version, ",
+                "row_data.link_name, row_data.ordinal"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogicalRelation {
+    rows: i64,
+    digest: String,
+}
+
+pub async fn capture_partition_snapshot(
+    config: &PartitionSnapshotConfig,
+) -> Result<PartitionSnapshotCapture> {
+    let manifest: PreparedManifest = read_regular_json(&config.manifest_path, "manifest")?;
+    validate_manifest(&manifest)?;
+    let audit: TenantPredicateAudit =
+        read_regular_json(&config.query_audit_path, "query audit")?;
+    validate_query_audit(&audit)?;
+
+    let baseline_path = config.baseline_path();
+    let shadow_path = config.shadow_path();
+    ensure_outputs_available(&baseline_path, &shadow_path)?;
+
+    let db = connect_benchmark_database(&config.database_url).await?;
+    db.execute_unprepared("SET jit = off; SET lock_timeout = '5s'; SET statement_timeout = 0;")
+        .await
+        .context("failed to pin partition evidence session settings")?;
+    let database_metadata = read_database_metadata(&db).await?;
+    ensure!(
+        database_metadata.server_version_num.starts_with("16"),
+        "partition evidence requires PostgreSQL 16, got {}",
+        database_metadata.server_version_num
+    );
+    ensure!(database_metadata.jit == "off", "partition evidence requires jit=off");
+    ensure_unpartitioned_source(&db, "index_entities").await?;
+    ensure_unpartitioned_source(&db, "index_links").await?;
+
+    acquire_capture_lock(&db, &manifest.evidence_id).await?;
+    ensure_shadow_absent(&db, &manifest.shadow_relations.entities).await?;
+    ensure_shadow_absent(&db, &manifest.shadow_relations.links).await?;
+    db.execute_unprepared(&render_shadow_bootstrap(&manifest))
+        .await
+        .context("failed to create deterministic partition evidence shadow tables")?;
+
+    let transaction = db.begin().await.context("failed to start snapshot transaction")?;
+    transaction
+        .execute_unprepared("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+        .await
+        .context("failed to pin repeatable-read snapshot")?;
+    let baseline_generated_at = Utc::now();
+    let distinct_tenants = distinct_tenants(&transaction).await?;
+    ensure!(distinct_tenants > 0, "partition evidence requires at least one tenant");
+    let baseline_entities = relation_evidence(
+        &transaction,
+        "index_entities",
+        RelationKind::Entities,
+    )
+    .await?;
+    let baseline_links =
+        relation_evidence(&transaction, "index_links", RelationKind::Links).await?;
+    copy_relation(
+        &transaction,
+        "index_entities",
+        &manifest.shadow_relations.entities.parent,
+    )
+    .await?;
+    copy_relation(
+        &transaction,
+        "index_links",
+        &manifest.shadow_relations.links.parent,
+    )
+    .await?;
+    transaction
+        .commit()
+        .await
+        .context("failed to commit shadow snapshot copy")?;
+
+    attach_shadow_source_integrity(&db, &manifest).await?;
+    analyze_shadow(&db, &manifest.shadow_relations.entities.parent).await?;
+    analyze_shadow(&db, &manifest.shadow_relations.links.parent).await?;
+
+    let shadow_entities = shadow_relation_evidence(
+        &db,
+        &manifest.shadow_relations.entities,
+        RelationKind::Entities,
+    )
+    .await?;
+    let shadow_links = shadow_relation_evidence(
+        &db,
+        &manifest.shadow_relations.links,
+        RelationKind::Links,
+    )
+    .await?;
+    let current_entities = logical_relation(&db, "index_entities", RelationKind::Entities).await?;
+    let current_links = logical_relation(&db, "index_links", RelationKind::Links).await?;
+    let caught_up = current_entities.rows == shadow_entities.rows
+        && current_entities.digest == shadow_entities.digest
+        && current_links.rows == shadow_links.rows
+        && current_links.digest == shadow_links.digest;
+    let orphan_links = orphan_link_count(&db, &manifest).await?;
+    let foreign_keys_validated = shadow_foreign_key_validated(&db, &manifest).await?;
+
+    let baseline = BaselineSnapshot {
+        generated_at: baseline_generated_at,
+        distinct_tenants,
+        tenant_predicate_audit: audit,
+        entities: baseline_entities,
+        links: baseline_links,
+    };
+    let shadow = ShadowSnapshot {
+        generated_at: Utc::now(),
+        caught_up,
+        foreign_keys_validated,
+        orphan_links,
+        entities: shadow_entities,
+        links: shadow_links,
+    };
+    ensure_snapshot_parity(&baseline, &shadow)?;
+    ensure!(orphan_links == 0, "shadow snapshot contains {orphan_links} orphan links");
+    ensure!(foreign_keys_validated, "shadow source foreign key is not validated");
+    ensure_database_metadata_stable(&db, &database_metadata, "partition snapshot capture").await?;
+
+    publish_snapshot_pair(&baseline_path, &baseline, &shadow_path, &shadow)?;
+    release_capture_lock(&db, &manifest.evidence_id).await?;
+    Ok(PartitionSnapshotCapture {
+        evidence_id: manifest.evidence_id,
+        baseline_path,
+        shadow_path,
+        baseline_rows: checked_total_rows(&baseline)?,
+        shadow_rows: checked_shadow_total_rows(&shadow)?,
+    })
+}
+
+fn read_regular_json<T: DeserializeOwned>(path: &Path, label: &str) -> Result<T> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {label} at {path:?}"))?;
+    ensure!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "{label} must be a regular non-symlink file"
+    );
+    let bytes = fs::read(path).with_context(|| format!("failed to read {label} at {path:?}"))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("failed to parse {label} JSON"))
+}
+
+fn validate_manifest(manifest: &PreparedManifest) -> Result<()> {
+    ensure!(manifest.contract == MANIFEST_CONTRACT, "unexpected manifest contract");
+    ensure!(manifest.repository == "RusTokRs/RusTok", "unexpected manifest repository");
+    ensure!(is_lower_hex(&manifest.commit, 40), "manifest commit must be lowercase SHA-1");
+    ensure!(
+        !manifest.run_key.is_empty() && manifest.run_key.len() <= 128,
+        "manifest run_key must be bounded and non-empty"
+    );
+    ensure!(manifest.postgres_image == "postgres:16", "manifest must pin postgres:16");
+    ensure!(manifest.strategy == "tenant_hash", "manifest strategy must be tenant_hash");
+    ensure!(
+        manifest.plan_digest_contract == "normalized_partition_plan_v1",
+        "unexpected plan digest contract"
+    );
+    ensure!(
+        (2..=128).contains(&manifest.modulus) && manifest.modulus.is_power_of_two(),
+        "manifest modulus must be a power of two between 2 and 128"
+    );
+    ensure!(is_lower_hex(&manifest.evidence_id, 64), "invalid evidence_id");
+    ensure!(
+        manifest.shadow_plan_version == SHADOW_PLAN_VERSION,
+        "unexpected shadow plan version"
+    );
+
+    let modulus = manifest.modulus.to_string();
+    let definition = [
+        "rustok-index-partition",
+        SHADOW_PLAN_VERSION,
+        manifest.evidence_id.as_str(),
+        "tenant_hash",
+        modulus.as_str(),
+    ]
+    .join("\u{1f}");
+    let definition_hash = sha256_hex(definition.as_bytes());
+    ensure!(
+        manifest.shadow_relations.definition_hash == definition_hash,
+        "manifest shadow definition hash does not match the evidence identity"
+    );
+    let suffix = &definition_hash[..24];
+    validate_relation_plan(
+        &manifest.shadow_relations.entities,
+        "index_entities",
+        &format!("index_entities_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    validate_relation_plan(
+        &manifest.shadow_relations.links,
+        "index_links",
+        &format!("index_links_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    Ok(())
+}
+
+fn validate_relation_plan(
+    plan: &RelationPlan,
+    expected_source: &str,
+    expected_parent: &str,
+    modulus: u32,
+) -> Result<()> {
+    ensure!(plan.source == expected_source, "unexpected relation source");
+    ensure!(plan.parent == expected_parent, "unexpected shadow parent name");
+    validate_identifier(&plan.parent)?;
+    ensure!(
+        plan.partitions.len() == modulus as usize,
+        "shadow relation must contain exactly {modulus} partitions"
+    );
+    for (remainder, partition) in plan.partitions.iter().enumerate() {
+        validate_identifier(partition)?;
+        ensure!(
+            partition == &format!("{expected_parent}_p{remainder:03}"),
+            "unexpected shadow partition name"
+        );
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str) -> Result<()> {
+    ensure!(!value.is_empty() && value.len() <= 63, "invalid PostgreSQL identifier length");
+    ensure!(
+        value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "PostgreSQL identifier contains unsupported characters"
+    );
+    Ok(())
+}
+
+fn validate_query_audit(audit: &TenantPredicateAudit) -> Result<()> {
+    ensure!(audit.contract == QUERY_AUDIT_CONTRACT, "unexpected query audit contract");
+    ensure!(audit.total_templates > 0, "query audit must contain templates");
+    ensure!(
+        audit.tenant_scoped_templates >= 0
+            && audit.tenant_scoped_templates <= audit.total_templates,
+        "tenant-scoped template count is outside the audited range"
+    );
+    Ok(())
+}
+
+fn ensure_outputs_available(baseline_path: &Path, shadow_path: &Path) -> Result<()> {
+    ensure!(baseline_path != shadow_path, "baseline and shadow outputs must be distinct");
+    ensure!(!baseline_path.exists(), "refusing to overwrite {baseline_path:?}");
+    ensure!(!shadow_path.exists(), "refusing to overwrite {shadow_path:?}");
+    Ok(())
+}
+
+async fn ensure_unpartitioned_source(db: &DatabaseConnection, relation: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT c.relkind::text AS relkind, c.relispartition, ",
+                "EXISTS (SELECT 1 FROM pg_partitioned_table p WHERE p.partrelid = c.oid) AS partitioned ",
+                "FROM pg_class c WHERE c.oid = $1::regclass"
+            ),
+            vec![relation.into()],
+        ))
+        .await?
+        .with_context(|| format!("canonical relation {relation} was not found"))?;
+    let relkind: String = row.try_get("", "relkind")?;
+    let relispartition: bool = row.try_get("", "relispartition")?;
+    let partitioned: bool = row.try_get("", "partitioned")?;
+    ensure!(
+        relkind == "r" && !relispartition && !partitioned,
+        "canonical relation {relation} must remain an ordinary unpartitioned table"
+    );
+    Ok(())
+}
+
+async fn ensure_shadow_absent(db: &DatabaseConnection, plan: &RelationPlan) -> Result<()> {
+    for relation in std::iter::once(&plan.parent).chain(plan.partitions.iter()) {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                "SELECT to_regclass($1)::text AS relation",
+                vec![relation.clone().into()],
+            ))
+            .await?
+            .context("shadow existence query returned no row")?;
+        let existing: Option<String> = row.try_get("", "relation")?;
+        ensure!(existing.is_none(), "shadow relation already exists: {relation}");
+    }
+    Ok(())
+}
+
+async fn acquire_capture_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    db.query_one(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+        vec![format!("rustok-index-partition-snapshot:{evidence_id}").into()],
+    ))
+    .await?
+    .context("partition capture advisory lock returned no row")?;
+    Ok(())
+}
+
+async fn release_capture_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT pg_advisory_unlock(hashtextextended($1, 0)) AS unlocked",
+            vec![format!("rustok-index-partition-snapshot:{evidence_id}").into()],
+        ))
+        .await?
+        .context("partition capture advisory unlock returned no row")?;
+    let unlocked: bool = row.try_get("", "unlocked")?;
+    ensure!(unlocked, "partition capture advisory lock was not held");
+    Ok(())
+}
+
+fn render_shadow_bootstrap(manifest: &PreparedManifest) -> String {
+    let mut statements = vec!["BEGIN;".to_owned()];
+    for plan in [
+        &manifest.shadow_relations.entities,
+        &manifest.shadow_relations.links,
+    ] {
+        statements.push(format!(
+            "CREATE TABLE {} (LIKE {} INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING IDENTITY INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY HASH (tenant_id);",
+            quote_identifier(&plan.parent),
+            quote_identifier(&plan.source),
+        ));
+        statements.push(format!(
+            "COMMENT ON TABLE {} IS 'rustok-index-partition:{}';",
+            quote_identifier(&plan.parent),
+            manifest.evidence_id,
+        ));
+        for (remainder, partition) in plan.partitions.iter().enumerate() {
+            statements.push(format!(
+                "CREATE TABLE {} PARTITION OF {} FOR VALUES WITH (MODULUS {}, REMAINDER {});",
+                quote_identifier(partition),
+                quote_identifier(&plan.parent),
+                manifest.modulus,
+                remainder,
+            ));
+        }
+    }
+    statements.push("COMMIT;".to_owned());
+    statements.join("\n")
+}
+
+async fn distinct_tenants<C: ConnectionTrait>(db: &C) -> Result<i64> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT count(DISTINCT tenant_id)::bigint AS distinct_tenants FROM (",
+                "SELECT tenant_id FROM index_entities UNION ALL ",
+                "SELECT tenant_id FROM index_links) tenants"
+            )
+            .to_owned(),
+        ))
+        .await?
+        .context("distinct tenant query returned no row")?;
+    Ok(row.try_get("", "distinct_tenants")?)
+}
+
+async fn logical_relation<C: ConnectionTrait>(
+    db: &C,
+    relation: &str,
+    kind: RelationKind,
+) -> Result<LogicalRelation> {
+    let sql = format!(
+        concat!(
+            "SELECT count(*)::bigint AS rows, ",
+            "COALESCE(md5(string_agg(md5(row_to_json(row_data)::text), '' ORDER BY {})), md5('')) AS digest_seed ",
+            "FROM (SELECT * FROM {}) row_data"
+        ),
+        kind.digest_order(),
+        quote_identifier(relation),
+    );
+    let row = db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql))
+        .await?
+        .with_context(|| format!("relation digest query returned no row for {relation}"))?;
+    let rows: i64 = row.try_get("", "rows")?;
+    let digest_seed: String = row.try_get("", "digest_seed")?;
+    let digest = sha256_hex(
+        format!(
+            "{RELATION_DIGEST_CONTRACT}\u{1f}{}\u{1f}{rows}\u{1f}{digest_seed}",
+            kind.label()
+        )
+        .as_bytes(),
+    );
+    Ok(LogicalRelation { rows, digest })
+}
+
+async fn relation_evidence<C: ConnectionTrait>(
+    db: &C,
+    relation: &str,
+    kind: RelationKind,
+) -> Result<RelationEvidence> {
+    let logical = logical_relation(db, relation, kind).await?;
+    Ok(RelationEvidence {
+        rows: logical.rows,
+        bytes: relation_size(db, relation).await?,
+        digest: logical.digest,
+    })
+}
+
+async fn shadow_relation_evidence(
+    db: &DatabaseConnection,
+    plan: &RelationPlan,
+    kind: RelationKind,
+) -> Result<ShadowRelationEvidence> {
+    let logical = logical_relation(db, &plan.parent, kind).await?;
+    let mut partition_bytes = Vec::with_capacity(plan.partitions.len());
+    for partition in &plan.partitions {
+        partition_bytes.push(relation_size(db, partition).await?);
+    }
+    let bytes = partition_bytes.iter().try_fold(0_i64, |total, value| {
+        total.checked_add(*value).context("shadow relation byte count overflow")
+    })?;
+    Ok(ShadowRelationEvidence {
+        rows: logical.rows,
+        bytes,
+        digest: logical.digest,
+        partition_bytes,
+    })
+}
+
+async fn relation_size<C: ConnectionTrait>(db: &C, relation: &str) -> Result<i64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT pg_total_relation_size($1::regclass)::bigint AS bytes",
+            vec![relation.into()],
+        ))
+        .await?
+        .with_context(|| format!("relation size query returned no row for {relation}"))?;
+    let bytes: i64 = row.try_get("", "bytes")?;
+    ensure!(bytes > 0, "relation {relation} has a non-positive physical size");
+    Ok(bytes)
+}
+
+async fn copy_relation<C: ConnectionTrait>(db: &C, source: &str, target: &str) -> Result<()> {
+    db.execute_unprepared(&format!(
+        "INSERT INTO {} SELECT * FROM {};",
+        quote_identifier(target),
+        quote_identifier(source),
+    ))
+    .await
+    .with_context(|| format!("failed to copy {source} into {target}"))?;
+    Ok(())
+}
+
+async fn attach_shadow_source_integrity(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+) -> Result<()> {
+    let suffix = &manifest.evidence_id[..16];
+    let unique_index = format!("idx_pe_{suffix}_entity_source");
+    let foreign_key = format!("fk_pe_{suffix}_link_source");
+    validate_identifier(&unique_index)?;
+    validate_identifier(&foreign_key)?;
+    db.execute_unprepared(&format!(
+        concat!(
+            "CREATE UNIQUE INDEX {} ON {} (",
+            "tenant_id, module_name, entity_name, schema_version, entity_id, locale_key, source_version);"
+        ),
+        quote_identifier(&unique_index),
+        quote_identifier(&manifest.shadow_relations.entities.parent),
+    ))
+    .await
+    .context("failed to create the shadow entity source-version uniqueness contract")?;
+    db.execute_unprepared(&format!(
+        concat!(
+            "ALTER TABLE {} ADD CONSTRAINT {} FOREIGN KEY (",
+            "tenant_id, source_module, source_entity, source_schema_version, source_entity_id, source_locale_key, source_version",
+            ") REFERENCES {} (",
+            "tenant_id, module_name, entity_name, schema_version, entity_id, locale_key, source_version",
+            ") ON UPDATE RESTRICT ON DELETE CASCADE;"
+        ),
+        quote_identifier(&manifest.shadow_relations.links.parent),
+        quote_identifier(&foreign_key),
+        quote_identifier(&manifest.shadow_relations.entities.parent),
+    ))
+    .await
+    .context("failed to add and validate the shadow source foreign key")?;
+    Ok(())
+}
+
+async fn analyze_shadow(db: &DatabaseConnection, relation: &str) -> Result<()> {
+    db.execute_unprepared(&format!("ANALYZE {};", quote_identifier(relation)))
+        .await
+        .with_context(|| format!("failed to analyze shadow relation {relation}"))?;
+    Ok(())
+}
+
+async fn orphan_link_count(db: &DatabaseConnection, manifest: &PreparedManifest) -> Result<i64> {
+    let links = quote_identifier(&manifest.shadow_relations.links.parent);
+    let entities = quote_identifier(&manifest.shadow_relations.entities.parent);
+    let sql = format!(
+        concat!(
+            "SELECT count(*)::bigint AS orphan_links FROM {links} l LEFT JOIN {entities} e ON ",
+            "e.tenant_id = l.tenant_id AND e.module_name = l.source_module AND ",
+            "e.entity_name = l.source_entity AND e.schema_version = l.source_schema_version AND ",
+            "e.entity_id = l.source_entity_id AND e.locale_key = l.source_locale_key AND ",
+            "e.source_version = l.source_version WHERE e.tenant_id IS NULL"
+        )
+    );
+    let row = db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql))
+        .await?
+        .context("orphan-link query returned no row")?;
+    Ok(row.try_get("", "orphan_links")?)
+}
+
+async fn shadow_foreign_key_validated(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+) -> Result<bool> {
+    let name = format!("fk_pe_{}_link_source", &manifest.evidence_id[..16]);
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT convalidated FROM pg_constraint ",
+                "WHERE conrelid = $1::regclass AND conname = $2"
+            ),
+            vec![
+                manifest.shadow_relations.links.parent.clone().into(),
+                name.into(),
+            ],
+        ))
+        .await?
+        .context("shadow foreign-key catalog row was not found")?;
+    Ok(row.try_get("", "convalidated")?)
+}
+
+fn ensure_snapshot_parity(baseline: &BaselineSnapshot, shadow: &ShadowSnapshot) -> Result<()> {
+    ensure!(
+        baseline.entities.rows == shadow.entities.rows
+            && baseline.entities.digest == shadow.entities.digest,
+        "entity shadow snapshot diverged from the repeatable-read baseline"
+    );
+    ensure!(
+        baseline.links.rows == shadow.links.rows && baseline.links.digest == shadow.links.digest,
+        "link shadow snapshot diverged from the repeatable-read baseline"
+    );
+    Ok(())
+}
+
+fn checked_total_rows(baseline: &BaselineSnapshot) -> Result<i64> {
+    baseline
+        .entities
+        .rows
+        .checked_add(baseline.links.rows)
+        .context("baseline row count overflow")
+}
+
+fn checked_shadow_total_rows(shadow: &ShadowSnapshot) -> Result<i64> {
+    shadow
+        .entities
+        .rows
+        .checked_add(shadow.links.rows)
+        .context("shadow row count overflow")
+}
+
+fn publish_snapshot_pair(
+    baseline_path: &Path,
+    baseline: &BaselineSnapshot,
+    shadow_path: &Path,
+    shadow: &ShadowSnapshot,
+) -> Result<()> {
+    let baseline_bytes = json_bytes(baseline)?;
+    let shadow_bytes = json_bytes(shadow)?;
+    if let Some(parent) = baseline_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create evidence directory {parent:?}"))?;
+    }
+    if let Some(parent) = shadow_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create evidence directory {parent:?}"))?;
+    }
+    ensure_outputs_available(baseline_path, shadow_path)?;
+    let baseline_temp = temporary_path(baseline_path);
+    let shadow_temp = temporary_path(shadow_path);
+    write_new_file(&baseline_temp, &baseline_bytes)?;
+    if let Err(error) = write_new_file(&shadow_temp, &shadow_bytes) {
+        let _ = fs::remove_file(&baseline_temp);
+        return Err(error);
+    }
+    let result = (|| -> Result<()> {
+        fs::hard_link(&baseline_temp, baseline_path)
+            .with_context(|| format!("failed to publish {baseline_path:?}"))?;
+        if let Err(error) = fs::hard_link(&shadow_temp, shadow_path) {
+            let _ = fs::remove_file(baseline_path);
+            return Err(error).with_context(|| format!("failed to publish {shadow_path:?}"));
+        }
+        Ok(())
+    })();
+    let _ = fs::remove_file(&baseline_temp);
+    let _ = fs::remove_file(&shadow_temp);
+    result
+}
+
+fn json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value).context("failed to serialize evidence JSON")?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(format!(".tmp-{}", std::process::id()));
+    PathBuf::from(value)
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("failed to create temporary evidence file {path:?}"))?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to write temporary evidence file {path:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync temporary evidence file {path:?}"))?;
+    Ok(())
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest() -> PreparedManifest {
+        let evidence_id = "a".repeat(64);
+        let definition = [
+            "rustok-index-partition",
+            SHADOW_PLAN_VERSION,
+            evidence_id.as_str(),
+            "tenant_hash",
+            "4",
+        ]
+        .join("\u{1f}");
+        let definition_hash = sha256_hex(definition.as_bytes());
+        let suffix = &definition_hash[..24];
+        let plan = |source: &str| {
+            let parent = format!("{source}_shadow_{suffix}");
+            RelationPlan {
+                source: source.to_owned(),
+                partitions: (0..4)
+                    .map(|remainder| format!("{parent}_p{remainder:03}"))
+                    .collect(),
+                parent,
+            }
+        };
+        PreparedManifest {
+            contract: MANIFEST_CONTRACT.to_owned(),
+            repository: "RusTokRs/RusTok".to_owned(),
+            commit: "1".repeat(40),
+            run_key: "fixture-run-1".to_owned(),
+            postgres_image: "postgres:16".to_owned(),
+            strategy: "tenant_hash".to_owned(),
+            plan_digest_contract: "normalized_partition_plan_v1".to_owned(),
+            modulus: 4,
+            evidence_id,
+            shadow_plan_version: SHADOW_PLAN_VERSION.to_owned(),
+            shadow_relations: ShadowRelations {
+                definition_hash,
+                entities: plan("index_entities"),
+                links: plan("index_links"),
+            },
+        }
+    }
+
+    #[test]
+    fn deterministic_manifest_and_bootstrap_remain_shadow_only() {
+        let manifest = manifest();
+        validate_manifest(&manifest).unwrap();
+        let sql = render_shadow_bootstrap(&manifest);
+        assert!(sql.contains("PARTITION BY HASH (tenant_id)"));
+        assert!(sql.contains("MODULUS 4, REMAINDER 3"));
+        for forbidden in [
+            "ALTER TABLE \"index_entities\"",
+            "ALTER TABLE \"index_links\"",
+            "DROP TABLE",
+            "RENAME TO",
+            "VACUUM FULL",
+        ] {
+            assert!(!sql.contains(forbidden), "bootstrap contains {forbidden}");
+        }
+    }
+
+    #[test]
+    fn query_audit_and_relation_digest_contract_fail_closed() {
+        validate_query_audit(&TenantPredicateAudit {
+            contract: QUERY_AUDIT_CONTRACT.to_owned(),
+            total_templates: 2,
+            tenant_scoped_templates: 2,
+        })
+        .unwrap();
+        assert!(
+            validate_query_audit(&TenantPredicateAudit {
+                contract: QUERY_AUDIT_CONTRACT.to_owned(),
+                total_templates: 1,
+                tenant_scoped_templates: 2,
+            })
+            .is_err()
+        );
+        let digest = sha256_hex(
+            format!("{RELATION_DIGEST_CONTRACT}\u{1f}entities\u{1f}1\u{1f}seed").as_bytes(),
+        );
+        assert_eq!(digest.len(), 64);
+    }
+}

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -65,6 +65,7 @@ const runContract = (args) => {
     'verify-index-secondary-index-lifecycle.mjs',
     'verify-index-partition-admission.mjs',
     'verify-index-partition-evidence.mjs',
+    'verify-index-partition-snapshot-capture.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',

--- a/scripts/verify/verify-index-partition-snapshot-capture.mjs
+++ b/scripts/verify/verify-index-partition-snapshot-capture.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-partition-snapshot-capture] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runner = requireMarkers('ops/benches/src/index_storage/partition_snapshot.rs', [
+  'INDEX_PARTITION_ALLOW_SHADOW_COPY',
+  'index_partition_query_audit_v1',
+  'index_partition_relation_digest_v1',
+  'partition evidence requires PostgreSQL 16',
+  'partition evidence requires jit=off',
+  'must remain an ordinary unpartitioned table',
+  'pg_advisory_lock(hashtextextended($1, 0))',
+  'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ',
+  'CREATE TABLE {} (LIKE {} INCLUDING DEFAULTS INCLUDING GENERATED INCLUDING IDENTITY INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY HASH (tenant_id)',
+  'INSERT INTO {} SELECT * FROM {}',
+  'CREATE UNIQUE INDEX {} ON {}',
+  'ADD CONSTRAINT {} FOREIGN KEY',
+  'row_to_json(row_data)::text',
+  'shadow relation byte count overflow',
+  'shadow source foreign key is not validated',
+  'entity shadow snapshot diverged from the repeatable-read baseline',
+  'link shadow snapshot diverged from the repeatable-read baseline',
+  'fs::hard_link(&baseline_temp, baseline_path)',
+  'fs::hard_link(&shadow_temp, shadow_path)',
+  'refusing to overwrite {baseline_path:?}',
+  'refusing to overwrite {shadow_path:?}',
+]);
+
+for (const forbidden of [
+  'ALTER TABLE "index_entities"',
+  'ALTER TABLE "index_links"',
+  'DROP TABLE "index_entities"',
+  'DROP TABLE "index_links"',
+  'RENAME TO index_entities',
+  'RENAME TO index_links',
+  'VACUUM FULL',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (runner.includes(forbidden)) fail(`snapshot runner contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('ops/benches/src/bin/index_partition_snapshot_capture.rs', [
+  'PartitionSnapshotConfig::from_env()',
+  'capture_partition_snapshot(&config).await?',
+  'index partition snapshot capture complete',
+]);
+
+requireMarkers('ops/benches/src/index_storage/mod.rs', [
+  'mod partition_snapshot;',
+  'PartitionSnapshotConfig',
+  'capture_partition_snapshot',
+]);
+
+requireMarkers('ops/benches/Cargo.toml', [
+  'sha2 = { workspace = true }',
+  'name = "index-partition-snapshot-capture"',
+  'path = "src/bin/index_partition_snapshot_capture.rs"',
+]);
+
+requireMarkers('ops/benches/README.md', [
+  'Index partition snapshot capture',
+  'INDEX_PARTITION_ALLOW_SHADOW_COPY=1',
+  'INDEX_PARTITION_QUERY_AUDIT',
+  'index-partition-snapshot-capture',
+  'does not rename, drop, or alter the canonical production relations',
+]);
+
+requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
+  'index_partition_query_audit_v1',
+  'index-partition-snapshot-capture',
+  'baseline.json',
+  'shadow.json',
+  'repeatable-read snapshot',
+  'Query, mutation, maintenance, and cutover artifacts remain separate owner-run',
+  'measurements. A failed attempt may leave partial shadow state for inspection',
+]);
+
+requireMarkers('crates/rustok-index/docs/README.md', [
+  'M3 partition baseline/shadow snapshot runner: `complete`',
+  'The real query, mutation,',
+  'maintenance, and cutover measurements remain open.',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M3 partition baseline/shadow snapshot runner: `complete`',
+  '- [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.',
+  '- [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.',
+  'The eighth M3 slice adds an owner-operated PostgreSQL snapshot runner.',
+]);
+
+requireMarkers('scripts/verify/index-storage-tooling.mjs', [
+  "'verify-index-partition-snapshot-capture.mjs'",
+]);
+
+requireMarkers('.github/workflows/index-storage-smoke.yml', [
+  'scripts/verify/verify-index-partition-snapshot-capture.mjs',
+  'node --check scripts/verify/verify-index-partition-snapshot-capture.mjs',
+  '--bin index-partition-snapshot-capture',
+]);
+
+console.log('[verify-index-partition-snapshot-capture] OK');


### PR DESCRIPTION
## Summary

- continue M3 with an owner-operated PostgreSQL baseline/shadow snapshot runner for the canonical `index_entities` and `index_links` relations;
- require explicit `INDEX_PARTITION_ALLOW_SHADOW_COPY=1` opt-in before creating or filling any shadow relation;
- consume the immutable prepared partition manifest and a reviewed `index_partition_query_audit_v1` file;
- require PostgreSQL 16 with JIT disabled and reject canonical relations that are already partitioned;
- validate evidence-ID-bound shadow definition hashes, parent names, child names, modulus, and PostgreSQL identifier bounds;
- serialize one evidence ID through a PostgreSQL advisory lock and reject pre-existing shadow relations;
- create only deterministic tenant-hash shadow parents and children;
- capture baseline row counts, physical sizes, distinct tenants, and logical SHA-256 digests and copy entities plus links from the same repeatable-read snapshot;
- create a shadow-only source-version unique index and validated source foreign key, then verify orphan-link state;
- record one positive physical size per child partition and calculate shadow logical digests;
- compare the completed shadow against both the repeatable-read baseline and the current canonical relations, exposing post-copy catch-up state;
- publish `baseline.json` and `shadow.json` as a no-clobber pair through temporary files and hard-link publication;
- leave evidence-ID-bound shadow relations in place for later query, mutation, maintenance, and cutover-rehearsal measurements;
- add a dedicated `index-partition-snapshot-capture` benchmark binary, static contract guard, lightweight CI build coverage, runbook updates, and roadmap synchronization;
- keep production rename/drop, cutover, runtime dual-write/replay, bounded production copy/checkpointing, and durable global operation ownership outside this slice.

## Previous slice recheck

- PR #2315 was rechecked with no comments, reviews, review threads, or status checks and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Commerce and Inventory changes.

## Important behavior

- the snapshot runner operates on an owner-approved evidence database, not as production runtime composition;
- the explicit copy opt-in is mandatory;
- the canonical production relations are read only and must remain ordinary unpartitioned tables;
- only evidence-ID-bound shadow tables, a shadow-only unique index, and a shadow-only foreign key are created;
- relation parity is represented by a stable SHA-256 digest bound to relation kind and row count;
- a concurrent canonical write after the repeatable-read copy yields `caught_up=false` rather than being silently ignored;
- failed attempts may leave partial shadow state for operator inspection; retained outputs and shadow names are never silently reused;
- the canonical packet assembler and validator still decide whether the complete evidence packet is structurally valid or admitted;
- baseline/shadow capture alone does not authorize production partitioning.

## Validation

Not run, per repository-owner instruction. Suggested owner checks:

```bash
cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
cargo test -p rustok-benchmarks partition_snapshot
node scripts/verify/verify-index-partition-snapshot-capture.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

The PostgreSQL snapshot runner and real partition evidence were not executed.

## Next M3 slices

Add the owner-operated query evidence runner for baseline/shadow p95 and normalized plan digests, followed by mutation/WAL, maintenance, and cutover-rehearsal capture. Then assemble and validate one retained real packet before any production partition lifecycle is implemented.