### PR TITLE
feat(index): add partition query evidence

### DIFF
--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -39,6 +39,7 @@ on:
       - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
+      - "scripts/verify/verify-index-partition-query-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -82,6 +83,7 @@ on:
       - "scripts/verify/index-partition-evidence-assembly.test.mjs"
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
+      - "scripts/verify/verify-index-partition-query-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -148,6 +150,7 @@ jobs:
             node --check scripts/verify/index-partition-evidence-assembly.test.mjs
             node --check scripts/verify/verify-index-partition-evidence.mjs
             node --check scripts/verify/verify-index-partition-snapshot-capture.mjs
+            node --check scripts/verify/verify-index-partition-query-evidence.mjs
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
             node --test scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -202,6 +205,7 @@ jobs:
             --bin index-storage-mutation-benchmark \
             --bin index-storage-maintenance-benchmark \
             --bin index-partition-snapshot-capture \
+            --bin index-partition-query-evidence \
             2>&1 | tee evidence/index-storage/build/release-build.log
 
       - name: Archive release build diagnostic

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,7 +26,7 @@ without runtime fan-out.
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
-- retained partition evidence preparation, snapshot capture, assembly, and validation;
+- retained partition evidence preparation, snapshot/query capture, assembly, and validation;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -164,23 +164,32 @@ bundle, rejects symbolic links and aliases, calculates exact-byte SHA-256 hashes
 and publishes a structurally validated packet without accepting precomputed packet
 fields or pass flags.
 
-The owner-operated partition snapshot runner now captures `baseline.json` and
+The owner-operated partition snapshot runner captures `baseline.json` and
 `shadow.json` from one PostgreSQL repeatable-read snapshot. It requires an explicit
 shadow-copy opt-in, PostgreSQL 16 with JIT disabled, ordinary unpartitioned
 canonical relations, deterministic evidence-ID-bound names, and a reviewed tenant
 query audit. It creates and fills only shadow parents/children, attaches a
 shadow-only source-version uniqueness/FK contract, calculates logical SHA-256
 parity, physical child sizes, orphan state, and post-copy catch-up, and publishes
-the pair without overwriting retained evidence. The real query, mutation,
-maintenance, and cutover measurements remain open.
+the pair without overwriting retained evidence.
+
+The owner-operated query evidence runner validates the same manifest and shadow
+catalog, enables partition pruning, and executes exactly the manifest query run
+count inside one read-only repeatable-read transaction. It requires result digest
+parity, retains full baseline/shadow JSON EXPLAIN samples, alternates measurement
+order, calculates p95, normalizes logical plan identity with
+`normalized_partition_plan_v1`, and fails unless every shadow query reads exactly
+one child per used logical relation. It publishes `query.json` without overwrite
+and performs no writes. Real mutation, maintenance, and cutover evidence remain
+open.
 
 Final validation calculates tenant coverage, digest parity, latency regression,
 WAL amplification, partition skew, lock duration, rollback state, and typed
 rejection reasons. The repository owner still executes and retains the complete
 PostgreSQL packet.
 
-PostgreSQL Testcontainers/concurrency evidence, query execution, and batch
-ingestion remain later M3/M4/M5 slices.
+PostgreSQL Testcontainers/concurrency evidence, production query execution, and
+batch ingestion remain later M3/M4/M5 slices.
 
 ## Status
 
@@ -201,10 +210,12 @@ ingestion remain later M3/M4/M5 slices.
 - M3 partition evidence packet tooling: `complete`
 - M3 partition evidence capture/assembly: `complete`
 - M3 partition baseline/shadow snapshot runner: `complete`
+- M3 partition query evidence runner: `complete`
 - Production persistence: mutation writes, schema/index coordination, partition
-  admission, snapshot capture, evidence assembly, and evidence validation
-  implemented; query adapter, real query/mutation/maintenance/cutover partition
-  evidence, and production partition lifecycle not yet implemented
+  admission, snapshot/query capture, evidence assembly, and evidence validation
+  implemented; query adapter, real retained packet execution, mutation,
+  maintenance, and cutover evidence remain open, and production partition lifecycle
+  is not yet implemented
 
 ## Verification
 
@@ -217,6 +228,8 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo xtask module test index`
 - `cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture`
 - `cargo test -p rustok-benchmarks partition_snapshot`
+- `cargo check -p rustok-benchmarks --bin index-partition-query-evidence`
+- `cargo test -p rustok-benchmarks partition_query`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
 - `node --test scripts/verify/index-partition-evidence-assembly.test.mjs`
@@ -224,6 +237,7 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `node scripts/verify/verify-index-partition-admission.mjs`
 - `node scripts/verify/verify-index-partition-evidence.mjs`
 - `node scripts/verify/verify-index-partition-snapshot-capture.mjs`
+- `node scripts/verify/verify-index-partition-query-evidence.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -68,23 +68,24 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 partition evidence packet tooling: `complete`
 - M3 partition evidence capture/assembly: `complete`
 - M3 partition baseline/shadow snapshot runner: `complete`
+- M3 partition query evidence runner: `complete`
 - Production persistence: mutation writes, schema coordination, secondary-index
-  lifecycle, fail-closed partition admission, snapshot capture, evidence assembly,
-  and evidence validation implemented; the real query/mutation/maintenance/cutover
-  partition evidence, query adapter, and production partition lifecycle are not yet
-  implemented
+  lifecycle, fail-closed partition admission, snapshot/query capture, evidence
+  assembly, and evidence validation implemented; real retained execution,
+  mutation/maintenance/cutover evidence, query adapter, and production partition
+  lifecycle are not yet implemented
 
 The active production crate contains the generic domain/application core, the M3
 production migrations, an Index-owned transactional mutation adapter, a durable
 schema-application lease store, a schema-derived secondary-index manager, and a
 measured partition-admission contract that emits shadow bootstrap plans only. The
 repository also contains immutable partition-manifest preparation, owner-operated
-baseline/shadow snapshot capture, exact-byte raw artifact assembly, and measured
-packet validation tooling. Query adapters, retained query/mutation/maintenance/
-cutover partition evidence, production copy/constraint/index attachment,
-replay/cutover, batch ingestion, and PostgreSQL Testcontainers evidence remain
-open. Benchmark DDL and generated evidence stay under `ops/benches`, outside the
-production module.
+baseline/shadow snapshot and query capture, exact-byte raw artifact assembly, and
+measured packet validation tooling. Query adapters, retained real packet execution,
+mutation/maintenance/cutover partition evidence, production copy/constraint/index
+attachment, replay/cutover, batch ingestion, and PostgreSQL Testcontainers evidence
+remain open. Benchmark DDL and generated evidence stay under `ops/benches`, outside
+the production module.
 
 ## Ownership
 
@@ -138,6 +139,7 @@ ops/benches/src/index_storage/
   mutation_runner.rs
   maintenance_runner.rs
   partition_snapshot.rs
+  partition_query.rs
   sql/
 ```
 
@@ -250,7 +252,10 @@ unpartitioned until a separate shadow packet passes admission.
 - [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
       no-clobber packet publication.
 - [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
-- [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
+- [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
+- [ ] Execute and retain PostgreSQL baseline/shadow and query evidence with the
+      owner-operated runners.
+- [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.
 - [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
       rollback, and durable global operation ownership.
 - [ ] Add PostgreSQL Testcontainers fixtures.
@@ -329,8 +334,19 @@ source-version unique index and validated source foreign key protect link parity
 The runner records baseline/shadow rows, physical bytes, logical SHA-256 digests,
 child sizes, orphan state, FK state, and post-copy catch-up, then publishes
 `baseline.json` and `shadow.json` together without overwriting retained evidence.
-It does not execute query, mutation, maintenance, or cutover measurements and never
-renames, drops, or alters the canonical production relations.
+It never renames, drops, or alters canonical production relations.
+
+The ninth M3 slice adds owner-operated baseline/shadow query evidence. It validates
+the immutable manifest and evidence-bound shadow catalog, requires PostgreSQL 16,
+JIT off, partition pruning on, and ordinary unpartitioned canonical tables, and
+executes exactly the manifest query run count in one read-only repeatable-read
+transaction. Deterministic tenant-scoped entity/link templates must preserve result
+digest parity. Alternating samples retain full JSON EXPLAIN evidence, calculate
+nearest-rank p95, normalize logical plan identity with
+`normalized_partition_plan_v1`, and prove exactly one child is read for each used
+shadow relation. The runner publishes `query.json` once and performs no production
+mutation, replay, rename, drop, or cutover work. Real database execution remains an
+owner step.
 
 ### M4 - Query engine v1
 
@@ -421,6 +437,8 @@ node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
 cargo test -p rustok-benchmarks partition_snapshot
+cargo check -p rustok-benchmarks --bin index-partition-query-evidence
+cargo test -p rustok-benchmarks partition_query
 ```
 
 Targeted M3 maintainer checks:
@@ -435,6 +453,7 @@ node scripts/verify/verify-index-secondary-index-lifecycle.mjs
 node scripts/verify/verify-index-partition-admission.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
 node scripts/verify/verify-index-partition-snapshot-capture.mjs
+node scripts/verify/verify-index-partition-query-evidence.mjs
 ```
 
 ## Progress log
@@ -460,5 +479,9 @@ node scripts/verify/verify-index-partition-snapshot-capture.mjs
   routing.
 - 2026-07-27: added owner-operated PostgreSQL baseline/shadow snapshot capture,
   repeatable-read copy, shadow integrity validation, logical SHA-256 parity, child
-  size evidence, no-clobber pair publication, and static/CI guards. Repository
-  tests, verifiers, and real PostgreSQL evidence remain for the owner to execute.
+  size evidence, no-clobber pair publication, and static/CI guards.
+- 2026-07-27: added owner-operated baseline/shadow query evidence capture, exact
+  result parity, alternating full JSON EXPLAIN samples, p95 measurement, normalized
+  logical plan digests, exact child-pruning proof, no-clobber `query.json`
+  publication, and static/CI guards. Repository tests, verifiers, and real
+  PostgreSQL evidence remain for the owner to execute.

--- a/crates/rustok-index/docs/partition-evidence-runbook.md
+++ b/crates/rustok-index/docs/partition-evidence-runbook.md
@@ -7,32 +7,32 @@ relations remain unpartitioned unless one retained packet validates to `admitted
 
 ## Tooling boundary
 
-The evidence flow has four explicit boundaries:
+The evidence flow has five explicit boundaries:
 
 1. `partition-prepare` binds an immutable run manifest to one SHA-256
    `evidence_id` and emits deterministic shadow-only bootstrap SQL.
 2. `index-partition-snapshot-capture` captures one repeatable-read baseline, creates
    the evidence-ID-bound shadow tables, copies the same snapshot, validates source
    integrity, and publishes `baseline.json` plus `shadow.json`.
