### PR TITLE
Use typed storefront shipping enrichment errors

### DIFF
--- a/crates/rustok-commerce/docs/storefront-shipping-enrichment-typed-error-envelope.md
+++ b/crates/rustok-commerce/docs/storefront-shipping-enrichment-typed-error-envelope.md
@@ -1,0 +1,109 @@
+# Storefront shipping enrichment typed GraphQL error envelope
+
+Status: source-ready / unvalidated.
+
+## Scope
+
+This slice continues the open ecommerce correlation-safe mapper and non-`PortError`
+public-envelope work. It covers the mounted storefront GraphQL helper that enriches a
+cart's delivery groups with currently available shipping options.
+
+The broad ecommerce mapper result remains open. This source change does not claim that
+all GraphQL, REST, native, owner-port, compatibility, or remote-adapter boundaries are
+complete.
+
+## Mounted cutover
+
+`graphql/mutations/mod.rs` keeps the former cart and legacy helper implementations
+private and mounts `typed_shipping_enrichment_helper.rs` through the existing layered
+helper module. The cart mutation resolver continues to call `enrich_storefront_cart`
+with the same arguments and receives the same `async_graphql::Result<CartResponse>`
+contract.
+
+The mounted helper now calls `enrich_cart_delivery_groups_typed` directly. It no longer
+passes the typed fulfillment result through the compatibility conversion
+`CommerceError::Validation(error.to_string())` or through an intermediate GraphQL error
+containing owner text.
+
+Shipping-option listing, currency filtering, public-channel visibility, shipping-profile
+compatibility, selected-option adoption, delivery-group mutation, and success response
+shape remain in the existing owner-provided typed implementation.
+
+## Typed owner outcomes
+
+Every current `FulfillmentError` variant is classified explicitly:
+
+- validation;
+- shipping option not found;
+- fulfillment not found;
+- lifecycle conflict;
+- storage unavailable.
+
+The fulfillment database variant is retained as a typed technical cause for
+error-severity diagnostics. Ordinary validation, not-found, and lifecycle outcomes are
+classified without adding their raw owner messages to warning fields.
+
+## Stable public policy
+
+Every covered outcome preserves the existing public GraphQL envelope:
+
+| Field | Value |
+| --- | --- |
+| message | `Cart shipping details are temporarily unavailable` |
+| code | `CART_ENRICHMENT_UNAVAILABLE` |
+| retryable | `true` |
+
+The owner validation text, database cause, channel slug, locale values, currency code,
+shipping option details, and cart projections are not copied into the public message.
+
+## Diagnostics
+
+The typed boundary records:
+
+- truthful owner `rustok_fulfillment`;
+- owner operation `list_shipping_options`;
+- stable internal code, kind, and retryability;
+- tenant and cart UUIDs;
+- line-item and delivery-group counts;
+- character lengths for currency code, effective channel slug, requested locale, and
+  tenant default locale;
+- stable public code and retryability;
+- boundary `commerce_graphql_storefront_shipping_enrichment`.
+
+Only the typed fulfillment database cause is attached to the technical error event.
+Ordinary owner rejections use warning severity without a raw owner-error payload field.
+
+## Compatibility
+
+The former `safe_helpers.rs`, `helpers.rs`, and compatibility
+`enrich_cart_delivery_groups` conversion remain private source. Their mounted helper
+symbol is overridden by the typed implementation. Scoped `dead_code` allowances keep
+that intentionally retained compatibility source from breaking `-Dwarnings` until a
+separate retirement task has compile and upgraded-path evidence.
+
+## Open boundaries
+
+This slice does not:
+
+- replace direct `FulfillmentService` construction inside the typed owner adapter with
+  host-composed ports;
+- change REST storefront shipping enrichment;
+- add native transport parity;
+- remove the compatibility `CommerceError::Validation(error.to_string())` source;
+- provide runtime, remote-profile, restart, or multi-database evidence;
+- promote ecommerce FBA or FFA status;
+- close the broad mapper and public-envelope work item.
+
+## Verification
+
+Suggested focused checks:
+
+```bash
+node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
+node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
+node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+cargo check -p rustok-commerce --lib
+```
+
+These commands and runtime GraphQL scenarios were not executed while preparing this
+source slice, per maintainer instruction. FBA and FFA status remain unchanged.

--- a/crates/rustok-commerce/src/graphql/mutations/layered_order_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/layered_order_helpers.rs
@@ -4,4 +4,5 @@ pub(crate) use super::safe_order_helpers_impl::*;
 pub(crate) use super::typed_line_item_helpers::{
     resolve_storefront_line_item_input, validate_storefront_line_item_quantity,
 };
