### PR TITLE
Compose GraphQL shipping option reads in application host

### DIFF
--- a/apps/server/src/graphql/schema.rs
+++ b/apps/server/src/graphql/schema.rs
@@ -42,6 +42,8 @@ use flex::graphql::FlexGraphqlRuntime;
 use rustok_auth::graphql::{AuthMutation, AuthQuery, OAuthMutation, OAuthQuery};
 #[cfg(feature = "mod-blog")]
 use rustok_blog::graphql::{BlogGraphqlRateLimitPolicy, BlogGraphqlRateLimiterHandle};
+#[cfg(feature = "mod-commerce")]
+use rustok_commerce::graphql_runtime::CommerceShippingOptionReadScope;
 #[cfg(feature = "mod-content")]
 use rustok_content::graphql::{NodeBodyLoader, NodeLoader, NodeTranslationLoader};
 #[cfg(feature = "mod-forum")]
@@ -189,6 +191,9 @@ pub fn build_schema(dependencies: GraphqlSchemaDependencies) -> AppSchema {
         TenantNameLoader::new(db.clone()),
         tokio::spawn,
     ));
+
+    #[cfg(feature = "mod-commerce")]
+    let builder = builder.extension(CommerceShippingOptionReadScope);
 
     #[cfg(feature = "mod-forum")]
     let builder = builder.extension(ForumGraphqlErrorExtension);

--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -4,12 +4,12 @@ use rustok_api::HostRuntimeContext;
 
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
-/// Attach the host-composed commerce provider registries to a capability runtime.
+/// Attach the host-composed commerce provider registries and owner read runtimes to a capability
+/// runtime.
 ///
-/// A registry already installed in `ServerRuntimeContext` is always preserved so
-/// external adapters registered by the host remain visible to every transport.
-/// When no payment registry exists, the process-owned provider runtime composes
-/// the manual baseline and any deployment-configured external adapters once.
+/// Values already installed in `ServerRuntimeContext` are always preserved so external adapters
+/// registered by the host remain visible to every transport. When no provider runtime exists, the
+/// process composes the deterministic built-in baseline once.
 pub fn attach_commerce_provider_registries(
     host: HostRuntimeContext,
     server: &ServerRuntimeContext,
@@ -42,6 +42,21 @@ pub fn attach_commerce_provider_registries(
                 registry
             });
         host.with_shared_value(registry)
+    };
+
+    #[cfg(all(feature = "mod-commerce", feature = "mod-fulfillment"))]
+    let host = {
+        let runtime = server
+            .shared_get::<rustok_commerce::graphql_runtime::CommerceShippingOptionReadRuntime>()
+            .unwrap_or_else(|| {
+                let runtime =
+                    rustok_commerce::graphql_runtime::CommerceShippingOptionReadRuntime::in_process(
+                        server.db_clone(),
+                    );
+                server.shared_insert(runtime.clone());
+                runtime
+            });
+        host.with_shared_value(runtime)
     };
 
     #[cfg(feature = "mod-commerce")]

--- a/crates/rustok-commerce/Cargo.toml
+++ b/crates/rustok-commerce/Cargo.toml
@@ -42,13 +42,13 @@ serde_json.workspace = true
 sha2.workspace = true
 hex.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 utoipa = { workspace = true, features = ["uuid", "chrono", "decimal"] }
 uuid.workspace = true
 validator.workspace = true
 
 [dev-dependencies]
-tokio.workspace = true
 rustok-test-utils.workspace = true
 rustok-tenant.workspace = true
 tower.workspace = true

--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -4,8 +4,8 @@ Status: `source_ready_unvalidated`
 
 ## Shipping-option read cutover
 
-The safe commerce GraphQL query facade now routes all mounted shipping-option
-reads through fulfillment-owned read ports:
+The safe Commerce GraphQL query facade routes all mounted shipping-option reads
+through fulfillment-owned read ports:
 
 - `storefront_shipping_options` delegates
   `ShippingOptionReadPort::list_shipping_option_projections`;
@@ -23,9 +23,28 @@ lifecycle reads not covered by this slice:
 - fulfillment lookup/list;
 - order-to-fulfillment lookup.
 
-This is a partial topology result. It closes concrete service delegation for
-shipping-option query reads, but it does not claim that every fulfillment query
-method is owner-port composed.
+This is a partial topology result. It closes concrete service and provider
+construction for mounted shipping-option GraphQL reads, but it does not claim
+that every fulfillment query method is owner-port composed.
+
+## Application-host composition
+
+The server's commerce runtime bootstrap constructs one
+`CommerceShippingOptionReadRuntime` from the storefront and administrative root
+factories, caches it in `ServerRuntimeContext`, and attaches it to
+`HostRuntimeContext`. The manifest GraphQL data factory requires that typed
+runtime and stores it in `CommerceGraphqlRuntimeData`.
+
+`CommerceShippingOptionReadScope` is mounted as an async-graphql extension. For
+each resolver it copies the typed runtime into a Tokio task-local scope. The
+private fulfillment facade resolves that scoped runtime and clones both owner
+ports; it no longer imports or calls either root in-process factory.
+
+Directly embedded schemas that do not mount the server extension retain an
+explicit `CommerceShippingOptionReadRuntime::in_process` compatibility fallback
+in the public Commerce GraphQL runtime module. The fallback preserves existing
+standalone schema tests and embeddings without turning the private facade back
+into a provider constructor.
 
 ## Retained read context
 
