### PR TITLE
feat(forum): compose reply-create audience transports

### DIFF
--- a/crates/rustok-forum/CRATE_API.md
+++ b/crates/rustok-forum/CRATE_API.md
@@ -19,6 +19,10 @@
 - `pub struct graphql::ForumGraphqlRuntimeData`; `graphql::attach_schema_data(GraphqlRuntimeInputs)`
 - `TopicService::update_command(tenant_id, topic_id, security, UpdateTopicCommandInput) -> TopicResponse`
 - `ReplyService::create_command(tenant_id, security, topic_id, CreateReplyCommandInput) -> ReplyResponse`
+- `ReplyService::create_with_audience_context(tenant_id, security, topic_id, PortContext, CreateReplyInput) -> ReplyResponse`
+- `ReplyService::create_command_with_audience_context(tenant_id, security, topic_id, PortContext, CreateReplyCommandInput) -> ReplyResponse`
+- `ReplyService::with_audience_facts(db, event_bus, SharedForumAudienceFactsPort) -> ReplyService`
+- `pub struct ForumReplyCreateAudienceAuthorizationService`, `ForumReplyCreateAudienceAuthorization`
 - `ReplyService::update_command(tenant_id, reply_id, security, UpdateReplyCommandInput) -> ReplyResponse`
 - `CategoryService::tree(tenant_id, security, CategoryTreeQuery) -> CategoryTreeResponse`
 - `CategoryService::move_category(tenant_id, category_id, security, MoveCategoryInput) -> MoveCategoryResponse`
@@ -108,8 +112,14 @@
 - Effective reply-create audience is the root-to-category conjunction of every non-empty local layer.
 - Managed `get` and atomic replacement `set` require `forum_categories:manage`; empty constraints restore inheritance.
 - PostgreSQL and SQLite enforce tenant/category ownership, typed roles/trust/effects, immutable rows, and bounded direct channel/group/allow/deny inserts.
-- `FORUM-20AU` publishes owner persistence only and does not yet change `ReplyService::create`, GraphQL, REST, or transport DTOs.
-- Run `node scripts/verify/verify-forum-category-reply-create-audience-policy.mjs` after changing this boundary.
+- `FORUM-20AU` publishes normalized owner persistence; `FORUM-20AV` composes the inherited policy into every public reply-create owner method before any raw owner write.
+- Categories without a reply-create layer retain historical behavior; local role and explicit-user decisions require no owner facts.
+- Unresolved trust, Channel, or Groups selectors require an exact caller `PortContext` and an injected `SharedForumAudienceFactsPort`; missing composition fails closed.
+- Authorization resolves the tenant-scoped topic/category identity and runs before reply, body, relation, counter, user-stat, and domain-event writes with one generic public denial.
+- `FORUM-20AW` composes GraphQL and REST reply-create calls through exact authenticated `PortContext` values and reuses the host-published optional facts port without adding identity to DTOs.
+- Both legacy and inline-quote GraphQL and REST reply-create transports preserve the owner gate before writes; locally decidable policies remain compatible when the provider is absent.
+- `ForumGraphqlRuntimeData` and `ForumHttpRuntime` create `ReplyService` from the same optional `SharedForumAudienceFactsPort` already used by topic creation.
+- Run `node scripts/verify/verify-forum-category-reply-create-audience-policy.mjs`, `node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs`, and `node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs` after changing this boundary.
 ### Category presentation contract
 - Existing `icon` storage is interpreted as an `icon_key` and accepts only a bounded lowercase kebab-case semantic token at the database write boundary.
 - Category colors remain bounded hexadecimal colors; CSS declarations and arbitrary color expressions are rejected.
@@ -260,7 +270,7 @@ Legacy Forum lifecycle events remain root `DomainEvent` variants. Mention events
 - Returns a quote command response through a post-commit read that can fail after the write committed.
 - Imports raw topic/reply implementation modules instead of the root owner facades.
 - Treats `forum_user_stats` activity counters as Forum trust state.
-- Applies reply-create audience persistence directly inside `ReplyService` before the separate authorization slice.
+- Builds reply-create audience identity from DTO fields or bypasses the exact transport context and host-composed `ReplyService`.
 - Passes methods to `ModerationService` without `tenant_id` — it is now required.
 
 ## Minimum Contract Set
@@ -279,6 +289,7 @@ Legacy Forum lifecycle events remain root `DomainEvent` variants. Mention events
 - Category subtree lifecycle is tenant-scoped, atomic, idempotent and enforced at the database boundary for category hierarchy and topic placement.
 - Category topic policy is tenant-scoped and enforced at the database boundary for topic inserts and category reassignment.
 - Category topic-create and reply-create audience layers are normalized, independently inherited, bounded, immutable on direct update and separate from content visibility.