-3. The owner executes the remaining query, mutation, maintenance, and cutover
-   rehearsal measurements. `partition-assemble` reads all six exact raw files,
-   calculates their exact-byte SHA-256 identities, and publishes one structurally
-   validated packet.
-4. `partition-validate` recalculates admission metrics and atomically publishes
+3. `index-partition-query-evidence` compares canonical and shadow query behavior in
+   one read-only repeatable-read transaction and publishes `query.json`.
+4. The owner executes mutation, maintenance, and cutover rehearsal measurements.
+   `partition-assemble` reads all six exact raw files, calculates their exact-byte
+   SHA-256 identities, and publishes one structurally validated packet.
+5. `partition-validate` recalculates admission metrics and atomically publishes
    `admission.json`.
 
-The preparer, snapshot runner, and assembler refuse to overwrite retained outputs.
-The validator removes stale admission output before validation and writes a new file
-only after the complete packet is accepted structurally.
+The preparer, snapshot runner, query runner, and assembler refuse to overwrite
+retained outputs. The validator removes stale admission output before validation
+and writes a new file only after the complete packet is accepted structurally.
 
 None of these tools renames or drops production relations, performs production
 cutover, or starts runtime replay or dual-write. The snapshot runner creates and
-fills only deterministic shadow relations and adds a shadow-only source-version
-unique index and validated source foreign key.
+fills only deterministic shadow relations. The query runner is read-only.
 
 ## Prepare an immutable run
 
-Create a configuration file such as `evidence/index-partition/config.json`:
+Create `evidence/index-partition/config.json`:
 
 ```json
 {
@@ -65,11 +65,8 @@ Create a configuration file such as `evidence/index-partition/config.json`:
 ```
 
 Use an immutable reviewed commit. `run_key` identifies exactly one run attempt and
-must not be reused for a rerun. Modulus must be a power of two from 2 through 128.
-PostgreSQL image is pinned to `postgres:16`. Repetition counts are exact and must
-all be positive.
-
-Prepare the manifest and bootstrap SQL:
+must not be reused. Modulus must be a power of two from 2 through 128. PostgreSQL
+image is pinned to `postgres:16`. Repetition counts are exact and positive.
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-prepare \
@@ -78,25 +75,15 @@ node scripts/verify/index-storage-tooling.mjs partition-prepare \
   --bootstrap evidence/index-partition/bootstrap.sql
 ```
 
-`evidence_id` is the SHA-256 digest of canonical manifest input, including the
-commit and unique run key. Shadow relation names use the same
-`tenant_hash_shadow_v1` definition contract as `PartitionShadowPlan`: the
-definition hash binds evidence identity, strategy, and modulus, and the first 24
-hexadecimal characters form the relation suffix.
-
-Review `bootstrap.sql` before execution. It may contain only:
-
-- `CREATE TABLE ... LIKE index_entities ... PARTITION BY HASH (tenant_id)`;
-- `CREATE TABLE ... LIKE index_links ... PARTITION BY HASH (tenant_id)`;
-- child `PARTITION OF` statements for every remainder;
-- owner comments bound to the evidence identity.
-
-It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`, copy,
-replay, dual-write, or cutover statements.
+`evidence_id` is the SHA-256 digest of canonical manifest input. Shadow relation
+names use `tenant_hash_shadow_v1`; the definition hash binds evidence identity,
+strategy, and modulus. Review `bootstrap.sql`. It may contain only shadow parent,
+child, and owner-comment statements. Production `ALTER`, `DROP`, `RENAME`, copy,
+replay, dual-write, and cutover statements are forbidden.
 
 ## Audit tenant-scoped query coverage
 
-Create a reviewed `query-audit.json` beside the manifest:
+Create reviewed `query-audit.json` beside the manifest:
 
 ```json
 {
@@ -106,15 +93,15 @@ Create a reviewed `query-audit.json` beside the manifest:
 }
 ```
 
-The counts describe the exact query-template set that will later produce
-`query.json`. The snapshot runner records these values in `baseline.json`; the
-admission validator calculates coverage and requires exactly 10,000 basis points.
-The runner does not silently assume full coverage.
+The snapshot runner records these values in `baseline.json`; the admission validator
+calculates tenant-predicate coverage and requires exactly 10,000 basis points. The
+query evidence runner independently requires a tenant identity in every generated
+measurement query.
 
 ## Capture the baseline and shadow snapshot
 
-Run the snapshot binary against an owner-approved PostgreSQL 16 evidence database
-that already contains the canonical Index migrations and representative data:
+Run against an owner-approved PostgreSQL 16 evidence database that already contains
+the canonical Index migrations and representative data:
 
 ```bash
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
@@ -128,44 +115,84 @@ cargo run -p rustok-benchmarks --bin index-partition-snapshot-capture --release
 The explicit copy opt-in is mandatory. The runner:
 
 - requires PostgreSQL 16 and pins JIT off;
-- rejects a canonical entity or link table that is already partitioned;
-- verifies the deterministic manifest shadow names and serializes one evidence ID
-  through a PostgreSQL advisory lock;
-- creates only the tenant-hash shadow parents and children;
+- rejects canonical entity or link tables that are already partitioned;
+- validates deterministic shadow names and serializes one evidence ID with an
+  advisory lock;
+- creates only tenant-hash shadow parents and children;
 - reads baseline cardinality and logical digests and copies both canonical relations
   from the same repeatable-read snapshot;
 - creates a shadow-only unique source-version index and validated source foreign key;
-- records exact row counts, physical bytes, one positive byte size per child,
-  SHA-256 logical digests, orphan count, FK state, and post-copy catch-up state;
+- records rows, bytes, child sizes, SHA-256 logical digests, orphan count, FK state,
+  and post-copy catch-up state;
 - publishes `baseline.json` and `shadow.json` together with no-clobber semantics.
 
-The relation digest contract hashes an ordered sequence of per-row PostgreSQL JSON
-identities and then binds relation kind and row count to
-`index_partition_relation_digest_v1`. It is intended for baseline/shadow parity,
-not as a replacement for the retained raw rows or database backup.
+The snapshot runner leaves evidence-ID-bound shadow tables in place. A failed
+attempt may leave partial state for inspection; use a new manifest and run key
+rather than editing or overwriting evidence.
 
-The runner intentionally leaves its evidence-ID-bound shadow tables in place.
-Query, mutation, maintenance, and cutover artifacts remain separate owner-run
-measurements. A failed attempt may leave partial shadow state for inspection; use a
-new manifest and run key rather than editing or overwriting the failed evidence.
+## Capture baseline/shadow query evidence
 
-## Capture all retained raw artifacts
+After the matching snapshot succeeds, run:
 
-The complete bundle contains six raw JSON artifacts. They are regular files, never
-symbolic links:
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_QUERY_EVIDENCE=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+INDEX_PARTITION_QUERY_SAMPLES=7 \
+cargo run -p rustok-benchmarks --bin index-partition-query-evidence --release
+```
+
+The explicit query opt-in is mandatory. The runner validates:
+
+- the complete canonical manifest identity and deterministic shadow plan;
+- PostgreSQL 16, JIT off, and `enable_partition_pruning=on`;
+- ordinary unpartitioned canonical relations;
+- manifest-bound shadow parent comments, child names, and partition bounds.
+
+It then executes exactly `manifest.repetitions.query` unique tenant-scoped runs in
+one read-only repeatable-read transaction. The deterministic template set covers
+entity scope pages, keyset pages, exact counts, link scope pages, and source/link
+joins when link rows exist. Each run:
+
+- calculates baseline and shadow result rows and SHA-256 result digest parity;
+- alternates baseline/shadow execution order across samples;
+- retains full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` inputs;
+- calculates nearest-rank baseline and shadow p95 latency;
+- calculates `normalized_partition_plan_v1` SHA-256 plan identities;
+- rejects unstable normalized plans or relation reads across samples;
+- rejects baseline access to shadow relations and shadow access to canonical tables;
+- requires a shadow plan to prune to exactly one entity or link child partition for
+  every logical relation used by the query.
+
+The plan normalizer excludes runtime timing, buffers/WAL counters, costs, row
+estimates, physical relation/index names, and partition suffixes. It retains the
+logical template, tenant predicate contract, predicates, ordering, join type and
+algorithm, aggregate/sort/limit structure, and collapsed partition scan shape.
+Physical partition fan-out therefore cannot be hidden, while expected
+unpartitioned-versus-single-child scan differences do not create false plan drift.
+
+The runner publishes a top-level JSON array to `query.json` using temporary-file and
+hard-link no-clobber semantics. Besides the packet-required fields (`name`, p95
+latencies, and plan digests), each run retains result parity, relation-read identity,
+and every raw EXPLAIN sample for review. It performs no mutation or cutover work.
+
+## Capture the remaining raw artifacts
+
+The complete bundle contains six regular, non-symlink JSON files:
 
 - `baseline.json` — produced by the snapshot runner;
 - `shadow.json` — produced by the snapshot runner;
-- `query.json` — an array of baseline/shadow query p95 and normalized plan digests;
-- `mutation.json` — an array of mutation p95 and WAL measurements;
-- `maintenance.json` — an array of ordinary VACUUM/dead-tuple measurements;
-- `cutover.json` — an array of lock rehearsals and rollback/invariance facts.
+- `query.json` — produced by the query evidence runner;
+- `mutation.json` — mutation p95 and WAL measurements;
+- `maintenance.json` — ordinary VACUUM/dead-tuple measurements;
+- `cutover.json` — lock rehearsals and rollback/invariance facts.
 
-The artifact producer must write final files once. Do not edit measurements after
-the run. A formatting-only byte change intentionally creates a different raw
-artifact digest even when parsed JSON values are equal.
+The owner still executes mutation, maintenance, and cutover rehearsal evidence.
+Final files are written once and never edited after measurement. A formatting-only
+byte change intentionally changes the raw artifact digest.
 
-Create `capture.json` beside those six artifacts:
+Create `capture.json` beside the six artifacts:
 
 ```json
 {
@@ -197,15 +224,11 @@ Create `capture.json` beside those six artifacts:
 }
 ```
 
-Artifact paths are relative to `capture.json` and must remain inside the canonical
-bundle. Paths and underlying file identities must be unique: absolute paths, `..`
-traversal, duplicate roles, directories, symbolic links, and hard-link aliases fail
-closed. The manifest, capture descriptor, raw artifacts, and output packet must not
-alias each other.
+Artifact paths are relative to `capture.json` and remain inside the canonical
+bundle. Absolute paths, traversal, duplicates, directories, symbolic links, hard
+link aliases, and input/output aliases fail closed.
 
 ## Assemble the measured packet
-
-Run:
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-assemble \
@@ -214,88 +237,44 @@ node scripts/verify/index-storage-tooling.mjs partition-assemble \
   --output evidence/index-partition/partition-packet.json
 ```
 
-The assembler reads every raw artifact exactly once, hashes its exact bytes, parses
-the required object or array shape, constructs contract
-`index_partition_evidence_packet_v1`, and runs the canonical structural validator.
-It refuses to overwrite an existing packet and does not accept precomputed raw
-hashes, packet fields, admission reasons, or pass/fail flags from `capture.json`.
-
-The packet records:
-
-- runner repository, commit, run key, job, operating system, and architecture;
-- PostgreSQL system identifier and database name, so all sections remain bound to
-  one database instance;
-- SHA-256 digests for the retained raw baseline, shadow, query, mutation,
-  maintenance, and cutover artifacts;
-- parsed baseline, shadow, query, mutation, maintenance, and cutover evidence.
-
-The repository, commit, and run key in runner provenance must exactly match the
-manifest. Raw-artifact roles are exact; missing or additional roles fail
-validation.
+The assembler reads each raw artifact exactly once, hashes its exact bytes, parses
+the required shape, constructs `index_partition_evidence_packet_v1`, and runs the
+canonical structural validator. It refuses overwrite and does not accept caller
+supplied hashes, packet fields, admission reasons, or pass/fail flags.
 
 ## Required measured evidence
 
