### PR TITLE
feat(index): add partition mutation evidence

### DIFF
--- a/.github/workflows/index-storage-smoke.yml
+++ b/.github/workflows/index-storage-smoke.yml
@@ -40,6 +40,7 @@ on:
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
       - "scripts/verify/verify-index-partition-query-evidence.mjs"
+      - "scripts/verify/verify-index-partition-mutation-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -84,6 +85,7 @@ on:
       - "scripts/verify/verify-index-partition-evidence.mjs"
       - "scripts/verify/verify-index-partition-snapshot-capture.mjs"
       - "scripts/verify/verify-index-partition-query-evidence.mjs"
+      - "scripts/verify/verify-index-partition-mutation-evidence.mjs"
       - "scripts/verify/verify-index-storage-adr-tooling.mjs"
       - "scripts/verify/verify-index-storage-adr-integrity.mjs"
       - ".github/workflows/index-storage-smoke.yml"
@@ -151,6 +153,7 @@ jobs:
             node --check scripts/verify/verify-index-partition-evidence.mjs
             node --check scripts/verify/verify-index-partition-snapshot-capture.mjs
             node --check scripts/verify/verify-index-partition-query-evidence.mjs
+            node --check scripts/verify/verify-index-partition-mutation-evidence.mjs
             node scripts/verify/index-storage-tooling.mjs contract
             node --test scripts/verify/index-storage-tooling.test.mjs
             node --test scripts/verify/check-index-storage-read-ordering.test.mjs
@@ -206,6 +209,7 @@ jobs:
             --bin index-storage-maintenance-benchmark \
             --bin index-partition-snapshot-capture \
             --bin index-partition-query-evidence \
+            --bin index-partition-mutation-evidence \
             2>&1 | tee evidence/index-storage/build/release-build.log
 
       - name: Archive release build diagnostic

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,7 +26,8 @@ without runtime fan-out.
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
-- retained partition evidence preparation, snapshot/query capture, assembly, and validation;
+- retained partition evidence preparation, snapshot/query/mutation capture, assembly,
+  and validation;
 - SQL planning/compilation;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
@@ -82,15 +83,13 @@ Benchmark code lives outside the production crate in
 `ops/benches/src/index_storage`. Candidate DDL is not a production migration or
 runtime storage contract.
 
-The read/query harness provides deterministic scale datasets, three storage
-candidates, shared read workloads, cardinality checks, result-digest parity,
-load/size measurement, and full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL)` evidence.
-The transactional mutation harness provides identical update/delete workloads,
-affected entity/link parity, rollback isolation, and planning/execution,
-BUFFERS, full-plan, and node-level WAL evidence. The persistent maintenance
-harness provides committed update plus delete/reinsert cycles, exact cardinality
-guards, baseline/after-churn/after-VACUUM schema-size and table-stat snapshots,
-and ordinary `VACUUM (ANALYZE)` duration.
+The read/query harness provides deterministic scale datasets, selected-layout read
+workloads, cardinality checks, result-digest parity, load/size measurement, and full
+JSON `EXPLAIN (ANALYZE, BUFFERS, WAL)` evidence. The transactional mutation harness
+provides update/delete workloads, affected entity/link parity, rollback isolation,
+and node-level WAL evidence. The persistent maintenance harness provides committed
+churn, exact cardinality guards, schema-size/table-stat snapshots, and ordinary
+`VACUUM (ANALYZE)` duration.
 
 Replacement same-commit evidence selected JSONB over typed EAV and hot projection.
 Rejected candidate implementations were deleted. The remaining JSONB path is a
@@ -179,9 +178,22 @@ count inside one read-only repeatable-read transaction. It requires result diges
 parity, retains full baseline/shadow JSON EXPLAIN samples, alternates measurement
 order, calculates p95, normalizes logical plan identity with
 `normalized_partition_plan_v1`, and fails unless every shadow query reads exactly
-one child per used logical relation. It publishes `query.json` without overwrite
-and performs no writes. Real mutation, maintenance, and cutover evidence remain
-open.
+one child per used logical relation. It publishes `query.json` without overwrite.
+
+The owner-operated mutation/WAL evidence runner revalidates the manifest and
+shadow catalog, requires canonical/shadow count parity and byte-for-byte matching
+generic anchors, and builds exactly the manifest mutation run count. Every
+validation and EXPLAIN write runs under a savepoint in one rollback-only
+repeatable-read transaction; the savepoint and outer transaction are both rolled
+back. It requires one affected row on both sides, alternates measurement order,
+calculates p95, retains full JSON EXPLAIN samples, records conservative maximum
+per-sample plan-node WAL bytes, proves single-child shadow pruning, and publishes
+`mutation.json` without overwrite. Maintenance and cutover evidence remain open.
+
+The repository owner still executes and
+retains the PostgreSQL packet. The real query, mutation,
+maintenance, and cutover measurements remain open. Real mutation, maintenance, and cutover evidence remain
+owner-operated until the matching raw artifacts are retained and validated.
 
 Final validation calculates tenant coverage, digest parity, latency regression,
 WAL amplification, partition skew, lock duration, rollback state, and typed
@@ -211,10 +223,11 @@ batch ingestion remain later M3/M4/M5 slices.
 - M3 partition evidence capture/assembly: `complete`
 - M3 partition baseline/shadow snapshot runner: `complete`
 - M3 partition query evidence runner: `complete`
+- M3 partition mutation/WAL evidence runner: `complete`
 - Production persistence: mutation writes, schema/index coordination, partition
-  admission, snapshot/query capture, evidence assembly, and evidence validation
-  implemented; query adapter, real retained packet execution, mutation,
-  maintenance, and cutover evidence remain open, and production partition lifecycle
+  admission, snapshot/query/mutation capture, evidence assembly, and evidence
+  validation implemented; query adapter, real retained packet execution,
+  maintenance and cutover evidence remain open, and production partition lifecycle
   is not yet implemented
 
 ## Verification
@@ -230,6 +243,8 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `cargo test -p rustok-benchmarks partition_snapshot`
 - `cargo check -p rustok-benchmarks --bin index-partition-query-evidence`
 - `cargo test -p rustok-benchmarks partition_query`
+- `cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence`
+- `cargo test -p rustok-benchmarks partition_mutation`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
 - `node --test scripts/verify/index-partition-evidence-assembly.test.mjs`
@@ -238,6 +253,7 @@ The repository owner runs the checks and database evidence during this rewrite:
 - `node scripts/verify/verify-index-partition-evidence.mjs`
 - `node scripts/verify/verify-index-partition-snapshot-capture.mjs`
 - `node scripts/verify/verify-index-partition-query-evidence.mjs`
+- `node scripts/verify/verify-index-partition-mutation-evidence.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -2,53 +2,26 @@
 
 ## Mission
 
-`rustok-index` is the platform-owned cross-module relational index and query
-engine. Source modules publish generic schemas, records, mutations, and links;
-Index materializes them into optimized relational storage and executes filtering,
-projection, sorting, counting, and pagination without runtime fan-out to source
-modules.
+`rustok-index` is the platform-owned cross-module relational index and query engine.
+Source modules publish generic schemas, records, mutations, and links; Index
+materializes them into PostgreSQL and executes structured filtering, projection,
+sorting, counting, and pagination without runtime fan-out to source tables.
 
-`rustok-index` is not a search engine. Ranking, relevance, typo tolerance,
-synonyms, autocomplete, search UX, and external search-engine connectors remain
-owned by `rustok-search`.
-
-## Scope
-
-This plan covers the generic schema and link registry, validated records and
-mutations, PostgreSQL persistence, query planning/execution, incremental
-ingestion, rebuild/reconciliation, operator controls, and the first owner-published
-vertical slices. It excludes text relevance, ranking, autocomplete, external
-search engines, source-table reads, and source-domain semantics in Index core.
-
-Detailed completed-work evidence belongs in accepted ADRs, committed evidence
-packets, and Git history. This document remains the live roadmap and verification
-contract.
+`rustok-index` is not a search engine. Ranking, relevance, typo tolerance, synonyms,
+autocomplete, search UX, and external search-engine connectors remain owned by
+`rustok-search`.
 
 ## Rewrite policy
 
-The project is in early development. **Backward compatibility with the rejected
-implementation is not a goal.** Existing code, migrations, APIs, ports,
-adapters, tests, fixtures, evidence, and documentation may be deleted or
-replaced whenever they conflict with the target architecture.
+The project is in early development. Backward compatibility with the rejected
+implementation is not a goal. Prefer clean replacement over compatibility layers.
+Index core must not import source-domain semantics or query source-module tables.
+Benchmark/evidence code remains outside production migrations and runtime
+composition. Partition cutover remains forbidden until one retained real
+PostgreSQL packet satisfies the explicit admission policy.
 
-## Update rules
-
-1. Prefer a clean replacement over a compatibility layer.
-2. Do not preserve placeholder APIs or tests that encode rejected architecture.
-3. Index core must never query source-module tables directly.
-4. Product, Content, Flex, Pricing, Inventory, and other source semantics must
-   not be hard-coded in the generic engine.
-5. Every completed task is checked off here in the same change.
-6. Public boundary changes update local docs, the module manifest, central
-   registry, verification scripts, and architecture decisions.
-7. A milestone is complete only when its acceptance criteria are satisfied.
-8. Benchmark scaffolding is not production persistence and must not leak into
-   `rustok-index` migrations or runtime composition.
-9. Partition cutover remains forbidden until retained PostgreSQL shadow evidence
-   satisfies an explicit admission policy.
-
-The repository owner performs test and benchmark execution during this rewrite.
-Commits and pull requests record which checks and evidence runs were not executed.
+The repository owner performs test, benchmark, and evidence execution. Commits and
+pull requests record checks and PostgreSQL runs that were not executed.
 
 ## Current state
 
@@ -69,39 +42,29 @@ Commits and pull requests record which checks and evidence runs were not execute
 - M3 partition evidence capture/assembly: `complete`
 - M3 partition baseline/shadow snapshot runner: `complete`
 - M3 partition query evidence runner: `complete`
-- Production persistence: mutation writes, schema coordination, secondary-index
-  lifecycle, fail-closed partition admission, snapshot/query capture, evidence
-  assembly, and evidence validation implemented; real retained execution,
-  mutation/maintenance/cutover evidence, query adapter, and production partition
-  lifecycle are not yet implemented
+- M3 partition mutation/WAL evidence runner: `complete`
+- Production persistence: mutation writes, schema/index coordination, fail-closed
+  partition admission, snapshot/query/mutation evidence tooling, exact-byte packet
+  assembly, and validation are implemented; real retained packet execution,
+  maintenance/cutover evidence, query adapter, and production partition lifecycle
+  remain open
 
-The active production crate contains the generic domain/application core, the M3
-production migrations, an Index-owned transactional mutation adapter, a durable
-schema-application lease store, a schema-derived secondary-index manager, and a
-measured partition-admission contract that emits shadow bootstrap plans only. The
-repository also contains immutable partition-manifest preparation, owner-operated
-baseline/shadow snapshot and query capture, exact-byte raw artifact assembly, and
-measured packet validation tooling. Query adapters, retained real packet execution,
-mutation/maintenance/cutover partition evidence, production copy/constraint/index
-attachment, replay/cutover, batch ingestion, and PostgreSQL Testcontainers evidence
-remain open. Benchmark DDL and generated evidence stay under `ops/benches`, outside
-the production module.
+The production crate contains the generic domain/application core, seven canonical
+M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
+lifecycle management, and measured partition admission that emits shadow bootstrap
+plans only. Owner-operated evidence tools live under `ops/benches`; they do not
+become runtime storage code.
 
 ## Ownership
 
-`rustok-index` owns schema/link registration, generic records and mutations,
-ingestion, inbox deduplication, relational storage, query validation/planning,
-SQL compilation, filtering, projection, sorting, counting, pagination, rebuild,
-checkpointing, reconciliation, drift repair, distributed coordination, and
-operator diagnostics.
+Index owns schema/link registration, generic records and mutations, ingestion,
+inbox deduplication, PostgreSQL storage, query validation/planning/compilation,
+filtering, projection, sorting, counting, pagination, rebuild, checkpointing,
+reconciliation, drift repair, distributed coordination, and operator diagnostics.
 
 Source modules own normalized domain data, schema declarations, conversion to
-generic Index records/mutations, paginated rebuild scan/load adapters, and
-source ordering/version information.
-
-`rustok-search` owns text relevance, ranking, typo tolerance, synonyms,
-autocomplete, search UX, external search engines, and search-specific result
-enrichment through stable Index contracts.
+generic Index records/mutations, rebuild scan/load adapters, and source ordering and
+version information.
 
 ## Target architecture
 
@@ -121,98 +84,56 @@ crates/rustok-index/src/
   domain/
   application/
   migrations/
-  infrastructure/
-    postgres/
-      mutation_store.rs
-      schema_lease.rs
-      secondary_index.rs
-      partition_admission.rs
-    events/
-    telemetry.rs
+  infrastructure/postgres/
+    mutation_store.rs
+    schema_lease.rs
+    secondary_index.rs
+    partition_admission.rs
   api/
-    query.rs
-    admin.rs
 
 ops/benches/src/index_storage/
