### PR TITLE
Retain pricing read local context

### DIFF
--- a/crates/rustok-pricing/docs/implementation-plan.md
+++ b/crates/rustok-pricing/docs/implementation-plan.md
@@ -14,6 +14,15 @@ and retain GraphQL as the parallel selected path.
 policy, typed error mapping, and declared fallback profiles, but the FBA
 provider has not yet been executed against live persistence or a remote
 consumer path.
+
+Canonical root read construction now uses `InProcessPricingReadPort`. The wrapper
+retains the delegated `PortContext`, typed identity and bounded request-shape facts,
+and exact local outcome context around the unchanged `PricingService` port
+implementation. Known identifying validation, not-found, and conflict envelopes are
+returned with stable non-identifying messages while preserving kind, code, and
+retryability. The legacy module-path read factory remains an explicit compatibility
+path, and the write factory remains unchanged.
+
 The port accepts variant-first resolution when a cart snapshot has no product
 id and returns the full resolved-price projection required to persist pricing
 adjustments; cart storefront repricing therefore no longer calls
@@ -46,9 +55,13 @@ evidence only; no live provider-consumer transport execution has been recorded.
 - FBA status: `boundary_ready` — provider metadata and static contract evidence
   are ready, while runtime contract and fallback execution remain pending.
 - Structural shape: `core_transport_ui`
+- Canonical root read provider: `InProcessPricingReadPort`; owner execution remains
+  `PricingService` in `ports.rs`, and `rustok_pricing::ports` is a compatibility path.
 - Evidence: `crates/rustok-pricing/contracts/pricing-fba-registry.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-contract-test-static-matrix.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-runtime-contract-smoke.json`,
+  `crates/rustok-pricing/docs/read-local-context.md`,
+  `scripts/verify/verify-pricing-read-local-context.mjs`,
   `scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs`,
   `scripts/verify/verify-pricing-admin-boundary.mjs`, and
   `scripts/verify/verify-pricing-storefront-boundary.mjs`.
@@ -78,11 +91,19 @@ evidence only; no live provider-consumer transport execution has been recorded.
    promotions orchestration remains owned by `rustok-commerce`.
    Dependency: the stable owner transport and product variant data. Verification:
    targeted pricing resolution and money-semantics tests.
+4. Prove canonical pricing diagnostics and retire compatibility bypasses.
+   **Status:** source-complete / unvalidated for root read construction. Execute
+   invalid-context, product/variant mismatch, missing price/list, duplicate identity,
+   inventory conflict, storage, and invariant scenarios and retain traces proving that
+   raw handles, SKUs, UUID-bearing messages, quantities, currencies, and prices do not
+   cross the canonical boundary. Audit direct `rustok_pricing::ports` callers and
+   either migrate or explicitly accept them.
 
 ## Verification
 
 - `npm run verify:pricing:admin-boundary`
 - `npm run verify:pricing:storefront-boundary`
+- `node scripts/verify/verify-pricing-read-local-context.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo test -p rustok-pricing --test pricing_read_port_runtime`
 
@@ -93,3 +114,5 @@ evidence only; no live provider-consumer transport execution has been recorded.
   multi-layer promotions workflow.
 - Hosts only compose owner UI packages and pass effective locale, channel, and
   runtime context without creating package-local fallback chains.
+- Keep raw handles, SKUs, currency values, prices, percentages, and returned pricing
+  rows out of owner diagnostics; retain only typed identity and bounded shape facts.