@@ -62,7 +81,7 @@ fail-closed coverage for the complete port kind set and are not status
 promotions.
 
 The administrative resolver source still contains its existing
-`async_graphql::Error::new(err.to_string())` call. The private facade now returns
+`async_graphql::Error::new(err.to_string())` call. The private facade returns
 `ShippingOptionAdminQueryError`, whose inherent `to_string` method consumes the
 adapter and returns the already-typed `BoundaryError`. Rust resolves that
 inherent method before the standard `ToString` trait, so no string is created,
@@ -108,8 +127,8 @@ owner-local diagnostics and technical database cause.
 ## Preserved contracts
 
 - `query.rs` is unchanged and remains facade-routed.
-- Both existing source-level `FulfillmentService::new(db.clone())` calls still
-  resolve through the private safe facade.
+- Existing source-level `FulfillmentService::new(db.clone())` calls still resolve
+  through the private safe facade.
 - Single shipping-option not-found still returns `None` rather than a GraphQL
   error.
 - Storefront active-only semantics, currency, channel-visibility, and
@@ -119,6 +138,8 @@ owner-local diagnostics and technical database cause.
 - Shipping-option GraphQL DTOs and successful results are unchanged.
 - Fulfillment lifecycle and order lookup remain on the isolated concrete
   delegate.
+- Directly embedded schemas keep an explicit compatibility fallback without
+  changing the mounted server composition path.
 - Admin order lookup and non-not-found single shipping-option failures keep their
   existing generic `COMMERCE_QUERY_OPERATION_FAILED` fail-closed envelope after
   stable compatibility conversion.
@@ -127,17 +148,15 @@ owner-local diagnostics and technical database cause.
 
 ## Still open
 
-- Inject both shipping-option read ports from the application host rather than
-  using root in-process factories inside the private facade.
 - Add public-channel propagation to the shipping-option query `PortContext`.
 - Publish owner ports for fulfillment lifecycle query reads, then remove the
   remaining concrete `FulfillmentService` field.
 - Migrate REST/native shipping reads and retain parity evidence.
 - Continue reviewing order, payment, customer, inventory, region, channel,
-  catalog, and remaining commerce query conversions that still pass through
+  catalog, and remaining Commerce query conversions that still pass through
   dynamic strings.
-- Add compile, transport, deadline, REST/native parity, and remote evidence
-  before promoting any FBA/FFA status.
+- Add compile, mounted transport, deadline, REST/native parity, and remote
+  evidence before promoting any FBA/FFA status.
 
 ## Intended checks
 
@@ -146,6 +165,7 @@ node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
 node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
 cargo check -p rustok-commerce --lib
