### PR TITLE
Publish fulfillment admin shipping option read port

### DIFF
--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -23,15 +23,15 @@ projections. Fulfillment owner uses `FulfillmentService::list_by_order` and
 `create_fulfillment`; mounted commerce checkout no longer queries the
 `fulfillments` table or constructs `FulfillmentService`.
 
-Complete shipping-option active list, administrative list-all, and lookup now
-have a separate read-only owner boundary, `ShippingOptionReadPort`. The root
-in-process factory owns `FulfillmentService` construction, requires read policy,
-preserves requested and default locale values, and maps owner failures to stable
-`PortError` envelopes. Mounted commerce GraphQL shipping-option validation,
-shipping enrichment, and storefront listing use this port instead of
-constructing `FulfillmentService` directly. The administrative list-all owner
-contract is source-ready for the remaining mounted GraphQL cutover. The
-seller/cart `ShippingSelectionPort` contract is unchanged.
+Complete shipping-option active list and lookup use `ShippingOptionReadPort`,
+while administrative list-all uses the separate `ShippingOptionAdminReadPort`.
+The root in-process factories own `FulfillmentService` construction, require read
+policy, preserve requested and default locale values, and map owner failures to
+stable `PortError` envelopes. Mounted commerce GraphQL shipping-option
+validation, shipping enrichment, and storefront listing use the storefront port
+instead of constructing `FulfillmentService` directly. The administrative
+list-all owner contract is source-ready for the remaining mounted GraphQL
+cutover. The seller/cart `ShippingSelectionPort` contract is unchanged.
 
 Stable fulfillment keys and metadata identity remain owner-local compatibility
 mechanisms. Duplicate keys fail closed. A typed durable checkout fulfillment
@@ -49,8 +49,9 @@ identity and database uniqueness migration remain open.
 - Published checkout execution port: `CheckoutFulfillmentExecutionPort`.
 - Mounted in-process provider: `TypedCheckoutFulfillmentExecutionPort` over the
   existing owner execution adapter.