-### Baseline
+### Baseline and shadow
 
-The unpartitioned baseline records:
-
-- generation timestamp;
-- distinct tenant count;
-- audited query-template count and tenant-scoped template count;
-- exact entity rows, bytes, and SHA-256 logical digest;
-- exact link rows, bytes, and SHA-256 logical digest.
-
-Tenant-predicate coverage is calculated by the validator. Admission requires
-exactly 10,000 basis points.
-
-### Shadow
-
-The shadow section records:
-
-- generation timestamp and caught-up state;
-- validated foreign-key state and orphan-link count;
-- exact entity/link rows, bytes, and logical digests;
-- one positive byte size for every entity partition;
-- one positive byte size for every link partition.
-
-Partition-size skew is calculated from the largest child divided by the mean child
-size. The packet cannot supply a precomputed pass/fail value. Timestamps must
-satisfy baseline generation before shadow generation before packet completion.
+Baseline records timestamps, distinct tenants, audited query coverage, and exact
+entity/link rows, bytes, and logical digests. Shadow records timestamps, catch-up,
+validated FK state, orphan count, logical parity, and one positive size per child.
+Partition skew and all admission decisions are calculated later.
 
 ### Query measurements
 
-Each query run records a unique name, baseline and shadow p95 latency, and SHA-256
-plan digests. Both digests follow `normalized_partition_plan_v1` and must be
-produced by the same reviewed logical plan normalization. Runtime timing,
-buffer/WAL counters, and physical relation, alias, and index names are excluded;
-operator, join, predicate, ordering, grouping, and partition-pruning semantics are
-retained. Raw baseline and shadow
-`EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` artifacts remain mandatory retained
-inputs for reviewer verification. The validator calculates maximum non-negative
-latency regression and counts normalized plan-digest changes.
+Each unique query run records baseline/shadow p95 and SHA-256 plan digests. Both use
+`normalized_partition_plan_v1`. Raw EXPLAIN samples, result digest parity, and exact
+child relation reads remain retained reviewer evidence. The validator calculates
+maximum non-negative latency regression and counts plan digest changes.
 
 ### Mutation and WAL measurements
 
-Each mutation run records a unique name, baseline and shadow p95 latency, and
-baseline/shadow WAL bytes. The validator calculates maximum latency regression and
-maximum WAL amplification.
+Each run records baseline/shadow p95 and WAL bytes. The validator calculates maximum
+latency regression and WAL amplification.
 
 ### Maintenance measurements
 
-Each maintenance run records baseline/shadow ordinary VACUUM duration and dead
-tuple counts. `VACUUM FULL` is not valid evidence and production health must not
-depend on exclusive rewrites.
+Each run records baseline/shadow ordinary VACUUM duration and dead tuples.
+`VACUUM FULL` is invalid evidence.
 
 ### Cutover rehearsals
 
-Each rehearsal records measured lock duration plus two independent facts: rollback
-was verified and production relations remained unchanged. This evidence is a
-rehearsal boundary only; the implementation still contains no production cutover
-operation.
+Each rehearsal records lock duration, rollback verification, and confirmation that
+production relations remained unchanged. This is evidence only; production cutover
+is not implemented here.
 
 ## Validate and publish admission
-
-Run:
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-validate \
@@ -303,40 +282,25 @@ node scripts/verify/index-storage-tooling.mjs partition-validate \
   --output evidence/index-partition/admission.json
 ```
 
-The validator recomputes manifest identity and deterministic relation names,
-checks provenance, raw-artifact hashes, timestamp order, exact repetition counts,
-and calculates tenant coverage, latency regression, WAL amplification, partition
-skew, lock duration, cardinality/digest parity, and all typed rejection reasons.
-
-`admission.json` uses contract `index_partition_admission_v1` and contains both the
-manifest `evidence_id` and a SHA-256 `packet_digest` calculated from the complete
-canonical packet. It returns either:
-
-- `admitted` with an empty reasons list; or
-- `keep_unpartitioned` with calculated typed reasons.
-
-A structurally invalid or incomplete packet produces no admission output.
+The validator recomputes manifest identity, provenance, raw hashes, timestamp order,
+repetition counts, tenant coverage, digest parity, latency/WAL regression, partition
+skew, lock duration, rollback facts, and typed rejection reasons. It publishes
+`index_partition_admission_v1` with either `admitted` or `keep_unpartitioned`. A
+structurally invalid packet produces no admission output.
 
 ## Retention and review
 
 Retain together:
 
-- `config.json`;
-- `manifest.json`;
-- `bootstrap.sql`;
-- `query-audit.json`;
-- `capture.json`;
-- all six raw JSON artifacts and deeper PostgreSQL logs/EXPLAIN inputs from which
-  they were derived;
-- `partition-packet.json`;
-- `admission.json`;
+- `config.json`, `manifest.json`, `bootstrap.sql`, and `query-audit.json`;
+- all six raw JSON artifacts and their deeper PostgreSQL/EXPLAIN inputs;
+- `capture.json`, `partition-packet.json`, and `admission.json`;
 - PostgreSQL logs and runner metadata.
 
-Do not combine files from different commits, PostgreSQL instances, manifests, run
-keys, or run attempts. A validated packet is necessary but not sufficient for
-production partitioning. Reviewers must still approve durable global operation
-ownership, copy/checkpoint semantics, production constraint and index attachment,
-catch-up or replay, cutover, rollback, and failure recovery in later changes.
+Do not combine files from different commits, instances, manifests, run keys, or run
+attempts. Admission is necessary but not sufficient for production partitioning.
+Reviewers must separately approve durable ownership, bounded copy/checkpointing,
+constraint/index attachment, catch-up/replay, cutover, rollback, and recovery.
 
 ## Suggested repository checks
 
@@ -344,10 +308,13 @@ The repository owner runs:
 
 ```bash
 cargo test -p rustok-benchmarks partition_snapshot
+cargo test -p rustok-benchmarks partition_query
 cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
+cargo check -p rustok-benchmarks --bin index-partition-query-evidence
 node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
 node scripts/verify/verify-index-partition-snapshot-capture.mjs
+node scripts/verify/verify-index-partition-query-evidence.mjs
 node scripts/verify/index-storage-tooling.mjs contract
 ```

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -45,6 +45,10 @@ path = "src/bin/index_storage_maintenance_benchmark.rs"
 name = "index-partition-snapshot-capture"
 path = "src/bin/index_partition_snapshot_capture.rs"
 
+[[bin]]
+name = "index-partition-query-evidence"
+path = "src/bin/index_partition_query_evidence.rs"
+
 [[bench]]
 name = "tenant_cache"
 harness = false

--- a/ops/benches/README.md
+++ b/ops/benches/README.md
@@ -19,6 +19,8 @@ This is a standalone workspace crate named `rustok-benchmarks`.
   pre/post-VACUUM evidence runner.
 - `src/bin/index_partition_snapshot_capture.rs` — owner-operated M3 baseline/shadow
   snapshot runner for the canonical Index relations.
+- `src/bin/index_partition_query_evidence.rs` — owner-operated M3 baseline/shadow
+  query latency, result-parity, plan-normalization, and pruning evidence runner.
 
 ## Purpose
 
@@ -35,11 +37,13 @@ The M2 runners create only schemas prefixed with `idx_bench_`:
 Use a dedicated database because those schemas are dropped and recreated on every
 M2 run.
 
-The M3 partition snapshot runner is different. It reads the canonical
+The M3 partition runners are different. The snapshot runner reads the canonical
 `index_entities` and `index_links` tables, creates deterministic evidence-ID-bound
-shadow parents and children, and copies one repeatable-read snapshot into them. It
-does not rename, drop, or alter the canonical production relations. Run it only
-against an owner-approved PostgreSQL 16 evidence database.
+shadow parents and children, and copies one repeatable-read snapshot into them. The
+query runner then compares those canonical and shadow relations inside a read-only
+repeatable-read transaction. Neither runner renames, drops, or alters the canonical
+production relations. Run them only against an owner-approved PostgreSQL 16
+evidence database.
 
 ## Typical Criterion usage
 
@@ -123,6 +127,41 @@ The runner intentionally leaves its evidence-ID-bound shadow tables in place for
 later query, mutation, maintenance, and cutover-rehearsal measurements. A failed
 run may also leave partial shadow state for operator inspection; use a new manifest
 and run key rather than silently reusing or overwriting retained evidence.
+
+## Index partition query evidence
+
+Run this only after the matching snapshot runner has completed and left the
+manifest-bound shadow relations in place:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_QUERY_EVIDENCE=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+INDEX_PARTITION_QUERY_SAMPLES=7 \
+cargo run -p rustok-benchmarks --bin index-partition-query-evidence --release
+```
+
+The explicit query opt-in is mandatory. The runner validates the complete prepared
+manifest, PostgreSQL 16/JIT settings, canonical-table invariants, shadow comments,
+child names, and partition bounds before measurement. It builds exactly
+`manifest.repetitions.query` unique tenant-scoped runs from deterministic canonical
+entity/link anchors and executes every comparison inside one read-only
+repeatable-read transaction.
+
+For every run it verifies baseline/shadow result digest parity, alternates execution
+order, calculates nearest-rank p95 latency, retains full JSON
+`EXPLAIN (ANALYZE, BUFFERS, WAL)` samples, and produces
+`normalized_partition_plan_v1` SHA-256 digests. The normalizer removes physical
+relation/index names and runtime counters while retaining logical operators, join
+shape/type, predicates, ordering, and tenant-hash pruning semantics. Every shadow
+sample must read exactly one child partition for each used entity or link relation;
+canonical and unrelated relations fail closed.
+
+The completed top-level array is published once as `query.json` through temporary
+file plus hard-link no-clobber semantics. The runner performs no mutation,
+maintenance, replay, rename, drop, or cutover operation. It produces evidence only;
+the packet assembler and admission validator remain authoritative.
 
 Scale values for the M2 runners:
 