+cargo check -p rustok-server --features mod-commerce
 ```
 
 Tests, Cargo commands, formatting commands, verifiers, workflow checks, and CI

--- a/crates/rustok-commerce/src/graphql/safe_query.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query.rs
@@ -415,7 +415,6 @@ mod source {
             ListAllShippingOptionProjectionsRequest, ListFulfillmentsInput,
             ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
             ShippingOptionAdminReadPort, ShippingOptionReadPort, ShippingOptionResponse,
-            in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
         };
         use ::sea_orm::{DatabaseConnection, DbErr};
         use ::uuid::Uuid;
@@ -446,10 +445,15 @@ mod source {
 
         impl FulfillmentService {
             pub fn new(db: DatabaseConnection) -> Self {
+                let shipping_option_runtime =
+                    crate::graphql_runtime::shipping_option_read_runtime_for_current_graphql_scope(
+                        db.clone(),
+                    );
                 Self {
-                    inner: ::rustok_fulfillment::FulfillmentService::new(db.clone()),
-                    shipping_option_reads: in_process_shipping_option_read_port(db.clone()),
-                    shipping_option_admin_reads: in_process_shipping_option_admin_read_port(db),
+                    inner: ::rustok_fulfillment::FulfillmentService::new(db),
+                    shipping_option_reads: shipping_option_runtime.shipping_option_read_port(),
+                    shipping_option_admin_reads: shipping_option_runtime
+                        .shipping_option_admin_read_port(),
                 }
             }
 

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -1,18 +1,110 @@
-use async_graphql::Context;
+use std::sync::Arc;
+
+use async_graphql::extensions::{
+    Extension, ExtensionContext, ExtensionFactory, NextResolve, ResolveInfo,
+};
+use async_graphql::{Context, ServerResult, Value};
 use rustok_fulfillment::providers::FulfillmentProviderRegistry;
+use rustok_fulfillment::{
+    ShippingOptionAdminReadPort, ShippingOptionReadPort,
+    in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
+};
 use rustok_payment::providers::PaymentProviderRegistry;
 use sea_orm::DatabaseConnection;
 
-/// Provider registries available to every commerce GraphQL resolver.
+/// Host-selected shipping-option read ports used by mounted commerce GraphQL resolvers.
 ///
-/// Hosts may supply composed registries through `HostRuntimeContext`. The built-in
-/// manual adapters remain a deterministic fallback for tests and deployments that
-/// have not installed external providers.
+/// The application host composes this runtime once and carries it through
+/// `HostRuntimeContext`. Directly embedded schemas that do not install the mounted
+/// extension retain an explicit in-process compatibility fallback outside the query facade.
+#[derive(Clone)]
+pub struct CommerceShippingOptionReadRuntime {
+    shipping_option_reads: Arc<dyn ShippingOptionReadPort>,
+    shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>,
+}
+
+impl CommerceShippingOptionReadRuntime {
+    pub fn new(
+        shipping_option_reads: Arc<dyn ShippingOptionReadPort>,
+        shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>,
+    ) -> Self {
+        Self {
+            shipping_option_reads,
+            shipping_option_admin_reads,
+        }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(
+            in_process_shipping_option_read_port(db.clone()),
+            in_process_shipping_option_admin_read_port(db),
+        )
+    }
+
+    pub fn shipping_option_read_port(&self) -> Arc<dyn ShippingOptionReadPort> {
+        self.shipping_option_reads.clone()
+    }
+
+    pub fn shipping_option_admin_read_port(&self) -> Arc<dyn ShippingOptionAdminReadPort> {
+        self.shipping_option_admin_reads.clone()
+    }
+}
+
+tokio::task_local! {
+    static CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME: CommerceShippingOptionReadRuntime;
+}
+
+/// Resolver-scoped bridge from schema runtime data to the private compatibility facade.
+#[derive(Default)]
+pub struct CommerceShippingOptionReadScope;
+
+impl ExtensionFactory for CommerceShippingOptionReadScope {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(CommerceShippingOptionReadScopeExtension)
+    }
+}
+
+struct CommerceShippingOptionReadScopeExtension;
+
+#[async_trait::async_trait]
+impl Extension for CommerceShippingOptionReadScopeExtension {
+    async fn resolve(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        info: ResolveInfo<'_>,
+        next: NextResolve<'_>,
+    ) -> ServerResult<Option<Value>> {
+        let Some(runtime_data) = ctx.data_opt::<CommerceGraphqlRuntimeData>() else {
+            return next.run(ctx, info).await;
+        };
+        CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME
+            .scope(
+                runtime_data.shipping_option_read_runtime(),
+                next.run(ctx, info),
+            )
+            .await
+    }
+}
+
+pub(crate) fn shipping_option_read_runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+) -> CommerceShippingOptionReadRuntime {
+    CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| CommerceShippingOptionReadRuntime::in_process(db))
+}
+
+/// Provider registries and host-composed ports available to every commerce GraphQL resolver.
+///
+/// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual
+/// provider registries remain deterministic fallbacks for tests and deployments that have not
+/// installed external providers. Mounted shipping-option reads are required host data.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
+    shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
 }
 
 impl CommerceGraphqlRuntimeData {
@@ -26,6 +118,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn marketplace_financial_runtime(&self) -> crate::MarketplaceFinancialRuntime {
         self.marketplace_financial_runtime.clone()
+    }
+
+    pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
+        self.shipping_option_read_runtime.clone()
     }
 }
 
@@ -44,6 +140,12 @@ pub fn attach_schema_data(
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
                 "commerce GraphQL requires MarketplaceFinancialRuntime in host composition"
+                    .to_string()
+            })?,
+        shipping_option_read_runtime: inputs
+            .shared_get::<CommerceShippingOptionReadRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires CommerceShippingOptionReadRuntime in host composition"
                     .to_string()
             })?,
     })

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -35,11 +35,15 @@ Complete shipping-option active list and lookup use `ShippingOptionReadPort`,
 while administrative list-all uses the separate `ShippingOptionAdminReadPort`.
 The root in-process factories own `FulfillmentService` construction, require read
 policy, preserve requested and default locale values, and map owner failures to
-stable `PortError` envelopes. Mounted commerce GraphQL shipping-option
-validation, shipping enrichment, storefront listing, single lookup, and
-administrative list-all now route through those owner ports. The private Commerce
-facade retains one concrete `FulfillmentService` only for fulfillment lifecycle
-and order-to-fulfillment compatibility reads. The seller/cart
+stable `PortError` envelopes. The application host now composes both read ports
+once in `HostRuntimeContext`; manifest GraphQL runtime data carries them into a
+resolver-scoped async task, and the private Commerce facade only consumes those
+scoped owner ports. Mounted shipping enrichment, storefront listing, single
+lookup, and administrative list-all therefore no longer construct their
+in-process providers inside the Commerce seam. The facade retains one concrete
+`FulfillmentService` only for fulfillment lifecycle and order-to-fulfillment
+compatibility reads. Directly embedded standalone schemas retain an explicit
+in-process compatibility fallback outside the facade. The seller/cart
 `ShippingSelectionPort` contract is unchanged.
 
 Stable fulfillment keys and metadata identity remain owner-local compatibility
@@ -73,7 +77,8 @@ identity and database uniqueness migration remain open.
   owner-admin/storefront, checkout execution, and typed lifecycle split.
 - `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` and
   `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs` guard the
-  internal shipping-option read boundaries and mounted GraphQL query cutover.
+  internal shipping-option read boundaries, mounted GraphQL query cutover, and
+  server host composition.
 - No status promotion is claimed from source. Compile, upgraded database,
   contention, restart, mounted transport, and remote evidence remain missing.
 
@@ -111,8 +116,9 @@ identity and database uniqueness migration remain open.
 - [x] Cut mounted GraphQL single lookup and administrative `shipping_options`
   list-all over to owner read ports while preserving optional-not-found and
   `FULFILLMENT_*` public envelopes.
-- [ ] Inject the read ports from the application host rather than constructing
-  root in-process providers inside the commerce seam.
+- [x] Inject both read ports from application-host composition through typed
+  runtime data and resolver-scoped async context; keep standalone fallback outside
+  the private facade.
 - [ ] Execute compile, mounted GraphQL, REST/native parity, deadline, failure,
   and remote-profile evidence.
 
@@ -148,16 +154,15 @@ identity and database uniqueness migration remain open.
    **Done when:** production-like execution proves degraded fallback and typed
    adapter errors while `FulfillmentService` remains the sole lifecycle owner.
 
-5. **Prove and host-compose shipping-option reads.** Execute active list,
-   administrative list-all, and lookup through mounted GraphQL consumers,
-   compare REST/native behavior, and move provider construction to the
-   application host.
+5. **Prove shipping-option transport parity.** Execute active list,
+   administrative list-all, and lookup through mounted GraphQL consumers and
+   compare REST/native behavior against the same owner projections.
    **Depends on:** compiled fulfillment/commerce crates and mounted transport
    fixtures.
    **Done when:** all transports retain locale/channel/deadline context, expose
    identical owner projections with correct active/inactive semantics, and no
-   commerce transport constructs a concrete fulfillment service or in-process
-   provider.
+   mounted commerce transport constructs a concrete fulfillment service or
+   in-process read provider.
 
 6. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -72,6 +72,24 @@ or one growing storefront interface. That keeps storefront active-only semantics
 separate from the admin requirement to inspect inactive shipping options and
 avoids breaking existing `ShippingOptionReadPort` implementors.
 
+## Application-host composition
+
+The mounted server composes one `CommerceShippingOptionReadRuntime` from the two
+root factories and stores it in `HostRuntimeContext`. Manifest-generated Commerce
+GraphQL runtime data requires that typed runtime during schema construction.
+`CommerceShippingOptionReadScope` then copies the runtime into a Tokio task-local
+scope for each resolver execution.
+
+The private Commerce fulfillment facade resolves the scoped runtime and clones
+its two owner ports. It no longer imports or calls the root in-process factories.
+This preserves the unchanged `query.rs` compatibility facade while keeping
+provider construction in the application host.
+
+Directly embedded schemas that do not install the mounted server extension use
+an explicit `CommerceShippingOptionReadRuntime::in_process` compatibility
+fallback in the Commerce GraphQL runtime module. The fallback is outside the
+private facade and is not evidence of mounted transport composition or parity.
+
 ## Stable owner errors
 
 | Owner outcome | Port kind | Code | Retryable |
@@ -109,8 +127,7 @@ validation, not-found, and conflict events do not add raw owner message fields.
 
 ## Mounted commerce cutover
 
-Mounted Commerce GraphQL shipping-option paths now use the root read-port
-factories:
+Mounted Commerce GraphQL shipping-option paths use the host-composed read ports:
 
 - shipping-option validation and single query lookup call
   `read_shipping_option_projection`;
@@ -146,6 +163,7 @@ node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs
 node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
 cargo check -p rustok-fulfillment --lib
 cargo check -p rustok-commerce --lib
+cargo check -p rustok-server --features mod-commerce
 ```
 
 No command was executed locally in this source wave.