-- Source-ready internal read boundary: `ShippingOptionReadPort`; this is not a
-  new FBA provider contract and does not change registry status.
+- Source-ready internal read boundaries: `ShippingOptionReadPort` and
+  `ShippingOptionAdminReadPort`; these are not new FBA provider contracts and do
+  not change registry status.
 - Contract and provider evidence:
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-contract-test-static-matrix.json`,
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-static-matrix.json`,
@@ -62,7 +63,7 @@ identity and database uniqueness migration remain open.
   `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the
   owner-admin/storefront, checkout execution, and typed lifecycle split.
 - `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` guards the
-  internal shipping-option read boundary and mounted storefront commerce
+  internal shipping-option read boundaries and mounted storefront commerce
   cutover.
 - No status promotion is claimed from source. Compile, upgraded database,
   contention, restart, mounted transport, and remote evidence remain missing.
@@ -86,20 +87,22 @@ identity and database uniqueness migration remain open.
 
 ## Shipping-option read source checklist
 
-- [x] Publish active list, administrative list-all, and lookup operations through
-  `ShippingOptionReadPort`.
+- [x] Publish active list and lookup through `ShippingOptionReadPort`.
+- [x] Publish administrative list-all through the separate
+  `ShippingOptionAdminReadPort`.
 - [x] Keep active storefront listing and complete administrative listing as
-  explicit operations rather than an overloaded request flag.
+  separate traits rather than an overloaded request flag or a growing storefront
+  interface.
 - [x] Preserve requested and tenant-default locale arguments.
 - [x] Require read policy and parse tenant identity from `PortContext`.
 - [x] Map all current `FulfillmentError` variants to stable `PortError` values.
-- [x] Export a canonical root in-process factory.
+- [x] Export canonical root in-process factories.
 - [x] Remove direct `FulfillmentService` construction from mounted commerce
   GraphQL shipping-option validation, enrichment, and storefront listing.
 - [ ] Cut the mounted administrative GraphQL `shipping_options` query over to
   `list_all_shipping_option_projections`.
-- [ ] Inject the read port from the application host rather than constructing the
-  root in-process provider inside the commerce seam.
+- [ ] Inject the read ports from the application host rather than constructing
+  root in-process providers inside the commerce seam.
 - [ ] Execute compile, mounted GraphQL, REST/native parity, deadline, failure,
   and remote-profile evidence.
 
@@ -136,8 +139,8 @@ identity and database uniqueness migration remain open.
    adapter errors while `FulfillmentService` remains the sole lifecycle owner.
 
 5. **Prove and host-compose shipping-option reads.** Cut the mounted
-   administrative list-all query over to the owner port, execute active list,
-   administrative list-all, and lookup through mounted GraphQL consumers,
+   administrative list-all query over to the admin owner port, execute active
+   list, administrative list-all, and lookup through mounted GraphQL consumers,
    compare REST/native behavior, and move provider construction to the
    application host.
    **Depends on:** compiled fulfillment/commerce crates and mounted transport

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Implementation plan for `rustok-fulfillment`
 
-Last reviewed: 2026-07-27
+Last reviewed: 2026-07-28
 
 ## Current state
 
@@ -23,21 +23,15 @@ projections. Fulfillment owner uses `FulfillmentService::list_by_order` and
 `create_fulfillment`; mounted commerce checkout no longer queries the
 `fulfillments` table or constructs `FulfillmentService`.
 
-The root in-process checkout factory now mounts
-`TypedCheckoutFulfillmentExecutionPort`. Ensure and recovery reads accept
-`Pending`, `Shipped`, and `Delivered` owner states. `Cancelled` and unknown
-lifecycle values fail closed with a typed manual-reconciliation outcome instead
-of being adopted as a successful checkout fulfillment set. The underlying
-execution adapter remains the persistence/idempotency delegate, so transport
-contracts and request DTOs are unchanged.
-
-Complete shipping-option list and lookup now have a separate read-only owner
-boundary, `ShippingOptionReadPort`. The root in-process factory owns
-`FulfillmentService` construction, requires read policy, preserves requested
-and default locale values, and maps owner failures to stable `PortError`
-envelopes. Mounted commerce GraphQL shipping-option validation and shipping
-enrichment use this port instead of constructing `FulfillmentService` directly.
-The seller/cart `ShippingSelectionPort` contract is unchanged.
+Complete shipping-option active list, administrative list-all, and lookup now
+have a separate read-only owner boundary, `ShippingOptionReadPort`. The root
+in-process factory owns `FulfillmentService` construction, requires read policy,
+preserves requested and default locale values, and maps owner failures to stable
+`PortError` envelopes. Mounted commerce GraphQL shipping-option validation,
+shipping enrichment, and storefront listing use this port instead of
+constructing `FulfillmentService` directly. The administrative list-all owner
+contract is source-ready for the remaining mounted GraphQL cutover. The
+seller/cart `ShippingSelectionPort` contract is unchanged.
 
 Stable fulfillment keys and metadata identity remain owner-local compatibility
 mechanisms. Duplicate keys fail closed. A typed durable checkout fulfillment
@@ -68,7 +62,8 @@ identity and database uniqueness migration remain open.
   `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the
   owner-admin/storefront, checkout execution, and typed lifecycle split.
 - `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` guards the
-  internal shipping-option read boundary and mounted commerce cutover.
+  internal shipping-option read boundary and mounted storefront commerce
+  cutover.
 - No status promotion is claimed from source. Compile, upgraded database,
   contention, restart, mounted transport, and remote evidence remain missing.
 
@@ -91,14 +86,18 @@ identity and database uniqueness migration remain open.
 
 ## Shipping-option read source checklist
 
-- [x] Publish complete list and lookup operations through
+- [x] Publish active list, administrative list-all, and lookup operations through
   `ShippingOptionReadPort`.
+- [x] Keep active storefront listing and complete administrative listing as
+  explicit operations rather than an overloaded request flag.
 - [x] Preserve requested and tenant-default locale arguments.
 - [x] Require read policy and parse tenant identity from `PortContext`.
 - [x] Map all current `FulfillmentError` variants to stable `PortError` values.
 - [x] Export a canonical root in-process factory.
 - [x] Remove direct `FulfillmentService` construction from mounted commerce
-  GraphQL shipping-option validation and enrichment.
+  GraphQL shipping-option validation, enrichment, and storefront listing.
+- [ ] Cut the mounted administrative GraphQL `shipping_options` query over to
+  `list_all_shipping_option_projections`.
 - [ ] Inject the read port from the application host rather than constructing the
   root in-process provider inside the commerce seam.
 - [ ] Execute compile, mounted GraphQL, REST/native parity, deadline, failure,
@@ -136,14 +135,17 @@ identity and database uniqueness migration remain open.
    **Done when:** production-like execution proves degraded fallback and typed
    adapter errors while `FulfillmentService` remains the sole lifecycle owner.
 
