### PR TITLE
Record shipping option transport parity audit

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -46,6 +46,36 @@ in the public Commerce GraphQL runtime module. The fallback preserves existing
 standalone schema tests and embeddings without turning the private facade back
 into a provider constructor.
 
+## Transport parity source inventory
+
+The source inventory at
+`crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`
+compares the mounted GraphQL projection reads with the current Commerce REST and
+FFA/native surfaces. It is explicitly marked `source_audit_only_unvalidated` and
+is not runtime parity evidence.
+
+The inventory records:
+
+- mounted GraphQL active list, administrative list-all, and single lookup use the
+  host-composed owner ports;
+- storefront REST still creates `FulfillmentService` directly for the active
+  list, then applies the same currency, public-channel, and shipping-profile
+  filters as GraphQL;
+- admin REST still creates `FulfillmentService` directly for list-all and single
+  lookup, while preserving inactive-before-filter semantics and the existing
+  active, currency, provider, search, and pagination filters;
+- the native FFA surface does not publish complete shipping-option projection
+  list or lookup operations; it owns seller/cart selection through
+  `ShippingSelectionPort` over native-server and GraphQL transports;
+- projection parity therefore does not justify adding projection reads to the
+  native selection contract without a concrete consumer contract.
+
+The decision retained by the inventory is to migrate the existing REST
+projection reads to `CommerceShippingOptionReadRuntime` next, preserving their
+successful response filtering and HTTP public envelopes. The focused guard
+`scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
+locks this audited topology until that cutover deliberately updates the evidence.
+
 ## Retained read context
 
 Each port-backed shipping-option query constructs `PortContext` with:
@@ -140,6 +170,10 @@ owner-local diagnostics and technical database cause.
   delegate.
 - Directly embedded schemas keep an explicit compatibility fallback without
   changing the mounted server composition path.
+- Current REST success filtering is retained by the source inventory but REST is
+  not yet owner-port composed.
+- Native seller/cart selection remains a separate contract and is not treated as
+  a complete projection-read transport.
 - Admin order lookup and non-not-found single shipping-option failures keep their
   existing generic `COMMERCE_QUERY_OPERATION_FAILED` fail-closed envelope after
   stable compatibility conversion.
@@ -148,20 +182,26 @@ owner-local diagnostics and technical database cause.
 
 ## Still open
 
+- Migrate storefront REST active-list plus admin REST list-all and single lookup
+  to the host-composed shipping-option read runtime.
+- Preserve existing HTTP status/code/message policy while mapping typed
+  `PortErrorKind` without owner-message control flow.
 - Add public-channel propagation to the shipping-option query `PortContext`.
 - Publish owner ports for fulfillment lifecycle query reads, then remove the
   remaining concrete `FulfillmentService` field.
-- Migrate REST/native shipping reads and retain parity evidence.
+- Add mounted GraphQL/REST execution evidence; no native projection evidence is
+  required until a native projection consumer contract exists.
 - Continue reviewing order, payment, customer, inventory, region, channel,
   catalog, and remaining Commerce query conversions that still pass through
   dynamic strings.
-- Add compile, mounted transport, deadline, REST/native parity, and remote
-  evidence before promoting any FBA/FFA status.
+- Add compile, mounted transport, deadline, REST parity, and remote evidence
+  before promoting any FBA/FFA status.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
 node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
 cargo check -p rustok-commerce --lib

--- a/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-28",
+  "status": "source_audit_only_unvalidated",
+  "source_revision": "aa1f12d7660bda14daa5d8ade11d3074418a573f",
+  "scope": "shipping-option projection reads across mounted commerce transports",
+  "graphql": {
+    "composition": "application_host",
+    "runtime": "CommerceShippingOptionReadRuntime",
+    "operations": [
+      "ShippingOptionReadPort::list_shipping_option_projections",
+      "ShippingOptionReadPort::read_shipping_option_projection",
+      "ShippingOptionAdminReadPort::list_all_shipping_option_projections"
+    ],
+    "storefront_active_only": true,
+    "admin_inactive_before_filters": true,
+    "single_lookup_optional_not_found": true
+  },
+  "rest": {
+    "composition": "direct_concrete_service",
+    "storefront_active_list": {
+      "source": "crates/rustok-commerce/src/controllers/store/products.rs",
+      "operation": "FulfillmentService::list_shipping_options",
+      "currency_filter_retained": true,
+      "public_channel_filter_retained": true,
+      "shipping_profile_filter_retained": true
+    },
+    "admin_list_all": {
+      "source": "crates/rustok-commerce/src/controllers/admin/shipping.rs",
+      "operation": "FulfillmentService::list_all_shipping_options",
+      "inactive_before_filters": true,
+      "active_currency_provider_search_pagination_retained": true
+    },
+    "admin_lookup": {
+      "source": "crates/rustok-commerce/src/controllers/admin/shipping.rs",
+      "operation": "FulfillmentService::get_shipping_option"
+    },
+    "cutover_required": true
+  },
+  "native_ffa": {
+    "projection_read_surface": "absent_by_design",
+    "selection_surface": "ShippingSelectionPort",
+    "selection_transports": [
+      "native_server",
+      "graphql"
+    ],
+    "expand_selection_contract_for_projection_parity": false
+  },
+  "decision": {
+    "next_slice": "migrate_rest_projection_reads_to_host_composed_owner_ports",
+    "preserve_existing_http_success_filters": true,
+    "preserve_existing_http_public_envelopes": true,
+    "do_not_add_native_projection_api_without_a_consumer_contract": true
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -46,6 +46,13 @@ compatibility reads. Directly embedded standalone schemas retain an explicit
 in-process compatibility fallback outside the facade. The seller/cart
 `ShippingSelectionPort` contract is unchanged.
 
+A source-only transport inventory now records that Commerce REST still constructs
+`FulfillmentService` for storefront active-list and admin list-all/lookup, even
+though it preserves the same successful filtering semantics. The native FFA
+surface owns seller/cart selection and does not publish complete projection list
+or lookup operations. The retained next implementation decision is REST cutover
+to the host-composed owner ports without expanding `ShippingSelectionPort`.
+
 Stable fulfillment keys and metadata identity remain owner-local compatibility
 mechanisms. Duplicate keys fail closed. A typed durable checkout fulfillment
 identity and database uniqueness migration remain open.
@@ -70,15 +77,19 @@ identity and database uniqueness migration remain open.
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-static-matrix.json`,
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-runtime-smoke.json`,
   and `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-live-adapter-evidence.json`.
+- Source-only shipping-option transport inventory:
+  `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`.
+  It is unvalidated source evidence and does not promote any status.
 - `scripts/verify/verify-fulfillment-admin-boundary.mjs`,
   `scripts/verify/verify-fulfillment-storefront-boundary.mjs`,
   `scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`, and
   `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the
   owner-admin/storefront, checkout execution, and typed lifecycle split.
-- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs` and
-  `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs` guard the
-  internal shipping-option read boundaries, mounted GraphQL query cutover, and
-  server host composition.
+- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`,
+  `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`, and
+  `scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
+  guard the internal read boundaries, mounted GraphQL host composition, and the
+  explicit REST/native source inventory.
 - No status promotion is claimed from source. Compile, upgraded database,
   contention, restart, mounted transport, and remote evidence remain missing.
 
@@ -119,8 +130,14 @@ identity and database uniqueness migration remain open.
 - [x] Inject both read ports from application-host composition through typed
   runtime data and resolver-scoped async context; keep standalone fallback outside
   the private facade.
-- [ ] Execute compile, mounted GraphQL, REST/native parity, deadline, failure,
-  and remote-profile evidence.
+- [x] Retain a source-only GraphQL/REST/native inventory that distinguishes
+  complete projection reads from seller/cart selection and records the REST
+  cutover decision without claiming runtime parity.
+- [ ] Cut Commerce REST storefront active-list and admin list-all/lookup over to
+  the same host-composed owner runtime while preserving HTTP envelopes and local
+  success filters.
+- [ ] Execute compile, mounted GraphQL/REST parity, deadline, locale, channel,
+  failure, and remote-profile evidence.
 
 ## Open results
 
@@ -154,15 +171,18 @@ identity and database uniqueness migration remain open.
    **Done when:** production-like execution proves degraded fallback and typed
    adapter errors while `FulfillmentService` remains the sole lifecycle owner.
 
-5. **Prove shipping-option transport parity.** Execute active list,
-   administrative list-all, and lookup through mounted GraphQL consumers and
-   compare REST/native behavior against the same owner projections.
-   **Depends on:** compiled fulfillment/commerce crates and mounted transport
-   fixtures.
-   **Done when:** all transports retain locale/channel/deadline context, expose
-   identical owner projections with correct active/inactive semantics, and no
-   mounted commerce transport constructs a concrete fulfillment service or
-   in-process read provider.
+5. **Cut REST projection reads over and prove transport parity.** Replace the
+   existing Commerce REST storefront active-list and admin list-all/lookup
+   concrete service construction with `CommerceShippingOptionReadRuntime`, then
+   execute mounted GraphQL/REST comparisons against the same owner projections.
+   Native seller/cart selection remains a separate contract and needs no complete
+   projection surface without a consumer.
+   **Depends on:** host runtime wiring for Commerce HTTP plus compiled
+   fulfillment/commerce crates and mounted transport fixtures.
+   **Done when:** GraphQL and REST retain locale/channel/deadline context, expose
+   identical owner projections with correct active/inactive semantics, preserve
+   their public envelopes, and no mounted projection transport constructs a
+   concrete fulfillment service or in-process read provider.
 
 6. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.
@@ -178,6 +198,7 @@ identity and database uniqueness migration remain open.
 - `node scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs`
 - `node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
