### PR TITLE
Use fulfillment admin read port in GraphQL queries

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -4,26 +4,28 @@ Status: `source_ready_unvalidated`
 
 ## Shipping-option read cutover
 
-The safe commerce GraphQL query facade now routes the mounted shipping-option
-reads through fulfillment's canonical `ShippingOptionReadPort`:
+The safe commerce GraphQL query facade now routes all mounted shipping-option
+reads through fulfillment-owned read ports:
 
 - `storefront_shipping_options` delegates
-  `list_shipping_option_projections`;
+  `ShippingOptionReadPort::list_shipping_option_projections`;
 - single shipping-option lookup delegates
-  `read_shipping_option_projection`.
+  `ShippingOptionReadPort::read_shipping_option_projection`;
+- administrative `shipping_options` delegates
+  `ShippingOptionAdminReadPort::list_all_shipping_option_projections`.
 
 The unchanged `query.rs` source still imports and constructs the private
-`rustok_fulfillment::FulfillmentService` facade. Inside that facade,
-shipping-option methods now use a separate owner read-port field. The facade
-keeps one concrete `FulfillmentService` delegate only for operations not covered
-by this slice:
+`rustok_fulfillment::FulfillmentService` facade. Inside that facade, storefront
+and administrative shipping-option methods use separate owner read-port fields.
+The facade keeps one concrete `FulfillmentService` delegate only for fulfillment
+lifecycle reads not covered by this slice:
 
-- admin `list_all_shipping_options`;
 - fulfillment lookup/list;
 - order-to-fulfillment lookup.
 
-This is a partial topology result. It does not claim that all fulfillment query
-methods are owner-port composed.
+This is a partial topology result. It closes concrete service delegation for
+shipping-option query reads, but it does not claim that every fulfillment query
+method is owner-port composed.
 
 ## Retained read context
 
@@ -42,7 +44,8 @@ propagation remains open for a later source/query signature change.
 
 ## Typed owner mapping
 
-The storefront list facade maps `PortErrorKind` without using owner message text:
+Storefront and administrative list facades map `PortErrorKind` without using
+owner message text:
 
 | Port kind | Public message | Public code | Retryable |
 | --- | --- | --- | --- |
@@ -54,12 +57,20 @@ The storefront list facade maps `PortErrorKind` without using owner message text
 | InvariantViolation | `Fulfillment query could not be completed safely` | `FULFILLMENT_OPERATION_FAILED` | false |
 
 The validation, not-found, conflict, and unavailable envelopes preserve the
-existing `FulfillmentError` public policy. Forbidden and invariant outcomes are
+existing fulfillment public policy. Forbidden and invariant outcomes are
 fail-closed coverage for the complete port kind set and are not status
 promotions.
 
-Single lookup preserves the existing source contract rather than changing
-`query.rs`:
+The administrative resolver source still contains its existing
+`async_graphql::Error::new(err.to_string())` call. The private facade now returns
+`ShippingOptionAdminQueryError`, whose inherent `to_string` method consumes the
+adapter and returns the already-typed `BoundaryError`. Rust resolves that
+inherent method before the standard `ToString` trait, so no string is created,
+parsed, matched, or used as a control-flow protocol. The same public
+`FULFILLMENT_*` message, code, and retryability values reach GraphQL extensions.
+
+Single lookup preserves the existing optional-result source contract rather than
+changing `query.rs`:
 
 - owner `NotFound` becomes the stable compatibility variant
   `ShippingOptionNotFound`, so the resolver still returns `Ok(None)`;
@@ -68,8 +79,8 @@ Single lookup preserves the existing source contract rather than changing
 - the unchanged resolver converts those stable values through its existing
   generic `COMMERCE_QUERY_OPERATION_FAILED` redaction path.
 
-No `PortError.message` or original fulfillment message is copied into these
-compatibility values.
+No `PortError.message` or original fulfillment message is copied into the
+compatibility values or administrative GraphQL boundary.
 
 ## Diagnostics
 