--- a/crates/rustok-pricing/docs/read-local-context.md
+++ b/crates/rustok-pricing/docs/read-local-context.md
@@ -1,0 +1,123 @@
+# Pricing read local outcome context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice protects the canonical root construction for all six `PricingReadPort`
+operations:
+
+- `resolve_product_price`;
+- `read_price_list_projection`;
+- `list_active_price_list_projections`;
+- `read_admin_product_pricing_projection`;
+- `read_storefront_product_pricing_projection`;
+- `preview_variant_discount`.
+
+The owner implementation in `ports.rs` remains the persistence and domain-policy
+delegate. `InProcessPricingReadPort` retains the delegated context and safe request
+facts, invokes that implementation unchanged, classifies known owner envelopes, and
+returns either the unchanged error or the same kind/code/retryability with a stable
+non-identifying message.
+
+## Canonical root cutover
+
+Root `rustok_pricing::in_process_pricing_read_port` now constructs
+`InProcessPricingReadPort`. Current commerce, checkout, GraphQL, REST, admin, and
+storefront consumers importing the root factory therefore use the guarded path without
+changing their requests or orchestration.
+
+`rustok_pricing::ports::in_process_pricing_read_port` remains available as an explicit
+compatibility path. It is not counted as covered by this source slice. The root write
+factory remains unchanged because this PR is deliberately read-only.
+
+## Preserved owner behavior
+
+The wrapper does not change:
+
+- `PortCallPolicy::read()` admission or deadline semantics;
+- tenant parsing and tenant isolation;
+- product/variant consistency checks;
+- price-list, channel, locale, quantity, and fallback resolution;
+- pricing service method selection or ordering;
+- request and response DTOs;
+- error kind, code, or retryability;
+- `PricingWritePort` construction and execution;
+- runtime evidence status or FBA/FFA status.
+
+## Safe request facts
+
+Diagnostics may retain typed identifiers and bounded shape facts required to locate a
+failed owner call:
+
+- product, variant, region, channel, and price-list UUIDs;
+- selected price-list UUID;
+- requested quantity;
+- character lengths for currency code, channel slug, locale, fallback locale,
+  storefront handle, and public channel slug.
+
+The wrapper does not log raw storefront handles, SKUs, channel slugs, currency values,
+discount percentages, prices, compare-at prices, titles, rows, or returned pricing
+projections. It records only the original public-message character count, never the
+original text.
+
+## Stabilized messages
+
+Known identifying owner envelopes keep their existing kind, code, and retryability but
+receive stable messages at the canonical boundary:
+
+| Code | Stable message |
+| --- | --- |
+| `pricing.tenant_id_invalid` | `pricing request context is invalid` |
+| `pricing.variant_product_mismatch` | `variant does not belong to the requested product` |
+| `pricing.price_not_found` | `price was not found` |
+| `pricing.price_list_not_found` | `price list was not found` |
+| `pricing.product_not_found` | `product was not found` |
+| `pricing.variant_not_found` | `variant was not found` |
+| `pricing.duplicate_handle` | `pricing handle is already in use` |
+| `pricing.duplicate_sku` | `pricing SKU is already in use` |
+| `pricing.insufficient_inventory` | `inventory is insufficient for the pricing operation` |
+| `pricing.shipping_profile_not_found` | `shipping profile was not found` |
+| `pricing.duplicate_shipping_profile_slug` | `shipping profile slug is already in use` |
+
+Already-stable validation, conflict, unavailable, and invariant envelopes are recorded
+without changing their message. Unknown errors and shared `port.*` admission errors pass
+through without an additional local event.
+
+## Diagnostic context
+
+Covered outcomes record:
+
+- truthful owner `rustok_pricing`;
+- exact public and local operation names;
+- boundary `pricing_read_port`;
+- correlation, tenant, actor, channel, locale, causation, trace, idempotency, and
+  deadline context;
+- claim and role counts rather than claim contents;
+- safe request facts;
+- stable code, safe public message, message length, kind, and retryability.
+
+Unavailable, timeout, and invariant outcomes use error severity. Validation, not-found,
+and conflict outcomes use warning severity.
+
+## Static evidence
+
+`scripts/verify/verify-pricing-read-local-context.mjs` locks:
+
+- the root factory cutover and unchanged compatibility/write paths;
+- all six unchanged owner delegations;
+- complete context and safe request-fact retention;
+- stable message replacement with preserved kind/code/retryability;
+- technical-versus-ordinary severity;
+- absence of raw pricing payload logging.
+
+Intended focused verification:
+
+```bash
+node scripts/verify/verify-pricing-read-local-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-pricing --lib
+cargo check -p rustok-commerce --lib
+```
+
+These commands are not executed in this source wave; validation remains maintainer-owned.