+- `node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs`
 - `npm run verify:ecommerce:fba`
@@ -189,7 +210,7 @@ identity and database uniqueness migration remain open.
 - Targeted checkout fulfillment create/adopt/read, cancelled/unknown lifecycle,
   duplicate identity, process-exit, restart, and multi-fulfillment tests.
 - Targeted shipping-option active list, administrative list-all, lookup locale,
-  context, owner-error, GraphQL, REST/native parity, and remote-profile tests.
+  context, owner-error, GraphQL/REST parity, and remote-profile tests.
 
 No verification command was executed in this source wave.
 

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -90,6 +90,44 @@ an explicit `CommerceShippingOptionReadRuntime::in_process` compatibility
 fallback in the Commerce GraphQL runtime module. The fallback is outside the
 private facade and is not evidence of mounted transport composition or parity.
 
+## Transport parity source inventory
+
+`contracts/evidence/shipping-option-read-transport-parity-source.json` records a
+source-only inventory at revision
+`aa1f12d7660bda14daa5d8ade11d3074418a573f`. Its status is
+`source_audit_only_unvalidated`; it does not claim compiled or mounted behavior.
+
+The inventory establishes three distinct transport states:
+
+1. Mounted GraphQL active list, admin list-all, and lookup consume the
+   application-host runtime and fulfillment owner ports.
+2. Commerce REST preserves the same successful projection filtering, but its
+   storefront active list and admin list-all/lookup still construct concrete
+   `FulfillmentService` instances.
+3. Fulfillment storefront FFA exposes seller/cart shipping selection over native
+   server and GraphQL paths. It does not expose complete shipping-option
+   projection list or lookup operations.
+
+The third state is not a missing parity implementation: `ShippingSelectionPort`
+and the complete projection read ports have different consumers and semantics.
+A projection API must not be added to the native selection surface merely to make
+transport counts look symmetrical.
+
+The retained decision is therefore:
+
+- migrate the existing REST projection reads to the host-composed owner runtime;
+- preserve storefront currency/channel/profile filters;
+- preserve admin inactive-before-filter behavior and active/currency/provider/
+  search/pagination filters;
+- preserve current HTTP public status/code/message policy through typed
+  `PortErrorKind` mapping;
+- leave the native selection contract unchanged unless a complete projection
+  consumer is designed.
+
+`scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
+locks this inventory and decision until the REST cutover deliberately updates
+both source and evidence.
+
 ## Stable owner errors
 
 | Owner outcome | Port kind | Code | Retryable |
@@ -149,8 +187,8 @@ inactive options before the existing local active, currency, provider, search,
 and pagination filters are applied.
 
 Delivery-group projection is a pure Commerce function receiving owner
-projections. Existing REST/native compatibility adapters delegate to the same
-pure function, so those transports are not changed by this slice.
+projections. Existing selection adapters continue to delegate to the separate
+`ShippingSelectionPort`; they are not projection-read transports.
 
 ## Verification
 
@@ -159,6 +197,7 @@ Focused source guards:
 ```bash
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
 node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs
 node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
 cargo check -p rustok-fulfillment --lib
@@ -172,8 +211,11 @@ No command was executed locally in this source wave.
 
 This slice does not:
 