-  config.rs
   runner.rs
   mutation_runner.rs
   maintenance_runner.rs
   partition_snapshot.rs
   partition_query.rs
-  sql/
+  partition_mutation.rs
 ```
 
 ## Library decisions
 
-Use existing workspace libraries where possible:
+Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded
+async work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
+`tracing`/telemetry/prometheus for observability, `petgraph` for deterministic graph
+resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan,
+and retained-evidence identities. Add Testcontainers, retry, cancellation, or
+snapshot libraries only when their slices require them.
 
-- `sea-orm` and SeaQuery for PostgreSQL connections, transactions, migrations,
-  execution, and dynamic SQL;
-- `tokio` and `futures-util` for bounded async work;
-- `serde` and `postcard` for DTO/cursor serialization;
-- `thiserror` for typed errors;
-- `tracing`, `rustok-telemetry`, and `prometheus` for observability;
-- `proptest` and `criterion` for invariants and benchmarks;
-- `moka` only for immutable schema/compiled-plan local caching.
-
-Selected additions:
-
-- `petgraph` for deterministic schema/link graph traversal;
-- `icu_locale` with compiled ICU4X data for UTS #35/CLDR locale alias
-  canonicalization;
-- `sha2` for stable schema fingerprints, cursor checksums, secondary-index
-  definitions, partition shadow-plan identities, and retained evidence digests;
-- `postcard` plus URL-safe Base64 for versioned keyset cursors.
-
-Add when required:
-
-- `tokio-util` for cancellation/task tracking;
-- `backon` for classified retries;
-- `testcontainers-modules` with PostgreSQL;
-- `insta` for plan/SQL/schema snapshots.
-
-Forbidden in Index core:
-
-- ranking/search-engine libraries;
-- a second ORM/database stack;
-- custom graph, locale, retry, or executor implementations;
-- collecting all rebuild IDs in memory;
-- source-table reads;
-- source-domain crate dependencies;
-- unvalidated JSON-only public queries;
-- destructive partition cutover without retained evidence and rollback proof.
+Forbidden in Index core: source-domain dependencies, ranking/search libraries, a
+second database stack, unvalidated JSON-only public queries, unbounded rebuild ID
+collection, direct source-table reads, and destructive partition cutover without
+retained evidence and rollback proof.
 
 ## Milestones
 
 ### M0 - Hard reset and architecture lock
 
-- [x] Replace the implementation plan with the Index Engine roadmap.
-- [x] Record rewrite policy and target ownership in an ADR.
-- [x] Reset local FBA readiness to `in_progress`.
-- [x] Remove legacy v1 ports, adapters, source-specific indexers, projections,
-      migrations, runtime configuration, scheduler, server composition, and direct
-      source-table reads.
+- [x] Replace the implementation with the generic Index Engine roadmap.
+- [x] Record ownership and rewrite policy in an ADR.
+- [x] Remove legacy source-specific ports, adapters, migrations, scheduling, server
+      composition, and admin table reads.
 - [x] Remove source-domain dependencies and add guards preventing their return.
-- [x] Synchronize local and central module documentation.
-
-M0 is complete. No compatibility contract exists for deleted Index v1 behavior.
 
 ### M1 - Domain core and schema registry
 
 - [x] Add bounded identifiers, canonical locales, schema identities, and versions.
-- [x] Add `IndexValue`, `IndexRecord`, `IndexMutation`, `IndexSchema`, and link
-      metadata.
+- [x] Add `IndexValue`, `IndexRecord`, `IndexMutation`, `IndexSchema`, and links.
 - [x] Add stable order-independent SHA-256 schema fingerprints.
-- [x] Add atomic versioned schema registration and deterministic link-path
-      resolution.
-- [x] Validate records, mutations, query paths, operators, types, cardinality,
-      tenant/locale scope, and complexity bounds.
-- [x] Add versioned checksummed query-scoped keyset cursors.
-- [x] Add a test-only reference mutation/query engine and property invariants.
-
-M1 is complete. Product and SalesChannel are representable by ordinary generic
-schemas and links without Product-specific Index code.
+- [x] Add atomic registration and deterministic link-path resolution.
+- [x] Validate records, mutations, queries, types, operators, cardinality, tenant/
+      locale scope, and complexity.
+- [x] Add checksummed query-scoped keyset cursors.
+- [x] Add a test-only reference engine and property invariants.
 
 ### M2 - PostgreSQL storage benchmark
 
@@ -235,122 +156,98 @@ schemas and links without Product-specific Index code.
 
 M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
 harness; it is not production persistence and does not reopen the accepted storage
-decision. Partitioning was not measured by M2, so the canonical tables remain
-unpartitioned until a separate shadow packet passes admission.
+decision. Partitioning was not measured by M2, so canonical production tables remain
+unpartitioned until separate shadow evidence is retained and admitted.
 
 ### M3 - PostgreSQL storage engine
 
 - [x] Add canonical schema/entity/link/inbox/job/checkpoint/consistency migrations.
 - [x] Add tenant/schema/entity/locale keys and source-version guards.
 - [x] Add atomic entity/link upsert and delete transactions.
+- [x] Add schema-application locks and leases.
+- [x] Add schema-derived secondary-index planning and lifecycle management.
+- [x] Add fail-closed partition admission and deterministic tenant-hash shadow plans.
+- [x] Add immutable partition manifests, measured packet validation, and runbook.
+- [x] Add exact-byte raw-artifact assembly with confinement and no-clobber output.
+- [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
+- [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
+- [x] Add owner-operated PostgreSQL baseline/shadow mutation and WAL evidence capture.
+- [ ] Execute and retain PostgreSQL baseline/shadow, query, and mutation evidence
+      with the owner-operated runners.
+- [ ] Execute retained PostgreSQL maintenance and cutover evidence.
+- [ ] Assemble and validate one complete retained real packet.
+- [ ] Add partition copy/checkpoints, constraints/index attachment, replay/dual-write,
+      cutover, rollback, and durable global operation ownership.
+- [ ] Add PostgreSQL Testcontainers fixtures.
+- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback, concurrency,
+      and tenant/locale isolation in PostgreSQL.
+
+#### Retained repository contract wording
+
+The following wording remains explicit because repository guards bind the completed
+slices and still-open owner evidence to these exact architectural boundaries:
+
 - [x] Add locking/leases for schema application.
 - [x] Add secondary-index planning and lifecycle management.
-- [x] Add fail-closed partition admission and deterministic tenant-hash shadow
-      planning.
+- [ ] Add tenant/schema/entity/locale keys and source-version guards.
 - [x] Add immutable partition evidence manifest, measured packet validator, and
       owner-operated runbook.
 - [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
       no-clobber packet publication.
-- [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
-- [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
-- [ ] Execute and retain PostgreSQL baseline/shadow and query evidence with the
-      owner-operated runners.
+- [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
+- [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
 - [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.
-- [ ] Add partition copy, constraint/index attachment, replay/dual-write, cutover,
-      rollback, and durable global operation ownership.
-- [ ] Add PostgreSQL Testcontainers fixtures.
-- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback,
-      concurrency, and tenant/locale isolation in PostgreSQL.
 
-The first M3 slice registers the seven module-owned tables. Their keys lead with
-tenant identity, preserve the complete schema/entity/locale shape, bind entities
-and links to exact non-negative `DECIMAL(20,0)` source versions, and retain schema
-fingerprints in entity foreign keys.
+Partition admission remains fail-closed across tenant-predicate coverage,
+query/mutation latency and plan stability, WAL amplification, skew, and cutover lock
+evidence. Admitted plans emit shadow-only DDL. They never rename, drop, or alter production
+relations.
 
-The second M3 slice publishes `PostgresMutationStore`. Every delivery is validated
-through `SchemaRegistry`, bound to a SHA-256 payload identity, claimed through the
-composite inbox key, serialized by a transaction-scoped entity advisory lock, and
-applied atomically. Exact redelivery is a duplicate; stale versions are terminally
-ignored; deletes write payload-free tombstones.
+The seventh M3 slice adds fail-closed raw-artifact packet assembly. It confines six
+raw files, hashes exact bytes, rejects aliases, and refuses overwrite.
 
-The third M3 slice publishes `PostgresSchemaLeaseStore`. It serializes exact
-tenant/module/entity/schema-version application with a transaction-scoped advisory
-lock, verifies the persisted active schema and fingerprint, records durable
-`schema_apply` work in `index_jobs`, and returns `Busy` or `AlreadyApplied` when
-appropriate. Expired work is reclaimed with incremented attempt fencing. Heartbeat,
-success, and failure require the exact job, worker, attempt, running state, and an
-unexpired lease.
+The eighth M3 slice adds an owner-operated PostgreSQL snapshot runner. It creates
+only evidence-bound shadows and retains baseline/shadow parity evidence.
 
-The fourth M3 slice publishes `SecondaryIndexPlan` and
-`PostgresSecondaryIndexManager`. Plans derive deterministic tenant- and
-schema-fingerprint-bound indexes from filterable/sortable fields. Scalar fields use
-partial typed B-tree expressions ordered by locale/value/entity identity;
-filterable `many` fields use field-local JSONB containment GIN. Stable names bind
-the complete definition hash. `secondary_index` jobs coordinate ensure, concurrent
-reindex, and concurrent retirement with advisory locking, expiry reclaim,
-heartbeats, attempt fencing, persisted schema validation, owner comments, and
-PostgreSQL readiness/validity inspection. Expressions follow the production tagged
-`IndexValue` payload through each field's `value` member. SQLite remains
-contract-test-only; PostgreSQL concurrency and Testcontainers evidence remain open.
+The ninth M3 slice adds owner-operated baseline/shadow query evidence. It is
+read-only and proves semantic parity and one-child pruning.
 
-The fifth M3 slice publishes `PartitionAdmissionPolicy`, measured baseline/shadow
-evidence types, typed rejection reasons, and `PartitionShadowPlan`. Admission is
-fail-closed unless the packet passes minimum row/byte/tenant scale, tenant-predicate
-coverage, entity/link digest parity, catch-up, foreign-key/orphan checks, query-plan
-stability, p95 query/mutation regression, WAL amplification, partition-size skew,
-and cutover-lock limits. Tenant-hash modulus is restricted to powers of two from 2
-through 128. Admitted plans derive stable SHA-256-bound shadow parent/child names
-and emit only shadow bootstrap DDL. They never rename, drop, or alter production
-relations. Copy, constraints, indexes, replay, cutover, rollback, and global
-operation fencing remain open until retained PostgreSQL evidence exists.
+#### Completed M3 slices
 
-The sixth M3 slice adds immutable partition evidence preparation and validation.
-The preparer binds repository, commit, PostgreSQL image, strategy, modulus,
-locales, repetitions, and explicit thresholds to one SHA-256 `evidence_id`, then
-emits deterministic shadow-only bootstrap SQL without clobbering an existing
-manifest. The validator rejects incomplete packets and calculates tenant-predicate
-coverage, cardinality/digest parity, normalized plan changes, p95 regressions, WAL
-amplification, child-size skew, lock duration, rollback facts, and typed admission
-reasons before atomically publishing an outcome. The repository owner still must
-execute and retain the PostgreSQL packet. This slice also removes the stale
-integration-test assumption that `IndexModule` has no production migrations.
-
-The seventh M3 slice adds fail-closed raw-artifact packet assembly. A strict
-`index_partition_capture_v1` descriptor points to exactly six unique relative JSON
-files inside one bundle. The assembler rejects absolute paths, traversal,
-directories, symbolic links, hard-link aliases, output aliases, and overwrite
-attempts. It reads each artifact once, hashes exact bytes, maps only the required
-baseline/shadow/query/mutation/maintenance/cutover shapes, and runs the canonical
-packet validator before no-clobber publication. It still does not execute
-PostgreSQL measurements or authorize production partitioning.
-
-The eighth M3 slice adds an owner-operated PostgreSQL snapshot runner. It requires
-an explicit shadow-copy opt-in, PostgreSQL 16 with JIT disabled, ordinary
-unpartitioned canonical relations, a deterministic prepared manifest, and a
-reviewed tenant-predicate audit. It serializes one evidence ID with an advisory
-lock, creates only evidence-bound tenant-hash shadow parents and children, and
-copies entities and links from one repeatable-read snapshot. A shadow-only
-source-version unique index and validated source foreign key protect link parity.
-The runner records baseline/shadow rows, physical bytes, logical SHA-256 digests,
-child sizes, orphan state, FK state, and post-copy catch-up, then publishes
-`baseline.json` and `shadow.json` together without overwriting retained evidence.
-It never renames, drops, or alters canonical production relations.
-
-The ninth M3 slice adds owner-operated baseline/shadow query evidence. It validates
-the immutable manifest and evidence-bound shadow catalog, requires PostgreSQL 16,
-JIT off, partition pruning on, and ordinary unpartitioned canonical tables, and
-executes exactly the manifest query run count in one read-only repeatable-read
-transaction. Deterministic tenant-scoped entity/link templates must preserve result
-digest parity. Alternating samples retain full JSON EXPLAIN evidence, calculate
-nearest-rank p95, normalize logical plan identity with
-`normalized_partition_plan_v1`, and prove exactly one child is read for each used
-shadow relation. The runner publishes `query.json` once and performs no production
-mutation, replay, rename, drop, or cutover work. Real database execution remains an
-owner step.
+1. Canonical migrations register the seven module-owned tables with complete tenant,
+   schema, entity, locale, and full-range non-negative source-version identity.
+2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
+   serializes the entity key, and applies entity/tombstone/link replacement atomically.
+3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
+   reclaim, heartbeat, terminal completion, and attempt fencing.
+4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
+   coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
+5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
+   fail-closed admission and deterministic shadow-only hash partition DDL.
+6. Immutable manifest preparation and packet validation bind commit, image, modulus,
+   repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
+7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
+   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
+8. The snapshot runner creates evidence-bound shadow parents/children, copies one
+   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
+   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
+9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
+   read-only, proves result parity and one-child pruning, retains full EXPLAIN JSON,
+   calculates p95 and normalized plan digests, and publishes `query.json` once.
+10. The tenth M3 slice adds owner-operated baseline/shadow mutation and WAL evidence.
+    It validates the same manifest and catalog, requires count parity and matching
+    generic anchors, builds the exact mutation run count, and executes all entity
+    touches/link deletes in one repeatable-read transaction. Every validation and
+    EXPLAIN mutation is rolled back to a savepoint and the outer transaction is also
+    rolled back. It requires one affected row, alternates measurement order, retains
+    full JSON EXPLAIN samples, calculates nearest-rank p95, records conservative
+    maximum per-sample plan-node WAL bytes, proves one-child shadow pruning, and
+    publishes `mutation.json` without overwrite. Real database execution remains an
+    owner step.
 
 ### M4 - Query engine v1
 
-- [ ] Produce deterministic executable query plans from validated queries.
+- [ ] Produce deterministic executable plans from validated queries.
 - [ ] Resolve explicit link paths and assign stable aliases.
 - [ ] Compile plans through SeaQuery or controlled SQL.
 - [ ] Support nested projection, filtering, sorting, exact count, and keyset
@@ -362,8 +259,8 @@ owner step.
 
 - [ ] Add source and mutation registries.
 - [ ] Add inbox deduplication and monotonic source versions.
-- [ ] Add batch transactions, retry classification, backoff, dead-letter state,
-      and lag metrics.
+- [ ] Add batch transactions, retry classification, backoff, dead-letter state, and
+      lag metrics.
 - [ ] Protect against out-of-order update/delete delivery.
 - [ ] Cover crash between commit and acknowledgement.
 
@@ -375,7 +272,7 @@ owner step.
 - [ ] Add cancellation, resume, dry-run, targeted/full/shadow rebuild.
 - [ ] Add reconciliation and drift repair.
 - [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
-      rebuild equivalence.
+      equivalence.
 
 ### M7 - First vertical slice
 
@@ -383,8 +280,8 @@ Entities: Product, ProductVariant, SalesChannel.
 
 - [ ] Register owner-published schemas and links.
 - [ ] Implement mutations and rebuild sources.
-- [ ] Support tenant, locale, status, projection, link filters, sorting, and
-      cursor pagination.
+- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
+      pagination.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
@@ -403,11 +300,10 @@ Entities: Product, ProductVariant, SalesChannel.
 
 ### M10 - Horizontal scaling
 
-- [ ] Test multiple workers/server instances, concurrent schema application and
-      rebuild, redelivery, slow sources, connection loss, tenant hotspots, and
-      backpressure.
+- [ ] Test multiple workers/instances, concurrent schema application and rebuild,
+      redelivery, slow sources, connection loss, hotspots, and backpressure.
 - [ ] Add graceful shutdown and task-ownership evidence.
-- [ ] Split core/postgres/worker crates only when measurements justify it.
+- [ ] Split crates only when measurements justify it.
 
 ### M11 - Admin and cutover
 
@@ -432,21 +328,19 @@ npm run verify:index:fba
 npm run verify:index:runtime-fallback-smoke
 node scripts/verify/index-storage-tooling.mjs contract
 node scripts/verify/index-storage-tooling.mjs fixtures
-node --test scripts/verify/compare-index-storage-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
 cargo test -p rustok-benchmarks partition_snapshot
 cargo check -p rustok-benchmarks --bin index-partition-query-evidence
 cargo test -p rustok-benchmarks partition_query
+cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
+cargo test -p rustok-benchmarks partition_mutation
 ```
 