--- a/ops/benches/src/bin/index_partition_query_evidence.rs
+++ b/ops/benches/src/bin/index_partition_query_evidence.rs
@@ -1,0 +1,17 @@
+use rustok_benchmarks::index_storage::{
+    PartitionQueryConfig, capture_partition_query_evidence,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = PartitionQueryConfig::from_env()?;
+    let capture = capture_partition_query_evidence(&config).await?;
+    println!(
+        "index partition query evidence complete: evidence_id={} runs={} samples_per_run={} output={}",
+        capture.evidence_id,
+        capture.runs,
+        capture.samples_per_run,
+        capture.output_path.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -4,6 +4,7 @@ mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
+mod partition_query;
 mod partition_snapshot;
 mod report_provenance;
 mod runner;
@@ -17,6 +18,9 @@ pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
+pub use partition_query::{
+    PartitionQueryCapture, PartitionQueryConfig, capture_partition_query_evidence,
+};
 pub use partition_snapshot::{
     BaselineSnapshot, PartitionSnapshotCapture, PartitionSnapshotConfig, RelationEvidence,
     ShadowRelationEvidence, ShadowSnapshot, TenantPredicateAudit, capture_partition_snapshot,

--- a/ops/benches/src/index_storage/partition_query.rs
+++ b/ops/benches/src/index_storage/partition_query.rs
@@ -1,0 +1,1455 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    fs::{self, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value as SeaValue,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use sha2::{Digest, Sha256};
+
+use super::{
+    connect_benchmark_database, ensure_database_metadata_stable, read_database_metadata,
+};
+
+const MANIFEST_CONTRACT: &str = "index_partition_evidence_manifest_v1";
+const SHADOW_PLAN_VERSION: &str = "tenant_hash_shadow_v1";
+const PLAN_DIGEST_CONTRACT: &str = "normalized_partition_plan_v1";
+const QUERY_OPT_IN: &str = "INDEX_PARTITION_ALLOW_QUERY_EVIDENCE";
+const DEFAULT_QUERY_SAMPLES: usize = 7;
+const MAX_QUERY_SAMPLES: usize = 100;
+
+#[derive(Debug, Clone)]
+pub struct PartitionQueryConfig {
+    pub database_url: String,
+    pub manifest_path: PathBuf,
+    pub output_path: PathBuf,
+    pub samples: usize,
+}
+
+impl PartitionQueryConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(QUERY_OPT_IN).as_deref(), Ok("1")),
+            "{QUERY_OPT_IN}=1 is required because the runner executes measured PostgreSQL queries"
+        );
+        let database_url = env::var("DATABASE_URL")
+            .context("DATABASE_URL is required for index partition query evidence")?;
+        let manifest_path = env::var("INDEX_PARTITION_MANIFEST")
+            .map(PathBuf::from)
+            .context("INDEX_PARTITION_MANIFEST is required")?;
+        let output_path = env::var("INDEX_PARTITION_QUERY_OUTPUT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                env::var("INDEX_PARTITION_EVIDENCE_ROOT")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|_| PathBuf::from("target/index-partition-evidence"))
+                    .join("query.json")
+            });
+        let samples = env::var("INDEX_PARTITION_QUERY_SAMPLES")
+            .unwrap_or_else(|_| DEFAULT_QUERY_SAMPLES.to_string())
+            .parse::<usize>()
+            .context("INDEX_PARTITION_QUERY_SAMPLES must be an integer")?;
+        ensure!(
+            (3..=MAX_QUERY_SAMPLES).contains(&samples),
+            "INDEX_PARTITION_QUERY_SAMPLES must be between 3 and {MAX_QUERY_SAMPLES}"
+        );
+        ensure!(
+            manifest_path != output_path,
+            "manifest and query evidence output paths must be distinct"
+        );
+        Ok(Self {
+            database_url,
+            manifest_path,
+            output_path,
+            samples,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PreparedManifest {
+    contract: String,
+    repository: String,
+    commit: String,
+    run_key: String,
+    postgres_image: String,
+    strategy: String,
+    plan_digest_contract: String,
+    modulus: u32,
+    locales: Vec<String>,
+    repetitions: EvidenceRepetitions,
+    thresholds: JsonValue,
+    evidence_id: String,
+    shadow_plan_version: String,
+    shadow_relations: ShadowRelations,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct EvidenceRepetitions {
+    query: usize,
+    mutation: usize,
+    maintenance: usize,
+    cutover: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ShadowRelations {
+    definition_hash: String,
+    entities: RelationPlan,
+    links: RelationPlan,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelationPlan {
+    source: String,
+    parent: String,
+    partitions: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct EntityAnchor {
+    tenant_id: String,
+    module_name: String,
+    entity_name: String,
+    schema_version: i32,
+    entity_id: String,
+    locale_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct LinkAnchor {
+    tenant_id: String,
+    source_module: String,
+    source_entity: String,
+    source_schema_version: i32,
+    source_locale_key: String,
+    link_name: String,
+}
+
+#[derive(Debug, Clone)]
+struct QueryCase {
+    name: String,
+    template: &'static str,
+    baseline_sql: String,
+    shadow_sql: String,
+    values: Vec<SeaValue>,
+    logical_relations: Vec<&'static str>,
+    logical_predicates: Vec<&'static str>,
+    logical_ordering: Vec<&'static str>,
+    uses_entities: bool,
+    uses_links: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PlanRelationReads {
+    entities: Vec<String>,
+    links: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryExplainSample {
+    sample: usize,
+    execution_time_ms: f64,
+    plan_digest: String,
+    relation_reads: PlanRelationReads,
+    explain: JsonValue,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PartitionQueryRunEvidence {
+    name: String,
+    template: String,
+    sample_count: usize,
+    baseline_p95_ms: f64,
+    shadow_p95_ms: f64,
+    baseline_plan_digest: String,
+    shadow_plan_digest: String,
+    baseline_result_rows: i64,
+    shadow_result_rows: i64,
+    baseline_result_digest: String,
+    shadow_result_digest: String,
+    baseline_relation_reads: PlanRelationReads,
+    shadow_relation_reads: PlanRelationReads,
+    baseline_explain_samples: Vec<QueryExplainSample>,
+    shadow_explain_samples: Vec<QueryExplainSample>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionQueryCapture {
+    pub evidence_id: String,
+    pub output_path: PathBuf,
+    pub runs: usize,
+    pub samples_per_run: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum QuerySide {
+    Baseline,
+    Shadow,
+}
+
+pub async fn capture_partition_query_evidence(
+    config: &PartitionQueryConfig,
+) -> Result<PartitionQueryCapture> {
+    ensure_output_available(&config.output_path)?;
+    let (manifest, raw_manifest) = read_manifest(&config.manifest_path)?;
+    validate_manifest(&manifest, &raw_manifest)?;
+
+    let db = connect_benchmark_database(&config.database_url).await?;
+    db.execute_unprepared(
+        "SET jit = off; SET lock_timeout = '5s'; SET statement_timeout = 0; SET enable_partition_pruning = on;",
+    )
+    .await
+    .context("failed to pin partition query evidence session settings")?;
+    let database_metadata = read_database_metadata(&db).await?;
+    ensure!(
+        database_metadata.server_version_num.starts_with("16"),
+        "partition query evidence requires PostgreSQL 16, got {}",
+        database_metadata.server_version_num
+    );
+    ensure!(
+        database_metadata.jit == "off",
+        "partition query evidence requires jit=off"
+    );
+    ensure_session_setting(&db, "enable_partition_pruning", "on").await?;
+    ensure_unpartitioned_source(&db, "index_entities").await?;
+    ensure_unpartitioned_source(&db, "index_links").await?;
+    validate_shadow_catalog(&db, &manifest).await?;
+
+    acquire_query_lock(&db, &manifest.evidence_id).await?;
+    let capture_result = capture_locked_queries(&db, &manifest, config.samples).await;
+    let release_result = release_query_lock(&db, &manifest.evidence_id).await;
+    let runs = match capture_result {
+        Ok(runs) => {
+            release_result?;
+            runs
+        }
+        Err(error) => {
+            let _ = release_result;
+            return Err(error);
+        }
+    };
+
+    ensure_database_metadata_stable(&db, &database_metadata, "partition query evidence").await?;
+    publish_query_artifact(&config.output_path, &runs)?;
+    Ok(PartitionQueryCapture {
+        evidence_id: manifest.evidence_id,
+        output_path: config.output_path.clone(),
+        runs: runs.len(),
+        samples_per_run: config.samples,
+    })
+}
+
+async fn capture_locked_queries(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+    samples: usize,
+) -> Result<Vec<PartitionQueryRunEvidence>> {
+    let transaction = db
+        .begin()
+        .await
+        .context("failed to start partition query evidence transaction")?;
+    transaction
+        .execute_unprepared("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY;")
+        .await
+        .context("failed to pin read-only repeatable-read query evidence snapshot")?;
+
+    let entity_anchors = load_entity_anchors(&transaction, manifest.repetitions.query).await?;
+    ensure!(
+        !entity_anchors.is_empty(),
+        "partition query evidence requires at least one canonical entity row"
+    );
+    let link_anchors = load_link_anchors(&transaction, manifest.repetitions.query).await?;
+    let cases = build_query_cases(manifest, &entity_anchors, &link_anchors)?;
+    ensure!(
+        cases.len() == manifest.repetitions.query,
+        "partition query runner did not build the exact manifest query run count"
+    );
+
+    let mut runs = Vec::with_capacity(cases.len());
+    for case in &cases {
+        runs.push(capture_query_case(&transaction, manifest, case, samples).await?);
+    }
+    transaction
+        .commit()
+        .await
+        .context("failed to complete read-only partition query evidence transaction")?;
+    Ok(runs)
+}
+
+fn read_manifest(path: &Path) -> Result<(PreparedManifest, JsonValue)> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect partition manifest at {path:?}"))?;
+    ensure!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "partition manifest must be a regular non-symlink file"
+    );
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read partition manifest at {path:?}"))?;
+    let raw: JsonValue = serde_json::from_slice(&bytes)
+        .context("failed to parse partition manifest JSON")?;
+    let manifest = serde_json::from_value(raw.clone())
+        .context("failed to deserialize prepared partition manifest")?;
+    Ok((manifest, raw))
+}
+
+fn validate_manifest(manifest: &PreparedManifest, raw: &JsonValue) -> Result<()> {
+    ensure!(manifest.contract == MANIFEST_CONTRACT, "unexpected manifest contract");
+    ensure!(manifest.repository == "RusTokRs/RusTok", "unexpected manifest repository");
+    ensure!(is_lower_hex(&manifest.commit, 40), "manifest commit must be a lowercase full SHA-1");
+    ensure!(
+        !manifest.run_key.is_empty() && manifest.run_key.len() <= 128,
+        "manifest run_key must be non-empty and bounded"
+    );
+    ensure!(manifest.postgres_image == "postgres:16", "manifest must pin postgres:16");
+    ensure!(manifest.strategy == "tenant_hash", "manifest strategy must be tenant_hash");
+    ensure!(
+        manifest.plan_digest_contract == PLAN_DIGEST_CONTRACT,
+        "unexpected plan digest contract"
+    );
+    ensure!(
+        manifest.modulus >= 2
+            && manifest.modulus <= 128
+            && manifest.modulus.is_power_of_two(),
+        "manifest modulus must be a power of two between 2 and 128"
+    );
+    ensure!(
+        !manifest.locales.is_empty()
+            && manifest.locales.iter().all(|locale| !locale.is_empty())
+            && manifest.locales.iter().collect::<BTreeSet<_>>().len() == manifest.locales.len(),
+        "manifest locales must be unique and non-empty"
+    );
+    ensure!(
+        manifest.repetitions.query > 0
+            && manifest.repetitions.mutation > 0
+            && manifest.repetitions.maintenance > 0
+            && manifest.repetitions.cutover > 0,
+        "manifest repetition counts must all be positive"
+    );
+    ensure!(manifest.thresholds.is_object(), "manifest thresholds must be an object");
+    ensure!(is_lower_hex(&manifest.evidence_id, 64), "invalid manifest evidence_id");
+    ensure!(
+        manifest.shadow_plan_version == SHADOW_PLAN_VERSION,
+        "unexpected shadow plan version"
+    );
+
+    let mut input = raw
+        .as_object()
+        .cloned()
+        .context("prepared manifest must be a JSON object")?;
+    for key in ["evidence_id", "shadow_plan_version", "shadow_relations"] {
+        ensure!(input.remove(key).is_some(), "prepared manifest is missing {key}");
+    }
+    let expected_evidence_id = sha256_hex(&canonical_json_bytes(&JsonValue::Object(input))?);
+    ensure!(
+        expected_evidence_id == manifest.evidence_id,
+        "manifest evidence_id does not match canonical manifest input"
+    );
+
+    let modulus = manifest.modulus.to_string();
+    let definition = [
+        "rustok-index-partition",
+        SHADOW_PLAN_VERSION,
+        manifest.evidence_id.as_str(),
+        "tenant_hash",
+        modulus.as_str(),
+    ]
+    .join("\u{1f}");
+    let definition_hash = sha256_hex(definition.as_bytes());
+    ensure!(
+        manifest.shadow_relations.definition_hash == definition_hash,
+        "shadow definition hash does not match evidence identity"
+    );
+    let suffix = &definition_hash[..24];
+    validate_relation_plan(
+        &manifest.shadow_relations.entities,
+        "index_entities",
+        &format!("index_entities_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    validate_relation_plan(
+        &manifest.shadow_relations.links,
+        "index_links",
+        &format!("index_links_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    Ok(())
+}
+
+fn validate_relation_plan(
+    plan: &RelationPlan,
+    expected_source: &str,
+    expected_parent: &str,
+    modulus: u32,
+) -> Result<()> {
+    ensure!(plan.source == expected_source, "unexpected shadow source relation");
+    ensure!(plan.parent == expected_parent, "unexpected shadow parent relation");
+    validate_identifier(&plan.parent)?;
+    ensure!(
+        plan.partitions.len() == modulus as usize,
+        "shadow relation must contain exactly {modulus} child partitions"
+    );
+    for (remainder, partition) in plan.partitions.iter().enumerate() {
+        validate_identifier(partition)?;
+        ensure!(
+            partition == &format!("{expected_parent}_p{remainder:03}"),
+            "unexpected shadow child relation"
+        );
+    }
+    Ok(())
+}
+
+async fn ensure_session_setting(
+    db: &DatabaseConnection,
+    setting: &str,
+    expected: &str,
+) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT current_setting($1) AS value",
+            vec![setting.into()],
+        ))
+        .await?
+        .context("session-setting query returned no row")?;
+    let actual: String = row.try_get("", "value")?;
+    ensure!(actual == expected, "requires {setting}={expected}, got {actual}");
+    Ok(())
+}
+
+async fn ensure_unpartitioned_source(db: &DatabaseConnection, relation: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT c.relkind::text AS relkind, c.relispartition, ",
+                "EXISTS (SELECT 1 FROM pg_partitioned_table p WHERE p.partrelid = c.oid) AS partitioned ",
+                "FROM pg_class c WHERE c.oid = to_regclass($1)"
+            ),
+            vec![relation.into()],
+        ))
+        .await?
+        .with_context(|| format!("canonical relation {relation} was not found"))?;
+    let relkind: String = row.try_get("", "relkind")?;
+    let relispartition: bool = row.try_get("", "relispartition")?;
+    let partitioned: bool = row.try_get("", "partitioned")?;
+    ensure!(
+        relkind == "r" && !relispartition && !partitioned,
+        "canonical relation {relation} must remain an ordinary unpartitioned table"
+    );
+    Ok(())
+}
+
+async fn validate_shadow_catalog(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+) -> Result<()> {
+    validate_shadow_relation_catalog(db, manifest, &manifest.shadow_relations.entities).await?;
+    validate_shadow_relation_catalog(db, manifest, &manifest.shadow_relations.links).await?;
+    Ok(())
+}
+
+async fn validate_shadow_relation_catalog(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+    plan: &RelationPlan,
+) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT c.relkind::text AS relkind, obj_description(c.oid, 'pg_class') AS comment ",
+                "FROM pg_class c WHERE c.oid = to_regclass($1)"
+            ),
+            vec![plan.parent.clone().into()],
+        ))
+        .await?
+        .with_context(|| format!("shadow parent {} was not found", plan.parent))?;
+    let relkind: String = row.try_get("", "relkind")?;
+    let comment: Option<String> = row.try_get("", "comment")?;
+    let expected_comment = format!("rustok-index-partition:{}", manifest.evidence_id);
+    ensure!(relkind == "p", "shadow parent {} must be partitioned", plan.parent);
+    ensure!(
+        comment.as_deref() == Some(expected_comment.as_str()),
+        "shadow parent {} is not bound to the evidence identity",
+        plan.parent
+    );
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT child.relname, child.relispartition, ",
+                "pg_get_expr(child.relpartbound, child.oid) AS bound ",
+                "FROM pg_inherits inheritance ",
+                "JOIN pg_class child ON child.oid = inheritance.inhrelid ",
+                "WHERE inheritance.inhparent = to_regclass($1) ORDER BY child.relname"
+            ),
+            vec![plan.parent.clone().into()],
+        ))
+        .await?;
+    ensure!(
+        rows.len() == plan.partitions.len(),
+        "shadow parent {} has an unexpected child count",
+        plan.parent
+    );
+    let mut children = BTreeMap::new();
+    for row in rows {
+        let name: String = row.try_get("", "relname")?;
+        let relispartition: bool = row.try_get("", "relispartition")?;
+        let bound: String = row.try_get("", "bound")?;
+        ensure!(relispartition, "shadow child {name} is not a partition");
+        children.insert(name, bound.to_ascii_lowercase());
+    }
+    for (remainder, partition) in plan.partitions.iter().enumerate() {
+        let bound = children
+            .get(partition)
+            .with_context(|| format!("shadow child {partition} is missing"))?;
+        ensure!(
+            bound.contains(&format!("modulus {}", manifest.modulus))
+                && bound.contains(&format!("remainder {remainder}")),
+            "shadow child {partition} has an unexpected bound: {bound}"
+        );
+    }
+    Ok(())
+}
+
+async fn acquire_query_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    db.query_one(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+        vec![format!("rustok-index-partition-query:{evidence_id}").into()],
+    ))
+    .await?
+    .context("query advisory lock returned no row")?;
+    Ok(())
+}
+
+async fn release_query_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT pg_advisory_unlock(hashtextextended($1, 0)) AS unlocked",
+            vec![format!("rustok-index-partition-query:{evidence_id}").into()],
+        ))
+        .await?
+        .context("query advisory unlock returned no row")?;
+    let unlocked: bool = row.try_get("", "unlocked")?;
+    ensure!(unlocked, "query advisory lock was not held");
+    Ok(())
+}
+
+async fn load_entity_anchors<C: ConnectionTrait>(
+    db: &C,
+    requested: usize,
+) -> Result<Vec<EntityAnchor>> {
+    let limit = i64::try_from(requested.max(1)).context("query run count exceeds i64")?;
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT tenant_id::text AS tenant_id, module_name, entity_name, schema_version, ",
+                "entity_id::text AS entity_id, locale_key FROM index_entities ",
+                "ORDER BY tenant_id, module_name, entity_name, schema_version, locale_key, entity_id LIMIT $1"
+            ),
+            vec![limit.into()],
+        ))
+        .await
+        .context("failed to load entity query anchors")?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(EntityAnchor {
+                tenant_id: row.try_get("", "tenant_id")?,
+                module_name: row.try_get("", "module_name")?,
+                entity_name: row.try_get("", "entity_name")?,
+                schema_version: row.try_get("", "schema_version")?,
+                entity_id: row.try_get("", "entity_id")?,
+                locale_key: row.try_get("", "locale_key")?,
+            })
+        })
+        .collect()
+}
+
+async fn load_link_anchors<C: ConnectionTrait>(
+    db: &C,
+    requested: usize,
+) -> Result<Vec<LinkAnchor>> {
+    let limit = i64::try_from(requested.max(1)).context("query run count exceeds i64")?;
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT tenant_id::text AS tenant_id, source_module, source_entity, ",
+                "source_schema_version, source_locale_key, link_name FROM index_links ",
+                "ORDER BY tenant_id, source_module, source_entity, source_schema_version, ",
+                "source_locale_key, link_name, source_entity_id, source_version, ordinal LIMIT $1"
+            ),
+            vec![limit.into()],
+        ))
+        .await
+        .context("failed to load link query anchors")?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(LinkAnchor {
+                tenant_id: row.try_get("", "tenant_id")?,
+                source_module: row.try_get("", "source_module")?,
+                source_entity: row.try_get("", "source_entity")?,
+                source_schema_version: row.try_get("", "source_schema_version")?,
+                source_locale_key: row.try_get("", "source_locale_key")?,
+                link_name: row.try_get("", "link_name")?,
+            })
+        })
+        .collect()
+}
+
+fn build_query_cases(
+    manifest: &PreparedManifest,
+    entities: &[EntityAnchor],
+    links: &[LinkAnchor],
+) -> Result<Vec<QueryCase>> {
+    ensure!(!entities.is_empty(), "entity query anchors must not be empty");
+    let template_count = if links.is_empty() { 3 } else { 5 };
+    let mut cases = Vec::with_capacity(manifest.repetitions.query);
+    for index in 0..manifest.repetitions.query {
+        let ordinal = index + 1;
+        let case = match index % template_count {
+            0 => entity_scope_case(
+                ordinal,
+                &entities[index % entities.len()],
+                &manifest.shadow_relations.entities.parent,
+            ),
+            1 => entity_keyset_case(
+                ordinal,
+                &entities[index % entities.len()],
+                &manifest.shadow_relations.entities.parent,
+            ),
+            2 => entity_count_case(
+                ordinal,
+                &entities[index % entities.len()],
+                &manifest.shadow_relations.entities.parent,
+            ),
+            3 => link_scope_case(
+                ordinal,
+                &links[index % links.len()],
+                &manifest.shadow_relations.links.parent,
+            ),
+            4 => source_link_join_case(
+                ordinal,
+                &links[index % links.len()],
+                &manifest.shadow_relations.entities.parent,
+                &manifest.shadow_relations.links.parent,
+            ),
+            _ => unreachable!("query template sequence is bounded"),
+        };
+        cases.push(case);
+    }
+    Ok(cases)
+}
+
+fn entity_scope_case(ordinal: usize, anchor: &EntityAnchor, shadow: &str) -> QueryCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "SELECT e.entity_id::text AS entity_id, e.source_version::text AS source_version, ",
+                "e.payload, e.is_deleted FROM {} e WHERE e.tenant_id = $1::uuid ",
+                "AND e.module_name = $2 AND e.entity_name = $3 AND e.schema_version = $4::integer ",
+                "AND e.locale_key = $5 ORDER BY e.entity_id LIMIT 100"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    QueryCase {
+        name: format!("entity-scope-page-{ordinal:03}"),
+        template: "entity_scope_page_v1",
+        baseline_sql: render("index_entities"),
+        shadow_sql: render(shadow),
+        values: entity_scope_values(anchor),
+        logical_relations: vec!["entities"],
+        logical_predicates: vec![
+            "tenant_id = ?",
+            "module_name = ?",
+            "entity_name = ?",
+            "schema_version = ?",
+            "locale_key = ?",
+        ],
+        logical_ordering: vec!["entity_id ASC"],
+        uses_entities: true,
+        uses_links: false,
+    }
+}
+
+fn entity_keyset_case(ordinal: usize, anchor: &EntityAnchor, shadow: &str) -> QueryCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "SELECT e.entity_id::text AS entity_id, e.source_version::text AS source_version, ",
+                "e.payload, e.is_deleted FROM {} e WHERE e.tenant_id = $1::uuid ",
+                "AND e.module_name = $2 AND e.entity_name = $3 AND e.schema_version = $4::integer ",
+                "AND e.locale_key = $5 AND e.entity_id >= $6::uuid ",
+                "ORDER BY e.entity_id LIMIT 100"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    let mut values = entity_scope_values(anchor);
+    values.push(anchor.entity_id.clone().into());
+    QueryCase {
+        name: format!("entity-keyset-page-{ordinal:03}"),
+        template: "entity_keyset_page_v1",
+        baseline_sql: render("index_entities"),
+        shadow_sql: render(shadow),
+        values,
+        logical_relations: vec!["entities"],
+        logical_predicates: vec![
+            "tenant_id = ?",
+            "module_name = ?",
+            "entity_name = ?",
+            "schema_version = ?",
+            "locale_key = ?",
+            "entity_id >= ?",
+        ],
+        logical_ordering: vec!["entity_id ASC"],
+        uses_entities: true,
+        uses_links: false,
+    }
+}
+
+fn entity_count_case(ordinal: usize, anchor: &EntityAnchor, shadow: &str) -> QueryCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "SELECT count(*)::bigint AS result_count FROM {} e ",
+                "WHERE e.tenant_id = $1::uuid AND e.module_name = $2 AND e.entity_name = $3 ",
+                "AND e.schema_version = $4::integer AND e.locale_key = $5"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    QueryCase {
+        name: format!("entity-exact-count-{ordinal:03}"),
+        template: "entity_exact_count_v1",
+        baseline_sql: render("index_entities"),
+        shadow_sql: render(shadow),
+        values: entity_scope_values(anchor),
+        logical_relations: vec!["entities"],
+        logical_predicates: vec![
+            "tenant_id = ?",
+            "module_name = ?",
+            "entity_name = ?",
+            "schema_version = ?",
+            "locale_key = ?",
+        ],
+        logical_ordering: vec![],
+        uses_entities: true,
+        uses_links: false,
+    }
+}
+
+fn link_scope_case(ordinal: usize, anchor: &LinkAnchor, shadow: &str) -> QueryCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "SELECT l.source_entity_id::text AS source_entity_id, ",
+                "l.source_version::text AS source_version, l.link_name, l.ordinal, ",
+                "l.target_module, l.target_entity, l.target_schema_version, ",
+                "l.target_entity_id::text AS target_entity_id, l.target_locale_key ",
+                "FROM {} l WHERE l.tenant_id = $1::uuid AND l.source_module = $2 ",
+                "AND l.source_entity = $3 AND l.source_schema_version = $4::integer ",
+                "AND l.source_locale_key = $5 AND l.link_name = $6 ",
+                "ORDER BY l.source_entity_id, l.source_version, l.ordinal LIMIT 100"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    QueryCase {
+        name: format!("link-scope-page-{ordinal:03}"),
+        template: "link_scope_page_v1",
+        baseline_sql: render("index_links"),
+        shadow_sql: render(shadow),
+        values: link_scope_values(anchor),
+        logical_relations: vec!["links"],
+        logical_predicates: vec![
+            "tenant_id = ?",
+            "source_module = ?",
+            "source_entity = ?",
+            "source_schema_version = ?",
+            "source_locale_key = ?",
+            "link_name = ?",
+        ],
+        logical_ordering: vec![
+            "source_entity_id ASC",
+            "source_version ASC",
+            "ordinal ASC",
+        ],
+        uses_entities: false,
+        uses_links: true,
+    }
+}
+
+fn source_link_join_case(
+    ordinal: usize,
+    anchor: &LinkAnchor,
+    entity_shadow: &str,
+    link_shadow: &str,
+) -> QueryCase {
+    let render = |entities: &str, links: &str| {
+        format!(
+            concat!(
+                "SELECT e.entity_id::text AS entity_id, e.source_version::text AS source_version, ",
+                "l.link_name, l.ordinal, l.target_module, l.target_entity, ",
+                "l.target_schema_version, l.target_entity_id::text AS target_entity_id, ",
+                "l.target_locale_key FROM {} e JOIN {} l ON l.tenant_id = e.tenant_id ",
+                "AND l.source_module = e.module_name AND l.source_entity = e.entity_name ",
+                "AND l.source_schema_version = e.schema_version AND l.source_entity_id = e.entity_id ",
+                "AND l.source_locale_key = e.locale_key AND l.source_version = e.source_version ",
+                "WHERE e.tenant_id = $1::uuid AND e.module_name = $2 AND e.entity_name = $3 ",
+                "AND e.schema_version = $4::integer AND e.locale_key = $5 AND l.link_name = $6 ",
+                "ORDER BY e.entity_id, l.source_version, l.ordinal LIMIT 100"
+            ),
+            quote_identifier(entities),
+            quote_identifier(links),
+        )
+    };
+    QueryCase {
+        name: format!("source-link-join-{ordinal:03}"),
+        template: "source_link_join_v1",
+        baseline_sql: render("index_entities", "index_links"),
+        shadow_sql: render(entity_shadow, link_shadow),
+        values: link_scope_values(anchor),
+        logical_relations: vec!["entities", "links"],
+        logical_predicates: vec![
+            "tenant_id = ?",
+            "module_name = source_module",
+            "entity_name = source_entity",
+            "schema_version = source_schema_version",
+            "entity_id = source_entity_id",
+            "locale_key = source_locale_key",
+            "source_version = link_source_version",
+            "link_name = ?",
+        ],
+        logical_ordering: vec!["entity_id ASC", "source_version ASC", "ordinal ASC"],
+        uses_entities: true,
+        uses_links: true,
+    }
+}
+
+fn entity_scope_values(anchor: &EntityAnchor) -> Vec<SeaValue> {
+    vec![
+        anchor.tenant_id.clone().into(),
+        anchor.module_name.clone().into(),
+        anchor.entity_name.clone().into(),
+        anchor.schema_version.into(),
+        anchor.locale_key.clone().into(),
+    ]
+}
+
+fn link_scope_values(anchor: &LinkAnchor) -> Vec<SeaValue> {
+    vec![
+        anchor.tenant_id.clone().into(),
+        anchor.source_module.clone().into(),
+        anchor.source_entity.clone().into(),
+        anchor.source_schema_version.into(),
+        anchor.source_locale_key.clone().into(),
+        anchor.link_name.clone().into(),
+    ]
+}
+
+async fn capture_query_case<C: ConnectionTrait>(
+    db: &C,
+    manifest: &PreparedManifest,
+    case: &QueryCase,
+    samples: usize,
+) -> Result<PartitionQueryRunEvidence> {
+    let (baseline_result_rows, baseline_result_digest) =
+        result_digest(db, &case.baseline_sql, &case.values).await?;
+    let (shadow_result_rows, shadow_result_digest) =
+        result_digest(db, &case.shadow_sql, &case.values).await?;
+    ensure!(
+        baseline_result_rows == shadow_result_rows
+            && baseline_result_digest == shadow_result_digest,
+        "query {} produced different baseline and shadow results",
+        case.name
+    );
+
+    let mut baseline_samples = Vec::with_capacity(samples);
+    let mut shadow_samples = Vec::with_capacity(samples);
+    for sample in 1..=samples {
+        if sample % 2 == 1 {
+            baseline_samples.push(
+                explain_sample(db, manifest, case, QuerySide::Baseline, sample).await?,
+            );
+            shadow_samples.push(
+                explain_sample(db, manifest, case, QuerySide::Shadow, sample).await?,
+            );
+        } else {
+            shadow_samples.push(
+                explain_sample(db, manifest, case, QuerySide::Shadow, sample).await?,
+            );
+            baseline_samples.push(
+                explain_sample(db, manifest, case, QuerySide::Baseline, sample).await?,
+            );
+        }
+    }
+
+    let baseline_plan_digest = stable_plan_digest(&baseline_samples, &case.name, "baseline")?;
+    let shadow_plan_digest = stable_plan_digest(&shadow_samples, &case.name, "shadow")?;
+    let baseline_relation_reads = stable_relation_reads(&baseline_samples, &case.name, "baseline")?;
+    let shadow_relation_reads = stable_relation_reads(&shadow_samples, &case.name, "shadow")?;
+    let baseline_p95_ms = percentile_95(
+        &baseline_samples
+            .iter()
+            .map(|sample| sample.execution_time_ms)
+            .collect::<Vec<_>>(),
+    )?;
+    let shadow_p95_ms = percentile_95(
+        &shadow_samples
+            .iter()
+            .map(|sample| sample.execution_time_ms)
+            .collect::<Vec<_>>(),
+    )?;
+
+    Ok(PartitionQueryRunEvidence {
+        name: case.name.clone(),
+        template: case.template.to_owned(),
+        sample_count: samples,
+        baseline_p95_ms,
+        shadow_p95_ms,
+        baseline_plan_digest,
+        shadow_plan_digest,
+        baseline_result_rows,
+        shadow_result_rows,
+        baseline_result_digest,
+        shadow_result_digest,
+        baseline_relation_reads,
+        shadow_relation_reads,
+        baseline_explain_samples: baseline_samples,
+        shadow_explain_samples: shadow_samples,
+    })
+}
+
+async fn result_digest<C: ConnectionTrait>(
+    db: &C,
+    sql: &str,
+    values: &[SeaValue],
+) -> Result<(i64, String)> {
+    let wrapped = format!(
+        "SELECT row_to_json(result)::text AS result_json FROM ({sql}) AS result"
+    );
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            wrapped,
+            values.to_vec(),
+        ))
+        .await
+        .context("partition query result digest statement failed")?;
+    let row_count = i64::try_from(rows.len()).context("query result row count exceeds i64")?;
+    let mut payload = Vec::new();
+    for row in rows {
+        let value: String = row
+            .try_get("", "result_json")
+            .context("query result digest row did not contain result_json")?;
+        payload.extend_from_slice(value.len().to_string().as_bytes());
+        payload.push(b':');
+        payload.extend_from_slice(value.as_bytes());
+    }
+    Ok((row_count, sha256_hex(&payload)))
+}
+
+async fn explain_sample<C: ConnectionTrait>(
+    db: &C,
+    manifest: &PreparedManifest,
+    case: &QueryCase,
+    side: QuerySide,
+    sample: usize,
+) -> Result<QueryExplainSample> {
+    let sql = match side {
+        QuerySide::Baseline => &case.baseline_sql,
+        QuerySide::Shadow => &case.shadow_sql,
+    };
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            format!("EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON) {sql}"),
+            case.values.clone(),
+        ))
+        .await
+        .with_context(|| format!("failed to execute EXPLAIN for query {}", case.name))?
+        .context("partition query EXPLAIN returned no row")?;
+    let explain: JsonValue = row
+        .try_get("", "QUERY PLAN")
+        .context("partition query EXPLAIN did not contain QUERY PLAN JSON")?;
+    Ok(QueryExplainSample {
+        sample,
+        execution_time_ms: explain_execution_time(&explain)?,
+        plan_digest: normalized_plan_digest(&explain, case)?,
+        relation_reads: validate_plan_relations(&explain, manifest, case, side)?,
+        explain,
+    })
+}
+
+fn explain_execution_time(explain: &JsonValue) -> Result<f64> {
+    let value = explain_root(explain)?
+        .get("Execution Time")
+        .and_then(JsonValue::as_f64)
+        .context("EXPLAIN is missing numeric Execution Time")?;
+    ensure!(
+        value.is_finite() && value >= 0.0,
+        "EXPLAIN Execution Time must be non-negative"
+    );
+    Ok(value)
+}
+
+fn normalized_plan_digest(explain: &JsonValue, case: &QueryCase) -> Result<String> {
+    let plan = explain_root(explain)?
+        .get("Plan")
+        .context("EXPLAIN is missing Plan")?;
+    let normalized = json!({
+        "contract": PLAN_DIGEST_CONTRACT,
+        "template": case.template,
+        "tenant_hash_pruning_key": "tenant_id",
+        "relations": &case.logical_relations,
+        "predicates": &case.logical_predicates,
+        "ordering": &case.logical_ordering,
+        "plan": normalize_plan_node(plan)?,
+    });
+    Ok(sha256_hex(&canonical_json_bytes(&normalized)?))
+}
+
+fn normalize_plan_node(value: &JsonValue) -> Result<JsonValue> {
+    let node = value.as_object().context("plan node must be an object")?;
+    let node_type = node
+        .get("Node Type")
+        .and_then(JsonValue::as_str)
+        .context("plan node is missing Node Type")?;
+    let children = node
+        .get("Plans")
+        .map(|plans| {
+            plans
+                .as_array()
+                .context("plan Plans must be an array")?
+                .iter()
+                .map(normalize_plan_node)
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    if node_type == "Subquery Scan" && children.len() == 1 {
+        return Ok(children.into_iter().next().expect("one child was checked"));
+    }
+    if is_scan_node(node_type) {
+        return Ok(json!({ "operator": "scan" }));
+    }
+    if node_type.ends_with("Append") {
+        let mut unique = BTreeMap::new();
+        for child in children {
+            let key = String::from_utf8(canonical_json_bytes(&child)?)
+                .context("canonical normalized plan was not UTF-8")?;
+            unique.insert(key, child);
+        }
+        let mut children = unique.into_values().collect::<Vec<_>>();
+        if children.len() == 1 {
+            return Ok(children.remove(0));
+        }
+        return Ok(json!({ "operator": "append", "children": children }));
+    }
+
+    let mut normalized = JsonMap::new();
+    normalized.insert(
+        "operator".to_owned(),
+        JsonValue::String(normalize_operator(node_type)),
+    );
+    for (source, target) in [
+        ("Join Type", "join_type"),
+        ("Strategy", "strategy"),
+        ("Partial Mode", "partial_mode"),
+    ] {
+        if let Some(value) = node.get(source).and_then(JsonValue::as_str) {
+            normalized.insert(target.to_owned(), JsonValue::String(value.to_ascii_lowercase()));
+        }
+    }
+    if !children.is_empty() {
+        normalized.insert("children".to_owned(), JsonValue::Array(children));
+    }
+    Ok(JsonValue::Object(normalized))
+}
+
+fn is_scan_node(node_type: &str) -> bool {
+    node_type.contains("Scan") || matches!(node_type, "BitmapAnd" | "BitmapOr")
+}
+
+fn normalize_operator(node_type: &str) -> String {
+    node_type
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn validate_plan_relations(
+    explain: &JsonValue,
+    manifest: &PreparedManifest,
+    case: &QueryCase,
+    side: QuerySide,
+) -> Result<PlanRelationReads> {
+    let mut names = BTreeSet::new();
+    collect_relation_names(explain, &mut names);
+    let entity_children = manifest
+        .shadow_relations
+        .entities
+        .partitions
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let link_children = manifest
+        .shadow_relations
+        .links
+        .partitions
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let all_shadow = entity_children
+        .union(&link_children)
+        .cloned()
+        .chain([
+            manifest.shadow_relations.entities.parent.clone(),
+            manifest.shadow_relations.links.parent.clone(),
+        ])
+        .collect::<BTreeSet<_>>();
+
+    match side {
+        QuerySide::Baseline => {
+            ensure!(
+                names.is_disjoint(&all_shadow),
+                "baseline query {} accessed a shadow relation",
+                case.name
+            );
+            ensure!(
+                !case.uses_entities || names.contains("index_entities"),
+                "baseline query {} did not access index_entities",
+                case.name
+            );
+            ensure!(
+                !case.uses_links || names.contains("index_links"),
+                "baseline query {} did not access index_links",
+                case.name
+            );
+            Ok(PlanRelationReads {
+                entities: names
+                    .contains("index_entities")
+                    .then(|| "index_entities".to_owned())
+                    .into_iter()
+                    .collect(),
+                links: names
+                    .contains("index_links")
+                    .then(|| "index_links".to_owned())
+                    .into_iter()
+                    .collect(),
+            })
+        }
+        QuerySide::Shadow => {
+            ensure!(
+                !names.contains("index_entities") && !names.contains("index_links"),
+                "shadow query {} accessed a canonical relation",
+                case.name
+            );
+            let entities = names
+                .intersection(&entity_children)
+                .cloned()
+                .collect::<Vec<_>>();
+            let links = names
+                .intersection(&link_children)
+                .cloned()
+                .collect::<Vec<_>>();
+            let expected_entities = if case.uses_entities { 1 } else { 0 };
+            let expected_links = if case.uses_links { 1 } else { 0 };
+            ensure!(
+                entities.len() == expected_entities,
+                "shadow query {} must prune entities to exactly one child when used",
+                case.name
+            );
+            ensure!(
+                links.len() == expected_links,
+                "shadow query {} must prune links to exactly one child when used",
+                case.name
+            );
+            let allowed = entity_children.union(&link_children).cloned().collect::<BTreeSet<_>>();
+            ensure!(
+                names.is_subset(&allowed),
+                "shadow query {} accessed a relation outside the evidence plan: {:?}",
+                case.name,
+                names.difference(&allowed).collect::<Vec<_>>()
+            );
+            Ok(PlanRelationReads { entities, links })
+        }
+    }
+}
+
+fn collect_relation_names(value: &JsonValue, names: &mut BTreeSet<String>) {
+    match value {
+        JsonValue::Array(values) => {
+            for value in values {
+                collect_relation_names(value, names);
+            }
+        }
+        JsonValue::Object(values) => {
+            if let Some(name) = values.get("Relation Name").and_then(JsonValue::as_str) {
+                names.insert(name.to_owned());
+            }
+            for value in values.values() {
+                collect_relation_names(value, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn explain_root(explain: &JsonValue) -> Result<&JsonMap<String, JsonValue>> {
+    let entries = explain.as_array().context("EXPLAIN must be a JSON array")?;
+    ensure!(entries.len() == 1, "EXPLAIN must contain exactly one root entry");
+    entries[0].as_object().context("EXPLAIN root must be an object")
+}
+
+fn stable_plan_digest(
+    samples: &[QueryExplainSample],
+    query: &str,
+    side: &str,
+) -> Result<String> {
+    let digests = samples
+        .iter()
+        .map(|sample| sample.plan_digest.clone())
+        .collect::<BTreeSet<_>>();
+    ensure!(
+        digests.len() == 1,
+        "query {query} had unstable {side} normalized plans across samples"
+    );
+    Ok(digests.into_iter().next().expect("one digest was checked"))
+}
+
+fn stable_relation_reads(
+    samples: &[QueryExplainSample],
+    query: &str,
+    side: &str,
+) -> Result<PlanRelationReads> {
+    let first = samples
+        .first()
+        .context("query evidence sample set must not be empty")?
+        .relation_reads
+        .clone();
+    ensure!(
+        samples.iter().all(|sample| sample.relation_reads == first),
+        "query {query} had unstable {side} relation reads across samples"
+    );
+    Ok(first)
+}
+
+fn percentile_95(values: &[f64]) -> Result<f64> {
+    ensure!(!values.is_empty(), "p95 sample set must not be empty");
+    let mut sorted = values.to_vec();
+    ensure!(
+        sorted.iter().all(|value| value.is_finite() && *value >= 0.0),
+        "p95 samples must be finite and non-negative"
+    );
+    sorted.sort_by(|left, right| left.total_cmp(right));
+    let rank = ((sorted.len() * 95).div_ceil(100)).max(1) - 1;
+    let value = sorted[rank];
+    ensure!(value > 0.0, "measured p95 must be greater than zero");
+    Ok(value)
+}
+
+fn ensure_output_available(path: &Path) -> Result<()> {
+    ensure!(!path.exists(), "refusing to overwrite {path:?}");
+    Ok(())
+}
+
+fn publish_query_artifact(path: &Path, runs: &[PartitionQueryRunEvidence]) -> Result<()> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create query evidence directory {parent:?}"))?;
+    }
+    ensure_output_available(path)?;
+    let mut bytes = serde_json::to_vec_pretty(runs)
+        .context("failed to serialize partition query evidence")?;
+    bytes.push(b'\n');
+    let temporary = temporary_path(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .with_context(|| format!("failed to create temporary query evidence file {temporary:?}"))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("failed to write temporary query evidence file {temporary:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync temporary query evidence file {temporary:?}"))?;
+    let publish = fs::hard_link(&temporary, path)
+        .with_context(|| format!("failed to publish query evidence to {path:?}"));
+    let _ = fs::remove_file(&temporary);
+    publish
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(format!(".tmp-{}", std::process::id()));
+    PathBuf::from(value)
+}
+
+fn canonical_json_bytes(value: &JsonValue) -> Result<Vec<u8>> {
+    serde_json::to_vec(&canonicalize_json(value))
+        .context("failed to serialize canonical partition query JSON")
+}
+
+fn canonicalize_json(value: &JsonValue) -> JsonValue {
+    match value {
+        JsonValue::Array(values) => {
+            JsonValue::Array(values.iter().map(canonicalize_json).collect())
+        }
+        JsonValue::Object(values) => {
+            let mut sorted = JsonMap::new();
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                sorted.insert(key.clone(), canonicalize_json(&values[key]));
+            }
+            JsonValue::Object(sorted)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn validate_identifier(value: &str) -> Result<()> {
+    ensure!(
+        !value.is_empty() && value.len() <= 63,
+        "invalid PostgreSQL identifier length"
+    );
+    ensure!(
+        value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "PostgreSQL identifier contains unsupported characters"
+    );
+    Ok(())
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn case() -> QueryCase {
+        QueryCase {
+            name: "fixture-001".to_owned(),
+            template: "entity_scope_page_v1",
+            baseline_sql: String::new(),
+            shadow_sql: String::new(),
+            values: vec![],
+            logical_relations: vec!["entities"],
+            logical_predicates: vec!["tenant_id = ?"],
+            logical_ordering: vec!["entity_id ASC"],
+            uses_entities: true,
+            uses_links: false,
+        }
+    }
+
+    #[test]
+    fn partition_append_and_unpartitioned_scan_share_logical_digest() {
+        let baseline = json!([{
+            "Execution Time": 1.0,
+            "Plan": {"Node Type": "Index Scan", "Relation Name": "index_entities"}
+        }]);
+        let shadow = json!([{
+            "Execution Time": 1.1,
+            "Plan": {
+                "Node Type": "Append",
+                "Plans": [{"Node Type": "Seq Scan", "Relation Name": "shadow_p003"}]
+            }
+        }]);
+        assert_eq!(
+            normalized_plan_digest(&baseline, &case()).unwrap(),
+            normalized_plan_digest(&shadow, &case()).unwrap()
+        );
+    }
+
+    #[test]
+    fn join_algorithm_change_changes_normalized_digest() {
+        let nested = json!([{
+            "Execution Time": 1.0,
+            "Plan": {
+                "Node Type": "Nested Loop",
+                "Join Type": "Inner",
+                "Plans": [{"Node Type": "Seq Scan"}, {"Node Type": "Index Scan"}]
+            }
+        }]);
+        let hash = json!([{
+            "Execution Time": 1.0,
+            "Plan": {
+                "Node Type": "Hash Join",
+                "Join Type": "Inner",
+                "Plans": [
+                    {"Node Type": "Seq Scan"},
+                    {"Node Type": "Hash", "Plans": [{"Node Type": "Seq Scan"}]}
+                ]
+            }
+        }]);
+        assert_ne!(
+            normalized_plan_digest(&nested, &case()).unwrap(),
+            normalized_plan_digest(&hash, &case()).unwrap()
+        );
+    }
+
+    #[test]
+    fn p95_uses_nearest_rank_and_requires_positive_measurement() {
+        assert_eq!(percentile_95(&[1.0, 2.0, 3.0]).unwrap(), 3.0);
+        assert!(percentile_95(&[0.0, 0.0, 0.0]).is_err());
+    }
+
+    #[test]
+    fn generated_queries_remain_tenant_scoped_and_read_only() {
+        let anchor = EntityAnchor {
+            tenant_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+            module_name: "catalog".to_owned(),
+            entity_name: "product".to_owned(),
+            schema_version: 1,
+            entity_id: "00000000-0000-0000-0000-000000000002".to_owned(),
+            locale_key: "en-US".to_owned(),
+        };
+        let query = entity_scope_case(1, &anchor, "index_entities_shadow_fixture");
+        for sql in [&query.baseline_sql, &query.shadow_sql] {
+            assert!(sql.contains("tenant_id = $1::uuid"));
+            assert!(sql.contains("ORDER BY e.entity_id LIMIT 100"));
+            for forbidden in ["INSERT", "UPDATE", "DELETE", "ALTER", "DROP", "RENAME"] {
+                assert!(!sql.contains(forbidden), "query contains {forbidden}");
+            }
+        }
+    }
+}

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -66,6 +66,7 @@ const runContract = (args) => {
     'verify-index-partition-admission.mjs',
     'verify-index-partition-evidence.mjs',
     'verify-index-partition-snapshot-capture.mjs',
+    'verify-index-partition-query-evidence.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',

--- a/scripts/verify/verify-index-partition-query-evidence.mjs
+++ b/scripts/verify/verify-index-partition-query-evidence.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-partition-query-evidence] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runner = requireMarkers('ops/benches/src/index_storage/partition_query.rs', [
+  'INDEX_PARTITION_ALLOW_QUERY_EVIDENCE',
+  'normalized_partition_plan_v1',
+  'partition query evidence requires PostgreSQL 16',
+  'partition query evidence requires jit=off',
+  'SET enable_partition_pruning = on',
+  'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY',
+  'EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)',
+  'manifest evidence_id does not match canonical manifest input',
+  'query {} produced different baseline and shadow results',
+  'had unstable {side} normalized plans across samples',
+  'must prune entities to exactly one child when used',
+  'must prune links to exactly one child when used',
+  'cases.len() == manifest.repetitions.query',
+  'baseline_p95_ms',
+  'shadow_p95_ms',
+  'baseline_plan_digest',
+  'shadow_plan_digest',
+  'baseline_explain_samples',
+  'shadow_explain_samples',
+  'fs::hard_link(&temporary, path)',
+  'refusing to overwrite {path:?}',
+]);
+
+for (const forbidden of [
+  'ALTER TABLE "index_entities"',
+  'ALTER TABLE "index_links"',
+  'DROP TABLE "index_entities"',
+  'DROP TABLE "index_links"',
+  'RENAME TO index_entities',
+  'RENAME TO index_links',
+  'INSERT INTO index_entities',
+  'INSERT INTO index_links',
+  'UPDATE index_entities',
+  'UPDATE index_links',
+  'DELETE FROM index_entities',
+  'DELETE FROM index_links',
+  'VACUUM FULL',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (runner.includes(forbidden)) fail(`query runner contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('ops/benches/src/bin/index_partition_query_evidence.rs', [
+  'PartitionQueryConfig::from_env()',
+  'capture_partition_query_evidence(&config).await?',
+  'index partition query evidence complete',
+]);
+
+requireMarkers('ops/benches/src/index_storage/mod.rs', [
+  'mod partition_query;',
+  'PartitionQueryConfig',
+  'capture_partition_query_evidence',
+]);
+
+requireMarkers('ops/benches/Cargo.toml', [
+  'name = "index-partition-query-evidence"',
+  'path = "src/bin/index_partition_query_evidence.rs"',
+]);
+
+requireMarkers('ops/benches/README.md', [
+  'Index partition query evidence',
+  'INDEX_PARTITION_ALLOW_QUERY_EVIDENCE=1',
+  'INDEX_PARTITION_QUERY_SAMPLES=7',
+  'index-partition-query-evidence',
+  'read-only repeatable-read transaction',
+  'retains full JSON',
+  '`EXPLAIN (ANALYZE, BUFFERS, WAL)` samples',
+]);
+
+requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
+  'index-partition-query-evidence',
+  'normalized_partition_plan_v1',
+  'query.json',
+  'exactly one entity or link child partition',
+  'result digest parity',
+]);
+
+requireMarkers('crates/rustok-index/docs/README.md', [
+  'M3 partition query evidence runner: `complete`',
+  'Real mutation, maintenance, and cutover evidence remain',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M3 partition query evidence runner: `complete`',
+  '- [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.',
+  '- [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.',
+  'The ninth M3 slice adds owner-operated baseline/shadow query evidence.',
+]);
+
+requireMarkers('scripts/verify/index-storage-tooling.mjs', [
+  "'verify-index-partition-query-evidence.mjs'",
+]);
+
+requireMarkers('.github/workflows/index-storage-smoke.yml', [
+  'scripts/verify/verify-index-partition-query-evidence.mjs',
+  'node --check scripts/verify/verify-index-partition-query-evidence.mjs',
+  '--bin index-partition-query-evidence',
+]);
+
+console.log('[verify-index-partition-query-evidence] OK');


### PR DESCRIPTION
## Summary

- continue M3 with an owner-operated PostgreSQL baseline/shadow query evidence runner for the canonical `index_entities` and `index_links` relations and their evidence-ID-bound tenant-hash shadows;
- require explicit `INDEX_PARTITION_ALLOW_QUERY_EVIDENCE=1` opt-in before executing measured queries;
- consume and independently revalidate the immutable prepared partition manifest, canonical SHA-256 `evidence_id`, deterministic shadow definition hash, relation names, child names, modulus, and repetition contract;
- require PostgreSQL 16 with JIT disabled and partition pruning enabled;
- reject canonical relations that are already partitioned and reject missing, renamed, incorrectly commented, or incorrectly bounded shadow parents/children;
- serialize one evidence ID through a PostgreSQL advisory lock;
- select deterministic generic entity/link anchors from canonical Index rows without importing source-domain semantics;
- build exactly `manifest.repetitions.query` unique tenant-scoped runs covering entity scope pages, keyset pages, exact counts, link scope pages, and source/link joins when link rows exist;
- execute the complete comparison in one read-only repeatable-read transaction;
- calculate exact baseline/shadow result row counts and length-prefixed JSON SHA-256 digests and fail on semantic divergence;
- alternate baseline/shadow execution order and retain full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` for every sample;
- calculate nearest-rank p95 latency for both sides;
- calculate `normalized_partition_plan_v1` digests that exclude runtime counters and physical relation/index identity while retaining logical templates, predicates, ordering, operator/join shape, and pruning semantics;
- reject unstable normalized plans or unstable relation reads across samples;
- prove every shadow query prunes each used logical entity/link relation to exactly one manifest child and never accesses canonical or unrelated relations;
- publish one top-level `query.json` array with temporary-file plus hard-link no-clobber semantics;
- add a dedicated `index-partition-query-evidence` binary, static contract guard, lightweight workflow build coverage, owner runbook updates, and roadmap synchronization;
- keep production writes, replay/dual-write, rename/drop, cutover, maintenance, and durable global partition-operation ownership outside this slice.

## Previous slice recheck

- PR #2319 was rechecked with no comments, reviews, review threads, or status checks and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Inventory changes.

## Important behavior

- the runner operates only on an owner-approved PostgreSQL evidence database;
- the explicit query opt-in is mandatory;
- all measured SQL is tenant-scoped and the measurement transaction is read-only;
- canonical and shadow results must match before timings are accepted;
- raw EXPLAIN JSON remains retained reviewer evidence; normalized hashes do not replace it;
- baseline/shadow plan digests are not forced equal by the runner, so the admission validator can calculate and reject measured plan drift;
- physical partition suffixes and expected single-child scan wrappers are normalized away, while join/operator changes and partition fan-out remain visible;
- query evidence is published only after every run and sample succeeds and an existing `query.json` is never overwritten;
- this runner does not execute or authorize production partitioning;
- the real PostgreSQL snapshot/query evidence run and complete packet remain owner-operated and were not executed in this change.

## Validation

Not run, per repository-owner instruction. Suggested owner checks:

```bash
cargo check -p rustok-benchmarks --bin index-partition-query-evidence
cargo test -p rustok-benchmarks partition_query
node scripts/verify/verify-index-partition-query-evidence.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

The PostgreSQL query evidence runner and real partition packet were not executed.

## Next M3 slices

Add owner-operated mutation/WAL evidence, then ordinary-VACUUM maintenance evidence and cutover/rollback rehearsal capture. After all six raw artifacts exist, assemble and validate one retained real packet before implementing any production partition lifecycle.