### PR TITLE
Retain customer read local context

### DIFF
--- a/crates/rustok-customer/contracts/evidence/customer-read-projection-runtime-smoke.json
+++ b/crates/rustok-customer/contracts/evidence/customer-read-projection-runtime-smoke.json
@@ -27,7 +27,7 @@
     {
       "case": "invalid_tenant_id",
       "expected_kind": "validation",
-      "expected_code": "customer.tenant_id_invalid",
+      "expected_code": "customer.context_invalid",
       "retryable": false
     },
     {

--- a/crates/rustok-customer/docs/README.md
+++ b/crates/rustok-customer/docs/README.md
@@ -27,6 +27,7 @@
 - cross-module contract changes must be synchronized with `rustok-commerce` and neighboring split modules;
 - `CustomerService` normalizes email before uniqueness check and storage, so create/update do not allow trimmed duplicates within a tenant; duplicate `user_id` linkage remains tenant-scoped and does not turn the customer into auth/user domain.
 - `CustomerReadPort` uses the common `PortContext`/`PortError`, requires read deadline semantics and maps invalid tenant / not found to typed port errors. Its user-projection operation lets storefront consumers resolve an authenticated customer without constructing `CustomerService`; no-compile runtime smoke is captured in `contracts/evidence/customer-read-projection-runtime-smoke.json`, but `transport_verified` still requires compiled runtime execution.
+- canonical root `in_process_customer_read_port` uses `InProcessCustomerReadPort` to retain complete delegated context and safe request facts for exact stable local outcomes. The legacy module-path factory remains available under `rustok_customer::ports` for compatibility.
 
 ## FFA split for admin
 
@@ -36,6 +37,8 @@ The admin package now uses framework-agnostic defaults `admin/src/core.rs`, a fa
 
 - No-compile source/evidence gates for iterations without compilation:
   - `node scripts/verify/verify-customer-admin-boundary.mjs`
+  - `node scripts/verify/verify-customer-read-local-context.mjs`
+  - `node scripts/verify/verify-customer-read-policy-context.mjs`
   - `node scripts/verify/verify-customer-fba-no-compile.mjs`
   - `node scripts/verify/verify-ecommerce-fba-contract-evidence.mjs`
   - `node scripts/verify/verify-ecommerce-provider-spi-evidence.mjs`
@@ -48,4 +51,6 @@ The admin package now uses framework-agnostic defaults `admin/src/core.rs`, a fa
 ## Related documents
 
 - [README crate](../README.md)
+- [Customer read policy context](./read-port-policy-context.md)
+- [Customer read local outcome context](./read-local-context.md)
 - [Commerce split plan](../../rustok-commerce/docs/implementation-plan.md)

--- a/crates/rustok-customer/docs/implementation-plan.md
+++ b/crates/rustok-customer/docs/implementation-plan.md
@@ -10,6 +10,8 @@ The admin surface is an accepted single-adapter owner fragment: it is an authent
 
 Customer detail/create/update enrichment now constructs `ProfilePresentationService` with the authenticated request audience before calling the existing customer/profile bridge. Human operators use their real profile actor id; service principals use trusted-service audience without claiming profile ownership. The bridge therefore applies Profiles `public` / `authenticated` / `followers_only` / `private` policy before returning a localized summary and no longer passes raw `ProfileService` from the custom host.
 
+Canonical root `CustomerReadPort` construction now uses `InProcessCustomerReadPort`, which retains the complete delegated `PortContext` plus safe operation-specific request facts for exact stable local outcomes and returns the same public-safe `PortError`. The persistent implementation in `ports.rs` remains unchanged and available as an explicit compatibility path. Raw search, email, customer rows, profile names, preferred locales, and profile payloads are not logged.
+
 ## FFA/FBA boundary
 
 - FFA status: `in_progress`
@@ -17,8 +19,9 @@ Customer detail/create/update enrichment now constructs `ProfilePresentationServ
 - Structural shape: `core_transport_ui`
 - FBA provider contract: `CustomerReadPort` / `customer.read_projection.v1` in `crates/rustok-customer/contracts/customer-fba-registry.json`.
 - `read_customer_projection_by_user` is the owner boundary for storefront authenticated-customer lookup; commerce must not construct `CustomerService`.
+- Canonical root construction is `InProcessCustomerReadPort` / `in_process_customer_read_port`; `rustok_customer::ports` remains a compatibility path rather than the covered root entrypoint.
 - Static and source-locked runtime evidence: `crates/rustok-customer/contracts/evidence/customer-contract-test-static-matrix.json`, `crates/rustok-customer/contracts/evidence/customer-runtime-contract-smoke.json`, and `crates/rustok-customer/contracts/evidence/customer-read-projection-runtime-smoke.json`.
-- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers.
+- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers; `node scripts/verify/verify-customer-read-local-context.mjs` locks canonical local context retention.
 
 ## Open results
 
@@ -39,18 +42,21 @@ Customer detail/create/update enrichment now constructs `ProfilePresentationServ
    **Depends on:** a product requirement and the public auth/profile contracts.
    **Done when:** new flows have a module-owned API, tenant-isolation tests, and no duplicate policy in auth, Profiles, or Commerce.
 
-4. **Add diagnostics only for demonstrated operational need.** Tie metrics, tracing, or runbook additions to an observed customer lookup, ownership, or integration failure mode.
-   **Depends on:** production or staging evidence.
-   **Done when:** the diagnostic identifies the owning boundary and has an actionable recovery procedure.
+4. **Retain actionable customer read diagnostics without payload leakage.**
+   **Status:** source-complete / unvalidated for canonical root reads. The reopened ecommerce correlation-safe mapper audit demonstrated that owner-local customer outcomes retained only partial context. The root wrapper now records complete context, exact owner/local operations, stable envelopes, typed identity or shape-only request facts, and technical-versus-ordinary severity.
+   **Remaining evidence:** execute the focused guard, compile the owner and mounted consumers, and retain runtime traces for not-found, invalid-context, storage, profile-unavailable, and list-validation outcomes. Audit direct compatibility-path callers separately.
+   **Done when:** runtime evidence proves canonical root consumers emit actionable diagnostics without raw customer/profile payloads and compatibility bypasses are either removed or explicitly accepted.
 
 ## Verification
 
 - `npm run verify:customer:admin-boundary`
+- `node scripts/verify/verify-customer-read-local-context.mjs`
+- `node scripts/verify/verify-customer-read-policy-context.mjs`
 - `node scripts/verify/verify-customer-fba-no-compile.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo xtask module validate customer`
 - `cargo xtask module test customer`
-- targeted customer CRUD, identity, ownership, profile-bridge, and audience-matrix tests
+- targeted customer CRUD, identity, ownership, profile-bridge, audience-matrix, and local-outcome tests
 
 ## Change rules
 
@@ -58,3 +64,4 @@ Customer detail/create/update enrichment now constructs `ProfilePresentationServ
 2. Customer/profile presentation must use the Profiles owner audience-bound service; customer permissions must not bypass profile visibility or claim profile ownership.
 3. Update local documentation, `rustok-module.toml`, and related auth/profile docs when the customer contract changes.
 4. Update this status block and `docs/modules/registry.md` with an FFA/FBA boundary change.
+5. Keep raw customer/profile payloads out of owner diagnostics; retain only typed identity or bounded shape facts needed for recovery.

--- a/crates/rustok-customer/docs/read-local-context.md
+++ b/crates/rustok-customer/docs/read-local-context.md
@@ -1,0 +1,148 @@
+# Customer read local outcome context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice retains stable owner-local outcome context for the canonical root customer read construction:
+
+- `CustomerReadPort::read_customer_projection`;
+- `CustomerReadPort::read_customer_projection_by_user`;
+- `CustomerReadPort::list_customer_projections`;
+- `CustomerReadPort::list_profile_enrichment`;
+- root `InProcessCustomerReadPort`;
+- root `in_process_customer_read_port`.
+
+The existing owner implementation in `ports.rs` remains unchanged. A root wrapper retains the delegated
+`PortContext` and safe request facts, calls the original `CustomerService` port implementation, classifies
+only exact stable returned `PortError` envelopes, and returns the same error unchanged.
+
+## Canonical root cutover
+
+The crate keeps `pub mod ports`, so the existing trait, request/response DTOs, service implementation, and
+module-path factory remain available for compatibility. Root exports now separate contracts from canonical
+construction:
+
+- `CustomerReadPort` and its DTOs continue to come from `ports`;
+- root `InProcessCustomerReadPort` and `in_process_customer_read_port` come from `read_context`.
+
+Current Commerce consumers import the root factory, so they use the wrapper without changing transport or
+orchestration source. Callers that deliberately construct through `rustok_customer::ports` remain an
+explicit compatibility bypass and are not counted as covered by this slice.
+
+## Delegation order
+
+Each wrapper operation performs the same sequence:
+
+1. clone the accepted `PortContext` for diagnostics;
+2. retain operation-specific safe request facts;
+3. delegate the original context and request to the unchanged owner implementation;
+4. inspect only a returned `PortError`;
+5. emit a local event only when the exact stable code and message are covered;
+6. return the same `PortError` unchanged.
+
+The persistent owner continues to own read-policy admission, tenant parsing, page validation, tenant-scoped
+queries, profile enrichment, DTO construction, and public error mapping.
+
+## Safe request facts
+
+Covered diagnostics may retain:
+
+- typed customer id for `read_customer_projection`;
+- typed user id for `read_customer_projection_by_user`;
+- page, page size, and search character length for `list_customer_projections`;
+- requested and unique user-id counts for `list_profile_enrichment`.
+
+The wrapper does not retain raw search text, customer names, email addresses, profile names, preferred
+locale values, customer records, result rows, or profile payloads.
+
+## Covered stable outcomes
+
+The mapper requires exact `operation + code + message` matches where an outcome is operation-specific.
+Unknown envelopes pass through without an additional event.
+
+| Stable envelope | Covered operation | Local operation | Severity |
+| --- | --- | --- | --- |
+| `customer.context_invalid` / `customer request context is invalid` | all | `validate_tenant_context` | warning |
+| `customer.page_invalid` / `customer projection page is invalid` | list customers | `validate_page` | warning |
+| `customer.per_page_invalid` / `customer projection page size is invalid` | list customers | `validate_page_size` | warning |
+| `customer.database_unavailable` / `customer storage is temporarily unavailable` | all | `owner_storage` | error |
+| `customer.customer_not_found` / `customer was not found` | customer-id read | `load_customer` | warning |
+| `customer.customer_by_user_not_found` / `customer was not found for the requested user` | user-id read | `load_customer_by_user` | warning |
+| `customer.validation` / `customer request is invalid` | all | `validate_owner_request` | warning |
+| `customer.profile_unavailable` / `customer profile projection is temporarily unavailable` | all | `load_profile_projection` | error |
+
+Unavailable, timeout, and invariant kinds use error severity. Validation and not-found outcomes use warning
+severity.
+
+## Retained diagnostic context
+
+Covered outcomes record:
+
+- truthful owner `rustok_customer`;
+- exact public owner operation;
+- operation-specific local label;
+- boundary `customer_read_port`;
+- correlation id and tenant id;
+- typed actor, channel, and locale;
+- causation id and traceparent when available;
+- idempotency key and deadline when available;
+- safe operation-specific request facts;
+- exact stable code and public-safe message;
+- typed error kind and retryability;
+- the complete delegated `PortError`.
+
+## Preserved behavior
+
+This work does not change:
+
+- the `CustomerReadPort` trait or DTOs;
+- `CustomerService` queries and profile bridge behavior;
+- `PortCallPolicy::read()` admission or deadline semantics;
+- tenant parsing and tenant isolation;
+- page and page-size bounds;
+- optional authenticated-customer not-found behavior in Commerce consumers;
+- public codes, messages, kinds, or retryability;
+- FBA or FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-customer-read-local-context.mjs` guards:
+
+- legacy module compatibility plus canonical root wrapper construction;
+- context and safe-fact retention before unchanged owner delegation;
+- all four operations and exact operation constants;
+- exact stable code-and-message classification;
+- complete `PortContext`, safe request-fact, and delegated-error fields;
+- technical versus ordinary severity;
+- absence of raw search, customer, email, profile, and result payload logging;
+- same delegated error return.
+
+The customer no-compile FBA guard also checks the root wrapper while retaining `ports.rs` as the owner
+implementation source. The runtime-smoke typed-error matrix is synchronized with the existing
+`customer.context_invalid` contract; this is evidence repair, not a public error change.
+
+## Remaining gaps
+
+The ecommerce correlation-safe mapper task remains open for:
+
+- direct callers that deliberately bypass the root wrapper through `rustok_customer::ports`;
+- consumer-side GraphQL, REST, native, and operator mappings not already covered by focused slices;
+- customer write adapters and profile transports;
+- remaining promotion, ecommerce, and non-`PortError` envelopes;
+- compiled, runtime, restart, remote-profile, and cross-transport evidence.
+
+No architecture status is promoted from source inspection alone.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-customer-read-local-context.mjs
+node scripts/verify/verify-customer-read-policy-context.mjs
+node scripts/verify/verify-customer-fba-no-compile.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-customer --lib
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-customer/docs/read-port-policy-context.md
+++ b/crates/rustok-customer/docs/read-port-policy-context.md
@@ -32,8 +32,26 @@ The diagnostic event records:
 - `list_customer_projections`
 - `list_profile_enrichment`
 
-This includes the owner method used by the three current commerce GraphQL customer
+This includes the owner method used by the current Commerce authenticated-customer
 identity reads.
+
+## Canonical local outcomes
+
+Canonical root construction now adds a separate post-delegation context wrapper for
+stable local outcomes. Root `InProcessCustomerReadPort` and
+`in_process_customer_read_port` retain the complete delegated context and only safe
+operation-specific request facts before calling the unchanged `CustomerService` port
+implementation.
+
+The wrapper classifies exact stable context, page, storage, not-found, validation, and
+profile-projection envelopes and returns the same delegated `PortError`. It does not
+log raw search text, email, names, customer rows, or profile payloads. The complete
+contract is documented in [read-local-context.md](./read-local-context.md).
+
+The policy event and local-outcome event have different phases. Policy rejection is
+recorded before owner delegation; a covered local outcome is recorded after the owner
+implementation returns. Direct callers of the compatibility factory under
+`rustok_customer::ports` do not pass through the root wrapper.
 
 ## Preserved contracts
 
@@ -41,22 +59,24 @@ The change does not alter:
 
 - the `CustomerReadPort` trait;
 - request or response DTOs;
-- the in-process provider factory;
 - read deadline requirements;
 - tenant parsing or list validation;
 - customer service calls;
 - existing customer error-to-`PortError` codes, kinds, messages, and retryability;
 - GraphQL not-found handling (`unauthenticated` or optional `None`);
-- GraphQL fallback envelopes or successful responses.
+- GraphQL fallback envelopes or successful responses;
+- FBA or FFA status.
 
 The policy helper rethrows the exact original `PortError` after diagnostics are retained.
+The root local-outcome wrapper also returns the exact delegated `PortError` unchanged.
 
 ## Still open
 
-This slice does not claim full customer transport completion. Remaining work includes:
+This work does not claim full customer transport completion. Remaining work includes:
 
+- direct callers that bypass canonical root construction through `rustok_customer::ports`;
 - retaining consumer-side `PortContext` at every non-owner GraphQL, REST, native, and
-  operator mapping boundary;
+  operator mapping boundary not already covered by focused slices;
 - auditing customer write adapters and profile transports;
 - adding runtime/transport evidence and compile validation;
 - completing the wider ecommerce correlation-safe mapper cleanup.
@@ -66,7 +86,9 @@ No ecommerce FBA/FFA status is promoted.
 ## Intended verification
 
 ```bash
+node scripts/verify/verify-customer-read-local-context.mjs
 node scripts/verify/verify-customer-read-policy-context.mjs
+node scripts/verify/verify-customer-fba-no-compile.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-customer --lib
 cargo check -p rustok-commerce --lib

--- a/crates/rustok-customer/src/lib.rs
+++ b/crates/rustok-customer/src/lib.rs
@@ -8,12 +8,18 @@ pub mod entities;
 pub mod error;
 pub mod migrations;
 pub mod ports;
+mod read_context;
 pub mod services;
 
 pub use dto::*;
 pub use entities::*;
 pub use error::{CustomerError, CustomerResult};
-pub use ports::*;
+pub use ports::{
+    CustomerListProjectionRequest, CustomerListProjectionResponse, CustomerProfileEnrichment,
+    CustomerProfileEnrichmentRequest, CustomerProjectionRequest, CustomerReadPort,
+    CustomerUserProjectionRequest,
+};
+pub use read_context::{InProcessCustomerReadPort, in_process_customer_read_port};
 pub use services::CustomerService;
 
 pub struct CustomerModule;

--- a/crates/rustok-customer/src/read_context.rs
+++ b/crates/rustok-customer/src/read_context.rs
@@ -1,0 +1,269 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::dto::CustomerResponse;
+use crate::ports::{
+    CustomerListProjectionRequest, CustomerListProjectionResponse, CustomerProfileEnrichment,
+    CustomerProfileEnrichmentRequest, CustomerProjectionRequest, CustomerReadPort,
+    CustomerUserProjectionRequest,
+};
+use crate::services::CustomerService;
+
+const CUSTOMER_OWNER: &str = "rustok_customer";
+const CUSTOMER_READ_BOUNDARY: &str = "customer_read_port";
+const READ_CUSTOMER_PROJECTION_OPERATION: &str = "read_customer_projection";
+const READ_CUSTOMER_PROJECTION_BY_USER_OPERATION: &str = "read_customer_projection_by_user";
+const LIST_CUSTOMER_PROJECTIONS_OPERATION: &str = "list_customer_projections";
+const LIST_PROFILE_ENRICHMENT_OPERATION: &str = "list_profile_enrichment";
+
+#[derive(Debug, Clone, Default)]
+struct CustomerReadDiagnosticFacts {
+    customer_id: Option<Uuid>,
+    user_id: Option<Uuid>,
+    page: Option<u64>,
+    per_page: Option<u64>,
+    search_length: Option<usize>,
+    requested_user_count: Option<usize>,
+    unique_user_count: Option<usize>,
+}
+
+/// Canonical in-process customer read provider with retained local outcome context.
+pub struct InProcessCustomerReadPort {
+    inner: CustomerService,
+}
+
+impl InProcessCustomerReadPort {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: CustomerService::new(db),
+        }
+    }
+
+    /// Wraps a host-composed customer service without changing owner behavior.
+    pub fn from_service(inner: CustomerService) -> Self {
+        Self { inner }
+    }
+}
+
+/// Builds the canonical owner-managed in-process customer read provider.
+pub fn in_process_customer_read_port(db: DatabaseConnection) -> Arc<dyn CustomerReadPort> {
+    Arc::new(InProcessCustomerReadPort::new(db))
+}
+
+#[async_trait]
+impl CustomerReadPort for InProcessCustomerReadPort {
+    async fn read_customer_projection(
+        &self,
+        context: PortContext,
+        request: CustomerProjectionRequest,
+    ) -> Result<CustomerResponse, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = CustomerReadDiagnosticFacts {
+            customer_id: Some(request.customer_id),
+            ..CustomerReadDiagnosticFacts::default()
+        };
+        let result = CustomerReadPort::read_customer_projection(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_customer_read_local_port_error(
+                &diagnostic_context,
+                READ_CUSTOMER_PROJECTION_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn read_customer_projection_by_user(
+        &self,
+        context: PortContext,
+        request: CustomerUserProjectionRequest,
+    ) -> Result<CustomerResponse, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = CustomerReadDiagnosticFacts {
+            user_id: Some(request.user_id),
+            ..CustomerReadDiagnosticFacts::default()
+        };
+        let result =
+            CustomerReadPort::read_customer_projection_by_user(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_customer_read_local_port_error(
+                &diagnostic_context,
+                READ_CUSTOMER_PROJECTION_BY_USER_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn list_customer_projections(
+        &self,
+        context: PortContext,
+        request: CustomerListProjectionRequest,
+    ) -> Result<CustomerListProjectionResponse, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = CustomerReadDiagnosticFacts {
+            page: Some(request.page),
+            per_page: Some(request.per_page),
+            search_length: request
+                .search
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..CustomerReadDiagnosticFacts::default()
+        };
+        let result =
+            CustomerReadPort::list_customer_projections(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_customer_read_local_port_error(
+                &diagnostic_context,
+                LIST_CUSTOMER_PROJECTIONS_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn list_profile_enrichment(
+        &self,
+        context: PortContext,
+        request: CustomerProfileEnrichmentRequest,
+    ) -> Result<Vec<CustomerProfileEnrichment>, PortError> {
+        let diagnostic_context = context.clone();
+        let requested_user_count = request.user_ids.len();
+        let unique_user_count = request.user_ids.iter().copied().collect::<HashSet<_>>().len();
+        let diagnostic_facts = CustomerReadDiagnosticFacts {
+            requested_user_count: Some(requested_user_count),
+            unique_user_count: Some(unique_user_count),
+            ..CustomerReadDiagnosticFacts::default()
+        };
+        let result = CustomerReadPort::list_profile_enrichment(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_customer_read_local_port_error(
+                &diagnostic_context,
+                LIST_PROFILE_ENRICHMENT_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+}
+
+fn map_customer_read_local_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    facts: &CustomerReadDiagnosticFacts,
+    error: PortError,
+) -> PortError {
+    let local_operation = match (
+        owner_operation,
+        error.code.as_str(),
+        error.message.as_str(),
+    ) {
+        (_, "customer.context_invalid", "customer request context is invalid") => {
+            "validate_tenant_context"
+        }
+        (
+            LIST_CUSTOMER_PROJECTIONS_OPERATION,
+            "customer.page_invalid",
+            "customer projection page is invalid",
+        ) => "validate_page",
+        (
+            LIST_CUSTOMER_PROJECTIONS_OPERATION,
+            "customer.per_page_invalid",
+            "customer projection page size is invalid",
+        ) => "validate_page_size",
+        (
+            _,
+            "customer.database_unavailable",
+            "customer storage is temporarily unavailable",
+        ) => "owner_storage",
+        (
+            READ_CUSTOMER_PROJECTION_OPERATION,
+            "customer.customer_not_found",
+            "customer was not found",
+        ) => "load_customer",
+        (
+            READ_CUSTOMER_PROJECTION_BY_USER_OPERATION,
+            "customer.customer_by_user_not_found",
+            "customer was not found for the requested user",
+        ) => "load_customer_by_user",
+        (_, "customer.validation", "customer request is invalid") => "validate_owner_request",
+        (
+            _,
+            "customer.profile_unavailable",
+            "customer profile projection is temporarily unavailable",
+        ) => "load_profile_projection",
+        _ => return error,
+    };
+
+    let technical_failure = matches!(
+        &error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+
+    if technical_failure {
+        tracing::error!(
+            error = ?error,
+            owner = CUSTOMER_OWNER,
+            operation = owner_operation,
+            local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            customer_id = ?facts.customer_id,
+            user_id = ?facts.user_id,
+            page = ?facts.page,
+            per_page = ?facts.per_page,
+            search_length = ?facts.search_length,
+            requested_user_count = ?facts.requested_user_count,
+            unique_user_count = ?facts.unique_user_count,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = CUSTOMER_READ_BOUNDARY,
+            "customer read local technical outcome retained delegated context"
+        );
+    } else {
+        tracing::warn!(
+            error = ?error,
+            owner = CUSTOMER_OWNER,
+            operation = owner_operation,
+            local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            customer_id = ?facts.customer_id,
+            user_id = ?facts.user_id,
+            page = ?facts.page,
+            per_page = ?facts.per_page,
+            search_length = ?facts.search_length,
+            requested_user_count = ?facts.requested_user_count,
+            unique_user_count = ?facts.unique_user_count,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = CUSTOMER_READ_BOUNDARY,
+            "customer read local outcome retained delegated context"
+        );
+    }
+
+    error
+}

--- a/scripts/verify/verify-customer-fba-no-compile.mjs
+++ b/scripts/verify/verify-customer-fba-no-compile.mjs
@@ -13,7 +13,7 @@ class CustomerFbaNoCompileVerificationError extends Error {
 const read = (path) => readFileSync(new URL(path, root), 'utf8');
 const readJson = (path) => JSON.parse(read(path));
 const fail = (message) => { throw new CustomerFbaNoCompileVerificationError(message); };
-const sameSet = (actual, expected) => Array.isArray(actual) && Array.isArray(expected) && actual.length === expected.length && expected.every((item) => actual.includes(item));
+const sameSet = (actual, expected) => Array.isArray(actual) && actual.length === expected.length && expected.every((item) => actual.includes(item));
 
 export function verifyCustomerFbaNoCompile() {
   const registryPath = 'crates/rustok-customer/contracts/customer-fba-registry.json';
@@ -23,7 +23,9 @@ export function verifyCustomerFbaNoCompile() {
   const registry = readJson(registryPath);
   const staticEvidence = readJson(staticEvidencePath);
   const runtimeSmoke = readJson(runtimeSmokePath);
+  const libSource = read('crates/rustok-customer/src/lib.rs');
   const portSource = read('crates/rustok-customer/src/ports.rs');
+  const wrapperSource = read('crates/rustok-customer/src/read_context.rs');
   const cargo = read('crates/rustok-customer/Cargo.toml');
   const manifest = read('crates/rustok-customer/rustok-module.toml');
   const plan = read(planPath);
@@ -48,7 +50,16 @@ export function verifyCustomerFbaNoCompile() {
   if (!manifest.includes('contract_version = "customer.read_projection.v1"')) fail('customer manifest contract version drift');
   if (!centralRegistry.includes('| `customer` |') || !centralRegistry.includes(registryPath)) fail('central readiness board must reference customer FBA registry');
   if (!portSource.includes('trait CustomerReadPort')) fail('CustomerReadPort trait missing');
-  if (!portSource.includes('require_policy(PortCallPolicy::read())?')) fail('CustomerReadPort must enforce read policy');
+  if (!portSource.includes('require_customer_read_policy(&context, owner_operation)?;')) fail('CustomerReadPort operations must use the shared read-policy helper');
+  if (!portSource.includes('context\n        .require_policy(PortCallPolicy::read())')) fail('CustomerReadPort helper must enforce read policy');
+  if (!libSource.includes('pub mod ports;') || !libSource.includes('mod read_context;')) fail('customer crate must retain ports and compose the root context wrapper');
+  if (!libSource.includes('pub use ports::{') || !libSource.includes('CustomerReadPort,')) fail('customer crate must export read contracts from ports');
+  if (!libSource.includes('pub use read_context::{InProcessCustomerReadPort, in_process_customer_read_port};')) fail('customer root factory must use the context wrapper');
+  if (!wrapperSource.includes('impl CustomerReadPort for InProcessCustomerReadPort')) fail('customer root wrapper must implement CustomerReadPort');
+  if (!wrapperSource.includes('CustomerReadPort::read_customer_projection(&self.inner, context, request).await')) fail('customer wrapper must delegate customer-id reads');
+  if (!wrapperSource.includes('CustomerReadPort::read_customer_projection_by_user(&self.inner, context, request).await')) fail('customer wrapper must delegate user-id reads');
+  if (!wrapperSource.includes('CustomerReadPort::list_customer_projections(&self.inner, context, request).await')) fail('customer wrapper must delegate list reads');
+  if (!wrapperSource.includes('CustomerReadPort::list_profile_enrichment(&self.inner, context, request).await')) fail('customer wrapper must delegate profile enrichment reads');
 
   for (const operation of ['read_customer_projection', 'read_customer_projection_by_user', 'list_customer_projections', 'list_profile_enrichment']) {
     if (!portSource.includes(`${operation}(`)) fail(`CustomerReadPort missing ${operation}`);
@@ -65,9 +76,10 @@ export function verifyCustomerFbaNoCompile() {
   if (runtimeSmoke.status !== 'source_locked_live_runtime_pending') fail('runtime smoke status drift');
   if (runtimeSmoke.promotion_allowed !== false) fail('runtime smoke must block promotion');
   if (runtimeSmoke.source_tests !== 'crates/rustok-customer/tests/customer_service_test.rs') fail('runtime smoke source tests drift');
-  for (const expectedCode of ['port.deadline_required', 'customer.tenant_id_invalid', 'customer.customer_not_found']) {
+  for (const expectedCode of ['port.deadline_required', 'customer.context_invalid', 'customer.customer_not_found']) {
     if (!JSON.stringify(runtimeSmoke.typed_error_matrix).includes(expectedCode)) fail(`runtime smoke missing typed error ${expectedCode}`);
   }
+  if (JSON.stringify(runtimeSmoke.typed_error_matrix).includes('customer.tenant_id_invalid')) fail('runtime smoke retains superseded customer tenant error code');
 
   for (const doc of [plan, readme, localDocs]) {
     if (!doc.includes('node scripts/verify/verify-customer-fba-no-compile.mjs')) fail('customer docs must reference the no-compile customer gate');
@@ -75,6 +87,7 @@ export function verifyCustomerFbaNoCompile() {
   if (!plan.includes('- FBA status: `boundary_ready`')) fail('plan FBA status drift');
   if (!plan.includes('Local documentation is synchronized')) fail('plan must record synchronized local documentation');
   if (!plan.includes('no-compile')) fail('plan must record the active no-compile verification gate');
+  if (!plan.includes('InProcessCustomerReadPort')) fail('plan must record canonical customer root construction');
 
   for (const consumer of commerceCustomerConsumers) {
     if (consumer.includes('CustomerService::new') || consumer.includes('use rustok_customer::CustomerService')) {
@@ -83,6 +96,9 @@ export function verifyCustomerFbaNoCompile() {
   }
   if (!commerceCustomerConsumers.some((consumer) => consumer.includes('read_customer_projection_by_user('))) {
     fail('commerce customer consumers must invoke CustomerReadPort user projection');
+  }
+  if (!commerceCustomerConsumers.some((consumer) => consumer.includes('in_process_customer_read_port'))) {
+    fail('commerce customer consumers must compose the canonical root customer factory');
   }
 }
 

--- a/scripts/verify/verify-customer-read-local-context.mjs
+++ b/scripts/verify/verify-customer-read-local-context.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const wrapper = read('crates/rustok-customer/src/read_context.rs');
+const ports = read('crates/rustok-customer/src/ports.rs');
+const lib = read('crates/rustok-customer/src/lib.rs');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [lib, 'pub mod ports;', 'legacy customer ports module'],
+  [lib, 'mod read_context;', 'private customer context wrapper module'],
+  [lib, 'pub use ports::{', 'selective root contract exports'],
+  [lib, 'CustomerReadPort,', 'root customer read trait export'],
+  [lib, 'pub use read_context::{InProcessCustomerReadPort, in_process_customer_read_port};', 'canonical root wrapper exports'],
+  [ports, 'pub fn in_process_customer_read_port(db: DatabaseConnection)', 'legacy module-path factory'],
+  [ports, 'Arc::new(crate::CustomerService::new(db))', 'unchanged persistent factory behavior'],
+  [wrapper, 'pub struct InProcessCustomerReadPort', 'canonical wrapper type'],
+  [wrapper, 'inner: CustomerService', 'unchanged owner implementation delegation'],
+  [wrapper, 'pub fn new(db: DatabaseConnection) -> Self', 'default wrapper constructor'],
+  [wrapper, 'pub fn from_service(inner: CustomerService) -> Self', 'host-composed service constructor'],
+  [wrapper, 'pub fn in_process_customer_read_port(db: DatabaseConnection)', 'canonical wrapper factory'],
+  [wrapper, 'Arc::new(InProcessCustomerReadPort::new(db))', 'canonical wrapper construction'],
+  [wrapper, 'impl CustomerReadPort for InProcessCustomerReadPort', 'wrapper trait implementation'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const [operation, request, response] of [
+  ['read_customer_projection', 'CustomerProjectionRequest', 'CustomerResponse'],
+  ['read_customer_projection_by_user', 'CustomerUserProjectionRequest', 'CustomerResponse'],
+  ['list_customer_projections', 'CustomerListProjectionRequest', 'CustomerListProjectionResponse'],
+  ['list_profile_enrichment', 'CustomerProfileEnrichmentRequest', 'Vec<CustomerProfileEnrichment>'],
+]) {
+  requireText(wrapper, `async fn ${operation}(`, `${operation} wrapper operation`);
+  requireText(wrapper, `request: ${request}`, `${operation} request contract`);
+  requireText(wrapper, `Result<${response}, PortError>`, `${operation} response contract`);
+  requireText(wrapper, `CustomerReadPort::${operation}(&self.inner, context, request).await`, `${operation} unchanged delegation`);
+}
+
+for (const [value, label] of [
+  ['let diagnostic_context = context.clone();', 'retained delegated context'],
+  ['CustomerReadDiagnosticFacts', 'safe request facts'],
+  ['customer_id: Some(request.customer_id)', 'typed customer identity'],
+  ['user_id: Some(request.user_id)', 'typed user identity'],
+  ['page: Some(request.page)', 'list page fact'],
+  ['per_page: Some(request.per_page)', 'list page-size fact'],
+  ['.map(|value| value.chars().count())', 'search length only'],
+  ['requested_user_count: Some(requested_user_count)', 'profile request count'],
+  ['unique_user_count: Some(unique_user_count)', 'profile unique count'],
+  ['map_customer_read_local_port_error(', 'post-delegation local mapper'],
+  ['owner = CUSTOMER_OWNER', 'truthful customer owner'],
+  ['operation = owner_operation', 'exact owner operation'],
+  ['local_operation,', 'local operation label'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['customer_id = ?facts.customer_id', 'customer fact logging'],
+  ['user_id = ?facts.user_id', 'user fact logging'],
+  ['search_length = ?facts.search_length', 'search length logging'],
+  ['requested_user_count = ?facts.requested_user_count', 'profile count logging'],
+  ['internal_code = %error.code', 'stable internal code'],
+  ['internal_message = %error.message', 'public-safe internal message'],
+  ['error_kind = ?error.kind', 'typed error kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = CUSTOMER_READ_BOUNDARY', 'customer read boundary'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
+  ['"customer read local technical outcome retained delegated context"', 'technical diagnostic event'],
+  ['"customer read local outcome retained delegated context"', 'ordinary diagnostic event'],
+  ['_ => return error', 'unknown envelope pass-through'],
+]) {
+  requireText(wrapper, value, label);
+}
+
+for (const [code, message, operation] of [
+  ['customer.context_invalid', 'customer request context is invalid', 'validate_tenant_context'],
+  ['customer.page_invalid', 'customer projection page is invalid', 'validate_page'],
+  ['customer.per_page_invalid', 'customer projection page size is invalid', 'validate_page_size'],
+  ['customer.database_unavailable', 'customer storage is temporarily unavailable', 'owner_storage'],
+  ['customer.customer_not_found', 'customer was not found', 'load_customer'],
+  ['customer.customer_by_user_not_found', 'customer was not found for the requested user', 'load_customer_by_user'],
+  ['customer.validation', 'customer request is invalid', 'validate_owner_request'],
+  ['customer.profile_unavailable', 'customer profile projection is temporarily unavailable', 'load_profile_projection'],
+]) {
+  requireText(wrapper, `"${code}"`, `${code} exact code`);
+  requireText(wrapper, `"${message}"`, `${code} exact message`);
+  requireText(wrapper, `"${operation}"`, `${code} local operation`);
+}
+
+for (const [value, label] of [
+  ['search = ?', 'raw search text'],
+  ['search = %', 'raw search text'],
+  ['email = ?', 'raw email'],
+  ['email = %', 'raw email'],
+  ['first_name =', 'raw first name'],
+  ['last_name =', 'raw last name'],
+  ['preferred_locale =', 'raw preferred locale'],
+  ['request = ?', 'raw request payload'],
+  ['result = ?', 'raw result payload'],
+  ['items = ?', 'raw customer rows'],
+]) {
+  forbidText(wrapper, value, label);
+}
+
+requireText(ports, 'require_customer_read_policy(&context, owner_operation)?;', 'unchanged policy admission');
+requireText(ports, 'parse_port_tenant_id(&context, owner_operation)?;', 'unchanged tenant parsing');
+requireText(ports, 'validate_customer_list_projection_request(&context, owner_operation, &request)?;', 'unchanged list validation');
+requireText(ports, 'customer_error_to_port_error(&context, owner_operation, error)', 'unchanged public error mapping');
+
+if (!/\n\s*error\n\}/.test(wrapper)) {
+  failures.push('same delegated PortError return: missing terminal error return');
+}
+
+if (failures.length > 0) {
+  console.error('Customer read local context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Canonical customer reads retain complete local context and safe request facts without changing owner behavior',
+);


### PR DESCRIPTION
## Summary

- continue ecommerce implementation-plan item 10 with a focused `rustok-customer` correlation-safe owner slice;
- add canonical root `InProcessCustomerReadPort` construction for all four `CustomerReadPort` operations while leaving the persistent implementation in `ports.rs` unchanged;
- retain the delegated `PortContext` and operation-specific safe request facts before unchanged owner delegation;
- classify only exact stable operation/code/message outcomes for tenant context, pagination, storage, not-found, validation, and profile projection failures;
- use error severity for unavailable/timeout/invariant outcomes and warning severity for ordinary validation/not-found outcomes;
- return the same delegated `PortError` unchanged and pass policy or unknown envelopes through without changing owner behavior;
- deliberately avoid logging raw search text, email, customer names/rows, profile names/locales, result rows, or profile payloads;
- preserve `rustok_customer::ports` as an explicit compatibility path while routing root `in_process_customer_read_port` through the wrapper;
- add focused source-ready/unvalidated documentation and a static guard;
- repair stale customer no-compile markers for shared read-policy admission and canonical root construction;
- align the runtime-smoke typed-error matrix with the current public-safe `customer.context_invalid` source contract without promoting FBA/FFA status.

## Recheck

- continued from merged tax local-context PR #2326;
- confirmed #2326 was squash-merged into `main` as `12138dcbfcc165a4b2034ec98af5dc2095e41797` and its source branch was deleted automatically;
- confirmed no open PR overlaps this customer owner scope;
- confirmed the branch is based directly on current `main`, is zero commits behind, and changes exactly nine files;
- confirmed current Commerce consumers import the canonical root customer factory and do not construct `CustomerService` directly;
- confirmed `ports.rs` admission, tenant parsing, tenant-scoped service calls, DTOs, public codes/messages/kinds/retryability, and compatibility factory remain unchanged;
- found pre-existing stale assertions in `crates/rustok-customer/tests/customer_service_test.rs`: they still expect the superseded `customer.tenant_id_invalid` code and an identifier-bearing not-found message, while current sanitized production source already uses `customer.context_invalid` and `customer was not found`. This PR does not restore unsafe public behavior; test-expectation synchronization remains explicit validation follow-up.

## Boundary

This PR closes stable owner-local outcome context retention for canonical root customer reads. It does not close direct compatibility-path callers, remaining consumer-side GraphQL/REST/native/operator mappings, customer write adapters, profile transports, stale historical test expectations, or compiled/runtime/remote-profile evidence.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks after synchronizing the historical test expectations:

```bash
node scripts/verify/verify-customer-read-local-context.mjs
node scripts/verify/verify-customer-read-policy-context.mjs
node scripts/verify/verify-customer-fba-no-compile.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-customer --lib
cargo check -p rustok-commerce --lib
```