@@ -154,8 +172,6 @@ No command was executed locally in this source wave.
 
 This slice does not:
 
-- inject the read ports from the application host rather than root in-process
-  factories;
 - propagate public channel into every query read context;
 - migrate REST/native shipping reads;
 - publish owner read ports for fulfillment lifecycle and order-to-fulfillment
@@ -163,5 +179,5 @@ This slice does not:
 - retire `FulfillmentService` from fulfillment-owned compatibility adapters;
 - modify `ShippingSelectionPort`;
 - add or change an FBA registry contract;
-- provide runtime, remote-profile, restart, or contention evidence;
+- provide compile, mounted runtime, remote-profile, restart, or contention evidence;
 - promote fulfillment or ecommerce FFA/FBA status.

--- a/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
@@ -12,7 +12,11 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 
 const query = read('crates/rustok-commerce/src/graphql/query.rs');
 const facade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const commerceCargo = read('crates/rustok-commerce/Cargo.toml');
 const owner = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const serverComposition = read('apps/server/src/services/commerce_provider_runtime.rs');
+const serverSchema = read('apps/server/src/graphql/schema.rs');
 const failures = [];
 
 const requireText = (source, value, label) => {
@@ -36,6 +40,12 @@ const shim = between(
   'mod rustok_fulfillment_shim {',
   '    use self::rustok_api_shim as rustok_api;',
   'private fulfillment facade',
+);
+const constructor = between(
+  shim,
+  'pub fn new(db: DatabaseConnection) -> Self {',
+  'pub async fn get_shipping_option(',
+  'fulfillment facade constructor',
 );
 const optionLookup = between(
   shim,
@@ -71,119 +81,74 @@ const portBoundary = between(
 for (const [value, label] of [
   ['mod rustok_fulfillment_shim {', 'private fulfillment facade'],
   ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'safe fulfillment routing'],
-  ['inner: ::rustok_fulfillment::FulfillmentService', 'legacy fulfillment delegate'],
-  ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'shipping option read port field'],
+  ['inner: ::rustok_fulfillment::FulfillmentService', 'legacy lifecycle delegate'],
+  ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'storefront read port field'],
   [
     'shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>',
-    'administrative shipping option read port field',
-  ],
-  ['::rustok_fulfillment::FulfillmentService::new(db.clone())', 'legacy constructor isolation'],
-  [
-    'shipping_option_reads: in_process_shipping_option_read_port(db.clone())',
-    'canonical storefront read factory',
-  ],
-  [
-    'shipping_option_admin_reads: in_process_shipping_option_admin_read_port(db)',
-    'canonical administrative read factory',
+    'administrative read port field',
   ],
   ['pub async fn list_all_shipping_options(', 'administrative all-options facade'],
   ['pub async fn find_by_order(', 'order fulfillment facade'],
   ['FulfillmentResult<Option<FulfillmentResponse>>', 'order fulfillment typed result'],
-  ['"shipping_options"', 'admin shipping query field'],
-  ['"list_all_shipping_option_projections"', 'admin shipping owner operation'],
-  ['"order"', 'admin order query field'],
-  ['"find_by_order"', 'order fulfillment owner operation'],
 ]) {
   requireText(facade, value, label);
 }
 
 for (const [value, label] of [
-  ['ShippingOptionReadPort', 'owner storefront read trait'],
-  ['ShippingOptionAdminReadPort', 'owner administrative read trait'],
-  ['ListShippingOptionProjectionsRequest', 'list projection request'],
-  ['ListAllShippingOptionProjectionsRequest', 'admin list projection request'],
-  ['ReadShippingOptionProjectionRequest', 'lookup projection request'],
-  ['in_process_shipping_option_read_port', 'root storefront read factory'],
-  ['in_process_shipping_option_admin_read_port', 'root administrative read factory'],
-  ['PortActor, PortContext, PortError, PortErrorKind', 'port context imports'],
-  ['fn shipping_option_query_context(', 'query context builder'],
-  ['PortActor::service("rustok-commerce.graphql-query-shipping-options")', 'query service actor'],
-  ['format!("graphql-fulfillment:{query_field}:{resource}")', 'query correlation'],
-  ['.with_deadline(std::time::Duration::from_secs(2))', 'query deadline'],
+  [
+    'shipping_option_read_runtime_for_current_graphql_scope(',
+    'resolver-scoped runtime resolution',
+  ],
+  ['shipping_option_runtime.shipping_option_read_port()', 'host storefront read port'],
+  [
+    'shipping_option_runtime\n                        .shipping_option_admin_read_port()',
+    'host administrative read port',
+  ],
+  ['::rustok_fulfillment::FulfillmentService::new(db)', 'isolated lifecycle constructor'],
 ]) {
-  requireText(shim, value, label);
+  requireText(constructor, value, label);
+}
+for (const value of [
+  'in_process_shipping_option_read_port',
+  'in_process_shipping_option_admin_read_port',
+]) {
+  forbidText(shim, value, 'private facade must not construct shipping-option ports');
 }
 
 for (const [source, value, label] of [
-  [optionLookup, 'FulfillmentResult<ShippingOptionResponse>', 'optional lookup compatibility result'],
+  [optionLookup, 'FulfillmentResult<ShippingOptionResponse>', 'optional lookup result'],
   [optionLookup, '.read_shipping_option_projection(', 'owner option lookup'],
   [optionLookup, 'ReadShippingOptionProjectionRequest {', 'typed lookup request'],
-  [optionLookup, 'context.clone(),', 'lookup context delegation'],
-  [
-    optionLookup,
-    'map_shipping_option_lookup_port_error(',
-    'lookup compatibility adapter',
-  ],
-  [
-    optionLookup,
-    '"read_shipping_option_projection"',
-    'lookup owner operation',
-  ],
-  [optionList, 'Result<Vec<ShippingOptionResponse>, BoundaryError>', 'direct list boundary result'],
-  [optionList, '.list_shipping_option_projections(', 'owner option list'],
-  [optionList, 'ListShippingOptionProjectionsRequest {', 'typed list request'],
-  [optionList, 'context.clone(),', 'list context delegation'],
-  [optionList, 'map_shipping_option_port_error(', 'list boundary mapper'],
-  [
-    optionList,
-    '"list_shipping_option_projections"',
-    'list owner operation',
-  ],
+  [optionLookup, 'map_shipping_option_lookup_port_error(', 'lookup compatibility adapter'],
+  [optionList, 'Result<Vec<ShippingOptionResponse>, BoundaryError>', 'storefront list result'],
+  [optionList, '.list_shipping_option_projections(', 'owner storefront list'],
+  [optionList, 'ListShippingOptionProjectionsRequest {', 'typed storefront request'],
+  [optionList, 'map_shipping_option_port_error(', 'storefront boundary mapper'],
   [
     optionAdminList,
     'Result<Vec<ShippingOptionResponse>, ShippingOptionAdminQueryError>',
     'typed admin adapter result',
   ],
-  [optionAdminList, '.list_all_shipping_option_projections(', 'owner admin option list'],
-  [optionAdminList, 'ListAllShippingOptionProjectionsRequest {', 'typed admin list request'],
-  [optionAdminList, 'context.clone(),', 'admin list context delegation'],
+  [optionAdminList, '.list_all_shipping_option_projections(', 'owner admin list'],
+  [optionAdminList, 'ListAllShippingOptionProjectionsRequest {', 'typed admin request'],
   [
     optionAdminList,
     'ShippingOptionAdminQueryError(map_shipping_option_port_error(',
     'admin boundary adapter',
-  ],
-  [
-    optionAdminList,
-    '"list_all_shipping_option_projections"',
-    'admin list owner operation',
   ],
 ]) {
   requireText(source, value, label);
 }
 
 for (const [value, label] of [
-  ['pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);', 'typed admin query error'],
-  ['pub(crate) fn to_string(self) -> BoundaryError', 'non-string source compatibility bridge'],
+  ['pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);', 'typed admin error'],
+  ['pub(crate) fn to_string(self) -> BoundaryError', 'non-string source bridge'],
   ['self.0', 'boundary preservation'],
 ]) {
   requireText(shim, value, label);
 }
 for (const value of ['impl std::fmt::Display', 'impl Display', 'format!("{}", self.0)']) {
   forbidText(shim, value, 'admin boundary must not serialize through text');
-}
-
-const projectionLookups = optionLookup.match(/\.read_shipping_option_projection\(/g) ?? [];
-if (projectionLookups.length !== 1) {
-  failures.push(`expected one shipping-option projection lookup, found ${projectionLookups.length}`);
-}
-const projectionLists = optionList.match(/\.list_shipping_option_projections\(/g) ?? [];
-if (projectionLists.length !== 1) {
-  failures.push(`expected one shipping-option projection list, found ${projectionLists.length}`);
-}
-const adminProjectionLists =
-  optionAdminList.match(/\.list_all_shipping_option_projections\(/g) ?? [];
-if (adminProjectionLists.length !== 1) {
-  failures.push(`expected one administrative shipping-option projection list, found ${adminProjectionLists.length}`);
 }
 
 for (const [value, label] of [
@@ -193,54 +158,82 @@ for (const [value, label] of [
   ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'availability classification'],
   ['PortErrorKind::Forbidden', 'forbidden classification'],
   ['PortErrorKind::InvariantViolation', 'invariant classification'],
-  ['"Fulfillment query is invalid"', 'existing validation message'],
-  ['"FULFILLMENT_REQUEST_INVALID"', 'existing validation code'],
-  ['"Fulfillment resource was not found"', 'existing not-found message'],
-  ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'existing not-found code'],
-  ['"Fulfillment state conflicts with this query"', 'existing conflict message'],
-  ['"FULFILLMENT_STATE_CONFLICT"', 'existing conflict code'],
-  ['"Fulfillment data is temporarily unavailable"', 'existing unavailable message'],
-  ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'existing unavailable code'],
-  ['FulfillmentError::ShippingOptionNotFound(shipping_option_id)', 'optional not-found compatibility'],
-  ['FulfillmentError::InvalidTransition {', 'conflict compatibility'],
-  ['DbErr::Custom("fulfillment storage is temporarily unavailable".to_string())', 'availability compatibility'],
-  ['"OPTIONAL_NONE"', 'optional-none diagnostic policy'],
-  ['"COMMERCE_QUERY_OPERATION_FAILED"', 'lookup fail-closed diagnostic policy'],
-  ['fn port_error_kind_name(', 'stable kind classifier'],
-  ['fn is_technical_port_error(', 'technical classifier'],
-  ['fn log_shipping_option_port_error(', 'shared context logger'],
+  ['"FULFILLMENT_REQUEST_INVALID"', 'validation code'],
+  ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'not-found code'],
+  ['"FULFILLMENT_STATE_CONFLICT"', 'conflict code'],
+  ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'unavailable code'],
+  ['"FULFILLMENT_ACCESS_DENIED"', 'forbidden code'],
+  ['"FULFILLMENT_OPERATION_FAILED"', 'invariant code'],
   ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['context_locale_length = context.locale.len()', 'locale context'],
   ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['query_field,', 'query field context'],
-  ['operation,', 'owner operation context'],
-  ['shipping_option_id = ?shipping_option_id', 'option identity'],
-  ['requested_locale_length = requested_locale.map(str::len)', 'requested locale length'],
-  ['tenant_default_locale_length = tenant_default_locale.map(str::len)', 'default locale length'],
-  ['error_kind,', 'stable kind diagnostic'],
   ['owner_code = %error.code', 'stable owner code'],
-  ['owner_kind = ?error.kind', 'owner kind'],
-  ['owner_retryable = error.retryable', 'owner retryability'],
-  ['public_code,', 'public code'],
-  ['public_retryable,', 'public retryability'],
-  ['tracing::error!(', 'technical severity'],
-  ['tracing::warn!(', 'ordinary severity'],
-  ['BoundaryError::Public {', 'direct list boundary result'],
+  ['BoundaryError::Public {', 'typed public boundary'],
 ]) {
   requireText(portBoundary, value, label);
 }
 
 for (const [value, label] of [
+  ['pub struct CommerceShippingOptionReadRuntime {', 'host read runtime'],
+  ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'runtime storefront port'],
+  [
+    'shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>',
+    'runtime administrative port',
+  ],
+  ['pub fn new(', 'host-injectable runtime constructor'],
+  ['pub fn in_process(db: DatabaseConnection) -> Self', 'standalone compatibility factory'],
+  ['in_process_shipping_option_read_port(db.clone())', 'standalone storefront factory'],
+  ['in_process_shipping_option_admin_read_port(db)', 'standalone admin factory'],
+  ['tokio::task_local! {', 'async task-local scope'],
+  ['CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME', 'scoped runtime identity'],
+  ['pub struct CommerceShippingOptionReadScope;', 'GraphQL scope extension'],
+  ['impl ExtensionFactory for CommerceShippingOptionReadScope', 'extension factory'],
+  ['ctx.data_opt::<CommerceGraphqlRuntimeData>()', 'schema runtime lookup'],
+  ['.scope(', 'resolver task scope'],
+  ['.try_with(Clone::clone)', 'facade runtime lookup'],
+  ['CommerceShippingOptionReadRuntime::in_process(db)', 'standalone fallback'],
+  [
+    '.shared_get::<CommerceShippingOptionReadRuntime>()',
+    'manifest runtime-data host requirement',
+  ],
+]) {
+  requireText(graphqlRuntime, value, label);
+}
+
+for (const [value, label] of [
+  [
+    'shared_get::<rustok_commerce::graphql_runtime::CommerceShippingOptionReadRuntime>()',
+    'server runtime reuse',
+  ],
+  [
+    'CommerceShippingOptionReadRuntime::in_process(',
+    'server in-process baseline composition',
+  ],
+  ['server.shared_insert(runtime.clone());', 'server runtime cache'],
+  ['host.with_shared_value(runtime)', 'host runtime attachment'],
+]) {
+  requireText(serverComposition, value, label);
+}
+
+for (const [value, label] of [
+  [
+    'use rustok_commerce::graphql_runtime::CommerceShippingOptionReadScope;',
+    'server extension import',
+  ],
+  [
+    'let builder = builder.extension(CommerceShippingOptionReadScope);',
+    'server extension mount',
+  ],
+]) {
+  requireText(serverSchema, value, label);
+}
+requireText(commerceCargo, 'tokio.workspace = true', 'task-local runtime dependency');
+
+for (const [value, label] of [
   ['use rustok_fulfillment::FulfillmentService;', 'unchanged query import'],
   ['let mut options = FulfillmentService::new(db.clone())', 'storefront facade constructor'],
-  ['.list_shipping_options(', 'storefront shipping option call'],
-  ['let fulfillment = FulfillmentService::new(db.clone())', 'admin order facade constructor'],
-  ['.find_by_order(tenant_id, id)', 'admin order fulfillment call'],
-  ['Err(rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_))', 'optional not-found source contract'],
-  ['Err(err) => return Err(err.to_string().into())', 'existing lookup fail-closed conversion'],
-  ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'unchanged mapped query source'],
+  ['let fulfillment = FulfillmentService::new(db.clone())', 'lifecycle facade constructor'],
+  ['Err(rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_))', 'optional none'],
+  ['Err(err) => return Err(err.to_string().into())', 'lookup fail-closed conversion'],
 ]) {
   requireText(query, value, label);
 }
