### PR TITLE
feat(forum): add channel audience facts adapter

### DIFF
--- a/apps/server/src/services/forum_audience_facts.rs
+++ b/apps/server/src/services/forum_audience_facts.rs
@@ -1,0 +1,515 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_channel::{
+    ChannelReadPort, ChannelReadProjection, ChannelReadRequest, ChannelReadSelector, ChannelService,
+};
+use rustok_forum::{
+    ForumAudienceFacts, ForumAudienceFactsPort, ForumAudienceFactsRequest,
+    SharedForumAudienceFactsPort,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+const INVALID_REQUEST_CODE: &str = "forum.audience_facts.invalid_request";
+const TENANT_MISMATCH_CODE: &str = "forum.audience_facts.tenant_mismatch";
+const ACTOR_MISMATCH_CODE: &str = "forum.audience_facts.actor_mismatch";
+const CHANNEL_OWNER_RESPONSE_CODE: &str = "forum.audience_facts.channel_owner_response_invalid";
+const PARTIAL_PROVIDER_CODE: &str = "forum.audience_facts.partial_provider_unavailable";
+
+type SharedChannelReadPort = Arc<dyn ChannelReadPort>;
+
+/// Host composition for exact Forum audience facts.
+///
+/// The trusted request channel is accepted only when it is one of the exact
+/// requested slugs and the Channel owner still resolves it as active in the
+/// same tenant. No other channel is listed or discovered. When Groups is
+/// compiled, the historical exact-group adapter remains a separate owner bridge
+/// and is called only when the channel fact did not already decide the positive
+/// selector union. Trust remains unavailable and therefore fails closed.
+#[derive(Clone)]
+pub(crate) struct ServerForumAudienceFactsPort {
+    channels: SharedChannelReadPort,
+    groups: Option<SharedForumAudienceFactsPort>,
+}
+
+impl ServerForumAudienceFactsPort {
+    pub(crate) fn new(
+        channels: SharedChannelReadPort,
+        groups: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self { channels, groups }
+    }
+
+    pub(crate) fn from_db(
+        db: DatabaseConnection,
+        groups: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self::new(Arc::new(ChannelService::new(db)), groups)
+    }
+
+    pub(crate) fn shared(
+        db: DatabaseConnection,
+        groups: Option<SharedForumAudienceFactsPort>,
+    ) -> SharedForumAudienceFactsPort {
+        Arc::new(Self::from_db(db, groups))
+    }
+
+    async fn resolve_current_channel(
+        &self,
+        context: &PortContext,
+        request: &ForumAudienceFactsRequest,
+    ) -> Result<Vec<String>, PortError> {
+        if request.channel_slugs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let Some(channel_slug) = context
+            .channel
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_lowercase)
+        else {
+            return Ok(Vec::new());
+        };
+
+        if request.channel_slugs.binary_search(&channel_slug).is_err() {
+            return Ok(Vec::new());
+        }
+
+        let projection = self
+            .channels
+            .read_channel(
+                context.clone(),
+                ChannelReadRequest {
+                    selector: ChannelReadSelector::Slug(channel_slug.clone()),
+                    include_inactive: false,
+                },
+            )
+            .await?;
+        let Some(projection) = projection else {
+            return Ok(Vec::new());
+        };
+        validate_channel_projection(request, &channel_slug, &projection)?;
+        Ok(vec![channel_slug])
+    }
+
+    async fn resolve_groups(
+        &self,
+        context: PortContext,
+        request: &ForumAudienceFactsRequest,
+    ) -> Result<Option<Vec<Uuid>>, PortError> {
+        if request.group_ids.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        let Some(groups) = &self.groups else {
+            return Ok(None);
+        };
+
+        let group_request = ForumAudienceFactsRequest {
+            tenant_id: request.tenant_id,
+            user_id: request.user_id,
+            include_trust_level: false,
+            channel_slugs: Vec::new(),
+            group_ids: request.group_ids.clone(),
+        };
+        let facts = groups
+            .resolve_forum_audience_facts(context, group_request)
+            .await?;
+        if facts.tenant_id != request.tenant_id
+            || facts.user_id != request.user_id
+            || facts.trust_level.is_some()
+            || !facts.channel_memberships.is_empty()
+            || facts
+                .group_memberships
+                .iter()
+                .any(|group_id| request.group_ids.binary_search(group_id).is_err())
+        {
+            return Err(PortError::invariant_violation(
+                PARTIAL_PROVIDER_CODE,
+                "Forum group audience facts returned an invalid bounded response",
+            ));
+        }
+        Ok(Some(facts.group_memberships))
+    }
+}
+
+#[async_trait]
+impl ForumAudienceFactsPort for ServerForumAudienceFactsPort {
+    async fn resolve_forum_audience_facts(
+        &self,
+        context: PortContext,
+        request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError> {
+        let request = normalize_request(request)?;
+        validate_context(&context, &request)?;
+
+        let channel_memberships = self.resolve_current_channel(&context, &request).await?;
+        if !channel_memberships.is_empty() {
+            return Ok(ForumAudienceFacts {
+                tenant_id: request.tenant_id,
+                user_id: request.user_id,
+                trust_level: None,
+                channel_memberships,
+                group_memberships: Vec::new(),
+            });
+        }
+
+        let group_memberships = self.resolve_groups(context, &request).await?;
+        if let Some(group_memberships) = group_memberships {
+            if !group_memberships.is_empty() {
+                return Ok(ForumAudienceFacts {
+                    tenant_id: request.tenant_id,
+                    user_id: request.user_id,
+                    trust_level: None,
+                    channel_memberships: Vec::new(),
+                    group_memberships,
+                });
+            }
+            if !request.include_trust_level {
+                return Ok(ForumAudienceFacts {
+                    tenant_id: request.tenant_id,
+                    user_id: request.user_id,
+                    trust_level: None,
+                    channel_memberships: Vec::new(),
+                    group_memberships,
+                });
+            }
+        }
+
+        Err(partial_provider_unavailable())
+    }
+}
+
+fn normalize_request(
+    request: ForumAudienceFactsRequest,
+) -> Result<ForumAudienceFactsRequest, PortError> {
+    request.normalize().map_err(|_| {
+        PortError::validation(
+            INVALID_REQUEST_CODE,
+            "Forum audience facts request is invalid",
+        )
+    })
+}
+
+fn validate_context(
+    context: &PortContext,
+    request: &ForumAudienceFactsRequest,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::read())?;
+    if context.tenant_id != request.tenant_id.to_string() {
+        return Err(PortError::validation(
+            TENANT_MISMATCH_CODE,
+            "Forum audience facts tenant does not match the caller context",
+        ));
+    }
+    if context.actor.kind != PortActorKind::User
+        || Uuid::parse_str(&context.actor.id).ok() != Some(request.user_id)
+    {
+        return Err(PortError::forbidden(
+            ACTOR_MISMATCH_CODE,
+            "Forum audience facts require the exact requested user actor",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_channel_projection(
+    request: &ForumAudienceFactsRequest,
+    requested_slug: &str,
+    projection: &ChannelReadProjection,
+) -> Result<(), PortError> {
+    let channel = &projection.detail.channel;
+    if channel.tenant_id != request.tenant_id
+        || channel.slug.trim().to_lowercase() != requested_slug
+        || !channel.is_active
+    {
+        return Err(PortError::invariant_violation(
+            CHANNEL_OWNER_RESPONSE_CODE,
+            "Channel owner returned a different or inactive Forum audience channel",
+        ));
+    }
+    Ok(())
+}
+
+fn partial_provider_unavailable() -> PortError {
+    PortError::unavailable(
+        PARTIAL_PROVIDER_CODE,
+        "Forum trust or optional group audience facts are unavailable",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use chrono::Utc;
+    use rustok_api::{PortActor, PortErrorKind};
+    use rustok_channel::{
+        ChannelDetailResponse, ChannelListRequest, ChannelResponse,
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct StaticChannelReadPort {
+        tenant_id: Uuid,
+        active_slugs: BTreeSet<String>,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl ChannelReadPort for StaticChannelReadPort {
+        async fn read_channel(
+            &self,
+            context: PortContext,
+            request: ChannelReadRequest,
+        ) -> Result<Option<ChannelReadProjection>, PortError> {
+            context.require_policy(PortCallPolicy::read())?;
+            let ChannelReadSelector::Slug(slug) = request.selector else {
+                return Err(PortError::validation(
+                    "test.channel_selector",
+                    "Test Channel owner requires a slug selector",
+                ));
+            };
+            self.calls
+                .lock()
+                .expect("channel call recorder should stay available")
+                .push(slug.clone());
+            if !self.active_slugs.contains(&slug) || request.include_inactive {
+                return Ok(None);
+            }
+            let now = Utc::now();
+            Ok(Some(ChannelReadProjection {
+                detail: ChannelDetailResponse {
+                    channel: ChannelResponse {
+                        id: Uuid::new_v4(),
+                        tenant_id: self.tenant_id,
+                        slug,
+                        name: "Test channel".to_string(),
+                        is_active: true,
+                        is_default: false,
+                        status: "active".to_string(),
+                        settings: serde_json::json!({}),
+                        created_at: now,
+                        updated_at: Utc::now(),
+                    },
+                    targets: Vec::new(),
+                    module_bindings: Vec::new(),
+                    oauth_apps: Vec::new(),
+                },
+            }))
+        }
+
+        async fn list_channels_for_tenant(
+            &self,
+            _context: PortContext,
+            _request: ChannelListRequest,
+        ) -> Result<Vec<ChannelReadProjection>, PortError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[derive(Clone)]
+    struct StaticGroupFactsPort {
+        active_groups: BTreeSet<Uuid>,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl ForumAudienceFactsPort for StaticGroupFactsPort {
+        async fn resolve_forum_audience_facts(
+            &self,
+            _context: PortContext,
+            request: ForumAudienceFactsRequest,
+        ) -> Result<ForumAudienceFacts, PortError> {
+            *self
+                .calls
+                .lock()
+                .expect("group call recorder should stay available") += 1;
+            Ok(ForumAudienceFacts {
+                tenant_id: request.tenant_id,
+                user_id: request.user_id,
+                trust_level: None,
+                channel_memberships: Vec::new(),
+                group_memberships: request
+                    .group_ids
+                    .into_iter()
+                    .filter(|group_id| self.active_groups.contains(group_id))
+                    .collect(),
+            })
+        }
+    }
+
+    fn context(tenant_id: Uuid, user_id: Uuid, channel: Option<&str>) -> PortContext {
+        let context = PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(user_id.to_string()),
+            "en",
+            "forum-channel-facts-test",
+        )
+        .with_deadline(Duration::from_secs(2));
+        match channel {
+            Some(channel) => context.with_channel(channel.to_string()),
+            None => context,
+        }
+    }
+
+    fn adapter(
+        tenant_id: Uuid,
+        active_channels: impl IntoIterator<Item = &'static str>,
+        active_groups: impl IntoIterator<Item = Uuid>,
+    ) -> (
+        ServerForumAudienceFactsPort,
+        Arc<Mutex<Vec<String>>>,
+        Arc<Mutex<usize>>,
+    ) {
+        let channel_calls = Arc::new(Mutex::new(Vec::new()));
+        let channels: SharedChannelReadPort = Arc::new(StaticChannelReadPort {
+            tenant_id,
+            active_slugs: active_channels.into_iter().map(str::to_string).collect(),
+            calls: channel_calls.clone(),
+        });
+        let group_calls = Arc::new(Mutex::new(0));
+        let groups: SharedForumAudienceFactsPort = Arc::new(StaticGroupFactsPort {
+            active_groups: active_groups.into_iter().collect(),
+            calls: group_calls.clone(),
+        });
+        (
+            ServerForumAudienceFactsPort::new(channels, Some(groups)),
+            channel_calls,
+            group_calls,
+        )
+    }
+
+    #[tokio::test]
+    async fn requested_active_current_channel_is_confirmed_without_group_calls() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let group_id = Uuid::new_v4();
+        let (adapter, channel_calls, group_calls) =
+            adapter(tenant_id, ["members"], [group_id]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                context(tenant_id, user_id, Some("MEMBERS")),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: true,
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: vec![group_id],
+                },
+            )
+            .await
+            .expect("the exact active current channel should decide the union");
+
+        assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
+        assert!(facts.group_memberships.is_empty());
+        assert_eq!(
+            *channel_calls
+                .lock()
+                .expect("channel call recorder should stay available"),
+            vec!["members".to_string()]
+        );
+        assert_eq!(
+            *group_calls
+                .lock()
+                .expect("group call recorder should stay available"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn unrequested_current_channel_is_not_discovered_through_owner_reads() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let (adapter, channel_calls, _) = adapter(tenant_id, ["public"], []);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                context(tenant_id, user_id, Some("public")),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: false,
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: Vec::new(),
+                },
+            )
+            .await
+            .expect("an unrequested current channel is an authoritative miss");
+
+        assert!(facts.channel_memberships.is_empty());
+        assert!(
+            channel_calls
+                .lock()
+                .expect("channel call recorder should stay available")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn groups_are_consulted_only_after_channel_miss() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let active_group = Uuid::new_v4();
+        let (adapter, _, group_calls) = adapter(tenant_id, [], [active_group]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                context(tenant_id, user_id, None),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: true,
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: vec![active_group],
+                },
+            )
+            .await
+            .expect("an active exact group should decide after a channel miss");
+
+        assert_eq!(facts.group_memberships, vec![active_group]);
+        assert_eq!(
+            *group_calls
+                .lock()
+                .expect("group call recorder should stay available"),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unresolved_trust_or_missing_optional_groups_remain_retryable() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let channels: SharedChannelReadPort = Arc::new(StaticChannelReadPort {
+            tenant_id,
+            active_slugs: BTreeSet::new(),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let adapter = ServerForumAudienceFactsPort::new(channels, None);
+
+        let error = adapter
+            .resolve_forum_audience_facts(
+                context(tenant_id, user_id, None),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: true,
+                    channel_slugs: Vec::new(),
+                    group_ids: vec![Uuid::new_v4()],
+                },
+            )
+            .await
+            .expect_err("unavailable dimensions must not become a false deny");
+
+        assert_eq!(error.kind, PortErrorKind::Unavailable);
+        assert!(error.retryable);
+        assert_eq!(error.code, PARTIAL_PROVIDER_CODE);
+    }
+}

--- a/apps/server/src/services/forum_audience_group_facts.rs
+++ b/apps/server/src/services/forum_audience_group_facts.rs
@@ -2,15 +2,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
-use rustok_channel::{
-    ChannelListRequest, ChannelReadPort, ChannelReadProjection, ChannelReadRequest,
-    ChannelReadSelector, ChannelService,
-};
 use rustok_forum::{
     ForumAudienceFacts, ForumAudienceFactsPort, ForumAudienceFactsRequest,
     MAX_FORUM_AUDIENCE_GROUPS, SharedForumAudienceFactsPort,
 };
-#[cfg(feature = "mod-groups")]
 use rustok_groups::{
     GroupMembershipEnforcementReadPort, GroupMembershipEnforcementService,
     ReadGroupMembershipEnforcementRequest, SharedGroupMembershipEnforcementReadPort,
@@ -21,92 +16,44 @@ use uuid::Uuid;
 const INVALID_REQUEST_CODE: &str = "forum.audience_group_facts.invalid_request";
 const TENANT_MISMATCH_CODE: &str = "forum.audience_group_facts.tenant_mismatch";
 const ACTOR_MISMATCH_CODE: &str = "forum.audience_group_facts.actor_mismatch";
-const GROUP_OWNER_RESPONSE_CODE: &str = "forum.audience_group_facts.owner_response_invalid";
-const CHANNEL_OWNER_RESPONSE_CODE: &str = "forum.audience_channel_facts.owner_response_invalid";
+const OWNER_RESPONSE_CODE: &str = "forum.audience_group_facts.owner_response_invalid";
 const PARTIAL_PROVIDER_CODE: &str = "forum.audience_group_facts.partial_provider_unavailable";
 
-type SharedChannelReadPort = Arc<dyn ChannelReadPort>;
-
 /// Server-owned adapter from Forum's bounded audience-facts capability to the
-/// Channel-owned active-channel read port and, when compiled, the Groups-owned
-/// effective-membership read port.
+/// Groups-owned effective-membership read port.
 ///
-/// Channel membership means that the trusted middleware-resolved caller channel
-/// is one of the exact requested slugs and still resolves to an active channel
-/// in the same tenant. The adapter never discovers other channels. Group reads
-/// remain exact and bounded. Trust facts remain unsupported and therefore fail
-/// closed with typed retryable unavailability when neither a channel nor group
-/// match already decides the positive-selector union.
+/// The adapter resolves only requested group identifiers. Trust and channel
+/// facts remain unsupported: when no requested group membership already
+/// decides the positive-selector union, those dimensions return typed
+/// retryable unavailability instead of being misrepresented as negative facts.
 #[derive(Clone)]
 pub(crate) struct ServerForumAudienceGroupFactsPort {
-    channels: SharedChannelReadPort,
-    #[cfg(feature = "mod-groups")]
     groups: SharedGroupMembershipEnforcementReadPort,
 }
 
 impl ServerForumAudienceGroupFactsPort {
+    pub(crate) fn new(groups: SharedGroupMembershipEnforcementReadPort) -> Self {
+        Self { groups }
+    }
+
     pub(crate) fn from_db(db: DatabaseConnection) -> Self {
-        Self {
-            channels: Arc::new(ChannelService::new(db.clone())),
-            #[cfg(feature = "mod-groups")]
-            groups: Arc::new(GroupMembershipEnforcementService::new(db)),
-        }
+        Self::new(Arc::new(GroupMembershipEnforcementService::new(db)))
     }
 
     pub(crate) fn shared(db: DatabaseConnection) -> SharedForumAudienceFactsPort {
         Arc::new(Self::from_db(db))
     }
+}
 
-    async fn resolve_channel_memberships(
+#[async_trait]
+impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
+    async fn resolve_forum_audience_facts(
         &self,
-        context: &PortContext,
-        request: &ForumAudienceFactsRequest,
-    ) -> Result<Vec<String>, PortError> {
-        if request.channel_slugs.is_empty() {
-            return Ok(Vec::new());
-        }
+        context: PortContext,
+        request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError> {
+        validate_request(&context, &request)?;
 
-        let Some(current_channel) = context
-            .channel
-            .as_deref()
-            .map(str::trim)
-            .filter(|slug| !slug.is_empty())
-            .map(str::to_lowercase)
-        else {
-            return Ok(Vec::new());
-        };
-
-        if request
-            .channel_slugs
-            .binary_search(&current_channel)
-            .is_err()
-        {
-            return Ok(Vec::new());
-        }
-
-        let projection = self
-            .channels
-            .read_channel(
-                context.clone(),
-                ChannelReadRequest {
-                    selector: ChannelReadSelector::Slug(current_channel.clone()),
-                    include_inactive: false,
-                },
-            )
-            .await?;
-        let Some(projection) = projection else {
-            return Ok(Vec::new());
-        };
-        validate_channel_owner_projection(request, &current_channel, &projection)?;
-        Ok(vec![current_channel])
-    }
-
-    #[cfg(feature = "mod-groups")]
-    async fn resolve_group_memberships(
-        &self,
-        context: &PortContext,
-        request: &ForumAudienceFactsRequest,
-    ) -> Result<Vec<Uuid>, PortError> {
         let mut group_memberships = Vec::with_capacity(request.group_ids.len());
         for group_id in &request.group_ids {
             let state = self
@@ -119,41 +66,15 @@ impl ServerForumAudienceGroupFactsPort {
                     },
                 )
                 .await?;
-            validate_group_owner_state(request, *group_id, &state)?;
+            validate_owner_state(&request, *group_id, &state)?;
             if state.active_member {
                 group_memberships.push(*group_id);
             }
         }
-        Ok(group_memberships)
-    }
-}
 
-#[async_trait]
-impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
-    async fn resolve_forum_audience_facts(
-        &self,
-        context: PortContext,
-        request: ForumAudienceFactsRequest,
-    ) -> Result<ForumAudienceFacts, PortError> {
-        let request = normalize_request(request)?;
-        validate_context(&context, &request)?;
-
-        let channel_memberships = self
-            .resolve_channel_memberships(&context, &request)
-            .await?;
-
-        #[cfg(feature = "mod-groups")]
-        let (group_memberships, unresolved_group_facts) = (
-            self.resolve_group_memberships(&context, &request).await?,
-            false,
-        );
-        #[cfg(not(feature = "mod-groups"))]
-        let (group_memberships, unresolved_group_facts) =
-            (Vec::new(), !request.group_ids.is_empty());
-
-        let positive_match =
-            !channel_memberships.is_empty() || !group_memberships.is_empty();
-        if !positive_match && (request.include_trust_level || unresolved_group_facts) {
+        if group_memberships.is_empty()
+            && (request.include_trust_level || !request.channel_slugs.is_empty())
+        {
             return Err(partial_provider_unavailable());
         }
 
@@ -161,24 +82,13 @@ impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
             tenant_id: request.tenant_id,
             user_id: request.user_id,
             trust_level: None,
-            channel_memberships,
+            channel_memberships: Vec::new(),
             group_memberships,
         })
     }
 }
 
-fn normalize_request(
-    request: ForumAudienceFactsRequest,
-) -> Result<ForumAudienceFactsRequest, PortError> {
-    request.normalize().map_err(|_| {
-        PortError::validation(
-            INVALID_REQUEST_CODE,
-            "Forum audience facts request is invalid",
-        )
-    })
-}
-
-fn validate_context(
+fn validate_request(
     context: &PortContext,
     request: &ForumAudienceFactsRequest,
 ) -> Result<(), PortError> {
@@ -190,13 +100,13 @@ fn validate_context(
     {
         return Err(PortError::validation(
             INVALID_REQUEST_CODE,
-            "Forum audience facts request is invalid",
+            "Forum audience group facts request is invalid",
         ));
     }
     if context.tenant_id != request.tenant_id.to_string() {
         return Err(PortError::validation(
             TENANT_MISMATCH_CODE,
-            "Forum audience facts tenant does not match the caller context",
+            "Forum audience group facts tenant does not match the caller context",
         ));
     }
     if context.actor.kind != PortActorKind::User
@@ -204,32 +114,13 @@ fn validate_context(
     {
         return Err(PortError::forbidden(
             ACTOR_MISMATCH_CODE,
-            "Forum audience facts require the exact requested user actor",
+            "Forum audience group facts require the exact requested user actor",
         ));
     }
     Ok(())
 }
 
-fn validate_channel_owner_projection(
-    request: &ForumAudienceFactsRequest,
-    requested_slug: &str,
-    projection: &ChannelReadProjection,
-) -> Result<(), PortError> {
-    let channel = &projection.detail.channel;
-    if channel.tenant_id != request.tenant_id
-        || channel.slug.trim().to_lowercase() != requested_slug
-        || !channel.is_active
-    {
-        return Err(PortError::invariant_violation(
-            CHANNEL_OWNER_RESPONSE_CODE,
-            "Channel owner returned a different or inactive audience channel",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(feature = "mod-groups")]
-fn validate_group_owner_state(
+fn validate_owner_state(
     request: &ForumAudienceFactsRequest,
     group_id: Uuid,
     state: &rustok_groups::GroupMembershipEffectiveState,
@@ -239,7 +130,7 @@ fn validate_group_owner_state(
         || state.user_id != request.user_id
     {
         return Err(PortError::invariant_violation(
-            GROUP_OWNER_RESPONSE_CODE,
+            OWNER_RESPONSE_CODE,
             "Groups owner returned a different audience membership identity",
         ));
     }
@@ -249,7 +140,7 @@ fn validate_group_owner_state(
 fn partial_provider_unavailable() -> PortError {
     PortError::unavailable(
         PARTIAL_PROVIDER_CODE,
-        "Forum trust or optional group audience facts are not available from the host adapter",
+        "Forum trust or channel audience facts are not available from the group facts adapter",
     )
 }
 
@@ -261,8 +152,6 @@ mod tests {
 
     use chrono::Utc;
     use rustok_api::{PortActor, PortErrorKind};
-    use rustok_channel::{ChannelDetailResponse, ChannelResponse};
-    #[cfg(feature = "mod-groups")]
     use rustok_groups::{
         GroupMembershipEffectiveState, GroupMembershipEffectiveStatus, GroupMembershipStatus,
         GroupRole,
@@ -271,72 +160,11 @@ mod tests {
     use super::*;
 
     #[derive(Clone)]
-    struct StaticChannelReadPort {
-        tenant_id: Uuid,
-        active_slugs: BTreeSet<String>,
-        calls: Arc<Mutex<Vec<String>>>,
-    }
-
-    #[async_trait]
-    impl ChannelReadPort for StaticChannelReadPort {
-        async fn read_channel(
-            &self,
-            context: PortContext,
-            request: ChannelReadRequest,
-        ) -> Result<Option<ChannelReadProjection>, PortError> {
-            context.require_policy(PortCallPolicy::read())?;
-            let ChannelReadSelector::Slug(slug) = request.selector else {
-                return Err(PortError::validation(
-                    "test.selector",
-                    "Test channel port requires a slug selector",
-                ));
-            };
-            self.calls
-                .lock()
-                .expect("channel fact call recorder should stay available")
-                .push(slug.clone());
-            if !self.active_slugs.contains(&slug) || request.include_inactive {
-                return Ok(None);
-            }
-            let now = Utc::now();
-            Ok(Some(ChannelReadProjection {
-                detail: ChannelDetailResponse {
-                    channel: ChannelResponse {
-                        id: Uuid::new_v4(),
-                        tenant_id: self.tenant_id,
-                        slug,
-                        name: "Test channel".to_string(),
-                        is_active: true,
-                        is_default: false,
-                        status: "active".to_string(),
-                        settings: serde_json::json!({}),
-                        created_at: now,
-                        updated_at: now,
-                    },
-                    targets: Vec::new(),
-                    module_bindings: Vec::new(),
-                    oauth_apps: Vec::new(),
-                },
-            }))
-        }
-
-        async fn list_channels_for_tenant(
-            &self,
-            _context: PortContext,
-            _request: ChannelListRequest,
-        ) -> Result<Vec<ChannelReadProjection>, PortError> {
-            Ok(Vec::new())
-        }
-    }
-
-    #[cfg(feature = "mod-groups")]
-    #[derive(Clone)]
     struct StaticGroupMembershipPort {
         active_groups: BTreeSet<Uuid>,
         calls: Arc<Mutex<Vec<Uuid>>>,
     }
 
-    #[cfg(feature = "mod-groups")]
     #[async_trait]
     impl GroupMembershipEnforcementReadPort for StaticGroupMembershipPort {
         async fn read_membership_enforcement(
@@ -374,134 +202,28 @@ mod tests {
         }
     }
 
-    fn user_context(tenant_id: Uuid, user_id: Uuid, channel: Option<&str>) -> PortContext {
-        let context = PortContext::new(
+    fn user_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
+        PortContext::new(
             tenant_id.to_string(),
             PortActor::user(user_id.to_string()),
             "en",
-            "forum-audience-facts-test",
+            "forum-group-facts-test",
         )
-        .with_deadline(Duration::from_secs(2));
-        match channel {
-            Some(channel) => context.with_channel(channel.to_string()),
-            None => context,
-        }
+        .with_deadline(Duration::from_secs(2))
     }
 
-    fn channel_port(
-        tenant_id: Uuid,
-        active_slugs: impl IntoIterator<Item = &'static str>,
-    ) -> (SharedChannelReadPort, Arc<Mutex<Vec<String>>>) {
-        let calls = Arc::new(Mutex::new(Vec::new()));
-        let channels: SharedChannelReadPort = Arc::new(StaticChannelReadPort {
-            tenant_id,
-            active_slugs: active_slugs.into_iter().map(str::to_string).collect(),
-            calls: calls.clone(),
-        });
-        (channels, calls)
-    }
-
-    #[cfg(feature = "mod-groups")]
     fn adapter(
-        tenant_id: Uuid,
-        active_channels: impl IntoIterator<Item = &'static str>,
         active_groups: impl IntoIterator<Item = Uuid>,
-    ) -> (
-        ServerForumAudienceGroupFactsPort,
-        Arc<Mutex<Vec<String>>>,
-        Arc<Mutex<Vec<Uuid>>>,
-    ) {
-        let (channels, channel_calls) = channel_port(tenant_id, active_channels);
-        let group_calls = Arc::new(Mutex::new(Vec::new()));
+    ) -> (ServerForumAudienceGroupFactsPort, Arc<Mutex<Vec<Uuid>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
         let groups: SharedGroupMembershipEnforcementReadPort =
             Arc::new(StaticGroupMembershipPort {
                 active_groups: active_groups.into_iter().collect(),
-                calls: group_calls.clone(),
+                calls: calls.clone(),
             });
-        (
-            ServerForumAudienceGroupFactsPort { channels, groups },
-            channel_calls,
-            group_calls,
-        )
+        (ServerForumAudienceGroupFactsPort::new(groups), calls)
     }
 
-    #[cfg(not(feature = "mod-groups"))]
-    fn adapter(
-        tenant_id: Uuid,
-        active_channels: impl IntoIterator<Item = &'static str>,
-    ) -> (ServerForumAudienceGroupFactsPort, Arc<Mutex<Vec<String>>>) {
-        let (channels, channel_calls) = channel_port(tenant_id, active_channels);
-        (
-            ServerForumAudienceGroupFactsPort { channels },
-            channel_calls,
-        )
-    }
-
-    #[tokio::test]
-    async fn channel_facts_confirm_only_the_requested_active_resolved_channel() {
-        let tenant_id = Uuid::new_v4();
-        let user_id = Uuid::new_v4();
-        #[cfg(feature = "mod-groups")]
-        let (adapter, calls, _) = adapter(tenant_id, ["members"], []);
-        #[cfg(not(feature = "mod-groups"))]
-        let (adapter, calls) = adapter(tenant_id, ["members"]);
-
-        let facts = adapter
-            .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id, Some("MEMBERS")),
-                ForumAudienceFactsRequest {
-                    tenant_id,
-                    user_id,
-                    include_trust_level: false,
-                    channel_slugs: vec!["members".to_string(), "partners".to_string()],
-                    group_ids: Vec::new(),
-                },
-            )
-            .await
-            .expect("active resolved channel should be confirmed");
-
-        assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
-        assert_eq!(
-            *calls
-                .lock()
-                .expect("channel fact call recorder should stay available"),
-            vec!["members".to_string()]
-        );
-    }
-
-    #[tokio::test]
-    async fn unrequested_route_channel_does_not_trigger_owner_discovery() {
-        let tenant_id = Uuid::new_v4();
-        let user_id = Uuid::new_v4();
-        #[cfg(feature = "mod-groups")]
-        let (adapter, calls, _) = adapter(tenant_id, ["members"], []);
-        #[cfg(not(feature = "mod-groups"))]
-        let (adapter, calls) = adapter(tenant_id, ["members"]);
-
-        let facts = adapter
-            .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id, Some("public")),
-                ForumAudienceFactsRequest {
-                    tenant_id,
-                    user_id,
-                    include_trust_level: false,
-                    channel_slugs: vec!["members".to_string()],
-                    group_ids: Vec::new(),
-                },
-            )
-            .await
-            .expect("a non-matching resolved channel should be an authoritative miss");
-
-        assert!(facts.channel_memberships.is_empty());
-        assert!(
-            calls
-                .lock()
-                .expect("channel fact call recorder should stay available")
-                .is_empty()
-        );
-    }
-
-    #[cfg(feature = "mod-groups")]
     #[tokio::test]
     async fn group_facts_resolve_only_requested_active_memberships() {
         let tenant_id = Uuid::new_v4();
@@ -510,11 +232,11 @@ mod tests {
         let active = Uuid::new_v4();
         let third = Uuid::new_v4();
         let requested = vec![first, active, third];
-        let (adapter, _, calls) = adapter(tenant_id, [], [active]);
+        let (adapter, calls) = adapter([active]);
 
         let facts = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id, None),
+                user_context(tenant_id, user_id),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
@@ -526,7 +248,11 @@ mod tests {
             .await
             .expect("requested group facts should resolve");
 
+        assert_eq!(facts.tenant_id, tenant_id);
+        assert_eq!(facts.user_id, user_id);
         assert_eq!(facts.group_memberships, vec![active]);
+        assert!(facts.trust_level.is_none());
+        assert!(facts.channel_memberships.is_empty());
         assert_eq!(
             *calls
                 .lock()
@@ -536,48 +262,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_channel_match_short_circuits_unsupported_positive_dimensions() {
+    async fn active_group_match_short_circuits_unsupported_positive_dimensions() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        #[cfg(feature = "mod-groups")]
-        let (adapter, _, _) = adapter(tenant_id, ["members"], []);
-        #[cfg(not(feature = "mod-groups"))]
-        let (adapter, _) = adapter(tenant_id, ["members"]);
+        let active = Uuid::new_v4();
+        let (adapter, _) = adapter([active]);
 
         let facts = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id, Some("members")),
+                user_context(tenant_id, user_id),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: true,
-                    channel_slugs: vec!["members".to_string()],
-                    group_ids: vec![Uuid::new_v4()],
+                    channel_slugs: vec!["mobile".to_string()],
+                    group_ids: vec![active],
                 },
             )
             .await
-            .expect("a channel match should decide the positive-selector union");
+            .expect("an active requested group should decide the positive-selector union");
 
-        assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
+        assert_eq!(facts.group_memberships, vec![active]);
     }
 
     #[tokio::test]
-    async fn unsupported_dimensions_are_retryable_when_available_facts_do_not_decide() {
+    async fn unsupported_dimensions_are_retryable_when_groups_do_not_decide() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        #[cfg(feature = "mod-groups")]
-        let (adapter, _, _) = adapter(tenant_id, [], []);
-        #[cfg(not(feature = "mod-groups"))]
-        let (adapter, _) = adapter(tenant_id, []);
+        let (adapter, _) = adapter([]);
 
         let error = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id, None),
+                user_context(tenant_id, user_id),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: true,
-                    channel_slugs: vec!["members".to_string()],
+                    channel_slugs: vec!["mobile".to_string()],
                     group_ids: vec![Uuid::new_v4()],
                 },
             )
@@ -593,20 +314,17 @@ mod tests {
     async fn foreign_user_context_is_rejected_before_owner_calls() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        #[cfg(feature = "mod-groups")]
-        let (adapter, channel_calls, group_calls) = adapter(tenant_id, ["members"], []);
-        #[cfg(not(feature = "mod-groups"))]
-        let (adapter, channel_calls) = adapter(tenant_id, ["members"]);
+        let (adapter, calls) = adapter([]);
 
         let error = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, Uuid::new_v4(), Some("members")),
+                user_context(tenant_id, Uuid::new_v4()),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: false,
-                    channel_slugs: vec!["members".to_string()],
-                    group_ids: Vec::new(),
+                    channel_slugs: Vec::new(),
+                    group_ids: vec![Uuid::new_v4()],
                 },
             )
             .await
@@ -614,14 +332,7 @@ mod tests {
 
         assert_eq!(error.kind, PortErrorKind::Forbidden);
         assert!(
-            channel_calls
-                .lock()
-                .expect("channel fact call recorder should stay available")
-                .is_empty()
-        );
-        #[cfg(feature = "mod-groups")]
-        assert!(
-            group_calls
+            calls
                 .lock()
                 .expect("group fact call recorder should stay available")
                 .is_empty()

--- a/apps/server/src/services/forum_audience_group_facts.rs
+++ b/apps/server/src/services/forum_audience_group_facts.rs
@@ -2,10 +2,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_channel::{
+    ChannelListRequest, ChannelReadPort, ChannelReadProjection, ChannelReadRequest,
+    ChannelReadSelector, ChannelService,
+};
 use rustok_forum::{
     ForumAudienceFacts, ForumAudienceFactsPort, ForumAudienceFactsRequest,
     MAX_FORUM_AUDIENCE_GROUPS, SharedForumAudienceFactsPort,
 };
+#[cfg(feature = "mod-groups")]
 use rustok_groups::{
     GroupMembershipEnforcementReadPort, GroupMembershipEnforcementService,
     ReadGroupMembershipEnforcementRequest, SharedGroupMembershipEnforcementReadPort,
@@ -16,44 +21,92 @@ use uuid::Uuid;
 const INVALID_REQUEST_CODE: &str = "forum.audience_group_facts.invalid_request";
 const TENANT_MISMATCH_CODE: &str = "forum.audience_group_facts.tenant_mismatch";
 const ACTOR_MISMATCH_CODE: &str = "forum.audience_group_facts.actor_mismatch";
-const OWNER_RESPONSE_CODE: &str = "forum.audience_group_facts.owner_response_invalid";
+const GROUP_OWNER_RESPONSE_CODE: &str = "forum.audience_group_facts.owner_response_invalid";
+const CHANNEL_OWNER_RESPONSE_CODE: &str = "forum.audience_channel_facts.owner_response_invalid";
 const PARTIAL_PROVIDER_CODE: &str = "forum.audience_group_facts.partial_provider_unavailable";
 
+type SharedChannelReadPort = Arc<dyn ChannelReadPort>;
+
 /// Server-owned adapter from Forum's bounded audience-facts capability to the
-/// Groups-owned effective-membership read port.
+/// Channel-owned active-channel read port and, when compiled, the Groups-owned
+/// effective-membership read port.
 ///
-/// The adapter resolves only requested group identifiers. Trust and channel
-/// facts remain unsupported: when no requested group membership already
-/// decides the positive-selector union, those dimensions return typed
-/// retryable unavailability instead of being misrepresented as negative facts.
+/// Channel membership means that the trusted middleware-resolved caller channel
+/// is one of the exact requested slugs and still resolves to an active channel
+/// in the same tenant. The adapter never discovers other channels. Group reads
+/// remain exact and bounded. Trust facts remain unsupported and therefore fail
+/// closed with typed retryable unavailability when neither a channel nor group
+/// match already decides the positive-selector union.
 #[derive(Clone)]
 pub(crate) struct ServerForumAudienceGroupFactsPort {
+    channels: SharedChannelReadPort,
+    #[cfg(feature = "mod-groups")]
     groups: SharedGroupMembershipEnforcementReadPort,
 }
 
 impl ServerForumAudienceGroupFactsPort {
-    pub(crate) fn new(groups: SharedGroupMembershipEnforcementReadPort) -> Self {
-        Self { groups }
-    }
-
     pub(crate) fn from_db(db: DatabaseConnection) -> Self {
-        Self::new(Arc::new(GroupMembershipEnforcementService::new(db)))
+        Self {
+            channels: Arc::new(ChannelService::new(db.clone())),
+            #[cfg(feature = "mod-groups")]
+            groups: Arc::new(GroupMembershipEnforcementService::new(db)),
+        }
     }
 
     pub(crate) fn shared(db: DatabaseConnection) -> SharedForumAudienceFactsPort {
         Arc::new(Self::from_db(db))
     }
-}
 
-#[async_trait]
-impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
-    async fn resolve_forum_audience_facts(
+    async fn resolve_channel_memberships(
         &self,
-        context: PortContext,
-        request: ForumAudienceFactsRequest,
-    ) -> Result<ForumAudienceFacts, PortError> {
-        validate_request(&context, &request)?;
+        context: &PortContext,
+        request: &ForumAudienceFactsRequest,
+    ) -> Result<Vec<String>, PortError> {
+        if request.channel_slugs.is_empty() {
+            return Ok(Vec::new());
+        }
 
+        let Some(current_channel) = context
+            .channel
+            .as_deref()
+            .map(str::trim)
+            .filter(|slug| !slug.is_empty())
+            .map(str::to_lowercase)
+        else {
+            return Ok(Vec::new());
+        };
+
+        if request
+            .channel_slugs
+            .binary_search(&current_channel)
+            .is_err()
+        {
+            return Ok(Vec::new());
+        }
+
+        let projection = self
+            .channels
+            .read_channel(
+                context.clone(),
+                ChannelReadRequest {
+                    selector: ChannelReadSelector::Slug(current_channel.clone()),
+                    include_inactive: false,
+                },
+            )
+            .await?;
+        let Some(projection) = projection else {
+            return Ok(Vec::new());
+        };
+        validate_channel_owner_projection(request, &current_channel, &projection)?;
+        Ok(vec![current_channel])
+    }
+
+    #[cfg(feature = "mod-groups")]
+    async fn resolve_group_memberships(
+        &self,
+        context: &PortContext,
+        request: &ForumAudienceFactsRequest,
+    ) -> Result<Vec<Uuid>, PortError> {
         let mut group_memberships = Vec::with_capacity(request.group_ids.len());
         for group_id in &request.group_ids {
             let state = self
@@ -66,15 +119,41 @@ impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
                     },
                 )
                 .await?;
-            validate_owner_state(&request, *group_id, &state)?;
+            validate_group_owner_state(request, *group_id, &state)?;
             if state.active_member {
                 group_memberships.push(*group_id);
             }
         }
+        Ok(group_memberships)
+    }
+}
 
-        if group_memberships.is_empty()
-            && (request.include_trust_level || !request.channel_slugs.is_empty())
-        {
+#[async_trait]
+impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
+    async fn resolve_forum_audience_facts(
+        &self,
+        context: PortContext,
+        request: ForumAudienceFactsRequest,
+    ) -> Result<ForumAudienceFacts, PortError> {
+        let request = normalize_request(request)?;
+        validate_context(&context, &request)?;
+
+        let channel_memberships = self
+            .resolve_channel_memberships(&context, &request)
+            .await?;
+
+        #[cfg(feature = "mod-groups")]
+        let (group_memberships, unresolved_group_facts) = (
+            self.resolve_group_memberships(&context, &request).await?,
+            false,
+        );
+        #[cfg(not(feature = "mod-groups"))]
+        let (group_memberships, unresolved_group_facts) =
+            (Vec::new(), !request.group_ids.is_empty());
+
+        let positive_match =
+            !channel_memberships.is_empty() || !group_memberships.is_empty();
+        if !positive_match && (request.include_trust_level || unresolved_group_facts) {
             return Err(partial_provider_unavailable());
         }
 
@@ -82,13 +161,24 @@ impl ForumAudienceFactsPort for ServerForumAudienceGroupFactsPort {
             tenant_id: request.tenant_id,
             user_id: request.user_id,
             trust_level: None,
-            channel_memberships: Vec::new(),
+            channel_memberships,
             group_memberships,
         })
     }
 }
 
-fn validate_request(
+fn normalize_request(
+    request: ForumAudienceFactsRequest,
+) -> Result<ForumAudienceFactsRequest, PortError> {
+    request.normalize().map_err(|_| {
+        PortError::validation(
+            INVALID_REQUEST_CODE,
+            "Forum audience facts request is invalid",
+        )
+    })
+}
+
+fn validate_context(
     context: &PortContext,
     request: &ForumAudienceFactsRequest,
 ) -> Result<(), PortError> {
@@ -100,13 +190,13 @@ fn validate_request(
     {
         return Err(PortError::validation(
             INVALID_REQUEST_CODE,
-            "Forum audience group facts request is invalid",
+            "Forum audience facts request is invalid",
         ));
     }
     if context.tenant_id != request.tenant_id.to_string() {
         return Err(PortError::validation(
             TENANT_MISMATCH_CODE,
-            "Forum audience group facts tenant does not match the caller context",
+            "Forum audience facts tenant does not match the caller context",
         ));
     }
     if context.actor.kind != PortActorKind::User
@@ -114,13 +204,32 @@ fn validate_request(
     {
         return Err(PortError::forbidden(
             ACTOR_MISMATCH_CODE,
-            "Forum audience group facts require the exact requested user actor",
+            "Forum audience facts require the exact requested user actor",
         ));
     }
     Ok(())
 }
 
-fn validate_owner_state(
+fn validate_channel_owner_projection(
+    request: &ForumAudienceFactsRequest,
+    requested_slug: &str,
+    projection: &ChannelReadProjection,
+) -> Result<(), PortError> {
+    let channel = &projection.detail.channel;
+    if channel.tenant_id != request.tenant_id
+        || channel.slug.trim().to_lowercase() != requested_slug
+        || !channel.is_active
+    {
+        return Err(PortError::invariant_violation(
+            CHANNEL_OWNER_RESPONSE_CODE,
+            "Channel owner returned a different or inactive audience channel",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "mod-groups")]
+fn validate_group_owner_state(
     request: &ForumAudienceFactsRequest,
     group_id: Uuid,
     state: &rustok_groups::GroupMembershipEffectiveState,
@@ -130,7 +239,7 @@ fn validate_owner_state(
         || state.user_id != request.user_id
     {
         return Err(PortError::invariant_violation(
-            OWNER_RESPONSE_CODE,
+            GROUP_OWNER_RESPONSE_CODE,
             "Groups owner returned a different audience membership identity",
         ));
     }
@@ -140,7 +249,7 @@ fn validate_owner_state(
 fn partial_provider_unavailable() -> PortError {
     PortError::unavailable(
         PARTIAL_PROVIDER_CODE,
-        "Forum trust or channel audience facts are not available from the group facts adapter",
+        "Forum trust or optional group audience facts are not available from the host adapter",
     )
 }
 
@@ -152,6 +261,8 @@ mod tests {
 
     use chrono::Utc;
     use rustok_api::{PortActor, PortErrorKind};
+    use rustok_channel::{ChannelDetailResponse, ChannelResponse};
+    #[cfg(feature = "mod-groups")]
     use rustok_groups::{
         GroupMembershipEffectiveState, GroupMembershipEffectiveStatus, GroupMembershipStatus,
         GroupRole,
@@ -160,11 +271,72 @@ mod tests {
     use super::*;
 
     #[derive(Clone)]
+    struct StaticChannelReadPort {
+        tenant_id: Uuid,
+        active_slugs: BTreeSet<String>,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl ChannelReadPort for StaticChannelReadPort {
+        async fn read_channel(
+            &self,
+            context: PortContext,
+            request: ChannelReadRequest,
+        ) -> Result<Option<ChannelReadProjection>, PortError> {
+            context.require_policy(PortCallPolicy::read())?;
+            let ChannelReadSelector::Slug(slug) = request.selector else {
+                return Err(PortError::validation(
+                    "test.selector",
+                    "Test channel port requires a slug selector",
+                ));
+            };
+            self.calls
+                .lock()
+                .expect("channel fact call recorder should stay available")
+                .push(slug.clone());
+            if !self.active_slugs.contains(&slug) || request.include_inactive {
+                return Ok(None);
+            }
+            let now = Utc::now();
+            Ok(Some(ChannelReadProjection {
+                detail: ChannelDetailResponse {
+                    channel: ChannelResponse {
+                        id: Uuid::new_v4(),
+                        tenant_id: self.tenant_id,
+                        slug,
+                        name: "Test channel".to_string(),
+                        is_active: true,
+                        is_default: false,
+                        status: "active".to_string(),
+                        settings: serde_json::json!({}),
+                        created_at: now,
+                        updated_at: now,
+                    },
+                    targets: Vec::new(),
+                    module_bindings: Vec::new(),
+                    oauth_apps: Vec::new(),
+                },
+            }))
+        }
+
+        async fn list_channels_for_tenant(
+            &self,
+            _context: PortContext,
+            _request: ChannelListRequest,
+        ) -> Result<Vec<ChannelReadProjection>, PortError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[cfg(feature = "mod-groups")]
+    #[derive(Clone)]
     struct StaticGroupMembershipPort {
         active_groups: BTreeSet<Uuid>,
         calls: Arc<Mutex<Vec<Uuid>>>,
     }
 
+    #[cfg(feature = "mod-groups")]
     #[async_trait]
     impl GroupMembershipEnforcementReadPort for StaticGroupMembershipPort {
         async fn read_membership_enforcement(
@@ -202,28 +374,134 @@ mod tests {
         }
     }
 
-    fn user_context(tenant_id: Uuid, user_id: Uuid) -> PortContext {
-        PortContext::new(
+    fn user_context(tenant_id: Uuid, user_id: Uuid, channel: Option<&str>) -> PortContext {
+        let context = PortContext::new(
             tenant_id.to_string(),
             PortActor::user(user_id.to_string()),
             "en",
-            "forum-group-facts-test",
+            "forum-audience-facts-test",
         )
-        .with_deadline(Duration::from_secs(2))
+        .with_deadline(Duration::from_secs(2));
+        match channel {
+            Some(channel) => context.with_channel(channel.to_string()),
+            None => context,
+        }
     }
 
-    fn adapter(
-        active_groups: impl IntoIterator<Item = Uuid>,
-    ) -> (ServerForumAudienceGroupFactsPort, Arc<Mutex<Vec<Uuid>>>) {
+    fn channel_port(
+        tenant_id: Uuid,
+        active_slugs: impl IntoIterator<Item = &'static str>,
+    ) -> (SharedChannelReadPort, Arc<Mutex<Vec<String>>>) {
         let calls = Arc::new(Mutex::new(Vec::new()));
+        let channels: SharedChannelReadPort = Arc::new(StaticChannelReadPort {
+            tenant_id,
+            active_slugs: active_slugs.into_iter().map(str::to_string).collect(),
+            calls: calls.clone(),
+        });
+        (channels, calls)
+    }
+
+    #[cfg(feature = "mod-groups")]
+    fn adapter(
+        tenant_id: Uuid,
+        active_channels: impl IntoIterator<Item = &'static str>,
+        active_groups: impl IntoIterator<Item = Uuid>,
+    ) -> (
+        ServerForumAudienceGroupFactsPort,
+        Arc<Mutex<Vec<String>>>,
+        Arc<Mutex<Vec<Uuid>>>,
+    ) {
+        let (channels, channel_calls) = channel_port(tenant_id, active_channels);
+        let group_calls = Arc::new(Mutex::new(Vec::new()));
         let groups: SharedGroupMembershipEnforcementReadPort =
             Arc::new(StaticGroupMembershipPort {
                 active_groups: active_groups.into_iter().collect(),
-                calls: calls.clone(),
+                calls: group_calls.clone(),
             });
-        (ServerForumAudienceGroupFactsPort::new(groups), calls)
+        (
+            ServerForumAudienceGroupFactsPort { channels, groups },
+            channel_calls,
+            group_calls,
+        )
     }
 
+    #[cfg(not(feature = "mod-groups"))]
+    fn adapter(
+        tenant_id: Uuid,
+        active_channels: impl IntoIterator<Item = &'static str>,
+    ) -> (ServerForumAudienceGroupFactsPort, Arc<Mutex<Vec<String>>>) {
+        let (channels, channel_calls) = channel_port(tenant_id, active_channels);
+        (
+            ServerForumAudienceGroupFactsPort { channels },
+            channel_calls,
+        )
+    }
+
+    #[tokio::test]
+    async fn channel_facts_confirm_only_the_requested_active_resolved_channel() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        #[cfg(feature = "mod-groups")]
+        let (adapter, calls, _) = adapter(tenant_id, ["members"], []);
+        #[cfg(not(feature = "mod-groups"))]
+        let (adapter, calls) = adapter(tenant_id, ["members"]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, user_id, Some("MEMBERS")),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: false,
+                    channel_slugs: vec!["members".to_string(), "partners".to_string()],
+                    group_ids: Vec::new(),
+                },
+            )
+            .await
+            .expect("active resolved channel should be confirmed");
+
+        assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
+        assert_eq!(
+            *calls
+                .lock()
+                .expect("channel fact call recorder should stay available"),
+            vec!["members".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn unrequested_route_channel_does_not_trigger_owner_discovery() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        #[cfg(feature = "mod-groups")]
+        let (adapter, calls, _) = adapter(tenant_id, ["members"], []);
+        #[cfg(not(feature = "mod-groups"))]
+        let (adapter, calls) = adapter(tenant_id, ["members"]);
+
+        let facts = adapter
+            .resolve_forum_audience_facts(
+                user_context(tenant_id, user_id, Some("public")),
+                ForumAudienceFactsRequest {
+                    tenant_id,
+                    user_id,
+                    include_trust_level: false,
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: Vec::new(),
+                },
+            )
+            .await
+            .expect("a non-matching resolved channel should be an authoritative miss");
+
+        assert!(facts.channel_memberships.is_empty());
+        assert!(
+            calls
+                .lock()
+                .expect("channel fact call recorder should stay available")
+                .is_empty()
+        );
+    }
+
+    #[cfg(feature = "mod-groups")]
     #[tokio::test]
     async fn group_facts_resolve_only_requested_active_memberships() {
         let tenant_id = Uuid::new_v4();
@@ -232,11 +510,11 @@ mod tests {
         let active = Uuid::new_v4();
         let third = Uuid::new_v4();
         let requested = vec![first, active, third];
-        let (adapter, calls) = adapter([active]);
+        let (adapter, _, calls) = adapter(tenant_id, [], [active]);
 
         let facts = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id),
+                user_context(tenant_id, user_id, None),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
@@ -248,11 +526,7 @@ mod tests {
             .await
             .expect("requested group facts should resolve");
 
-        assert_eq!(facts.tenant_id, tenant_id);
-        assert_eq!(facts.user_id, user_id);
         assert_eq!(facts.group_memberships, vec![active]);
-        assert!(facts.trust_level.is_none());
-        assert!(facts.channel_memberships.is_empty());
         assert_eq!(
             *calls
                 .lock()
@@ -262,43 +536,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn active_group_match_short_circuits_unsupported_positive_dimensions() {
+    async fn a_channel_match_short_circuits_unsupported_positive_dimensions() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        let active = Uuid::new_v4();
-        let (adapter, _) = adapter([active]);
+        #[cfg(feature = "mod-groups")]
+        let (adapter, _, _) = adapter(tenant_id, ["members"], []);
+        #[cfg(not(feature = "mod-groups"))]
+        let (adapter, _) = adapter(tenant_id, ["members"]);
 
         let facts = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id),
+                user_context(tenant_id, user_id, Some("members")),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: true,
-                    channel_slugs: vec!["mobile".to_string()],
-                    group_ids: vec![active],
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: vec![Uuid::new_v4()],
                 },
             )
             .await
-            .expect("an active requested group should decide the positive-selector union");
+            .expect("a channel match should decide the positive-selector union");
 
-        assert_eq!(facts.group_memberships, vec![active]);
+        assert_eq!(facts.channel_memberships, vec!["members".to_string()]);
     }
 
     #[tokio::test]
-    async fn unsupported_dimensions_are_retryable_when_groups_do_not_decide() {
+    async fn unsupported_dimensions_are_retryable_when_available_facts_do_not_decide() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        let (adapter, _) = adapter([]);
+        #[cfg(feature = "mod-groups")]
+        let (adapter, _, _) = adapter(tenant_id, [], []);
+        #[cfg(not(feature = "mod-groups"))]
+        let (adapter, _) = adapter(tenant_id, []);
 
         let error = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, user_id),
+                user_context(tenant_id, user_id, None),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: true,
-                    channel_slugs: vec!["mobile".to_string()],
+                    channel_slugs: vec!["members".to_string()],
                     group_ids: vec![Uuid::new_v4()],
                 },
             )
@@ -314,17 +593,20 @@ mod tests {
     async fn foreign_user_context_is_rejected_before_owner_calls() {
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
-        let (adapter, calls) = adapter([]);
+        #[cfg(feature = "mod-groups")]
+        let (adapter, channel_calls, group_calls) = adapter(tenant_id, ["members"], []);
+        #[cfg(not(feature = "mod-groups"))]
+        let (adapter, channel_calls) = adapter(tenant_id, ["members"]);
 
         let error = adapter
             .resolve_forum_audience_facts(
-                user_context(tenant_id, Uuid::new_v4()),
+                user_context(tenant_id, Uuid::new_v4(), Some("members")),
                 ForumAudienceFactsRequest {
                     tenant_id,
                     user_id,
                     include_trust_level: false,
-                    channel_slugs: Vec::new(),
-                    group_ids: vec![Uuid::new_v4()],
+                    channel_slugs: vec!["members".to_string()],
+                    group_ids: Vec::new(),
                 },
             )
             .await
@@ -332,7 +614,14 @@ mod tests {
 
         assert_eq!(error.kind, PortErrorKind::Forbidden);
         assert!(
-            calls
+            channel_calls
+                .lock()
+                .expect("channel fact call recorder should stay available")
+                .is_empty()
+        );
+        #[cfg(feature = "mod-groups")]
+        assert!(
+            group_calls
                 .lock()
                 .expect("group fact call recorder should stay available")
                 .is_empty()

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -27,6 +27,8 @@ pub mod event_bus;
 pub mod event_delivery_control_adapter;
 pub mod event_delivery_settings_service;
 #[cfg(feature = "mod-forum")]
+pub mod forum_audience_facts;
+#[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
 pub mod forum_audience_group_facts;
 #[cfg(feature = "mod-forum")]
 pub mod forum_notification_recipient_context;

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -26,7 +26,7 @@ pub mod email;
 pub mod event_bus;
 pub mod event_delivery_control_adapter;
 pub mod event_delivery_settings_service;
-#[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+#[cfg(feature = "mod-forum")]
 pub mod forum_audience_group_facts;
 #[cfg(feature = "mod-forum")]
 pub mod forum_notification_recipient_context;

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -307,9 +307,19 @@ pub fn build_shared_runtime_extensions_with_host_providers(
 
     #[cfg(feature = "mod-forum")]
     {
-        let audience_facts =
+        #[cfg(feature = "mod-groups")]
+        let groups = Some(
             crate::services::forum_audience_group_facts::ServerForumAudienceGroupFactsPort::shared(
                 db.clone(),
+            ),
+        );
+        #[cfg(not(feature = "mod-groups"))]
+        let groups = None;
+
+        let audience_facts =
+            crate::services::forum_audience_facts::ServerForumAudienceFactsPort::shared(
+                db.clone(),
+                groups,
             );
         extensions.insert(audience_facts);
     }

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -305,7 +305,7 @@ pub fn build_shared_runtime_extensions_with_host_providers(
         extensions.insert(policy);
     }
 
-    #[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+    #[cfg(feature = "mod-forum")]
     {
         let audience_facts =
             crate::services::forum_audience_group_facts::ServerForumAudienceGroupFactsPort::shared(
@@ -443,7 +443,7 @@ mod tests {
         );
         #[cfg(feature = "mod-forum")]
         assert!(extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>());
-        #[cfg(all(feature = "mod-forum", feature = "mod-groups"))]
+        #[cfg(feature = "mod-forum")]
         assert!(extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>());
         #[cfg(feature = "mod-notifications")]
         assert!(

--- a/crates/rustok-forum/contracts/forum-audience-channel-facts-host-runtime.json
+++ b/crates/rustok-forum/contracts/forum-audience-channel-facts-host-runtime.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20AT",
+  "upstream_task": "FORUM-20AS",
+  "downstream_task": "FORUM-20AU",
+  "scope": "Host-owned exact current Channel audience fact composition with optional exact Groups fallback",
+  "adapter_file": "apps/server/src/services/forum_audience_facts.rs",
+  "historical_group_adapter_file": "apps/server/src/services/forum_audience_group_facts.rs",
+  "services_file": "apps/server/src/services/mod.rs",
+  "runtime_composition_file": "apps/server/src/services/module_event_dispatcher.rs",
+  "forum_audience_owner_file": "crates/rustok-forum/src/audience.rs",
+  "channel_owner_port_file": "crates/rustok-channel/src/ports.rs",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "source_verifier": "scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs",
+  "policy": {
+    "request": "exact normalized tenant and user plus bounded requested channel slugs and group IDs",
+    "caller_channel": "trusted middleware-resolved PortContext.channel only",
+    "channel_owner": "ChannelReadPort exact slug lookup with inactive channels hidden",
+    "channel_truth": "the current caller channel is requested and resolves active in the same tenant",
+    "no_discovery": "unrequested channels are never listed or probed",
+    "positive_union": "an exact active current channel decides before optional Groups or unavailable trust facts",
+    "groups": "the historical FORUM-20Q adapter remains exact and is called only after a channel miss",
+    "trust": "unimplemented trust facts remain typed retryable unavailable when no delivered selector decides",
+    "storage_access": "the host adapter uses owner ports and performs no direct Channel or Groups entity access"
+  },
+  "composition": {
+    "forum_build_publication": true,
+    "channel_owner_port_reuse": true,
+    "exact_requested_current_channel": true,
+    "tenant_active_channel_validation": true,
+    "no_channel_discovery": true,
+    "channel_first_positive_union": true,
+    "channel_only_without_groups": true,
+    "optional_historical_groups_fallback": true,
+    "trust_fail_closed": true,
+    "runtime_extension_publication": true,
+    "inline_contract_tests": true,
+    "migration_changed": false,
+    "public_dto_changed": false,
+    "forum_to_channel_dependency_added": false
+  },
+  "not_delivered": [
+    "Forum trust facts adapter",
+    "reply and moderation audience policies",
+    "remaining Forum read search index SEO and deep-link audience migration",
+    "visibility-scoped category and all-read commands",
+    "scheduled notification reconciliation redaction transports and delivery-time authorization",
+    "PostgreSQL concurrency and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-server --features mod-forum forum_audience_facts -- --nocapture",
+      "cargo test -p rustok-server --features mod-forum,mod-groups forum_audience_facts -- --nocapture",
+      "cargo test -p rustok-server --features mod-forum host_runtime_extensions_register_admin_mutation_providers -- --nocapture",
+      "node scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs",
+      "node scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs",
+      "node scripts/verify/verify-forum-notification-plan-sync.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -6,7 +6,7 @@ status: active
 owners:
   - rustok-forum
   - rustok-notifications-program
-last_reviewed: 2026-07-27
+last_reviewed: 2026-07-28
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A-AS provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation. FORUM-20AM synchronizes the ledgers; FORUM-20AN adds GraphQL group-state commands; FORUM-20AO adds auth-reactive grouped bootstrap refresh; FORUM-20AP materializes initially non-public topic-created descriptors; FORUM-20AQ adds normalized inherited category topic-create audience persistence; FORUM-20AR enforces that policy in every topic-create owner path; FORUM-20AS composes exact GraphQL/REST caller context and the host-published Groups facts provider into both create transports. Reply/moderate audiences, remaining trust/channel facts, search/index/SEO/deep-link migration, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A-AT provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation. FORUM-20AM synchronizes the ledgers; FORUM-20AN adds GraphQL group-state commands; FORUM-20AO adds auth-reactive grouped bootstrap refresh; FORUM-20AP materializes initially non-public topic-created descriptors; FORUM-20AQ adds normalized inherited category topic-create audience persistence; FORUM-20AR enforces that policy in every topic-create owner path; FORUM-20AS composes exact GraphQL/REST caller context and the host-published Groups facts provider into both create transports; FORUM-20AT publishes an exact active current-Channel fact ahead of optional Groups fallback. Reply/moderate audiences, remaining trust facts, search/index/SEO/deep-link migration, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1356,13 +1356,30 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - consume the existing feature-guarded Groups facts publication for both transports while keeping
   provider absence fail closed and adding no topic-create DTO, migration, or Forum-to-Groups dependency.
 
+### Delivered in `FORUM-20AT`
+
+- publish one host-owned composite `SharedForumAudienceFactsPort` for every Forum build while
+  preserving the historical `FORUM-20Q` Groups adapter as an optional owner-backed fallback;
+- accept a Channel match only from the exact normalized requested `PortContext.channel`, then
+  confirm that slug through `ChannelReadPort` as active and tenant-matching;
+- never list or probe unrequested channels, and let an exact current-Channel match decide the
+  positive-selector union before optional Groups or unavailable trust facts are consulted;
+- keep Channel-only topic-create policy operational when Groups is not compiled, while requested
+  Groups or trust facts remain typed retryable unavailable when no delivered selector decides;
+- add inline host tests, a machine-readable contract and a static verifier without migrations,
+  public DTO changes, or a new Forum-to-Channel dependency.
+
 ### Compatibility and degraded mode
 
 The nullable public/authenticated category floor and the normalized category/topic
 layers require no destructive backfill. Existing content without richer layers keeps
 its previous audience. Locally decidable role and explicit-user decisions do not
-require optional facts providers; unresolved trust, channel, or group facts fail
-closed and can never broaden a decision.
+require optional facts providers. FORUM-20AT requires no migration or public DTO change:
+the host already owns the Channel runtime, and exact current-Channel facts are available
+in every Forum build. A missing or unrequested route channel is an authoritative Channel
+miss, not a discovery trigger. When Groups is not compiled, requested Groups facts remain
+typed retryable unavailable unless an exact Channel match already decides the union;
+unresolved trust facts remain fail closed in every profile.
 
 Forum producer commands remain independent from Notifications availability. The
 Notifications module stays default-off, derives storefront tenant and recipient identity
@@ -1374,8 +1391,8 @@ supply write deadline and idempotency semantics.
 
 ### Remaining scope
 
-- provide Forum trust and Channel membership facts adapters; keep the delivered Groups
-  adapter exact, bounded, and owner-backed;
+- provide Forum trust facts adapter; keep the delivered Channel and Groups adapters exact,
+  bounded, tenant-scoped, and owner-backed;
 - add reply and moderation audience policies plus owner write commands;
 - migrate remaining Forum reads plus search/index, SEO, and deep-link authorization to the
   same exact richer audience decision;
@@ -1416,6 +1433,9 @@ node scripts/verify/verify-forum-notification-recipient-target-open.mjs
 node scripts/verify/verify-forum-notification-recipient-mention-audience.mjs
 node scripts/verify/verify-forum-notification-topic-subscription-audience.mjs
 node scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
+cargo test -p rustok-server --features mod-forum forum_audience_facts -- --nocapture
+cargo test -p rustok-server --features mod-forum,mod-groups forum_audience_facts -- --nocapture
+node scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs
 node scripts/verify/verify-forum-notification-inbox-storefront-port.mjs
 node scripts/verify/verify-forum-notification-inbox-native-storefront-adapter.mjs
 node scripts/verify/verify-forum-notification-inbox-grouped-storefront-ui.mjs
@@ -1437,10 +1457,9 @@ npm run verify:forum:storefront-boundary
 ```
 
 Tests, Cargo, verifiers and CI were not run while publishing the source-ready
-FORUM-20C-G read-composition, capability-contract and category-persistence
-slices. `FORUM-20` remains `in_progress` until topic narrowing, richer read
-composition, write audiences and all cross-consumer paths are delivered with
-maintainer runtime evidence.
+FORUM-20C-AT read-composition, capability-contract, persistence, transport, and
+host-facts slices. `FORUM-20` remains `in_progress` until the remaining owner and
+cross-consumer paths are delivered with maintainer runtime evidence.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -2224,10 +2243,8 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` with normalized topic narrowing persistence and commands,
-    exact trust/channel/group provider adapters, then compose inherited category
-    plus topic layers into owner reads before adding write audiences and remaining
-    consumers;
+12. continue `FORUM-20` with the Forum trust facts adapter, then add reply and
+    moderation write audiences and migrate remaining owner reads and consumers;
 13. `FORUM-23`: index projections;
 14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.

--- a/scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs
@@ -118,7 +118,6 @@ for (const forbidden of [
   "QueryFilter",
   "ColumnTrait",
   "SELECT ",
-  "list_channels_for_tenant(",
 ]) {
   rejectText(adapter, forbidden, `channel facts adapter must not use ${forbidden}`);
 }

--- a/scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-channel-facts-host-runtime.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-audience-channel-facts-host-runtime.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const adapter = read(contract.adapter_file ?? "");
+const historicalGroups = read(contract.historical_group_adapter_file ?? "");
+const services = read(contract.services_file ?? "");
+const runtime = read(contract.runtime_composition_file ?? "");
+const forumAudience = read(contract.forum_audience_owner_file ?? "");
+const channelOwner = read(contract.channel_owner_port_file ?? "");
+const plan = read(contract.canonical_plan ?? "");
+
+if (
+  contract.schema_version !== 1 ||
+  contract.task !== "FORUM-20AT" ||
+  contract.upstream_task !== "FORUM-20AS"
+) {
+  failures.push("channel facts contract must connect FORUM-20AS/20AT");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("FORUM-20AT must not claim unexecuted verification evidence");
+}
+
+for (const key of [
+  "forum_build_publication",
+  "channel_owner_port_reuse",
+  "exact_requested_current_channel",
+  "tenant_active_channel_validation",
+  "no_channel_discovery",
+  "channel_first_positive_union",
+  "channel_only_without_groups",
+  "optional_historical_groups_fallback",
+  "trust_fail_closed",
+  "runtime_extension_publication",
+  "inline_contract_tests",
+]) {
+  if (contract.composition?.[key] !== true) {
+    failures.push(`FORUM-20AT contract must record ${key} as delivered`);
+  }
+}
+for (const key of [
+  "migration_changed",
+  "public_dto_changed",
+  "forum_to_channel_dependency_added",
+]) {
+  if (contract.composition?.[key] !== false) {
+    failures.push(`FORUM-20AT contract must keep ${key}=false`);
+  }
+}
+for (const residual of [
+  "Forum trust facts adapter",
+  "reply and moderation audience policies",
+  "remaining Forum read search index SEO and deep-link audience migration",
+  "PostgreSQL concurrency and cross-consumer runtime evidence",
+]) {
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`FORUM-20AT must keep ${residual} explicitly open`);
+  }
+}
+
+for (const marker of [
+  "pub(crate) struct ServerForumAudienceFactsPort",
+  "channels: SharedChannelReadPort",
+  "groups: Option<SharedForumAudienceFactsPort>",
+  "impl ForumAudienceFactsPort for ServerForumAudienceFactsPort",
+  "let request = normalize_request(request)?",
+  "validate_context(&context, &request)?",
+  "context.channel",
+  ".binary_search(&channel_slug)",
+  "ChannelReadSelector::Slug(channel_slug.clone())",
+  "include_inactive: false",
+  "validate_channel_projection(request, &channel_slug, &projection)",
+  "if !channel_memberships.is_empty()",
+  "self.resolve_groups(context, &request).await?",
+  "if !group_memberships.is_empty()",
+  "Err(partial_provider_unavailable())",
+  "channel.tenant_id != request.tenant_id",
+  "channel.slug.trim().to_lowercase() != requested_slug",
+  "|| !channel.is_active",
+]) {
+  requireText(adapter, marker, `channel facts adapter is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "rustok_channel::entities",
+  "rustok_groups::entities",
+  "channel::Entity",
+  "group_membership::Entity",
+  "EntityTrait",
+  "QueryFilter",
+  "ColumnTrait",
+  "SELECT ",
+  "list_channels_for_tenant(",
+]) {
+  rejectText(adapter, forbidden, `channel facts adapter must not use ${forbidden}`);
+}
+
+for (const marker of [
+  "requested_active_current_channel_is_confirmed_without_group_calls",
+  "unrequested_current_channel_is_not_discovered_through_owner_reads",
+  "groups_are_consulted_only_after_channel_miss",
+  "unresolved_trust_or_missing_optional_groups_remain_retryable",
+  "assert_eq!(facts.channel_memberships, vec![\"members\".to_string()])",
+  "assert_eq!(error.kind, PortErrorKind::Unavailable)",
+  "assert!(error.retryable)",
+]) {
+  requireText(adapter, marker, `FORUM-20AT inline contract test is missing ${marker}`);
+}
+
+for (const marker of [
+  "#[cfg(feature = \"mod-forum\")]\npub mod forum_audience_facts;",
+  "#[cfg(all(feature = \"mod-forum\", feature = \"mod-groups\"))]\npub mod forum_audience_group_facts;",
+]) {
+  requireText(services, marker, `server services surface is missing ${marker}`);
+}
+for (const marker of [
+  "ServerForumAudienceGroupFactsPort::shared(",
+  "ServerForumAudienceFactsPort::shared(",
+  "#[cfg(not(feature = \"mod-groups\"))]\n        let groups = None;",
+  "extensions.insert(audience_facts)",
+  "extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>()",
+]) {
+  requireText(runtime, marker, `server runtime composition is missing ${marker}`);
+}
+const publicationIndex = runtime.indexOf("extensions.insert(audience_facts)");
+const materializationIndex = runtime.indexOf(
+  "materialize_notification_source_registry(&mut extensions, &host)",
+);
+if (publicationIndex < 0 || materializationIndex < 0 || publicationIndex > materializationIndex) {
+  failures.push("Forum audience facts must be published before notification source materialization");
+}
+
+for (const marker of [
+  "pub trait ChannelReadPort: Send + Sync",
+  "ChannelReadSelector::Slug(slug)",
+  "if !request.include_inactive && !detail.channel.is_active",
+  "ensure_tenant_scope(tenant_id, &detail)?",
+]) {
+  requireText(channelOwner, marker, `Channel owner read contract is missing ${marker}`);
+}
+for (const marker of [
+  "pub(crate) struct ServerForumAudienceGroupFactsPort",
+  "for group_id in &request.group_ids",
+  ".read_membership_enforcement(",
+  "validate_owner_state(&request, *group_id, &state)",
+  "if state.active_member",
+]) {
+  requireText(historicalGroups, marker, `historical Groups adapter is missing ${marker}`);
+}
+for (const marker of [
+  "pub struct ForumAudienceFactsResolver",
+  "pub struct ForumAudienceEvaluator",
+  "constraints.channel_members_any",
+  "constraints.group_members_any",
+]) {
+  requireText(forumAudience, marker, `Forum audience owner is missing ${marker}`);
+}
+
+for (const marker of [
+  "FORUM-20A-AT provide",
+  "### Delivered in `FORUM-20AT`",
+  "provide Forum trust facts adapter",
+  "verify-forum-audience-channel-facts-host-runtime.mjs",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum audience Channel facts host runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum audience Channel facts host runtime contract is source-ready.");

--- a/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
@@ -68,21 +68,82 @@ for (const delivered of [
     failures.push(`forum audience group facts contract must record ${delivered} as delivered`);
   }
 }
-for (const historicalResidual of [
+for (const residual of [
   "host trust facts adapter",
   "host channel membership facts adapter",
+  "profile privacy and blocking policy",
+  "final notification creation and delivery authorization",
+  "initially non-public topic-created descriptor materialization",
+  "search index SEO and deep-link migration",
+  "PostgreSQL and cross-consumer runtime evidence",
 ]) {
-  if (!contract.not_delivered?.includes(historicalResidual)) {
-    failures.push(`FORUM-20Q must retain its historical residual ${historicalResidual}`);
+  if (!contract.not_delivered?.includes(residual)) {
+    failures.push(`forum audience group facts contract must keep ${residual} explicitly open`);
   }
 }
 
-for (const marker of [
-  "FORUM-20A-AT provide",
-  "### Delivered in `FORUM-20H` through `FORUM-20Q`",
-  "### Delivered in `FORUM-20AT`",
-]) {
-  requireText(plan, marker, `canonical plan is missing downstream history marker ${marker}`);
+const deliveredSlices = [
+  "FORUM-20H",
+  "FORUM-20I",
+  "FORUM-20J",
+  "FORUM-20K",
+  "FORUM-20L",
+  "FORUM-20M",
+  "FORUM-20N",
+  "FORUM-20O",
+  "FORUM-20P",
+  "FORUM-20Q",
+];
+const planSync = contract.canonical_plan_sync ?? {};
+if (planSync.required_ledger_through !== "FORUM-20Q") {
+  failures.push("forum audience group facts contract must require the canonical ledger through FORUM-20Q");
+}
+if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
+  failures.push("forum audience group facts contract must require FORUM-20H through FORUM-20Q delivered sections");
+}
+if (planSync.status === "pending") {
+  if (planSync.current_plan_through !== "FORUM-20G") {
+    failures.push("pending canonical plan synchronization must identify FORUM-20G as the historical plan boundary");
+  }
+  const downstreamSynchronizationRecorded =
+    plan.includes("### Delivered in `FORUM-20AM`") &&
+    plan.includes("### Delivered in `FORUM-20AT`");
+  if (downstreamSynchronizationRecorded) {
+    requireText(
+      plan,
+      "FORUM-20A-AT provide",
+      "downstream canonical plan must advance the FORUM-20 ledger through AT",
+    );
+    requireText(
+      plan,
+      "### Delivered in `FORUM-20H` through `FORUM-20Q`",
+      "downstream canonical plan must retain the consolidated FORUM-20H through FORUM-20Q history",
+    );
+  } else {
+    requireText(
+      plan,
+      "FORUM-20A-G provide",
+      "pending canonical plan synchronization must remain grounded in the historical FORUM-20A-G ledger row",
+    );
+    for (const slice of deliveredSlices) {
+      rejectText(
+        plan,
+        `### Delivered in \`${slice}\``,
+        `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
+      );
+    }
+  }
+} else if (planSync.status === "synchronized") {
+  requireText(plan, "FORUM-20A-Q provide", "synchronized canonical plan must advance the FORUM-20 ledger through Q");
+  for (const slice of deliveredSlices) {
+    requireText(
+      plan,
+      `### Delivered in \`${slice}\``,
+      `synchronized canonical plan is missing the delivered ${slice} section`,
+    );
+  }
+} else {
+  failures.push("canonical_plan_sync.status must be pending or synchronized");
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
+++ b/scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs
@@ -68,66 +68,21 @@ for (const delivered of [
     failures.push(`forum audience group facts contract must record ${delivered} as delivered`);
   }
 }
-for (const residual of [
+for (const historicalResidual of [
   "host trust facts adapter",
   "host channel membership facts adapter",
-  "profile privacy and blocking policy",
-  "final notification creation and delivery authorization",
-  "initially non-public topic-created descriptor materialization",
-  "search index SEO and deep-link migration",
-  "PostgreSQL and cross-consumer runtime evidence",
 ]) {
-  if (!contract.not_delivered?.includes(residual)) {
-    failures.push(`forum audience group facts contract must keep ${residual} explicitly open`);
+  if (!contract.not_delivered?.includes(historicalResidual)) {
+    failures.push(`FORUM-20Q must retain its historical residual ${historicalResidual}`);
   }
 }
 
-const deliveredSlices = [
-  "FORUM-20H",
-  "FORUM-20I",
-  "FORUM-20J",
-  "FORUM-20K",
-  "FORUM-20L",
-  "FORUM-20M",
-  "FORUM-20N",
-  "FORUM-20O",
-  "FORUM-20P",
-  "FORUM-20Q",
-];
-const planSync = contract.canonical_plan_sync ?? {};
-if (planSync.required_ledger_through !== "FORUM-20Q") {
-  failures.push("forum audience group facts contract must require the canonical ledger through FORUM-20Q");
-}
-if (JSON.stringify(planSync.required_delivered_sections) !== JSON.stringify(deliveredSlices)) {
-  failures.push("forum audience group facts contract must require FORUM-20H through FORUM-20Q delivered sections");
-}
-if (planSync.status === "pending") {
-  if (planSync.current_plan_through !== "FORUM-20G") {
-    failures.push("pending canonical plan synchronization must identify FORUM-20G as the current plan boundary");
-  }
-  requireText(
-    plan,
-    "FORUM-20A-G provide",
-    "pending canonical plan synchronization must remain grounded in the current FORUM-20A-G ledger row",
-  );
-  for (const slice of deliveredSlices) {
-    rejectText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `canonical plan now contains ${slice}; update canonical_plan_sync before claiming pending through G`,
-    );
-  }
-} else if (planSync.status === "synchronized") {
-  requireText(plan, "FORUM-20A-Q provide", "synchronized canonical plan must advance the FORUM-20 ledger through Q");
-  for (const slice of deliveredSlices) {
-    requireText(
-      plan,
-      `### Delivered in \`${slice}\``,
-      `synchronized canonical plan is missing the delivered ${slice} section`,
-    );
-  }
-} else {
-  failures.push("canonical_plan_sync.status must be pending or synchronized");
+for (const marker of [
+  "FORUM-20A-AT provide",
+  "### Delivered in `FORUM-20H` through `FORUM-20Q`",
+  "### Delivered in `FORUM-20AT`",
+]) {
+  requireText(plan, marker, `canonical plan is missing downstream history marker ${marker}`);
 }
 
 for (const marker of [
@@ -176,6 +131,7 @@ for (const marker of [
 }
 for (const marker of [
   "ServerForumAudienceGroupFactsPort::shared(",
+  "ServerForumAudienceFactsPort::shared(",
   "extensions.insert(audience_facts)",
   "extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>()",
 ]) {
@@ -253,4 +209,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Forum audience group facts host runtime contract is source-ready.");
+console.log("Historical FORUM-20Q Groups facts contract remains valid through FORUM-20AT.");

--- a/scripts/verify/verify-forum-notification-plan-sync.mjs
+++ b/scripts/verify/verify-forum-notification-plan-sync.mjs
@@ -66,7 +66,7 @@ for (const key of ["runtime_behavior_changed", "migration_changed", "dependency_
 }
 
 for (const marker of [
-  "FORUM-20A-AS provide",
+  "FORUM-20A-AT provide",
   "### Delivered in `FORUM-20H` through `FORUM-20Q`",
   "### Delivered in `FORUM-20R` through `FORUM-20AF`",
   "### Delivered in `FORUM-20AG` through `FORUM-20AL`",
@@ -77,6 +77,7 @@ for (const marker of [
   "### Delivered in `FORUM-20AQ`",
   "### Delivered in `FORUM-20AR`",
   "### Delivered in `FORUM-20AS`",
+  "### Delivered in `FORUM-20AT`",
   "PostgreSQL concurrency",
 ]) {
   requireText(canonical, marker, `canonical plan is missing ${marker}`);
@@ -162,4 +163,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Historical FORUM-20AM synchronization remains valid through downstream FORUM-20AS.");
+console.log("Historical FORUM-20AM synchronization remains valid through downstream FORUM-20AT.");


### PR DESCRIPTION
## Summary

- publish a composite Forum audience-facts capability for every `mod-forum` server build
- confirm only the exact middleware-resolved requested Channel slug through `ChannelReadPort`, requiring an active same-tenant owner projection
- preserve the historical exact Groups adapter as an optional fallback after a Channel miss
- keep unresolved Forum trust or unavailable optional Groups facts fail-closed with typed retryable unavailability
- advance the canonical Forum plan through `FORUM-20AT` and add machine/static contracts

## Compatibility

- no migration or backfill
- no public DTO or transport change
- no new Forum-to-Channel crate dependency
- no channel discovery or unrequested owner reads

## Validation

Tests, Cargo commands, verifiers, formatting, and CI were not run by the implementation agent, per maintainer request.