### PR TITLE
Retain pricing write local context

### DIFF
--- a/crates/rustok-pricing/docs/implementation-plan.md
+++ b/crates/rustok-pricing/docs/implementation-plan.md
@@ -15,13 +15,21 @@ policy, typed error mapping, and declared fallback profiles, but the FBA
 provider has not yet been executed against live persistence or a remote
 consumer path.
 
-Canonical root read construction now uses `InProcessPricingReadPort`. The wrapper
+Canonical root read construction uses `InProcessPricingReadPort`. The wrapper
 retains the delegated `PortContext`, typed identity and bounded request-shape facts,
 and exact local outcome context around the unchanged `PricingService` port
 implementation. Known identifying validation, not-found, and conflict envelopes are
 returned with stable non-identifying messages while preserving kind, code, and
 retryability. The legacy module-path read factory remains an explicit compatibility
-path, and the write factory remains unchanged.
+path.
+
+Canonical root write construction now uses `InProcessPricingWritePort`. The wrapper
+retains the delegated write/idempotency context and safe typed identity or bounded
+shape facts for all four `PricingWritePort` operations. Known identifier-, handle-,
+SKU-, quantity-, and owner-value-bearing messages are normalized while preserving
+kind, code, and retryability. `PricingService`, the write trait and DTOs, GraphQL
+mutations, saved projections, event publication, and the module-path compatibility
+factory remain unchanged.
 
 The port accepts variant-first resolution when a cart snapshot has no product
 id and returns the full resolved-price projection required to persist pricing
@@ -41,7 +49,7 @@ an authenticated actor, locale, channel, correlation, and deadline context.
 The storefront product-pricing-by-handle GraphQL root uses the matching public
 projection operation and retains its channel-visibility input.
 The GraphQL discount preview uses the typed read port with an authenticated actor.
-`PricingWritePort` now owns the GraphQL admin mutations for variant-price upsert,
+`PricingWritePort` owns the GraphQL admin mutations for variant-price upsert,
 percentage-discount application, active price-list percentage rules, and price-list
 channel scope. The provider enforces deadline and idempotency semantics before it
 invokes the pricing owner service, returns the saved owner projection, and preserves
@@ -55,13 +63,16 @@ evidence only; no live provider-consumer transport execution has been recorded.
 - FBA status: `boundary_ready` — provider metadata and static contract evidence
   are ready, while runtime contract and fallback execution remain pending.
 - Structural shape: `core_transport_ui`
-- Canonical root read provider: `InProcessPricingReadPort`; owner execution remains
-  `PricingService` in `ports.rs`, and `rustok_pricing::ports` is a compatibility path.
+- Canonical root providers: `InProcessPricingReadPort` and
+  `InProcessPricingWritePort`; owner execution remains `PricingService` in
+  `ports.rs`, and `rustok_pricing::ports` is a compatibility path.
 - Evidence: `crates/rustok-pricing/contracts/pricing-fba-registry.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-contract-test-static-matrix.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-runtime-contract-smoke.json`,
   `crates/rustok-pricing/docs/read-local-context.md`,
+  `crates/rustok-pricing/docs/write-local-context.md`,
   `scripts/verify/verify-pricing-read-local-context.mjs`,
+  `scripts/verify/verify-pricing-write-local-context.mjs`,
   `scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs`,
   `scripts/verify/verify-pricing-admin-boundary.mjs`, and
   `scripts/verify/verify-pricing-storefront-boundary.mjs`.
@@ -92,18 +103,21 @@ evidence only; no live provider-consumer transport execution has been recorded.
    Dependency: the stable owner transport and product variant data. Verification:
    targeted pricing resolution and money-semantics tests.
 4. Prove canonical pricing diagnostics and retire compatibility bypasses.
-   **Status:** source-complete / unvalidated for root read construction. Execute
-   invalid-context, product/variant mismatch, missing price/list, duplicate identity,
-   inventory conflict, storage, and invariant scenarios and retain traces proving that
-   raw handles, SKUs, UUID-bearing messages, quantities, currencies, and prices do not
-   cross the canonical boundary. Audit direct `rustok_pricing::ports` callers and
-   either migrate or explicitly accept them.
+   **Status:** source-complete / unvalidated for root read and write construction.
+   Execute invalid-context, invalid-actor, product/variant mismatch, missing
+   price/list, duplicate identity, inventory conflict, storage, and invariant
+   scenarios and retain traces proving that raw handles, SKUs, UUID-bearing
+   messages, quantities, currencies, prices, and percentages do not cross the
+   canonical boundary. Audit direct `rustok_pricing::ports` callers and either
+   migrate or explicitly accept them. Shared `port.*` admission diagnostics,
+   runtime evidence, and remote-profile parity remain open.
 
 ## Verification
 
 - `npm run verify:pricing:admin-boundary`
 - `npm run verify:pricing:storefront-boundary`
 - `node scripts/verify/verify-pricing-read-local-context.mjs`