@@ -252,46 +245,32 @@ for (const [value, label] of [
 ]) {
   requireText(adminQuery, value, label);
 }
-
-const legacyConstructors =
-  facade.match(/::rustok_fulfillment::FulfillmentService::new\(db\.clone\(\)\)/g) ?? [];
-if (legacyConstructors.length !== 1) {
-  failures.push(`expected one remaining concrete fulfillment constructor, found ${legacyConstructors.length}`);
-}
-const readFactories =
-  facade.match(/in_process_shipping_option_read_port\(db\.clone\(\)\)/g) ?? [];
-if (readFactories.length !== 1) {
-  failures.push(`expected one shipping-option read factory, found ${readFactories.length}`);
-}
-const adminReadFactories =
-  facade.match(/in_process_shipping_option_admin_read_port\(db\)/g) ?? [];
-if (adminReadFactories.length !== 1) {
-  failures.push(`expected one administrative shipping-option read factory, found ${adminReadFactories.length}`);
-}
-
-for (const value of [
-  '.get_shipping_option(tenant_id, id, requested_locale, tenant_default_locale)',
-  '.list_shipping_options(\n                        tenant_id,',
-  '.list_all_shipping_options(tenant_id, requested_locale, tenant_default_locale)',
-  'error.message',
-]) {
-  forbidText(
-    optionLookup + optionList + optionAdminList + portBoundary,
-    value,
-    'shipping-option query port boundary',
-  );
-}
-
 forbidText(
   query,
   '::rustok_fulfillment::FulfillmentService',
   'query source must remain facade-routed',
 );
 