@@ -91,7 +102,7 @@ The port-backed query boundary records:
 
 Unavailable, timeout, and invariant outcomes use error severity and retain the
 stable typed `PortError`. Ordinary outcomes use warning severity without an
-owner message field. The fulfillment owner port independently retains its
+owner message field. The fulfillment owner ports independently retain their
 owner-local diagnostics and technical database cause.
 
 ## Preserved contracts
@@ -101,11 +112,13 @@ owner-local diagnostics and technical database cause.
   resolve through the private safe facade.
 - Single shipping-option not-found still returns `None` rather than a GraphQL
   error.
-- Storefront currency, channel-visibility, and shipping-profile filtering remain
-  unchanged after owner projections are returned.
+- Storefront active-only semantics, currency, channel-visibility, and
+  shipping-profile filtering remain unchanged after owner projections return.
+- Administrative list-all still includes inactive options before local active,
+  currency, provider, search, and pagination filtering.
 - Shipping-option GraphQL DTOs and successful results are unchanged.
-- Admin `list_all_shipping_options` and fulfillment lifecycle query behavior
-  remain on the existing concrete delegate.
+- Fulfillment lifecycle and order lookup remain on the isolated concrete
+  delegate.
 - Admin order lookup and non-not-found single shipping-option failures keep their
   existing generic `COMMERCE_QUERY_OPERATION_FAILED` fail-closed envelope after
   stable compatibility conversion.
@@ -114,11 +127,12 @@ owner-local diagnostics and technical database cause.
 
 ## Still open
 
-- Inject `ShippingOptionReadPort` from the application host rather than using the
-  root in-process factory inside the private facade.
+- Inject both shipping-option read ports from the application host rather than
+  using root in-process factories inside the private facade.
 - Add public-channel propagation to the shipping-option query `PortContext`.
-- Publish owner ports for admin list-all and fulfillment lifecycle query reads,
-  then remove the remaining concrete `FulfillmentService` field.
+- Publish owner ports for fulfillment lifecycle query reads, then remove the
+  remaining concrete `FulfillmentService` field.
+- Migrate REST/native shipping reads and retain parity evidence.
 - Continue reviewing order, payment, customer, inventory, region, channel,
   catalog, and remaining commerce query conversions that still pass through
   dynamic strings.