+- Topic/reply create transports derive exact tenant, actor, claims, locale, deadline, and route channel only from authenticated runtime contexts and use the same host-published optional audience facts port.
 - Category icon/color values are bounded safe tokens; cover media candidates are tenant-scoped and transport-neutral.
 - Category cover writes fail closed when Media is unavailable; reads degrade only for an explicitly absent optional Media owner and never swallow provider errors.
 - Mention extraction is bounded, format-aware and code/escape-safe; profile resolution is tenant-scoped and privacy fail-closed.

--- a/crates/rustok-forum/contracts/forum-reply-create-audience-transport-composition.json
+++ b/crates/rustok-forum/contracts/forum-reply-create-audience-transport-composition.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20AW",
+  "upstream_task": "FORUM-20AV",
+  "scope": "GraphQL, REST, and host-runtime composition for exact reply-create audience facts",
+  "transport_context_file": "crates/rustok-forum/src/reply_create_transport.rs",
+  "graphql_runtime_file": "crates/rustok-forum/src/graphql/runtime_data.rs",
+  "graphql_legacy_mutation_file": "crates/rustok-forum/src/graphql/mutation.rs",
+  "graphql_command_mutation_file": "crates/rustok-forum/src/graphql/content_commands.rs",
+  "http_runtime_file": "crates/rustok-forum/src/controllers/mod.rs",
+  "http_legacy_create_file": "crates/rustok-forum/src/controllers/replies.rs",
+  "http_command_create_file": "crates/rustok-forum/src/controllers/content_commands.rs",
+  "owner_enforcement_file": "crates/rustok-forum/src/services/reply_facade.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md",
+  "crate_api": "crates/rustok-forum/CRATE_API.md",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "source_verifier": "scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs",
+  "composition": {
+    "shared_exact_transport_context_builder": true,
+    "auth_tenant_request_identity_validation": true,
+    "dto_identity_forbidden": true,
+    "read_deadline_semantics": true,
+    "permission_claim_forwarding": true,
+    "resolved_route_channel_forwarding": true,
+    "graphql_legacy_create_composed": true,
+    "graphql_command_create_composed": true,
+    "rest_legacy_create_composed": true,
+    "rest_command_create_composed": true,
+    "graphql_runtime_facts_consumed": true,
+    "http_runtime_facts_consumed": true,
+    "host_extension_facts_reused": true,
+    "missing_provider_fail_closed": true,
+    "local_policy_compatibility_preserved": true,
+    "owner_authorization_before_writes_preserved": true,
+    "migration_changed": false,
+    "reply_create_dto_changed": false,
+    "forum_groups_dependency_added": false,
+    "trust_facts_adapter_added": false,
+    "topic_local_narrowing_added": false,
+    "moderation_audience_added": false,
+    "canonical_plan_rewritten": false
+  },
+  "closes_upstream_residuals": [
+    "GraphQL reply-create audience context composition",
+    "REST reply-create audience context composition",
+    "host runtime Forum audience facts injection for reply creation"
+  ],
+  "not_delivered": [
+    "safe canonical Forum plan ledger update through FORUM-20AW",
+    "topic-local reply audience narrowing",
+    "moderation audience policy persistence and enforcement",
+    "Forum trust owner state and facts adapter",
+    "remaining Forum read search index SEO and deep-link audience migration",
+    "visibility-scoped category and all-read commands",
+    "tenant-wide scheduled reconciliation and payload redaction",
+    "channel delivery enqueue and delivery-time authorization",
+    "PostgreSQL concurrency and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "commands": [
+      "cargo test -p rustok-forum reply_create_transport -- --nocapture",
+      "cargo test -p rustok-forum graphql::runtime_data -- --nocapture",
+      "node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs",
+      "node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs",
+      "cargo xtask module validate forum"
+    ],
+    "execution_status": "not_run_by_implementation_agent"
+  }
+}