+const concreteConstructors =
+  facade.match(/::rustok_fulfillment::FulfillmentService::new\(db\)/g) ?? [];
+if (concreteConstructors.length !== 1) {
+  failures.push(`expected one remaining lifecycle constructor, found ${concreteConstructors.length}`);
+}
+const runtimeReadFactories =
+  graphqlRuntime.match(/in_process_shipping_option_read_port\(db\.clone\(\)\)/g) ?? [];
+if (runtimeReadFactories.length !== 1) {
+  failures.push(`expected one standalone storefront factory, found ${runtimeReadFactories.length}`);
+}
+const runtimeAdminFactories =
+  graphqlRuntime.match(/in_process_shipping_option_admin_read_port\(db\)/g) ?? [];
+if (runtimeAdminFactories.length !== 1) {
+  failures.push(`expected one standalone admin factory, found ${runtimeAdminFactories.length}`);
+}
+
 for (const [value, label] of [
   ['pub trait ShippingOptionReadPort: Send + Sync {', 'owner storefront read port'],
   ['pub trait ShippingOptionAdminReadPort: Send + Sync {', 'owner admin read port'],
-  ['async fn list_all_shipping_option_projections(', 'owner admin list operation'],
+  ['async fn list_all_shipping_option_projections(', 'owner admin operation'],
   ['context.require_policy(PortCallPolicy::read())?', 'owner read policy'],
   ['PortError::new(kind, code, message, retryable)', 'owner stable error'],
 ]) {
@@ -305,5 +284,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL shipping-option lookup, storefront list, and administrative list-all use fulfillment owner read ports with retained context, typed public envelopes, and isolated legacy lifecycle reads',
+  '✔ Mounted Commerce GraphQL shipping-option reads use host-composed fulfillment ports with resolver-scoped runtime data, retained typed envelopes, standalone compatibility, and isolated lifecycle reads',
 );