--- a/crates/rustok-commerce/src/graphql/safe_query.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query.rs
@@ -412,9 +412,10 @@ mod source {
         use ::rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
         use ::rustok_fulfillment::{
             FulfillmentError, FulfillmentResponse, FulfillmentResult,
-            ListFulfillmentsInput, ListShippingOptionProjectionsRequest,
-            ReadShippingOptionProjectionRequest, ShippingOptionReadPort,
-            ShippingOptionResponse, in_process_shipping_option_read_port,
+            ListAllShippingOptionProjectionsRequest, ListFulfillmentsInput,
+            ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
+            ShippingOptionAdminReadPort, ShippingOptionReadPort, ShippingOptionResponse,
+            in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
         };
         use ::sea_orm::{DatabaseConnection, DbErr};
         use ::uuid::Uuid;
@@ -428,16 +429,27 @@ mod source {
         const GRAPHQL_QUERY_FULFILLMENT_BOUNDARY: &str =
             "commerce_graphql_query_fulfillment_facade";
 
+        pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);
+
+        impl ShippingOptionAdminQueryError {
+            #[allow(clippy::inherent_to_string, clippy::wrong_self_convention)]
+            pub(crate) fn to_string(self) -> BoundaryError {
+                self.0
+            }
+        }
+
         pub struct FulfillmentService {
             inner: ::rustok_fulfillment::FulfillmentService,
             shipping_option_reads: Arc<dyn ShippingOptionReadPort>,
+            shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>,
         }
 
         impl FulfillmentService {
             pub fn new(db: DatabaseConnection) -> Self {
                 Self {
                     inner: ::rustok_fulfillment::FulfillmentService::new(db.clone()),
-                    shipping_option_reads: in_process_shipping_option_read_port(db),
+                    shipping_option_reads: in_process_shipping_option_read_port(db.clone()),
+                    shipping_option_admin_reads: in_process_shipping_option_admin_read_port(db),
                 }
             }
 
@@ -518,21 +530,33 @@ mod source {
                 tenant_id: Uuid,
                 requested_locale: Option<&str>,
                 tenant_default_locale: Option<&str>,
-            ) -> FulfillmentResult<Vec<ShippingOptionResponse>> {
-                self.inner
-                    .list_all_shipping_options(tenant_id, requested_locale, tenant_default_locale)
+            ) -> Result<Vec<ShippingOptionResponse>, ShippingOptionAdminQueryError> {
+                let context = shipping_option_query_context(
+                    tenant_id,
+                    "shipping_options",
+                    None,
+                    requested_locale,
+                    tenant_default_locale,
+                );
+                self.shipping_option_admin_reads
+                    .list_all_shipping_option_projections(
+                        context.clone(),
+                        ListAllShippingOptionProjectionsRequest {
+                            requested_locale: requested_locale.map(str::to_owned),
+                            tenant_default_locale: tenant_default_locale.map(str::to_owned),
+                        },
+                    )
                     .await
                     .map_err(|error| {
-                        log_fulfillment_query_error(
-                            &error,
-                            tenant_id,
+                        ShippingOptionAdminQueryError(map_shipping_option_port_error(
+                            error,
+                            &context,
                             "shipping_options",
-                            "list_all_shipping_options",
+                            "list_all_shipping_option_projections",
                             None,
                             requested_locale,
                             tenant_default_locale,
-                        );
-                        error
+                        ))
                     })
             }
 

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -36,10 +36,11 @@ while administrative list-all uses the separate `ShippingOptionAdminReadPort`.
 The root in-process factories own `FulfillmentService` construction, require read
 policy, preserve requested and default locale values, and map owner failures to
 stable `PortError` envelopes. Mounted commerce GraphQL shipping-option
-validation, shipping enrichment, and storefront listing use the storefront port
-instead of constructing `FulfillmentService` directly. The administrative
-list-all owner contract is source-ready for the remaining mounted GraphQL
-cutover. The seller/cart `ShippingSelectionPort` contract is unchanged.
+validation, shipping enrichment, storefront listing, single lookup, and
+administrative list-all now route through those owner ports. The private Commerce
+facade retains one concrete `FulfillmentService` only for fulfillment lifecycle
+and order-to-fulfillment compatibility reads. The seller/cart
+`ShippingSelectionPort` contract is unchanged.
 
 Stable fulfillment keys and metadata identity remain owner-local compatibility
 mechanisms. Duplicate keys fail closed. A typed durable checkout fulfillment
@@ -70,9 +71,9 @@ identity and database uniqueness migration remain open.
   `scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`, and
   `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the
   owner-admin/storefront, checkout execution, and typed lifecycle split.
-- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` guards the
-  internal shipping-option read boundaries and mounted storefront commerce
-  cutover.
+- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` and
+  `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs` guard the
+  internal shipping-option read boundaries and mounted GraphQL query cutover.
 - No status promotion is claimed from source. Compile, upgraded database,
   contention, restart, mounted transport, and remote evidence remain missing.
 
@@ -107,8 +108,9 @@ identity and database uniqueness migration remain open.
 - [x] Export canonical root in-process factories.
 - [x] Remove direct `FulfillmentService` construction from mounted commerce
   GraphQL shipping-option validation, enrichment, and storefront listing.
-- [ ] Cut the mounted administrative GraphQL `shipping_options` query over to
-  `list_all_shipping_option_projections`.
+- [x] Cut mounted GraphQL single lookup and administrative `shipping_options`
+  list-all over to owner read ports while preserving optional-not-found and
+  `FULFILLMENT_*` public envelopes.
 - [ ] Inject the read ports from the application host rather than constructing
   root in-process providers inside the commerce seam.
 - [ ] Execute compile, mounted GraphQL, REST/native parity, deadline, failure,
@@ -146,9 +148,8 @@ identity and database uniqueness migration remain open.
    **Done when:** production-like execution proves degraded fallback and typed
    adapter errors while `FulfillmentService` remains the sole lifecycle owner.
 
-5. **Prove and host-compose shipping-option reads.** Cut the mounted
-   administrative list-all query over to the admin owner port, execute active
-   list, administrative list-all, and lookup through mounted GraphQL consumers,
+5. **Prove and host-compose shipping-option reads.** Execute active list,
+   administrative list-all, and lookup through mounted GraphQL consumers,
    compare REST/native behavior, and move provider construction to the
    application host.
    **Depends on:** compiled fulfillment/commerce crates and mounted transport
@@ -171,6 +172,7 @@ identity and database uniqueness migration remain open.
 - `node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`
 - `node scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs`
 - `node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
+- `node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs`
 - `npm run verify:ecommerce:fba`

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -8,7 +8,7 @@ Status: source-ready, unvalidated.
 read boundaries for complete shipping-option projections needed by mounted
 ecommerce transports.
 
-It is separate from `ShippingSelectionPort`:
+They are separate from `ShippingSelectionPort`:
 
 - `ShippingSelectionPort` owns seller/cart selection workflow;
 - `ShippingOptionReadPort` owns storefront active-list and single-option reads;
@@ -46,7 +46,7 @@ Locale values remain request data rather than being inferred from public error
 text. The delegated `PortContext` independently carries tenant, actor, channel,
 locale, correlation, causation, trace, and deadline facts.
 
-## In-process adapter
+## In-process adapters
 
 `InProcessShippingOptionReadPort` and
 `InProcessShippingOptionAdminReadPort` own `FulfillmentService` construction and
@@ -109,25 +109,31 @@ validation, not-found, and conflict events do not add raw owner message fields.
 
 ## Mounted commerce cutover
 
-The mounted storefront GraphQL helpers use the root read-port factory:
+Mounted Commerce GraphQL shipping-option paths now use the root read-port
+factories:
 
-- shipping-option validation calls `read_shipping_option_projection`;
+- shipping-option validation and single query lookup call
+  `read_shipping_option_projection`;
 - cart shipping enrichment and storefront query listing call
-  `list_shipping_option_projections`.
-
-The separate admin owner port now publishes
-`list_all_shipping_option_projections` for the mounted administrative GraphQL
-`shipping_options` query. This source slice publishes and verifies that owner
-contract; the transport cutover remains a separate bounded change so the
-existing public envelope can be preserved and reviewed independently.
+  `list_shipping_option_projections`;
+- administrative `shipping_options` calls
+  `list_all_shipping_option_projections`.
 
 Commerce builds a read `PortContext` with a service actor, resource-scoped
 correlation id, request locale, optional public channel where applicable, and a
-two-second deadline. Existing GraphQL public envelopes remain unchanged.
+two-second deadline. Existing optional-not-found behavior and public GraphQL
+`FULFILLMENT_*` message, code, and retryability envelopes remain unchanged.
 
-Delivery-group projection is a pure commerce function receiving owner
-projections. The existing compatibility service adapter delegates to the same
-pure function, so legacy REST/native behavior is not changed by this slice.
+The administrative resolver source retains its existing `.to_string()` call for
+source compatibility, but the private Commerce facade returns a typed adapter
+whose inherent method yields the already-classified GraphQL boundary. No owner
+message is serialized, parsed, or matched. Administrative list-all still returns
+inactive options before the existing local active, currency, provider, search,
+and pagination filters are applied.
+
+Delivery-group projection is a pure Commerce function receiving owner
+projections. Existing REST/native compatibility adapters delegate to the same
+pure function, so those transports are not changed by this slice.
 
 ## Verification
 
@@ -135,6 +141,7 @@ Focused source guards:
 
 ```bash
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
+node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
 node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs
 node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
 cargo check -p rustok-fulfillment --lib
@@ -147,11 +154,12 @@ No command was executed locally in this source wave.
 
 This slice does not:
 
-- cut the mounted administrative GraphQL `shipping_options` query over to
-  `list_all_shipping_option_projections`;
 - inject the read ports from the application host rather than root in-process
   factories;
-- migrate REST/native storefront shipping reads;
+- propagate public channel into every query read context;
+- migrate REST/native shipping reads;
+- publish owner read ports for fulfillment lifecycle and order-to-fulfillment
+  query paths;
 - retire `FulfillmentService` from fulfillment-owned compatibility adapters;
 - modify `ShippingSelectionPort`;
 - add or change an FBA registry contract;

--- a/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
@@ -49,6 +49,18 @@ const optionList = between(
   'pub async fn list_all_shipping_options(',
   'shipping option list facade',
 );
+const optionAdminList = between(
+  shim,
+  'pub async fn list_all_shipping_options(',
+  'pub async fn get_fulfillment(',
+  'administrative shipping option list facade',
+);
+const adminQuery = between(
+  query,
+  'async fn shipping_options(',
+  'async fn shipping_profiles(',
+  'administrative shipping options query',
+);
 const portBoundary = between(
   shim,
   'fn map_shipping_option_lookup_port_error(',
@@ -61,14 +73,24 @@ for (const [value, label] of [
   ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'safe fulfillment routing'],
   ['inner: ::rustok_fulfillment::FulfillmentService', 'legacy fulfillment delegate'],
   ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'shipping option read port field'],
+  [
+    'shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>',
+    'administrative shipping option read port field',
+  ],
   ['::rustok_fulfillment::FulfillmentService::new(db.clone())', 'legacy constructor isolation'],
-  ['shipping_option_reads: in_process_shipping_option_read_port(db)', 'canonical read factory'],
-  ['pub async fn list_all_shipping_options(', 'legacy all-options facade'],
+  [
+    'shipping_option_reads: in_process_shipping_option_read_port(db.clone())',
+    'canonical storefront read factory',
+  ],
+  [
+    'shipping_option_admin_reads: in_process_shipping_option_admin_read_port(db)',
+    'canonical administrative read factory',
+  ],
+  ['pub async fn list_all_shipping_options(', 'administrative all-options facade'],
   ['pub async fn find_by_order(', 'order fulfillment facade'],
-  ['FulfillmentResult<Vec<ShippingOptionResponse>>', 'legacy typed result'],
   ['FulfillmentResult<Option<FulfillmentResponse>>', 'order fulfillment typed result'],
   ['"shipping_options"', 'admin shipping query field'],
-  ['"list_all_shipping_options"', 'admin shipping operation'],
+  ['"list_all_shipping_option_projections"', 'admin shipping owner operation'],
   ['"order"', 'admin order query field'],
   ['"find_by_order"', 'order fulfillment owner operation'],
 ]) {
@@ -76,10 +98,13 @@ for (const [value, label] of [
 }
 
 for (const [value, label] of [
-  ['ShippingOptionReadPort', 'owner read trait'],
+  ['ShippingOptionReadPort', 'owner storefront read trait'],
+  ['ShippingOptionAdminReadPort', 'owner administrative read trait'],
   ['ListShippingOptionProjectionsRequest', 'list projection request'],
+  ['ListAllShippingOptionProjectionsRequest', 'admin list projection request'],
   ['ReadShippingOptionProjectionRequest', 'lookup projection request'],
-  ['in_process_shipping_option_read_port', 'root read factory'],
+  ['in_process_shipping_option_read_port', 'root storefront read factory'],
+  ['in_process_shipping_option_admin_read_port', 'root administrative read factory'],
   ['PortActor, PortContext, PortError, PortErrorKind', 'port context imports'],
   ['fn shipping_option_query_context(', 'query context builder'],
   ['PortActor::service("rustok-commerce.graphql-query-shipping-options")', 'query service actor'],
@@ -114,8 +139,37 @@ for (const [source, value, label] of [
     '"list_shipping_option_projections"',
     'list owner operation',
   ],
+  [
+    optionAdminList,
+    'Result<Vec<ShippingOptionResponse>, ShippingOptionAdminQueryError>',
+    'typed admin adapter result',
+  ],
+  [optionAdminList, '.list_all_shipping_option_projections(', 'owner admin option list'],
+  [optionAdminList, 'ListAllShippingOptionProjectionsRequest {', 'typed admin list request'],
+  [optionAdminList, 'context.clone(),', 'admin list context delegation'],
+  [
+    optionAdminList,
+    'ShippingOptionAdminQueryError(map_shipping_option_port_error(',
+    'admin boundary adapter',
+  ],
+  [
+    optionAdminList,
+    '"list_all_shipping_option_projections"',
+    'admin list owner operation',
+  ],
 ]) {
   requireText(source, value, label);
+}
+
+for (const [value, label] of [
+  ['pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);', 'typed admin query error'],
+  ['pub(crate) fn to_string(self) -> BoundaryError', 'non-string source compatibility bridge'],
+  ['self.0', 'boundary preservation'],
+]) {
+  requireText(shim, value, label);
+}
+for (const value of ['impl std::fmt::Display', 'impl Display', 'format!("{}", self.0)']) {
+  forbidText(shim, value, 'admin boundary must not serialize through text');
 }
 
 const projectionLookups = optionLookup.match(/\.read_shipping_option_projection\(/g) ?? [];
@@ -125,6 +179,11 @@ if (projectionLookups.length !== 1) {
 const projectionLists = optionList.match(/\.list_shipping_option_projections\(/g) ?? [];
 if (projectionLists.length !== 1) {
   failures.push(`expected one shipping-option projection list, found ${projectionLists.length}`);
+}
+const adminProjectionLists =
+  optionAdminList.match(/\.list_all_shipping_option_projections\(/g) ?? [];
+if (adminProjectionLists.length !== 1) {
+  failures.push(`expected one administrative shipping-option projection list, found ${adminProjectionLists.length}`);
 }
 
 for (const [value, label] of [
@@ -181,9 +240,17 @@ for (const [value, label] of [
   ['.find_by_order(tenant_id, id)', 'admin order fulfillment call'],
   ['Err(rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_))', 'optional not-found source contract'],
   ['Err(err) => return Err(err.to_string().into())', 'existing lookup fail-closed conversion'],
-  ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'existing admin order public conversion'],
+  ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'unchanged mapped query source'],
 ]) {
   requireText(query, value, label);
+}
+for (const [value, label] of [
+  ['.list_all_shipping_options(', 'admin facade call'],
+  ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'typed admin source bridge'],
+  ['active: None,', 'admin active filter'],
+  ['items.retain(|option| option.active == active);', 'admin active filtering'],
+]) {
+  requireText(adminQuery, value, label);
 }
 
 const legacyConstructors =
@@ -191,17 +258,28 @@ const legacyConstructors =
 if (legacyConstructors.length !== 1) {
   failures.push(`expected one remaining concrete fulfillment constructor, found ${legacyConstructors.length}`);
 }
-const readFactories = facade.match(/in_process_shipping_option_read_port\(db\)/g) ?? [];
+const readFactories =
+  facade.match(/in_process_shipping_option_read_port\(db\.clone\(\)\)/g) ?? [];
 if (readFactories.length !== 1) {
   failures.push(`expected one shipping-option read factory, found ${readFactories.length}`);
+}
+const adminReadFactories =
+  facade.match(/in_process_shipping_option_admin_read_port\(db\)/g) ?? [];
+if (adminReadFactories.length !== 1) {
+  failures.push(`expected one administrative shipping-option read factory, found ${adminReadFactories.length}`);
 }
 
 for (const value of [
   '.get_shipping_option(tenant_id, id, requested_locale, tenant_default_locale)',
   '.list_shipping_options(\n                        tenant_id,',
+  '.list_all_shipping_options(tenant_id, requested_locale, tenant_default_locale)',
   'error.message',
 ]) {
-  forbidText(optionLookup + optionList + portBoundary, value, 'shipping-option query port boundary');
+  forbidText(
+    optionLookup + optionList + optionAdminList + portBoundary,
+    value,
+    'shipping-option query port boundary',
+  );
 }
 
 forbidText(
@@ -211,7 +289,9 @@ forbidText(
 );
 
 for (const [value, label] of [
-  ['pub trait ShippingOptionReadPort: Send + Sync {', 'owner read port'],
+  ['pub trait ShippingOptionReadPort: Send + Sync {', 'owner storefront read port'],
+  ['pub trait ShippingOptionAdminReadPort: Send + Sync {', 'owner admin read port'],
+  ['async fn list_all_shipping_option_projections(', 'owner admin list operation'],
   ['context.require_policy(PortCallPolicy::read())?', 'owner read policy'],
   ['PortError::new(kind, code, message, retryable)', 'owner stable error'],
 ]) {
@@ -225,5 +305,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL shipping-option queries use the fulfillment read port with retained context, optional lookup compatibility, and isolated legacy lifecycle reads',
+  '✔ Commerce GraphQL shipping-option lookup, storefront list, and administrative list-all use fulfillment owner read ports with retained context, typed public envelopes, and isolated legacy lifecycle reads',
 );


### PR DESCRIPTION
## Summary

- continue the open ecommerce topology P0 by routing the mounted administrative GraphQL `shipping_options` query through fulfillment's separate `ShippingOptionAdminReadPort`;
- keep the storefront `ShippingOptionReadPort` active-only and preserve the administrative list-all contract, including inactive shipping options before the existing local filters and pagination;
- add a second typed read-port field to the private Commerce fulfillment facade and construct both owner adapters through their canonical root factories;
- retain tenant, service actor, requested/default locale, query/resource correlation id, and two-second deadline in the administrative owner call;
- delegate to `list_all_shipping_option_projections` with `ListAllShippingOptionProjectionsRequest` instead of the concrete `FulfillmentService::list_all_shipping_options` method;
- map every `PortErrorKind` through the existing `FULFILLMENT_*` message/code/retryability boundary without using `PortError.message` or owner text as a protocol;
- preserve the unchanged `query.rs` source with a typed source-compatibility adapter whose inherent `to_string` returns the classified `BoundaryError`, so no string is created, parsed, or matched;
- leave one concrete fulfillment service delegate only for fulfillment lifecycle/list and order-to-fulfillment compatibility reads;
- update the focused guard and Commerce/Fulfillment source-ready plans without changing FBA/FFA status.

## Recheck

- continued from merged admin shipping-option owner-contract PR #2337, squash-merged into `main` as `735d7e5391dfcee4a2cdbb1dbde610ffd95a7cae`; its source branch was deleted;
- confirmed no open PR overlaps the mounted administrative shipping-option query scope;
- confirmed the existing admin resolver must retain inactive options before applying active, currency, provider, search, and pagination filters;
- confirmed the current source still converted the concrete fulfillment result through `err.to_string()` before this facade cutover;
- confirmed the branch was rebuilt as one commit directly on current `main` after unrelated Forum work landed;
- confirmed the branch is zero commits behind and changes exactly five Commerce/Fulfillment source, guard, and documentation files.

## Boundary

This PR closes concrete fulfillment service delegation for the mounted administrative GraphQL shipping-option list-all query. It does not inject the read ports from the application host, add public-channel context to every query, migrate REST/native shipping reads, publish fulfillment lifecycle read ports, remove the facade's remaining concrete service field, change Product/Order/Payment topology, provide runtime/remote evidence, or promote fulfillment/ecommerce FBA or FFA status.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
cargo check -p rustok-commerce --lib
cargo check -p rustok-fulfillment --lib
```

## Next slice

Move shipping-option read-port construction from the private Commerce facade into application-host composition, then compare mounted GraphQL with REST/native behavior before any status promotion.