--- a/crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md
+++ b/crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md
@@ -1,0 +1,40 @@
+# FORUM-20AW reply-create audience transport composition
+
+Status: source-ready / unvalidated.
+
+## Delivered
+
+- GraphQL legacy `createForumReply` and inline-quote `createForumReplyWithQuotes` build an exact authenticated read-only `PortContext` before invoking the reply owner.
+- REST legacy and command reply-create handlers build the same exact context from `TenantContext`, `AuthContext`, and `RequestContext`.
+- Tenant and actor identity come only from authenticated transport extensions; request DTOs do not carry or select either identity.
+- The context forwards effective permission claims, the resolved route channel when available, request locale, a bounded five-second deadline, and a unique transport correlation identity.
+- `ForumGraphqlRuntimeData` and `ForumHttpRuntime` compose `ReplyService` from the same optional `SharedForumAudienceFactsPort` already published by the host for topic creation.
+- Missing provider composition remains compatible for unrestricted, role-only, and explicit-user decisions; unresolved trust, Channel, or Groups selectors continue to fail closed in the owner.
+- Both public reply-create owner methods remain gated before reply, body, relation, counter, user-stat, and event writes.
+
+## Boundary
+
+- No reply-create, quote, GraphQL, REST, or OpenAPI DTO fields changed.
+- No migrations or dependencies changed.
+- No Forum-to-Groups crate dependency was added.
+- No trust facts adapter or Forum trust owner state was added.
+- No topic-local reply audience narrowing or moderation audience policy was added.
+- The host publication path is reused without a second provider registry or transport-owned facts query.
+
+## Canonical plan debt
+
+The canonical `crates/rustok-forum/docs/implementation-plan.md` is intentionally not rewritten in this slice. The available GitHub contents API requires complete-file replacement, while that roadmap exceeds two thousand lines; risking unrelated roadmap loss is not acceptable. A later safe repository-local edit must advance the FORUM-20 ledger through `FORUM-20AW`, place this delivered section after `FORUM-20AV`, and retain reply topic-local narrowing plus moderation audience work as remaining scope.
+
+## Validation status
+
+The following commands are source-ready but were not run by the implementation agent:
+
+```text
+cargo test -p rustok-forum reply_create_transport -- --nocapture
+cargo test -p rustok-forum graphql::runtime_data -- --nocapture
+node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
+node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs
+cargo xtask module validate forum
+```
+
+Tests, Cargo commands, formatting, verifier execution, workflows, and CI remain the maintainer's responsibility for this slice.

--- a/crates/rustok-forum/src/controllers/content_commands.rs
+++ b/crates/rustok-forum/src/controllers/content_commands.rs
@@ -13,6 +13,9 @@ use crate::{
     CreateReplyCommandInput, CreateTopicCommandInput, ReplyResponse, ReplyService, TopicResponse,
     TopicService, UpdateReplyCommandInput, UpdateTopicCommandInput,
 };
+use crate::reply_create_transport::{
+    ForumReplyCreateTransport, reply_create_audience_port_context,
+};
 use crate::topic_create_transport::{
     ForumTopicCreateTransport, topic_create_audience_port_context,
 };
@@ -113,6 +116,7 @@ pub async fn create_reply(
     State(runtime): State<crate::controllers::ForumHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(topic_id): Path<Uuid>,
     Json(input): Json<CreateReplyCommandInput>,
 ) -> HttpResult<(StatusCode, Json<ReplyResponse>)> {
@@ -121,8 +125,23 @@ pub async fn create_reply(
         Permission::FORUM_REPLIES_CREATE,
         "Permission denied: forum_replies:create required",
     )?;
-    let reply = ReplyService::new(runtime.db_clone(), runtime.event_bus())
-        .create_command(tenant.id, forum_security(&auth), topic_id, input)
+    let audience_context = reply_create_audience_port_context(
+        ForumReplyCreateTransport::Rest,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        tenant.default_locale.as_str(),
+    )
+    .map_err(command_error)?;
+    let reply = runtime
+        .reply_service()
+        .create_command_with_audience_context(
+            tenant.id,
+            forum_security(&auth),
+            topic_id,
+            audience_context,
+            input,
+        )
         .await
         .map_err(command_error)?;
     Ok((StatusCode::CREATED, Json(reply)))

--- a/crates/rustok-forum/src/controllers/mod.rs
+++ b/crates/rustok-forum/src/controllers/mod.rs
@@ -46,6 +46,17 @@ impl ForumHttpRuntime {
             None => crate::TopicService::new(self.db_clone(), self.event_bus()),
         }
     }