### PR DESCRIPTION
## Summary

- continue the open ecommerce topology P0 by moving mounted Commerce GraphQL shipping-option read-port construction out of the private query facade and into application-host composition;
- add `CommerceShippingOptionReadRuntime`, holding the fulfillment-owned storefront and administrative shipping-option read ports and accepting arbitrary host-selected implementations through a public typed constructor;
- compose the in-process baseline once in the server's commerce provider runtime, cache it in `ServerRuntimeContext`, and attach it to `HostRuntimeContext`;
- require the typed runtime in manifest-generated `CommerceGraphqlRuntimeData` so mounted schema construction fails closed when host composition is missing;
- mount `CommerceShippingOptionReadScope` as an async-graphql resolver extension and carry the selected runtime through a Tokio task-local scope;
- make the private fulfillment facade consume the scoped ports instead of importing or calling either root in-process shipping-option factory;
- retain an explicit `CommerceShippingOptionReadRuntime::in_process` fallback outside the facade for directly embedded schemas that do not use the mounted server extension;
- preserve storefront active-only semantics, administrative list-all including inactive options before existing filters, optional lookup not-found behavior, and current typed `FULFILLMENT_*` public envelopes;
- keep the remaining concrete `FulfillmentService` delegate isolated to fulfillment lifecycle/list and order-to-fulfillment compatibility reads;
- update the focused static guard and Commerce/Fulfillment source-ready documentation without promoting FBA/FFA status.

