### PR TITLE
Use owner ports for REST shipping option reads

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -1,209 +1,162 @@
 # GraphQL query fulfillment owner context
 
-Status: `source_ready_unvalidated`
+Status: `source_cutover_ready_unvalidated`
 
-## Shipping-option read cutover
+## Shipping-option owner reads
 
-The safe Commerce GraphQL query facade routes all mounted shipping-option reads
-through fulfillment-owned read ports:
+Mounted Commerce GraphQL and REST projection reads now consume the same
+application-host-composed fulfillment boundaries:
 
-- `storefront_shipping_options` delegates
+- storefront active list uses
   `ShippingOptionReadPort::list_shipping_option_projections`;
-- single shipping-option lookup delegates
+- single shipping-option lookup uses
   `ShippingOptionReadPort::read_shipping_option_projection`;
-- administrative `shipping_options` delegates
+- administrative list-all uses
   `ShippingOptionAdminReadPort::list_all_shipping_option_projections`.
 
-The unchanged `query.rs` source still imports and constructs the private
-`rustok_fulfillment::FulfillmentService` facade. Inside that facade, storefront
-and administrative shipping-option methods use separate owner read-port fields.
-The facade keeps one concrete `FulfillmentService` delegate only for fulfillment
-lifecycle reads not covered by this slice:
+The ports return fulfillment-owned `ShippingOptionResponse` projections. Commerce
+continues to apply transport-specific filtering and public error policy after the
+owner projection returns.
 
-- fulfillment lookup/list;
-- order-to-fulfillment lookup.
-
-This is a partial topology result. It closes concrete service and provider
-construction for mounted shipping-option GraphQL reads, but it does not claim
-that every fulfillment query method is owner-port composed.
+This remains a partial fulfillment-query topology result. The private GraphQL
+compatibility facade still retains one concrete `FulfillmentService` delegate for
+fulfillment lifecycle list/lookup and order-to-fulfillment reads that do not yet
+have published owner query ports.
 
 ## Application-host composition
 
-The server's commerce runtime bootstrap constructs one
-`CommerceShippingOptionReadRuntime` from the storefront and administrative root
-factories, caches it in `ServerRuntimeContext`, and attaches it to
-`HostRuntimeContext`. The manifest GraphQL data factory requires that typed
-runtime and stores it in `CommerceGraphqlRuntimeData`.
+The server bootstrap constructs one `CommerceShippingOptionReadRuntime` from the
+storefront and administrative root factories, caches it in
+`ServerRuntimeContext`, and attaches it to `HostRuntimeContext`.
 
-`CommerceShippingOptionReadScope` is mounted as an async-graphql extension. For
-each resolver it copies the typed runtime into a Tokio task-local scope. The
-private fulfillment facade resolves that scoped runtime and clones both owner
-ports; it no longer imports or calls either root in-process factory.
+GraphQL consumes that runtime through manifest data and
+`CommerceShippingOptionReadScope`. The private query facade clones the scoped
+owner ports and does not construct read providers.
 
-Directly embedded schemas that do not mount the server extension retain an
-explicit `CommerceShippingOptionReadRuntime::in_process` compatibility fallback
-in the public Commerce GraphQL runtime module. The fallback preserves existing
-standalone schema tests and embeddings without turning the private facade back
-into a provider constructor.
+Commerce HTTP router construction consumes the same typed runtime from
+`HostRuntimeContext` and stores it in `CommerceHttpRuntime`. HTTP startup fails
+closed when the runtime is absent. The REST handlers clone the owner ports from
+that state; they do not construct `FulfillmentService` or root in-process read
+providers for shipping-option projection reads.
 
-## Transport parity source inventory
+Directly embedded GraphQL schemas that do not mount the server extension retain
+an explicit `CommerceShippingOptionReadRuntime::in_process` compatibility
+fallback in the public GraphQL runtime module. This fallback is outside the
+private facade and is not mounted transport parity evidence.
+
+## REST source cutover
 
 The source inventory at
 `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`
-compares the mounted GraphQL projection reads with the current Commerce REST and
-FFA/native surfaces. It is explicitly marked `source_audit_only_unvalidated` and
-is not runtime parity evidence.
+has status `source_cutover_ready_unvalidated`.
 
-The inventory records:
+It records the following source topology:
 
-- mounted GraphQL active list, administrative list-all, and single lookup use the
-  host-composed owner ports;
-- storefront REST still creates `FulfillmentService` directly for the active
-  list, then applies the same currency, public-channel, and shipping-profile
-  filters as GraphQL;
-- admin REST still creates `FulfillmentService` directly for list-all and single
-  lookup, while preserving inactive-before-filter semantics and the existing
+- mounted GraphQL and Commerce REST obtain both read ports from the same
+  `CommerceShippingOptionReadRuntime`;
+- storefront REST delegates active-list loading to
+  `list_shipping_option_projections`, then retains its currency,
+  public-channel-visibility, and shipping-profile compatibility filters;
+- admin REST delegates complete list loading to
+  `list_all_shipping_option_projections`, preserving inactive options before
   active, currency, provider, search, and pagination filters;
-- the native FFA surface does not publish complete shipping-option projection
-  list or lookup operations; it owns seller/cart selection through
-  `ShippingSelectionPort` over native-server and GraphQL transports;
-- projection parity therefore does not justify adding projection reads to the
-  native selection contract without a concrete consumer contract.
+- admin REST single lookup delegates to `read_shipping_option_projection`;
+- admin shipping-option create, update, deactivate, and reactivate remain
+  lifecycle mutations over the concrete owner service and are outside this read
+  cutover;
+- the native fulfillment storefront surface remains seller/cart selection through
+  `ShippingSelectionPort`; it does not publish complete projection list/lookup
+  operations without a consumer contract.
 
-The decision retained by the inventory is to migrate the existing REST
-projection reads to `CommerceShippingOptionReadRuntime` next, preserving their
-successful response filtering and HTTP public envelopes. The focused guard
-`scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
-locks this audited topology until that cutover deliberately updates the evidence.
+The inventory is source evidence only. It does not claim compiled handlers,
+mounted request execution, GraphQL/REST result parity, or any FFA/FBA promotion.
 
 ## Retained read context
 
-Each port-backed shipping-option query constructs `PortContext` with:
+GraphQL shipping-option reads construct `PortContext` with:
 
 - tenant identity;
 - service actor `rustok-commerce.graphql-query-shipping-options`;
-- requested locale, falling back to tenant default locale and then `en`;
+- requested locale with tenant/default fallback data retained separately;
 - query-field and resource-scoped correlation id;
 - two-second deadline.
 
-Requested and tenant-default locale values are also retained as explicit owner
-request fields. Single lookup retains the shipping-option UUID. The current
-query source does not pass public channel into the facade method, so channel
-propagation remains open for a later source/query signature change.
+The current GraphQL query signature does not carry public channel into every
+shipping-option read context, so that propagation remains open.
 
-## Typed owner mapping
+REST shipping-option reads construct `PortContext` with:
 
-Storefront and administrative list facades map `PortErrorKind` without using
-owner message text:
+- tenant identity;
+- authenticated user actor for admin reads;
+- authenticated user actor or storefront service actor for public reads;
+- request locale;
+- effective public channel when available, including cart-derived channel for
+  storefront list requests;
+- resource-scoped correlation id;
+- two-second deadline.
 
-| Port kind | Public message | Public code | Retryable |
-| --- | --- | --- | --- |
-| Validation | `Fulfillment query is invalid` | `FULFILLMENT_REQUEST_INVALID` | false |
-| NotFound | `Fulfillment resource was not found` | `FULFILLMENT_RESOURCE_NOT_FOUND` | false |
-| Conflict | `Fulfillment state conflicts with this query` | `FULFILLMENT_STATE_CONFLICT` | false |
-| Unavailable / Timeout | `Fulfillment data is temporarily unavailable` | `FULFILLMENT_TEMPORARILY_UNAVAILABLE` | true |
-| Forbidden | `Fulfillment query is not permitted` | `FULFILLMENT_ACCESS_DENIED` | false |
-| InvariantViolation | `Fulfillment query could not be completed safely` | `FULFILLMENT_OPERATION_FAILED` | false |
+Requested and tenant-default locale values remain explicit owner request fields.
+Single lookup retains the shipping-option UUID.
 
-The validation, not-found, conflict, and unavailable envelopes preserve the
-existing fulfillment public policy. Forbidden and invariant outcomes are
-fail-closed coverage for the complete port kind set and are not status
-promotions.
+## Typed public mapping
 
-The administrative resolver source still contains its existing
-`async_graphql::Error::new(err.to_string())` call. The private facade returns
-`ShippingOptionAdminQueryError`, whose inherent `to_string` method consumes the
-adapter and returns the already-typed `BoundaryError`. Rust resolves that
-inherent method before the standard `ToString` trait, so no string is created,
-parsed, matched, or used as a control-flow protocol. The same public
-`FULFILLMENT_*` message, code, and retryability values reach GraphQL extensions.
+GraphQL retains its existing typed `FULFILLMENT_*` boundary policy and optional
+single-lookup not-found behavior. No `PortError.message` is parsed or matched as
+control flow.
 
-Single lookup preserves the existing optional-result source contract rather than
-changing `query.rs`:
+REST maps `PortErrorKind` directly to the existing static Commerce HTTP policy:
 
-- owner `NotFound` becomes the stable compatibility variant
-  `ShippingOptionNotFound`, so the resolver still returns `Ok(None)`;
-- validation, conflict, unavailable, timeout, forbidden, and invariant outcomes
-  become stable compatibility `FulfillmentError` values;
-- the unchanged resolver converts those stable values through its existing
-  generic `COMMERCE_QUERY_OPERATION_FAILED` redaction path.
+| Port kind | Storefront policy | Admin policy |
+| --- | --- | --- |
+| Validation | `400 commerce_store_shipping_invalid` | `400 commerce_admin_fulfillment_invalid` |
+| NotFound | `404 commerce_store_not_found` | `404 commerce_admin_not_found` |
+| Conflict | `409 commerce_store_shipping_state_conflict` | `409 commerce_admin_fulfillment_state_conflict` |
+| Forbidden | `401 commerce_store_denied` | `401 commerce_permission_denied` |
+| Unavailable / Timeout | `503 commerce_store_shipping_unavailable` | `503 commerce_admin_fulfillment_storage_unavailable` |
+| InvariantViolation | `500 commerce_store_shipping_failed` | `500 commerce_admin_fulfillment_failed` |
 
-No `PortError.message` or original fulfillment message is copied into the
-compatibility values or administrative GraphQL boundary.
-
-## Diagnostics
-
-The port-backed query boundary records:
-
-- truthful owner `rustok_fulfillment`;
-- correlation id;
-- tenant and service actor;
-- context locale length;
-- deadline;
-- GraphQL query field;
-- exact owner port operation;
-- optional shipping-option id;
-- requested/default locale lengths;
-- stable port error kind name;
-- owner code, kind, and retryability;
-- public or optional-result policy;
-- boundary `commerce_graphql_query_fulfillment_facade`.
-
-Unavailable, timeout, and invariant outcomes use error severity and retain the
-stable typed `PortError`. Ordinary outcomes use warning severity without an
-owner message field. The fulfillment owner ports independently retain their
-owner-local diagnostics and technical database cause.
+These mappings use fixed transport-owned messages. Owner error code, kind,
+retryability, correlation, actor, locale, channel, resource identity, and deadline
+are retained in diagnostics without exposing the owner message.
 
 ## Preserved contracts
 
-- `query.rs` is unchanged and remains facade-routed.
-- Existing source-level `FulfillmentService::new(db.clone())` calls still resolve
-  through the private safe facade.
-- Single shipping-option not-found still returns `None` rather than a GraphQL
-  error.
-- Storefront active-only semantics, currency, channel-visibility, and
-  shipping-profile filtering remain unchanged after owner projections return.
+- GraphQL `query.rs` remains facade-routed and successful GraphQL DTOs are
+  unchanged.
+- Single GraphQL shipping-option not-found still returns `None`.
+- Storefront owner list remains active-only.
+- Storefront REST currency, channel visibility, and shipping-profile filters are
+  unchanged after owner projections return.
 - Administrative list-all still includes inactive options before local active,
   currency, provider, search, and pagination filtering.
-- Shipping-option GraphQL DTOs and successful results are unchanged.
-- Fulfillment lifecycle and order lookup remain on the isolated concrete
-  delegate.
-- Directly embedded schemas keep an explicit compatibility fallback without
-  changing the mounted server composition path.
-- Current REST success filtering is retained by the source inventory but REST is
-  not yet owner-port composed.
-- Native seller/cart selection remains a separate contract and is not treated as
-  a complete projection-read transport.
-- Admin order lookup and non-not-found single shipping-option failures keep their
-  existing generic `COMMERCE_QUERY_OPERATION_FAILED` fail-closed envelope after
-  stable compatibility conversion.
-- The fulfillment FFA/FBA status and `ShippingSelectionPort` contract are
-  unchanged.
+- REST successful DTOs and route shapes are unchanged.
+- Admin shipping-option mutations retain their existing concrete lifecycle
+  service and typed `FulfillmentError` HTTP mapper.
+- Fulfillment lifecycle GraphQL reads remain on the isolated concrete delegate.
+- Native seller/cart selection remains a separate contract.
+- Fulfillment FFA/FBA status is unchanged.
 
 ## Still open
 
-- Migrate storefront REST active-list plus admin REST list-all and single lookup
-  to the host-composed shipping-option read runtime.
-- Preserve existing HTTP status/code/message policy while mapping typed
-  `PortErrorKind` without owner-message control flow.
-- Add public-channel propagation to the shipping-option query `PortContext`.
-- Publish owner ports for fulfillment lifecycle query reads, then remove the
-  remaining concrete `FulfillmentService` field.
-- Add mounted GraphQL/REST execution evidence; no native projection evidence is
-  required until a native projection consumer contract exists.
-- Continue reviewing order, payment, customer, inventory, region, channel,
-  catalog, and remaining Commerce query conversions that still pass through
-  dynamic strings.
-- Add compile, mounted transport, deadline, REST parity, and remote evidence
-  before promoting any FBA/FFA status.
+- Execute mounted GraphQL/REST active-list, list-all, and lookup parity fixtures.
+- Prove locale, effective channel, deadline, optional not-found, and typed failure
+  behavior through mounted requests.
+- Add public-channel propagation to every GraphQL shipping-option query context.
+- Publish owner ports for fulfillment lifecycle query reads and remove the
+  remaining concrete GraphQL facade delegate.
+- Continue converting remaining Commerce query boundaries that still use dynamic
+  strings.
+- Add compile and remote-profile evidence before promoting any FFA/FBA status.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
 node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
+node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
-node scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
 cargo check -p rustok-commerce --lib
 cargo check -p rustok-server --features mod-commerce
 ```

--- a/crates/rustok-commerce/src/controllers/admin/shipping.rs
+++ b/crates/rustok-commerce/src/controllers/admin/shipping.rs
@@ -3,10 +3,15 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::Permission;
-use rustok_api::{AuthContext, TenantContext};
-use rustok_fulfillment::FulfillmentService;
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
 use rustok_fulfillment::error::FulfillmentError;
+use rustok_fulfillment::{
+    FulfillmentService, ListAllShippingOptionProjectionsRequest,
+    ReadShippingOptionProjectionRequest,
+};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -143,6 +148,94 @@ fn map_admin_shipping_option_error(
     HttpError::new(status, code, message)
 }
 