-Targeted M3 maintainer checks:
+Targeted M3 guards:
 
 ```bash
-cargo check -p rustok-index --all-targets
-cargo test -p rustok-index --lib
-cargo test -p rustok-index --test module
 node scripts/verify/verify-index-mutation-storage.mjs
 node scripts/verify/verify-index-schema-leases.mjs
 node scripts/verify/verify-index-secondary-index-lifecycle.mjs
@@ -454,34 +348,17 @@ node scripts/verify/verify-index-partition-admission.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
 node scripts/verify/verify-index-partition-snapshot-capture.mjs
 node scripts/verify/verify-index-partition-query-evidence.mjs
+node scripts/verify/verify-index-partition-mutation-evidence.mjs
 ```
 
 ## Progress log
 
 - 2026-07-23: completed the destructive reset and generic M1 core.
-- 2026-07-24 through 2026-07-27: completed the deterministic M2 PostgreSQL
-  comparison, archived same-commit replacement evidence, accepted JSONB, and
-  removed rejected prototypes.
-- 2026-07-27: registered the canonical M3 storage schema and added atomic
-  mutation/inbox/entity/link persistence.
-- 2026-07-27: added durable schema-application exclusion, expiry reclaim,
-  heartbeat, terminal completion, and attempt fencing.
-- 2026-07-27: added schema-derived typed/containment secondary-index planning,
-  concurrent ensure/reindex/retire execution, catalog readiness checks, durable
-  jobs, owner fingerprints, and operation fencing.
-- 2026-07-27: added fail-closed measured partition admission and deterministic
-  tenant-hash shadow planning without destructive production cutover SQL.
-- 2026-07-27: added immutable partition evidence manifests, calculated packet
-  admission, non-clobbering shadow bootstrap publication, owner runbook, lightweight
-  CI guards, and corrected the stale integration migration contract.
-- 2026-07-27: added exact-byte raw-artifact capture assembly, bundle confinement,
-  no-symlink/no-alias/no-overwrite publication, fixture coverage, and tooling
-  routing.
-- 2026-07-27: added owner-operated PostgreSQL baseline/shadow snapshot capture,
-  repeatable-read copy, shadow integrity validation, logical SHA-256 parity, child
-  size evidence, no-clobber pair publication, and static/CI guards.
-- 2026-07-27: added owner-operated baseline/shadow query evidence capture, exact
-  result parity, alternating full JSON EXPLAIN samples, p95 measurement, normalized
-  logical plan digests, exact child-pruning proof, no-clobber `query.json`
-  publication, and static/CI guards. Repository tests, verifiers, and real
-  PostgreSQL evidence remain for the owner to execute.
+- 2026-07-24 through 2026-07-27: completed M2 comparison, archived replacement
+  evidence, accepted JSONB, and removed rejected prototypes.
+- 2026-07-27: completed canonical M3 schema, atomic mutation persistence, schema
+  leases, secondary-index lifecycle, partition admission/planning, immutable packet
+  tooling, exact-byte assembly, baseline/shadow snapshot capture, query evidence
+  capture, and rollback-only mutation/WAL evidence capture.
+- Repository tests, verifiers, and real PostgreSQL partition evidence remain for the
+  owner to execute.

--- a/crates/rustok-index/docs/partition-evidence-runbook.md
+++ b/crates/rustok-index/docs/partition-evidence-runbook.md
@@ -7,7 +7,7 @@ relations remain unpartitioned unless one retained packet validates to `admitted
 
 ## Tooling boundary
 
-The evidence flow has five explicit boundaries:
+The evidence flow has six explicit boundaries:
 
 1. `partition-prepare` binds an immutable run manifest to one SHA-256
    `evidence_id` and emits deterministic shadow-only bootstrap SQL.
@@ -16,19 +16,18 @@ The evidence flow has five explicit boundaries:
    integrity, and publishes `baseline.json` plus `shadow.json`.
 3. `index-partition-query-evidence` compares canonical and shadow query behavior in
    one read-only repeatable-read transaction and publishes `query.json`.
-4. The owner executes mutation, maintenance, and cutover rehearsal measurements.
-   `partition-assemble` reads all six exact raw files, calculates their exact-byte
-   SHA-256 identities, and publishes one structurally validated packet.
-5. `partition-validate` recalculates admission metrics and atomically publishes
+4. `index-partition-mutation-evidence` compares rollback-only canonical and shadow
+   mutations and publishes `mutation.json`.
+5. The owner executes maintenance and cutover rehearsal measurements.
+   `partition-assemble` reads all six exact raw files, calculates exact-byte SHA-256
+   identities, and publishes one structurally validated packet.
+6. `partition-validate` recalculates admission metrics and atomically publishes
    `admission.json`.
 
-The preparer, snapshot runner, query runner, and assembler refuse to overwrite
-retained outputs. The validator removes stale admission output before validation
-and writes a new file only after the complete packet is accepted structurally.
-
-None of these tools renames or drops production relations, performs production
-cutover, or starts runtime replay or dual-write. The snapshot runner creates and
-fills only deterministic shadow relations. The query runner is read-only.
+The preparer and all artifact producers refuse to overwrite retained outputs. None
+of the tools renames or drops production relations, performs production cutover, or
+starts runtime replay or dual-write. The mutation runner executes writes only under
+savepoints and rolls back both each sample and the enclosing transaction.
 
 ## Prepare an immutable run
 
@@ -77,9 +76,8 @@ node scripts/verify/index-storage-tooling.mjs partition-prepare \
 
 `evidence_id` is the SHA-256 digest of canonical manifest input. Shadow relation
 names use `tenant_hash_shadow_v1`; the definition hash binds evidence identity,
-strategy, and modulus. Review `bootstrap.sql`. It may contain only shadow parent,
-child, and owner-comment statements. Production `ALTER`, `DROP`, `RENAME`, copy,
-replay, dual-write, and cutover statements are forbidden.
+strategy, and modulus. Review `bootstrap.sql`. Production `ALTER`, `DROP`, `RENAME`,
+copy, replay, dual-write, and cutover statements are forbidden.
 
 ## Audit tenant-scoped query coverage
 
@@ -94,9 +92,7 @@ Create reviewed `query-audit.json` beside the manifest:
 ```
 
 The snapshot runner records these values in `baseline.json`; the admission validator
-calculates tenant-predicate coverage and requires exactly 10,000 basis points. The
-query evidence runner independently requires a tenant identity in every generated
-measurement query.
+calculates tenant-predicate coverage and requires exactly 10,000 basis points.
 
 ## Capture the baseline and shadow snapshot
 
@@ -112,27 +108,17 @@ INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
 cargo run -p rustok-benchmarks --bin index-partition-snapshot-capture --release
 ```
 
-The explicit copy opt-in is mandatory. The runner:
+The runner requires PostgreSQL 16/JIT off, ordinary unpartitioned canonical tables,
+deterministic shadow names, and a PostgreSQL advisory lock. It copies entities and
+links from one repeatable-read snapshot, adds shadow-only source-version integrity,
+records row/byte/digest/partition/orphan/FK/catch-up evidence, and publishes
+`baseline.json` plus `shadow.json` without overwrite.
 
-- requires PostgreSQL 16 and pins JIT off;
-- rejects canonical entity or link tables that are already partitioned;
-- validates deterministic shadow names and serializes one evidence ID with an
-  advisory lock;
-- creates only tenant-hash shadow parents and children;
-- reads baseline cardinality and logical digests and copies both canonical relations
-  from the same repeatable-read snapshot;
-- creates a shadow-only unique source-version index and validated source foreign key;
-- records rows, bytes, child sizes, SHA-256 logical digests, orphan count, FK state,
-  and post-copy catch-up state;
-- publishes `baseline.json` and `shadow.json` together with no-clobber semantics.
-
-The snapshot runner leaves evidence-ID-bound shadow tables in place. A failed
-attempt may leave partial state for inspection; use a new manifest and run key
-rather than editing or overwriting evidence.
+Query, mutation, maintenance, and cutover artifacts remain separate owner-run
+measurements. A failed attempt may leave partial shadow state for inspection;
+operators must use a fresh run key rather than silently reusing retained output.
 
 ## Capture baseline/shadow query evidence
-
-After the matching snapshot succeeds, run:
 
 ```bash
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
@@ -143,39 +129,54 @@ INDEX_PARTITION_QUERY_SAMPLES=7 \
 cargo run -p rustok-benchmarks --bin index-partition-query-evidence --release
 ```
 
-The explicit query opt-in is mandatory. The runner validates:
+The query runner executes exactly `manifest.repetitions.query` unique tenant-scoped
+runs in one read-only repeatable-read transaction. Each run verifies result digest
+parity, alternates execution order, retains full JSON
+`EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)`, calculates nearest-rank p95 and
+`normalized_partition_plan_v1`, and requires each used shadow relation to prune to
+exactly one entity or link child partition. It publishes `query.json` once.
 
-- the complete canonical manifest identity and deterministic shadow plan;
-- PostgreSQL 16, JIT off, and `enable_partition_pruning=on`;
-- ordinary unpartitioned canonical relations;
-- manifest-bound shadow parent comments, child names, and partition bounds.
+## Capture baseline/shadow mutation and WAL evidence
 
-It then executes exactly `manifest.repetitions.query` unique tenant-scoped runs in
-one read-only repeatable-read transaction. The deterministic template set covers
-entity scope pages, keyset pages, exact counts, link scope pages, and source/link
-joins when link rows exist. Each run:
+Run only after the matching snapshot succeeds and the evidence-ID-bound shadow
+relations remain unchanged:
 
-- calculates baseline and shadow result rows and SHA-256 result digest parity;
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+INDEX_PARTITION_MUTATION_SAMPLES=7 \
+cargo run -p rustok-benchmarks --bin index-partition-mutation-evidence --release
+```
+
+The explicit mutation opt-in is mandatory. Before measuring, the runner revalidates
+the canonical manifest identity, PostgreSQL 16, JIT off, partition pruning,
+`synchronous_commit=on`, ordinary canonical tables, shadow comments, child names,
+and partition bounds. It requires canonical/shadow row-count parity and loads only
+byte-for-byte matching generic entity/link anchors.
+
+The runner creates exactly `manifest.repetitions.mutation` unique runs, alternating
+entity timestamp touches and link deletes when matching links exist. The full run
+uses one rollback-only repeatable-read transaction. Every validation and EXPLAIN
+mutation is rolled back to a savepoint, and the outer transaction is rolled back as
+well. No mutation is committed.
+
+Each run:
+
+- requires exactly one affected row on baseline and shadow;
 - alternates baseline/shadow execution order across samples;
