### PR TITLE
Retain tax calculation local context

### DIFF
--- a/crates/rustok-tax/contracts/evidence/tax-runtime-contract-smoke.json
+++ b/crates/rustok-tax/contracts/evidence/tax-runtime-contract-smoke.json
@@ -7,6 +7,14 @@
   "fallback_profiles": ["embedded_native"],
   "degraded_modes": ["block_checkout_with_tax_refresh"],
   "cases": [
-    { "operation": "calculate_tax", "source_order": ["context.require_policy(PortCallPolicy::read())?", ".calculate(request)", ".map_err(tax_error_to_port_error)"] }
+    {
+      "operation": "calculate_tax",
+      "source_order": [
+        "let owner_operation = \"calculate_tax\";",
+        "require_tax_calculation_policy(&context, owner_operation)?;",
+        ".calculate(request)",
+        ".map_err(|error| tax_error_to_port_error(&context, owner_operation, error))?"
+      ]
+    }
   ]
 }

--- a/crates/rustok-tax/docs/README.md
+++ b/crates/rustok-tax/docs/README.md
@@ -1,4 +1,4 @@
-﻿# `rustok-tax` Documentation
+# `rustok-tax` Documentation
 
 `rustok-tax` — foundation crate for the tax bounded context in the commerce family.
 
@@ -21,11 +21,19 @@
 
 ## Integration
 
-- `rustok-cart` calls `TaxCalculationPort` for recalculating cart tax lines;
+- `rustok-cart` calls the canonical root `TaxCalculationPort` factory for recalculating cart tax lines;
+- the root in-process factory retains safe local outcome context while the legacy `ports` module path
+  remains available for compatibility;
 - checkout transfers the provider-aware tax snapshot to `rustok-order`;
 - transport surface is still published through `rustok-commerce`.
+
+## Context contracts
+
+- [Tax calculation policy context](./calculation-port-policy-context.md)
+- [Tax calculation local outcome context](./calculation-local-context.md)
 
 ## Verification
 
 - targeted unit tests in `rustok-tax`;
+- static policy and local-outcome context guards under `scripts/verify`;
 - compile-check for `rustok-tax`, `rustok-cart`, `rustok-order`, `rustok-commerce`.