+fn admin_shipping_option_read_port_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    shipping_option_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = shipping_option_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-shipping-option:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_admin_shipping_option_port_error(
+    context: AdminShippingOptionErrorContext,
+    port_context: &PortContext,
+    owner_operation: &'static str,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_fulfillment_failed",
+            "Fulfillment operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_SHIPPING_OPTION_OWNER,
+        owner_operation,
+        correlation_id = %port_context.correlation_id,
+        tenant_id = %context.tenant_id,
+        shipping_option_id = ?context.shipping_option_id,
+        operation = %context.operation,
+        actor = ?port_context.actor,
+        channel = ?port_context.channel,
+        locale = %port_context.locale,
+        deadline_ms = ?port_context.deadline_ms,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_SHIPPING_BOUNDARY,
+        "commerce admin shipping option read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
 async fn validate_shipping_option_profile_inputs(
     db: &sea_orm::DatabaseConnection,
     tenant_id: Uuid,
@@ -175,7 +268,7 @@ pub async fn list_shipping_profiles(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Query(params): Query<ListShippingProfilesParams>,
 ) -> HttpResult<Json<PaginatedResponse<ShippingProfileResponse>>> {
     ensure_permissions(
@@ -254,7 +347,7 @@ pub async fn show_shipping_profile(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ShippingProfileResponse>> {
     ensure_permissions(
@@ -389,7 +482,7 @@ pub async fn list_shipping_options(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Query(params): Query<ListShippingOptionsParams>,
 ) -> HttpResult<Json<PaginatedResponse<ShippingOptionResponse>>> {
     ensure_permissions(
@@ -399,16 +492,28 @@ pub async fn list_shipping_options(
     )?;
 
     let pagination = params.pagination.unwrap_or_default();
-    let mut items = FulfillmentService::new(runtime.db_clone())
-        .list_all_shipping_options(
-            tenant.id,
-            Some(request_context.locale.as_str()),
-            Some(tenant.default_locale.as_str()),
+    let read_context = admin_shipping_option_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        None,
+        "list_shipping_options",
+    );
+    let mut items = runtime
+        .shipping_option_admin_read_port()
+        .list_all_shipping_option_projections(
+            read_context.clone(),
+            ListAllShippingOptionProjectionsRequest {
+                requested_locale: Some(request_context.locale.clone()),
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
         )
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
+            map_admin_shipping_option_port_error(
                 AdminShippingOptionErrorContext::new(tenant.id, None, "list_shipping_options"),
+                &read_context,
+                "list_all_shipping_option_projections",
                 error,
             )
         })?;
@@ -499,7 +604,7 @@ pub async fn show_shipping_option(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ShippingOptionResponse>> {
     ensure_permissions(
@@ -508,17 +613,33 @@ pub async fn show_shipping_option(
         "Permission denied: fulfillments:read required",
     )?;
 
-    let option = FulfillmentService::new(runtime.db_clone())
-        .get_shipping_option(
-            tenant.id,
-            id,
-            Some(request_context.locale.as_str()),
-            Some(tenant.default_locale.as_str()),
+    let read_context = admin_shipping_option_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "get_shipping_option",
+    );
+    let option = runtime
+        .shipping_option_read_port()
+        .read_shipping_option_projection(
+            read_context.clone(),
+            ReadShippingOptionProjectionRequest {
+                shipping_option_id: id,
+                requested_locale: Some(request_context.locale.clone()),
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
         )
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
-                AdminShippingOptionErrorContext::new(tenant.id, Some(id), "get_shipping_option"),
+            map_admin_shipping_option_port_error(
+                AdminShippingOptionErrorContext::new(
+                    tenant.id,
+                    Some(id),
+                    "get_shipping_option",
+                ),
+                &read_context,
+                "read_shipping_option_projection",
                 error,
             )
         })?;

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -21,6 +21,7 @@ pub struct CommerceHttpRuntime {
     event_bus: TransactionalEventBus,
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
+    shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
 
@@ -45,6 +46,19 @@ impl CommerceHttpRuntime {
         self.fulfillment_provider_registry.clone()
     }
 
+    fn shipping_option_read_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::ShippingOptionReadPort> {
+        self.shipping_option_read_runtime.shipping_option_read_port()
+    }
+
+    fn shipping_option_admin_read_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::ShippingOptionAdminReadPort> {
+        self.shipping_option_read_runtime
+            .shipping_option_admin_read_port()
+    }
+
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
             .operator_service(self.db_clone(), self.event_bus())
@@ -65,6 +79,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require TransactionalEventBus in HostRuntimeContext"
                 )
             })?;
+        let shipping_option_read_runtime = runtime
+            .shared_get::<crate::graphql_runtime::CommerceShippingOptionReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require CommerceShippingOptionReadRuntime in HostRuntimeContext"
+                )
+            })?;
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
@@ -81,6 +102,7 @@ impl CommerceHttpRuntime {
             fulfillment_provider_registry: runtime
                 .shared_get::<FulfillmentProviderRegistry>()
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
+            shipping_option_read_runtime,
             marketplace_financial_runtime,
         })
     }

--- a/crates/rustok-commerce/src/controllers/store/products.rs
+++ b/crates/rustok-commerce/src/controllers/store/products.rs
@@ -4,10 +4,11 @@ use axum::{
     http::StatusCode,
 };
 use rustok_api::{
-    OptionalAuthContext, PortActor, PortContext, PortError, RequestContext, TenantContext,
+    OptionalAuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
 };
 use rustok_cart::{CartStorefrontReadRequest, in_process_cart_storefront_port};
-use rustok_fulfillment::{FulfillmentService, error::FulfillmentError};
+use rustok_fulfillment::ListShippingOptionProjectionsRequest;
 use rustok_product::{
     CatalogService, CommerceError as ProductError,
     entities::{product, product_translation},
@@ -208,49 +209,96 @@ fn map_storefront_shipping_context_error(
     )
 }
 
-fn map_storefront_fulfillment_error(
-    error: FulfillmentError,
+fn storefront_shipping_option_port_context(
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&rustok_api::AuthContext>,
+    public_channel_slug: Option<&str>,
+    requested_cart_id: Option<Uuid>,
+) -> PortContext {
+    let actor = auth
+        .map(|value| PortActor::user(value.user_id.to_string()))
+        .unwrap_or_else(|| PortActor::service("rustok-commerce.storefront-shipping-options"));
+    let resource_id = requested_cart_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        actor,
+        request_context.locale.as_str(),
+        format!("commerce-store-shipping-options:list:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match public_channel_slug {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_storefront_shipping_port_error(
+    error: PortError,
+    context: &PortContext,
     operation: &'static str,
     tenant_id: Uuid,
     cart_id: Option<Uuid>,
 ) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
-        FulfillmentError::Validation(_) => (
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
             StatusCode::BAD_REQUEST,
             "commerce_store_shipping_invalid",
             "Shipping request is invalid",
             "validation",
         ),
-        FulfillmentError::ShippingOptionNotFound(_) | FulfillmentError::FulfillmentNotFound(_) => (
+        PortErrorKind::NotFound => (
             StatusCode::NOT_FOUND,
             "commerce_store_not_found",
             "Commerce resource not found",
             "not_found",
         ),
-        FulfillmentError::InvalidTransition { .. } => (
+        PortErrorKind::Conflict => (
             StatusCode::CONFLICT,
             "commerce_store_shipping_state_conflict",
             "Shipping operation conflicts with the current state",
             "state_conflict",
         ),
-        FulfillmentError::Database(_) => (
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_store_denied",
+            "Store access is denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_store_shipping_unavailable",
             "Shipping service is temporarily unavailable",
-            "database",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_shipping_failed",
+            "Shipping operation could not be completed safely",
+            "invariant_violation",
         ),
     };
-    storefront_auxiliary_public_error(
-        &error,
-        "rustok_fulfillment",
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_fulfillment",
+        owner_operation = "list_shipping_option_projections",
         operation,
-        tenant_id,
-        cart_id,
-        status,
-        code,
-        message,
+        correlation_id = %context.correlation_id,
+        tenant_id = %tenant_id,
+        cart_id = ?cart_id,
+        actor = ?context.actor,
+        channel = ?context.channel,
+        locale = %context.locale,
+        deadline_ms = ?context.deadline_ms,
+        internal_code = %error.code,
+        retryable = error.retryable,
         error_kind,
-    )
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_auxiliary_http",
+        "storefront shipping-option owner read failed"
+    );
+    HttpError::new(status, code, message)
 }
 
 /// List published storefront products
@@ -596,17 +644,27 @@ pub async fn list_shipping_options(
             )
         };
 
-    let service = FulfillmentService::new(runtime.db_clone());
-    let mut options = service
-        .list_shipping_options(
-            tenant.id,
-            Some(request_context.locale.as_str()),
-            Some(tenant.default_locale.as_str()),
+    let read_context = storefront_shipping_option_port_context(
+        tenant.id,
+        &request_context,
+        auth.0.as_ref(),
+        public_channel_slug.as_deref(),
+        requested_cart_id,
+    );
+    let mut options = runtime
+        .shipping_option_read_port()
+        .list_shipping_option_projections(
+            read_context.clone(),
+            ListShippingOptionProjectionsRequest {
+                requested_locale: Some(request_context.locale.clone()),
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
         )
         .await
         .map_err(|error| {
-            map_storefront_fulfillment_error(
+            map_storefront_shipping_port_error(
                 error,
+                &read_context,
                 "list_shipping_options",
                 tenant.id,
                 requested_cart_id,

--- a/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json
@@ -1,12 +1,16 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "generated_at": "2026-07-28",
-  "status": "source_audit_only_unvalidated",
-  "source_revision": "aa1f12d7660bda14daa5d8ade11d3074418a573f",
+  "status": "source_cutover_ready_unvalidated",
+  "source_base_revision": "862291c0f0b8bcf869c444c49c2681c5a36349ca",
   "scope": "shipping-option projection reads across mounted commerce transports",
-  "graphql": {
+  "shared_runtime": {
     "composition": "application_host",
     "runtime": "CommerceShippingOptionReadRuntime",
+    "host_context": "HostRuntimeContext"
+  },
+  "graphql": {
+    "composition": "application_host",
     "operations": [
       "ShippingOptionReadPort::list_shipping_option_projections",
       "ShippingOptionReadPort::read_shipping_option_projection",
@@ -17,25 +21,38 @@
     "single_lookup_optional_not_found": true
   },
   "rest": {
-    "composition": "direct_concrete_service",
+    "composition": "application_host",
+    "runtime_state": "CommerceHttpRuntime",
     "storefront_active_list": {
       "source": "crates/rustok-commerce/src/controllers/store/products.rs",
-      "operation": "FulfillmentService::list_shipping_options",
+      "operation": "ShippingOptionReadPort::list_shipping_option_projections",
       "currency_filter_retained": true,
       "public_channel_filter_retained": true,
-      "shipping_profile_filter_retained": true
+      "shipping_profile_filter_retained": true,
+      "effective_public_channel_in_port_context": true
     },
     "admin_list_all": {
       "source": "crates/rustok-commerce/src/controllers/admin/shipping.rs",
-      "operation": "FulfillmentService::list_all_shipping_options",
+      "operation": "ShippingOptionAdminReadPort::list_all_shipping_option_projections",
       "inactive_before_filters": true,
       "active_currency_provider_search_pagination_retained": true
     },
     "admin_lookup": {
       "source": "crates/rustok-commerce/src/controllers/admin/shipping.rs",
-      "operation": "FulfillmentService::get_shipping_option"
+      "operation": "ShippingOptionReadPort::read_shipping_option_projection"
     },
-    "cutover_required": true
+    "context": {
+      "tenant": true,
+      "actor": true,
+      "locale": true,
+      "channel_when_available": true,
+      "resource_scoped_correlation_id": true,
+      "deadline_ms": 2000
+    },
+    "legacy_http_envelopes_retained": true,
+    "concrete_service_read_construction": false,
+    "mutation_service_construction_unchanged": true,
+    "cutover_required": false
   },
   "native_ffa": {
     "projection_read_surface": "absent_by_design",
@@ -47,11 +64,12 @@
     "expand_selection_contract_for_projection_parity": false
   },
   "decision": {
-    "next_slice": "migrate_rest_projection_reads_to_host_composed_owner_ports",
+    "next_slice": "execute_mounted_graphql_rest_projection_parity",
     "preserve_existing_http_success_filters": true,
     "preserve_existing_http_public_envelopes": true,
     "do_not_add_native_projection_api_without_a_consumer_contract": true
   },
+  "runtime_parity_proven": false,
   "validation": {
     "tests_run": false,
     "cargo_run": false,

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -4,11 +4,11 @@ Last reviewed: 2026-07-28
 
 ## Current state
 
-`rustok-fulfillment` owns shipping options, fulfillments, typed fulfillment
-items, shipping-selection policy, and provider SPI policy. The commerce module
-composes delivery groups, checkout, and multi-fulfillment orchestration; it
-must not duplicate fulfillment transport, selection materialization, carrier
-lifecycle persistence, or fulfillment recovery queries.
+`rustok-fulfillment` owns shipping options, fulfillments, typed fulfillment items,
+shipping-selection policy, and provider SPI policy. Commerce composes delivery
+groups, checkout, and multi-fulfillment orchestration; it must not duplicate
+fulfillment transport, selection materialization, carrier lifecycle persistence,
+or fulfillment recovery queries.
 
 The owner storefront handles seller-aware shipping selection through native and
 GraphQL transports. Selection identity is exactly `shipping_profile_slug +
@@ -17,45 +17,50 @@ capability, health, unavailable mode, and degraded fallback before an adapter
 call, while `FulfillmentService` remains the lifecycle owner.
 
 Checkout fulfillment create/adopt/read enters through
-`CheckoutFulfillmentExecutionPort`. Commerce sends typed order-line commands
-derived from the immutable checkout plan and receives normalized fulfillment
-projections. Fulfillment owner uses `FulfillmentService::list_by_order` and
-`create_fulfillment`; mounted commerce checkout no longer queries the
-`fulfillments` table or constructs `FulfillmentService`.
+`CheckoutFulfillmentExecutionPort`. Commerce sends typed order-line commands from
+the immutable checkout plan and receives normalized owner projections. The owner
+uses `FulfillmentService::list_by_order` and `create_fulfillment`; mounted Commerce
+checkout no longer queries fulfillment persistence or constructs the service.
 
-The root in-process checkout factory now mounts
+The root in-process checkout factory mounts
 `TypedCheckoutFulfillmentExecutionPort`. Ensure and recovery reads accept
-`Pending`, `Shipped`, and `Delivered` owner states. `Cancelled` and unknown
-lifecycle values fail closed with a typed manual-reconciliation outcome instead
-of being adopted as a successful checkout fulfillment set. The underlying
-execution adapter remains the persistence/idempotency delegate, so transport
-contracts and request DTOs are unchanged.
+`Pending`, `Shipped`, and `Delivered`. `Cancelled` and unknown lifecycle values
+fail closed with typed manual reconciliation. Durable typed checkout fulfillment
+identity and a concurrency-safe uniqueness constraint remain open.
 
-Complete shipping-option active list and lookup use `ShippingOptionReadPort`,
-while administrative list-all uses the separate `ShippingOptionAdminReadPort`.
-The root in-process factories own `FulfillmentService` construction, require read
-policy, preserve requested and default locale values, and map owner failures to
-stable `PortError` envelopes. The application host now composes both read ports
-once in `HostRuntimeContext`; manifest GraphQL runtime data carries them into a
-resolver-scoped async task, and the private Commerce facade only consumes those
-scoped owner ports. Mounted shipping enrichment, storefront listing, single
-lookup, and administrative list-all therefore no longer construct their
-in-process providers inside the Commerce seam. The facade retains one concrete
-`FulfillmentService` only for fulfillment lifecycle and order-to-fulfillment
-compatibility reads. Directly embedded standalone schemas retain an explicit
-in-process compatibility fallback outside the facade. The seller/cart
-`ShippingSelectionPort` contract is unchanged.
+Complete shipping-option active list and lookup use `ShippingOptionReadPort`;
+administrative list-all uses the separate `ShippingOptionAdminReadPort`. Root
+in-process adapters own `FulfillmentService` construction, require read policy,
+preserve requested/default locale, and map owner failures to stable `PortError`.
 
-A source-only transport inventory now records that Commerce REST still constructs
-`FulfillmentService` for storefront active-list and admin list-all/lookup, even
-though it preserves the same successful filtering semantics. The native FFA
-surface owns seller/cart selection and does not publish complete projection list
-or lookup operations. The retained next implementation decision is REST cutover
-to the host-composed owner ports without expanding `ShippingSelectionPort`.
+The application host composes one `CommerceShippingOptionReadRuntime` in
+`HostRuntimeContext`. Mounted GraphQL consumes it through manifest runtime data
+and resolver scope. Mounted Commerce REST consumes the same runtime through
+`CommerceHttpRuntime`.
 
-Stable fulfillment keys and metadata identity remain owner-local compatibility
-mechanisms. Duplicate keys fail closed. A typed durable checkout fulfillment
-identity and database uniqueness migration remain open.
+The following mounted projection reads no longer construct a concrete fulfillment
+service or in-process read provider inside Commerce:
+
+- GraphQL validation, enrichment, storefront listing, single lookup, and admin
+  list-all;
+- REST storefront active-list;
+- REST admin list-all and single lookup.
+
+The GraphQL facade retains one concrete `FulfillmentService` only for fulfillment
+lifecycle and order-to-fulfillment compatibility reads. Admin REST
+shipping-option mutations continue to use the concrete lifecycle owner and are
+outside the projection-read cutover. Directly embedded GraphQL schemas retain an
+explicit in-process compatibility fallback outside the private facade.
+
+The source transport inventory now has status
+`source_cutover_ready_unvalidated`. It records host-composed GraphQL/REST source
+topology, retained filters and HTTP envelopes, context/deadline propagation, and
+the absence of concrete read construction. It explicitly records
+`runtime_parity_proven: false`.
+
+The native FFA surface remains seller/cart selection through
+`ShippingSelectionPort`; it does not publish complete projection list or lookup
+operations. No projection API should be added without a concrete consumer.
 
 ## FFA/FBA boundary
 
@@ -67,31 +72,19 @@ identity and database uniqueness migration remain open.
 - Additional workflow contract: `fulfillment.checkout_execution.v1` in
   `crates/rustok-fulfillment/contracts/fulfillment-checkout-execution-v1.json`.
 - Published checkout execution port: `CheckoutFulfillmentExecutionPort`.
-- Mounted in-process provider: `TypedCheckoutFulfillmentExecutionPort` over the
-  existing owner execution adapter.
+- Mounted checkout provider: `TypedCheckoutFulfillmentExecutionPort` over the
+  owner execution adapter.
 - Source-ready internal read boundaries: `ShippingOptionReadPort` and
-  `ShippingOptionAdminReadPort`; these are not new FBA provider contracts and do
-  not change registry status.
-- Contract and provider evidence:
-  `crates/rustok-fulfillment/contracts/evidence/fulfillment-contract-test-static-matrix.json`,
-  `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-static-matrix.json`,
-  `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-runtime-smoke.json`,
-  and `crates/rustok-fulfillment/contracts/evidence/fulfillment-provider-spi-live-adapter-evidence.json`.
-- Source-only shipping-option transport inventory:
+  `ShippingOptionAdminReadPort`; these are not new FBA provider contracts.
+- Contract/provider evidence remains in the existing fulfillment evidence
+  matrices and live-adapter files.
+- Shipping-option source evidence:
   `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`.
-  It is unvalidated source evidence and does not promote any status.
-- `scripts/verify/verify-fulfillment-admin-boundary.mjs`,
-  `scripts/verify/verify-fulfillment-storefront-boundary.mjs`,
-  `scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`, and
-  `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the
-  owner-admin/storefront, checkout execution, and typed lifecycle split.
-- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`,
-  `scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`, and
-  `scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
-  guard the internal read boundaries, mounted GraphQL host composition, and the
-  explicit REST/native source inventory.
-- No status promotion is claimed from source. Compile, upgraded database,
-  contention, restart, mounted transport, and remote evidence remain missing.
+  It is unvalidated source evidence and does not promote status.
+- Focused guards cover owner boundaries, GraphQL host composition, REST host
+  composition, typed HTTP envelopes, and the separate native selection surface.
+- Compile, migrated database, mounted transport, restart, contention, and remote
+  evidence remain missing.
 
 ## Checkout execution source checklist
 
@@ -101,10 +94,9 @@ identity and database uniqueness migration remain open.
   owner module.
 - [x] Mount the root in-process factory through typed lifecycle validation.
 - [x] Accept pending, shipped, and delivered replay projections.
-- [x] Route cancelled and unknown checkout fulfillment lifecycle states to
-  manual reconciliation.
-- [x] Guard the mounted commerce path against direct construction of the legacy
-  in-process execution adapter.
+- [x] Route cancelled and unknown lifecycle states to manual reconciliation.
+- [x] Guard mounted Commerce against direct construction of the legacy execution
+  adapter.
 - [ ] Replace metadata identity with owner-owned typed persistence and a
   concurrency-safe uniqueness constraint.
 - [ ] Execute compile, create/adopt/read, duplicate identity, lifecycle,
@@ -113,82 +105,84 @@ identity and database uniqueness migration remain open.
 ## Shipping-option read source checklist
 
 - [x] Publish active list and lookup through `ShippingOptionReadPort`.
-- [x] Publish administrative list-all through the separate
+- [x] Publish administrative list-all through
   `ShippingOptionAdminReadPort`.
-- [x] Keep active storefront listing and complete administrative listing as
-  separate traits rather than an overloaded request flag or a growing storefront
-  interface.
+- [x] Keep storefront active listing and complete admin listing as separate traits.
 - [x] Preserve requested and tenant-default locale arguments.
 - [x] Require read policy and parse tenant identity from `PortContext`.
 - [x] Map all current `FulfillmentError` variants to stable `PortError` values.
 - [x] Export canonical root in-process factories.
-- [x] Remove direct `FulfillmentService` construction from mounted commerce
-  GraphQL shipping-option validation, enrichment, and storefront listing.
-- [x] Cut mounted GraphQL single lookup and administrative `shipping_options`
-  list-all over to owner read ports while preserving optional-not-found and
-  `FULFILLMENT_*` public envelopes.
-- [x] Inject both read ports from application-host composition through typed
-  runtime data and resolver-scoped async context; keep standalone fallback outside
-  the private facade.
-- [x] Retain a source-only GraphQL/REST/native inventory that distinguishes
-  complete projection reads from seller/cart selection and records the REST
-  cutover decision without claiming runtime parity.
-- [ ] Cut Commerce REST storefront active-list and admin list-all/lookup over to
-  the same host-composed owner runtime while preserving HTTP envelopes and local
-  success filters.
-- [ ] Execute compile, mounted GraphQL/REST parity, deadline, locale, channel,
-  failure, and remote-profile evidence.
+- [x] Remove direct service construction from mounted GraphQL shipping-option
+  validation, enrichment, listing, lookup, and admin list-all.
+- [x] Inject both owner ports through application-host composition and resolver
+  scope; keep standalone fallback outside the private facade.
+- [x] Retain a source inventory that distinguishes complete projection reads from
+  seller/cart selection without claiming runtime parity.
+- [x] Add the shared runtime to `CommerceHttpRuntime` and cut REST storefront
+  active-list plus admin list-all/lookup over to owner ports.
+- [x] Preserve storefront currency/channel/profile filters and admin
+  inactive-before-filter plus active/currency/provider/search/pagination behavior.
+- [x] Preserve existing REST status/code/message policy through typed
+  `PortErrorKind` mapping without owner-message control flow.
+- [x] Propagate REST tenant, actor, locale, effective channel, correlation, and
+  two-second deadline context.
+- [ ] Execute compile, mounted GraphQL/REST active-list/list-all/lookup parity,
+  deadline, locale, channel, optional-not-found, failure, and remote evidence.
 
 ## Open results
 
 1. **Prove checkout fulfillment identity and replay.** Execute create/adopt/read,
    duplicate key, partial set, concurrent create, process-exit, restart, and
-   upgraded metadata scenarios through the mounted commerce stage.
-   **Depends on:** compiled commerce/fulfillment crates and migrated databases.
+   upgraded metadata scenarios through mounted Commerce.
+   **Depends on:** compiled crates and migrated databases.
    **Done when:** one immutable plan produces one exact fulfillment set and every
    conflicting, cancelled, unknown, or duplicate identity fails closed.
 
-2. **Replace metadata identity with typed persistence.** Add an owner-owned
-   checkout fulfillment identity and uniqueness constraint without adding a
-   foreign key to commerce-owned checkout tables.
-   **Depends on:** retained upgraded compatibility evidence for current keys.
+2. **Replace metadata identity with typed persistence.** Add owner-owned checkout
+   fulfillment identity and uniqueness without a foreign key to Commerce checkout
+   tables.
+   **Depends on:** upgraded compatibility evidence for current keys.
    **Done when:** recovery no longer scans metadata and concurrent creation cannot
-   commit two rows for one checkout fulfillment index.
+   commit duplicate fulfillment indices.
 
 3. **Prove mixed-cart and multi-fulfillment edge cases.** Cover seller-aware
    selection, partial shipment/delivery, reopen/reship recovery, remaining
-   quantity, and grouped checkout interactions without moving order or payment
-   transitions into this module.
-   **Depends on:** order-line and commerce delivery-group contracts.
-   **Done when:** targeted tests cover valid and rejected transitions for a
-   mixed cart and multiple fulfillment records.
+   quantity, and grouped checkout interactions.
+   **Depends on:** order-line and Commerce delivery-group contracts.
+   **Done when:** targeted tests cover valid and rejected transitions for mixed
+   carts and multiple fulfillment records.
 
 4. **Wire production carrier adapters through the provider registry.** Add
-   concrete carrier configuration, quote, label, cancellation, and replay-safe
-   tracking-webhook execution only through guarded provider seams.
-   **Depends on:** approved carrier credentials, webhook ingress, and
-   deployment-owned secret management.
-   **Done when:** production-like execution proves degraded fallback and typed
-   adapter errors while `FulfillmentService` remains the sole lifecycle owner.
+   production-like quote, label, cancellation, tracking-webhook, and replay-safe
+   behavior through guarded provider seams.
+   **Depends on:** approved credentials, webhook ingress, and deployment secret
+   management.
+   **Done when:** execution proves degraded fallback and typed adapter errors while
+   `FulfillmentService` remains the lifecycle owner.
 
-5. **Cut REST projection reads over and prove transport parity.** Replace the
-   existing Commerce REST storefront active-list and admin list-all/lookup
-   concrete service construction with `CommerceShippingOptionReadRuntime`, then
-   execute mounted GraphQL/REST comparisons against the same owner projections.
-   Native seller/cart selection remains a separate contract and needs no complete
-   projection surface without a consumer.
-   **Depends on:** host runtime wiring for Commerce HTTP plus compiled
-   fulfillment/commerce crates and mounted transport fixtures.
+5. **Prove mounted shipping-option transport parity.** Execute active list,
+   administrative list-all, and lookup through mounted GraphQL and REST consumers
+   against the same owner projections. Native seller/cart selection remains a
+   separate contract and needs no complete projection surface without a consumer.
+   **Depends on:** compiled fulfillment/Commerce/server crates and mounted
+   transport fixtures.
    **Done when:** GraphQL and REST retain locale/channel/deadline context, expose
-   identical owner projections with correct active/inactive semantics, preserve
-   their public envelopes, and no mounted projection transport constructs a
-   concrete fulfillment service or in-process read provider.
+   equivalent projections with correct active/inactive semantics, preserve public
+   envelopes, and no mounted projection transport constructs a concrete read
+   service or provider.
 
-6. **Execute remote contracts.** Turn shipping-selection and checkout-execution
+6. **Publish remaining fulfillment query read ports.** Add owner boundaries for
+   fulfillment lifecycle list/lookup and order-to-fulfillment reads, then remove
+   the remaining concrete delegate from the GraphQL compatibility facade.
+   **Depends on:** stable projection and optional-not-found contracts.
+   **Done when:** all mounted fulfillment query reads consume host-composed owner
+   ports and lifecycle ownership remains in fulfillment.
+
+7. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.
-   **Depends on:** a remote adapter environment and a commerce consumer.
-   **Done when:** deadline, idempotency, typed-error, identity, and fallback
-   parity are proven.
+   **Depends on:** a remote adapter environment and a Commerce consumer.
+   **Done when:** deadline, idempotency, typed-error, identity, and fallback parity
+   are proven.
 
 ## Verification
 
@@ -199,6 +193,9 @@ identity and database uniqueness migration remain open.
 - `node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
 - `node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
+- `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
+- `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
+- `node scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs`
 - `node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs`
 - `npm run verify:ecommerce:fba`
@@ -207,18 +204,16 @@ identity and database uniqueness migration remain open.
 - `cargo xtask module test fulfillment`
 - `cargo check -p rustok-fulfillment --all-features`
 - `cargo check -p rustok-commerce --all-features`
-- Targeted checkout fulfillment create/adopt/read, cancelled/unknown lifecycle,
-  duplicate identity, process-exit, restart, and multi-fulfillment tests.
-- Targeted shipping-option active list, administrative list-all, lookup locale,
-  context, owner-error, GraphQL/REST parity, and remote-profile tests.
+- Targeted checkout fulfillment identity/lifecycle/restart/contention tests.
+- Targeted shipping-option GraphQL/REST parity, context, error, and remote tests.
 
 No verification command was executed in this source wave.
 
 ## Change rules
 
 1. Keep shipping selection, shipping-option projections, fulfillment lifecycle,
-   checkout fulfillment identity, and carrier policy here.
+   checkout fulfillment identity, and carrier policy in this module.
 2. Update local documentation, contracts, `rustok-module.toml`, and the umbrella
-   commerce plan with a delivery or provider contract change.
-3. Update this status block and `docs/modules/registry.md` only with proven
-   FFA/FBA boundary changes.
+   Commerce plan with a delivery/provider contract change.
+3. Update status blocks and `docs/modules/registry.md` only with proven FFA/FBA
+   boundary changes.

--- a/crates/rustok-fulfillment/docs/shipping-option-read-port.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-port.md
@@ -1,56 +1,50 @@
 # Shipping-option read port
 
-Status: source-ready, unvalidated.
+Status: source-cutover-ready, unvalidated.
 
 ## Scope
 
 `ShippingOptionReadPort` and `ShippingOptionAdminReadPort` are fulfillment-owned
-read boundaries for complete shipping-option projections needed by mounted
-ecommerce transports.
+read boundaries for complete shipping-option projections consumed by mounted
+Commerce transports.
 
-They are separate from `ShippingSelectionPort`:
+They remain separate from `ShippingSelectionPort`:
 
 - `ShippingSelectionPort` owns seller/cart selection workflow;
 - `ShippingOptionReadPort` owns storefront active-list and single-option reads;
 - `ShippingOptionAdminReadPort` owns the complete administrative list-all read;
-- the selection contract and its provider registry are unchanged;
+- the selection provider registry is unchanged;
 - no new FBA provider contract or status promotion is claimed.
 
 ## Operations
 
-The two ports publish three read-only operations:
+The ports publish three read-only operations:
 
-- `list_shipping_option_projections` for the storefront-visible active list;
-- `list_all_shipping_option_projections` for the complete administrative list,
+- `list_shipping_option_projections` returns the active storefront list;
+- `list_all_shipping_option_projections` returns the complete administrative list,
   including inactive options;
-- `read_shipping_option_projection` for one complete owner projection.
+- `read_shipping_option_projection` returns one complete owner projection.
 
-All operations return the existing fulfillment-owned `ShippingOptionResponse`.
-This keeps metadata, allowed shipping-profile slugs, active state, localization
-facts, and provider identity inside the owner projection without defining a
-second partial commerce copy.
+All operations return the existing fulfillment-owned `ShippingOptionResponse`,
+including metadata, allowed shipping-profile slugs, active state, localization
+facts, provider identity, and price/currency data.
 
-## Requests
+## Requests and context
 
 `ListShippingOptionProjectionsRequest` and
-`ListAllShippingOptionProjectionsRequest` carry:
+`ListAllShippingOptionProjectionsRequest` carry requested locale and tenant
+default locale. `ReadShippingOptionProjectionRequest` additionally carries the
+shipping-option UUID.
 
-- requested locale;
-- tenant default locale.
-
-`ReadShippingOptionProjectionRequest` additionally carries:
-
-- shipping-option id.
-
-Locale values remain request data rather than being inferred from public error
-text. The delegated `PortContext` independently carries tenant, actor, channel,
-locale, correlation, causation, trace, and deadline facts.
+`PortContext` independently carries tenant, actor, channel, locale, correlation,
+causation, trace, idempotency, and deadline facts. Every read operation requires
+read policy and therefore a non-zero deadline.
 
 ## In-process adapters
 
 `InProcessShippingOptionReadPort` and
-`InProcessShippingOptionAdminReadPort` own `FulfillmentService` construction and
-are exported through separate root factories:
+`InProcessShippingOptionAdminReadPort` own concrete `FulfillmentService`
+construction and are exported through the canonical root factories:
 
 ```rust
 in_process_shipping_option_read_port(db)
@@ -61,72 +55,98 @@ The adapters:
 
 1. require read policy;
 2. parse tenant identity from `PortContext`;
-3. delegate active list, administrative list-all, or lookup to
-   `FulfillmentService`;
+3. delegate active list, administrative list-all, or lookup to the owner service;
 4. preserve requested/default locale arguments;
-5. map every `FulfillmentError` variant to a stable `PortError`;
+5. map every current `FulfillmentError` variant to stable `PortError` values;
 6. return the owner projection unchanged on success.
 
-The two list contracts remain separate traits rather than one overloaded request
-or one growing storefront interface. That keeps storefront active-only semantics
-separate from the admin requirement to inspect inactive shipping options and
-avoids breaking existing `ShippingOptionReadPort` implementors.
+The active-list and admin list-all contracts remain separate traits. This keeps
+storefront active-only semantics distinct from the admin requirement to inspect
+inactive options.
 
 ## Application-host composition
 
 The mounted server composes one `CommerceShippingOptionReadRuntime` from the two
-root factories and stores it in `HostRuntimeContext`. Manifest-generated Commerce
-GraphQL runtime data requires that typed runtime during schema construction.
-`CommerceShippingOptionReadScope` then copies the runtime into a Tokio task-local
-scope for each resolver execution.
+root factories, caches it in `ServerRuntimeContext`, and attaches it to
+`HostRuntimeContext`. Existing host-installed implementations are preserved.
 
-The private Commerce fulfillment facade resolves the scoped runtime and clones
-its two owner ports. It no longer imports or calls the root in-process factories.
-This preserves the unchanged `query.rs` compatibility facade while keeping
-provider construction in the application host.
+Mounted GraphQL requires this runtime through manifest data and bridges it into a
+resolver-scoped Tokio task-local. The private GraphQL compatibility facade clones
+the two owner ports and does not construct providers.
 
-Directly embedded schemas that do not install the mounted server extension use
-an explicit `CommerceShippingOptionReadRuntime::in_process` compatibility
-fallback in the Commerce GraphQL runtime module. The fallback is outside the
-private facade and is not evidence of mounted transport composition or parity.
+Mounted Commerce HTTP requires the same runtime while building
+`CommerceHttpRuntime`. HTTP router construction fails closed when the typed
+runtime is missing. Storefront and admin REST handlers clone the ports from HTTP
+state and do not construct a concrete fulfillment service for projection reads.
 
-## Transport parity source inventory
+Directly embedded GraphQL schemas retain the explicit
+`CommerceShippingOptionReadRuntime::in_process` fallback outside the private
+facade. That compatibility path is not mounted runtime parity evidence.
 
-`contracts/evidence/shipping-option-read-transport-parity-source.json` records a
-source-only inventory at revision
-`aa1f12d7660bda14daa5d8ade11d3074418a573f`. Its status is
-`source_audit_only_unvalidated`; it does not claim compiled or mounted behavior.
+## Mounted Commerce source cutover
 
-The inventory establishes three distinct transport states:
+GraphQL shipping-option paths use the owner ports for validation, enrichment,
+storefront listing, single lookup, and administrative list-all.
 
-1. Mounted GraphQL active list, admin list-all, and lookup consume the
-   application-host runtime and fulfillment owner ports.
-2. Commerce REST preserves the same successful projection filtering, but its
-   storefront active list and admin list-all/lookup still construct concrete
-   `FulfillmentService` instances.
-3. Fulfillment storefront FFA exposes seller/cart shipping selection over native
-   server and GraphQL paths. It does not expose complete shipping-option
-   projection list or lookup operations.
+Commerce REST now uses the same host-composed runtime for:
 
-The third state is not a missing parity implementation: `ShippingSelectionPort`
-and the complete projection read ports have different consumers and semantics.
-A projection API must not be added to the native selection surface merely to make
-transport counts look symmetrical.
+- storefront `GET /store/shipping-options` through
+  `list_shipping_option_projections`;
+- admin `GET /admin/shipping-options` through
+  `list_all_shipping_option_projections`;
+- admin `GET /admin/shipping-options/{id}` through
+  `read_shipping_option_projection`.
 
-The retained decision is therefore:
+Admin create, update, deactivate, and reactivate remain lifecycle mutations over
+`FulfillmentService`; this read cutover does not change them.
 
-- migrate the existing REST projection reads to the host-composed owner runtime;
-- preserve storefront currency/channel/profile filters;
-- preserve admin inactive-before-filter behavior and active/currency/provider/
-  search/pagination filters;
-- preserve current HTTP public status/code/message policy through typed
-  `PortErrorKind` mapping;
-- leave the native selection contract unchanged unless a complete projection
-  consumer is designed.
+### REST context
 
-`scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
-locks this inventory and decision until the REST cutover deliberately updates
-both source and evidence.
+Storefront list uses:
+
+- authenticated user actor when available, otherwise service actor
+  `rustok-commerce.storefront-shipping-options`;
+- request locale;
+- effective public channel, including the cart-derived channel when a cart is
+  supplied;
+- cart or tenant scoped correlation id;
+- two-second deadline.
+
+Admin list and lookup use:
+
+- authenticated user actor;
+- request locale;
+- request channel when available;
+- tenant or shipping-option scoped correlation id;
+- two-second deadline.
+
+Requested and tenant-default locales remain explicit owner request fields.
+
+### Preserved success semantics
+
+Storefront owner projections remain active-only. Commerce then preserves its
+existing currency, public-channel metadata visibility, and shipping-profile
+compatibility filters.
+
+Administrative list-all receives inactive and active options before Commerce
+applies active, currency, provider, search, and pagination filters. Single lookup
+continues returning the existing successful REST DTO.
+
+### Preserved HTTP policy
+
+REST maps `PortErrorKind` directly to fixed Commerce-owned HTTP envelopes. It does
+not parse, match, or expose `PortError.message`.
+
+Storefront preserves `commerce_store_shipping_invalid`,
+`commerce_store_not_found`, `commerce_store_shipping_state_conflict`,
+`commerce_store_denied`, `commerce_store_shipping_unavailable`, and
+`commerce_store_shipping_failed` policies.
+
+Admin preserves `commerce_admin_fulfillment_invalid`,
+`commerce_admin_not_found`, `commerce_admin_fulfillment_state_conflict`,
+`commerce_permission_denied`,
+`commerce_admin_fulfillment_storage_unavailable`, and the fail-closed
+`commerce_admin_fulfillment_failed` policy.
 
 ## Stable owner errors
 
@@ -139,67 +159,43 @@ both source and evidence.
 | Storage failure | Unavailable | `fulfillment.database_unavailable` | true |
 | Invalid tenant context | Validation | `fulfillment.context_invalid` | false |
 
-Messages are stable owner-safe summaries. Validation text and database text are
-not copied into the returned `PortError.message`.
+Owner messages are stable safe summaries. Validation details and database text are
+not copied into the returned public error.
 
 ## Diagnostics
 
-The owner boundary records:
+The owner boundary records operation, correlation id, tenant, actor, channel
+length, locale length, deadline, optional shipping-option id, requested/default
+locale lengths, error kind, code, and retryability. Only the technical database
+event retains the typed database cause.
 
-- owner and operation;
-- correlation id;
-- tenant id;
-- actor;
-- channel length;
-- locale length;
-- causation-id presence;
-- traceparent presence;
-- deadline;
-- optional shipping-option id;
-- requested-locale length;
-- default-locale length;
-- internal error kind, code, and retryability.
+Commerce REST additionally records the transport operation, resource identity,
+actor, effective channel, locale, deadline, owner code, kind, retryability,
+public code, and HTTP status. The owner message is not used as a protocol.
 
-Only the technical database event retains the typed owner cause. Ordinary
-validation, not-found, and conflict events do not add raw owner message fields.
+## Source evidence
 
-## Mounted commerce cutover
+`contracts/evidence/shipping-option-read-transport-parity-source.json` has status
+`source_cutover_ready_unvalidated`. It records that GraphQL and REST share the
+application-host runtime, concrete read construction is absent from mounted
+Commerce handlers, native projection reads remain absent by design, and runtime
+parity has not been proven.
 
-Mounted Commerce GraphQL shipping-option paths use the host-composed read ports:
-
-- shipping-option validation and single query lookup call
-  `read_shipping_option_projection`;
-- cart shipping enrichment and storefront query listing call
-  `list_shipping_option_projections`;
-- administrative `shipping_options` calls
-  `list_all_shipping_option_projections`.
-
-Commerce builds a read `PortContext` with a service actor, resource-scoped
-correlation id, request locale, optional public channel where applicable, and a
-two-second deadline. Existing optional-not-found behavior and public GraphQL
-`FULFILLMENT_*` message, code, and retryability envelopes remain unchanged.
-
-The administrative resolver source retains its existing `.to_string()` call for
-source compatibility, but the private Commerce facade returns a typed adapter
-whose inherent method yields the already-classified GraphQL boundary. No owner
-message is serialized, parsed, or matched. Administrative list-all still returns
-inactive options before the existing local active, currency, provider, search,
-and pagination filters are applied.
-
-Delivery-group projection is a pure Commerce function receiving owner
-projections. Existing selection adapters continue to delegate to the separate
-`ShippingSelectionPort`; they are not projection-read transports.
+The fulfillment storefront FFA continues to expose seller/cart shipping selection
+over native-server and GraphQL paths. It is not a complete projection-read
+transport and must not be expanded merely for numerical transport symmetry.
 
 ## Verification
 
-Focused source guards:
+Focused intended checks:
 
 ```bash
 node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
 node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
-node scripts/verify/verify-commerce-graphql-shipping-option-typed-error.mjs
-node scripts/verify/verify-commerce-graphql-shipping-enrichment-typed-error.mjs
+node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs
 cargo check -p rustok-fulfillment --lib
 cargo check -p rustok-commerce --lib
 cargo check -p rustok-server --features mod-commerce
@@ -209,17 +205,15 @@ No command was executed locally in this source wave.
 
 ## Remaining work
 
-This slice does not:
+This source slice does not:
 
-- migrate Commerce REST storefront active-list or admin list-all/lookup to the
-  host-composed read ports;
-- execute GraphQL/REST parity, deadline, locale, channel, or failure fixtures;
+- prove mounted GraphQL/REST active-list, list-all, or lookup parity;
+- execute deadline, locale, channel, optional-not-found, or failure fixtures;
 - add a native complete-projection read surface without a consumer contract;
 - propagate public channel into every GraphQL query read context;
-- publish owner read ports for fulfillment lifecycle and order-to-fulfillment
-  query paths;
-- retire `FulfillmentService` from fulfillment-owned compatibility adapters;
-- modify `ShippingSelectionPort`;
-- add or change an FBA registry contract;
-- provide compile, mounted runtime, remote-profile, restart, or contention evidence;
+- publish owner query ports for fulfillment lifecycle and order-to-fulfillment
+  reads;
+- retire `FulfillmentService` from fulfillment-owned adapters or admin mutations;
+- modify `ShippingSelectionPort` or an FBA registry contract;
+- provide compile, remote-profile, restart, or contention evidence;
 - promote fulfillment or ecommerce FFA/FBA status.

--- a/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
@@ -13,6 +13,7 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const apiPorts = read('crates/rustok-api/src/ports.rs');
 const shippingService = read('crates/rustok-commerce/src/services/shipping_profile.rs');
 const failures = [];
 
@@ -38,198 +39,215 @@ const profileMapper = between(
   'fn map_admin_shipping_option_error(',
   'shipping-profile mapper',
 );
-const optionMapper = between(
+const mutationMapper = between(
   shipping,
   'fn map_admin_shipping_option_error(',
-  'async fn validate_shipping_option_profile_inputs(',
-  'shipping-option mapper',
+  'fn admin_shipping_option_read_port_context(',
+  'shipping-option mutation mapper',
 );
+const readContext = between(
+  shipping,
+  'fn admin_shipping_option_read_port_context(',
+  'fn map_admin_shipping_option_port_error(',
+  'shipping-option read context',
+);
+const readMapper = between(
+  shipping,
+  'fn map_admin_shipping_option_port_error(',
+  'async fn validate_shipping_option_profile_inputs(',
+  'shipping-option read mapper',
+);
+const listRoute = between(
+  shipping,
+  'pub async fn list_shipping_options(',
+  '/// Create admin shipping option',
+  'shipping-option list route',
+);
+const createRoute = between(
+  shipping,
+  'pub async fn create_shipping_option(',
+  '/// Show admin shipping option',
+  'shipping-option create route',
+);
+const showRoute = between(
+  shipping,
+  'pub async fn show_shipping_option(',
+  '/// Update admin shipping option',
+  'shipping-option show route',
+);
+const updateRoute = between(
+  shipping,
+  'pub async fn update_shipping_option(',
+  '/// Deactivate admin shipping option',
+  'shipping-option update route',
+);
+const deactivateRoute = between(
+  shipping,
+  'pub async fn deactivate_shipping_option(',
+  '/// Reactivate admin shipping option',
+  'shipping-option deactivate route',
+);
+const reactivateStart = shipping.indexOf('pub async fn reactivate_shipping_option(');
+const reactivateRoute = reactivateStart < 0 ? '' : shipping.slice(reactivateStart);
+if (reactivateStart < 0) failures.push('shipping-option reactivate route: unable to isolate source block');
 
 for (const [value, label] of [
   ['CommerceError, ShippingProfileService', 'typed commerce error import'],
-  ['use rustok_fulfillment::error::FulfillmentError;', 'typed fulfillment error import'],
-  ['fn map_shipping_profile_error(error: CommerceError)', 'local shipping profile mapper'],
-  ['fn map_admin_shipping_option_error(', 'local shipping option mapper'],
-  ['async fn validate_shipping_option_profile_inputs(', 'local profile validation helper'],
-  [
-    'const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";',
-    'shipping-option owner constant',
-  ],
-  [
-    'const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";',
-    'shipping HTTP boundary constant',
-  ],
-  ['struct AdminShippingOptionErrorContext {', 'shipping-option context'],
-  ['tenant_id: Uuid,', 'tenant context field'],
-  ['shipping_option_id: Option<Uuid>,', 'truthful option identity field'],
-  ["operation: &'static str,", 'operation field'],
+  ['use rustok_fulfillment::error::FulfillmentError;', 'typed mutation error import'],
+  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed read error imports'],
+  ['ListAllShippingOptionProjectionsRequest', 'typed admin list request'],
+  ['ReadShippingOptionProjectionRequest', 'typed admin lookup request'],
+  ['fn map_shipping_profile_error(error: CommerceError)', 'profile mapper'],
+  ['fn map_admin_shipping_option_error(', 'mutation mapper'],
+  ['fn admin_shipping_option_read_port_context(', 'read context builder'],
+  ['fn map_admin_shipping_option_port_error(', 'read port mapper'],
+  ['async fn validate_shipping_option_profile_inputs(', 'profile validation helper'],
+  ['const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";', 'HTTP boundary'],
 ]) requireText(shipping, value, label);
 
 for (const [value, label] of [
   ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'duplicate profile slug mapping'],
+  ['CommerceError::DuplicateShippingProfileSlug(_)', 'profile conflict mapping'],
   ['CommerceError::Validation(_)', 'profile validation mapping'],
   ['CommerceError::Database(_)', 'profile database mapping'],
   ['StatusCode::NOT_FOUND', 'profile not-found status'],
   ['StatusCode::CONFLICT', 'profile conflict status'],
-  ['StatusCode::BAD_REQUEST', 'profile bad-request status'],
+  ['StatusCode::BAD_REQUEST', 'profile validation status'],
   ['StatusCode::SERVICE_UNAVAILABLE', 'profile unavailable status'],
   ['StatusCode::INTERNAL_SERVER_ERROR', 'profile fail-closed status'],
-  ['"commerce_admin_not_found"', 'shared not-found code'],
   ['"commerce_admin_shipping_profile_conflict"', 'profile conflict code'],
   ['"commerce_admin_shipping_profile_invalid"', 'profile invalid code'],
   ['"commerce_admin_shipping_profile_storage_unavailable"', 'profile storage code'],
   ['"commerce_admin_shipping_profile_failed"', 'profile fail-closed code'],
-  ['"unexpected_commerce_error"', 'unexpected owner variant kind'],
-  ['error = ?error', 'profile typed internal cause'],
-  ['owner = "rustok_commerce.shipping_profile"', 'profile owner logging'],
-  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'profile boundary logging'],
-  ['HttpError::new(status, code, message)', 'profile static envelope construction'],
+  ['HttpError::new(status, code, message)', 'profile static envelope'],
 ]) requireText(profileMapper, value, label);
 
-for (const value of [
-  'CommerceError::ProductNotFound(_)',
-  'CommerceError::VariantNotFound(_)',
-  'CommerceError::DuplicateHandle { .. }',
-  'CommerceError::DuplicateSku(_)',
-  'CommerceError::InvalidPrice(_)',
-  'CommerceError::InsufficientInventory { .. }',
-  'CommerceError::InvalidOptionCombination',
-  'CommerceError::NoVariants',
-  'CommerceError::CannotDeletePublished',
-  'CommerceError::Rich(_)',
-  'CommerceError::Core(_)',
-]) requireText(profileMapper, value, 'fail-closed unrelated commerce variant');
+for (const [value, label] of [
+  ['FulfillmentError::Validation(_)', 'mutation validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation not-found mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict mapping'],
+  ['FulfillmentError::Database(_)', 'mutation unavailable mapping'],
+  ['"commerce_admin_fulfillment_invalid"', 'mutation invalid code'],
+  ['"commerce_admin_not_found"', 'mutation not-found code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'mutation conflict code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'mutation unavailable code'],
+  ['HttpError::new(status, code, message)', 'mutation static envelope'],
+]) requireText(mutationMapper, value, label);
 
 for (const [value, label] of [
-  ['error: FulfillmentError,', 'owned fulfillment cause'],
-  ['FulfillmentError::Validation(_)', 'option validation mapping'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'option not-found mapping'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'unexpected fulfillment not-found mapping'],
-  ['FulfillmentError::InvalidTransition { .. }', 'option transition mapping'],
-  ['FulfillmentError::Database(_)', 'option database mapping'],
-  ['StatusCode::BAD_REQUEST', 'option bad-request status'],
-  ['StatusCode::NOT_FOUND', 'option not-found status'],
-  ['StatusCode::CONFLICT', 'option conflict status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'option unavailable status'],
-  ['"commerce_admin_fulfillment_invalid"', 'option validation code'],
-  ['"commerce_admin_not_found"', 'option not-found code'],
-  ['"commerce_admin_fulfillment_state_conflict"', 'option conflict code'],
-  ['"commerce_admin_fulfillment_storage_unavailable"', 'option storage code'],
-  ['"Fulfillment request is invalid"', 'static option validation message'],
-  ['"Commerce resource not found"', 'static option not-found message'],
+  ['PortActor::user(auth.user_id.to_string())', 'read user actor'],
+  ['request_context.locale.as_str()', 'read locale'],
+  ['format!("commerce-admin-shipping-option:{operation}:{resource_id}")', 'read correlation id'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
+  ['request_context.channel_slug.as_deref()', 'read channel'],
+]) requireText(readContext, value, label);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'read validation kind'],
+  ['PortErrorKind::NotFound', 'read not-found kind'],
+  ['PortErrorKind::Conflict', 'read conflict kind'],
+  ['PortErrorKind::Forbidden', 'read forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'read unavailable kinds'],
+  ['PortErrorKind::InvariantViolation', 'read invariant kind'],
+  ['StatusCode::BAD_REQUEST', 'read validation status'],
+  ['StatusCode::NOT_FOUND', 'read not-found status'],
+  ['StatusCode::CONFLICT', 'read conflict status'],
+  ['StatusCode::UNAUTHORIZED', 'read forbidden status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'read unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'read invariant status'],
+  ['"commerce_admin_fulfillment_invalid"', 'read validation code'],
+  ['"commerce_admin_not_found"', 'read not-found code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'read conflict code'],
+  ['"commerce_permission_denied"', 'read forbidden code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'read unavailable code'],
+  ['"commerce_admin_fulfillment_failed"', 'read invariant code'],
+  ['error = ?error', 'typed owner cause'],
+  ['correlation_id = %port_context.correlation_id', 'correlation log'],
+  ['internal_code = %error.code', 'owner code log'],
+  ['retryable = error.retryable', 'retryability log'],
+  ['HttpError::new(status, code, message)', 'read static envelope'],
+]) requireText(readMapper, value, label);
+
+for (const [block, getter, operation, request, label] of [
   [
-    '"Fulfillment operation conflicts with the current state"',
-    'static option conflict message',
+    listRoute,
+    '.shipping_option_admin_read_port()',
+    '.list_all_shipping_option_projections(',
+    'ListAllShippingOptionProjectionsRequest {',
+    'list route',
   ],
-  ['"Fulfillment storage is temporarily unavailable"', 'static option storage message'],
-  ['error = ?error', 'option typed internal cause'],
-  ['owner = ADMIN_SHIPPING_OPTION_OWNER', 'option owner logging'],
-  ['tenant_id = %context.tenant_id', 'option tenant logging'],
-  ['shipping_option_id = ?context.shipping_option_id', 'option identity logging'],
-  ['operation = %context.operation', 'option operation logging'],
-  ['error_kind,', 'option error-kind logging'],
-  ['public_code = code', 'option public-code logging'],
-  ['status = %status', 'option status logging'],
-  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'option boundary logging'],
-  ['HttpError::new(status, code, message)', 'option static envelope construction'],
-]) requireText(optionMapper, value, label);
-
-for (const [value, label] of [
-  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
-  ['ProductNotFound(Uuid)', 'owner product variant'],
-  ['VariantNotFound(Uuid)', 'owner variant variant'],
-  ['DuplicateHandle { handle: String, locale: String }', 'owner duplicate handle variant'],
-  ['DuplicateSku(String)', 'owner duplicate SKU variant'],
-  ['InvalidPrice(String)', 'owner invalid price variant'],
-  ['InsufficientInventory { requested: i32, available: i32 }', 'owner inventory variant'],
-  ['InvalidOptionCombination', 'owner option-combination variant'],
-  ['Validation(String)', 'owner validation variant'],
-  ['ShippingProfileNotFound(Uuid)', 'owner shipping profile variant'],
-  ['DuplicateShippingProfileSlug(String)', 'owner duplicate profile slug variant'],
-  ['NoVariants', 'owner no-variants variant'],
-  ['CannotDeletePublished', 'owner published-delete variant'],
-  ['Rich(#[source] Box<RichError>)', 'owner rich variant'],
-  ['Core(#[from] CoreError)', 'owner core variant'],
-]) requireText(commerceErrors, value, label);
-
-for (const [value, label] of [
-  ['Validation(String)', 'fulfillment validation variant'],
-  ['ShippingOptionNotFound(Uuid)', 'fulfillment shipping option variant'],
-  ['FulfillmentNotFound(Uuid)', 'fulfillment resource variant'],
-  ['InvalidTransition { from: String, to: String }', 'fulfillment transition variant'],
-  ['Database(#[from] DbErr)', 'fulfillment database variant'],
-]) requireText(fulfillmentErrors, value, label);
-
-for (const [value, label] of [
-  ['CommerceError::Validation(error.to_string())', 'shipping service validation construction'],
   [
-    'CommerceError::ShippingProfileNotFound(shipping_profile_id)',
-    'shipping service not-found construction',
+    showRoute,
+    '.shipping_option_read_port()',
+    '.read_shipping_option_projection(',
+    'ReadShippingOptionProjectionRequest {',
+    'show route',
   ],
-  ['CommerceError::DuplicateShippingProfileSlug(', 'shipping service conflict construction'],
-  ['active_profile.insert(&self.db).await?;', 'shipping service database propagation'],
-]) requireText(shippingService, value, label);
+]) {
+  requireText(block, getter, `${label} host runtime getter`);
+  requireText(block, operation, `${label} owner operation`);
+  requireText(block, request, `${label} typed request`);
+  requireText(block, 'map_admin_shipping_option_port_error(', `${label} port mapper`);
+  requireText(block, 'requested_locale: Some(request_context.locale.clone())', `${label} locale forwarding`);
+  requireText(block, 'tenant_default_locale: Some(tenant.default_locale.clone())', `${label} fallback forwarding`);
+  forbidText(block, 'FulfillmentService::new(', `${label} concrete read service`);
+}
+
+for (const [block, operation, label] of [
+  [createRoute, '.create_shipping_option(tenant.id, input)', 'create route'],
+  [updateRoute, '.update_shipping_option(tenant.id, id, input)', 'update route'],
+  [deactivateRoute, '.deactivate_shipping_option(tenant.id, id)', 'deactivate route'],
+  [reactivateRoute, '.reactivate_shipping_option(tenant.id, id)', 'reactivate route'],
+]) {
+  requireText(block, 'FulfillmentService::new(runtime.db_clone())', `${label} concrete mutation service`);
+  requireText(block, operation, `${label} mutation operation`);
+  requireText(block, 'map_admin_shipping_option_error(', `${label} mutation mapper`);
+}
 
 for (const [value, label] of [
-  ['pub async fn list_shipping_profiles(', 'profile list handler'],
-  ['pub async fn create_shipping_profile(', 'profile create handler'],
-  ['pub async fn show_shipping_profile(', 'profile detail handler'],
-  ['pub async fn update_shipping_profile(', 'profile update handler'],
-  ['pub async fn deactivate_shipping_profile(', 'profile deactivate handler'],
-  ['pub async fn reactivate_shipping_profile(', 'profile reactivate handler'],
-  ['pub async fn list_shipping_options(', 'option list handler'],
-  ['pub async fn create_shipping_option(', 'option create handler'],
-  ['pub async fn show_shipping_option(', 'option detail handler'],
-  ['pub async fn update_shipping_option(', 'option update handler'],
-  ['pub async fn deactivate_shipping_option(', 'option deactivate handler'],
-  ['pub async fn reactivate_shipping_option(', 'option reactivate handler'],
-  ['list_shipping_profiles(', 'profile list service call'],
-  ['create_shipping_profile(tenant.id, input)', 'profile create service call'],
-  ['get_shipping_profile(', 'profile detail service call'],
-  ['update_shipping_profile(tenant.id, id, input)', 'profile update service call'],
-  ['deactivate_shipping_profile(tenant.id, id)', 'profile deactivate service call'],
-  ['reactivate_shipping_profile(tenant.id, id)', 'profile reactivate service call'],
-  ['list_all_shipping_options(', 'option list service call'],
-  ['create_shipping_option(tenant.id, input)', 'option create service call'],
-  ['get_shipping_option(', 'option detail service call'],
-  ['update_shipping_option(tenant.id, id, input)', 'option update service call'],
-  ['deactivate_shipping_option(tenant.id, id)', 'option deactivate service call'],
-  ['reactivate_shipping_option(tenant.id, id)', 'option reactivate service call'],
-  ['page: pagination.page', 'pagination page forwarding'],
-  ['per_page: pagination.limit()', 'pagination size forwarding'],
   ['items.retain(|option| option.active == active)', 'active filter'],
   ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
   ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
   ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
+  ['skip(pagination.offset() as usize)', 'pagination offset'],
+  ['take(pagination.limit() as usize)', 'pagination limit'],
+  ['validate_shipping_option_profile_inputs(', 'profile validation helper'],
 ]) requireText(shipping, value, label);
+
+for (const [content, value, label] of [
+  [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'commerce database variant'],
+  [commerceErrors, 'Validation(String)', 'commerce validation variant'],
+  [fulfillmentErrors, 'Validation(String)', 'fulfillment validation variant'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'fulfillment shipping-option variant'],
+  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'fulfillment resource variant'],
+  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'fulfillment transition variant'],
+  [fulfillmentErrors, 'Database(#[from] DbErr)', 'fulfillment database variant'],
+  [apiPorts, 'pub enum PortErrorKind {', 'port kind enum'],
+  [apiPorts, 'InvariantViolation,', 'invariant port kind'],
+  [shippingService, 'CommerceError::Validation(error.to_string())', 'profile validation construction'],
+]) requireText(content, value, label);
 
 for (const value of [
   'err.to_string()',
   'other.to_string()',
+  'error.message',
+  'format!("{}: {}", error.code, error.message)',
   'HttpError::bad_request("commerce_operation_failed"',
-  'super::map_shipping_profile_error',
-  'super::validate_shipping_option_profile_inputs',
   '.map_err(super::map_fulfillment_error)?;',
-  'format!("Fulfillment request is invalid:',
 ]) forbidText(shipping, value, 'unsafe admin shipping public conversion');
 
-const profileMapperUses = shipping.match(/map_shipping_profile_error\(/g) ?? [];
-if (profileMapperUses.length !== 8) {
-  failures.push(`expected profile mapper definition plus seven uses, found ${profileMapperUses.length}`);
+const mutationMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
+if (mutationMapperUses.length !== 5) {
+  failures.push(`expected mutation mapper definition plus four uses, found ${mutationMapperUses.length}`);
 }
-
-const optionMapperUses =
-  shipping.match(
-    /map_admin_shipping_option_error\(\s+AdminShippingOptionErrorContext::new\(/g,
-  ) ?? [];
-if (optionMapperUses.length !== 6) {
-  failures.push(`expected six context-aware shipping-option mapper callsites, found ${optionMapperUses.length}`);
+const readMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
+if (readMapperUses.length !== 3) {
+  failures.push(`expected read mapper definition plus two uses, found ${readMapperUses.length}`);
 }
-
 const localValidationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
 if (localValidationUses.length !== 3) {
-  failures.push(`expected local validation helper definition plus two uses, found ${localValidationUses.length}`);
+  failures.push(`expected validation helper definition plus two uses, found ${localValidationUses.length}`);
 }
 
 if (failures.length > 0) {
@@ -239,5 +257,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping profile and option errors use stable context-aware public envelopes',
+  '✔ Commerce admin shipping reads use host-composed owner ports and stable HTTP envelopes while mutations retain lifecycle services',
 );

--- a/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
@@ -11,6 +11,7 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const apiPorts = read('crates/rustok-api/src/ports.rs');
 const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
 const failures = [];
 
@@ -30,11 +31,23 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const mapper = between(
+const legacyMapper = between(
   shipping,
   'fn map_admin_shipping_option_error(',
+  'fn admin_shipping_option_read_port_context(',
+  'admin shipping-option mutation mapper',
+);
+const readContextBuilder = between(
+  shipping,
+  'fn admin_shipping_option_read_port_context(',
+  'fn map_admin_shipping_option_port_error(',
+  'admin shipping-option read context builder',
+);
+const portMapper = between(
+  shipping,
+  'fn map_admin_shipping_option_port_error(',
   'async fn validate_shipping_option_profile_inputs(',
-  'admin shipping-option mapper',
+  'admin shipping-option port mapper',
 );
 const listRoute = between(
   shipping,
@@ -71,7 +84,10 @@ const reactivateRoute = reactivateStart < 0 ? '' : shipping.slice(reactivateStar
 if (reactivateStart < 0) failures.push('reactivate shipping option route: unable to isolate source block');
 
 for (const [value, label] of [
-  ['use rustok_fulfillment::error::FulfillmentError;', 'typed fulfillment error import'],
+  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed port imports'],
+  ['use rustok_fulfillment::error::FulfillmentError;', 'typed mutation error import'],
+  ['ListAllShippingOptionProjectionsRequest', 'admin list request'],
+  ['ReadShippingOptionProjectionRequest', 'admin lookup request'],
   [
     'const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";',
     'owner constant',
@@ -87,128 +103,110 @@ for (const [value, label] of [
 ]) requireText(shipping, value, label);
 
 for (const [value, label] of [
-  ['error: FulfillmentError,', 'owned typed cause'],
-  ['FulfillmentError::Validation(_)', 'validation variant'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option not-found variant'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
-  ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
-  ['FulfillmentError::Database(_)', 'database variant'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
+  ['request_context.locale.as_str()', 'request locale'],
+  ['format!("commerce-admin-shipping-option:{operation}:{resource_id}")', 'resource correlation id'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
+  ['request_context.channel_slug.as_deref()', 'channel propagation'],
+]) requireText(readContextBuilder, value, label);
+
+for (const [value, label] of [
+  ['error: PortError,', 'owned typed port cause'],
+  ['PortErrorKind::Validation', 'validation kind'],
+  ['PortErrorKind::NotFound', 'not-found kind'],
+  ['PortErrorKind::Conflict', 'conflict kind'],
+  ['PortErrorKind::Forbidden', 'forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable kinds'],
+  ['PortErrorKind::InvariantViolation', 'invariant kind'],
   ['StatusCode::BAD_REQUEST', 'bad-request status'],
   ['StatusCode::NOT_FOUND', 'not-found status'],
   ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::UNAUTHORIZED', 'forbidden status'],
   ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'invariant status'],
   ['"commerce_admin_fulfillment_invalid"', 'validation code'],
   ['"commerce_admin_not_found"', 'not-found code'],
   ['"commerce_admin_fulfillment_state_conflict"', 'conflict code'],
+  ['"commerce_permission_denied"', 'forbidden code'],
   ['"commerce_admin_fulfillment_storage_unavailable"', 'storage code'],
-  ['"Fulfillment request is invalid"', 'static validation message'],
-  ['"Commerce resource not found"', 'static not-found message'],
-  [
-    '"Fulfillment operation conflicts with the current state"',
-    'static conflict message',
-  ],
-  ['"Fulfillment storage is temporarily unavailable"', 'static storage message'],
+  ['"commerce_admin_fulfillment_failed"', 'fail-closed code'],
   ['error = ?error', 'typed internal cause'],
-  ['owner = ADMIN_SHIPPING_OPTION_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['shipping_option_id = ?context.shipping_option_id', 'option identity log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public-code log'],
-  ['status = %status', 'status log'],
-  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'single static envelope constructor'],
-]) requireText(mapper, value, label);
+  ['owner_operation,', 'owner operation log'],
+  ['correlation_id = %port_context.correlation_id', 'correlation log'],
+  ['actor = ?port_context.actor', 'actor log'],
+  ['channel = ?port_context.channel', 'channel log'],
+  ['locale = %port_context.locale', 'locale log'],
+  ['deadline_ms = ?port_context.deadline_ms', 'deadline log'],
+  ['internal_code = %error.code', 'owner code log'],
+  ['retryable = error.retryable', 'retryability log'],
+  ['HttpError::new(status, code, message)', 'static public envelope'],
+]) requireText(portMapper, value, label);
 
-for (const [block, operation, identity, serviceCall, label] of [
+for (const [block, operation, request, label] of [
   [
     listRoute,
-    '"list_shipping_options"',
-    'tenant.id, None,',
-    '.list_all_shipping_options(',
+    '.list_all_shipping_option_projections(',
+    'ListAllShippingOptionProjectionsRequest {',
     'list route',
   ],
   [
-    createRoute,
-    '"create_shipping_option"',
-    'tenant.id, None,',
-    '.create_shipping_option(tenant.id, input)',
-    'create route',
-  ],
-  [
     showRoute,
-    '"get_shipping_option"',
-    'tenant.id,\n                    Some(id),',
-    '.get_shipping_option(',
+    '.read_shipping_option_projection(',
+    'ReadShippingOptionProjectionRequest {',
     'show route',
   ],
-  [
-    updateRoute,
-    '"update_shipping_option"',
-    'tenant.id,\n                    Some(id),',
-    '.update_shipping_option(tenant.id, id, input)',
-    'update route',
-  ],
-  [
-    deactivateRoute,
-    '"deactivate_shipping_option"',
-    'tenant.id,\n                    Some(id),',
-    '.deactivate_shipping_option(tenant.id, id)',
-    'deactivate route',
-  ],
-  [
-    reactivateRoute,
-    '"reactivate_shipping_option"',
-    'tenant.id,\n                    Some(id),',
-    '.reactivate_shipping_option(tenant.id, id)',
-    'reactivate route',
-  ],
 ]) {
-  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
-  requireText(block, 'map_admin_shipping_option_error(', `${label} mapper handoff`);
-  requireText(block, 'AdminShippingOptionErrorContext::new(', `${label} context construction`);
-  requireText(block, operation, `${label} operation`);
-  requireText(block, identity, `${label} truthful identity`);
-  requireText(block, serviceCall, `${label} service contract`);
+  requireText(block, 'admin_shipping_option_read_port_context(', `${label} context construction`);
+  requireText(block, operation, `${label} owner operation`);
+  requireText(block, request, `${label} typed request`);
+  requireText(block, 'map_admin_shipping_option_port_error(', `${label} typed mapper`);
+  requireText(block, 'requested_locale: Some(request_context.locale.clone())', `${label} locale`);
+  requireText(block, 'tenant_default_locale: Some(tenant.default_locale.clone())', `${label} fallback locale`);
+  forbidText(block, 'FulfillmentService::new(', `${label} concrete service`);
+}
+
+for (const [block, operation, label] of [
+  [createRoute, '.create_shipping_option(tenant.id, input)', 'create route'],
+  [updateRoute, '.update_shipping_option(tenant.id, id, input)', 'update route'],
+  [deactivateRoute, '.deactivate_shipping_option(tenant.id, id)', 'deactivate route'],
+  [reactivateRoute, '.reactivate_shipping_option(tenant.id, id)', 'reactivate route'],
+]) {
+  requireText(block, 'FulfillmentService::new(runtime.db_clone())', `${label} lifecycle service`);
+  requireText(block, operation, `${label} service operation`);
+  requireText(block, 'map_admin_shipping_option_error(', `${label} legacy typed mapper`);
 }
 
 for (const [value, label] of [
-  ['[Permission::FULFILLMENTS_READ]', 'read permission'],
-  ['[Permission::FULFILLMENTS_CREATE]', 'create permission'],
-  ['[Permission::FULFILLMENTS_UPDATE]', 'update permission'],
-  ['page: pagination.page', 'pagination page forwarding'],
-  ['per_page: pagination.limit()', 'pagination size forwarding'],
-  ['items.retain(|option| option.active == active)', 'active filter'],
-  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
-  ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
-  ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
-  ['validate_shipping_option_profile_inputs(', 'profile validation helper'],
-]) requireText(shipping, value, label);
+  ['FulfillmentError::Validation(_)', 'mutation validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict variant'],
+  ['FulfillmentError::Database(_)', 'mutation database variant'],
+]) requireText(legacyMapper, value, label);
 
-const mapperUses =
-  shipping.match(
-    /map_admin_shipping_option_error\(\s+AdminShippingOptionErrorContext::new\(/g,
-  ) ?? [];
-if (mapperUses.length !== 6) {
-  failures.push(`expected six context-aware shipping-option mapper callsites, found ${mapperUses.length}`);
-}
-
-for (const [value, label] of [
-  ['Validation(String)', 'owner validation variant'],
-  ['ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
-  ['FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
-  ['InvalidTransition { from: String, to: String }', 'owner transition variant'],
-  ['Database(#[from] DbErr)', 'owner database variant'],
-]) requireText(fulfillmentErrors, value, label);
+for (const [content, value, label] of [
+  [apiPorts, 'pub enum PortErrorKind {', 'owner port error kinds'],
+  [apiPorts, 'InvariantViolation,', 'owner invariant kind'],
+  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
+]) requireText(content, value, label);
 
 for (const value of [
-  '.map_err(super::map_fulfillment_error)?;',
-  'format!("Fulfillment request is invalid:',
   'error.to_string()',
   'err.to_string()',
   'other.to_string()',
-  'HttpError::bad_request("commerce_operation_failed"',
+  'error.message',
+  'format!("{}: {}", error.code, error.message)',
+  '.map_err(super::map_fulfillment_error)?;',
 ]) forbidText(shipping, value, 'unsafe admin shipping-option public conversion');
+
+const legacyMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
+if (legacyMapperUses.length !== 5) {
+  failures.push(`expected mutation mapper definition plus four uses, found ${legacyMapperUses.length}`);
+}
+const portMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
+if (portMapperUses.length !== 3) {
+  failures.push(`expected port mapper definition plus two read uses, found ${portMapperUses.length}`);
+}
 
 if (failures.length > 0) {
   console.error('Commerce admin shipping-option error-context verification failed:');
@@ -217,5 +215,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping-option errors retain route context and static public envelopes',
+  '✔ Commerce admin shipping-option reads use typed owner-port context while mutations retain typed lifecycle envelopes',
 );

--- a/scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
+++ b/scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
@@ -34,52 +34,112 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const adminList = between(
+  adminRest,
+  'pub async fn list_shipping_options(',
+  '/// Create admin shipping option',
+  'admin shipping-option list',
+);
+const adminLookup = between(
+  adminRest,
+  'pub async fn show_shipping_option(',
+  '/// Update admin shipping option',
+  'admin shipping-option lookup',
+);
+const storefrontList = storefrontRest.slice(
+  storefrontRest.indexOf('pub async fn list_shipping_options('),
+);
+if (!storefrontList) failures.push('storefront shipping-option list: unable to isolate source block');
 
 for (const [source, value, label] of [
   [serverRuntime, 'CommerceShippingOptionReadRuntime::in_process(', 'host read runtime factory'],
   [serverRuntime, 'host.with_shared_value(runtime)', 'host read runtime attachment'],
-  [graphqlRuntime, 'pub struct CommerceShippingOptionReadRuntime', 'typed read runtime'],
-  [graphqlRuntime, 'CommerceShippingOptionReadScope', 'resolver-scoped runtime bridge'],
+  [graphqlRuntime, 'pub struct CommerceShippingOptionReadRuntime', 'typed shared read runtime'],
   [safeQuery, 'shipping_option_runtime.shipping_option_read_port()', 'GraphQL storefront port'],
   [
     safeQuery,
     'shipping_option_runtime\n                        .shipping_option_admin_read_port()',
     'GraphQL admin port',
   ],
+  [httpRuntime, 'shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime', 'HTTP runtime field'],
+  [httpRuntime, 'shipping_option_read_port(', 'HTTP storefront getter'],
+  [httpRuntime, 'shipping_option_admin_read_port(', 'HTTP admin getter'],
+  [
+    httpRuntime,
+    'Commerce HTTP routes require CommerceShippingOptionReadRuntime in HostRuntimeContext',
+    'HTTP fail-closed host requirement',
+  ],
 ]) {
   requireText(source, value, label);
-}
-
-for (const value of [
-  'in_process_shipping_option_read_port(db.clone())',
-  'in_process_shipping_option_admin_read_port(db)',
-]) {
-  forbidText(safeQuery, value, 'private GraphQL facade must not construct read providers');
 }
 
 for (const [source, value, label] of [
-  [httpRuntime, 'pub struct CommerceHttpRuntime', 'Commerce HTTP runtime'],
-  [adminRest, 'FulfillmentService::new(runtime.db_clone())', 'admin REST concrete service'],
-  [adminRest, '.list_all_shipping_options(', 'admin REST list-all operation'],
-  [adminRest, '.get_shipping_option(', 'admin REST lookup operation'],
-  [adminRest, 'items.retain(|option| option.active == active);', 'admin active filter'],
-  [adminRest, 'items.retain(|option| option.currency_code.eq_ignore_ascii_case(currency_code));', 'admin currency filter'],
-  [adminRest, 'items.retain(|option| option.provider_id.eq_ignore_ascii_case(provider_id));', 'admin provider filter'],
-  [adminRest, 'option.name.to_ascii_lowercase().contains(&search)', 'admin search filter'],
-  [storefrontRest, 'FulfillmentService::new(runtime.db_clone())', 'storefront REST concrete service'],
-  [storefrontRest, '.list_shipping_options(', 'storefront REST active list'],
-  [storefrontRest, 'option.currency_code.eq_ignore_ascii_case(currency_code)', 'storefront currency filter'],
-  [storefrontRest, 'is_metadata_visible_for_public_channel', 'storefront channel filter'],
-  [storefrontRest, 'is_shipping_option_compatible_with_profiles', 'storefront profile filter'],
+  [adminRest, 'fn admin_shipping_option_read_port_context(', 'admin read context builder'],
+  [adminRest, 'PortActor::user(auth.user_id.to_string())', 'admin user actor'],
+  [adminRest, 'request_context.locale.as_str()', 'admin locale context'],
+  [adminRest, 'request_context.channel_slug.as_deref()', 'admin channel propagation'],
+  [adminRest, 'with_deadline(std::time::Duration::from_secs(2))', 'admin read deadline'],
+  [adminRest, 'fn map_admin_shipping_option_port_error(', 'admin typed port mapper'],
+  [adminRest, 'PortErrorKind::Validation', 'admin validation mapping'],
+  [adminRest, 'PortErrorKind::NotFound', 'admin not-found mapping'],
+  [adminRest, 'PortErrorKind::Conflict', 'admin conflict mapping'],
+  [adminRest, 'PortErrorKind::Forbidden', 'admin forbidden mapping'],
+  [adminRest, 'PortErrorKind::Unavailable | PortErrorKind::Timeout', 'admin unavailable mapping'],
+  [adminRest, 'PortErrorKind::InvariantViolation', 'admin invariant mapping'],
+  [adminList, '.shipping_option_admin_read_port()', 'admin host-composed port'],
+  [adminList, '.list_all_shipping_option_projections(', 'admin owner operation'],
+  [adminLookup, '.shipping_option_read_port()', 'admin lookup host-composed port'],
+  [adminLookup, '.read_shipping_option_projection(', 'admin lookup owner operation'],
 ]) {
   requireText(source, value, label);
 }
 
-forbidText(
-  httpRuntime,
-  'CommerceShippingOptionReadRuntime',
-  'REST cutover must remain explicitly open until the next source slice',
-);
+for (const value of ['FulfillmentService::new(', '.list_all_shipping_options(', '.get_shipping_option(']) {
+  forbidText(adminList + adminLookup, value, 'admin read handlers must not construct concrete fulfillment reads');
+}
+
+for (const [value, label] of [
+  ['items.retain(|option| option.active == active);', 'admin active filter'],
+  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'admin currency filter'],
+  ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'admin provider filter'],
+  ['option.name.to_ascii_lowercase().contains(&search)', 'admin search filter'],
+  ['skip(pagination.offset() as usize)', 'admin pagination offset'],
+  ['take(pagination.limit() as usize)', 'admin pagination limit'],
+]) {
+  requireText(adminList, value, label);
+}
+
+for (const [source, value, label] of [
+  [storefrontRest, 'fn storefront_shipping_option_port_context(', 'storefront read context builder'],
+  [storefrontRest, 'PortActor::service("rustok-commerce.storefront-shipping-options")', 'storefront anonymous actor'],
+  [storefrontRest, 'PortActor::user(value.user_id.to_string())', 'storefront user actor'],
+  [storefrontRest, 'public_channel_slug: Option<&str>', 'storefront effective channel input'],
+  [storefrontRest, 'with_deadline(std::time::Duration::from_secs(2))', 'storefront read deadline'],
+  [storefrontRest, 'fn map_storefront_shipping_port_error(', 'storefront typed port mapper'],
+  [storefrontList, '.shipping_option_read_port()', 'storefront host-composed port'],
+  [storefrontList, '.list_shipping_option_projections(', 'storefront owner operation'],
+  [storefrontList, 'requested_locale: Some(request_context.locale.clone())', 'storefront requested locale'],
+  [storefrontList, 'tenant_default_locale: Some(tenant.default_locale.clone())', 'storefront fallback locale'],
+  [storefrontList, 'public_channel_slug.as_deref()', 'storefront effective channel propagation'],
+  [storefrontList, 'option.currency_code.eq_ignore_ascii_case(currency_code)', 'storefront currency filter'],
+  [storefrontList, 'is_metadata_visible_for_public_channel(', 'storefront channel filter'],
+  [storefrontList, 'is_shipping_option_compatible_with_profiles(', 'storefront profile filter'],
+]) {
+  requireText(source, value, label);
+}
+for (const value of ['FulfillmentService::new(', '.list_shipping_options(']) {
+  forbidText(storefrontList, value, 'storefront read handler must not construct concrete fulfillment reads');
+}
 
 for (const [source, value, label] of [
   [commerceStorefrontTransport, 'select_storefront_shipping_option(', 'Commerce selection handoff'],
@@ -95,7 +155,6 @@ for (const [source, value, label] of [
 ]) {
   requireText(source, value, label);
 }
-
 for (const value of [
   'list_shipping_option_projections',
   'list_all_shipping_option_projections',
@@ -109,20 +168,24 @@ for (const value of [
 }
 
 const expectedEvidence = {
-  status: 'source_audit_only_unvalidated',
-  graphqlComposition: 'application_host',
-  restComposition: 'direct_concrete_service',
-  restCutoverRequired: true,
+  status: 'source_cutover_ready_unvalidated',
+  sharedComposition: 'application_host',
+  restComposition: 'application_host',
+  concreteReadConstruction: false,
+  restCutoverRequired: false,
   nativeProjectionSurface: 'absent_by_design',
-  nextSlice: 'migrate_rest_projection_reads_to_host_composed_owner_ports',
+  nextSlice: 'execute_mounted_graphql_rest_projection_parity',
+  runtimeParityProven: false,
 };
 const actualEvidence = {
   status: evidence.status,
-  graphqlComposition: evidence.graphql?.composition,
+  sharedComposition: evidence.shared_runtime?.composition,
   restComposition: evidence.rest?.composition,
+  concreteReadConstruction: evidence.rest?.concrete_service_read_construction,
   restCutoverRequired: evidence.rest?.cutover_required,
   nativeProjectionSurface: evidence.native_ffa?.projection_read_surface,
   nextSlice: evidence.decision?.next_slice,
+  runtimeParityProven: evidence.runtime_parity_proven,
 };
 if (JSON.stringify(actualEvidence) !== JSON.stringify(expectedEvidence)) {
   failures.push(
@@ -141,7 +204,7 @@ for (const field of [
   'ci_run',
 ]) {
   if (evidence.validation?.[field] !== false) {
-    failures.push(`source evidence validation.${field} must remain false for this unvalidated audit`);
+    failures.push(`source evidence validation.${field} must remain false for this unvalidated cutover`);
   }
 }
 
@@ -152,5 +215,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Shipping-option source inventory records host-composed GraphQL reads, the explicit REST cutover gap, and the intentionally separate native selection surface',
+  '✔ Shipping-option GraphQL and REST projection reads share the host-composed owner runtime while native seller/cart selection remains separate',
 );

--- a/scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs
@@ -11,10 +11,11 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const controller = read('crates/rustok-commerce/src/controllers/store/products.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
 const apiPorts = read('crates/rustok-api/src/ports.rs');
 const webErrors = read('crates/rustok-web/src/lib.rs');
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
-const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
+const shippingOwnerPort = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
 const fulfillmentService = read('crates/rustok-fulfillment/src/services/fulfillment.rs');
 const storefrontShipping = read('crates/rustok-commerce/src/storefront_shipping.rs');
 const failures = [];
@@ -35,7 +36,7 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const portMapper = between(
+const auxiliaryPortMapper = between(
   controller,
   'fn map_storefront_auxiliary_port_error(',
   'fn storefront_auxiliary_public_error<E>(',
@@ -44,14 +45,20 @@ const portMapper = between(
 const shippingContextMapper = between(
   controller,
   'fn map_storefront_shipping_context_error(',
-  'fn map_storefront_fulfillment_error(',
+  'fn storefront_shipping_option_port_context(',
   'storefront shipping context mapper',
 );
-const fulfillmentMapper = between(
+const shippingReadContext = between(
   controller,
-  'fn map_storefront_fulfillment_error(',
+  'fn storefront_shipping_option_port_context(',
+  'fn map_storefront_shipping_port_error(',
+  'storefront shipping read context',
+);
+const shippingPortMapper = between(
+  controller,
+  'fn map_storefront_shipping_port_error(',
   '/// List published storefront products',
-  'storefront fulfillment mapper',
+  'storefront shipping port mapper',
 );
 const regionHandler = between(
   controller,
@@ -59,82 +66,126 @@ const regionHandler = between(
   '/// List active storefront shipping options',
   'storefront region handler',
 );
-const shippingHandler = controller.slice(controller.indexOf('pub async fn list_shipping_options('));
+const shippingStart = controller.indexOf('pub async fn list_shipping_options(');
+const shippingHandler = shippingStart < 0 ? '' : controller.slice(shippingStart);
+if (shippingStart < 0) failures.push('storefront shipping handler: unable to isolate source block');
 const auxiliaryBoundary = controller.slice(controller.indexOf('/// List available storefront regions'));
 
 for (const [value, label] of [
-  ['PortError, RequestContext', 'typed port error import'],
-  ['FulfillmentService, error::FulfillmentError', 'typed fulfillment error import'],
-  ['port_error_to_http_error', 'shared port HTTP mapper import'],
+  ['OptionalAuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed port imports'],
+  ['use rustok_fulfillment::ListShippingOptionProjectionsRequest;', 'typed shipping request'],
   ['fn map_storefront_auxiliary_port_error(', 'auxiliary port mapper'],
-  ['fn storefront_auxiliary_public_error<E>(', 'static auxiliary envelope helper'],
   ['fn map_storefront_shipping_context_error(', 'shipping context mapper'],
-  ['fn map_storefront_fulfillment_error(', 'fulfillment mapper'],
-  ['boundary = "commerce_storefront_auxiliary_http"', 'auxiliary boundary log'],
-  ['error = ?error', 'raw owner error log'],
-  ['owner,', 'owner log field'],
-  ['operation,', 'operation log field'],
-  ['tenant_id = %tenant_id', 'tenant log field'],
-  ['cart_id = ?cart_id', 'cart log field'],
-  ['public_code = code', 'public code log field'],
-  ['status = %status', 'status log field'],
-  ['HttpError::new(status, code, message)', 'static envelope construction'],
-]) {
-  requireText(controller, value, label);
-}
+  ['fn storefront_shipping_option_port_context(', 'shipping read context'],
+  ['fn map_storefront_shipping_port_error(', 'shipping port mapper'],
+  ['boundary = "commerce_storefront_auxiliary_http"', 'HTTP boundary'],
+]) requireText(controller, value, label);
 
 for (const [value, label] of [
-  ['port_error_to_http_error(error.clone())', 'shared port mapping'],
-  ['error_kind = ?error.kind', 'typed port kind log'],
-  ['retryable = error.retryable', 'port retryability log'],
-  ['public_code = %public.code', 'mapped port code log'],
-  ['status = %public.status', 'mapped port status log'],
-]) {
-  requireText(portMapper, value, label);
-}
+  ['port_error_to_http_error(error.clone())', 'shared auxiliary mapping'],
+  ['error_kind = ?error.kind', 'auxiliary error kind'],
+  ['retryable = error.retryable', 'auxiliary retryability'],
+  ['public_code = %public.code', 'auxiliary public code'],
+  ['status = %public.status', 'auxiliary public status'],
+]) requireText(auxiliaryPortMapper, value, label);
 
 for (const [value, label] of [
-  ['CommerceError::Database(_)', 'commerce database variant'],
-  ['CommerceError::ProductNotFound(_)', 'commerce product not-found variant'],
-  ['CommerceError::VariantNotFound(_)', 'commerce variant not-found variant'],
-  ['CommerceError::ShippingProfileNotFound(_)', 'commerce profile not-found variant'],
-  ['CommerceError::Validation(_)', 'commerce validation variant'],
-  ['CommerceError::DuplicateHandle { .. }', 'commerce duplicate handle variant'],
-  ['CommerceError::DuplicateSku(_)', 'commerce duplicate SKU variant'],
-  ['CommerceError::InvalidPrice(_)', 'commerce invalid price variant'],
-  ['CommerceError::InsufficientInventory { .. }', 'commerce inventory variant'],
-  ['CommerceError::InvalidOptionCombination', 'commerce option variant'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'commerce profile conflict variant'],
-  ['CommerceError::NoVariants', 'commerce no-variants variant'],
-  ['CommerceError::CannotDeletePublished', 'commerce state variant'],
-  ['CommerceError::Rich(_)', 'commerce rich variant'],
-  ['CommerceError::Core(_)', 'commerce core variant'],
-  ['"commerce_store_shipping_invalid"', 'shipping invalid code'],
-  ['"commerce_store_not_found"', 'storefront not-found code'],
-  ['"commerce_store_shipping_unavailable"', 'shipping unavailable code'],
-  ['"commerce_store_shipping_failed"', 'shipping fail-closed code'],
-  ['StatusCode::BAD_REQUEST', 'shipping validation status'],
-  ['StatusCode::NOT_FOUND', 'shipping not-found status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'shipping unavailable status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'shipping fail-closed status'],
-]) {
-  requireText(shippingContextMapper, value, label);
-}
+  ['CommerceError::Database(_)', 'context database variant'],
+  ['CommerceError::ShippingProfileNotFound(_)', 'context profile variant'],
+  ['CommerceError::Validation(_)', 'context validation variant'],
+  ['"commerce_store_shipping_invalid"', 'context invalid code'],
+  ['"commerce_store_not_found"', 'context not-found code'],
+  ['"commerce_store_shipping_unavailable"', 'context unavailable code'],
+  ['"commerce_store_shipping_failed"', 'context fail-closed code'],
+  ['HttpError::new(status, code, message)', 'context static envelope'],
+]) requireText(shippingContextMapper, value, label);
 
 for (const [value, label] of [
-  ['FulfillmentError::Validation(_)', 'fulfillment validation variant'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found variant'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
-  ['FulfillmentError::InvalidTransition { .. }', 'fulfillment transition variant'],
-  ['FulfillmentError::Database(_)', 'fulfillment database variant'],
-  ['"commerce_store_shipping_invalid"', 'fulfillment invalid code'],
-  ['"commerce_store_not_found"', 'fulfillment not-found code'],
-  ['"commerce_store_shipping_state_conflict"', 'fulfillment state code'],
-  ['"commerce_store_shipping_unavailable"', 'fulfillment unavailable code'],
-  ['StatusCode::CONFLICT', 'fulfillment conflict status'],
-]) {
-  requireText(fulfillmentMapper, value, label);
+  ['PortActor::user(value.user_id.to_string())', 'authenticated actor'],
+  ['PortActor::service("rustok-commerce.storefront-shipping-options")', 'anonymous actor'],
+  ['request_context.locale.as_str()', 'request locale'],
+  ['format!("commerce-store-shipping-options:list:{resource_id}")', 'resource correlation id'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
+  ['public_channel_slug: Option<&str>', 'effective channel input'],
+  ['Some(channel) => context.with_channel(channel)', 'effective channel propagation'],
+]) requireText(shippingReadContext, value, label);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'validation kind'],
+  ['PortErrorKind::NotFound', 'not-found kind'],
+  ['PortErrorKind::Conflict', 'conflict kind'],
+  ['PortErrorKind::Forbidden', 'forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable kinds'],
+  ['PortErrorKind::InvariantViolation', 'invariant kind'],
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['StatusCode::UNAUTHORIZED', 'forbidden status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'invariant status'],
+  ['"commerce_store_shipping_invalid"', 'invalid code'],
+  ['"commerce_store_not_found"', 'not-found code'],
+  ['"commerce_store_shipping_state_conflict"', 'conflict code'],
+  ['"commerce_store_denied"', 'forbidden code'],
+  ['"commerce_store_shipping_unavailable"', 'unavailable code'],
+  ['"commerce_store_shipping_failed"', 'invariant code'],
+  ['owner_operation = "list_shipping_option_projections"', 'owner operation log'],
+  ['correlation_id = %context.correlation_id', 'correlation log'],
+  ['channel = ?context.channel', 'channel log'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline log'],
+  ['internal_code = %error.code', 'owner code log'],
+  ['retryable = error.retryable', 'retryability log'],
+  ['HttpError::new(status, code, message)', 'static HTTP envelope'],
+]) requireText(shippingPortMapper, value, label);
+
+for (const [value, label] of [
+  ['ensure_storefront_channel_enabled_for_db(', 'region channel guard'],
+  ['.list_regions_for_tenant(', 'region port operation'],
+  ['PortActor::service("commerce.store-regions")', 'region actor'],
+  ['with_deadline(std::time::Duration::from_secs(3))', 'region deadline'],
+  ['map_storefront_auxiliary_port_error(', 'region mapper'],
+]) requireText(regionHandler, value, label);
+
+for (const [value, label] of [
+  ['ensure_storefront_channel_enabled_for_db(', 'shipping channel guard'],
+  ['current_customer_id_for_db(', 'customer lookup'],
+  ['let requested_cart_id = query.cart_id;', 'cart identity'],
+  ['in_process_cart_storefront_port(runtime.db_clone())', 'cart port'],
+  ['CartStorefrontReadRequest { cart_id }', 'cart request'],
+  ['ensure_store_cart_access(&cart, customer_id)', 'cart access'],
+  ['load_cart_shipping_profile_slugs(runtime.db(), tenant.id, &cart)', 'profile projection'],
+  ['storefront_public_channel_slug_for_cart(&cart, &request_context)', 'cart effective channel'],
+  ['public_channel_slug_from_request(&request_context)', 'request effective channel'],
+  ['storefront_shipping_option_port_context(', 'owner context'],
+  ['.shipping_option_read_port()', 'host-composed port'],
+  ['.list_shipping_option_projections(', 'owner list operation'],
+  ['ListShippingOptionProjectionsRequest {', 'typed owner request'],
+  ['requested_locale: Some(request_context.locale.clone())', 'requested locale'],
+  ['tenant_default_locale: Some(tenant.default_locale.clone())', 'default locale'],
+  ['map_storefront_shipping_port_error(', 'typed owner mapper'],
+  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
+  ['is_metadata_visible_for_public_channel(', 'channel filter'],
+  ['is_shipping_option_compatible_with_profiles(', 'profile filter'],
+  ['Ok(Json(options))', 'response'],
+]) requireText(shippingHandler, value, label);
+
+for (const value of ['FulfillmentService::new(', '.list_shipping_options(', 'map_storefront_fulfillment_error(']) {
+  forbidText(shippingHandler, value, 'storefront shipping concrete read path');
 }
+
+for (const [content, value, label] of [
+  [httpRuntime, 'shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime', 'HTTP runtime field'],
+  [httpRuntime, 'fn shipping_option_read_port(', 'HTTP runtime getter'],
+  [apiPorts, 'pub struct PortError {', 'port error type'],
+  [apiPorts, 'pub enum PortErrorKind {', 'port error kinds'],
+  [webErrors, 'pub fn port_error_to_http_error(error: PortError)', 'shared port HTTP mapper'],
+  [commerceErrors, 'Validation(String)', 'commerce validation variant'],
+  [shippingOwnerPort, 'pub trait ShippingOptionReadPort: Send + Sync', 'owner read port'],
+  [shippingOwnerPort, 'context.require_policy(PortCallPolicy::read())?', 'owner read policy'],
+  [shippingOwnerPort, '.list_shipping_options(', 'owner adapter active-list delegation'],
+  [fulfillmentService, 'shipping_option::Column::Active.eq(true)', 'owner service active-only filter'],
+  [storefrontShipping, 'pub async fn load_cart_shipping_profile_slugs(', 'profile projection function'],
+]) requireText(content, value, label);
 
 for (const value of [
   'commerce_operation_failed',
@@ -143,97 +194,19 @@ for (const value of [
   'error.message',
   'format!("{}: {}", error.code, error.message)',
   'HttpError::bad_request(',
-]) {
-  forbidText(auxiliaryBoundary, value, 'unsafe storefront auxiliary public conversion');
-}
+]) forbidText(auxiliaryBoundary, value, 'unsafe storefront auxiliary public conversion');
 
-for (const [value, label] of [
-  ['ensure_storefront_channel_enabled_for_db(', 'region channel guard'],
-  ['RegionService::new(runtime.db_clone())', 'region service construction'],
-  ['.list_regions_for_tenant(', 'region port call'],
-  ['PortActor::service("commerce.store-regions")', 'region service actor'],
-  ['format!("store-regions:{}", tenant.id)', 'region correlation identity'],
-  ['with_deadline(std::time::Duration::from_secs(3))', 'region deadline'],
-  ['requested_locale: Some(request_context.locale.clone())', 'region requested locale'],
-  ['tenant_default_locale: Some(tenant.default_locale.clone())', 'region fallback locale'],
-  ['"rustok_region"', 'region owner label'],
-  ['"list_regions"', 'region operation label'],
-  ['map_storefront_auxiliary_port_error(', 'region typed port mapper'],
-  ['map(|projection| projection.region)', 'region projection response'],
-]) {
-  requireText(regionHandler, value, label);
-}
-
-for (const [value, label] of [
-  ['ensure_storefront_channel_enabled_for_db(', 'shipping channel guard'],
-  ['current_customer_id_for_db(', 'customer lookup'],
-  ['let requested_cart_id = query.cart_id;', 'stable requested cart identity'],
-  ['in_process_cart_storefront_port(runtime.db_clone())', 'cart port construction'],
-  ['CartStorefrontReadRequest { cart_id }', 'cart read request'],
-  ['"rustok_cart"', 'cart owner label'],
-  ['"read_shipping_options_cart"', 'cart operation label'],
-  ['ensure_store_cart_access(&cart, customer_id)', 'cart access guard'],
-  ['load_cart_shipping_profile_slugs(runtime.db(), tenant.id, &cart)', 'shipping profile projection'],
-  ['"load_cart_shipping_profiles"', 'profile operation label'],
-  ['map_storefront_shipping_context_error(', 'typed profile mapper'],
-  ['resolve_context_from_cart_for_db(', 'cart context resolution'],
-  ['storefront_public_channel_slug_for_cart(&cart, &request_context)', 'cart channel resolution'],
-  ['resolve_context_for_db(', 'query context resolution'],
-  ['public_channel_slug_from_request(&request_context)', 'request channel resolution'],
-  ['FulfillmentService::new(runtime.db_clone())', 'fulfillment service construction'],
-  ['.list_shipping_options(', 'fulfillment option list'],
-  ['Some(request_context.locale.as_str())', 'shipping requested locale'],
-  ['Some(tenant.default_locale.as_str())', 'shipping fallback locale'],
-  ['"list_shipping_options"', 'fulfillment operation label'],
-  ['map_storefront_fulfillment_error(', 'typed fulfillment mapper'],
-  ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
-  ['is_metadata_visible_for_public_channel(', 'channel visibility filter'],
-  ['is_shipping_option_compatible_with_profiles(', 'profile compatibility filter'],
-  ['Ok(Json(options))', 'shipping response'],
-]) {
-  requireText(shippingHandler, value, label);
-}
-
-for (const [content, value, label] of [
-  [apiPorts, 'pub struct PortError {', 'owner port error type'],
-  [apiPorts, 'pub kind: PortErrorKind', 'owner port kind'],
-  [apiPorts, 'pub code: String', 'owner port code'],
-  [apiPorts, 'pub message: String', 'owner port message'],
-  [apiPorts, 'pub retryable: bool', 'owner port retryability'],
-  [webErrors, 'pub fn port_error_to_http_error(error: PortError)', 'shared port mapper'],
-  [webErrors, 'PortErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE', 'port unavailable status'],
-  [webErrors, 'PortErrorKind::Timeout => StatusCode::GATEWAY_TIMEOUT', 'port timeout status'],
-  [webErrors, 'PortErrorKind::InvariantViolation => StatusCode::INTERNAL_SERVER_ERROR', 'port invariant status'],
-  [webErrors, '"The requested service is temporarily unavailable"', 'safe unavailable message'],
-  [webErrors, '"The requested operation could not be completed"', 'safe invariant message'],
-  [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'owner commerce database variant'],
-  [commerceErrors, 'Validation(String)', 'owner commerce validation variant'],
-  [fulfillmentErrors, 'Validation(String)', 'owner fulfillment validation variant'],
-  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping option variant'],
-  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
-  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'owner transition variant'],
-  [fulfillmentErrors, 'Database(#[from] DbErr)', 'owner fulfillment database variant'],
-  [fulfillmentService, '-> FulfillmentResult<Vec<ShippingOptionResponse>>', 'typed fulfillment list result'],
-  [fulfillmentService, 'shipping_option::Column::TenantId.eq(tenant_id)', 'fulfillment tenant filter'],
-  [fulfillmentService, 'shipping_option::Column::Active.eq(true)', 'active option filter'],
-  [fulfillmentService, 'load_shipping_options_with_translations(', 'translation loading'],
-  [storefrontShipping, 'pub async fn load_cart_shipping_profile_slugs(', 'profile projection function'],
-  [storefrontShipping, '-> CommerceResult<BTreeSet<String>>', 'typed profile projection result'],
-]) {
-  requireText(content, value, label);
-}
-
-const portMapperUses = auxiliaryBoundary.match(/map_storefront_auxiliary_port_error\(/g) ?? [];
-if (portMapperUses.length !== 2) {
-  failures.push(`expected region and cart port mapper uses, found ${portMapperUses.length}`);
+const auxiliaryMapperUses = auxiliaryBoundary.match(/map_storefront_auxiliary_port_error\(/g) ?? [];
+if (auxiliaryMapperUses.length !== 2) {
+  failures.push(`expected region and cart auxiliary mapper uses, found ${auxiliaryMapperUses.length}`);
 }
 const shippingContextUses = auxiliaryBoundary.match(/map_storefront_shipping_context_error\(/g) ?? [];
 if (shippingContextUses.length !== 1) {
   failures.push(`expected one shipping context mapper use, found ${shippingContextUses.length}`);
 }
-const fulfillmentMapperUses = auxiliaryBoundary.match(/map_storefront_fulfillment_error\(/g) ?? [];
-if (fulfillmentMapperUses.length !== 1) {
-  failures.push(`expected one fulfillment mapper use, found ${fulfillmentMapperUses.length}`);
+const shippingPortUses = auxiliaryBoundary.match(/map_storefront_shipping_port_error\(/g) ?? [];
+if (shippingPortUses.length !== 1) {
+  failures.push(`expected one shipping owner-port mapper use, found ${shippingPortUses.length}`);
 }
 
 if (failures.length > 0) {
@@ -242,4 +215,6 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Storefront region and shipping-option reads use typed safe public envelopes');
+console.log(
+  '✔ Storefront region, cart, and shipping-option reads retain typed safe HTTP envelopes with host-composed shipping owner ports',
+);


### PR DESCRIPTION
## Summary

- continue the fulfillment shipping-option read plan after the source transport audit in PR #2345;
- require the host-composed `CommerceShippingOptionReadRuntime` while building `CommerceHttpRuntime`;
- expose the storefront and administrative fulfillment owner read ports from Commerce HTTP state;
- cut storefront `GET /store/shipping-options` over to `ShippingOptionReadPort::list_shipping_option_projections`;
- cut admin `GET /admin/shipping-options` over to `ShippingOptionAdminReadPort::list_all_shipping_option_projections`;
- cut admin `GET /admin/shipping-options/{id}` over to `ShippingOptionReadPort::read_shipping_option_projection`;
- preserve storefront currency, effective public-channel visibility, and shipping-profile compatibility filtering;
- preserve admin inactive-before-filter behavior plus active, currency, provider, search, and pagination filtering;
- preserve static Commerce HTTP status/code/message policy through exhaustive typed `PortErrorKind` mapping without owner-message parsing;
- propagate tenant, actor, locale, effective channel when available, resource-scoped correlation id, and a two-second read deadline;
- leave admin shipping-option create/update/deactivate/reactivate on the concrete fulfillment lifecycle owner;
- leave the native `ShippingSelectionPort` contract unchanged and do not add a complete projection API without a consumer;
- update source evidence, focused guards, and fulfillment/Commerce documentation without claiming runtime parity or FFA/FBA promotion.

## Recheck

- continued from merged PR #2345, squash commit `862291c0f0b8bcf869c444c49c2681c5a36349ca`;
- confirmed the server attaches one `CommerceShippingOptionReadRuntime` to the same `HostRuntimeContext` used by optional Axum module routers;
- confirmed no open PR overlapped the REST shipping-option owner-port scope;
- confirmed unrelated Forum PR #2346 and Index PR #2347 advanced `main` without touching this slice;
- rebuilt the branch as one atomic commit over current `main` commit `847dc2b45468bd1c72e9fc2f8732d6288d66c586`;
- confirmed the branch is one commit ahead, zero behind, and changes exactly eleven intended files.

## Preserved behavior

- storefront owner loading remains active-only;
- cart-derived public channel is forwarded to `PortContext` and remains the local visibility filter input;
- requested and tenant-default locale remain explicit owner request fields;
- admin list-all includes inactive options before local filtering and pagination;
- REST DTOs and successful route shapes are unchanged;
- admin mutation error handling and lifecycle service construction are unchanged;
- GraphQL optional not-found and `FULFILLMENT_*` policies are unchanged.

## Boundary

This PR completes the REST projection-read source cutover. It does not run mounted GraphQL/REST parity fixtures, add a native projection-read surface, publish fulfillment lifecycle query ports, remove the remaining GraphQL lifecycle delegate, alter provider registries, or promote fulfillment/ecommerce FFA or FBA status.

The retained source evidence status is `source_cutover_ready_unvalidated`, with `runtime_parity_proven: false`.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run locally, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
node scripts/verify/verify-commerce-storefront-auxiliary-http-error-safety.mjs
cargo check -p rustok-commerce --lib
cargo check -p rustok-server --features mod-commerce
```

## Next slice

Execute mounted GraphQL/REST active-list, administrative list-all, and lookup parity with locale, effective channel, deadline, optional-not-found, and typed failure evidence. After that, publish owner ports for fulfillment lifecycle query reads and remove the remaining concrete GraphQL compatibility delegate.