-5. **Prove and host-compose shipping-option reads.** Execute complete list and
-   lookup through the mounted GraphQL consumers, compare REST/native behavior,
-   and move provider construction to the application host.
+5. **Prove and host-compose shipping-option reads.** Cut the mounted
+   administrative list-all query over to the owner port, execute active list,
+   administrative list-all, and lookup through mounted GraphQL consumers,
+   compare REST/native behavior, and move provider construction to the
+   application host.
    **Depends on:** compiled fulfillment/commerce crates and mounted transport
    fixtures.
    **Done when:** all transports retain locale/channel/deadline context, expose
-   identical owner projections, and no commerce transport constructs a concrete
-   fulfillment service or in-process provider.
+   identical owner projections with correct active/inactive semantics, and no
+   commerce transport constructs a concrete fulfillment service or in-process
+   provider.
 
 6. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.
@@ -168,8 +170,8 @@ identity and database uniqueness migration remain open.
 - `cargo check -p rustok-commerce --all-features`
 - Targeted checkout fulfillment create/adopt/read, cancelled/unknown lifecycle,
   duplicate identity, process-exit, restart, and multi-fulfillment tests.
-- Targeted shipping-option list/read locale, context, owner-error, GraphQL,
-  REST/native parity, and remote-profile tests.
+- Targeted shipping-option active list, administrative list-all, lookup locale,
+  context, owner-error, GraphQL, REST/native parity, and remote-profile tests.
 
 No verification command was executed in this source wave.
 

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -23,6 +23,14 @@ projections. Fulfillment owner uses `FulfillmentService::list_by_order` and
 `create_fulfillment`; mounted commerce checkout no longer queries the
 `fulfillments` table or constructs `FulfillmentService`.
 
+The root in-process checkout factory now mounts
+`TypedCheckoutFulfillmentExecutionPort`. Ensure and recovery reads accept
+`Pending`, `Shipped`, and `Delivered` owner states. `Cancelled` and unknown
+lifecycle values fail closed with a typed manual-reconciliation outcome instead
+of being adopted as a successful checkout fulfillment set. The underlying
+execution adapter remains the persistence/idempotency delegate, so transport
+contracts and request DTOs are unchanged.
+
 Complete shipping-option active list and lookup use `ShippingOptionReadPort`,
 while administrative list-all uses the separate `ShippingOptionAdminReadPort`.
 The root in-process factories own `FulfillmentService` construction, require read

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -10,25 +10,29 @@ shipping-option projections needed by mounted ecommerce transports.
 It is separate from `ShippingSelectionPort`:
 
 - `ShippingSelectionPort` owns seller/cart selection workflow;
-- `ShippingOptionReadPort` owns complete read projections for list and lookup;
+- `ShippingOptionReadPort` owns complete read projections for active list,
+  administrative list-all, and lookup;
 - the selection contract and its provider registry are unchanged;
 - no new FBA provider contract or status promotion is claimed.
 
 ## Operations
 
-The port publishes two read-only operations:
+The port publishes three read-only operations:
 
-- `list_shipping_option_projections`;
-- `read_shipping_option_projection`.
+- `list_shipping_option_projections` for the storefront-visible active list;
+- `list_all_shipping_option_projections` for the complete administrative list,
+  including inactive options;
+- `read_shipping_option_projection` for one complete owner projection.
 
-Both return the existing fulfillment-owned `ShippingOptionResponse`. This keeps
-metadata, allowed shipping-profile slugs, active state, localization facts, and
-provider identity inside the owner projection without defining a second partial
-commerce copy.
+All operations return the existing fulfillment-owned `ShippingOptionResponse`.
+This keeps metadata, allowed shipping-profile slugs, active state, localization
+facts, and provider identity inside the owner projection without defining a
+second partial commerce copy.
 
 ## Requests
 
-`ListShippingOptionProjectionsRequest` carries:
+`ListShippingOptionProjectionsRequest` and
+`ListAllShippingOptionProjectionsRequest` carry:
 
 - requested locale;
 - tenant default locale.
@@ -54,10 +58,15 @@ The adapter:
 
 1. requires read policy;
 2. parses tenant identity from `PortContext`;
-3. delegates list or lookup to `FulfillmentService`;
+3. delegates active list, administrative list-all, or lookup to
+   `FulfillmentService`;
 4. preserves requested/default locale arguments;
 5. maps every `FulfillmentError` variant to a stable `PortError`;
 6. returns the owner projection unchanged on success.
+
+The two list contracts remain explicit rather than overloading one request with
+an administrative flag. That keeps storefront active-only semantics separate
+from the admin requirement to inspect inactive shipping options.
 
 ## Stable owner errors
 