--- a/crates/rustok-tax/docs/calculation-local-context.md
+++ b/crates/rustok-tax/docs/calculation-local-context.md
@@ -1,0 +1,149 @@
+# Tax calculation local outcome context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice retains stable local outcome context for the canonical root tax calculation construction:
+
+- `TaxCalculationPort::calculate_tax`;
+- root `InProcessTaxCalculationPort`;
+- root `in_process_tax_calculation_port`.
+
+The existing owner implementation in `ports.rs` remains unchanged. A root wrapper retains the delegated `PortContext` and safe request-shape facts, calls the existing `TaxService` port implementation, classifies only exact stable returned `PortError` envelopes, and returns the same error unchanged.
+
+## Canonical root cutover
+
+The crate keeps `pub mod ports`, so the existing module-path trait and factory remain available for compatibility. Root exports now separate the contract from canonical construction:
+
+- root `TaxCalculationPort` continues to come from `ports`;
+- root `InProcessTaxCalculationPort` and `in_process_tax_calculation_port` come from `calculation_context`.
+
+Current cart consumers import the root factory and therefore receive the wrapper without source changes. Hosts with a custom `TaxService` may use `InProcessTaxCalculationPort::from_service`. Direct callers that deliberately construct through `rustok_tax::ports` remain an explicit compatibility bypass.
+
+## Delegation order
+
+The wrapper performs no new admission, request validation, provider selection, or result validation. Its source order is:
+
+1. clone the incoming `PortContext` for diagnostics;
+2. retain safe request-shape facts;
+3. delegate the original context and request to the unchanged owner port;
+4. inspect only a returned `PortError`;
+5. emit a local event only when the exact stable code and message are covered;
+6. return the same `PortError` unchanged.
+
+Policy admission remains inside the existing owner implementation. Policy failures already retain complete owner context and are intentionally passed through without a second local event.
+
+## Retained request facts
+
+Covered diagnostics retain only typed identifiers, booleans, lengths, and counts:
+
+- currency-code character length;
+- optional channel id;
+- tax-exempt flag;
+- taxable amount count;
+- line-item target count;
+- shipping target count;
+- dual-target count;
+- country-rule count;
+- configured provider-id character length;
+- configured channel-provider-id character length;
+- configured country-code character length.
+
+The wrapper does not record raw currency, provider ids, country codes, tax rates, monetary amounts, tax classes, descriptions, policy rows, or provider result metadata.
+
+## Covered stable outcomes
+
+The mapper requires exact `code + message` pairs. Code-only matching is forbidden.
+
+Request and owner validation outcomes use warning severity:
+
+- `tax.currency_code_invalid` / `tax request is invalid`;
+- `tax.negative_policy_rate` / `tax request is invalid`;
+- `tax.country_code_invalid` / `tax request is invalid`;
+- `tax.negative_country_rate` / `tax request is invalid`;
+- `tax.duplicate_country_rule` / `tax request is invalid`;
+- `tax.negative_taxable_amount` / `tax request is invalid`;
+- `tax.validation` / `tax request is invalid`.
+
+Provider-result invariant outcomes use error severity:
+
+- `tax.negative_total` / `tax calculation result is invalid`;
+- `tax.exempt_customer_charged` / `tax calculation result is invalid`;
+- `tax.total_overflow` / `tax calculation result is invalid`;
+- `tax.total_mismatch` / `tax calculation result is invalid`;
+- `tax.provider_id_invalid` / `tax calculation result is invalid`;
+- `tax.negative_line` / `tax calculation result is invalid`;
+- `tax.currency_code_invalid` / `tax calculation result is invalid`;
+- `tax.currency_mismatch` / `tax calculation result is invalid`;
+- `tax.unknown_taxable_target` / `tax calculation result is invalid`.
+
+Unavailable and timeout kinds also use error severity if a future owner implementation returns a covered stable envelope with those kinds.
+
+## Retained diagnostic context
+
+Covered outcomes record:
+
+- truthful owner `rustok_tax`;
+- public operation `calculate_tax`;
+- operation-specific local label;
+- boundary `tax_calculation_port`;
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- safe request-shape facts described above;
+- exact stable internal code and public-safe message;
+- typed error kind and retryability;
+- the complete delegated `PortError`.
+
+## Preserved behavior
+
+This work does not change:
+
+- `PortCallPolicy::read()` admission;
+- request or result DTOs;
+- currency, policy, taxable-target, exempt-customer, line, or total validation;
+- provider resolution and `region_default` behavior;
+- custom provider composition through `TaxService`;
+- stable public codes, messages, kinds, or retryability;
+- the original owner error return;
+- FBA, FFA, or ecommerce audit status.
+
+## Static evidence
+
+`scripts/verify/verify-tax-calculation-local-context.mjs` guards:
+
+- legacy module compatibility plus canonical root factory cutover;
+- context and safe-fact retention before unchanged owner delegation;
+- post-delegation-only mapping and same delegated error return;
+- exact stable code-and-message classification;
+- technical versus ordinary severity;
+- complete available `PortContext`, safe request facts, and original `PortError` fields;
+- absence of raw currency, provider, country, monetary, tax-class, description, and metadata fields in wrapper diagnostics;
+- unchanged policy-admission and public request/result envelopes in `ports.rs`.
+
+## Remaining gaps
+
+The master ecommerce correlation-safe mapper task remains open for:
+
+- direct callers that deliberately bypass the root wrapper through `rustok_tax::ports`;
+- consumer-side tax transport context retention;
+- external-provider runtime, timeout, retry, and remote-profile evidence;
+- remaining customer, promotion, ecommerce, and non-`PortError` adapters;
+- compile and cross-transport verification.
+
+No architecture status is promoted from source-only evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-tax-calculation-local-context.mjs
+node scripts/verify/verify-tax-calculation-policy-context.mjs
+node scripts/verify/verify-tax-calculation-error-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-tax --lib
+cargo check -p rustok-cart --lib
+```

--- a/crates/rustok-tax/docs/calculation-port-policy-context.md
+++ b/crates/rustok-tax/docs/calculation-port-policy-context.md
@@ -25,6 +25,12 @@ The port now:
   severity for ordinary policy or validation rejection;
 - returns the original `PortError` unchanged after diagnostics.
 
+The canonical root factory now additionally wraps post-delegation stable validation
+and result-invariant outcomes. That separate contract is documented in
+[`calculation-local-context.md`](./calculation-local-context.md). Policy admission
+continues to run only in the owner implementation and is not duplicated by the root
+wrapper.
+
 ## Preserved behavior
 
 The change does not alter:
@@ -50,6 +56,10 @@ contract:
 - existing tax service mapping and public validation/result envelopes remain intact;
 - direct admission before owner-operation assignment is forbidden.
 
+`scripts/verify/verify-tax-calculation-local-context.mjs` separately guards the
+canonical root wrapper, safe request-shape facts, exact stable post-delegation
+classification, same-error return, and the legacy module-path compatibility boundary.
+
 ## Validation status
 
 Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and
@@ -58,15 +68,17 @@ CI were not run by the implementation agent, per maintainer instruction.
 Suggested focused checks:
 
 ```bash