+pub(crate) use super::typed_shipping_enrichment_helper::enrich_storefront_cart;
 pub(crate) use super::typed_shipping_option_helper::validate_selected_shipping_option;

--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -9,6 +9,8 @@ pub mod cart;
 mod cart_safe_helpers;
 #[path = "typed_line_item_helpers.rs"]
 mod typed_line_item_helpers;
+#[path = "typed_shipping_enrichment_helper.rs"]
+mod typed_shipping_enrichment_helper;
 #[path = "typed_shipping_option_helper.rs"]
 mod typed_shipping_option_helper;
 pub mod catalog;

--- a/crates/rustok-commerce/src/graphql/mutations/typed_shipping_enrichment_helper.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/typed_shipping_enrichment_helper.rs
@@ -1,0 +1,194 @@
+use async_graphql::{ErrorExtensions, Result};
+use rustok_api::RequestContext;
+use rustok_fulfillment::FulfillmentError;
+use uuid::Uuid;
+
+use crate::{
+    dto::CartResponse,
+    storefront_channel::normalize_public_channel_slug,
+    storefront_shipping::enrich_cart_delivery_groups_typed,
+};
+
+const STOREFRONT_SHIPPING_ENRICHMENT_GRAPHQL_BOUNDARY: &str =
+    "commerce_graphql_storefront_shipping_enrichment";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ShippingEnrichmentFailureKind {
+    Validation,
+    ShippingOptionNotFound,
+    FulfillmentNotFound,
+    LifecycleConflict,
+    StorageUnavailable,
+}
+
+#[derive(Debug)]
+struct ShippingEnrichmentFailure {
+    kind: ShippingEnrichmentFailureKind,
+    internal_code: &'static str,
+    internal_kind: &'static str,
+    internal_retryable: bool,
+    owner_error: FulfillmentError,
+}
+
+impl ShippingEnrichmentFailure {
+    fn from_owner(error: FulfillmentError) -> Self {
+        let (kind, internal_code, internal_kind, internal_retryable) = match &error {
+            FulfillmentError::Validation(_) => (
+                ShippingEnrichmentFailureKind::Validation,
+                "fulfillment.validation",
+                "validation",
+                false,
+            ),
+            FulfillmentError::ShippingOptionNotFound(_) => (
+                ShippingEnrichmentFailureKind::ShippingOptionNotFound,
+                "fulfillment.shipping_option_not_found",
+                "not_found",
+                false,
+            ),
+            FulfillmentError::FulfillmentNotFound(_) => (
+                ShippingEnrichmentFailureKind::FulfillmentNotFound,
+                "fulfillment.fulfillment_not_found",
+                "not_found",
+                false,
+            ),
+            FulfillmentError::InvalidTransition { .. } => (
+                ShippingEnrichmentFailureKind::LifecycleConflict,
+                "fulfillment.invalid_transition",
+                "conflict",
+                false,
+            ),
+            FulfillmentError::Database(_) => (
+                ShippingEnrichmentFailureKind::StorageUnavailable,
+                "fulfillment.database_unavailable",
+                "unavailable",
+                true,
+            ),
+        };
+
+        Self {
+            kind,
+            internal_code,
+            internal_kind,
+            internal_retryable,
+            owner_error: error,
+        }
+    }
+
+    fn technical_owner_error(&self) -> Option<&FulfillmentError> {
+        if matches!(self.kind, ShippingEnrichmentFailureKind::StorageUnavailable) {
+            Some(&self.owner_error)
+        } else {
+            None
+        }
+    }
+}
+
+fn public_graphql_error() -> async_graphql::Error {
+    async_graphql::Error::new("Cart shipping details are temporarily unavailable").extend_with(
+        |_, extensions| {
+            extensions.set("code", "CART_ENRICHMENT_UNAVAILABLE");
+            extensions.set("retryable", true);
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn shipping_enrichment_graphql_error(
+    failure: ShippingEnrichmentFailure,
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    line_item_count: usize,
+    delivery_group_count: usize,
+    currency_code_length: usize,
+    public_channel_slug: Option<&str>,
+    requested_locale: Option<&str>,
+    tenant_default_locale: Option<&str>,
+) -> async_graphql::Error {
+    let channel_slug_length = public_channel_slug.map(str::chars).map(Iterator::count);
+    let requested_locale_length = requested_locale.map(str::chars).map(Iterator::count);
+    let tenant_default_locale_length = tenant_default_locale.map(str::chars).map(Iterator::count);
+    let technical_owner_error = failure.technical_owner_error();
+
+    if matches!(failure.kind, ShippingEnrichmentFailureKind::StorageUnavailable) {
+        tracing::error!(
+            error = ?technical_owner_error,
+            owner = "rustok_fulfillment",
+            owner_operation = "list_shipping_options",
+            internal_code = failure.internal_code,
+            internal_kind = failure.internal_kind,
+            internal_retryable = failure.internal_retryable,
+            tenant_id = %tenant_id,
+            cart_id = %cart_id,
+            line_item_count,
+            delivery_group_count,
+            currency_code_length,
+            channel_slug_length = ?channel_slug_length,
+            requested_locale_length = ?requested_locale_length,
+            tenant_default_locale_length = ?tenant_default_locale_length,
+            public_code = "CART_ENRICHMENT_UNAVAILABLE",
+            public_retryable = true,
+            boundary = STOREFRONT_SHIPPING_ENRICHMENT_GRAPHQL_BOUNDARY,
+            "commerce GraphQL storefront shipping enrichment dependency failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = "rustok_fulfillment",
+            owner_operation = "list_shipping_options",
+            internal_code = failure.internal_code,
+            internal_kind = failure.internal_kind,
+            internal_retryable = failure.internal_retryable,
+            tenant_id = %tenant_id,
+            cart_id = %cart_id,
+            line_item_count,
+            delivery_group_count,
+            currency_code_length,
+            channel_slug_length = ?channel_slug_length,
+            requested_locale_length = ?requested_locale_length,
+            tenant_default_locale_length = ?tenant_default_locale_length,
+            public_code = "CART_ENRICHMENT_UNAVAILABLE",
+            public_retryable = true,
+            boundary = STOREFRONT_SHIPPING_ENRICHMENT_GRAPHQL_BOUNDARY,
+            "commerce GraphQL storefront shipping enrichment was rejected"
+        );
+    }
+
+    public_graphql_error()
+}
+
+pub(crate) async fn enrich_storefront_cart(
+    db: &sea_orm::DatabaseConnection,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    tenant_default_locale: &str,
+    cart: CartResponse,
+) -> Result<CartResponse> {
+    let cart_id = cart.id;
+    let line_item_count = cart.line_items.len();
+    let delivery_group_count = cart.delivery_groups.len();
+    let currency_code_length = cart.currency_code.chars().count();
+    let public_channel_slug = normalize_public_channel_slug(cart.channel_slug.as_deref())
+        .or_else(|| normalize_public_channel_slug(request_context.channel_slug.as_deref()));
+
+    enrich_cart_delivery_groups_typed(
+        db,
+        tenant_id,
+        cart,
+        public_channel_slug.as_deref(),
+        Some(request_context.locale.as_str()),
+        Some(tenant_default_locale),
+    )
+    .await
+    .map_err(|error| {
+        shipping_enrichment_graphql_error(
+            ShippingEnrichmentFailure::from_owner(error),
+            tenant_id,
+            cart_id,
+            line_item_count,
+            delivery_group_count,
+            currency_code_length,
+            public_channel_slug.as_deref(),
+            Some(request_context.locale.as_str()),
+            Some(tenant_default_locale),
+        )
+    })
+}

--- a/scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
+++ b/scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const moduleSource = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const layeredSource = read(
+  'crates/rustok-commerce/src/graphql/mutations/layered_order_helpers.rs',
+);
+const typedSource = read(
+  'crates/rustok-commerce/src/graphql/mutations/typed_shipping_enrichment_helper.rs',
+);
+const safeSource = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const legacySource = read('crates/rustok-commerce/src/graphql/mutations/helpers.rs');
+const ownerSource = read('crates/rustok-commerce/src/storefront_shipping.rs');
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const publicEnvelope = between(
+  typedSource,
+  'fn public_graphql_error()',
+  '#[allow(clippy::too_many_arguments)]\nfn shipping_enrichment_graphql_error(',
+  'public GraphQL envelope',
+);
+const mapper = between(
+  typedSource,
+  'fn shipping_enrichment_graphql_error(',
+  'pub(crate) async fn enrich_storefront_cart(',
+  'typed enrichment mapper',
+);
+const mountedHelper = typedSource.slice(
+  typedSource.indexOf('pub(crate) async fn enrich_storefront_cart('),
+);
+
+for (const [source, value, label] of [
+  [
+    moduleSource,
+    '#[path = "typed_shipping_enrichment_helper.rs"]\nmod typed_shipping_enrichment_helper;',
+    'private typed helper module',
+  ],
+  [
+    layeredSource,
+    'pub(crate) use super::typed_shipping_enrichment_helper::enrich_storefront_cart;',
+    'mounted typed override',
+  ],
+  [
+    moduleSource,
+    '#[allow(dead_code)]\n#[path = "safe_helpers.rs"]\nmod cart_safe_helpers;',
+    'private compatibility facade allowance',
+  ],
+  [
+    moduleSource,
+    '#[allow(dead_code)]\n#[path = "safe_legacy_helpers.rs"]\nmod legacy_helpers;',
+    'private legacy helper allowance',
+  ],
+  [safeSource, 'pub(crate) async fn enrich_storefront_cart(', 'compatibility facade'],
+  [safeSource, 'super::legacy_helpers::enrich_storefront_cart(', 'compatibility delegation'],
+  [legacySource, 'pub(crate) async fn enrich_storefront_cart(', 'legacy helper'],
+  [ownerSource, 'pub async fn enrich_cart_delivery_groups_typed(', 'typed owner adapter'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const [value, label] of [
+  ['enum ShippingEnrichmentFailureKind {', 'typed outcome enum'],
+  ['Validation,', 'validation outcome'],
+  ['ShippingOptionNotFound,', 'option not-found outcome'],
+  ['FulfillmentNotFound,', 'fulfillment not-found outcome'],
+  ['LifecycleConflict,', 'lifecycle outcome'],
+  ['StorageUnavailable,', 'storage outcome'],
+  ['owner_error: FulfillmentError', 'typed owner cause'],
+  ['FulfillmentError::Validation(_)', 'owner validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'owner option mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'owner fulfillment mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'owner transition mapping'],
+  ['FulfillmentError::Database(_)', 'owner database mapping'],
+  ['"fulfillment.validation"', 'validation internal code'],
+  ['"fulfillment.shipping_option_not_found"', 'option internal code'],
+  ['"fulfillment.fulfillment_not_found"', 'fulfillment internal code'],
+  ['"fulfillment.invalid_transition"', 'transition internal code'],
+  ['"fulfillment.database_unavailable"', 'database internal code'],
+]) {
+  requireText(typedSource, value, label);
+}
+
+for (const [value, label] of [
+  [
+    'async_graphql::Error::new("Cart shipping details are temporarily unavailable")',
+    'stable public message',
+  ],
+  ['extensions.set("code", "CART_ENRICHMENT_UNAVAILABLE")', 'stable public code'],
+  ['extensions.set("retryable", true)', 'stable public retryability'],
+]) {
+  requireText(publicEnvelope, value, label);
+}
+
+for (const [value, label] of [
+  ['error = ?technical_owner_error', 'technical typed cause'],
+  ['owner = "rustok_fulfillment"', 'truthful owner'],
+  ['owner_operation = "list_shipping_options"', 'truthful owner operation'],
+  ['internal_code = failure.internal_code', 'internal code'],
+  ['internal_kind = failure.internal_kind', 'internal kind'],
+  ['internal_retryable = failure.internal_retryable', 'internal retryability'],
+  ['tenant_id = %tenant_id', 'tenant context'],
+  ['cart_id = %cart_id', 'cart identity'],
+  ['line_item_count,', 'line item count'],
+  ['delivery_group_count,', 'delivery group count'],
+  ['currency_code_length,', 'currency length'],
+  ['channel_slug_length = ?channel_slug_length', 'channel length'],
+  ['requested_locale_length = ?requested_locale_length', 'requested locale length'],
+  ['tenant_default_locale_length = ?tenant_default_locale_length', 'default locale length'],
+  ['public_code = "CART_ENRICHMENT_UNAVAILABLE"', 'public code diagnostic'],
+  ['public_retryable = true', 'public retryability diagnostic'],
+  ['boundary = STOREFRONT_SHIPPING_ENRICHMENT_GRAPHQL_BOUNDARY', 'stable boundary'],
+  ['tracing::error!(', 'technical severity'],
+  ['tracing::warn!(', 'ordinary severity'],
+  ['public_graphql_error()', 'stable envelope return'],
+]) {
+  requireText(mapper, value, label);
+}
+
+for (const [value, label] of [
+  ['let cart_id = cart.id;', 'cart identity retained before move'],
+  ['let line_item_count = cart.line_items.len();', 'line item fact retained'],
+  ['let delivery_group_count = cart.delivery_groups.len();', 'delivery group fact retained'],
+  ['let currency_code_length = cart.currency_code.chars().count();', 'currency length retained'],
+  ['normalize_public_channel_slug(cart.channel_slug.as_deref())', 'cart channel normalization'],
+  ['normalize_public_channel_slug(request_context.channel_slug.as_deref())', 'request channel fallback'],
+  ['enrich_cart_delivery_groups_typed(', 'direct typed owner delegation'],
+  ['Some(request_context.locale.as_str())', 'requested locale delegation'],
+  ['Some(tenant_default_locale)', 'default locale delegation'],
+  ['ShippingEnrichmentFailure::from_owner(error)', 'typed owner mapping'],
+]) {
+  requireText(mountedHelper, value, label);
+}
+
+const typedCalls = mountedHelper.match(/enrich_cart_delivery_groups_typed\(/g) ?? [];
+if (typedCalls.length !== 1) {
+  failures.push(`expected one direct typed enrichment call, found ${typedCalls.length}`);
+}
+const mountedOverrides = layeredSource.match(/enrich_storefront_cart/g) ?? [];
+if (mountedOverrides.length !== 1) {
+  failures.push(`expected one mounted enrichment override, found ${mountedOverrides.length}`);
+}
+
+for (const value of [
+  'enrich_cart_delivery_groups(',
+  'CommerceError::Validation(error.to_string())',
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(format!("{error}"))',
+  'format!("{error:?}")',
+  'detail.contains(',
+  'error = ?failure.owner_error',
+  'public_channel_slug = %',
+  'public_channel_slug = ?',
+  'requested_locale = %',
+  'requested_locale = ?',
+  'tenant_default_locale = %',
+  'tenant_default_locale = ?',
+  'currency_code = %',
+  'currency_code = ?',
+]) {
+  forbidText(typedSource, value, 'typed storefront shipping enrichment boundary');
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL typed shipping enrichment verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ mounted storefront shipping enrichment delegates typed fulfillment outcomes to one stable GraphQL envelope',
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper and non-`PortError` public-envelope result with the mounted storefront GraphQL shipping-enrichment slice;
- route `enrich_storefront_cart` directly through the existing typed `enrich_cart_delivery_groups_typed` owner adapter;
- remove the mounted dependency on the compatibility chain `FulfillmentError -> CommerceError::Validation(error.to_string()) -> async_graphql::Error`;
- classify fulfillment validation, shipping-option not-found, fulfillment not-found, lifecycle conflict, and storage-unavailable outcomes explicitly;
- preserve the existing public GraphQL envelope for every covered outcome: `Cart shipping details are temporarily unavailable`, code `CART_ENRICHMENT_UNAVAILABLE`, retryable `true`;
- retain truthful fulfillment owner/operation, internal code/kind/retryability, tenant/cart identity, line-item and delivery-group counts, and bounded currency/channel/locale facts;
- attach the typed fulfillment cause only to the technical storage event and avoid raw ordinary owner-error payload fields;
- preserve all unrelated helper symbols through the private layered facade and keep the former safe/legacy compatibility implementations available but unmounted;
- add source-ready/unvalidated documentation and a focused static guard without changing FBA/FFA status.

## Recheck

- continued from merged typed storefront shipping-option PR #2331;
- confirmed #2331 was squash-merged into `main` as `6ce410574d27aff3aa0f5b51d5830f749b18de65` and its source branch was deleted automatically;
- confirmed no open PR overlaps the mounted storefront GraphQL shipping-enrichment helper;
- confirmed `enrich_cart_delivery_groups_typed` already owns shipping-option listing, currency filtering, channel visibility, profile compatibility, selected-option adoption, and result mutation;
- confirmed the mounted GraphQL helper still passed typed fulfillment failures through identifier-bearing compatibility text before the stable facade envelope;
- confirmed the cart resolver continues importing `enrich_storefront_cart` through `super::helpers::*` with the same signature and success response;
- confirmed all current `FulfillmentError` variants are classified explicitly;
- confirmed the branch is based directly on current `main`, is zero commits behind, and changes exactly five files.

## Boundary

This PR closes the raw compatibility conversion for mounted storefront GraphQL shipping enrichment. It does not replace direct `FulfillmentService` construction, change REST enrichment, add native parity, remove compatibility source, provide runtime/remote evidence, close the broad mapper item, or promote ecommerce FBA/FFA status.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
node scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
node scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
cargo check -p rustok-commerce --lib
```