@@ -96,16 +105,23 @@ validation, not-found, and conflict events do not add raw owner message fields.
 
 ## Mounted commerce cutover
 
-The mounted storefront GraphQL helpers now use the root read-port factory:
+The mounted storefront GraphQL helpers use the root read-port factory:
 
 - shipping-option validation calls `read_shipping_option_projection`;
-- cart shipping enrichment calls `list_shipping_option_projections`.
+- cart shipping enrichment and storefront query listing call
+  `list_shipping_option_projections`.
 
-Commerce builds a read `PortContext` with a service actor, cart-scoped
-correlation id, request locale, optional public channel, and a two-second
-deadline. The existing GraphQL public envelopes remain unchanged.
+The owner now also publishes `list_all_shipping_option_projections` for the
+mounted administrative GraphQL `shipping_options` query. This source slice
+publishes and verifies that owner contract; the transport cutover remains a
+separate bounded change so the existing public envelope can be preserved and
+reviewed independently.
 
-Delivery-group projection is now a pure commerce function receiving owner
+Commerce builds a read `PortContext` with a service actor, resource-scoped
+correlation id, request locale, optional public channel where applicable, and a
+two-second deadline. Existing GraphQL public envelopes remain unchanged.
+
+Delivery-group projection is a pure commerce function receiving owner
 projections. The existing compatibility service adapter delegates to the same
 pure function, so legacy REST/native behavior is not changed by this slice.
 
@@ -127,6 +143,8 @@ No command was executed locally in this source wave.
 
 This slice does not:
 
+- cut the mounted administrative GraphQL `shipping_options` query over to
+  `list_all_shipping_option_projections`;
 - inject the read port from the application host rather than the root in-process
   factory;
 - migrate REST/native storefront shipping reads;

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -4,20 +4,21 @@ Status: source-ready, unvalidated.
 
 ## Scope
 
-`ShippingOptionReadPort` is the fulfillment-owned read boundary for complete
-shipping-option projections needed by mounted ecommerce transports.
+`ShippingOptionReadPort` and `ShippingOptionAdminReadPort` are fulfillment-owned
+read boundaries for complete shipping-option projections needed by mounted
+ecommerce transports.
 
 It is separate from `ShippingSelectionPort`:
 
 - `ShippingSelectionPort` owns seller/cart selection workflow;
-- `ShippingOptionReadPort` owns complete read projections for active list,
-  administrative list-all, and lookup;
+- `ShippingOptionReadPort` owns storefront active-list and single-option reads;
+- `ShippingOptionAdminReadPort` owns the complete administrative list-all read;
 - the selection contract and its provider registry are unchanged;
 - no new FBA provider contract or status promotion is claimed.
 
 ## Operations
 
-The port publishes three read-only operations:
+The two ports publish three read-only operations:
 
 - `list_shipping_option_projections` for the storefront-visible active list;
 - `list_all_shipping_option_projections` for the complete administrative list,
@@ -47,26 +48,29 @@ locale, correlation, causation, trace, and deadline facts.
 
 ## In-process adapter
 
-`InProcessShippingOptionReadPort` owns `FulfillmentService` construction and is
-exported through the root factory:
+`InProcessShippingOptionReadPort` and
+`InProcessShippingOptionAdminReadPort` own `FulfillmentService` construction and
+are exported through separate root factories:
 
 ```rust
 in_process_shipping_option_read_port(db)
+in_process_shipping_option_admin_read_port(db)
 ```
 
-The adapter:
+The adapters:
 
-1. requires read policy;
-2. parses tenant identity from `PortContext`;
-3. delegates active list, administrative list-all, or lookup to
+1. require read policy;
+2. parse tenant identity from `PortContext`;
+3. delegate active list, administrative list-all, or lookup to
    `FulfillmentService`;
-4. preserves requested/default locale arguments;
-5. maps every `FulfillmentError` variant to a stable `PortError`;
-6. returns the owner projection unchanged on success.
+4. preserve requested/default locale arguments;
+5. map every `FulfillmentError` variant to a stable `PortError`;
+6. return the owner projection unchanged on success.
 
-The two list contracts remain explicit rather than overloading one request with
-an administrative flag. That keeps storefront active-only semantics separate
-from the admin requirement to inspect inactive shipping options.
+The two list contracts remain separate traits rather than one overloaded request
+or one growing storefront interface. That keeps storefront active-only semantics
+separate from the admin requirement to inspect inactive shipping options and
+avoids breaking existing `ShippingOptionReadPort` implementors.
 
 ## Stable owner errors
 