-- retains full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` inputs;
+- retains every full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` sample;
 - calculates nearest-rank baseline and shadow p95 latency;
-- calculates `normalized_partition_plan_v1` SHA-256 plan identities;
-- rejects unstable normalized plans or relation reads across samples;
-- rejects baseline access to shadow relations and shadow access to canonical tables;
-- requires a shadow plan to prune to exactly one entity or link child partition for
-  every logical relation used by the query.
+- records `baseline_wal_bytes` and `shadow_wal_bytes` as the conservative maximum
+  per-sample plan-node WAL bytes;
+- rejects unstable affected-row or relation-access evidence;
+- rejects baseline access to shadows and shadow access to canonical relations;
+- requires each shadow mutation target to prune to exactly one child partition.
 
-The plan normalizer excludes runtime timing, buffers/WAL counters, costs, row
-estimates, physical relation/index names, and partition suffixes. It retains the
-logical template, tenant predicate contract, predicates, ordering, join type and
-algorithm, aggregate/sort/limit structure, and collapsed partition scan shape.
-Physical partition fan-out therefore cannot be hidden, while expected
-unpartitioned-versus-single-child scan differences do not create false plan drift.
-
-The runner publishes a top-level JSON array to `query.json` using temporary-file and
-hard-link no-clobber semantics. Besides the packet-required fields (`name`, p95
-latencies, and plan digests), each run retains result parity, relation-read identity,
-and every raw EXPLAIN sample for review. It performs no mutation or cutover work.
+The runner publishes one top-level array to `mutation.json` using temporary-file and
+hard-link no-clobber semantics. WAL values are plan evidence, not persistent bloat
+or post-checkpoint storage measurements.
 
 ## Capture the remaining raw artifacts
 
@@ -184,13 +185,12 @@ The complete bundle contains six regular, non-symlink JSON files:
 - `baseline.json` — produced by the snapshot runner;
 - `shadow.json` — produced by the snapshot runner;
 - `query.json` — produced by the query evidence runner;
-- `mutation.json` — mutation p95 and WAL measurements;
+- `mutation.json` — produced by the mutation/WAL evidence runner;
 - `maintenance.json` — ordinary VACUUM/dead-tuple measurements;
 - `cutover.json` — lock rehearsals and rollback/invariance facts.
 
-The owner still executes mutation, maintenance, and cutover rehearsal evidence.
-Final files are written once and never edited after measurement. A formatting-only
-byte change intentionally changes the raw artifact digest.
+The owner still executes maintenance and cutover rehearsal evidence. Final files are
+written once and never edited after measurement.
 
 Create `capture.json` beside the six artifacts:
 
@@ -228,72 +228,73 @@ Artifact paths are relative to `capture.json` and remain inside the canonical
 bundle. Absolute paths, traversal, duplicates, directories, symbolic links, hard
 link aliases, and input/output aliases fail closed.
 
-## Assemble the measured packet
+## Retained artifact contract
+
+The packet bundle contains six raw JSON artifacts. They must be regular files, never symbolic links.
+The assembler rejects hard-link aliases so two artifact roles cannot reference the same inode.
+The PostgreSQL system identifier binds the database instance used for the run.
+The assembler calculates SHA-256 digests for the retained raw baseline, shadow,
+query, mutation, maintenance, and cutover bytes before parsing their contracts.
+Tenant-predicate coverage is calculated by the validator from the audited template
+counts. The packet cannot supply a precomputed pass/fail value; `packet_digest` and
+all admission metrics are recalculated from retained input.
+
+The reviewed bootstrap file is shadow-only. It must not contain production `ALTER TABLE`, `DROP TABLE`, `RENAME TO`
+statements, copy/replay/dual-write instructions, or cutover authorization.
+
+## Assemble and validate
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-assemble \
   --manifest evidence/index-partition/manifest.json \
   --capture evidence/index-partition/capture.json \
   --output evidence/index-partition/partition-packet.json
-```
 
-The assembler reads each raw artifact exactly once, hashes its exact bytes, parses
-the required shape, constructs `index_partition_evidence_packet_v1`, and runs the
-canonical structural validator. It refuses overwrite and does not accept caller
-supplied hashes, packet fields, admission reasons, or pass/fail flags.
-
-## Required measured evidence
-
-### Baseline and shadow
-
-Baseline records timestamps, distinct tenants, audited query coverage, and exact
-entity/link rows, bytes, and logical digests. Shadow records timestamps, catch-up,
-validated FK state, orphan count, logical parity, and one positive size per child.
-Partition skew and all admission decisions are calculated later.
-
-### Query measurements
-
-Each unique query run records baseline/shadow p95 and SHA-256 plan digests. Both use
-`normalized_partition_plan_v1`. Raw EXPLAIN samples, result digest parity, and exact
-child relation reads remain retained reviewer evidence. The validator calculates
-maximum non-negative latency regression and counts plan digest changes.
-
-### Mutation and WAL measurements
-
-Each run records baseline/shadow p95 and WAL bytes. The validator calculates maximum
-latency regression and WAL amplification.
-
-### Maintenance measurements
-
-Each run records baseline/shadow ordinary VACUUM duration and dead tuples.
-`VACUUM FULL` is invalid evidence.
-
-### Cutover rehearsals
-
-Each rehearsal records lock duration, rollback verification, and confirmation that
-production relations remained unchanged. This is evidence only; production cutover
-is not implemented here.
-
-## Validate and publish admission
-
-```bash
 node scripts/verify/index-storage-tooling.mjs partition-validate \
   --input evidence/index-partition/partition-packet.json \
   --output evidence/index-partition/admission.json
 ```
 
-The validator recomputes manifest identity, provenance, raw hashes, timestamp order,
-repetition counts, tenant coverage, digest parity, latency/WAL regression, partition
-skew, lock duration, rollback facts, and typed rejection reasons. It publishes
-`index_partition_admission_v1` with either `admitted` or `keep_unpartitioned`. A
-structurally invalid packet produces no admission output.
+The assembler reads every raw file once, hashes exact bytes, constructs
+`index_partition_evidence_packet_v1`, and refuses caller-supplied hashes or pass
+flags. The validator recomputes manifest identity, provenance, repetitions, tenant
+coverage, digest parity, query/mutation latency, WAL amplification, partition skew,
+lock duration, rollback facts, and typed reasons. Structurally invalid evidence
+produces no admission output.
+
+## Required measured evidence
+
+### Baseline and shadow
+
+Rows, bytes, tenants, audited query coverage, logical digests, child sizes, catch-up,
+FK validation, and orphan state.
+
+### Query measurements
+
+Unique names, baseline/shadow p95, normalized plan digests, result parity, exact
+child reads, and retained raw EXPLAIN samples.
+
+### Mutation and WAL measurements
+
+Unique names, exactly one affected row, baseline/shadow p95, positive maximum
+per-sample plan-node WAL bytes, exact shadow child pruning, and retained raw EXPLAIN
+samples. The validator calculates mutation latency regression and WAL amplification.
+
+### Maintenance measurements
+
+Baseline/shadow ordinary VACUUM duration and dead tuples. `VACUUM FULL` is invalid.
+
+### Cutover rehearsals
+
+Lock duration, rollback verification, and proof that production relations remained
+unchanged. Production cutover is not implemented by this runbook.
 
 ## Retention and review
 
 Retain together:
 
 - `config.json`, `manifest.json`, `bootstrap.sql`, and `query-audit.json`;
-- all six raw JSON artifacts and their deeper PostgreSQL/EXPLAIN inputs;
+- all six raw JSON artifacts and deeper PostgreSQL/EXPLAIN inputs;
 - `capture.json`, `partition-packet.json`, and `admission.json`;
 - PostgreSQL logs and runner metadata.
 
@@ -309,12 +310,15 @@ The repository owner runs:
 ```bash
 cargo test -p rustok-benchmarks partition_snapshot
 cargo test -p rustok-benchmarks partition_query
+cargo test -p rustok-benchmarks partition_mutation
 cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
 cargo check -p rustok-benchmarks --bin index-partition-query-evidence
+cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
 node --test scripts/verify/index-partition-evidence.test.mjs
 node --test scripts/verify/index-partition-evidence-assembly.test.mjs
 node scripts/verify/verify-index-partition-evidence.mjs
 node scripts/verify/verify-index-partition-snapshot-capture.mjs
 node scripts/verify/verify-index-partition-query-evidence.mjs
+node scripts/verify/verify-index-partition-mutation-evidence.mjs
 node scripts/verify/index-storage-tooling.mjs contract
 ```

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -49,6 +49,10 @@ path = "src/bin/index_partition_snapshot_capture.rs"
 name = "index-partition-query-evidence"
 path = "src/bin/index_partition_query_evidence.rs"
 
+[[bin]]
+name = "index-partition-mutation-evidence"
+path = "src/bin/index_partition_mutation_evidence.rs"
+
 [[bench]]
 name = "tenant_cache"
 harness = false

--- a/ops/benches/README.md
+++ b/ops/benches/README.md
@@ -21,6 +21,8 @@ This is a standalone workspace crate named `rustok-benchmarks`.
   snapshot runner for the canonical Index relations.
 - `src/bin/index_partition_query_evidence.rs` — owner-operated M3 baseline/shadow
   query latency, result-parity, plan-normalization, and pruning evidence runner.
+- `src/bin/index_partition_mutation_evidence.rs` — owner-operated M3 baseline/shadow
+  rollback-only mutation latency and WAL evidence runner.
 
 ## Purpose
 
@@ -40,10 +42,11 @@ M2 run.
 The M3 partition runners are different. The snapshot runner reads the canonical
 `index_entities` and `index_links` tables, creates deterministic evidence-ID-bound
 shadow parents and children, and copies one repeatable-read snapshot into them. The
-query runner then compares those canonical and shadow relations inside a read-only
-repeatable-read transaction. Neither runner renames, drops, or alters the canonical
-production relations. Run them only against an owner-approved PostgreSQL 16
-evidence database.
+query runner compares those canonical and shadow relations read-only. The mutation
+runner executes matched updates/deletes through savepoints inside one rollback-only
+repeatable-read transaction. None of these runners renames, drops, or cuts over the
+canonical relations. The snapshot runner does not rename, drop, or alter the canonical production relations.
+Run them only against an owner-approved PostgreSQL 16 evidence database.
 
 ## Typical Criterion usage
 
@@ -152,16 +155,41 @@ repeatable-read transaction.
 For every run it verifies baseline/shadow result digest parity, alternates execution
 order, calculates nearest-rank p95 latency, retains full JSON
 `EXPLAIN (ANALYZE, BUFFERS, WAL)` samples, and produces
-`normalized_partition_plan_v1` SHA-256 digests. The normalizer removes physical
-relation/index names and runtime counters while retaining logical operators, join
-shape/type, predicates, ordering, and tenant-hash pruning semantics. Every shadow
-sample must read exactly one child partition for each used entity or link relation;
-canonical and unrelated relations fail closed.
+`normalized_partition_plan_v1` SHA-256 digests. Every shadow sample must read exactly
+one child partition for each used relation. The completed top-level array is
+published once as `query.json` with no-clobber semantics.
 
-The completed top-level array is published once as `query.json` through temporary
-file plus hard-link no-clobber semantics. The runner performs no mutation,
-maintenance, replay, rename, drop, or cutover operation. It produces evidence only;
-the packet assembler and admission validator remain authoritative.
+## Index partition mutation/WAL evidence
+
+Run this only after snapshot capture and while the same manifest-bound shadow
+relations remain in place:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE=1 \
+INDEX_PARTITION_MANIFEST=evidence/index-partition/manifest.json \
+INDEX_PARTITION_EVIDENCE_ROOT=evidence/index-partition \
+INDEX_PARTITION_MUTATION_SAMPLES=7 \
+cargo run -p rustok-benchmarks --bin index-partition-mutation-evidence --release
+```
+
+The explicit mutation opt-in is mandatory. The runner revalidates the prepared
+manifest, PostgreSQL 16/JIT/pruning settings, canonical relations, shadow comments,
+child names, and partition bounds. It requires canonical/shadow row-count parity and
+selects only byte-for-byte matching generic entity/link anchors.
+
+It builds exactly `manifest.repetitions.mutation` unique entity-touch and link-delete
+runs. The complete comparison uses one rollback-only repeatable-read transaction.
+Every direct validation and every `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)`
+mutation is isolated by a savepoint, rolled back, and then the outer transaction is
+also rolled back. No measured write is committed.
+
+For every run the runner requires exactly one affected row on both sides, alternates
+baseline/shadow order, calculates nearest-rank p95 latency, retains every full JSON
+EXPLAIN sample, and records maximum per-sample plan-node WAL bytes conservatively in
+`baseline_wal_bytes` and `shadow_wal_bytes`. Each shadow mutation must prune its
+target to exactly one child partition. The completed array is published once as
+`mutation.json` with temporary-file plus hard-link no-clobber semantics.
 
 Scale values for the M2 runners:
 