+
+    fn reply_service(&self) -> crate::ReplyService {
+        match self.audience_facts.clone() {
+            Some(facts) => crate::ReplyService::with_audience_facts(
+                self.db_clone(),
+                self.event_bus(),
+                facts,
+            ),
+            None => crate::ReplyService::new(self.db_clone(), self.event_bus()),
+        }
+    }
 }
 
 impl ForumHttpRuntime {

--- a/crates/rustok-forum/src/controllers/replies.rs
+++ b/crates/rustok-forum/src/controllers/replies.rs
@@ -14,6 +14,9 @@ use crate::{
     CreateReplyInput, ListRepliesFilter, ReplyListItem, ReplyResponse, ReplyService,
     UpdateReplyInput, VoteService,
 };
+use crate::reply_create_transport::{
+    ForumReplyCreateTransport, reply_create_audience_port_context,
+};
 
 fn clamp_per_page(per_page: u64) -> u64 {
     per_page.min(100)
@@ -165,6 +168,7 @@ pub async fn create_reply(
     State(runtime): State<crate::controllers::ForumHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(topic_id): Path<Uuid>,
     Json(input): Json<CreateReplyInput>,
 ) -> HttpResult<(StatusCode, Json<ReplyResponse>)> {
@@ -174,9 +178,23 @@ pub async fn create_reply(
         "Permission denied: forum_replies:create required",
     )?;
 
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
-    let reply = service
-        .create(tenant.id, forum_security(&auth), topic_id, input)
+    let audience_context = reply_create_audience_port_context(
+        ForumReplyCreateTransport::Rest,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        tenant.default_locale.as_str(),
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    let reply = runtime
+        .reply_service()
+        .create_with_audience_context(
+            tenant.id,
+            forum_security(&auth),
+            topic_id,
+            audience_context,
+            input,
+        )
         .await
         .map_err(crate::controllers::map_forum_error)?;
     Ok((StatusCode::CREATED, Json(reply)))

--- a/crates/rustok-forum/src/graphql/content_commands.rs
+++ b/crates/rustok-forum/src/graphql/content_commands.rs
@@ -16,6 +16,9 @@ use crate::{
     ForumQuoteTargetKindInput, ReplyResponse, ReplyService, TopicResponse, TopicService,
     UpdateReplyCommandInput, UpdateTopicCommandInput,
 };
+use crate::reply_create_transport::{
+    ForumReplyCreateTransport, reply_create_audience_port_context,
+};
 use crate::topic_create_transport::{
     ForumTopicCreateTransport, topic_create_audience_port_context,
 };
@@ -193,11 +196,24 @@ impl ForumContentCommandMutation {
         )?;
         let tenant = ctx.data::<TenantContext>()?;
         let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
-        let reply = ReplyService::new(db.clone(), event_bus.clone())
-            .create_command(
+        let audience_context = reply_create_audience_port_context(
+            ForumReplyCreateTransport::Graphql,
+            tenant_id,
+            &auth,
+            ctx.data_opt::<rustok_api::RequestContext>(),
+            tenant.default_locale.as_str(),
+        )?;
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
+        let reply = runtime
+            .reply_service(db.clone(), event_bus.clone())
+            .create_command_with_audience_context(
                 tenant_id,
                 security(&auth),
                 topic_id,
+                audience_context,
                 CreateReplyCommandInput {
                     locale: input.locale,
                     content: input.content,

--- a/crates/rustok-forum/src/graphql/mutation.rs
+++ b/crates/rustok-forum/src/graphql/mutation.rs
@@ -17,6 +17,9 @@ use uuid::Uuid;
 use crate::{
     CategoryResponse, CategoryService, ReplyService, SubscriptionService, TopicService, VoteService,
 };
+use crate::reply_create_transport::{
+    ForumReplyCreateTransport, reply_create_audience_port_context,
+};
 use crate::topic_create_transport::{
     ForumTopicCreateTransport, topic_create_audience_port_context,
 };
@@ -386,15 +389,29 @@ impl ForumMutation {
             "Permission denied: forum_replies:create required",
         )?;
 
-        let service = ReplyService::new(db.clone(), event_bus.clone());
-        let reply = service
-            .create(
+        let tenant = ctx.data::<TenantContext>()?;
+        let tenant_id = resolve_tenant_scope(tenant, Some(tenant_id))?;
+        let audience_context = reply_create_audience_port_context(
+            ForumReplyCreateTransport::Graphql,
+            tenant_id,
+            &auth,
+            ctx.data_opt::<rustok_api::RequestContext>(),
+            tenant.default_locale.as_str(),
+        )?;
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
+        let reply = runtime
+            .reply_service(db.clone(), event_bus.clone())
+            .create_with_audience_context(
                 tenant_id,
                 rustok_core::SecurityContext::from_permission_snapshot(
                     Some(auth.user_id),
                     &auth.permissions,
                 ),
                 topic_id,
+                audience_context,
                 crate::CreateReplyInput {
                     locale: input.locale,
                     content: input.content,

--- a/crates/rustok-forum/src/graphql/runtime_data.rs
+++ b/crates/rustok-forum/src/graphql/runtime_data.rs
@@ -2,13 +2,13 @@ use rustok_api::graphql::GraphqlRuntimeInputs;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
-use crate::{SharedForumAudienceFactsPort, TopicService};
+use crate::{ReplyService, SharedForumAudienceFactsPort, TopicService};
 
 /// Manifest-attached Forum GraphQL runtime capabilities.
 ///
 /// The optional facts port is published by the host runtime extension registry.
-/// Its absence is preserved so locally decidable topic-create policies continue
-/// to work while trust, Channel, or Groups facts fail closed in the owner.
+/// Its absence is preserved so locally decidable create policies continue to
+/// work while trust, Channel, or Groups facts fail closed in the owner.
 #[derive(Clone, Default)]
 pub struct ForumGraphqlRuntimeData {
     audience_facts: Option<SharedForumAudienceFactsPort>,
@@ -31,6 +31,17 @@ impl ForumGraphqlRuntimeData {
         match self.audience_facts.clone() {
             Some(facts) => TopicService::with_audience_facts(db, event_bus, facts),
             None => TopicService::new(db, event_bus),
+        }
+    }
+
+    pub(crate) fn reply_service(
+        &self,
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> ReplyService {
+        match self.audience_facts.clone() {
+            Some(facts) => ReplyService::with_audience_facts(db, event_bus, facts),
+            None => ReplyService::new(db, event_bus),
         }
     }
 }

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -21,6 +21,7 @@ pub mod migrations;
 pub mod notification_recipient;
 mod notification_source;
 pub mod openapi;
+mod reply_create_transport;
 mod seo_targets;
 pub mod services;
 pub mod state_machine;

--- a/crates/rustok-forum/src/reply_create_transport.rs
+++ b/crates/rustok-forum/src/reply_create_transport.rs
@@ -1,0 +1,213 @@
+use std::time::Duration;
+
+use rustok_api::{AuthContext, PortContext, RequestContext};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+const FORUM_REPLY_CREATE_FACTS_DEADLINE: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ForumReplyCreateTransport {
+    Graphql,
+    Rest,
+}
+
+impl ForumReplyCreateTransport {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Graphql => "graphql",
+            Self::Rest => "rest",
+        }
+    }
+}
+
+/// Build the exact read-only caller context used by reply-create audience facts.
+///
+/// Tenant and user identity come only from authenticated transport extensions.
+/// Request DTOs never select either identity. When an HTTP request context is
+/// available, it must agree with the authenticated principal before any owner
+/// facts provider can be called.
+pub(crate) fn reply_create_audience_port_context(
+    transport: ForumReplyCreateTransport,
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request: Option<&RequestContext>,
+    fallback_locale: &str,
+) -> ForumResult<PortContext> {
+    if tenant_id.is_nil() || auth.tenant_id != tenant_id {
+        return Err(ForumError::Validation(
+            "Forum reply-create authenticated tenant does not match the requested tenant"
+                .to_string(),
+        ));
+    }
+
+    if let Some(request) = request {
+        if request.tenant_id != tenant_id {
+            return Err(ForumError::Validation(
+                "Forum reply-create request tenant does not match the requested tenant"
+                    .to_string(),
+            ));
+        }
+        if request.user_id != Some(auth.user_id) {
+            return Err(ForumError::Validation(
+                "Forum reply-create request actor does not match the authenticated user"
+                    .to_string(),
+            ));
+        }
+    }
+
+    let locale = request
+        .map(|request| request.locale.trim())
+        .filter(|locale| !locale.is_empty())
+        .unwrap_or_else(|| fallback_locale.trim());
+    if locale.is_empty() {
+        return Err(ForumError::Validation(
+            "Forum reply-create request locale is unavailable".to_string(),
+        ));
+    }
+
+    let mut context = PortContext::new(
+        tenant_id.to_string(),
+        auth.port_actor(),
+        locale,
+        format!(
+            "forum-{}-reply-create-{}-{}",
+            transport.label(),
+            auth.session_id,
+            Uuid::new_v4()
+        ),
+    )
+    .with_deadline(FORUM_REPLY_CREATE_FACTS_DEADLINE);
+
+    for permission in &auth.permissions {
+        context = context.with_claim(permission.to_string());
+    }
+    if let Some(channel_slug) = request
+        .and_then(|request| request.channel_slug.as_deref())
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty())
+    {
+        context = context.with_channel(channel_slug.to_string());
+    }
+
+    Ok(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{Permission, PortActorKind};
+
+    use super::*;
+
+    fn auth(tenant_id: Uuid, user_id: Uuid) -> AuthContext {
+        AuthContext {
+            user_id,
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions: vec![Permission::FORUM_REPLIES_CREATE],
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn request(tenant_id: Uuid, user_id: Uuid) -> RequestContext {
+        RequestContext {
+            tenant_id,
+            user_id: Some(user_id),
+            channel_id: Some(Uuid::new_v4()),
+            channel_slug: Some("members".to_string()),
+            channel_resolution_source: None,
+            locale: "ru-RU".to_string(),
+        }
+    }
+
+    #[test]
+    fn exact_rest_context_uses_authenticated_identity_deadline_claims_and_channel() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+        let request = request(tenant_id, user_id);
+
+        let context = reply_create_audience_port_context(
+            ForumReplyCreateTransport::Rest,
+            tenant_id,
+            &auth,
+            Some(&request),
+            "en",
+        )
+        .expect("trusted REST context should compose");
+
+        assert_eq!(context.tenant_id, tenant_id.to_string());
+        assert_eq!(context.actor.kind, PortActorKind::User);
+        assert_eq!(context.actor.id, user_id.to_string());
+        assert_eq!(context.locale, "ru-RU");
+        assert_eq!(context.channel.as_deref(), Some("members"));
+        assert_eq!(context.deadline_ms, Some(5_000));
+        assert_eq!(context.claims, vec![Permission::FORUM_REPLIES_CREATE.to_string()]);
+        assert!(context.correlation_id.starts_with("forum-rest-reply-create-"));
+    }
+
+    #[test]
+    fn graphql_context_without_http_request_uses_authenticated_tenant_and_fallback_locale() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        let context = reply_create_audience_port_context(
+            ForumReplyCreateTransport::Graphql,
+            tenant_id,
+            &auth,
+            None,
+            "en",
+        )
+        .expect("GraphQL connection context should compose without an HTTP request snapshot");
+
+        assert_eq!(context.locale, "en");
+        assert!(context.channel.is_none());
+        assert!(context.correlation_id.starts_with("forum-graphql-reply-create-"));
+    }
+
+    #[test]
+    fn mismatched_auth_request_tenant_or_user_fails_before_owner_facts() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        assert!(matches!(
+            reply_create_audience_port_context(
+                ForumReplyCreateTransport::Rest,
+                Uuid::new_v4(),
+                &auth,
+                None,
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("authenticated tenant")
+        ));
+
+        let foreign_tenant_request = request(Uuid::new_v4(), user_id);
+        assert!(matches!(
+            reply_create_audience_port_context(
+                ForumReplyCreateTransport::Rest,
+                tenant_id,
+                &auth,
+                Some(&foreign_tenant_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request tenant")
+        ));
+
+        let foreign_user_request = request(tenant_id, Uuid::new_v4());
+        assert!(matches!(
+            reply_create_audience_port_context(
+                ForumReplyCreateTransport::Rest,
+                tenant_id,
+                &auth,
+                Some(&foreign_user_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request actor")
+        ));
+    }
+}

--- a/scripts/verify/verify-forum-category-reply-create-audience-policy.mjs
+++ b/scripts/verify/verify-forum-category-reply-create-audience-policy.mjs
@@ -177,9 +177,21 @@ for (const marker of [
 for (const marker of [
   "ForumCategoryReplyCreateAudiencePolicyService",
   "reply-create audience policy",
-  "does not yet change `ReplyService::create`",
+  "FORUM-20AU",
 ]) {
   requireText(crateApi, marker, `Forum CRATE_API is missing ${marker}`);
+}
+if (
+  !crateApi.includes("does not yet change `ReplyService::create`") &&
+  !(
+    crateApi.includes("`FORUM-20AV`") &&
+    crateApi.includes("`FORUM-20AW`") &&
+    crateApi.includes("ReplyService::create_with_audience_context")
+  )
+) {
+  failures.push(
+    "Forum CRATE_API must retain the FORUM-20AU persistence-only statement or document downstream FORUM-20AV/20AW composition",
+  );
 }
 for (const marker of [
   "FORUM-20A-AU provide",

--- a/scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
+++ b/scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!relativePath || !existsSync(absolute)) {
+    failures.push(`${relativePath || "<missing path>"}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function between(source, start, end, label) {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0 || to <= from) {
+    failures.push(`${label}: bounded section is missing`);
+    return "";
+  }
+  return source.slice(from, to);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-reply-create-audience-transport-composition.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const transport = read(contract.transport_context_file ?? "");
+const graphqlRuntime = read(contract.graphql_runtime_file ?? "");
+const graphqlLegacy = read(contract.graphql_legacy_mutation_file ?? "");
+const graphqlCommand = read(contract.graphql_command_mutation_file ?? "");
+const graphqlTypes = read("crates/rustok-forum/src/graphql/types.rs");
+const httpRuntime = read(contract.http_runtime_file ?? "");
+const httpLegacy = read(contract.http_legacy_create_file ?? "");
+const httpCommand = read(contract.http_command_create_file ?? "");
+const owner = read(contract.owner_enforcement_file ?? "");
+const note = read(contract.owner_note ?? "");
+const crateApi = read(contract.crate_api ?? "");
+
+if (
+  contract.schema_version !== 1 ||
+  contract.task !== "FORUM-20AW" ||
+  contract.upstream_task !== "FORUM-20AV"
+) {
+  failures.push("reply-create transport contract must identify FORUM-20AW after FORUM-20AV");
+}
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("reply-create transport contract must not claim unexecuted evidence");
+}
+for (const key of [
+  "shared_exact_transport_context_builder",
+  "auth_tenant_request_identity_validation",
+  "dto_identity_forbidden",
+  "read_deadline_semantics",
+  "permission_claim_forwarding",
+  "resolved_route_channel_forwarding",
+  "graphql_legacy_create_composed",
+  "graphql_command_create_composed",
+  "rest_legacy_create_composed",
+  "rest_command_create_composed",
+  "graphql_runtime_facts_consumed",
+  "http_runtime_facts_consumed",
+  "host_extension_facts_reused",
+  "missing_provider_fail_closed",
+  "local_policy_compatibility_preserved",
+  "owner_authorization_before_writes_preserved",
+]) {
+  if (contract.composition?.[key] !== true) {
+    failures.push(`reply-create transport contract must record ${key}`);
+  }
+}
+for (const key of [
+  "migration_changed",
+  "reply_create_dto_changed",
+  "forum_groups_dependency_added",
+  "trust_facts_adapter_added",
+  "topic_local_narrowing_added",
+  "moderation_audience_added",
+  "canonical_plan_rewritten",
+]) {
+  if (contract.composition?.[key] !== false) {
+    failures.push(`reply-create transport contract must keep ${key} false`);
+  }
+}
+
+for (const marker of [
+  "enum ForumReplyCreateTransport",
+  "Graphql",
+  "Rest",
+  "reply_create_audience_port_context",
+  "auth.tenant_id != tenant_id",
+  "request.tenant_id != tenant_id",
+  "request.user_id != Some(auth.user_id)",
+  "auth.port_actor()",
+  "with_deadline(FORUM_REPLY_CREATE_FACTS_DEADLINE)",
+  "context.with_claim(permission.to_string())",
+  "request.channel_slug.as_deref()",
+  "context.with_channel(channel_slug.to_string())",
+  "forum-{}-reply-create-{}-{}",
+]) {
+  requireText(transport, marker, `shared reply-create transport context is missing ${marker}`);
+}
+for (const marker of [
+  "exact_rest_context_uses_authenticated_identity_deadline_claims_and_channel",
+  "graphql_context_without_http_request_uses_authenticated_tenant_and_fallback_locale",
+  "mismatched_auth_request_tenant_or_user_fails_before_owner_facts",
+  "context.deadline_ms, Some(5_000)",
+  "context.channel.as_deref(), Some(\"members\")",
+]) {
+  requireText(transport, marker, `reply-create transport inline contract test is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub struct ForumGraphqlRuntimeData",
+  "audience_facts: Option<SharedForumAudienceFactsPort>",
+  "inputs.shared_get::<SharedForumAudienceFactsPort>()",
+  "fn reply_service(",
+  "ReplyService::with_audience_facts",
+  "ReplyService::new",
+  "schema_factory_consumes_host_published_audience_facts_without_db_discovery",
+  "schema_factory_preserves_optional_provider_absence",
+]) {
+  requireText(graphqlRuntime, marker, `Forum GraphQL runtime data is missing ${marker}`);
+}
+
+const legacyGraphqlCreate = between(
+  graphqlLegacy,
+  "async fn create_forum_reply(",
+  "async fn set_forum_topic_vote(",
+  "legacy GraphQL reply-create",
+);
+const commandGraphqlCreate = between(
+  graphqlCommand,
+  "async fn create_forum_reply_with_quotes(",
+  "async fn update_forum_reply_with_quotes(",
+  "command GraphQL reply-create",
+);
+for (const [source, label, commandMarker] of [
+  [legacyGraphqlCreate, "legacy GraphQL reply-create", ".create_with_audience_context("],
+  [commandGraphqlCreate, "command GraphQL reply-create", ".create_command_with_audience_context("],
+]) {
+  for (const marker of [
+    "ForumGraphqlRuntimeData",
+    "reply_create_audience_port_context(",
+    "ForumReplyCreateTransport::Graphql",
+    "ctx.data_opt::<rustok_api::RequestContext>()",
+    ".reply_service(db.clone(), event_bus.clone())",
+    commandMarker,
+  ]) {
+    requireText(source, marker, `${label} is missing ${marker}`);
+  }
+}
+
+for (const marker of [
+  "audience_facts: Option<crate::SharedForumAudienceFactsPort>",
+  "runtime.shared_get::<crate::SharedForumAudienceFactsPort>()",
+  "fn reply_service(&self) -> crate::ReplyService",
+  "ReplyService::with_audience_facts",
+  "ReplyService::new",
+]) {
+  requireText(httpRuntime, marker, `Forum HTTP runtime is missing ${marker}`);
+}
+const legacyRestCreate = between(
+  httpLegacy,
+  "pub async fn create_reply(",
+  "pub async fn update_reply(",
+  "legacy REST reply-create",
+);
+const commandRestCreate = between(
+  httpCommand,
+  "pub async fn create_reply(",
+  "pub async fn update_reply(",
+  "command REST reply-create",
+);
+for (const [source, label, commandMarker] of [
+  [legacyRestCreate, "legacy REST reply-create", ".create_with_audience_context("],
+  [commandRestCreate, "command REST reply-create", ".create_command_with_audience_context("],
+]) {
+  for (const marker of [
+    "request_context: RequestContext",
+    ".reply_service()",
+    "reply_create_audience_port_context(",
+    "ForumReplyCreateTransport::Rest",
+    commandMarker,
+  ]) {
+    requireText(source, marker, `${label} is missing ${marker}`);
+  }
+}
+
+const ownerCreateHelper = between(
+  owner,
+  "async fn create_command_with_optional_audience_context(",
+  "pub async fn get(",
+  "reply-create owner helper",
+);
+for (const marker of [
+  ".require(tenant_id, topic_id, &security, context)",
+  ".create_command(tenant_id, security, topic_id, input)",
+]) {
+  requireText(ownerCreateHelper, marker, `reply-create owner helper is missing ${marker}`);
+}
+if (
+  ownerCreateHelper.indexOf(".require(tenant_id, topic_id, &security, context)") >
+  ownerCreateHelper.indexOf(".create_command(tenant_id, security, topic_id, input)")
+) {
+  failures.push("transport composition must preserve reply audience authorization before owner writes");
+}
+
+const legacyInput = between(
+  graphqlTypes,
+  "pub struct CreateForumReplyInput",
+  "pub struct CreateForumCategoryInput",
+  "legacy GraphQL reply-create input",
+);
+const commandInput = between(
+  graphqlCommand,
+  "pub struct CreateForumReplyWithQuotesInput",
+  "pub struct UpdateForumReplyWithQuotesInput",
+  "command GraphQL reply-create input",
+);
+for (const [input, label] of [
+  [legacyInput, "legacy GraphQL reply-create input"],
+  [commandInput, "command GraphQL reply-create input"],
+]) {
+  for (const forbidden of ["user_id", "actor_id", "recipient_id", "request_tenant_id"]) {
+    rejectText(input, forbidden, `${label} must not accept ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "# FORUM-20AW reply-create audience transport composition",
+  "source-ready / unvalidated",
+  "Tenant and actor identity come only from authenticated transport extensions",
+  "same optional `SharedForumAudienceFactsPort`",
+  "No Forum-to-Groups crate dependency was added",
+  "Canonical plan debt",
+  "not run by the implementation agent",
+]) {
+  requireText(note, marker, `reply-create transport owner note is missing ${marker}`);
+}
+for (const marker of [
+  "ReplyService::create_with_audience_context",
+  "ReplyService::create_command_with_audience_context",
+  "ReplyService::with_audience_facts",
+  "FORUM-20AW",
+  "GraphQL and REST reply-create",
+]) {
+  requireText(crateApi, marker, `Forum CRATE_API is missing ${marker}`);
+}
+
+if (failures.length > 0) {
+  console.error("Forum reply-create audience transport composition verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log("Forum reply-create audience transport composition contract is source-ready.");


### PR DESCRIPTION
## Summary

- add `FORUM-20AW` exact authenticated reply-create audience context composition
- forward tenant, actor, effective permissions, locale, bounded read deadline, and resolved route channel without adding identity to DTOs
- compose legacy and inline-quote reply creation in GraphQL and REST
- build `ReplyService` from the same optional host-published `SharedForumAudienceFactsPort` already used for topic creation
- preserve local role and explicit-user compatibility while unresolved trust, Channel, or Groups selectors fail closed
- preserve the `FORUM-20AV` owner gate before reply, body, relation, counter, user-stat, and event writes
- add a machine-readable contract, owner note, source verifier, and cumulative persistence-verifier compatibility

## Boundary

- no GraphQL, REST, OpenAPI, quote, or owner DTO changes
- no migrations or dependency changes
- no second provider registry and no Forum-to-Groups crate dependency
- no trust owner state or trust facts adapter
- no topic-local reply audience narrowing
- no moderation audience policy
- no host/server source changes; the existing runtime extension publication is reused

## Canonical plan limitation

The canonical Forum plan was not rewritten because the available GitHub contents API only supports complete-file replacement and the roadmap exceeds two thousand lines. Risking unrelated roadmap loss was rejected. The bounded FORUM-20AW owner note and contract record this debt explicitly; a later safe repository-local edit should advance the ledger through `FORUM-20AW` and fix the previously recorded historical grammar typo.

## Validation

Tests, Cargo commands, verifiers, formatting, workflow checks, and CI were not run by the implementation agent, per maintainer request.