@@ -111,11 +115,11 @@ The mounted storefront GraphQL helpers use the root read-port factory:
 - cart shipping enrichment and storefront query listing call
   `list_shipping_option_projections`.
 
-The owner now also publishes `list_all_shipping_option_projections` for the
-mounted administrative GraphQL `shipping_options` query. This source slice
-publishes and verifies that owner contract; the transport cutover remains a
-separate bounded change so the existing public envelope can be preserved and
-reviewed independently.
+The separate admin owner port now publishes
+`list_all_shipping_option_projections` for the mounted administrative GraphQL
+`shipping_options` query. This source slice publishes and verifies that owner
+contract; the transport cutover remains a separate bounded change so the
+existing public envelope can be preserved and reviewed independently.
 
 Commerce builds a read `PortContext` with a service actor, resource-scoped
 correlation id, request locale, optional public channel where applicable, and a
@@ -145,8 +149,8 @@ This slice does not:
 
 - cut the mounted administrative GraphQL `shipping_options` query over to
   `list_all_shipping_option_projections`;
-- inject the read port from the application host rather than the root in-process
-  factory;
+- inject the read ports from the application host rather than root in-process
+  factories;
 - migrate REST/native storefront shipping reads;
 - retire `FulfillmentService` from fulfillment-owned compatibility adapters;
 - modify `ShippingSelectionPort`;

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -28,9 +28,9 @@ pub use entities::*;
 pub use ports::*;
 pub use providers::*;
 pub use shipping_option_read::{
-    InProcessShippingOptionReadPort, ListShippingOptionProjectionsRequest,
-    ReadShippingOptionProjectionRequest, ShippingOptionReadPort,
-    in_process_shipping_option_read_port,
+    InProcessShippingOptionReadPort, ListAllShippingOptionProjectionsRequest,
+    ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
+    ShippingOptionReadPort, in_process_shipping_option_read_port,
 };
 pub use status::*;
 

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -28,9 +28,10 @@ pub use entities::*;
 pub use ports::*;
 pub use providers::*;
 pub use shipping_option_read::{
-    InProcessShippingOptionReadPort, ListAllShippingOptionProjectionsRequest,
-    ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
-    ShippingOptionReadPort, in_process_shipping_option_read_port,
+    InProcessShippingOptionAdminReadPort, InProcessShippingOptionReadPort,
+    ListAllShippingOptionProjectionsRequest, ListShippingOptionProjectionsRequest,
+    ReadShippingOptionProjectionRequest, ShippingOptionAdminReadPort, ShippingOptionReadPort,
+    in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
 };
 pub use status::*;
 

--- a/crates/rustok-fulfillment/src/shipping_option_read.rs
+++ b/crates/rustok-fulfillment/src/shipping_option_read.rs
@@ -16,6 +16,12 @@ pub trait ShippingOptionReadPort: Send + Sync {
         request: ListShippingOptionProjectionsRequest,
     ) -> Result<Vec<ShippingOptionResponse>, PortError>;
 