+- `node scripts/verify/verify-pricing-write-local-context.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo test -p rustok-pricing --test pricing_read_port_runtime`
 

--- a/crates/rustok-pricing/docs/write-local-context.md
+++ b/crates/rustok-pricing/docs/write-local-context.md
@@ -1,0 +1,123 @@
+# Pricing write local outcome context
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice retains stable owner-local outcome context for canonical root pricing writes:
+
+- `PricingWritePort::upsert_variant_price`;
+- `PricingWritePort::set_price_list_scope`;
+- `PricingWritePort::apply_variant_discount`;
+- `PricingWritePort::set_price_list_percentage_rule`;
+- root `InProcessPricingWritePort`;
+- root `in_process_pricing_write_port`.
+
+The existing owner implementation in `ports.rs` remains unchanged. The root wrapper retains the delegated
+`PortContext` and safe request facts, calls the original `PricingService` port implementation, classifies
+covered returned `PortError` envelopes, normalizes identifying messages, and preserves kind, code, and
+retryability.
+
+## Canonical root cutover
+
+The crate keeps `pub mod ports`, so the existing traits, requests, owner implementation, and module-path
+factories remain available for compatibility. Root construction is now split explicitly:
+
+- `InProcessPricingReadPort` owns canonical read construction;
+- `InProcessPricingWritePort` owns canonical write construction;
+- `rustok_pricing::ports` remains an explicit compatibility path.
+
+The commerce GraphQL admin pricing mutations import the root write factory, so variant-price upsert,
+discount application, price-list rule update, and price-list scope update use this wrapper without resolver
+changes.
+
+## Delegation order
+
+Each wrapper operation performs the same sequence:
+
+1. clone the accepted `PortContext` for diagnostics;
+2. retain operation-specific typed identity and bounded shape facts;
+3. delegate the original context and request to the unchanged owner implementation;
+4. inspect only a returned `PortError`;
+5. emit a local event only for a covered owner code;
+6. return the same envelope or the same kind/code/retryability with a stable message.
+
+The persistent owner continues to own write/idempotency admission, tenant and actor parsing, validation,
+price-list and variant mutation, event publication, saved projections, and public error selection.
+
+## Safe request facts
+
+Covered diagnostics may retain:
+
+- typed variant, price-list, and channel ids;
+- minimum and maximum quantity bounds;
+- currency-code, channel-slug, and fallback-locale character lengths;
+- whether compare-at amount or adjustment percent was supplied.
+
+The wrapper does not retain raw currency codes, channel slugs, fallback locales, handles, SKUs, prices,
+compare-at prices, percentages, titles, returned rows, or owner error text.
+
+## Covered stable outcomes
+
+The wrapper recognizes stable owner codes and preserves existing kind and retryability.
+
+| Stable code | Local operation | Canonical message policy |
+| --- | --- | --- |
+| `pricing.tenant_id_invalid` | `validate_tenant_context` | `pricing request context is invalid` |
+| `pricing.actor_id_invalid` | `validate_actor_context` | `pricing write actor is invalid` |
+| `pricing.database_unavailable` | `owner_storage` | unchanged shared unavailable message |
+| `pricing.product_not_found` | `load_product` | `product was not found` |
+| `pricing.variant_not_found` | `load_variant` | `variant was not found` |
+| `pricing.duplicate_handle` | `validate_handle_uniqueness` | `pricing handle is already in use` |
+| `pricing.duplicate_sku` | `validate_sku_uniqueness` | `pricing SKU is already in use` |
+| `pricing.validation` | `validate_owner_request` | unchanged stable validation message |
+| `pricing.insufficient_inventory` | `validate_inventory_requirement` | stable non-quantified conflict message |
+| `pricing.invalid_option_combination` | `validate_option_combination` | unchanged stable validation message |
+| `pricing.shipping_profile_not_found` | `load_shipping_profile` | `shipping profile was not found` |
+| `pricing.duplicate_shipping_profile_slug` | `validate_shipping_profile_slug_uniqueness` | stable non-identifying conflict message |
+| `pricing.no_variants` | `validate_product_variants` | unchanged stable validation message |
+| `pricing.cannot_delete_published` | `validate_published_product_state` | unchanged stable conflict message |
+| `pricing.rich_error` | `owner_rich_invariant` | unchanged shared invariant message |
+| `pricing.core_error` | `owner_core_invariant` | unchanged shared invariant message |
+
+Shared `port.*` admission envelopes and unknown future codes pass through without duplicate local
+classification. Admission-specific pricing diagnostics remain separate follow-up work.
+
+## Retained diagnostic context
+
+Covered outcomes record:
+
+- truthful owner `rustok_pricing`;
+- exact public owner operation and local operation;
+- boundary `pricing_write_port`;
+- correlation and tenant identity;
+- typed actor, channel, locale, claims, and roles shape;
+- causation id, traceparent, idempotency key, and deadline when available;
+- safe operation-specific request facts;
+- stable internal code and canonical public message;
+- original message character length without message content;
+- typed error kind, retryability, and the mapped public-safe `PortError`.
+
+Unavailable, timeout, and invariant outcomes use error severity. Ordinary validation, not-found, and
+conflict outcomes use warning severity.
+
+## Preserved behavior
+
+This work does not change:
+
+- `PricingWritePort`, request DTOs, or returned owner projections;
+- `PricingService` mutation methods or event publication;
+- write/idempotency/deadline admission order;
+- tenant and actor parsing;
+- price, compare-at, tier, channel-scope, percentage, or locale semantics;
+- GraphQL mutation arguments, permissions, public GraphQL envelopes, or success responses;
+- read construction or read diagnostics;
+- FBA or FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-pricing-write-local-context.mjs` guards canonical construction, four unchanged owner
+delegations, complete delegated context, safe request facts, stable message normalization, technical versus
+ordinary severity, mapped error return, and the absence of raw pricing payload logging.
+
+No verifier, formatting, Cargo, test, runtime, or remote-profile command was executed in this source wave.

--- a/crates/rustok-pricing/src/lib.rs
+++ b/crates/rustok-pricing/src/lib.rs
@@ -11,6 +11,7 @@ pub mod migrations;
 pub mod ports;
 mod read_context;
 pub mod services;
+mod write_context;
 
 pub use ports::{
     ActivePriceListProjectionRequest, ActivePriceListProjectionSnapshot,
@@ -19,9 +20,9 @@ pub use ports::{
     PricingReadPort, PricingWritePort, ResolveProductPriceRequest, ResolvedProductPriceSnapshot,
     SetPriceListPercentageRuleRequest, SetPriceListScopeRequest,
     StorefrontProductPricingProjectionRequest, UpsertVariantPriceRequest,
-    in_process_pricing_write_port,
 };
 pub use read_context::{InProcessPricingReadPort, in_process_pricing_read_port};
+pub use write_context::{InProcessPricingWritePort, in_process_pricing_write_port};
 
 pub use services::{
     ActivePriceListOption, AdminPricingPrice, AdminPricingProductDetail, AdminPricingProductList,

--- a/crates/rustok-pricing/src/write_context.rs
+++ b/crates/rustok-pricing/src/write_context.rs
@@ -323,7 +323,6 @@ fn map_pricing_write_local_port_error(
             original_message_length,
             error_kind = ?mapped_error.kind,
             retryable = mapped_error.retryable,
-            mapped_error = ?mapped_error,
             boundary = PRICING_WRITE_BOUNDARY,
             "pricing write local technical outcome retained delegated context"
         );
@@ -358,7 +357,6 @@ fn map_pricing_write_local_port_error(
             original_message_length,
             error_kind = ?mapped_error.kind,
             retryable = mapped_error.retryable,
-            mapped_error = ?mapped_error,
             boundary = PRICING_WRITE_BOUNDARY,
             "pricing write local outcome retained delegated context"
         );

--- a/crates/rustok-pricing/src/write_context.rs
+++ b/crates/rustok-pricing/src/write_context.rs
@@ -1,0 +1,368 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError, PortErrorKind};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::ports::{
+    ApplyVariantDiscountRequest, PricingWritePort, SetPriceListPercentageRuleRequest,
+    SetPriceListScopeRequest, UpsertVariantPriceRequest,
+};
+use crate::{ActivePriceListOption, AdminPricingPrice, PriceAdjustmentPreview, PricingService};
+
+const PRICING_OWNER: &str = "rustok_pricing";
+const PRICING_WRITE_BOUNDARY: &str = "pricing_write_port";
+const UPSERT_VARIANT_PRICE_OPERATION: &str = "upsert_variant_price";
+const SET_PRICE_LIST_SCOPE_OPERATION: &str = "set_price_list_scope";
+const APPLY_VARIANT_DISCOUNT_OPERATION: &str = "apply_variant_discount";
+const SET_PRICE_LIST_PERCENTAGE_RULE_OPERATION: &str = "set_price_list_percentage_rule";
+
+#[derive(Debug, Clone, Default)]
+struct PricingWriteDiagnosticFacts {
+    variant_id: Option<Uuid>,
+    price_list_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    min_quantity: Option<i32>,
+    max_quantity: Option<i32>,
+    currency_code_length: Option<usize>,
+    channel_slug_length: Option<usize>,
+    fallback_locale_length: Option<usize>,
+    compare_at_amount_present: Option<bool>,
+    adjustment_percent_present: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PricingWriteLocalOutcome {
+    local_operation: &'static str,
+    sanitized_message: Option<&'static str>,
+}
+
+/// Canonical in-process pricing write provider with retained local outcome context.
+pub struct InProcessPricingWritePort {
+    inner: PricingService,
+}
+
+impl InProcessPricingWritePort {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            inner: PricingService::new(db, event_bus),
+        }
+    }
+
+    /// Wraps a host-composed pricing service without changing owner execution.
+    pub fn from_service(inner: PricingService) -> Self {
+        Self { inner }
+    }
+}
+
+/// Builds the canonical owner-managed in-process pricing write provider.
+pub fn in_process_pricing_write_port(
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+) -> Arc<dyn PricingWritePort> {
+    Arc::new(InProcessPricingWritePort::new(db, event_bus))
+}
+
+#[async_trait]
+impl PricingWritePort for InProcessPricingWritePort {
+    async fn upsert_variant_price(
+        &self,
+        context: PortContext,
+        request: UpsertVariantPriceRequest,
+    ) -> Result<AdminPricingPrice, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingWriteDiagnosticFacts {
+            variant_id: Some(request.variant_id),
+            price_list_id: request.price_list_id,
+            channel_id: request.channel_id,
+            min_quantity: request.min_quantity,
+            max_quantity: request.max_quantity,
+            currency_code_length: Some(request.currency_code.chars().count()),
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            compare_at_amount_present: Some(request.compare_at_amount.is_some()),
+            ..PricingWriteDiagnosticFacts::default()
+        };
+        let result = PricingWritePort::upsert_variant_price(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_write_local_port_error(
+                &diagnostic_context,
+                UPSERT_VARIANT_PRICE_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn set_price_list_scope(
+        &self,
+        context: PortContext,
+        request: SetPriceListScopeRequest,
+    ) -> Result<ActivePriceListOption, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingWriteDiagnosticFacts {
+            price_list_id: Some(request.price_list_id),
+            channel_id: request.channel_id,
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingWriteDiagnosticFacts::default()
+        };
+        let result = PricingWritePort::set_price_list_scope(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_write_local_port_error(
+                &diagnostic_context,
+                SET_PRICE_LIST_SCOPE_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn apply_variant_discount(
+        &self,
+        context: PortContext,
+        request: ApplyVariantDiscountRequest,
+    ) -> Result<PriceAdjustmentPreview, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingWriteDiagnosticFacts {
+            variant_id: Some(request.variant_id),
+            price_list_id: request.price_list_id,
+            channel_id: request.channel_id,
+            currency_code_length: Some(request.currency_code.chars().count()),
+            channel_slug_length: request
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            ..PricingWriteDiagnosticFacts::default()
+        };
+        let result = PricingWritePort::apply_variant_discount(&self.inner, context, request).await;
+        result.map_err(|error| {
+            map_pricing_write_local_port_error(
+                &diagnostic_context,
+                APPLY_VARIANT_DISCOUNT_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+
+    async fn set_price_list_percentage_rule(
+        &self,
+        context: PortContext,
+        request: SetPriceListPercentageRuleRequest,
+    ) -> Result<ActivePriceListOption, PortError> {
+        let diagnostic_context = context.clone();
+        let diagnostic_facts = PricingWriteDiagnosticFacts {
+            price_list_id: Some(request.price_list_id),
+            fallback_locale_length: request
+                .fallback_locale
+                .as_ref()
+                .map(|value| value.chars().count()),
+            adjustment_percent_present: Some(request.adjustment_percent.is_some()),
+            ..PricingWriteDiagnosticFacts::default()
+        };
+        let result = PricingWritePort::set_price_list_percentage_rule(
+            &self.inner,
+            context,
+            request,
+        )
+        .await;
+        result.map_err(|error| {
+            map_pricing_write_local_port_error(
+                &diagnostic_context,
+                SET_PRICE_LIST_PERCENTAGE_RULE_OPERATION,
+                &diagnostic_facts,
+                error,
+            )
+        })
+    }
+}
+
+fn classify_pricing_write_local_outcome(error: &PortError) -> Option<PricingWriteLocalOutcome> {
+    let outcome = match (&error.kind, error.code.as_str()) {
+        (PortErrorKind::Validation, "pricing.tenant_id_invalid") => PricingWriteLocalOutcome {
+            local_operation: "validate_tenant_context",
+            sanitized_message: Some("pricing request context is invalid"),
+        },
+        (PortErrorKind::Validation, "pricing.actor_id_invalid") => PricingWriteLocalOutcome {
+            local_operation: "validate_actor_context",
+            sanitized_message: Some("pricing write actor is invalid"),
+        },
+        (PortErrorKind::Unavailable, "pricing.database_unavailable") => {
+            PricingWriteLocalOutcome {
+                local_operation: "owner_storage",
+                sanitized_message: None,
+            }
+        }
+        (PortErrorKind::NotFound, "pricing.product_not_found") => PricingWriteLocalOutcome {
+            local_operation: "load_product",
+            sanitized_message: Some("product was not found"),
+        },
+        (PortErrorKind::NotFound, "pricing.variant_not_found") => PricingWriteLocalOutcome {
+            local_operation: "load_variant",
+            sanitized_message: Some("variant was not found"),
+        },
+        (PortErrorKind::Conflict, "pricing.duplicate_handle") => PricingWriteLocalOutcome {
+            local_operation: "validate_handle_uniqueness",
+            sanitized_message: Some("pricing handle is already in use"),
+        },
+        (PortErrorKind::Conflict, "pricing.duplicate_sku") => PricingWriteLocalOutcome {
+            local_operation: "validate_sku_uniqueness",
+            sanitized_message: Some("pricing SKU is already in use"),
+        },
+        (PortErrorKind::Validation, "pricing.validation") => PricingWriteLocalOutcome {
+            local_operation: "validate_owner_request",
+            sanitized_message: None,
+        },
+        (PortErrorKind::Conflict, "pricing.insufficient_inventory") => {
+            PricingWriteLocalOutcome {
+                local_operation: "validate_inventory_requirement",
+                sanitized_message: Some("inventory is insufficient for the pricing operation"),
+            }
+        }
+        (PortErrorKind::Validation, "pricing.invalid_option_combination") => {
+            PricingWriteLocalOutcome {
+                local_operation: "validate_option_combination",
+                sanitized_message: None,
+            }
+        }
+        (PortErrorKind::NotFound, "pricing.shipping_profile_not_found") => {
+            PricingWriteLocalOutcome {
+                local_operation: "load_shipping_profile",
+                sanitized_message: Some("shipping profile was not found"),
+            }
+        }
+        (PortErrorKind::Conflict, "pricing.duplicate_shipping_profile_slug") => {
+            PricingWriteLocalOutcome {
+                local_operation: "validate_shipping_profile_slug_uniqueness",
+                sanitized_message: Some("shipping profile slug is already in use"),
+            }
+        }
+        (PortErrorKind::Validation, "pricing.no_variants") => PricingWriteLocalOutcome {
+            local_operation: "validate_product_variants",
+            sanitized_message: None,
+        },
+        (PortErrorKind::Conflict, "pricing.cannot_delete_published") => {
+            PricingWriteLocalOutcome {
+                local_operation: "validate_published_product_state",
+                sanitized_message: None,
+            }
+        }
+        (PortErrorKind::InvariantViolation, "pricing.rich_error") => PricingWriteLocalOutcome {
+            local_operation: "owner_rich_invariant",
+            sanitized_message: None,
+        },
+        (PortErrorKind::InvariantViolation, "pricing.core_error") => PricingWriteLocalOutcome {
+            local_operation: "owner_core_invariant",
+            sanitized_message: None,
+        },
+        _ => return None,
+    };
+    Some(outcome)
+}
+
+fn map_pricing_write_local_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    facts: &PricingWriteDiagnosticFacts,
+    error: PortError,
+) -> PortError {
+    let Some(outcome) = classify_pricing_write_local_outcome(&error) else {
+        return error;
+    };
+
+    let mapped_error = match outcome.sanitized_message {
+        Some(message) => PortError::new(
+            error.kind.clone(),
+            error.code.clone(),
+            message,
+            error.retryable,
+        ),
+        None => error.clone(),
+    };
+    let technical_failure = matches!(
+        &mapped_error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+    let original_message_length = error.message.chars().count();
+
+    if technical_failure {
+        tracing::error!(
+            owner = PRICING_OWNER,
+            operation = owner_operation,
+            local_operation = outcome.local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            claim_count = context.claims.len(),
+            role_count = context.roles.len(),
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            variant_id = ?facts.variant_id,
+            price_list_id = ?facts.price_list_id,
+            channel_id = ?facts.channel_id,
+            min_quantity = ?facts.min_quantity,
+            max_quantity = ?facts.max_quantity,
+            currency_code_length = ?facts.currency_code_length,
+            channel_slug_length = ?facts.channel_slug_length,
+            fallback_locale_length = ?facts.fallback_locale_length,
+            compare_at_amount_present = ?facts.compare_at_amount_present,
+            adjustment_percent_present = ?facts.adjustment_percent_present,
+            internal_code = %error.code,
+            public_message = %mapped_error.message,
+            original_message_length,
+            error_kind = ?mapped_error.kind,
+            retryable = mapped_error.retryable,
+            mapped_error = ?mapped_error,
+            boundary = PRICING_WRITE_BOUNDARY,
+            "pricing write local technical outcome retained delegated context"
+        );
+    } else {
+        tracing::warn!(
+            owner = PRICING_OWNER,
+            operation = owner_operation,
+            local_operation = outcome.local_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            claim_count = context.claims.len(),
+            role_count = context.roles.len(),
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            variant_id = ?facts.variant_id,
+            price_list_id = ?facts.price_list_id,
+            channel_id = ?facts.channel_id,
+            min_quantity = ?facts.min_quantity,
+            max_quantity = ?facts.max_quantity,
+            currency_code_length = ?facts.currency_code_length,
+            channel_slug_length = ?facts.channel_slug_length,
+            fallback_locale_length = ?facts.fallback_locale_length,
+            compare_at_amount_present = ?facts.compare_at_amount_present,
+            adjustment_percent_present = ?facts.adjustment_percent_present,
+            internal_code = %error.code,
+            public_message = %mapped_error.message,
+            original_message_length,
+            error_kind = ?mapped_error.kind,
+            retryable = mapped_error.retryable,
+            mapped_error = ?mapped_error,
+            boundary = PRICING_WRITE_BOUNDARY,
+            "pricing write local outcome retained delegated context"
+        );
+    }
+
+    mapped_error
+}

--- a/scripts/verify/verify-pricing-write-local-context.mjs
+++ b/scripts/verify/verify-pricing-write-local-context.mjs
@@ -126,7 +126,7 @@ for (const value of [
   'error.code.clone()',
   'error.retryable',
   'original_message_length = error.message.chars().count()',
-  'mapped_error = ?mapped_error',
+  'public_message = %mapped_error.message',
   'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
   'tracing::error!',
   'tracing::warn!',
@@ -151,6 +151,7 @@ for (const value of [
   'discount_percent =',
   'adjustment_percent =',
   'error = ?error',
+  'mapped_error = ?mapped_error',
   'internal_message = %error.message',
   'original_message =',
 ]) {

--- a/scripts/verify/verify-pricing-write-local-context.mjs
+++ b/scripts/verify/verify-pricing-write-local-context.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const lib = read('crates/rustok-pricing/src/lib.rs');
+const legacy = read('crates/rustok-pricing/src/ports.rs');
+const wrapper = read('crates/rustok-pricing/src/write_context.rs');
+const consumer = read('crates/rustok-commerce/src/graphql/mutations/pricing.rs');
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [lib, 'mod write_context;', 'private write wrapper module'],
+  [
+    lib,
+    'pub use write_context::{InProcessPricingWritePort, in_process_pricing_write_port};',
+    'canonical root write wrapper export',
+  ],
+  [lib, 'InProcessPricingReadPort, in_process_pricing_read_port', 'preserved root read wrapper'],
+  [legacy, 'pub fn in_process_pricing_write_port(', 'legacy compatibility factory'],
+  [legacy, 'impl PricingWritePort for crate::PricingService', 'unchanged write owner implementation'],
+  [wrapper, 'pub struct InProcessPricingWritePort', 'canonical write wrapper'],
+  [wrapper, 'pub fn from_service(inner: PricingService) -> Self', 'host composition constructor'],
+  [wrapper, 'pub fn in_process_pricing_write_port(', 'canonical write factory'],
+  [wrapper, 'Arc::new(InProcessPricingWritePort::new(db, event_bus))', 'wrapper factory construction'],
+  [wrapper, 'impl PricingWritePort for InProcessPricingWritePort', 'wrapper trait implementation'],
+  [wrapper, 'const PRICING_OWNER: &str = "rustok_pricing";', 'truthful owner'],
+  [wrapper, 'const PRICING_WRITE_BOUNDARY: &str = "pricing_write_port";', 'stable boundary'],
+  [consumer, 'in_process_pricing_write_port,', 'mounted root write factory import'],
+  [consumer, 'in_process_pricing_write_port(db.clone(), event_bus.clone())', 'mounted write construction'],
+]) {
+  requireText(source, value, label);
+}
+
+forbidText(
+  lib,
+  'pub use ports::in_process_pricing_write_port',
+  'legacy write factory exported as canonical root',
+);
+forbidText(lib, 'pub use ports::*;', 'wildcard root compatibility export');
+
+const operations = [
+  ['upsert_variant_price', 'UPSERT_VARIANT_PRICE_OPERATION'],
+  ['set_price_list_scope', 'SET_PRICE_LIST_SCOPE_OPERATION'],
+  ['apply_variant_discount', 'APPLY_VARIANT_DISCOUNT_OPERATION'],
+  ['set_price_list_percentage_rule', 'SET_PRICE_LIST_PERCENTAGE_RULE_OPERATION'],
+];
+
+for (const [operation, constant] of operations) {
+  requireText(wrapper, `PricingWritePort::${operation}(`, `${operation} unchanged owner delegation`);
+  requireText(wrapper, constant, `${operation} stable operation constant`);
+}
+const innerDelegations = wrapper.match(/&self\.inner/g) ?? [];
+if (innerDelegations.length !== operations.length) {
+  failures.push(
+    `expected ${operations.length} unchanged owner delegations, found ${innerDelegations.length}`,
+  );
+}
+
+const retainedContext = [
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'claim_count = context.claims.len()',
+  'role_count = context.roles.len()',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'deadline_ms = ?context.deadline_ms',
+];
+for (const value of retainedContext) {
+  requireText(wrapper, value, 'complete delegated pricing write context');
+}
+
+const safeFacts = [
+  'variant_id = ?facts.variant_id',
+  'price_list_id = ?facts.price_list_id',
+  'channel_id = ?facts.channel_id',
+  'min_quantity = ?facts.min_quantity',
+  'max_quantity = ?facts.max_quantity',
+  'currency_code_length = ?facts.currency_code_length',
+  'channel_slug_length = ?facts.channel_slug_length',
+  'fallback_locale_length = ?facts.fallback_locale_length',
+  'compare_at_amount_present = ?facts.compare_at_amount_present',
+  'adjustment_percent_present = ?facts.adjustment_percent_present',
+];
+for (const value of safeFacts) {
+  requireText(wrapper, value, 'safe pricing write request facts');
+}
+
+const sanitizedOutcomes = [
+  ['pricing.tenant_id_invalid', 'pricing request context is invalid'],
+  ['pricing.actor_id_invalid', 'pricing write actor is invalid'],
+  ['pricing.product_not_found', 'product was not found'],
+  ['pricing.variant_not_found', 'variant was not found'],
+  ['pricing.duplicate_handle', 'pricing handle is already in use'],
+  ['pricing.duplicate_sku', 'pricing SKU is already in use'],
+  ['pricing.insufficient_inventory', 'inventory is insufficient for the pricing operation'],
+  ['pricing.shipping_profile_not_found', 'shipping profile was not found'],
+  ['pricing.duplicate_shipping_profile_slug', 'shipping profile slug is already in use'],
+];
+for (const [code, message] of sanitizedOutcomes) {
+  requireText(wrapper, `"${code}"`, `${code} classification`);
+  requireText(wrapper, `Some("${message}")`, `${code} stable public message`);
+}
+
+for (const value of [
+  'PortError::new(',
+  'error.kind.clone()',
+  'error.code.clone()',
+  'error.retryable',
+  'original_message_length = error.message.chars().count()',
+  'mapped_error = ?mapped_error',
+  'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+  'tracing::error!',
+  'tracing::warn!',
+  'mapped_error\n}',
+]) {
+  requireText(wrapper, value, 'same envelope or safe-message mapping');
+}
+
+for (const value of [
+  'currency_code = %',
+  'currency_code = ?',
+  'channel_slug = %',
+  'channel_slug = ?',
+  'fallback_locale = %',
+  'fallback_locale = ?',
+  'handle = %',
+  'handle = ?',
+  'sku = %',
+  'sku = ?',
+  'amount =',
+  'compare_at_amount =',
+  'discount_percent =',
+  'adjustment_percent =',
+  'error = ?error',
+  'internal_message = %error.message',
+  'original_message =',
+]) {
+  forbidText(wrapper, value, 'raw pricing write payload logging');
+}
+
+for (const value of [
+  'format!("product {id} not found")',
+  'format!("variant {id} not found")',
+  'format!("duplicate handle `{handle}` for locale `{locale}`")',
+  'format!("duplicate sku `{sku}`")',
+  'format!("insufficient inventory: requested {requested}, available {available}")',
+  'format!("shipping profile {id} not found")',
+  'format!("duplicate shipping profile slug `{slug}`")',
+]) {
+  forbidText(wrapper, value, 'dynamic canonical write public message');
+}
+
+for (const value of [
+  '"port.idempotency_key_required"',
+  '"port.deadline_required"',
+]) {
+  forbidText(wrapper, value, 'shared admission envelope reclassification');
+}
+
+if (failures.length > 0) {
+  console.error('Pricing write local context verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ canonical pricing writes retain delegated context and publish only stable local outcomes',
+);


### PR DESCRIPTION
## Summary

- continue ecommerce implementation-plan item 10 with the canonical `rustok-pricing` write-owner slice;
- route root `in_process_pricing_write_port` construction through `InProcessPricingWritePort` for all four `PricingWritePort` operations;
- retain the delegated write/idempotency `PortContext`, truthful owner/operation labels, typed UUID identities, quantity bounds, and bounded string/presence facts before unchanged `PricingService` delegation;
- normalize known identifier-, handle-, SKU-, quantity-, and owner-value-bearing validation/not-found/conflict messages while preserving `PortError` kind, code, and retryability;
- keep already-stable and technical envelopes unchanged, and pass unknown/shared `port.*` admission errors through without duplicate local classification;
- avoid logging raw currencies, channel slugs, fallback locales, handles, SKUs, prices, compare-at prices, percentages, returned rows, or original owner error text;
- preserve `rustok_pricing::ports::in_process_pricing_write_port` as an explicit compatibility path;
- preserve the canonical read wrapper, `PricingService`, write trait/DTOs, mutation order, event publication, GraphQL permissions/envelopes, and success responses;
- add source-ready/unvalidated documentation and a focused static guard without promoting FBA/FFA status.

## Recheck

- continued from merged pricing read local-context PR #2328;
- confirmed #2328 was squash-merged into `main` as `37030a90ed227232df8b622773c67de41e1c5e12` and its source branch was deleted automatically;
- confirmed no open PR overlaps this pricing write owner scope;
- confirmed the commerce GraphQL admin pricing mutations mount the root write factory for variant-price upsert, discount application, price-list percentage-rule update, and price-list scope update;
- confirmed the branch is based directly on current `main`, is zero commits behind, and changes exactly five files;
- confirmed all four wrapper methods delegate the original context/request to the unchanged `PricingService` trait implementation;
- confirmed root read construction and all former root DTO/trait exports remain available;
- confirmed existing pricing runtime-smoke evidence should continue to inspect the unchanged owner implementation in `ports.rs` rather than treating the wrapper as persistence/runtime evidence.

## Boundary

This PR closes stable message safety and owner-local context retention for canonical root pricing writes. It does not close direct compatibility-path callers, shared `port.*` admission diagnostics, remote/runtime evidence, transport handoff, or remaining non-`PortError` ecommerce envelopes.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-pricing-write-local-context.mjs
node scripts/verify/verify-pricing-read-local-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-pricing --lib
cargo check -p rustok-commerce --lib
```