## Recheck

- continued from merged GraphQL admin read-port PR #2340, squash-merged as `89a6d35d86ac464621893133f73acde8d04db86e`; its source branch is deleted;
- confirmed no open PR overlaps this shipping-option host-composition scope;
- confirmed server `mod-commerce` includes `mod-fulfillment`, so mounted composition cannot enable Commerce without the required owner crate;
- confirmed `ExtensionContext::data_opt` is an established server extension pattern and resolver execution can read schema/runtime data;
- confirmed directly embedded Commerce schemas build without manifest runtime data, so the compatibility fallback remains explicit and outside the private facade;
- reconstructed the full original `safe_query.rs` from GitHub, verified its exact source blob SHA `e7350c7758da3fcb60cec0e95ab4104fe80aa9cc`, applied only the import and constructor changes, and published resulting blob `32091ae278915031d0aaec0873fe3e61d352c07b`;
- rebuilt the branch as one atomic commit directly on current `main` after unrelated Forum work landed;
- confirmed the branch is zero commits behind and changes exactly nine host/runtime/facade/guard/documentation files.

## Boundary

This PR moves mounted GraphQL shipping-option provider construction into application-host composition. It does not propagate public channel into every shipping-option query context, migrate REST/native shipping reads, publish owner ports for fulfillment lifecycle query reads, remove the facade's remaining concrete lifecycle delegate, change Product/Order/Payment topology, provide compile/mounted/runtime/remote evidence, or promote fulfillment/ecommerce FBA or FFA status.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
cargo check -p rustok-commerce --lib
cargo check -p rustok-server --features mod-commerce
```

## Next slice

Compare mounted GraphQL shipping-option active list, administrative list-all, and lookup behavior with REST/native consumers, retain parity/context evidence, and then decide whether to migrate those compatibility transports or publish fulfillment lifecycle query read ports.