+    async fn list_all_shipping_option_projections(
+        &self,
+        context: PortContext,
+        request: ListAllShippingOptionProjectionsRequest,
+    ) -> Result<Vec<ShippingOptionResponse>, PortError>;
+
     async fn read_shipping_option_projection(
         &self,
         context: PortContext,
@@ -25,6 +31,12 @@ pub trait ShippingOptionReadPort: Send + Sync {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ListShippingOptionProjectionsRequest {
+    pub requested_locale: Option<String>,
+    pub tenant_default_locale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ListAllShippingOptionProjectionsRequest {
     pub requested_locale: Option<String>,
     pub tenant_default_locale: Option<String>,
 }
@@ -81,6 +93,35 @@ impl ShippingOptionReadPort for InProcessShippingOptionReadPort {
                 map_owner_error(
                     &context,
                     "list_shipping_option_projections",
+                    None,
+                    requested_locale_length,
+                    tenant_default_locale_length,
+                    error,
+                )
+            })
+    }
+
+    async fn list_all_shipping_option_projections(
+        &self,
+        context: PortContext,
+        request: ListAllShippingOptionProjectionsRequest,
+    ) -> Result<Vec<ShippingOptionResponse>, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, "list_all_shipping_option_projections")?;
+        let requested_locale_length = request.requested_locale.as_deref().map(str::len);
+        let tenant_default_locale_length = request.tenant_default_locale.as_deref().map(str::len);
+
+        self.inner
+            .list_all_shipping_options(
+                tenant_id,
+                request.requested_locale.as_deref(),
+                request.tenant_default_locale.as_deref(),
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    "list_all_shipping_option_projections",
                     None,
                     requested_locale_length,
                     tenant_default_locale_length,

--- a/crates/rustok-fulfillment/src/shipping_option_read.rs
+++ b/crates/rustok-fulfillment/src/shipping_option_read.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{FulfillmentError, FulfillmentService, ShippingOptionResponse};
 
-/// Transport-neutral owner boundary for complete shipping-option reads.
+/// Transport-neutral owner boundary for storefront-complete shipping-option reads.
 #[async_trait]
 pub trait ShippingOptionReadPort: Send + Sync {
     async fn list_shipping_option_projections(
@@ -16,17 +16,21 @@ pub trait ShippingOptionReadPort: Send + Sync {
         request: ListShippingOptionProjectionsRequest,
     ) -> Result<Vec<ShippingOptionResponse>, PortError>;
 
-    async fn list_all_shipping_option_projections(
-        &self,
-        context: PortContext,
-        request: ListAllShippingOptionProjectionsRequest,
-    ) -> Result<Vec<ShippingOptionResponse>, PortError>;
-
     async fn read_shipping_option_projection(
         &self,
         context: PortContext,
         request: ReadShippingOptionProjectionRequest,
     ) -> Result<ShippingOptionResponse, PortError>;
+}
+
+/// Transport-neutral owner boundary for administrative shipping-option reads.
+#[async_trait]
+pub trait ShippingOptionAdminReadPort: Send + Sync {
+    async fn list_all_shipping_option_projections(
+        &self,
+        context: PortContext,
+        request: ListAllShippingOptionProjectionsRequest,
+    ) -> Result<Vec<ShippingOptionResponse>, PortError>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -64,10 +68,32 @@ impl InProcessShippingOptionReadPort {
     }
 }
 
+pub struct InProcessShippingOptionAdminReadPort {
+    inner: FulfillmentService,
+}
+
+impl InProcessShippingOptionAdminReadPort {
+    pub fn new(db: sea_orm::DatabaseConnection) -> Self {
+        Self {
+            inner: FulfillmentService::new(db),
+        }
+    }
+
+    pub fn from_service(inner: FulfillmentService) -> Self {
+        Self { inner }
+    }
+}
+
 pub fn in_process_shipping_option_read_port(
     db: sea_orm::DatabaseConnection,
 ) -> Arc<dyn ShippingOptionReadPort> {
     Arc::new(InProcessShippingOptionReadPort::new(db))
+}
+
+pub fn in_process_shipping_option_admin_read_port(
+    db: sea_orm::DatabaseConnection,
+) -> Arc<dyn ShippingOptionAdminReadPort> {
+    Arc::new(InProcessShippingOptionAdminReadPort::new(db))
 }
 
 #[async_trait]
@@ -101,35 +127,6 @@ impl ShippingOptionReadPort for InProcessShippingOptionReadPort {
             })
     }
 