--- a/ops/benches/src/bin/index_partition_mutation_evidence.rs
+++ b/ops/benches/src/bin/index_partition_mutation_evidence.rs
@@ -1,0 +1,17 @@
+use rustok_benchmarks::index_storage::{
+    PartitionMutationConfig, capture_partition_mutation_evidence,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = PartitionMutationConfig::from_env()?;
+    let capture = capture_partition_mutation_evidence(&config).await?;
+    println!(
+        "index partition mutation evidence complete: evidence_id={} runs={} samples_per_run={} output={}",
+        capture.evidence_id,
+        capture.runs,
+        capture.samples_per_run,
+        capture.output_path.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -4,6 +4,7 @@ mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
+mod partition_mutation;
 mod partition_query;
 mod partition_snapshot;
 mod report_provenance;
@@ -18,6 +19,9 @@ pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
+pub use partition_mutation::{
+    PartitionMutationCapture, PartitionMutationConfig, capture_partition_mutation_evidence,
+};
 pub use partition_query::{
     PartitionQueryCapture, PartitionQueryConfig, capture_partition_query_evidence,
 };

--- a/ops/benches/src/index_storage/partition_mutation.rs
+++ b/ops/benches/src/index_storage/partition_mutation.rs
@@ -1,0 +1,1262 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    fs::{self, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+    TransactionTrait, Value as SeaValue,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use sha2::{Digest, Sha256};
+
+use super::{
+    connect_benchmark_database, ensure_database_metadata_stable,
+    explain::parse_mutation_explain_metrics, read_database_metadata,
+};
+
+const MANIFEST_CONTRACT: &str = "index_partition_evidence_manifest_v1";
+const SHADOW_PLAN_VERSION: &str = "tenant_hash_shadow_v1";
+const PLAN_DIGEST_CONTRACT: &str = "normalized_partition_plan_v1";
+const MUTATION_OPT_IN: &str = "INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE";
+const DEFAULT_MUTATION_SAMPLES: usize = 7;
+const MAX_MUTATION_SAMPLES: usize = 100;
+const SAMPLE_SAVEPOINT: &str = "index_partition_mutation_sample";
+
+#[derive(Debug, Clone)]
+pub struct PartitionMutationConfig {
+    pub database_url: String,
+    pub manifest_path: PathBuf,
+    pub output_path: PathBuf,
+    pub samples: usize,
+}
+
+impl PartitionMutationConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(MUTATION_OPT_IN).as_deref(), Ok("1")),
+            "{MUTATION_OPT_IN}=1 is required because the runner executes rollback-only PostgreSQL mutations"
+        );
+        let database_url = env::var("DATABASE_URL")
+            .context("DATABASE_URL is required for index partition mutation evidence")?;
+        let manifest_path = env::var("INDEX_PARTITION_MANIFEST")
+            .map(PathBuf::from)
+            .context("INDEX_PARTITION_MANIFEST is required")?;
+        let output_path = env::var("INDEX_PARTITION_MUTATION_OUTPUT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                env::var("INDEX_PARTITION_EVIDENCE_ROOT")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|_| PathBuf::from("target/index-partition-evidence"))
+                    .join("mutation.json")
+            });
+        let samples = env::var("INDEX_PARTITION_MUTATION_SAMPLES")
+            .unwrap_or_else(|_| DEFAULT_MUTATION_SAMPLES.to_string())
+            .parse::<usize>()
+            .context("INDEX_PARTITION_MUTATION_SAMPLES must be an integer")?;
+        ensure!(
+            (3..=MAX_MUTATION_SAMPLES).contains(&samples),
+            "INDEX_PARTITION_MUTATION_SAMPLES must be between 3 and {MAX_MUTATION_SAMPLES}"
+        );
+        ensure!(
+            manifest_path != output_path,
+            "manifest and mutation evidence output paths must be distinct"
+        );
+        Ok(Self {
+            database_url,
+            manifest_path,
+            output_path,
+            samples,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PreparedManifest {
+    contract: String,
+    repository: String,
+    commit: String,
+    run_key: String,
+    postgres_image: String,
+    strategy: String,
+    plan_digest_contract: String,
+    modulus: u32,
+    locales: Vec<String>,
+    repetitions: EvidenceRepetitions,
+    thresholds: JsonValue,
+    evidence_id: String,
+    shadow_plan_version: String,
+    shadow_relations: ShadowRelations,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct EvidenceRepetitions {
+    query: usize,
+    mutation: usize,
+    maintenance: usize,
+    cutover: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ShadowRelations {
+    definition_hash: String,
+    entities: RelationPlan,
+    links: RelationPlan,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelationPlan {
+    source: String,
+    parent: String,
+    partitions: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct EntityAnchor {
+    tenant_id: String,
+    module_name: String,
+    entity_name: String,
+    schema_version: i32,
+    entity_id: String,
+    locale_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct LinkAnchor {
+    tenant_id: String,
+    source_module: String,
+    source_entity: String,
+    source_schema_version: i32,
+    source_entity_id: String,
+    source_locale_key: String,
+    source_version: String,
+    link_name: String,
+    ordinal: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MutationTarget {
+    Entities,
+    Links,
+}
+
+#[derive(Debug, Clone)]
+struct MutationCase {
+    name: String,
+    template: &'static str,
+    baseline_sql: String,
+    shadow_sql: String,
+    values: Vec<SeaValue>,
+    target: MutationTarget,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MutationSide {
+    Baseline,
+    Shadow,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct MutationRelationReads {
+    target_relations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MutationExplainSample {
+    sample: usize,
+    execution_time_ms: f64,
+    affected_rows: u64,
+    maximum_node_wal_records: u64,
+    maximum_node_wal_fpi: u64,
+    maximum_node_wal_bytes: u64,
+    shared_hit_blocks: u64,
+    shared_read_blocks: u64,
+    relation_reads: MutationRelationReads,
+    explain: JsonValue,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PartitionMutationRunEvidence {
+    name: String,
+    template: String,
+    sample_count: usize,
+    affected_rows: u64,
+    baseline_p95_ms: f64,
+    shadow_p95_ms: f64,
+    baseline_wal_bytes: u64,
+    shadow_wal_bytes: u64,
+    baseline_relation_reads: MutationRelationReads,
+    shadow_relation_reads: MutationRelationReads,
+    baseline_explain_samples: Vec<MutationExplainSample>,
+    shadow_explain_samples: Vec<MutationExplainSample>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionMutationCapture {
+    pub evidence_id: String,
+    pub output_path: PathBuf,
+    pub runs: usize,
+    pub samples_per_run: usize,
+}
+
+pub async fn capture_partition_mutation_evidence(
+    config: &PartitionMutationConfig,
+) -> Result<PartitionMutationCapture> {
+    ensure_output_available(&config.output_path)?;
+    let (manifest, raw_manifest) = read_manifest(&config.manifest_path)?;
+    validate_manifest(&manifest, &raw_manifest)?;
+
+    let db = connect_benchmark_database(&config.database_url).await?;
+    db.execute_unprepared(
+        "SET jit = off; SET lock_timeout = '5s'; SET statement_timeout = 0; SET enable_partition_pruning = on; SET synchronous_commit = on;",
+    )
+    .await
+    .context("failed to pin partition mutation evidence session settings")?;
+    let database_metadata = read_database_metadata(&db).await?;
+    ensure!(
+        database_metadata.server_version_num.starts_with("16"),
+        "partition mutation evidence requires PostgreSQL 16, got {}",
+        database_metadata.server_version_num
+    );
+    ensure!(
+        database_metadata.jit == "off",
+        "partition mutation evidence requires jit=off"
+    );
+    ensure_session_setting(&db, "enable_partition_pruning", "on").await?;
+    ensure_session_setting(&db, "synchronous_commit", "on").await?;
+    ensure_unpartitioned_source(&db, "index_entities").await?;
+    ensure_unpartitioned_source(&db, "index_links").await?;
+    validate_shadow_catalog(&db, &manifest).await?;
+
+    acquire_mutation_lock(&db, &manifest.evidence_id).await?;
+    let capture_result = capture_locked_mutations(&db, &manifest, config.samples).await;
+    let release_result = release_mutation_lock(&db, &manifest.evidence_id).await;
+    let runs = match capture_result {
+        Ok(runs) => {
+            release_result?;
+            runs
+        }
+        Err(error) => {
+            let _ = release_result;
+            return Err(error);
+        }
+    };
+
+    ensure_database_metadata_stable(&db, &database_metadata, "partition mutation evidence").await?;
+    publish_mutation_artifact(&config.output_path, &runs)?;
+    Ok(PartitionMutationCapture {
+        evidence_id: manifest.evidence_id,
+        output_path: config.output_path.clone(),
+        runs: runs.len(),
+        samples_per_run: config.samples,
+    })
+}
+
+async fn capture_locked_mutations(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+    samples: usize,
+) -> Result<Vec<PartitionMutationRunEvidence>> {
+    let transaction = db
+        .begin()
+        .await
+        .context("failed to start partition mutation evidence transaction")?;
+    transaction
+        .execute_unprepared("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+        .await
+        .context("failed to pin repeatable-read mutation evidence snapshot")?;
+
+    let capture_result = capture_mutations_in_transaction(&transaction, manifest, samples).await;
+    let rollback_result = transaction.rollback().await;
+    match capture_result {
+        Ok(runs) => {
+            rollback_result.context("failed to roll back partition mutation evidence transaction")?;
+            Ok(runs)
+        }
+        Err(error) => {
+            let _ = rollback_result;
+            Err(error)
+        }
+    }
+}
+
+async fn capture_mutations_in_transaction(
+    transaction: &DatabaseTransaction,
+    manifest: &PreparedManifest,
+    samples: usize,
+) -> Result<Vec<PartitionMutationRunEvidence>> {
+    ensure_relation_count_parity(
+        transaction,
+        "index_entities",
+        &manifest.shadow_relations.entities.parent,
+    )
+    .await?;
+    ensure_relation_count_parity(
+        transaction,
+        "index_links",
+        &manifest.shadow_relations.links.parent,
+    )
+    .await?;
+
+    let entity_anchors = load_entity_anchors(
+        transaction,
+        &manifest.shadow_relations.entities.parent,
+        manifest.repetitions.mutation,
+    )
+    .await?;
+    ensure!(
+        !entity_anchors.is_empty(),
+        "partition mutation evidence requires at least one matching canonical/shadow entity row"
+    );
+    let link_anchors = load_link_anchors(
+        transaction,
+        &manifest.shadow_relations.links.parent,
+        manifest.repetitions.mutation,
+    )
+    .await?;
+    let cases = build_mutation_cases(manifest, &entity_anchors, &link_anchors)?;
+    ensure!(
+        cases.len() == manifest.repetitions.mutation,
+        "partition mutation runner did not build the exact manifest mutation run count"
+    );
+
+    let mut runs = Vec::with_capacity(cases.len());
+    for case in &cases {
+        runs.push(capture_mutation_case(transaction, manifest, case, samples).await?);
+    }
+    Ok(runs)
+}
+
+fn read_manifest(path: &Path) -> Result<(PreparedManifest, JsonValue)> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect partition manifest at {path:?}"))?;
+    ensure!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "partition manifest must be a regular non-symlink file"
+    );
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read partition manifest at {path:?}"))?;
+    let raw: JsonValue = serde_json::from_slice(&bytes)
+        .context("failed to parse partition manifest JSON")?;
+    let manifest = serde_json::from_value(raw.clone())
+        .context("failed to deserialize prepared partition manifest")?;
+    Ok((manifest, raw))
+}
+
+fn validate_manifest(manifest: &PreparedManifest, raw: &JsonValue) -> Result<()> {
+    ensure!(manifest.contract == MANIFEST_CONTRACT, "unexpected manifest contract");
+    ensure!(manifest.repository == "RusTokRs/RusTok", "unexpected manifest repository");
+    ensure!(is_lower_hex(&manifest.commit, 40), "manifest commit must be a lowercase full SHA-1");
+    ensure!(
+        !manifest.run_key.is_empty() && manifest.run_key.len() <= 128,
+        "manifest run_key must be non-empty and bounded"
+    );
+    ensure!(manifest.postgres_image == "postgres:16", "manifest must pin postgres:16");
+    ensure!(manifest.strategy == "tenant_hash", "manifest strategy must be tenant_hash");
+    ensure!(
+        manifest.plan_digest_contract == PLAN_DIGEST_CONTRACT,
+        "unexpected plan digest contract"
+    );
+    ensure!(
+        manifest.modulus >= 2
+            && manifest.modulus <= 128
+            && manifest.modulus.is_power_of_two(),
+        "manifest modulus must be a power of two between 2 and 128"
+    );
+    ensure!(
+        !manifest.locales.is_empty()
+            && manifest.locales.iter().all(|locale| !locale.is_empty())
+            && manifest.locales.iter().collect::<BTreeSet<_>>().len() == manifest.locales.len(),
+        "manifest locales must be unique and non-empty"
+    );
+    ensure!(
+        manifest.repetitions.query > 0
+            && manifest.repetitions.mutation > 0
+            && manifest.repetitions.maintenance > 0
+            && manifest.repetitions.cutover > 0,
+        "manifest repetition counts must all be positive"
+    );
+    ensure!(manifest.thresholds.is_object(), "manifest thresholds must be an object");
+    ensure!(is_lower_hex(&manifest.evidence_id, 64), "invalid manifest evidence_id");
+    ensure!(
+        manifest.shadow_plan_version == SHADOW_PLAN_VERSION,
+        "unexpected shadow plan version"
+    );
+
+    let mut input = raw
+        .as_object()
+        .cloned()
+        .context("prepared manifest must be a JSON object")?;
+    for key in ["evidence_id", "shadow_plan_version", "shadow_relations"] {
+        ensure!(input.remove(key).is_some(), "prepared manifest is missing {key}");
+    }
+    let expected_evidence_id = sha256_hex(&canonical_json_bytes(&JsonValue::Object(input))?);
+    ensure!(
+        expected_evidence_id == manifest.evidence_id,
+        "manifest evidence_id does not match canonical manifest input"
+    );
+
+    let modulus = manifest.modulus.to_string();
+    let definition = [
+        "rustok-index-partition",
+        SHADOW_PLAN_VERSION,
+        manifest.evidence_id.as_str(),
+        "tenant_hash",
+        modulus.as_str(),
+    ]
+    .join("\u{1f}");
+    let definition_hash = sha256_hex(definition.as_bytes());
+    ensure!(
+        manifest.shadow_relations.definition_hash == definition_hash,
+        "shadow definition hash does not match evidence identity"
+    );
+    let suffix = &definition_hash[..24];
+    validate_relation_plan(
+        &manifest.shadow_relations.entities,
+        "index_entities",
+        &format!("index_entities_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    validate_relation_plan(
+        &manifest.shadow_relations.links,
+        "index_links",
+        &format!("index_links_shadow_{suffix}"),
+        manifest.modulus,
+    )?;
+    Ok(())
+}
+
+fn validate_relation_plan(
+    plan: &RelationPlan,
+    expected_source: &str,
+    expected_parent: &str,
+    modulus: u32,
+) -> Result<()> {
+    ensure!(plan.source == expected_source, "unexpected shadow source relation");
+    ensure!(plan.parent == expected_parent, "unexpected shadow parent relation");
+    validate_identifier(&plan.parent)?;
+    ensure!(
+        plan.partitions.len() == modulus as usize,
+        "shadow relation must contain exactly {modulus} child partitions"
+    );
+    for (remainder, partition) in plan.partitions.iter().enumerate() {
+        validate_identifier(partition)?;
+        ensure!(
+            partition == &format!("{expected_parent}_p{remainder:03}"),
+            "unexpected shadow child relation"
+        );
+    }
+    Ok(())
+}
+
+async fn ensure_session_setting(
+    db: &DatabaseConnection,
+    setting: &str,
+    expected: &str,
+) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT current_setting($1) AS value",
+            vec![setting.into()],
+        ))
+        .await?
+        .context("partition mutation session-setting query returned no row")?;
+    let actual: String = row.try_get("", "value")?;
+    ensure!(actual == expected, "requires {setting}={expected}, got {actual}");
+    Ok(())
+}
+
+async fn ensure_unpartitioned_source(db: &DatabaseConnection, relation: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT c.relkind::text AS relkind, c.relispartition, ",
+                "EXISTS (SELECT 1 FROM pg_partitioned_table p WHERE p.partrelid = c.oid) AS partitioned ",
+                "FROM pg_class c WHERE c.oid = to_regclass($1)"
+            ),
+            vec![relation.into()],
+        ))
+        .await?
+        .with_context(|| format!("canonical relation {relation} was not found"))?;
+    let relkind: String = row.try_get("", "relkind")?;
+    let relispartition: bool = row.try_get("", "relispartition")?;
+    let partitioned: bool = row.try_get("", "partitioned")?;
+    ensure!(
+        relkind == "r" && !relispartition && !partitioned,
+        "canonical relation {relation} must remain an ordinary unpartitioned table"
+    );
+    Ok(())
+}
+
+async fn validate_shadow_catalog(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+) -> Result<()> {
+    validate_shadow_relation_catalog(db, manifest, &manifest.shadow_relations.entities).await?;
+    validate_shadow_relation_catalog(db, manifest, &manifest.shadow_relations.links).await?;
+    Ok(())
+}
+
+async fn validate_shadow_relation_catalog(
+    db: &DatabaseConnection,
+    manifest: &PreparedManifest,
+    plan: &RelationPlan,
+) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT c.relkind::text AS relkind, obj_description(c.oid, 'pg_class') AS comment ",
+                "FROM pg_class c WHERE c.oid = to_regclass($1)"
+            ),
+            vec![plan.parent.clone().into()],
+        ))
+        .await?
+        .with_context(|| format!("shadow parent {} was not found", plan.parent))?;
+    let relkind: String = row.try_get("", "relkind")?;
+    let comment: Option<String> = row.try_get("", "comment")?;
+    let expected_comment = format!("rustok-index-partition:{}", manifest.evidence_id);
+    ensure!(relkind == "p", "shadow parent {} must be partitioned", plan.parent);
+    ensure!(
+        comment.as_deref() == Some(expected_comment.as_str()),
+        "shadow parent {} is not bound to the evidence identity",
+        plan.parent
+    );
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT child.relname, child.relispartition, ",
+                "pg_get_expr(child.relpartbound, child.oid) AS bound ",
+                "FROM pg_inherits inheritance ",
+                "JOIN pg_class child ON child.oid = inheritance.inhrelid ",
+                "WHERE inheritance.inhparent = to_regclass($1) ORDER BY child.relname"
+            ),
+            vec![plan.parent.clone().into()],
+        ))
+        .await?;
+    ensure!(
+        rows.len() == plan.partitions.len(),
+        "shadow parent {} has an unexpected child count",
+        plan.parent
+    );
+    let mut children = BTreeMap::new();
+    for row in rows {
+        let name: String = row.try_get("", "relname")?;
+        let relispartition: bool = row.try_get("", "relispartition")?;
+        let bound: String = row.try_get("", "bound")?;
+        ensure!(relispartition, "shadow child {name} is not a partition");
+        children.insert(name, bound.to_ascii_lowercase());
+    }
+    for (remainder, partition) in plan.partitions.iter().enumerate() {
+        let bound = children
+            .get(partition)
+            .with_context(|| format!("shadow child {partition} is missing"))?;
+        ensure!(
+            bound.contains(&format!("modulus {}", manifest.modulus))
+                && bound.contains(&format!("remainder {remainder}")),
+            "shadow child {partition} has an unexpected bound: {bound}"
+        );
+    }
+    Ok(())
+}
+
+async fn acquire_mutation_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    db.query_one(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+        vec![format!("rustok-index-partition-mutation:{evidence_id}").into()],
+    ))
+    .await?
+    .context("partition mutation advisory lock returned no row")?;
+    Ok(())
+}
+
+async fn release_mutation_lock(db: &DatabaseConnection, evidence_id: &str) -> Result<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT pg_advisory_unlock(hashtextextended($1, 0)) AS unlocked",
+            vec![format!("rustok-index-partition-mutation:{evidence_id}").into()],
+        ))
+        .await?
+        .context("partition mutation advisory unlock returned no row")?;
+    let unlocked: bool = row.try_get("", "unlocked")?;
+    ensure!(unlocked, "partition mutation advisory lock was not held");
+    Ok(())
+}
+
+async fn ensure_relation_count_parity(
+    transaction: &DatabaseTransaction,
+    canonical: &str,
+    shadow: &str,
+) -> Result<()> {
+    let sql = format!(
+        "SELECT (SELECT count(*)::bigint FROM {}) AS canonical_rows, (SELECT count(*)::bigint FROM {}) AS shadow_rows",
+        quote_identifier(canonical),
+        quote_identifier(shadow),
+    );
+    let row = transaction
+        .query_one(Statement::from_string(DbBackend::Postgres, sql))
+        .await?
+        .context("partition mutation relation count query returned no row")?;
+    let canonical_rows: i64 = row.try_get("", "canonical_rows")?;
+    let shadow_rows: i64 = row.try_get("", "shadow_rows")?;
+    ensure!(
+        canonical_rows == shadow_rows,
+        "partition mutation relation count parity failed for {canonical} and {shadow}: {canonical_rows} != {shadow_rows}"
+    );
+    Ok(())
+}
+
+async fn load_entity_anchors(
+    transaction: &DatabaseTransaction,
+    shadow: &str,
+    requested: usize,
+) -> Result<Vec<EntityAnchor>> {
+    let limit = i64::try_from(requested.max(1)).context("mutation run count exceeds i64")?;
+    let sql = format!(
+        concat!(
+            "SELECT c.tenant_id::text AS tenant_id, c.module_name, c.entity_name, ",
+            "c.schema_version, c.entity_id::text AS entity_id, c.locale_key ",
+            "FROM index_entities c JOIN {} s ON s.tenant_id = c.tenant_id ",
+            "AND s.module_name = c.module_name AND s.entity_name = c.entity_name ",
+            "AND s.schema_version = c.schema_version AND s.entity_id = c.entity_id ",
+            "AND s.locale_key = c.locale_key WHERE to_jsonb(c) = to_jsonb(s) ",
+            "ORDER BY c.tenant_id, c.module_name, c.entity_name, c.schema_version, ",
+            "c.locale_key, c.entity_id LIMIT $1"
+        ),
+        quote_identifier(shadow),
+    );
+    let rows = transaction
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![limit.into()],
+        ))
+        .await
+        .context("failed to load deterministic matching entity mutation anchors")?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(EntityAnchor {
+                tenant_id: row.try_get("", "tenant_id")?,
+                module_name: row.try_get("", "module_name")?,
+                entity_name: row.try_get("", "entity_name")?,
+                schema_version: row.try_get("", "schema_version")?,
+                entity_id: row.try_get("", "entity_id")?,
+                locale_key: row.try_get("", "locale_key")?,
+            })
+        })
+        .collect()
+}
+
+async fn load_link_anchors(
+    transaction: &DatabaseTransaction,
+    shadow: &str,
+    requested: usize,
+) -> Result<Vec<LinkAnchor>> {
+    let limit = i64::try_from(requested.max(1)).context("mutation run count exceeds i64")?;
+    let sql = format!(
+        concat!(
+            "SELECT c.tenant_id::text AS tenant_id, c.source_module, c.source_entity, ",
+            "c.source_schema_version, c.source_entity_id::text AS source_entity_id, ",
+            "c.source_locale_key, c.source_version::text AS source_version, c.link_name, c.ordinal ",
+            "FROM index_links c JOIN {} s ON s.tenant_id = c.tenant_id ",
+            "AND s.source_module = c.source_module AND s.source_entity = c.source_entity ",
+            "AND s.source_schema_version = c.source_schema_version ",
+            "AND s.source_entity_id = c.source_entity_id ",
+            "AND s.source_locale_key = c.source_locale_key ",
+            "AND s.source_version = c.source_version AND s.link_name = c.link_name ",
+            "AND s.ordinal = c.ordinal WHERE to_jsonb(c) = to_jsonb(s) ",
+            "ORDER BY c.tenant_id, c.source_module, c.source_entity, c.source_schema_version, ",
+            "c.source_locale_key, c.source_entity_id, c.source_version, c.link_name, c.ordinal LIMIT $1"
+        ),
+        quote_identifier(shadow),
+    );
+    let rows = transaction
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![limit.into()],
+        ))
+        .await
+        .context("failed to load deterministic matching link mutation anchors")?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(LinkAnchor {
+                tenant_id: row.try_get("", "tenant_id")?,
+                source_module: row.try_get("", "source_module")?,
+                source_entity: row.try_get("", "source_entity")?,
+                source_schema_version: row.try_get("", "source_schema_version")?,
+                source_entity_id: row.try_get("", "source_entity_id")?,
+                source_locale_key: row.try_get("", "source_locale_key")?,
+                source_version: row.try_get("", "source_version")?,
+                link_name: row.try_get("", "link_name")?,
+                ordinal: row.try_get("", "ordinal")?,
+            })
+        })
+        .collect()
+}
+
+fn build_mutation_cases(
+    manifest: &PreparedManifest,
+    entities: &[EntityAnchor],
+    links: &[LinkAnchor],
+) -> Result<Vec<MutationCase>> {
+    ensure!(!entities.is_empty(), "entity mutation anchors must not be empty");
+    let mut cases = Vec::with_capacity(manifest.repetitions.mutation);
+    for index in 0..manifest.repetitions.mutation {
+        let ordinal = index + 1;
+        if index % 2 == 1 && !links.is_empty() {
+            cases.push(link_delete_case(
+                ordinal,
+                &links[index % links.len()],
+                &manifest.shadow_relations.links.parent,
+            ));
+        } else {
+            cases.push(entity_touch_case(
+                ordinal,
+                &entities[index % entities.len()],
+                &manifest.shadow_relations.entities.parent,
+            ));
+        }
+    }
+    let names = cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    ensure!(names.len() == cases.len(), "partition mutation cases contain duplicate names");
+    Ok(cases)
+}
+
+fn entity_touch_case(ordinal: usize, anchor: &EntityAnchor, shadow: &str) -> MutationCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "UPDATE {} e SET updated_at = e.updated_at + INTERVAL '1 microsecond' ",
+                "WHERE e.tenant_id = $1::uuid AND e.module_name = $2 AND e.entity_name = $3 ",
+                "AND e.schema_version = $4::integer AND e.entity_id = $5::uuid ",
+                "AND e.locale_key = $6 RETURNING 1::bigint AS affected"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    MutationCase {
+        name: format!("entity-touch-{ordinal:03}"),
+        template: "entity_touch_v1",
+        baseline_sql: render("index_entities"),
+        shadow_sql: render(shadow),
+        values: vec![
+            anchor.tenant_id.clone().into(),
+            anchor.module_name.clone().into(),
+            anchor.entity_name.clone().into(),
+            anchor.schema_version.into(),
+            anchor.entity_id.clone().into(),
+            anchor.locale_key.clone().into(),
+        ],
+        target: MutationTarget::Entities,
+    }
+}
+
+fn link_delete_case(ordinal: usize, anchor: &LinkAnchor, shadow: &str) -> MutationCase {
+    let render = |relation: &str| {
+        format!(
+            concat!(
+                "DELETE FROM {} l WHERE l.tenant_id = $1::uuid AND l.source_module = $2 ",
+                "AND l.source_entity = $3 AND l.source_schema_version = $4::integer ",
+                "AND l.source_entity_id = $5::uuid AND l.source_locale_key = $6 ",
+                "AND l.source_version = $7::numeric AND l.link_name = $8 ",
+                "AND l.ordinal = $9::integer RETURNING 1::bigint AS affected"
+            ),
+            quote_identifier(relation),
+        )
+    };
+    MutationCase {
+        name: format!("link-delete-{ordinal:03}"),
+        template: "link_delete_v1",
+        baseline_sql: render("index_links"),
+        shadow_sql: render(shadow),
+        values: vec![
+            anchor.tenant_id.clone().into(),
+            anchor.source_module.clone().into(),
+            anchor.source_entity.clone().into(),
+            anchor.source_schema_version.into(),
+            anchor.source_entity_id.clone().into(),
+            anchor.source_locale_key.clone().into(),
+            anchor.source_version.clone().into(),
+            anchor.link_name.clone().into(),
+            anchor.ordinal.into(),
+        ],
+        target: MutationTarget::Links,
+    }
+}
+
+async fn capture_mutation_case(
+    transaction: &DatabaseTransaction,
+    manifest: &PreparedManifest,
+    case: &MutationCase,
+    samples: usize,
+) -> Result<PartitionMutationRunEvidence> {
+    let baseline_affected = validate_mutation_side(transaction, case, MutationSide::Baseline).await?;
+    let shadow_affected = validate_mutation_side(transaction, case, MutationSide::Shadow).await?;
+    ensure!(
+        baseline_affected == 1 && shadow_affected == baseline_affected,
+        "mutation {} did not affect exactly one matching row on both sides",
+        case.name
+    );
+
+    let mut baseline_samples = Vec::with_capacity(samples);
+    let mut shadow_samples = Vec::with_capacity(samples);
+    for sample in 1..=samples {
+        if sample % 2 == 1 {
+            baseline_samples.push(
+                explain_mutation_sample(transaction, manifest, case, MutationSide::Baseline, sample)
+                    .await?,
+            );
+            shadow_samples.push(
+                explain_mutation_sample(transaction, manifest, case, MutationSide::Shadow, sample)
+                    .await?,
+            );
+        } else {
+            shadow_samples.push(
+                explain_mutation_sample(transaction, manifest, case, MutationSide::Shadow, sample)
+                    .await?,
+            );
+            baseline_samples.push(
+                explain_mutation_sample(transaction, manifest, case, MutationSide::Baseline, sample)
+                    .await?,
+            );
+        }
+    }
+
+    ensure_stable_affected_rows(&baseline_samples, &case.name, "baseline")?;
+    ensure_stable_affected_rows(&shadow_samples, &case.name, "shadow")?;
+    let baseline_relation_reads =
+        stable_relation_reads(&baseline_samples, &case.name, "baseline")?;
+    let shadow_relation_reads = stable_relation_reads(&shadow_samples, &case.name, "shadow")?;
+    let baseline_p95_ms = percentile_95(
+        &baseline_samples
+            .iter()
+            .map(|sample| sample.execution_time_ms)
+            .collect::<Vec<_>>(),
+    )?;
+    let shadow_p95_ms = percentile_95(
+        &shadow_samples
+            .iter()
+            .map(|sample| sample.execution_time_ms)
+            .collect::<Vec<_>>(),
+    )?;
+    let baseline_wal_bytes = maximum_wal_bytes(&baseline_samples)?;
+    let shadow_wal_bytes = maximum_wal_bytes(&shadow_samples)?;
+
+    Ok(PartitionMutationRunEvidence {
+        name: case.name.clone(),
+        template: case.template.to_owned(),
+        sample_count: samples,
+        affected_rows: baseline_affected,
+        baseline_p95_ms,
+        shadow_p95_ms,
+        baseline_wal_bytes,
+        shadow_wal_bytes,
+        baseline_relation_reads,
+        shadow_relation_reads,
+        baseline_explain_samples: baseline_samples,
+        shadow_explain_samples: shadow_samples,
+    })
+}
+
+async fn validate_mutation_side(
+    transaction: &DatabaseTransaction,
+    case: &MutationCase,
+    side: MutationSide,
+) -> Result<u64> {
+    begin_sample_savepoint(transaction).await?;
+    let sql = mutation_sql(case, side);
+    let result = transaction
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql.to_owned(),
+            case.values.clone(),
+        ))
+        .await
+        .with_context(|| format!("failed to validate mutation {}", case.name));
+    let cleanup = rollback_sample_savepoint(transaction).await;
+    match result {
+        Ok(rows) => {
+            cleanup?;
+            for row in &rows {
+                let affected: i64 = row.try_get("", "affected")?;
+                ensure!(affected == 1, "mutation {} returned an invalid affected marker", case.name);
+            }
+            u64::try_from(rows.len()).context("mutation affected-row count exceeds u64")
+        }
+        Err(error) => {
+            let _ = cleanup;
+            Err(error)
+        }
+    }
+}
+
+async fn explain_mutation_sample(
+    transaction: &DatabaseTransaction,
+    manifest: &PreparedManifest,
+    case: &MutationCase,
+    side: MutationSide,
+    sample: usize,
+) -> Result<MutationExplainSample> {
+    begin_sample_savepoint(transaction).await?;
+    let sql = mutation_sql(case, side);
+    let result = transaction
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            format!("EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON) {sql}"),
+            case.values.clone(),
+        ))
+        .await
+        .with_context(|| format!("failed to execute mutation EXPLAIN for {}", case.name));
+    let cleanup = rollback_sample_savepoint(transaction).await;
+    let row = match result {
+        Ok(row) => {
+            cleanup?;
+            row.context("partition mutation EXPLAIN returned no row")?
+        }
+        Err(error) => {
+            let _ = cleanup;
+            return Err(error);
+        }
+    };
+    let explain: JsonValue = row
+        .try_get("", "QUERY PLAN")
+        .context("partition mutation EXPLAIN did not contain QUERY PLAN JSON")?;
+    let metrics = parse_mutation_explain_metrics(&explain)
+        .context("partition mutation EXPLAIN did not satisfy the WAL evidence contract")?;
+    ensure!(
+        metrics.execution_time_ms > 0.0,
+        "partition mutation execution time must be greater than zero"
+    );
+    ensure!(
+        metrics.maximum_node_wal_bytes > 0,
+        "partition mutation EXPLAIN must report positive WAL bytes"
+    );
+    let affected_rows = explain_affected_rows(&explain)?;
+    ensure!(affected_rows == 1, "mutation {} EXPLAIN affected {affected_rows} rows", case.name);
+    let relation_reads = validate_plan_relations(&explain, manifest, case, side)?;
+    Ok(MutationExplainSample {
+        sample,
+        execution_time_ms: metrics.execution_time_ms,
+        affected_rows,
+        maximum_node_wal_records: metrics.maximum_node_wal_records,
+        maximum_node_wal_fpi: metrics.maximum_node_wal_fpi,
+        maximum_node_wal_bytes: metrics.maximum_node_wal_bytes,
+        shared_hit_blocks: metrics.shared_hit_blocks,
+        shared_read_blocks: metrics.shared_read_blocks,
+        relation_reads,
+        explain,
+    })
+}
+
+fn mutation_sql(case: &MutationCase, side: MutationSide) -> &str {
+    match side {
+        MutationSide::Baseline => &case.baseline_sql,
+        MutationSide::Shadow => &case.shadow_sql,
+    }
+}
+
+async fn begin_sample_savepoint(transaction: &DatabaseTransaction) -> Result<()> {
+    transaction
+        .execute_unprepared(&format!("SAVEPOINT {SAMPLE_SAVEPOINT};"))
+        .await
+        .context("failed to create partition mutation sample savepoint")?;
+    Ok(())
+}
+
+async fn rollback_sample_savepoint(transaction: &DatabaseTransaction) -> Result<()> {
+    transaction
+        .execute_unprepared(&format!("ROLLBACK TO SAVEPOINT {SAMPLE_SAVEPOINT};"))
+        .await
+        .context("failed to roll back partition mutation sample")?;
+    transaction
+        .execute_unprepared(&format!("RELEASE SAVEPOINT {SAMPLE_SAVEPOINT};"))
+        .await
+        .context("failed to release partition mutation sample savepoint")?;
+    Ok(())
+}
+
+fn explain_affected_rows(explain: &JsonValue) -> Result<u64> {
+    let root = explain_root(explain)?;
+    let plan = root
+        .get("Plan")
+        .and_then(JsonValue::as_object)
+        .context("partition mutation EXPLAIN is missing Plan")?;
+    non_negative_integer(plan.get("Actual Rows"), "Plan.Actual Rows")
+}
+
+fn non_negative_integer(value: Option<&JsonValue>, label: &str) -> Result<u64> {
+    let value = value.with_context(|| format!("partition mutation EXPLAIN is missing {label}"))?;
+    if let Some(integer) = value.as_u64() {
+        return Ok(integer);
+    }
+    let number = value
+        .as_f64()
+        .with_context(|| format!("partition mutation EXPLAIN {label} must be numeric"))?;
+    ensure!(
+        number.is_finite() && number >= 0.0 && number.fract() == 0.0,
+        "partition mutation EXPLAIN {label} must be a non-negative integer"
+    );
+    ensure!(number <= u64::MAX as f64, "partition mutation EXPLAIN {label} exceeds u64");
+    Ok(number as u64)
+}
+
+fn validate_plan_relations(
+    explain: &JsonValue,
+    manifest: &PreparedManifest,
+    case: &MutationCase,
+    side: MutationSide,
+) -> Result<MutationRelationReads> {
+    let mut names = BTreeSet::new();
+    collect_relation_names(explain, &mut names);
+    let (canonical, plan) = match case.target {
+        MutationTarget::Entities => ("index_entities", &manifest.shadow_relations.entities),
+        MutationTarget::Links => ("index_links", &manifest.shadow_relations.links),
+    };
+    let all_shadow = manifest
+        .shadow_relations
+        .entities
+        .partitions
+        .iter()
+        .chain(manifest.shadow_relations.links.partitions.iter())
+        .cloned()
+        .chain([
+            manifest.shadow_relations.entities.parent.clone(),
+            manifest.shadow_relations.links.parent.clone(),
+        ])
+        .collect::<BTreeSet<_>>();
+
+    match side {
+        MutationSide::Baseline => {
+            ensure!(
+                names.contains(canonical),
+                "baseline mutation {} did not access {canonical}",
+                case.name
+            );
+            ensure!(
+                names.is_disjoint(&all_shadow),
+                "baseline mutation {} accessed a shadow relation",
+                case.name
+            );
+            ensure!(
+                names.iter().all(|name| name == canonical),
+                "baseline mutation {} accessed an unexpected relation: {:?}",
+                case.name,
+                names
+            );
+            Ok(MutationRelationReads {
+                target_relations: vec![canonical.to_owned()],
+            })
+        }
+        MutationSide::Shadow => {
+            ensure!(
+                !names.contains("index_entities") && !names.contains("index_links"),
+                "shadow mutation {} accessed a canonical relation",
+                case.name
+            );
+            let children = plan.partitions.iter().cloned().collect::<BTreeSet<_>>();
+            let touched_children = names.intersection(&children).cloned().collect::<Vec<_>>();
+            ensure!(
+                touched_children.len() == 1,
+                "shadow mutation {} must prune its target to exactly one child partition",
+                case.name
+            );
+            let allowed = children
+                .into_iter()
+                .chain([plan.parent.clone()])
+                .collect::<BTreeSet<_>>();
+            ensure!(
+                names.is_subset(&allowed),
+                "shadow mutation {} accessed a relation outside its manifest shadow plan: {:?}",
+                case.name,
+                names.difference(&allowed).collect::<Vec<_>>()
+            );
+            Ok(MutationRelationReads {
+                target_relations: names.into_iter().collect(),
+            })
+        }
+    }
+}
+
+fn collect_relation_names(value: &JsonValue, names: &mut BTreeSet<String>) {
+    match value {
+        JsonValue::Array(values) => {
+            for value in values {
+                collect_relation_names(value, names);
+            }
+        }
+        JsonValue::Object(values) => {
+            if let Some(name) = values.get("Relation Name").and_then(JsonValue::as_str) {
+                names.insert(name.to_owned());
+            }
+            for value in values.values() {
+                collect_relation_names(value, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn explain_root(explain: &JsonValue) -> Result<&JsonMap<String, JsonValue>> {
+    let entries = explain
+        .as_array()
+        .context("partition mutation EXPLAIN must be a JSON array")?;
+    ensure!(
+        entries.len() == 1,
+        "partition mutation EXPLAIN must contain exactly one root entry"
+    );
+    entries[0]
+        .as_object()
+        .context("partition mutation EXPLAIN root must be an object")
+}
+
+fn ensure_stable_affected_rows(
+    samples: &[MutationExplainSample],
+    mutation: &str,
+    side: &str,
+) -> Result<()> {
+    ensure!(
+        samples.iter().all(|sample| sample.affected_rows == 1),
+        "mutation {mutation} had unstable {side} affected-row evidence"
+    );
+    Ok(())
+}
+
+fn stable_relation_reads(
+    samples: &[MutationExplainSample],
+    mutation: &str,
+    side: &str,
+) -> Result<MutationRelationReads> {
+    let first = samples
+        .first()
+        .context("partition mutation evidence sample set must not be empty")?
+        .relation_reads
+        .clone();
+    ensure!(
+        samples.iter().all(|sample| sample.relation_reads == first),
+        "mutation {mutation} had unstable {side} relation access across samples"
+    );
+    Ok(first)
+}
+
+fn percentile_95(values: &[f64]) -> Result<f64> {
+    ensure!(!values.is_empty(), "p95 sample set must not be empty");
+    let mut sorted = values.to_vec();
+    ensure!(
+        sorted.iter().all(|value| value.is_finite() && *value > 0.0),
+        "p95 samples must be finite and greater than zero"
+    );
+    sorted.sort_by(|left, right| left.total_cmp(right));
+    let rank = ((sorted.len() * 95).div_ceil(100)).max(1) - 1;
+    Ok(sorted[rank])
+}
+
+fn maximum_wal_bytes(samples: &[MutationExplainSample]) -> Result<u64> {
+    let maximum = samples
+        .iter()
+        .map(|sample| sample.maximum_node_wal_bytes)
+        .max()
+        .context("partition mutation WAL sample set must not be empty")?;
+    ensure!(maximum > 0, "partition mutation WAL evidence must be positive");
+    Ok(maximum)
+}
+
+fn ensure_output_available(path: &Path) -> Result<()> {
+    ensure!(!path.exists(), "refusing to overwrite {path:?}");
+    Ok(())
+}
+
+fn publish_mutation_artifact(
+    path: &Path,
+    runs: &[PartitionMutationRunEvidence],
+) -> Result<()> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create mutation evidence directory {parent:?}"))?;
+    }
+    ensure_output_available(path)?;
+    let mut bytes = serde_json::to_vec_pretty(runs)
+        .context("failed to serialize partition mutation evidence")?;
+    bytes.push(b'\n');
+    let temporary = temporary_path(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .with_context(|| format!("failed to create temporary mutation evidence file {temporary:?}"))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("failed to write temporary mutation evidence file {temporary:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync temporary mutation evidence file {temporary:?}"))?;
+    let publish = fs::hard_link(&temporary, path)
+        .with_context(|| format!("failed to publish mutation evidence to {path:?}"));
+    let _ = fs::remove_file(&temporary);
+    publish
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(format!(".tmp-{}", std::process::id()));
+    PathBuf::from(value)
+}
+
+fn canonical_json_bytes(value: &JsonValue) -> Result<Vec<u8>> {
+    serde_json::to_vec(&canonical_json(value)).context("failed to serialize canonical JSON")
+}
+
+fn canonical_json(value: &JsonValue) -> JsonValue {
+    match value {
+        JsonValue::Array(values) => JsonValue::Array(values.iter().map(canonical_json).collect()),
+        JsonValue::Object(values) => {
+            let mut sorted = JsonMap::new();
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                sorted.insert(key.clone(), canonical_json(&values[key]));
+            }
+            JsonValue::Object(sorted)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_identifier(value: &str) -> Result<()> {
+    ensure!(
+        !value.is_empty()
+            && value.len() <= 63
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "invalid PostgreSQL identifier {value}"
+    );
+    Ok(())
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -67,6 +67,7 @@ const runContract = (args) => {
     'verify-index-partition-evidence.mjs',
     'verify-index-partition-snapshot-capture.mjs',
     'verify-index-partition-query-evidence.mjs',
+    'verify-index-partition-mutation-evidence.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',

--- a/scripts/verify/verify-index-partition-mutation-evidence.mjs
+++ b/scripts/verify/verify-index-partition-mutation-evidence.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-partition-mutation-evidence] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runner = requireMarkers('ops/benches/src/index_storage/partition_mutation.rs', [
+  'INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE',
+  'partition mutation evidence requires PostgreSQL 16',
+  'partition mutation evidence requires jit=off',
+  'SET synchronous_commit = on',
+  'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ',
+  'SAVEPOINT {SAMPLE_SAVEPOINT}',
+  'ROLLBACK TO SAVEPOINT {SAMPLE_SAVEPOINT}',
+  'transaction.rollback().await',
+  'EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)',
+  'maximum_node_wal_bytes',
+  'baseline_p95_ms',
+  'shadow_p95_ms',
+  'baseline_wal_bytes',
+  'shadow_wal_bytes',
+  'cases.len() == manifest.repetitions.mutation',
+  'partition mutation relation count parity failed',
+  'to_jsonb(c) = to_jsonb(s)',
+  'did not affect exactly one matching row on both sides',
+  'must prune its target to exactly one child partition',
+  'fs::hard_link(&temporary, path)',
+  'refusing to overwrite {path:?}',
+]);
+
+for (const forbidden of [
+  'COMMIT;',
+  '.commit().await',
+  'ALTER TABLE "index_entities"',
+  'ALTER TABLE "index_links"',
+  'DROP TABLE "index_entities"',
+  'DROP TABLE "index_links"',
+  'RENAME TO index_entities',
+  'RENAME TO index_links',
+  'VACUUM FULL',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (runner.includes(forbidden)) fail(`mutation runner contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('ops/benches/src/bin/index_partition_mutation_evidence.rs', [
+  'PartitionMutationConfig::from_env()',
+  'capture_partition_mutation_evidence(&config).await?',
+  'index partition mutation evidence complete',
+]);
+
+requireMarkers('ops/benches/src/index_storage/mod.rs', [
+  'mod partition_mutation;',
+  'PartitionMutationConfig',
+  'capture_partition_mutation_evidence',
+]);
+
+requireMarkers('ops/benches/Cargo.toml', [
+  'name = "index-partition-mutation-evidence"',
+  'path = "src/bin/index_partition_mutation_evidence.rs"',
+]);
+
+requireMarkers('ops/benches/README.md', [
+  'Index partition mutation/WAL evidence',
+  'INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE=1',
+  'INDEX_PARTITION_MUTATION_SAMPLES=7',
+  'index-partition-mutation-evidence',
+  'rollback-only repeatable-read transaction',
+  'maximum per-sample plan-node WAL bytes',
+]);
+
+requireMarkers('crates/rustok-index/docs/partition-evidence-runbook.md', [
+  'index-partition-mutation-evidence',
+  'mutation.json',
+  'maximum per-sample plan-node WAL bytes',
+  'Every validation and EXPLAIN mutation is rolled back to a savepoint',
+]);
+
+requireMarkers('crates/rustok-index/docs/README.md', [
+  'M3 partition mutation/WAL evidence runner: `complete`',
+  'maintenance and cutover evidence remain open',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M3 partition mutation/WAL evidence runner: `complete`',
+  '- [x] Add owner-operated PostgreSQL baseline/shadow mutation and WAL evidence capture.',
+  '- [ ] Execute retained PostgreSQL maintenance and cutover evidence.',
+  'The tenth M3 slice adds owner-operated baseline/shadow mutation and WAL evidence.',
+]);
+
+requireMarkers('scripts/verify/index-storage-tooling.mjs', [
+  "'verify-index-partition-mutation-evidence.mjs'",
+]);
+
+requireMarkers('.github/workflows/index-storage-smoke.yml', [
+  'scripts/verify/verify-index-partition-mutation-evidence.mjs',
+  'node --check scripts/verify/verify-index-partition-mutation-evidence.mjs',
+  '--bin index-partition-mutation-evidence',
+]);
+
+console.log('[verify-index-partition-mutation-evidence] OK');


### PR DESCRIPTION
## Summary

- continue M3 with an owner-operated PostgreSQL baseline/shadow mutation and WAL evidence runner;
- require explicit `INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE=1` opt-in;
- independently revalidate the immutable prepared manifest, canonical `evidence_id`, deterministic shadow definition, names, children, modulus, and repetition contract;
- require PostgreSQL 16 with JIT disabled, partition pruning enabled, and `synchronous_commit=on`;
- reject canonical relations that are already partitioned and reject missing or incorrectly bound shadow parents/children;
- serialize one evidence ID through a PostgreSQL advisory lock;
- require canonical/shadow entity and link row-count parity and select only byte-for-byte matching generic anchors;
- build exactly `manifest.repetitions.mutation` unique entity-touch and link-delete runs without source-domain semantics;
- execute the complete comparison inside one repeatable-read transaction that is always rolled back;
- isolate every direct validation and every measured mutation with a savepoint, roll it back, and release it before the next sample;
- require exactly one affected row on baseline and shadow;
- alternate baseline/shadow sample order and retain full JSON `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` evidence;
- calculate nearest-rank p95 latency and conservative maximum per-sample plan-node WAL bytes;
- reject unstable affected-row or relation-access evidence;
- prove every shadow mutation prunes its target to exactly one manifest child and never accesses canonical or unrelated relations;
- publish one top-level `mutation.json` array through temporary-file plus hard-link no-clobber semantics;
- add a dedicated binary, static contract guard, lightweight workflow build coverage, owner runbook updates, and roadmap synchronization;
- keep production commit, replay/dual-write, rename/drop, cutover, maintenance, and durable global partition-operation ownership outside this slice.

## Previous slice recheck

- PR #2322 was rechecked with no comments, reviews, review threads, or status checks and squash-merged into `main`;
- its source branch was removed automatically;
- this branch was rebuilt as one commit directly on the latest `main`, preserving unrelated Commerce, Customer, Payment, Pricing, Tax, and lockfile changes.

## Important behavior

- the runner is for an owner-approved evidence database only;
- rollback prevents logical mutation persistence, but PostgreSQL still generates the WAL and transient tuple effects being measured;
- every sample and the enclosing transaction are rolled back; the runner contains no commit path;
- `baseline_wal_bytes` and `shadow_wal_bytes` are conservative maximum plan-node WAL values from retained EXPLAIN samples, not persistent bloat measurements;
- no canonical DDL, rename, drop, replay, dual-write, or production cutover is implemented;
- the packet assembler and admission validator remain authoritative;
- the real PostgreSQL mutation evidence run and complete retained packet were not executed in this change.

## Validation

Not run, per repository-owner instruction. Suggested owner checks:

```bash
cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
cargo test -p rustok-benchmarks partition_mutation
node scripts/verify/verify-index-partition-mutation-evidence.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

## Next M3 slices

Add owner-operated ordinary-VACUUM maintenance evidence and cutover/rollback rehearsal capture. Then assemble and validate one retained real six-artifact packet before implementing any production partition lifecycle.