-- propagate public channel into every query read context;
-- migrate REST/native shipping reads;
+- migrate Commerce REST storefront active-list or admin list-all/lookup to the
+  host-composed read ports;
+- execute GraphQL/REST parity, deadline, locale, channel, or failure fixtures;
+- add a native complete-projection read surface without a consumer contract;
+- propagate public channel into every GraphQL query read context;
 - publish owner read ports for fulfillment lifecycle and order-to-fulfillment
   query paths;
 - retire `FulfillmentService` from fulfillment-owned compatibility adapters;

--- a/scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
+++ b/scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const adminRest = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const storefrontRest = read('crates/rustok-commerce/src/controllers/store/products.rs');
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const safeQuery = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const commerceStorefrontTransport = read('crates/rustok-commerce/storefront/src/transport/mod.rs');
+const commerceNativeAdapter = read(
+  'crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs',
+);
+const fulfillmentStorefrontTransport = read('crates/rustok-fulfillment/storefront/src/transport.rs');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json',
+  ),
+);
+
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [serverRuntime, 'CommerceShippingOptionReadRuntime::in_process(', 'host read runtime factory'],
+  [serverRuntime, 'host.with_shared_value(runtime)', 'host read runtime attachment'],
+  [graphqlRuntime, 'pub struct CommerceShippingOptionReadRuntime', 'typed read runtime'],
+  [graphqlRuntime, 'CommerceShippingOptionReadScope', 'resolver-scoped runtime bridge'],
+  [safeQuery, 'shipping_option_runtime.shipping_option_read_port()', 'GraphQL storefront port'],
+  [
+    safeQuery,
+    'shipping_option_runtime\n                        .shipping_option_admin_read_port()',
+    'GraphQL admin port',
+  ],
+]) {
+  requireText(source, value, label);
+}
+
+for (const value of [
+  'in_process_shipping_option_read_port(db.clone())',
+  'in_process_shipping_option_admin_read_port(db)',
+]) {
+  forbidText(safeQuery, value, 'private GraphQL facade must not construct read providers');
+}
+
+for (const [source, value, label] of [
+  [httpRuntime, 'pub struct CommerceHttpRuntime', 'Commerce HTTP runtime'],
+  [adminRest, 'FulfillmentService::new(runtime.db_clone())', 'admin REST concrete service'],
+  [adminRest, '.list_all_shipping_options(', 'admin REST list-all operation'],
+  [adminRest, '.get_shipping_option(', 'admin REST lookup operation'],
+  [adminRest, 'items.retain(|option| option.active == active);', 'admin active filter'],
+  [adminRest, 'items.retain(|option| option.currency_code.eq_ignore_ascii_case(currency_code));', 'admin currency filter'],
+  [adminRest, 'items.retain(|option| option.provider_id.eq_ignore_ascii_case(provider_id));', 'admin provider filter'],
+  [adminRest, 'option.name.to_ascii_lowercase().contains(&search)', 'admin search filter'],
+  [storefrontRest, 'FulfillmentService::new(runtime.db_clone())', 'storefront REST concrete service'],
+  [storefrontRest, '.list_shipping_options(', 'storefront REST active list'],
+  [storefrontRest, 'option.currency_code.eq_ignore_ascii_case(currency_code)', 'storefront currency filter'],
+  [storefrontRest, 'is_metadata_visible_for_public_channel', 'storefront channel filter'],
+  [storefrontRest, 'is_shipping_option_compatible_with_profiles', 'storefront profile filter'],
+]) {
+  requireText(source, value, label);
+}
+
+forbidText(
+  httpRuntime,
+  'CommerceShippingOptionReadRuntime',
+  'REST cutover must remain explicitly open until the next source slice',
+);
+
+for (const [source, value, label] of [
+  [commerceStorefrontTransport, 'select_storefront_shipping_option(', 'Commerce selection handoff'],
+  [
+    commerceStorefrontTransport,
+    'rustok_fulfillment_storefront::transport::select_shipping_option',
+    'fulfillment selection transport',
+  ],
+  [fulfillmentStorefrontTransport, 'pub async fn select_shipping_option(', 'selection transport API'],
+  [fulfillmentStorefrontTransport, 'ShippingSelectionDeliveryGroup', 'selection projection'],
+  [fulfillmentStorefrontTransport, 'UiTransportPath::NativeServer', 'native selection path'],
+  [fulfillmentStorefrontTransport, 'UiTransportPath::Graphql', 'GraphQL selection path'],
+]) {
+  requireText(source, value, label);
+}
+
+for (const value of [
+  'list_shipping_option_projections',
+  'list_all_shipping_option_projections',
+  'read_shipping_option_projection',
+]) {
+  forbidText(
+    commerceStorefrontTransport + commerceNativeAdapter + fulfillmentStorefrontTransport,
+    value,
+    'native FFA must not invent a projection-read surface',
+  );
+}
+
+const expectedEvidence = {
+  status: 'source_audit_only_unvalidated',
+  graphqlComposition: 'application_host',
+  restComposition: 'direct_concrete_service',
+  restCutoverRequired: true,
+  nativeProjectionSurface: 'absent_by_design',
+  nextSlice: 'migrate_rest_projection_reads_to_host_composed_owner_ports',
+};
+const actualEvidence = {
+  status: evidence.status,
+  graphqlComposition: evidence.graphql?.composition,
+  restComposition: evidence.rest?.composition,
+  restCutoverRequired: evidence.rest?.cutover_required,
+  nativeProjectionSurface: evidence.native_ffa?.projection_read_surface,
+  nextSlice: evidence.decision?.next_slice,
+};
+if (JSON.stringify(actualEvidence) !== JSON.stringify(expectedEvidence)) {
+  failures.push(
+    `source evidence mismatch: expected ${JSON.stringify(expectedEvidence)}, received ${JSON.stringify(actualEvidence)}`,
+  );
+}
+if (evidence.native_ffa?.expand_selection_contract_for_projection_parity !== false) {
+  failures.push('source evidence must keep selection and projection-read contracts separate');
+}
+for (const field of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+]) {
+  if (evidence.validation?.[field] !== false) {
+    failures.push(`source evidence validation.${field} must remain false for this unvalidated audit`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce shipping-option transport parity inventory verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Shipping-option source inventory records host-composed GraphQL reads, the explicit REST cutover gap, and the intentionally separate native selection surface',
+);


### PR DESCRIPTION
## Summary

- continue the fulfillment shipping-option read plan after host-composing mounted GraphQL reads in PR #2343;
- retain a source-only transport inventory for GraphQL, Commerce REST, and fulfillment storefront FFA/native surfaces;
- record that mounted GraphQL active list, admin list-all, and lookup use `CommerceShippingOptionReadRuntime` and fulfillment owner ports;
- record that Commerce REST preserves equivalent success filtering but still constructs concrete `FulfillmentService` for storefront active-list and admin list-all/lookup;
- record that the native FFA surface owns seller/cart selection through `ShippingSelectionPort` and intentionally does not publish complete projection list/lookup operations;
- retain the next implementation decision: migrate existing REST projection reads to the host-composed owner runtime without expanding the native selection contract;
- add a focused static inventory guard and update Commerce/Fulfillment documentation and the fulfillment implementation plan;
- keep the evidence status `source_audit_only_unvalidated` and do not promote FBA/FFA status.

## Recheck

- continued from merged PR #2343, squash commit `aa1f12d7660bda14daa5d8ade11d3074418a573f`;
- confirmed no open PR overlaps the shipping-option REST/native parity scope;
- confirmed storefront REST applies currency, public-channel, and shipping-profile filters after `FulfillmentService::list_shipping_options`;
- confirmed admin REST applies active, currency, provider, search, and pagination filters after complete `list_all_shipping_options`, and uses concrete service lookup for a single option;
- confirmed Commerce storefront native transport does not return shipping-option projections;
- confirmed fulfillment storefront native/GraphQL transport is a seller/cart selection surface, not a complete projection-read surface;
- rebuilt the branch as one atomic commit over current `main` after unrelated Index PR #2344 landed;
- confirmed the branch is zero commits behind and changes exactly five audit/evidence files.

## Boundary

This PR retains a source inventory and implementation decision. It does not migrate REST handlers, change HTTP envelopes, add a native projection API, modify `ShippingSelectionPort`, run mounted parity fixtures, publish lifecycle query ports, or promote fulfillment/ecommerce FBA or FFA status.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused check:

```bash
node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
```

## Next slice

Add `CommerceShippingOptionReadRuntime` to `CommerceHttpRuntime`, cut storefront REST active-list and admin REST list-all/lookup over to the fulfillment owner ports, preserve current HTTP status/code/message policy and local filters, then retain mounted GraphQL/REST parity evidence.