-    async fn list_all_shipping_option_projections(
-        &self,
-        context: PortContext,
-        request: ListAllShippingOptionProjectionsRequest,
-    ) -> Result<Vec<ShippingOptionResponse>, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
-        let tenant_id = parse_tenant_id(&context, "list_all_shipping_option_projections")?;
-        let requested_locale_length = request.requested_locale.as_deref().map(str::len);
-        let tenant_default_locale_length = request.tenant_default_locale.as_deref().map(str::len);
-
-        self.inner
-            .list_all_shipping_options(
-                tenant_id,
-                request.requested_locale.as_deref(),
-                request.tenant_default_locale.as_deref(),
-            )
-            .await
-            .map_err(|error| {
-                map_owner_error(
-                    &context,
-                    "list_all_shipping_option_projections",
-                    None,
-                    requested_locale_length,
-                    tenant_default_locale_length,
-                    error,
-                )
-            })
-    }
-
     async fn read_shipping_option_projection(
         &self,
         context: PortContext,
@@ -153,6 +150,38 @@ impl ShippingOptionReadPort for InProcessShippingOptionReadPort {
                     &context,
                     "read_shipping_option_projection",
                     Some(request.shipping_option_id),
+                    requested_locale_length,
+                    tenant_default_locale_length,
+                    error,
+                )
+            })
+    }
+}
+
+#[async_trait]
+impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort {
+    async fn list_all_shipping_option_projections(
+        &self,
+        context: PortContext,
+        request: ListAllShippingOptionProjectionsRequest,
+    ) -> Result<Vec<ShippingOptionResponse>, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, "list_all_shipping_option_projections")?;
+        let requested_locale_length = request.requested_locale.as_deref().map(str::len);
+        let tenant_default_locale_length = request.tenant_default_locale.as_deref().map(str::len);
+
+        self.inner
+            .list_all_shipping_options(
+                tenant_id,
+                request.requested_locale.as_deref(),
+                request.tenant_default_locale.as_deref(),
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    "list_all_shipping_option_projections",
+                    None,
                     requested_locale_length,
                     tenant_default_locale_length,
                     error,

--- a/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
@@ -33,21 +33,36 @@ const forbidText = (source, value, label) => {
 
 for (const [source, value, label] of [
   [ownerRoot, 'mod shipping_option_read;', 'private owner module'],
-  [ownerRoot, 'InProcessShippingOptionReadPort,', 'wrapper export'],
+  [ownerRoot, 'InProcessShippingOptionReadPort,', 'storefront wrapper export'],
+  [ownerRoot, 'InProcessShippingOptionAdminReadPort,', 'admin wrapper export'],
   [
     ownerRoot,
     'ListAllShippingOptionProjectionsRequest,',
     'administrative list request export',
   ],
-  [ownerRoot, 'ShippingOptionReadPort,', 'trait export'],
-  [ownerRoot, 'in_process_shipping_option_read_port,', 'root factory export'],
-  [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'read port trait'],
-  [ownerSource, 'pub struct InProcessShippingOptionReadPort {', 'in-process wrapper'],
-  [ownerSource, 'impl ShippingOptionReadPort for InProcessShippingOptionReadPort', 'wrapper implementation'],
+  [ownerRoot, 'ShippingOptionReadPort,', 'storefront trait export'],
+  [ownerRoot, 'ShippingOptionAdminReadPort,', 'admin trait export'],
+  [ownerRoot, 'in_process_shipping_option_read_port,', 'storefront factory export'],
+  [
+    ownerRoot,
+    'in_process_shipping_option_admin_read_port,',
+    'admin factory export',
+  ],
+  [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'storefront read port trait'],
+  [ownerSource, 'pub trait ShippingOptionAdminReadPort: Send + Sync {', 'admin read port trait'],
+  [ownerSource, 'pub struct InProcessShippingOptionReadPort {', 'storefront wrapper'],
+  [ownerSource, 'pub struct InProcessShippingOptionAdminReadPort {', 'admin wrapper'],
+  [ownerSource, 'impl ShippingOptionReadPort for InProcessShippingOptionReadPort', 'storefront wrapper implementation'],
+  [ownerSource, 'impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort', 'admin wrapper implementation'],
   [
     ownerSource,
     'pub fn in_process_shipping_option_read_port(',
-    'canonical factory',
+    'storefront canonical factory',
+  ],
+  [
+    ownerSource,
+    'pub fn in_process_shipping_option_admin_read_port(',
+    'admin canonical factory',
   ],
 ]) {
   requireText(source, value, label);
@@ -195,5 +210,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment owns active, administrative list-all, and lookup shipping-option projections behind one canonical read port while mounted storefront commerce retains owner context',
+  '✔ fulfillment owns storefront active/list lookup and administrative list-all projections behind separate canonical read ports while mounted storefront commerce retains owner context',
 );

--- a/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
@@ -34,6 +34,11 @@ const forbidText = (source, value, label) => {
 for (const [source, value, label] of [
   [ownerRoot, 'mod shipping_option_read;', 'private owner module'],
   [ownerRoot, 'InProcessShippingOptionReadPort,', 'wrapper export'],
+  [
+    ownerRoot,
+    'ListAllShippingOptionProjectionsRequest,',
+    'administrative list request export',
+  ],
   [ownerRoot, 'ShippingOptionReadPort,', 'trait export'],
   [ownerRoot, 'in_process_shipping_option_read_port,', 'root factory export'],
   [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'read port trait'],
@@ -49,17 +54,24 @@ for (const [source, value, label] of [
 }
 
 for (const [value, label] of [
-  ['async fn list_shipping_option_projections(', 'list operation'],
+  ['async fn list_shipping_option_projections(', 'active list operation'],
+  ['async fn list_all_shipping_option_projections(', 'administrative list operation'],
   ['async fn read_shipping_option_projection(', 'read operation'],
-  ['ListShippingOptionProjectionsRequest', 'list request'],
+  ['ListShippingOptionProjectionsRequest', 'active list request'],
+  ['ListAllShippingOptionProjectionsRequest', 'administrative list request'],
   ['ReadShippingOptionProjectionRequest', 'read request'],
   ['pub requested_locale: Option<String>', 'requested locale'],
   ['pub tenant_default_locale: Option<String>', 'default locale'],
   ['pub shipping_option_id: Uuid', 'option identity'],
   ['context.require_policy(PortCallPolicy::read())?', 'read admission policy'],
-  ['parse_tenant_id(&context, "list_shipping_option_projections")?', 'list tenant parse'],
+  ['parse_tenant_id(&context, "list_shipping_option_projections")?', 'active list tenant parse'],
+  [
+    'parse_tenant_id(&context, "list_all_shipping_option_projections")?',
+    'administrative list tenant parse',
+  ],
   ['parse_tenant_id(&context, "read_shipping_option_projection")?', 'read tenant parse'],
-  ['.list_shipping_options(', 'owner list delegation'],
+  ['.list_shipping_options(', 'owner active list delegation'],
+  ['.list_all_shipping_options(', 'owner administrative list delegation'],
   ['.get_shipping_option(', 'owner read delegation'],
   ['request.requested_locale.as_deref()', 'requested locale delegation'],
   ['request.tenant_default_locale.as_deref()', 'default locale delegation'],
@@ -69,7 +81,13 @@ for (const [value, label] of [
 
 const listDelegations = ownerSource.match(/\.list_shipping_options\(/g) ?? [];
 if (listDelegations.length !== 1) {
-  failures.push(`expected one owner list delegation, found ${listDelegations.length}`);
+  failures.push(`expected one owner active list delegation, found ${listDelegations.length}`);
+}
+const listAllDelegations = ownerSource.match(/\.list_all_shipping_options\(/g) ?? [];
+if (listAllDelegations.length !== 1) {
+  failures.push(
+    `expected one owner administrative list delegation, found ${listAllDelegations.length}`,
+  );
 }
 const readDelegations = ownerSource.match(/\.get_shipping_option\(/g) ?? [];
 if (readDelegations.length !== 1) {
@@ -177,5 +195,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment owns complete shipping-option reads behind a canonical read port and mounted commerce uses retained read context without concrete service construction',
+  '✔ fulfillment owns active, administrative list-all, and lookup shipping-option projections behind one canonical read port while mounted storefront commerce retains owner context',
 );


### PR DESCRIPTION
## Summary

- continue the open ecommerce topology P0 by publishing a fulfillment-owned `ShippingOptionAdminReadPort` for complete administrative shipping-option list-all projections;
- keep the existing storefront `ShippingOptionReadPort` unchanged, avoiding a breaking method addition and preserving active-only storefront semantics;
- add `ListAllShippingOptionProjectionsRequest`, `InProcessShippingOptionAdminReadPort`, and the canonical `in_process_shipping_option_admin_read_port` root factory;
- require read policy, parse tenant identity from `PortContext`, preserve requested/default locale arguments, and delegate only to fulfillment-owned `list_all_shipping_options`;
- reuse the stable fulfillment `PortError` mapping and correlation-safe diagnostics without exposing owner/database text;
- keep inactive shipping options visible to the administrative contract while the storefront list remains active-only;
- update fulfillment source documentation, the local implementation plan, and the focused static guard without promoting FBA/FFA status.

## Recheck

- continued from merged GraphQL shipping-option read-port PR #2336;
- confirmed #2336 is in `main` and its source branch is already deleted;
- confirmed no open PR overlaps the administrative shipping-option owner-read scope;
- confirmed the previous boundary explicitly left admin `list_all_shipping_options` on the compatibility delegate pending a separate owner contract;
- confirmed `ShippingOptionReadPort` has no other repository implementations, but kept it unchanged to avoid breaking external implementors;
- confirmed the branch is based directly on current `main`, is zero commits behind, and changes exactly five fulfillment source/documentation/guard files.

## Boundary

This PR publishes the separate administrative owner contract. It does not cut the mounted Commerce GraphQL `shipping_options` query over to the new port, inject either read port from the application host, migrate REST/native shipping reads, remove fulfillment lifecycle compatibility delegates, provide runtime/remote evidence, or promote fulfillment/ecommerce FBA or FFA status.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
```

## Next slice

Cut the mounted administrative GraphQL `shipping_options` query over to `ShippingOptionAdminReadPort` while preserving the current `FULFILLMENT_*` public message/code/retryability envelopes.