--- a/crates/rustok-pricing/src/lib.rs
+++ b/crates/rustok-pricing/src/lib.rs
@@ -9,9 +9,19 @@ pub mod entities {
 
 pub mod migrations;
 pub mod ports;
+mod read_context;
 pub mod services;
 
-pub use ports::*;
+pub use ports::{
+    ActivePriceListProjectionRequest, ActivePriceListProjectionSnapshot,
+    AdminProductPricingProjectionRequest, ApplyVariantDiscountRequest,
+    PreviewVariantDiscountRequest, PriceListProjectionRequest, PriceListProjectionSnapshot,
+    PricingReadPort, PricingWritePort, ResolveProductPriceRequest, ResolvedProductPriceSnapshot,
+    SetPriceListPercentageRuleRequest, SetPriceListScopeRequest,
+    StorefrontProductPricingProjectionRequest, UpsertVariantPriceRequest,
+    in_process_pricing_write_port,
+};
+pub use read_context::{InProcessPricingReadPort, in_process_pricing_read_port};
 
 pub use services::{
     ActivePriceListOption, AdminPricingPrice, AdminPricingProductDetail, AdminPricingProductList,

--- a/crates/rustok-pricing/src/read_context.rs
+++ b/crates/rustok-pricing/src/read_context.rs
@@ -1,0 +1,478 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError, PortErrorKind};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::ports::{
+    ActivePriceListProjectionRequest, ActivePriceListProjectionSnapshot,
+    AdminProductPricingProjectionRequest, PreviewVariantDiscountRequest,
+    PriceListProjectionRequest, PriceListProjectionSnapshot, PricingReadPort,
+    ResolveProductPriceRequest, ResolvedProductPriceSnapshot,
+    StorefrontProductPricingProjectionRequest,
+};
+use crate::{
+    AdminPricingProductDetail, PriceAdjustmentPreview, PricingService,
+    StorefrontPricingProductDetail,
+};
+
+const PRICING_OWNER: &str = "rustok_pricing";
+const PRICING_READ_BOUNDARY: &str = "pricing_read_port";
+const RESOLVE_PRODUCT_PRICE_OPERATION: &str = "resolve_product_price";
+const READ_PRICE_LIST_PROJECTION_OPERATION: &str = "read_price_list_projection";
+const LIST_ACTIVE_PRICE_LIST_PROJECTIONS_OPERATION: &str =
+    "list_active_price_list_projections";
+const READ_ADMIN_PRODUCT_PRICING_PROJECTION_OPERATION: &str =
+    "read_admin_product_pricing_projection";
+const READ_STOREFRONT_PRODUCT_PRICING_PROJECTION_OPERATION: &str =
+    "read_storefront_product_pricing_projection";
+const PREVIEW_VARIANT_DISCOUNT_OPERATION: &str = "preview_variant_discount";
+
+#[derive(Debug, Clone, Default)]
+struct PricingReadDiagnosticFacts {
+    product_id: Option<Uuid>,
+    variant_id: Option<Uuid>,
+    region_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    price_list_id: Option<Uuid>,
+    selected_price_list_id: Option<Uuid>,
+    quantity: Option<i32>,
+    currency_code_length: Option<usize>,
+    channel_slug_length: Option<usize>,
+    locale_length: Option<usize>,
+    fallback_locale_length: Option<usize>,
+    handle_length: Option<usize>,
+    public_channel_slug_length: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PricingReadLocalOutcome {
+    local_operation: &'static str,
+    sanitized_message: Option<&'static str>,
+}
+
+/// Canonical in-process pricing read provider with retained local outcome context.
+pub struct InProcessPricingReadPort {
+    inner: PricingService,
+}
+
+impl InProcessPricingReadPort {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            inner: PricingService::new(db, event_bus),
+        }
+    }
+
+    /// Wraps a host-composed pricing service without changing owner execution.
+    pub fn from_service(inner: PricingService) -> Self {
+        Self { inner }
+    }
+}
+
+/// Builds the canonical owner-managed in-process pricing read provider.
+pub fn in_process_pricing_read_port(
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+) -> Arc<dyn PricingReadPort> {
+    Arc::new(InProcessPricingReadPort::new(db, event_bus))
+}
+
+#[async_trait]
+impl PricingReadPort for InProcessPricingReadPort {
+    async fn resolve_product_price(
+        &self,
+        context: PortContext,
+        request: ResolveProductPriceRequest,
+    ) -> Result<ResolvedProductPriceSnapshot, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            product_id: request.product_id,
+            variant_id: Some(request.variant_id),
+            region_id: request.region_id,
+            channel_id: request.channel_id,
+            price_list_id: request.price_list_id,
+            quantity: request.quantity,
+            currency_code_length: Some(request.currency_code.chars().count()),
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result = PricingReadPort::resolve_product_price(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                RESOLVE_PRODUCT_PRICE_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn read_price_list_projection(
+        &self,
+        context: PortContext,
+        request: PriceListProjectionRequest,
+    ) -> Result<PriceListProjectionSnapshot, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            price_list_id: Some(request.price_list_id),
+            locale_length: request.locale.as_ref().map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result =
+            PricingReadPort::read_price_list_projection(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                READ_PRICE_LIST_PROJECTION_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn list_active_price_list_projections(
+        &self,
+        context: PortContext,
+        request: ActivePriceListProjectionRequest,
+    ) -> Result<Vec<ActivePriceListProjectionSnapshot>, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            channel_id: request.channel_id,
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            fallback_locale_length: request
+                .fallback_locale
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result = PricingReadPort::list_active_price_list_projections(
+            &self.inner,
+            context,
+            request,
+        )
+        .await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                LIST_ACTIVE_PRICE_LIST_PROJECTIONS_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn read_admin_product_pricing_projection(
+        &self,
+        context: PortContext,
+        request: AdminProductPricingProjectionRequest,
+    ) -> Result<AdminPricingProductDetail, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            product_id: Some(request.product_id),
+            selected_price_list_id: request.selected_price_list_id,
+            fallback_locale_length: request
+                .fallback_locale
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result = PricingReadPort::read_admin_product_pricing_projection(
+            &self.inner,
+            context,
+            request,
+        )
+        .await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                READ_ADMIN_PRODUCT_PRICING_PROJECTION_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn read_storefront_product_pricing_projection(
+        &self,
+        context: PortContext,
+        request: StorefrontProductPricingProjectionRequest,
+    ) -> Result<Option<StorefrontPricingProductDetail>, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            handle_length: Some(request.handle.chars().count()),
+            fallback_locale_length: request
+                .fallback_locale
+                .as_ref()
+                .map(|value| value.chars().count()),
+            public_channel_slug_length: request
+                .public_channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result = PricingReadPort::read_storefront_product_pricing_projection(
+            &self.inner,
+            context,
+            request,
+        )
+        .await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                READ_STOREFRONT_PRODUCT_PRICING_PROJECTION_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn preview_variant_discount(
+        &self,
+        context: PortContext,
+        request: PreviewVariantDiscountRequest,
+    ) -> Result<PriceAdjustmentPreview, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingReadDiagnosticFacts {
+            variant_id: Some(request.variant_id),
+            channel_id: request.channel_id,
+            price_list_id: request.price_list_id,
+            currency_code_length: Some(request.currency_code.chars().count()),
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingReadDiagnosticFacts::default()
+        };
+        let result = PricingReadPort::preview_variant_discount(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_read_local_port_error(
+                &diagnostic_context,
+                PREVIEW_VARIANT_DISCOUNT_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+}
+
+fn classify_pricing_read_local_outcome(
+    owner_operation: &'static str,
+    error: &PortError,
+) -> Option<PricingReadLocalOutcome> {
+    let outcome = match (owner_operation, &error.kind, error.code.as_str()) {
+        (_, PortErrorKind::Validation, "pricing.tenant_id_invalid") => PricingReadLocalOutcome {
+            local_operation: "validate_tenant_context",
+            sanitized_message: Some("pricing request context is invalid"),
+        },
+        (
+            RESOLVE_PRODUCT_PRICE_OPERATION,
+            PortErrorKind::Validation,
+            "pricing.variant_product_mismatch",
+        ) => PricingReadLocalOutcome {
+            local_operation: "validate_variant_product_identity",
+            sanitized_message: Some("variant does not belong to the requested product"),
+        },
+        (
+            RESOLVE_PRODUCT_PRICE_OPERATION,
+            PortErrorKind::NotFound,
+            "pricing.price_not_found",
+        ) => PricingReadLocalOutcome {
+            local_operation: "resolve_variant_price",
+            sanitized_message: Some("price was not found"),
+        },
+        (
+            READ_PRICE_LIST_PROJECTION_OPERATION,
+            PortErrorKind::NotFound,
+            "pricing.price_list_not_found",
+        ) => PricingReadLocalOutcome {
+            local_operation: "load_price_list_projection",
+            sanitized_message: Some("price list was not found"),
+        },
+        (_, PortErrorKind::Unavailable, "pricing.database_unavailable") => {
+            PricingReadLocalOutcome {
+                local_operation: "owner_storage",
+                sanitized_message: None,
+            }
+        }
+        (_, PortErrorKind::NotFound, "pricing.product_not_found") => PricingReadLocalOutcome {
+            local_operation: "load_product",
+            sanitized_message: Some("product was not found"),
+        },
+        (_, PortErrorKind::NotFound, "pricing.variant_not_found") => PricingReadLocalOutcome {
+            local_operation: "load_variant",
+            sanitized_message: Some("variant was not found"),
+        },
+        (_, PortErrorKind::Conflict, "pricing.duplicate_handle") => PricingReadLocalOutcome {
+            local_operation: "validate_handle_uniqueness",
+            sanitized_message: Some("pricing handle is already in use"),
+        },
+        (_, PortErrorKind::Conflict, "pricing.duplicate_sku") => PricingReadLocalOutcome {
+            local_operation: "validate_sku_uniqueness",
+            sanitized_message: Some("pricing SKU is already in use"),
+        },
+        (_, PortErrorKind::Validation, "pricing.validation") => PricingReadLocalOutcome {
+            local_operation: "validate_owner_request",
+            sanitized_message: None,
+        },
+        (_, PortErrorKind::Conflict, "pricing.insufficient_inventory") => {
+            PricingReadLocalOutcome {
+                local_operation: "validate_inventory_requirement",
+                sanitized_message: Some("inventory is insufficient for the pricing operation"),
+            }
+        }
+        (_, PortErrorKind::Validation, "pricing.invalid_option_combination") => {
+            PricingReadLocalOutcome {
+                local_operation: "validate_option_combination",
+                sanitized_message: None,
+            }
+        }
+        (_, PortErrorKind::NotFound, "pricing.shipping_profile_not_found") => {
+            PricingReadLocalOutcome {
+                local_operation: "load_shipping_profile",
+                sanitized_message: Some("shipping profile was not found"),
+            }
+        }
+        (_, PortErrorKind::Conflict, "pricing.duplicate_shipping_profile_slug") => {
+            PricingReadLocalOutcome {
+                local_operation: "validate_shipping_profile_slug_uniqueness",
+                sanitized_message: Some("shipping profile slug is already in use"),
+            }
+        }
+        (_, PortErrorKind::Validation, "pricing.no_variants") => PricingReadLocalOutcome {
+            local_operation: "validate_product_variants",
+            sanitized_message: None,
+        },
+        (_, PortErrorKind::Conflict, "pricing.cannot_delete_published") => {
+            PricingReadLocalOutcome {
+                local_operation: "validate_published_product_state",
+                sanitized_message: None,
+            }
+        }
+        (_, PortErrorKind::InvariantViolation, "pricing.rich_error") => {
+            PricingReadLocalOutcome {
+                local_operation: "owner_rich_invariant",
+                sanitized_message: None,
+            }
+        }
+        (_, PortErrorKind::InvariantViolation, "pricing.core_error") => {
+            PricingReadLocalOutcome {
+                local_operation: "owner_core_invariant",
+                sanitized_message: None,
+            }
+        }
+        _ => return None,
+    };
+    Some(outcome)
+}
+
+fn map_pricing_read_local_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    facts: &PricingReadDiagnosticFacts,
+    error: PortError,
+) -> PortError {
+    let Some(outcome) = classify_pricing_read_local_outcome(owner_operation, &error) else {
+        return error;
+    };
+
+    let mapped_error = match outcome.sanitized_message {
+        Some(message) => PortError::new(
+            error.kind.clone(),
+            error.code.clone(),
+            message,
+            error.retryable,
+        ),
+        None => error.clone(),
+    };
+    let technical_failure = matches!(
+        &mapped_error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+    let original_message_length = error.message.chars().count();
+
+    if technical_failure {
+        tracing::error!(
+            owner = PRICING_OWNER,
+            operation = owner_operation,
+            local_operation = outcome.local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            claim_count = context.claims.len(),
+            role_count = context.roles.len(),
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            product_id = ?facts.product_id,
+            variant_id = ?facts.variant_id,
+            region_id = ?facts.region_id,
+            channel_id = ?facts.channel_id,
+            price_list_id = ?facts.price_list_id,
+            selected_price_list_id = ?facts.selected_price_list_id,
+            quantity = ?facts.quantity,
+            currency_code_length = ?facts.currency_code_length,
+            channel_slug_length = ?facts.channel_slug_length,
+            locale_length = ?facts.locale_length,
+            fallback_locale_length = ?facts.fallback_locale_length,
+            handle_length = ?facts.handle_length,
+            public_channel_slug_length = ?facts.public_channel_slug_length,
+            internal_code = %error.code,
+            public_message = %mapped_error.message,
+            original_message_length,
+            error_kind = ?mapped_error.kind,
+            retryable = mapped_error.retryable,
+            boundary = PRICING_READ_BOUNDARY,
+            "pricing read local technical outcome retained delegated context"
+        );
+    } else {
+        tracing::warn!(
+            owner = PRICING_OWNER,
+            operation = owner_operation,
+            local_operation = outcome.local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            claim_count = context.claims.len(),
+            role_count = context.roles.len(),
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            product_id = ?facts.product_id,
+            variant_id = ?facts.variant_id,
+            region_id = ?facts.region_id,
+            channel_id = ?facts.channel_id,
+            price_list_id = ?facts.price_list_id,
+            selected_price_list_id = ?facts.selected_price_list_id,
+            quantity = ?facts.quantity,
+            currency_code_length = ?facts.currency_code_length,
+            channel_slug_length = ?facts.channel_slug_length,
+            locale_length = ?facts.locale_length,
+            fallback_locale_length = ?facts.fallback_locale_length,
+            handle_length = ?facts.handle_length,
+            public_channel_slug_length = ?facts.public_channel_slug_length,
+            internal_code = %error.code,
+            public_message = %mapped_error.message,
+            original_message_length,
+            error_kind = ?mapped_error.kind,
+            retryable = mapped_error.retryable,
+            boundary = PRICING_READ_BOUNDARY,
+            "pricing read local outcome retained delegated context"
+        );
+    }
+
+    mapped_error
+}

--- a/scripts/verify/verify-pricing-read-local-context.mjs
+++ b/scripts/verify/verify-pricing-read-local-context.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const lib = read('crates/rustok-pricing/src/lib.rs');
+const legacy = read('crates/rustok-pricing/src/ports.rs');
+const wrapper = read('crates/rustok-pricing/src/read_context.rs');
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [lib, 'mod read_context;', 'private wrapper module'],
+  [lib, 'pub use read_context::{InProcessPricingReadPort, in_process_pricing_read_port};', 'canonical root wrapper export'],
+  [lib, 'in_process_pricing_write_port,', 'unchanged root write factory'],
+  [legacy, 'pub fn in_process_pricing_read_port(', 'legacy compatibility factory'],
+  [legacy, 'impl PricingReadPort for crate::PricingService', 'unchanged owner implementation'],
+  [wrapper, 'pub struct InProcessPricingReadPort', 'canonical read wrapper'],
+  [wrapper, 'pub fn from_service(inner: PricingService) -> Self', 'host composition constructor'],
+  [wrapper, 'pub fn in_process_pricing_read_port(', 'canonical read factory'],
+  [wrapper, 'Arc::new(InProcessPricingReadPort::new(db, event_bus))', 'wrapper factory construction'],
+  [wrapper, 'impl PricingReadPort for InProcessPricingReadPort', 'wrapper trait implementation'],
+  [wrapper, 'const PRICING_OWNER: &str = "rustok_pricing";', 'truthful owner'],
+  [wrapper, 'const PRICING_READ_BOUNDARY: &str = "pricing_read_port";', 'stable boundary'],
+]) {
+  requireText(source, value, label);
+}
+
+forbidText(lib, 'pub use ports::*;', 'wildcard root compatibility export');
+forbidText(
+  lib,
+  'pub use ports::in_process_pricing_read_port',
+  'legacy read factory exported as canonical root',
+);
+
+const operations = [
+  ['resolve_product_price', 'RESOLVE_PRODUCT_PRICE_OPERATION'],
+  ['read_price_list_projection', 'READ_PRICE_LIST_PROJECTION_OPERATION'],
+  ['list_active_price_list_projections', 'LIST_ACTIVE_PRICE_LIST_PROJECTIONS_OPERATION'],
+  ['read_admin_product_pricing_projection', 'READ_ADMIN_PRODUCT_PRICING_PROJECTION_OPERATION'],
+  ['read_storefront_product_pricing_projection', 'READ_STOREFRONT_PRODUCT_PRICING_PROJECTION_OPERATION'],
+  ['preview_variant_discount', 'PREVIEW_VARIANT_DISCOUNT_OPERATION'],
+];
+
+for (const [operation, constant] of operations) {
+  requireText(
+    wrapper,
+    `PricingReadPort::${operation}(&self.inner`,
+    `${operation} unchanged owner delegation`,
+  );
+  requireText(wrapper, constant, `${operation} stable operation constant`);
+}
+
+const retainedContext = [
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'claim_count = context.claims.len()',
+  'role_count = context.roles.len()',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'deadline_ms = ?context.deadline_ms',
+];
+for (const value of retainedContext) {
+  requireText(wrapper, value, 'complete delegated pricing context');
+}
+
+const safeFacts = [
+  'product_id = ?facts.product_id',
+  'variant_id = ?facts.variant_id',
+  'region_id = ?facts.region_id',
+  'channel_id = ?facts.channel_id',
+  'price_list_id = ?facts.price_list_id',
+  'selected_price_list_id = ?facts.selected_price_list_id',
+  'quantity = ?facts.quantity',
+  'currency_code_length = ?facts.currency_code_length',
+  'channel_slug_length = ?facts.channel_slug_length',
+  'locale_length = ?facts.locale_length',
+  'fallback_locale_length = ?facts.fallback_locale_length',
+  'handle_length = ?facts.handle_length',
+  'public_channel_slug_length = ?facts.public_channel_slug_length',
+];
+for (const value of safeFacts) {
+  requireText(wrapper, value, 'safe pricing request facts');
+}
+
+const sanitizedOutcomes = [
+  ['pricing.tenant_id_invalid', 'pricing request context is invalid'],
+  ['pricing.variant_product_mismatch', 'variant does not belong to the requested product'],
+  ['pricing.price_not_found', 'price was not found'],
+  ['pricing.price_list_not_found', 'price list was not found'],
+  ['pricing.product_not_found', 'product was not found'],
+  ['pricing.variant_not_found', 'variant was not found'],
+  ['pricing.duplicate_handle', 'pricing handle is already in use'],
+  ['pricing.duplicate_sku', 'pricing SKU is already in use'],
+  ['pricing.insufficient_inventory', 'inventory is insufficient for the pricing operation'],
+  ['pricing.shipping_profile_not_found', 'shipping profile was not found'],
+  ['pricing.duplicate_shipping_profile_slug', 'shipping profile slug is already in use'],
+];
+for (const [code, message] of sanitizedOutcomes) {
+  requireText(wrapper, `"${code}"`, `${code} classification`);
+  requireText(wrapper, `Some("${message}")`, `${code} stable public message`);
+}
+
+for (const value of [
+  'PortError::new(',
+  'error.kind.clone()',
+  'error.code.clone()',
+  'error.retryable',
+  'original_message_length = error.message.chars().count()',
+  'return error;',
+  'mapped_error',
+  'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+  'tracing::error!',
+  'tracing::warn!',
+]) {
+  requireText(wrapper, value, 'same envelope or safe-message mapping');
+}
+
+for (const value of [
+  'handle = %',
+  'handle = ?',
+  'channel_slug = %',
+  'channel_slug = ?',
+  'public_channel_slug = %',
+  'public_channel_slug = ?',
+  'currency_code = %',
+  'currency_code = ?',
+  'discount_percent =',
+  'amount =',
+  'compare_at_amount =',
+  'error = ?error',
+  'internal_message = %error.message',
+  'original_message =',
+]) {
+  forbidText(wrapper, value, 'raw pricing payload logging');
+}
+
+for (const value of [
+  'format!("variant {variant_id} does not belong to product {product_id}")',
+  'format!("price for variant {variant_id} was not found")',
+  'format!("price list {} was not found", request.price_list_id)',
+  'format!("product {id} not found")',
+  'format!("variant {id} not found")',
+  'format!("duplicate handle `{handle}` for locale `{locale}`")',
+  'format!("duplicate sku `{sku}`")',
+  'format!("insufficient inventory: requested {requested}, available {available}")',
+  'format!("shipping profile {id} not found")',
+  'format!("duplicate shipping profile slug `{slug}`")',
+]) {
+  forbidText(wrapper, value, 'dynamic canonical public message');
+}
+
+if (failures.length > 0) {
+  console.error('Pricing read local context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ canonical pricing reads retain delegated context and publish only stable local outcomes',
+);

--- a/scripts/verify/verify-pricing-read-local-context.mjs
+++ b/scripts/verify/verify-pricing-read-local-context.mjs
@@ -58,10 +58,16 @@ const operations = [
 for (const [operation, constant] of operations) {
   requireText(
     wrapper,
-    `PricingReadPort::${operation}(&self.inner`,
+    `PricingReadPort::${operation}(`,
     `${operation} unchanged owner delegation`,
   );
   requireText(wrapper, constant, `${operation} stable operation constant`);
+}
+const innerDelegations = wrapper.match(/&self\.inner/g) ?? [];
+if (innerDelegations.length !== operations.length) {
+  failures.push(
+    `expected ${operations.length} unchanged owner delegations, found ${innerDelegations.length}`,
+  );
 }
 
 const retainedContext = [


### PR DESCRIPTION
## Summary

- continue ecommerce implementation-plan item 10 with a focused canonical `rustok-pricing` read-owner slice;
- route root `in_process_pricing_read_port` construction through `InProcessPricingReadPort` for all six `PricingReadPort` operations;
- retain the delegated `PortContext`, truthful owner/operation labels, typed UUID identities, quantity, and bounded string-length facts before unchanged `PricingService` delegation;
- normalize known identifying validation, not-found, and conflict messages while preserving `PortError` kind, code, and retryability;
- keep already-stable and technical envelopes unchanged, and pass unknown/shared `port.*` admission errors through without a duplicate local event;
- avoid logging raw storefront handles, SKUs, channel slugs, currencies, percentages, prices, compare-at prices, titles, rows, returned projections, or original error text;
- preserve `rustok_pricing::ports::in_process_pricing_read_port` as an explicit compatibility path;
- preserve the canonical root `PricingWritePort` factory and write execution unchanged;
- replace the wildcard root port export with an explicit parity-preserving export list so only the read factory is cut over;
- add source-ready/unvalidated documentation and a focused static guard without promoting FBA/FFA status.

## Recheck

- continued from merged customer local-context PR #2327;
- confirmed #2327 was squash-merged into `main` as `977d0f11caaf3d5d9d9bab42e9f416ecf467b814` and its source branch was deleted automatically;
- audited promotion and fulfillment before selecting this scope: cart promotion context is already covered by #2160/#2259/#2262, while fulfillment checkout context is covered by #2156/#2157/#2253/#2297/#2299/#2301; the standalone shipping-selection port currently has no canonical mounted consumer;
- confirmed no open PR overlaps this pricing owner scope;
- confirmed the branch is based directly on current `main`, is zero commits behind, and changes exactly five files;
- confirmed the existing pricing runtime-smoke should continue to inspect the unchanged owner implementation in `ports.rs`, not the new root wrapper;
- confirmed all former root port DTO/trait/write-factory exports remain available explicitly, with only the read factory replaced;
- confirmed `ports.rs`, pricing service selection/order, deadline policy, tenant isolation, request/response DTOs, and write behavior are unchanged.

## Boundary

This PR closes stable message safety and owner-local context retention for canonical root pricing reads. It does not close direct compatibility-path callers, pricing write local outcomes, remote/runtime evidence, transport handoff, or the remaining non-`PortError` ecommerce envelopes.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-pricing-read-local-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-pricing --lib
cargo check -p rustok-commerce --lib
```
