### PR TITLE
feat(index): orchestrate full retained partition capture

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -1,0 +1,40 @@
+# Index M3 full retained partition capture
+
+Status:
+
+- M3 partition cutover rehearsal evidence runner: `complete`.
+- M3 retained packet owner orchestration: `complete`.
+- Real retained PostgreSQL packet execution: `open`.
+- Production partition copy, replay, dual-write, cutover, rollback automation, cleanup, and query-adapter work: `forbidden before one retained admitted packet`.
+
+## Owner command
+
+Use one fresh immutable manifest and an empty bundle directory. The command refuses partial-output reuse and does not resume a failed attempt.
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_FULL_CAPTURE=1 \
+node scripts/verify/index-storage-tooling.mjs partition-capture \
+  --manifest evidence/index-partition/manifest.json \
+  --query-audit evidence/index-partition/query-audit.json \
+  --root evidence/index-partition/retained-run
+```
+
+The orchestration command runs, in order:
+
+1. `index-partition-snapshot-capture`;
+2. `index-partition-query-evidence`;
+3. `index-partition-mutation-evidence`;
+4. `index-partition-maintenance-evidence`;
+5. `index-partition-cutover-evidence`;
+6. `index-partition-capture-finalize`;
+7. exact-byte packet assembly;
+8. admission validation.
+
+`index-partition-capture-finalize` verifies all six retained raw files, reads the PostgreSQL 16 server version, JIT state, `pg_control_system()` system identifier, and current database name, and publishes `capture.json` once with runner provenance bound to the immutable manifest.
+
+The final retained directory contains `baseline.json`, `shadow.json`, `query.json`, `mutation.json`, `maintenance.json`, `cutover.json`, `capture.json`, `partition-packet.json`, and `admission.json`.
+
+A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
+
+This tooling does not authorize or implement production relation rename/drop, copy/replay, dual-write, cutover, cleanup, or query-adapter changes. Admission remains a measured owner decision based on the retained packet.

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -61,6 +61,10 @@ path = "src/bin/index_partition_maintenance_evidence.rs"
 name = "index-partition-cutover-evidence"
 path = "src/bin/index_partition_cutover_evidence.rs"
 
+[[bin]]
+name = "index-partition-capture-finalize"
+path = "src/bin/index_partition_capture_finalize.rs"
+
 [[bench]]
 name = "tenant_cache"
 harness = false

--- a/ops/benches/src/bin/index_partition_capture_finalize.rs
+++ b/ops/benches/src/bin/index_partition_capture_finalize.rs
@@ -1,0 +1,15 @@
+use rustok_benchmarks::index_storage::{
+    PartitionCaptureFinalizeConfig, finalize_partition_capture,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = PartitionCaptureFinalizeConfig::from_env()?;
+    let capture = finalize_partition_capture(&config).await?;
+    println!(
+        "index partition capture descriptor complete: evidence_id={} output={}",
+        capture.evidence_id,
+        capture.output_path.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -4,6 +4,7 @@ mod database_metadata;
 mod explain;
 mod maintenance_runner;
 mod mutation_runner;
+mod partition_capture;
 mod partition_cutover;
 mod partition_maintenance;
 mod partition_mutation;
@@ -21,6 +22,9 @@ pub use maintenance_runner::{
     MaintenanceBenchmarkReport, run_maintenance, write_maintenance_report,
 };
 pub use mutation_runner::{MutationBenchmarkReport, run_mutations, write_mutation_report};
+pub use partition_capture::{
+    PartitionCaptureFinalize, PartitionCaptureFinalizeConfig, finalize_partition_capture,
+};
 pub use partition_cutover::{
     PartitionCutoverCapture, PartitionCutoverConfig, capture_partition_cutover_evidence,
 };

--- a/ops/benches/src/index_storage/partition_capture.rs
+++ b/ops/benches/src/index_storage/partition_capture.rs
@@ -1,0 +1,365 @@
+use std::{
+    collections::BTreeSet,
+    env,
+    fs::{self, Metadata, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use chrono::{DateTime, Utc};
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use super::connect_benchmark_database;
+
+const MANIFEST_CONTRACT: &str = "index_partition_evidence_manifest_v1";
+const CAPTURE_CONTRACT: &str = "index_partition_capture_v1";
+const FINALIZE_OPT_IN: &str = "INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE";
+const ARTIFACT_FILES: [(&str, &str); 6] = [
+    ("baseline", "baseline.json"),
+    ("shadow", "shadow.json"),
+    ("query", "query.json"),
+    ("mutation", "mutation.json"),
+    ("maintenance", "maintenance.json"),
+    ("cutover", "cutover.json"),
+];
+
+#[derive(Debug, Clone)]
+pub struct PartitionCaptureFinalizeConfig {
+    pub database_url: String,
+    pub manifest_path: PathBuf,
+    pub output_root: PathBuf,
+    pub output_path: PathBuf,
+}
+
+impl PartitionCaptureFinalizeConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(FINALIZE_OPT_IN).as_deref(), Ok("1")),
+            "{FINALIZE_OPT_IN}=1 is required because the finalizer binds retained artifacts to one PostgreSQL identity"
+        );
+        let database_url = env::var("DATABASE_URL")
+            .context("DATABASE_URL is required for index partition capture finalization")?;
+        let manifest_path = env::var("INDEX_PARTITION_MANIFEST")
+            .map(PathBuf::from)
+            .context("INDEX_PARTITION_MANIFEST is required")?;
+        let output_root = env::var("INDEX_PARTITION_EVIDENCE_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("target/index-partition-evidence"));
+        let output_path = env::var("INDEX_PARTITION_CAPTURE_OUTPUT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| output_root.join("capture.json"));
+        ensure!(
+            manifest_path != output_path,
+            "manifest and capture descriptor paths must be distinct"
+        );
+        ensure!(
+            output_path.parent() == Some(output_root.as_path()),
+            "capture descriptor must be written directly inside the evidence root"
+        );
+        Ok(Self {
+            database_url,
+            manifest_path,
+            output_root,
+            output_path,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PreparedManifest {
+    contract: String,
+    repository: String,
+    commit: String,
+    run_key: String,
+    postgres_image: String,
+    evidence_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureDescriptor {
+    contract: &'static str,
+    completed_at: DateTime<Utc>,
+    run_provenance: CaptureRunProvenance,
+    database: CaptureDatabaseIdentity,
+    artifacts: CaptureArtifacts,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureRunProvenance {
+    repository: String,
+    commit: String,
+    run_key: String,
+    job: String,
+    runner_os: String,
+    runner_arch: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureDatabaseIdentity {
+    version: String,
+    server_version_num: String,
+    jit: String,
+    system_identifier: String,
+    database_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureArtifacts {
+    baseline: String,
+    shadow: String,
+    query: String,
+    mutation: String,
+    maintenance: String,
+    cutover: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionCaptureFinalize {
+    pub evidence_id: String,
+    pub output_path: PathBuf,
+}
+
+pub async fn finalize_partition_capture(
+    config: &PartitionCaptureFinalizeConfig,
+) -> Result<PartitionCaptureFinalize> {
+    let manifest: PreparedManifest = read_regular_json(&config.manifest_path, "manifest")?;
+    validate_manifest(&manifest)?;
+    ensure_output_available(&config.output_path)?;
+    let artifacts = validate_artifact_bundle(&config.output_root)?;
+
+    let db = connect_benchmark_database(&config.database_url).await?;
+    db.execute_unprepared("SET jit = off; SET statement_timeout = '30s';")
+        .await
+        .context("failed to pin capture-finalizer session settings")?;
+    let database = read_database_identity(&db).await?;
+
+    let descriptor = CaptureDescriptor {
+        contract: CAPTURE_CONTRACT,
+        completed_at: Utc::now(),
+        run_provenance: CaptureRunProvenance {
+            repository: manifest.repository,
+            commit: manifest.commit,
+            run_key: manifest.run_key,
+            job: first_non_empty_env(
+                &["INDEX_PARTITION_EVIDENCE_JOB", "GITHUB_JOB"],
+                "index-partition-evidence",
+            ),
+            runner_os: first_non_empty_env(&["RUNNER_OS"], env::consts::OS),
+            runner_arch: first_non_empty_env(&["RUNNER_ARCH"], env::consts::ARCH),
+        },
+        database,
+        artifacts,
+    };
+    publish_capture_descriptor(&config.output_path, &descriptor)?;
+
+    Ok(PartitionCaptureFinalize {
+        evidence_id: manifest.evidence_id,
+        output_path: config.output_path.clone(),
+    })
+}
+
+async fn read_database_identity(
+    db: &sea_orm::DatabaseConnection,
+) -> Result<CaptureDatabaseIdentity> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT version() AS version,",
+                " current_setting('server_version_num') AS server_version_num,",
+                " current_setting('jit') AS jit,",
+                " control.system_identifier::text AS system_identifier,",
+                " current_database() AS database_name",
+                " FROM pg_control_system() AS control"
+            )
+            .to_owned(),
+        ))
+        .await?
+        .context("partition capture database identity query returned no row")?;
+    let identity = CaptureDatabaseIdentity {
+        version: row.try_get("", "version")?,
+        server_version_num: row.try_get("", "server_version_num")?,
+        jit: row.try_get("", "jit")?,
+        system_identifier: row.try_get("", "system_identifier")?,
+        database_name: row.try_get("", "database_name")?,
+    };
+    ensure!(
+        identity.server_version_num.starts_with("16"),
+        "partition capture requires PostgreSQL 16, got {}",
+        identity.server_version_num
+    );
+    ensure!(identity.jit == "off", "partition capture requires jit=off");
+    ensure!(
+        !identity.system_identifier.is_empty()
+            && identity
+                .system_identifier
+                .bytes()
+                .all(|byte| byte.is_ascii_digit()),
+        "PostgreSQL system identifier must contain only digits"
+    );
+    ensure!(
+        !identity.database_name.is_empty(),
+        "PostgreSQL database name must not be empty"
+    );
+    Ok(identity)
+}
+
+fn validate_artifact_bundle(root: &Path) -> Result<CaptureArtifacts> {
+    let root_metadata = fs::symlink_metadata(root)
+        .with_context(|| format!("partition evidence root does not exist: {root:?}"))?;
+    ensure!(
+        !root_metadata.file_type().is_symlink() && root_metadata.is_dir(),
+        "partition evidence root must be a regular non-symlink directory"
+    );
+    let canonical_root = root
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize partition evidence root {root:?}"))?;
+    let mut identities = BTreeSet::new();
+    for (role, filename) in ARTIFACT_FILES {
+        let path = root.join(filename);
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("missing partition evidence artifact {role}: {path:?}"))?;
+        ensure!(
+            !metadata.file_type().is_symlink() && metadata.is_file(),
+            "partition evidence artifact {role} must be a regular non-symlink file"
+        );
+        ensure!(
+            metadata.len() > 0,
+            "partition evidence artifact {role} must not be empty"
+        );
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize partition evidence artifact {role}"))?;
+        ensure!(
+            canonical.starts_with(&canonical_root),
+            "partition evidence artifact {role} must stay inside the canonical evidence root"
+        );
+        ensure!(
+            identities.insert(file_identity(&metadata, &canonical)),
+            "partition evidence artifact {role} aliases another retained artifact"
+        );
+    }
+    Ok(CaptureArtifacts {
+        baseline: "baseline.json".to_owned(),
+        shadow: "shadow.json".to_owned(),
+        query: "query.json".to_owned(),
+        mutation: "mutation.json".to_owned(),
+        maintenance: "maintenance.json".to_owned(),
+        cutover: "cutover.json".to_owned(),
+    })
+}
+
+#[cfg(unix)]
+fn file_identity(metadata: &Metadata, _canonical: &Path) -> String {
+    use std::os::unix::fs::MetadataExt as _;
+    format!("{}:{}", metadata.dev(), metadata.ino())
+}
+
+#[cfg(not(unix))]
+fn file_identity(_metadata: &Metadata, canonical: &Path) -> String {
+    canonical.to_string_lossy().into_owned()
+}
+
+fn validate_manifest(manifest: &PreparedManifest) -> Result<()> {
+    ensure!(
+        manifest.contract == MANIFEST_CONTRACT,
+        "unexpected manifest contract"
+    );
+    ensure!(
+        manifest.repository == "RusTokRs/RusTok",
+        "unexpected manifest repository"
+    );
+    ensure!(
+        manifest.postgres_image == "postgres:16",
+        "manifest must pin postgres:16"
+    );
+    ensure!(
+        is_lower_hex(&manifest.commit, 40),
+        "manifest commit must be a full lowercase SHA"
+    );
+    ensure!(
+        is_lower_hex(&manifest.evidence_id, 64),
+        "manifest evidence_id must be SHA-256"
+    );
+    ensure!(
+        valid_run_key(&manifest.run_key),
+        "manifest run_key must be a bounded stable identifier"
+    );
+    Ok(())
+}
+
+fn valid_run_key(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= 128
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(*byte, b'.' | b'_' | b':' | b'-')
+        })
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn first_non_empty_env(names: &[&str], fallback: &str) -> String {
+    names
+        .iter()
+        .find_map(|name| env::var(name).ok().filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn read_regular_json<T: DeserializeOwned>(path: &Path, label: &str) -> Result<T> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {label} file {path:?}"))?;
+    ensure!(
+        !metadata.file_type().is_symlink() && metadata.is_file(),
+        "{label} must be a regular non-symlink file"
+    );
+    let bytes = fs::read(path).with_context(|| format!("failed to read {label} file {path:?}"))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("failed to parse {label} JSON {path:?}"))
+}
+
+fn ensure_output_available(path: &Path) -> Result<()> {
+    ensure!(!path.exists(), "refusing to overwrite {path:?}");
+    Ok(())
+}
+
+fn publish_capture_descriptor(path: &Path, descriptor: &CaptureDescriptor) -> Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create capture descriptor directory {parent:?}"))?;
+    }
+    ensure_output_available(path)?;
+    let mut bytes =
+        serde_json::to_vec_pretty(descriptor).context("failed to serialize capture descriptor")?;
+    bytes.push(b'\n');
+    let temporary = temporary_path(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .with_context(|| format!("failed to create temporary capture descriptor {temporary:?}"))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("failed to write temporary capture descriptor {temporary:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync temporary capture descriptor {temporary:?}"))?;
+    let publish = fs::hard_link(&temporary, path)
+        .with_context(|| format!("failed to publish capture descriptor to {path:?}"));
+    let _ = fs::remove_file(&temporary);
+    publish
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(format!(".tmp-{}", std::process::id()));
+    PathBuf::from(value)
+}

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -19,6 +19,7 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs packet --scale <smoke|100k|1m> [--root <directory>]
   node scripts/verify/index-storage-tooling.mjs compare --input <directory> [--input <directory>] [--output <directory>]
   node scripts/verify/index-storage-tooling.mjs partition-prepare --input <config.json> --manifest <manifest.json> --bootstrap <bootstrap.sql>
+  node scripts/verify/index-storage-tooling.mjs partition-capture --manifest <manifest.json> --query-audit <query-audit.json> --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
@@ -32,6 +33,7 @@ Commands:
   packet              Validate one smoke, 100k, or 1m storage evidence packet.
   compare             Generate a cross-scale storage comparison.
   partition-prepare   Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
+  partition-capture   Run every owner-operated raw capture, finalize capture identity, assemble, and validate.
   partition-assemble  Build one packet from six retained raw JSON artifacts and exact-byte hashes.
   partition-validate  Validate a measured partition packet and publish calculated admission output.
   hash                Print the SHA-256 digest of the exact comparison.json bytes.
@@ -70,6 +72,7 @@ const runContract = (args) => {
     'verify-index-partition-mutation-evidence.mjs',
     'verify-index-partition-maintenance-evidence.mjs',
     'verify-index-partition-cutover-evidence.mjs',
+    'verify-index-partition-full-capture.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',
@@ -197,6 +200,9 @@ switch (command) {
     break;
   case 'partition-prepare':
     runScript('prepare-index-partition-evidence.mjs', args);
+    break;
+  case 'partition-capture':
+    runScript('run-index-partition-evidence.mjs', args);
     break;
   case 'partition-assemble':
     runScript('assemble-index-partition-evidence.mjs', args);

--- a/scripts/verify/run-index-partition-evidence.mjs
+++ b/scripts/verify/run-index-partition-evidence.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { existsSync, lstatSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const prefix = '[run-index-partition-evidence]';
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fullCaptureOptIn = 'INDEX_PARTITION_ALLOW_FULL_CAPTURE';
+const rawArtifactNames = [
+  'baseline.json',
+  'shadow.json',
+  'query.json',
+  'mutation.json',
+  'maintenance.json',
+  'cutover.json',
+];
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const usage = () => {
+  console.log(`Usage:
+  node scripts/verify/run-index-partition-evidence.mjs \\
+    --manifest <manifest.json> \\
+    --query-audit <query-audit.json> \\
+    --root <bundle-directory> \\
+    [--packet <partition-packet.json>] \\
+    [--admission <admission.json>]
+
+The command requires DATABASE_URL and ${fullCaptureOptIn}=1.`);
+};
+
+const ensureInsideRoot = (root, filename, label) => {
+  const relative = path.relative(root, filename);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    fail(`${label} must stay inside the evidence root`);
+  }
+};
+
+const parseArgs = (args) => {
+  if (args.length === 1 && ['--help', '-h'].includes(args[0])) return null;
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--manifest', '--query-audit', '--root', '--packet', '--admission'].includes(flag)
+        || !value || value.startsWith('--')) {
+      fail('expected --manifest, --query-audit, --root, optional --packet, and optional --admission pairs');
+    }
+    if (values.has(flag)) fail(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  for (const flag of ['--manifest', '--query-audit', '--root']) {
+    if (!values.has(flag)) fail(`${flag} is required`);
+  }
+  const root = path.resolve(values.get('--root'));
+  const options = {
+    manifest: path.resolve(values.get('--manifest')),
+    queryAudit: path.resolve(values.get('--query-audit')),
+    root,
+    capture: path.join(root, 'capture.json'),
+    packet: path.resolve(values.get('--packet') ?? path.join(root, 'partition-packet.json')),
+    admission: path.resolve(values.get('--admission') ?? path.join(root, 'admission.json')),
+  };
+  if (new Set([
+    options.manifest,
+    options.queryAudit,
+    options.capture,
+    options.packet,
+    options.admission,
+  ]).size !== 5) {
+    fail('manifest, query audit, capture, packet, and admission paths must be distinct');
+  }
+  ensureInsideRoot(root, options.capture, 'capture output');
+  ensureInsideRoot(root, options.packet, 'packet output');
+  ensureInsideRoot(root, options.admission, 'admission output');
+  return options;
+};
+
+const ensureRegularFile = (filename, label) => {
+  let stat;
+  try {
+    stat = lstatSync(filename);
+  } catch (error) {
+    fail(`${label} is unavailable: ${error.message}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+};
+
+const preflight = (options) => {
+  ensureRegularFile(options.manifest, 'manifest');
+  ensureRegularFile(options.queryAudit, 'query audit');
+  if (existsSync(options.root)) {
+    const rootStat = lstatSync(options.root);
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+      fail('evidence root must be a regular non-symlink directory');
+    }
+  }
+  const outputs = [
+    ...rawArtifactNames.map((filename) => path.join(options.root, filename)),
+    options.capture,
+    options.packet,
+    options.admission,
+  ];
+  for (const output of outputs) {
+    if (existsSync(output)) {
+      fail(`refusing to reuse partial partition evidence output: ${output}`);
+    }
+  }
+};
+
+const runCommand = (command, args, label, environment = process.env) => {
+  console.log(`${prefix} ${label}`);
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: environment,
+  });
+  if (result.error) fail(`failed to start ${label}: ${result.error.message}`);
+  if (result.signal) fail(`${label} terminated by signal ${result.signal}`);
+  if (result.status !== 0) fail(`${label} exited with status ${result.status ?? 'unknown'}`);
+};
+
+const cargoRun = (binary, label, environment) => {
+  runCommand(
+    process.env.CARGO ?? 'cargo',
+    ['run', '-p', 'rustok-benchmarks', '--bin', binary, '--release'],
+    label,
+    environment,
+  );
+};
+
+const scriptPath = (filename) => path.join(scriptDirectory, filename);
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options === null) {
+    usage();
+    process.exit(0);
+  }
+  if (process.env[fullCaptureOptIn] !== '1') {
+    fail(`${fullCaptureOptIn}=1 is required because this command runs every owner-operated PostgreSQL evidence stage`);
+  }
+  if (!process.env.DATABASE_URL) fail('DATABASE_URL is required');
+  preflight(options);
+
+  const baseEnvironment = {
+    ...process.env,
+    INDEX_PARTITION_MANIFEST: options.manifest,
+    INDEX_PARTITION_EVIDENCE_ROOT: options.root,
+    INDEX_PARTITION_QUERY_OUTPUT: path.join(options.root, 'query.json'),
+    INDEX_PARTITION_MUTATION_OUTPUT: path.join(options.root, 'mutation.json'),
+    INDEX_PARTITION_MAINTENANCE_OUTPUT: path.join(options.root, 'maintenance.json'),
+    INDEX_PARTITION_CUTOVER_OUTPUT: path.join(options.root, 'cutover.json'),
+    INDEX_PARTITION_CAPTURE_OUTPUT: options.capture,
+  };
+
+  cargoRun(
+    'index-partition-snapshot-capture',
+    'capture baseline and retained shadow snapshot',
+    {
+      ...baseEnvironment,
+      INDEX_PARTITION_QUERY_AUDIT: options.queryAudit,
+      INDEX_PARTITION_ALLOW_SHADOW_COPY: '1',
+    },
+  );
+  cargoRun(
+    'index-partition-query-evidence',
+    'capture baseline/shadow query evidence',
+    { ...baseEnvironment, INDEX_PARTITION_ALLOW_QUERY_EVIDENCE: '1' },
+  );
+  cargoRun(
+    'index-partition-mutation-evidence',
+    'capture rollback-only mutation and WAL evidence',
+    { ...baseEnvironment, INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE: '1' },
+  );
+  cargoRun(
+    'index-partition-maintenance-evidence',
+    'capture ordinary-VACUUM maintenance evidence',
+    { ...baseEnvironment, INDEX_PARTITION_ALLOW_MAINTENANCE_EVIDENCE: '1' },
+  );
+  cargoRun(
+    'index-partition-cutover-evidence',
+    'capture cutover lock and rollback rehearsal evidence',
+    { ...baseEnvironment, INDEX_PARTITION_ALLOW_CUTOVER_EVIDENCE: '1' },
+  );
+  cargoRun(
+    'index-partition-capture-finalize',
+    'bind raw artifacts to runner and PostgreSQL identity',
+    { ...baseEnvironment, INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE: '1' },
+  );
+
+  runCommand(
+    process.execPath,
+    [
+      scriptPath('assemble-index-partition-evidence.mjs'),
+      '--manifest', options.manifest,
+      '--capture', options.capture,
+      '--output', options.packet,
+    ],
+    'assemble exact-byte retained partition packet',
+  );
+  runCommand(
+    process.execPath,
+    [
+      scriptPath('validate-index-partition-evidence.mjs'),
+      '--input', options.packet,
+      '--output', options.admission,
+    ],
+    'validate retained partition packet admission',
+  );
+  console.log(`${prefix} complete: bundle=${options.root}`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const prefix = '[verify-index-partition-full-capture]';
+const read = (filename) => readFileSync(filename, 'utf8');
+const requireMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (!source.includes(marker)) throw new Error(`${label} is missing ${marker}`);
+  }
+};
+const forbidMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) throw new Error(`${label} must not contain ${marker}`);
+  }
+};
+
+try {
+  const finalizer = read('ops/benches/src/index_storage/partition_capture.rs');
+  const binary = read('ops/benches/src/bin/index_partition_capture_finalize.rs');
+  const cargo = read('ops/benches/Cargo.toml');
+  const module = read('ops/benches/src/index_storage/mod.rs');
+  const orchestrator = read('scripts/verify/run-index-partition-evidence.mjs');
+  const tooling = read('scripts/verify/index-storage-tooling.mjs');
+  const runbook = read('crates/rustok-index/docs/partition-evidence-runbook.md');
+  const plan = read('crates/rustok-index/docs/implementation-plan.md');
+
+  requireMarkers(finalizer, [
+    'INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE',
+    'index_partition_capture_v1',
+    'pg_control_system()',
+    'system_identifier',
+    'capture.json',
+    'baseline.json',
+    'shadow.json',
+    'query.json',
+    'mutation.json',
+    'maintenance.json',
+    'cutover.json',
+    'create_new(true)',
+    'fs::hard_link',
+    'refusing to overwrite',
+  ], 'capture finalizer');
+  requireMarkers(binary, [
+    'PartitionCaptureFinalizeConfig::from_env()',
+    'finalize_partition_capture',
+  ], 'capture finalizer binary');
+  requireMarkers(cargo, [
+    'name = "index-partition-capture-finalize"',
+    'path = "src/bin/index_partition_capture_finalize.rs"',
+  ], 'benchmark Cargo targets');
+  requireMarkers(module, [
+    'mod partition_capture;',
+    'PartitionCaptureFinalizeConfig',
+    'finalize_partition_capture',
+  ], 'index storage module exports');
+  requireMarkers(orchestrator, [
+    'INDEX_PARTITION_ALLOW_FULL_CAPTURE',
+    'index-partition-snapshot-capture',
+    'index-partition-query-evidence',
+    'index-partition-mutation-evidence',
+    'index-partition-maintenance-evidence',
+    'index-partition-cutover-evidence',
+    'index-partition-capture-finalize',
+    'assemble-index-partition-evidence.mjs',
+    'validate-index-partition-evidence.mjs',
+    'refusing to reuse partial partition evidence output',
+  ], 'full capture orchestrator');
+  forbidMarkers(`${finalizer}\n${orchestrator}`, [
+    'DROP TABLE',
+    'TRUNCATE TABLE',
+    'ALTER TABLE index_entities',
+    'ALTER TABLE index_links',
+    'dual-write',
+  ], 'full capture tooling');
+  requireMarkers(tooling, [
+    'partition-capture',
+    'run-index-partition-evidence.mjs',
+    'verify-index-partition-full-capture.mjs',
+  ], 'index storage tooling router');
+  requireMarkers(runbook, [
+    'partition-capture',
+    'INDEX_PARTITION_ALLOW_FULL_CAPTURE=1',
+    'index-partition-capture-finalize',
+  ], 'partition evidence runbook');
+  requireMarkers(plan, [
+    'M3 partition cutover rehearsal evidence runner: `complete`',
+    'M3 retained packet owner orchestration: `complete`',
+  ], 'Index implementation plan');
+
+  console.log(`${prefix} contract satisfied`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -22,8 +22,7 @@ try {
   const module = read('ops/benches/src/index_storage/mod.rs');
   const orchestrator = read('scripts/verify/run-index-partition-evidence.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
-  const runbook = read('crates/rustok-index/docs/partition-evidence-runbook.md');
-  const plan = read('crates/rustok-index/docs/implementation-plan.md');
+  const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
 
   requireMarkers(finalizer, [
     'INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE',
@@ -79,14 +78,13 @@ try {
     'verify-index-partition-full-capture.mjs',
   ], 'index storage tooling router');
   requireMarkers(runbook, [
-    'partition-capture',
-    'INDEX_PARTITION_ALLOW_FULL_CAPTURE=1',
-    'index-partition-capture-finalize',
-  ], 'partition evidence runbook');
-  requireMarkers(plan, [
     'M3 partition cutover rehearsal evidence runner: `complete`',
     'M3 retained packet owner orchestration: `complete`',
-  ], 'Index implementation plan');
+    'Real retained PostgreSQL packet execution: `open`',
+    'INDEX_PARTITION_ALLOW_FULL_CAPTURE=1',
+    'index-partition-capture-finalize',
+    'forbidden before one retained admitted packet',
+  ], 'full partition capture runbook');
 
   console.log(`${prefix} contract satisfied`);
 } catch (error) {


### PR DESCRIPTION
## Summary

- continue late M3 after the cutover rehearsal runner landed in `main`;
- add an owner-operated `partition-capture` command that sequentially runs snapshot, query, mutation, maintenance, and cutover evidence against one prepared manifest and one database URL;
- require top-level `INDEX_PARTITION_ALLOW_FULL_CAPTURE=1` opt-in and preserve each existing stage-specific opt-in;
- preflight every raw, descriptor, packet, and admission output and refuse partial-output reuse or resume;
- add a Rust capture finalizer that verifies all six raw artifacts are regular, non-symlink, non-empty, root-confined, and non-aliasing;
- read PostgreSQL 16 identity from `version()`, `server_version_num`, `jit`, `pg_control_system().system_identifier`, and `current_database()`;
- bind repository, commit, run key, job, runner OS, runner architecture, and PostgreSQL identity into one non-overwriting `capture.json` descriptor;
- assemble the packet from exact retained bytes and immediately run admission validation;
- add a dedicated binary, Cargo/module exports, router command, owner runbook, and static contract guard;
- keep real retained packet execution open and keep production copy/replay, dual-write, relation lifecycle, cutover automation, cleanup, and query-adapter work forbidden before one retained admitted packet.

## Output bundle

A successful owner run publishes exactly:

- `baseline.json`
- `shadow.json`
- `query.json`
- `mutation.json`
- `maintenance.json`
- `cutover.json`
- `capture.json`
- `partition-packet.json`
- `admission.json`

## Failure semantics

- existing output at any expected path fails before the first runner;
- a partial or failed run is inspection-only and cannot be resumed;
- the next attempt requires a fresh manifest run key and a new empty directory;
- no production DDL or partition lifecycle is added by this slice.

## Validation

Not run, per repository-owner instruction.

Only Node syntax/help parsing was checked locally:

```bash
node --check scripts/verify/run-index-partition-evidence.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
node scripts/verify/run-index-partition-evidence.mjs --help
```

Suggested owner checks:

```bash
cargo check -p rustok-benchmarks --bin index-partition-capture-finalize
node scripts/verify/verify-index-partition-full-capture.mjs
node scripts/verify/index-storage-tooling.mjs contract
```

The real PostgreSQL capture, packet assembly from measured data, and admission decision were not executed.

## Next M3 step

Run one fresh owner capture against a prepared PostgreSQL 16 evidence database, retain the complete immutable bundle, review `admission.json`, and only then decide whether production partition lifecycle design may proceed.