+node scripts/verify/verify-tax-calculation-local-context.mjs
 node scripts/verify/verify-tax-calculation-policy-context.mjs
 node scripts/verify/verify-tax-calculation-error-context.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-tax --lib
+cargo check -p rustok-cart --lib
 ```
 
 ## Remaining work
 
-This does not close consumer-side tax transport context retention, promotion cleanup,
-mounted checkout compensation, or the remaining order, payment, fulfillment,
-inventory, customer, and ecommerce adapter mapper work. Architecture status must not
-be promoted from source inspection alone.
+This does not close direct legacy-module callers, consumer-side tax transport context
+retention, promotion cleanup, mounted checkout compensation, external-provider runtime
+evidence, or the remaining customer, promotion, and ecommerce adapter mapper work.
+Architecture status must not be promoted from source inspection alone.

--- a/crates/rustok-tax/docs/implementation-plan.md
+++ b/crates/rustok-tax/docs/implementation-plan.md
@@ -11,6 +11,12 @@ This module has no module-owned UI. `calculate_tax` is a read-like port with a
 required deadline and typed `PortError` mapping; it must not require write
 idempotency.
 
+The canonical root in-process factory now retains the complete delegated
+`PortContext` and safe request-shape facts for exact stable validation and
+result-invariant outcomes. Policy admission remains owned by the original port
+implementation, public errors are unchanged, and direct construction through the
+legacy `ports` module remains an explicit compatibility bypass.
+
 ## FFA/FBA boundary
 
 - FFA status: `not_started`
@@ -21,26 +27,37 @@ idempotency.
 - Static and executable no-compile evidence:
   `crates/rustok-tax/contracts/evidence/tax-contract-test-static-matrix.json`
   and `crates/rustok-tax/contracts/evidence/tax-runtime-contract-smoke.json`.
-- `scripts/verify/verify-tax-fba.mjs` locks provider metadata, port semantics,
-  plan/registry evidence, and fallback metadata.
+- `scripts/verify/verify-tax-fba.mjs` locks provider metadata, root construction,
+  port semantics, plan/registry evidence, and fallback metadata.
+- `scripts/verify/verify-tax-calculation-policy-context.mjs` and
+  `scripts/verify/verify-tax-calculation-local-context.mjs` lock owner policy and
+  post-delegation local context retention without promoting runtime evidence.
 
 ## Open results
 
 1. **Execute runtime contract and fallback evidence.** Run tax calculation
-   through the in-process and remote-adapter profiles before considering FBA
-   promotion.
+   through the canonical in-process and remote-adapter profiles before considering
+   FBA promotion.
    **Depends on:** cart consumers and a provider runtime environment.
-   **Done when:** deadline, typed validation errors, fallback profiles, and
-   provider-id snapshot propagation have executable evidence.
+   **Done when:** deadline, typed validation errors, context retention, fallback
+   profiles, and provider-id snapshot propagation have executable evidence.
 
-2. **Extend tax rules without bypassing the provider boundary.** Add
+2. **Close compatibility and consumer context gaps.** Audit direct callers of
+   `rustok_tax::ports`, migrate production construction to the canonical root
+   wrapper, and retain consumer-side transport context across cart/commerce
+   boundaries.
+   **Depends on:** mounted consumer inventory and transport ownership.
+   **Done when:** production callers cannot bypass canonical construction and
+   transport diagnostics retain the same request context without raw tax payloads.
+
+3. **Extend tax rules without bypassing the provider boundary.** Add
    jurisdiction metadata and rules beyond flat regional rates through the
    module-owned calculation contract.
    **Depends on:** region policy and a defined jurisdiction data model.
    **Done when:** rule selection is deterministic, serialized snapshots retain
    the selected provider, and cart/order totals agree.
 
-3. **Add external engines through a registry, not cart logic.** Introduce
+4. **Add external engines through a registry, not cart logic.** Introduce
    provider registration and external adapters only after their failure,
    fallback, and operational ownership are explicit.
    **Depends on:** approved provider integration and operational credentials.
@@ -49,6 +66,8 @@ idempotency.
 
 ## Verification
 
+- `node scripts/verify/verify-tax-calculation-local-context.mjs`
+- `node scripts/verify/verify-tax-calculation-policy-context.mjs`
 - `npm run verify:tax:fba`
 - `cargo xtask module validate tax`
 - `cargo xtask module test tax`

--- a/crates/rustok-tax/src/calculation_context.rs
+++ b/crates/rustok-tax/src/calculation_context.rs
@@ -1,0 +1,246 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError, PortErrorKind};
+use uuid::Uuid;
+
+use crate::ports::TaxCalculationPort;
+use crate::services::{TaxCalculationInput, TaxCalculationResult, TaxService};
+
+const TAX_OWNER: &str = "rustok_tax";
+const CALCULATE_TAX_OPERATION: &str = "calculate_tax";
+const TAX_CALCULATION_BOUNDARY: &str = "tax_calculation_port";
+
+#[derive(Debug, Clone)]
+struct TaxCalculationDiagnosticFacts {
+    currency_code_length: usize,
+    channel_id: Option<Uuid>,
+    customer_tax_exempt: bool,
+    taxable_amount_count: usize,
+    line_item_target_count: usize,
+    shipping_target_count: usize,
+    dual_target_count: usize,
+    country_rule_count: usize,
+    provider_id_length: Option<usize>,
+    channel_provider_id_length: Option<usize>,
+    country_code_length: Option<usize>,
+}
+
+/// Canonical in-process tax provider that retains safe local outcome context.
+pub struct InProcessTaxCalculationPort {
+    inner: TaxService,
+}
+
+impl InProcessTaxCalculationPort {
+    pub fn new() -> Self {
+        Self {
+            inner: TaxService::new(),
+        }
+    }
+
+    /// Wraps a host-composed tax service, including custom provider registries.
+    pub fn from_service(inner: TaxService) -> Self {
+        Self { inner }
+    }
+}
+
+impl Default for InProcessTaxCalculationPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn in_process_tax_calculation_port() -> Arc<dyn TaxCalculationPort> {
+    Arc::new(InProcessTaxCalculationPort::new())
+}
+
+#[async_trait]
+impl TaxCalculationPort for InProcessTaxCalculationPort {
+    async fn calculate_tax(
+        &self,
+        context: PortContext,
+        request: TaxCalculationInput,
+    ) -> Result<TaxCalculationResult, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = tax_calculation_diagnostic_facts(&request);
+        let result = self.inner.calculate_tax(context, request).await;
+        result.map_err(|error| {
+            map_tax_calculation_local_port_error(
+                &diagnostic_context,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+}
+
+fn tax_calculation_diagnostic_facts(
+    request: &TaxCalculationInput,
+) -> TaxCalculationDiagnosticFacts {
+    let line_item_target_count = request
+        .taxable_amounts
+        .iter()
+        .filter(|amount| amount.line_item_id.is_some())
+        .count();
+    let shipping_target_count = request
+        .taxable_amounts
+        .iter()
+        .filter(|amount| amount.shipping_option_id.is_some())
+        .count();
+    let dual_target_count = request
+        .taxable_amounts
+        .iter()
+        .filter(|amount| amount.line_item_id.is_some() && amount.shipping_option_id.is_some())
+        .count();
+
+    TaxCalculationDiagnosticFacts {
+        currency_code_length: request.currency_code.chars().count(),
+        channel_id: request.channel_id,
+        customer_tax_exempt: request.customer_tax_exempt,
+        taxable_amount_count: request.taxable_amounts.len(),
+        line_item_target_count,
+        shipping_target_count,
+        dual_target_count,
+        country_rule_count: request.policy.country_rules.len(),
+        provider_id_length: request
+            .policy
+            .provider_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        channel_provider_id_length: request
+            .policy
+            .channel_provider_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        country_code_length: request
+            .policy
+            .country_code
+            .as_ref()
+            .map(|value| value.chars().count()),
+    }
+}
+
+fn map_tax_calculation_local_port_error(
+    context: &PortContext,
+    facts: &TaxCalculationDiagnosticFacts,
+    error: PortError,
+) -> PortError {
+    let local_operation = match (error.code.as_str(), error.message.as_str()) {
+        ("tax.currency_code_invalid", "tax request is invalid") => "validate_currency_code",
+        ("tax.negative_policy_rate", "tax request is invalid") => "validate_policy_rate",
+        ("tax.country_code_invalid", "tax request is invalid") => {
+            "validate_country_rule_code"
+        }
+        ("tax.negative_country_rate", "tax request is invalid") => {
+            "validate_country_rule_rate"
+        }
+        ("tax.duplicate_country_rule", "tax request is invalid") => {
+            "validate_country_rule_uniqueness"
+        }
+        ("tax.negative_taxable_amount", "tax request is invalid") => {
+            "validate_taxable_amount"
+        }
+        ("tax.validation", "tax request is invalid") => "calculate_provider",
+        ("tax.negative_total", "tax calculation result is invalid") => {
+            "validate_result_total"
+        }
+        ("tax.exempt_customer_charged", "tax calculation result is invalid") => {
+            "validate_tax_exempt_result"
+        }
+        ("tax.total_overflow", "tax calculation result is invalid") => "sum_result_lines",
+        ("tax.total_mismatch", "tax calculation result is invalid") => {
+            "validate_result_total"
+        }
+        ("tax.provider_id_invalid", "tax calculation result is invalid") => {
+            "validate_provider_identity"
+        }
+        ("tax.negative_line", "tax calculation result is invalid") => {
+            "validate_result_line"
+        }
+        ("tax.currency_code_invalid", "tax calculation result is invalid") => {
+            "validate_result_currency"
+        }
+        ("tax.currency_mismatch", "tax calculation result is invalid") => {
+            "validate_result_currency"
+        }
+        ("tax.unknown_taxable_target", "tax calculation result is invalid") => {
+            "validate_result_target"
+        }
+        _ => return error,
+    };
+
+    let technical_failure = matches!(
+        &error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+
+    if technical_failure {
+        tracing::error!(
+            error = ?error,
+            owner = TAX_OWNER,
+            operation = CALCULATE_TAX_OPERATION,
+            local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            currency_code_length = facts.currency_code_length,
+            channel_id = ?facts.channel_id,
+            customer_tax_exempt = facts.customer_tax_exempt,
+            taxable_amount_count = facts.taxable_amount_count,
+            line_item_target_count = facts.line_item_target_count,
+            shipping_target_count = facts.shipping_target_count,
+            dual_target_count = facts.dual_target_count,
+            country_rule_count = facts.country_rule_count,
+            provider_id_length = ?facts.provider_id_length,
+            channel_provider_id_length = ?facts.channel_provider_id_length,
+            country_code_length = ?facts.country_code_length,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = TAX_CALCULATION_BOUNDARY,
+            "tax calculation local technical outcome retained delegated context"
+        );
+    } else {
+        tracing::warn!(
+            error = ?error,
+            owner = TAX_OWNER,
+            operation = CALCULATE_TAX_OPERATION,
+            local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            currency_code_length = facts.currency_code_length,
+            channel_id = ?facts.channel_id,
+            customer_tax_exempt = facts.customer_tax_exempt,
+            taxable_amount_count = facts.taxable_amount_count,
+            line_item_target_count = facts.line_item_target_count,
+            shipping_target_count = facts.shipping_target_count,
+            dual_target_count = facts.dual_target_count,
+            country_rule_count = facts.country_rule_count,
+            provider_id_length = ?facts.provider_id_length,
+            channel_provider_id_length = ?facts.channel_provider_id_length,
+            country_code_length = ?facts.country_code_length,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = TAX_CALCULATION_BOUNDARY,
+            "tax calculation local outcome retained delegated context"
+        );
+    }
+
+    error
+}

--- a/crates/rustok-tax/src/lib.rs
+++ b/crates/rustok-tax/src/lib.rs
@@ -2,12 +2,16 @@ use async_trait::async_trait;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod calculation_context;
 pub mod error;
 pub mod ports;
 pub mod services;
 
+pub use calculation_context::{
+    InProcessTaxCalculationPort, in_process_tax_calculation_port,
+};
 pub use error::{TaxError, TaxResult};
-pub use ports::*;
+pub use ports::TaxCalculationPort;
 pub use services::{
     CalculatedTaxLine, TaxCalculationInput, TaxCalculationResult, TaxPolicyCountryRule,
     TaxPolicySnapshot, TaxService, TaxableAmount,

--- a/scripts/verify/verify-tax-calculation-local-context.mjs
+++ b/scripts/verify/verify-tax-calculation-local-context.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+
+const wrapper = readFileSync(
+  new URL('crates/rustok-tax/src/calculation_context.rs', root),
+  'utf8',
+);
+const library = readFileSync(new URL('crates/rustok-tax/src/lib.rs', root), 'utf8');
+const owner = readFileSync(new URL('crates/rustok-tax/src/ports.rs', root), 'utf8');
+const evidence = readFileSync(
+  new URL('crates/rustok-tax/docs/calculation-local-context.md', root),
+  'utf8',
+);
+const failures = [];
+
+const requireIn = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidIn = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['mod calculation_context;', 'private context wrapper module'],
+  ['pub mod ports;', 'legacy module compatibility'],
+  ['pub use calculation_context::{', 'canonical wrapper exports'],
+  ['InProcessTaxCalculationPort, in_process_tax_calculation_port', 'root type and factory'],
+  ['pub use ports::TaxCalculationPort;', 'root trait contract'],
+]) {
+  requireIn(library, value, label);
+}
+forbidIn(library, 'pub use ports::*;', 'legacy wildcard root construction');
+
+for (const [value, label] of [
+  ['const TAX_OWNER: &str = "rustok_tax";', 'truthful owner'],
+  ['const CALCULATE_TAX_OPERATION: &str = "calculate_tax";', 'public operation'],
+  ['const TAX_CALCULATION_BOUNDARY: &str = "tax_calculation_port";', 'stable boundary'],
+  ['pub struct InProcessTaxCalculationPort', 'canonical wrapper type'],
+  ['inner: TaxService', 'unchanged owner service delegation'],
+  ['pub fn new() -> Self', 'default wrapper constructor'],
+  ['pub fn from_service(inner: TaxService) -> Self', 'host-composed service constructor'],
+  ['pub fn in_process_tax_calculation_port() -> Arc<dyn TaxCalculationPort>', 'canonical root factory'],
+  ['let diagnostic_context = context.clone();', 'delegated context retention'],
+  ['let diagnostic_facts = tax_calculation_diagnostic_facts(&request);', 'safe request fact retention'],
+  ['let result = self.inner.calculate_tax(context, request).await;', 'unchanged owner delegation'],
+  ['result.map_err(|error| {', 'post-delegation outcome mapping'],
+  ['map_tax_calculation_local_port_error(', 'local mapper use'],
+  ['_ => return error,', 'unknown outcome pass-through'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
+  ['"tax calculation local technical outcome retained delegated context"', 'technical diagnostic event'],
+  ['"tax calculation local outcome retained delegated context"', 'ordinary diagnostic event'],
+  ['error\n}', 'same delegated error return'],
+]) {
+  requireIn(wrapper, value, label);
+}
+
+const cloneIndex = wrapper.indexOf('let diagnostic_context = context.clone();');
+const factsIndex = wrapper.indexOf(
+  'let diagnostic_facts = tax_calculation_diagnostic_facts(&request);',
+);
+const delegateIndex = wrapper.indexOf(
+  'let result = self.inner.calculate_tax(context, request).await;',
+);
+const mapIndex = wrapper.indexOf('result.map_err(|error| {');
+if (!(cloneIndex >= 0 && cloneIndex < factsIndex && factsIndex < delegateIndex && delegateIndex < mapIndex)) {
+  failures.push('wrapper must retain context and safe facts before unchanged delegation, then map');
+}
+
+for (const [value, label] of [
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['currency_code_length = facts.currency_code_length', 'currency shape'],
+  ['channel_id = ?facts.channel_id', 'typed channel identity'],
+  ['customer_tax_exempt = facts.customer_tax_exempt', 'tax exemption flag'],
+  ['taxable_amount_count = facts.taxable_amount_count', 'taxable amount count'],
+  ['line_item_target_count = facts.line_item_target_count', 'line target count'],
+  ['shipping_target_count = facts.shipping_target_count', 'shipping target count'],
+  ['dual_target_count = facts.dual_target_count', 'dual target count'],
+  ['country_rule_count = facts.country_rule_count', 'country rule count'],
+  ['provider_id_length = ?facts.provider_id_length', 'provider id length'],
+  ['channel_provider_id_length = ?facts.channel_provider_id_length', 'channel provider id length'],
+  ['country_code_length = ?facts.country_code_length', 'country code length'],
+  ['internal_code = %error.code', 'stable internal code'],
+  ['internal_message = %error.message', 'public-safe internal message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = TAX_CALCULATION_BOUNDARY', 'boundary field'],
+]) {
+  requireIn(wrapper, value, label);
+}
+
+for (const [code, message, label] of [
+  ['tax.currency_code_invalid', 'tax request is invalid', 'request currency validation'],
+  ['tax.negative_policy_rate', 'tax request is invalid', 'policy rate validation'],
+  ['tax.country_code_invalid', 'tax request is invalid', 'country code validation'],
+  ['tax.negative_country_rate', 'tax request is invalid', 'country rate validation'],
+  ['tax.duplicate_country_rule', 'tax request is invalid', 'country rule uniqueness'],
+  ['tax.negative_taxable_amount', 'tax request is invalid', 'taxable amount validation'],
+  ['tax.validation', 'tax request is invalid', 'owner provider validation'],
+  ['tax.negative_total', 'tax calculation result is invalid', 'negative result total'],
+  ['tax.exempt_customer_charged', 'tax calculation result is invalid', 'exempt result invariant'],
+  ['tax.total_overflow', 'tax calculation result is invalid', 'result total overflow'],
+  ['tax.total_mismatch', 'tax calculation result is invalid', 'result total mismatch'],
+  ['tax.provider_id_invalid', 'tax calculation result is invalid', 'provider identity invariant'],
+  ['tax.negative_line', 'tax calculation result is invalid', 'negative result line'],
+  ['tax.currency_code_invalid', 'tax calculation result is invalid', 'result currency validation'],
+  ['tax.currency_mismatch', 'tax calculation result is invalid', 'result currency mismatch'],
+  ['tax.unknown_taxable_target', 'tax calculation result is invalid', 'unknown result target'],
+]) {
+  requireIn(wrapper, `("${code}", "${message}")`, label);
+}
+
+for (const [value, label] of [
+  ['currency_code =', 'raw currency value'],
+  ['provider_id =', 'raw provider identity'],
+  ['channel_provider_id =', 'raw channel provider identity'],
+  ['country_code =', 'raw country identity'],
+  ['tax_rate =', 'raw tax rate'],
+  ['amount =', 'raw monetary amount'],
+  ['item_tax_class =', 'raw item tax class'],
+  ['shipping_tax_class =', 'raw shipping tax class'],
+  ['description =', 'raw description'],
+  ['metadata =', 'raw provider metadata'],
+]) {
+  forbidIn(wrapper, value, label);
+}
+
+for (const [value, label] of [
+  ['pub fn in_process_tax_calculation_port() -> Arc<dyn TaxCalculationPort>', 'legacy module factory'],
+  ['require_tax_calculation_policy(&context, owner_operation)?;', 'unchanged policy admission'],
+  ['PortError::validation(code, "tax request is invalid")', 'stable request envelope'],
+  ['PortError::invariant_violation(code, "tax calculation result is invalid")', 'stable result envelope'],
+  ['PortError::validation("tax.validation", "tax request is invalid")', 'stable owner envelope'],
+]) {
+  requireIn(owner, value, label);
+}
+
+for (const [value, label] of [
+  ['Status: **source-ready / unvalidated**', 'unvalidated evidence status'],
+  ['Direct callers that deliberately construct through `rustok_tax::ports`', 'legacy bypass disclosure'],
+  ['does not record raw currency, provider ids, country codes, tax rates, monetary amounts', 'payload privacy contract'],
+  ['No architecture status is promoted from source-only evidence.', 'promotion boundary'],
+]) {
+  requireIn(evidence, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Tax calculation local context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Canonical tax calculation retains safe local outcome context and returns the same PortError',
+);

--- a/scripts/verify/verify-tax-fba.mjs
+++ b/scripts/verify/verify-tax-fba.mjs
@@ -32,6 +32,7 @@ export function verifyTaxFba({ root = defaultRoot } = {}) {
   const central = read(root, 'docs/modules/registry.md');
   const cargo = read(root, 'crates/rustok-tax/Cargo.toml');
   const libSource = read(root, 'crates/rustok-tax/src/lib.rs');
+  const contextSource = read(root, 'crates/rustok-tax/src/calculation_context.rs');
   const portSource = read(root, 'crates/rustok-tax/src/ports.rs');
   const servicesSource = read(root, 'crates/rustok-tax/src/services.rs');
 
@@ -48,16 +49,29 @@ export function verifyTaxFba({ root = defaultRoot } = {}) {
   if (port.context !== 'rustok_api::ports::PortContext') fail('tax port context drift');
   if (port.error !== 'rustok_api::ports::PortError') fail('tax port error drift');
   if (port.deadline_required !== true) fail('tax port must require deadline semantics');
-  if (port.idempotency_required !== false) fail('tax calculation remains read-like and must not require write idempotency');
+  if (port.idempotency_required !== false) fail('tax calculation remains read-like and must not require write idempotency semantics');
 
   if (!manifest.includes('[fba.provider]')) fail('tax manifest lacks provider metadata');
   if (!manifest.includes('registry = "contracts/tax-fba-registry.json"')) fail('tax manifest registry drift');
   if (!manifest.includes('contract_version = "tax.calculation.v1"')) fail('tax manifest contract version drift');
   if (!cargo.includes('rustok-api.workspace = true')) fail('tax Cargo.toml lacks rustok-api dependency');
-  if (!libSource.includes('pub mod ports;') || !libSource.includes('pub use ports::*;')) fail('tax lib.rs must export ports');
+  if (!libSource.includes('pub mod ports;') || !libSource.includes('pub use ports::TaxCalculationPort;')) {
+    fail('tax lib.rs must export the port module and root trait contract');
+  }
+  if (!libSource.includes('mod calculation_context;') || !libSource.includes('in_process_tax_calculation_port')) {
+    fail('tax lib.rs must export canonical context-preserving construction');
+  }
+  if (!contextSource.includes('impl TaxCalculationPort for InProcessTaxCalculationPort')) {
+    fail('tax canonical in-process wrapper must implement TaxCalculationPort');
+  }
+  if (!contextSource.includes('self.inner.calculate_tax(context, request).await')) {
+    fail('tax canonical wrapper must delegate through the owner port');
+  }
   if (!portSource.includes('trait TaxCalculationPort')) fail('tax port source lacks trait');
   if (!portSource.includes('impl TaxCalculationPort for crate::TaxService')) fail('tax port source lacks in-process TaxService impl');
-  if (!portSource.includes('context.require_policy(PortCallPolicy::read())?')) fail('tax calculate_tax must enforce shared read/deadline semantics');
+  if (!portSource.includes('require_tax_calculation_policy(&context, owner_operation)?;')) {
+    fail('tax calculate_tax must enforce shared read/deadline semantics');
+  }
   if (portSource.includes('require_write_semantics()?')) fail('tax calculate_tax must not require write idempotency semantics');
   if (!portSource.includes('PortError::validation("tax.validation"')) fail('tax errors must map to typed PortError validation');
   if (!servicesSource.includes('Serialize, Deserialize')) fail('tax service DTOs must be serializable for transport-neutral ports');
@@ -96,9 +110,10 @@ export function verifyTaxFba({ root = defaultRoot } = {}) {
   }
   const runtimeCase = runtimeSmoke.cases.find((entry) => entry.operation === 'calculate_tax');
   if (!runtimeCase) fail('tax runtime smoke calculate_tax case missing');
-  for (const marker of ['context.require_policy(PortCallPolicy::read())?', '.calculate(request)', '.map_err(tax_error_to_port_error)']) {
-    if (!runtimeCase.source_order.includes(marker)) fail(`tax runtime smoke source order missing ${marker}`);
-    if (!portSource.includes(marker) && !servicesSource.includes(marker)) fail(`tax runtime source missing ${marker}`);
+  for (const marker of runtimeCase.source_order) {
+    if (!portSource.includes(marker) && !servicesSource.includes(marker)) {
+      fail(`tax runtime source missing ${marker}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- continue ecommerce implementation-plan item 10 with a focused `rustok-tax` correlation-safe owner slice;
- add canonical root `InProcessTaxCalculationPort` construction that retains the delegated `PortContext` and safe request-shape facts around the unchanged tax owner port;
- classify only exact stable `code + message` request-validation and provider-result invariant outcomes, preserve technical-versus-ordinary severity, and return the same delegated `PortError`;
- deliberately avoid logging raw currency, provider ids, country codes, rates, monetary amounts, tax classes, descriptions, policy rows, or provider metadata;
- keep `rustok_tax::ports` available as an explicit compatibility path while routing root construction through the context wrapper;
- preserve custom provider composition through `InProcessTaxCalculationPort::from_service`;
- add source-ready/unvalidated contract documentation and a focused static guard;
- recheck and repair stale tax FBA guard/runtime-smoke markers that still required the old wildcard root export and pre-helper policy source order;
- synchronize the tax README, policy-context note, local implementation plan, and no-compile runtime evidence without promoting FBA/FFA status.

## Recheck

- continued from merged ecommerce/payment PR #2325;
- confirmed PR #2325 is merged into `main` and its old source branch is already deleted;
- confirmed there is no open overlapping tax local-context PR;
- confirmed open Index/Profiles work is disjoint from this tax owner scope;
- confirmed the branch is based on current `main` (`463de23f105adb09bdc4b3bfe3952b1237369945`), is zero commits behind, and changes exactly nine files;
- confirmed the existing `ports.rs` request/result validation and public-safe envelopes remain unchanged;
- confirmed current cart consumers import the canonical root factory, while the legacy module path remains documented as a compatibility bypass.

## Boundary

This PR closes stable owner-local outcome context retention for canonical root tax calculation construction. It does not close consumer-side tax transport context, legacy module-path callers, external-provider runtime evidence, remote profiles, or the broader ecommerce correlation-safe mapper task.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-tax-calculation-local-context.mjs
node scripts/verify/verify-tax-calculation-policy-context.mjs
node scripts/verify/verify-tax-calculation-error-context.mjs
node scripts/verify/verify-tax-fba.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-tax --lib
cargo check -p rustok-cart --lib
```