### PR TITLE
feat(index): add no-write partition capture plan

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -7,9 +7,26 @@ Status:
 - Real retained PostgreSQL packet execution: `open`.
 - Production partition copy, replay, dual-write, cutover, rollback automation, cleanup, and query-adapter work: `forbidden before one retained admitted packet`.
 
+## No-write preflight plan
+
+Run the same owner command with `--plan` before starting a fresh retained capture:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \
+INDEX_PARTITION_ALLOW_FULL_CAPTURE=1 \
+node scripts/verify/index-storage-tooling.mjs partition-capture --plan \
+  --manifest evidence/index-partition/manifest.json \
+  --query-audit evidence/index-partition/query-audit.json \
+  --root evidence/index-partition/retained-run
+```
+
+The plan requires the same `DATABASE_URL` presence and full-capture opt-in as the real command. It validates that the manifest and query audit are non-empty regular files, resolves every retained output inside the bundle root, rejects partial-output reuse, and prints the exact eight-stage execution contract as JSON.
+
+Plan mode does not open a PostgreSQL connection, does not start Cargo or Node evidence stages, does not create the bundle directory or any output file, and does not print the `DATABASE_URL` value. A successful plan confirms only local environment and filesystem readiness; PostgreSQL 16 identity, JIT state, and measured evidence remain runtime checks.
+
 ## Owner command
 
-Use one fresh immutable manifest and an empty bundle directory. The command refuses partial-output reuse and does not resume a failed attempt.
+Use one fresh immutable manifest and an empty bundle directory. The command refuses partial-output reuse and does not resume a failed attempt. After reviewing the no-write plan, rerun the same command without `--plan`:
 
 ```bash
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustok_index_evidence \

--- a/scripts/verify/index-partition-full-capture-plan.test.mjs
+++ b/scripts/verify/index-partition-full-capture-plan.test.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+
+const script = path.resolve('scripts/verify/run-index-partition-evidence.mjs');
+
+const fixture = () => {
+  const workspace = mkdtempSync(path.join(os.tmpdir(), 'index-partition-capture-plan-'));
+  const manifest = path.join(workspace, 'manifest.json');
+  const queryAudit = path.join(workspace, 'query-audit.json');
+  const root = path.join(workspace, 'bundle');
+  writeFileSync(manifest, '{}\n');
+  writeFileSync(queryAudit, '{}\n');
+  return { workspace, manifest, queryAudit, root };
+};
+
+const runPlan = ({ workspace, manifest, queryAudit, root }) => spawnSync(
+  process.execPath,
+  [
+    script,
+    '--plan',
+    '--manifest', manifest,
+    '--query-audit', queryAudit,
+    '--root', root,
+  ],
+  {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DATABASE_URL: 'postgres://secret-value-must-not-be-printed',
+      INDEX_PARTITION_ALLOW_FULL_CAPTURE: '1',
+      CARGO: path.join(workspace, 'missing-cargo'),
+    },
+  },
+);
+
+test('prints a no-write eight-stage full-capture plan', () => {
+  const context = fixture();
+  try {
+    const result = runPlan(context);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
+    assert.equal(existsSync(context.root), false);
+
+    const plan = JSON.parse(result.stdout);
+    assert.equal(plan.contract, 'index_partition_full_capture_plan_v1');
+    assert.equal(plan.mode, 'plan');
+    assert.equal(plan.preflight_completed, true);
+    assert.equal(plan.database_connection_attempted, false);
+    assert.equal(plan.writes_performed, false);
+    assert.deepEqual(plan.required_environment, [
+      'INDEX_PARTITION_ALLOW_FULL_CAPTURE',
+      'DATABASE_URL',
+    ]);
+    assert.deepEqual(
+      plan.stages.map((stage) => stage.identifier),
+      [
+        'index-partition-snapshot-capture',
+        'index-partition-query-evidence',
+        'index-partition-mutation-evidence',
+        'index-partition-maintenance-evidence',
+        'index-partition-cutover-evidence',
+        'index-partition-capture-finalize',
+        'assemble-index-partition-evidence.mjs',
+        'validate-index-partition-evidence.mjs',
+      ],
+    );
+    assert.equal(Object.keys(plan.outputs.raw).length, 6);
+    assert.doesNotMatch(result.stdout, /secret-value-must-not-be-printed/u);
+  } finally {
+    rmSync(context.workspace, { recursive: true, force: true });
+  }
+});
+
+test('plan refuses partial output reuse without starting Cargo', () => {
+  const context = fixture();
+  try {
+    mkdirSync(context.root);
+    writeFileSync(path.join(context.root, 'query.json'), '{}\n');
+
+    const result = runPlan(context);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /refusing to reuse partial partition evidence output/u);
+    assert.doesNotMatch(result.stderr, /failed to start/u);
+    assert.equal(existsSync(path.join(context.root, 'baseline.json')), false);
+  } finally {
+    rmSync(context.workspace, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify/index-partition-full-capture-plan.test.mjs
+++ b/scripts/verify/index-partition-full-capture-plan.test.mjs
@@ -57,6 +57,17 @@ test('prints a no-write eight-stage full-capture plan', () => {
       'INDEX_PARTITION_ALLOW_FULL_CAPTURE',
       'DATABASE_URL',
     ]);
+    assert.deepEqual(plan.stages[0].environment_overrides, [
+      'INDEX_PARTITION_MANIFEST',
+      'INDEX_PARTITION_EVIDENCE_ROOT',
+      'INDEX_PARTITION_QUERY_OUTPUT',
+      'INDEX_PARTITION_MUTATION_OUTPUT',
+      'INDEX_PARTITION_MAINTENANCE_OUTPUT',
+      'INDEX_PARTITION_CUTOVER_OUTPUT',
+      'INDEX_PARTITION_CAPTURE_OUTPUT',
+      'INDEX_PARTITION_QUERY_AUDIT',
+      'INDEX_PARTITION_ALLOW_SHADOW_COPY',
+    ]);
     assert.deepEqual(
       plan.stages.map((stage) => stage.identifier),
       [

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -19,7 +19,7 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs packet --scale <smoke|100k|1m> [--root <directory>]
   node scripts/verify/index-storage-tooling.mjs compare --input <directory> [--input <directory>] [--output <directory>]
   node scripts/verify/index-storage-tooling.mjs partition-prepare --input <config.json> --manifest <manifest.json> --bootstrap <bootstrap.sql>
-  node scripts/verify/index-storage-tooling.mjs partition-capture --manifest <manifest.json> --query-audit <query-audit.json> --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
+  node scripts/verify/index-storage-tooling.mjs partition-capture [--plan] --manifest <manifest.json> --query-audit <query-audit.json> --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
@@ -33,7 +33,7 @@ Commands:
   packet              Validate one smoke, 100k, or 1m storage evidence packet.
   compare             Generate a cross-scale storage comparison.
   partition-prepare   Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
-  partition-capture   Run every owner-operated raw capture, finalize capture identity, assemble, and validate.
+  partition-capture   Print a no-write preflight plan or run every owner-operated capture, assembly, and validation stage.
   partition-assemble  Build one packet from six retained raw JSON artifacts and exact-byte hashes.
   partition-validate  Validate a measured partition packet and publish calculated admission output.
   hash                Print the SHA-256 digest of the exact comparison.json bytes.
@@ -112,6 +112,7 @@ const runFixtures = (args) => {
     scriptPath('storage-decision-schema-text.test.mjs'),
     scriptPath('index-partition-evidence.test.mjs'),
     scriptPath('index-partition-evidence-assembly.test.mjs'),
+    scriptPath('index-partition-full-capture-plan.test.mjs'),
   ], 'Index storage fixture suites');
 };
 

--- a/scripts/verify/run-index-partition-evidence.mjs
+++ b/scripts/verify/run-index-partition-evidence.mjs
@@ -162,6 +162,16 @@ const runCommand = (command, args, label, environment = process.env) => {
 
 const scriptPath = (filename) => path.join(scriptDirectory, filename);
 
+const baseEnvironmentOverrides = [
+  'INDEX_PARTITION_MANIFEST',
+  'INDEX_PARTITION_EVIDENCE_ROOT',
+  'INDEX_PARTITION_QUERY_OUTPUT',
+  'INDEX_PARTITION_MUTATION_OUTPUT',
+  'INDEX_PARTITION_MAINTENANCE_OUTPUT',
+  'INDEX_PARTITION_CUTOVER_OUTPUT',
+  'INDEX_PARTITION_CAPTURE_OUTPUT',
+];
+
 const buildBaseEnvironment = (options) => ({
   ...process.env,
   INDEX_PARTITION_MANIFEST: options.manifest,
@@ -223,7 +233,7 @@ const buildStages = (options) => {
     command: cargoCommand,
     args: ['run', '-p', 'rustok-benchmarks', '--bin', stage.identifier, '--release'],
     environment: { ...baseEnvironment, ...stage.environment },
-    environmentOverrides: Object.keys(stage.environment),
+    environmentOverrides: [...baseEnvironmentOverrides, ...Object.keys(stage.environment)],
     outputs: stage.outputs.map((filename) => path.join(options.root, filename)),
   }));
 

--- a/scripts/verify/run-index-partition-evidence.mjs
+++ b/scripts/verify/run-index-partition-evidence.mjs
@@ -16,6 +16,13 @@ const rawArtifactNames = [
   'maintenance.json',
   'cutover.json',
 ];
+const pairFlags = new Set([
+  '--manifest',
+  '--query-audit',
+  '--root',
+  '--packet',
+  '--admission',
+]);
 
 const fail = (message) => {
   throw new Error(message);
@@ -24,13 +31,16 @@ const fail = (message) => {
 const usage = () => {
   console.log(`Usage:
   node scripts/verify/run-index-partition-evidence.mjs \\
+    [--plan] \\
     --manifest <manifest.json> \\
     --query-audit <query-audit.json> \\
     --root <bundle-directory> \\
     [--packet <partition-packet.json>] \\
     [--admission <admission.json>]
 
-The command requires DATABASE_URL and ${fullCaptureOptIn}=1.`);
+The command requires DATABASE_URL and ${fullCaptureOptIn}=1.
+--plan performs the same filesystem and environment preflight, prints a
+machine-readable execution plan, and starts no PostgreSQL, Cargo, or Node stage.`);
 };
 
 const ensureInsideRoot = (root, filename, label) => {
@@ -42,22 +52,37 @@ const ensureInsideRoot = (root, filename, label) => {
 
 const parseArgs = (args) => {
   if (args.length === 1 && ['--help', '-h'].includes(args[0])) return null;
+
   const values = new Map();
-  for (let index = 0; index < args.length; index += 2) {
+  let plan = false;
+  for (let index = 0; index < args.length; index += 1) {
     const flag = args[index];
+    if (['--help', '-h'].includes(flag)) {
+      fail('help must be the only argument');
+    }
+    if (flag === '--plan') {
+      if (plan) fail('--plan was provided more than once');
+      plan = true;
+      continue;
+    }
+    if (!pairFlags.has(flag)) {
+      fail(`unknown partition capture argument: ${flag}`);
+    }
     const value = args[index + 1];
-    if (!['--manifest', '--query-audit', '--root', '--packet', '--admission'].includes(flag)
-        || !value || value.startsWith('--')) {
-      fail('expected --manifest, --query-audit, --root, optional --packet, and optional --admission pairs');
+    if (!value || value.startsWith('--')) {
+      fail(`${flag} requires a value`);
     }
     if (values.has(flag)) fail(`${flag} was provided more than once`);
     values.set(flag, value);
+    index += 1;
   }
+
   for (const flag of ['--manifest', '--query-audit', '--root']) {
     if (!values.has(flag)) fail(`${flag} is required`);
   }
   const root = path.resolve(values.get('--root'));
   const options = {
+    plan,
     manifest: path.resolve(values.get('--manifest')),
     queryAudit: path.resolve(values.get('--query-audit')),
     root,
@@ -90,7 +115,17 @@ const ensureRegularFile = (filename, label) => {
   if (stat.isSymbolicLink() || !stat.isFile()) {
     fail(`${label} must be a regular non-symlink file`);
   }
+  if (stat.size === 0) fail(`${label} must not be empty`);
 };
+
+const outputContract = (options) => ({
+  raw: Object.fromEntries(
+    rawArtifactNames.map((filename) => [filename, path.join(options.root, filename)]),
+  ),
+  capture: options.capture,
+  packet: options.packet,
+  admission: options.admission,
+});
 
 const preflight = (options) => {
   ensureRegularFile(options.manifest, 'manifest');
@@ -102,7 +137,7 @@ const preflight = (options) => {
     }
   }
   const outputs = [
-    ...rawArtifactNames.map((filename) => path.join(options.root, filename)),
+    ...Object.values(outputContract(options).raw),
     options.capture,
     options.packet,
     options.admission,
@@ -125,95 +160,164 @@ const runCommand = (command, args, label, environment = process.env) => {
   if (result.status !== 0) fail(`${label} exited with status ${result.status ?? 'unknown'}`);
 };
 
-const cargoRun = (binary, label, environment) => {
-  runCommand(
-    process.env.CARGO ?? 'cargo',
-    ['run', '-p', 'rustok-benchmarks', '--bin', binary, '--release'],
-    label,
-    environment,
-  );
-};
-
 const scriptPath = (filename) => path.join(scriptDirectory, filename);
 
-try {
+const buildBaseEnvironment = (options) => ({
+  ...process.env,
+  INDEX_PARTITION_MANIFEST: options.manifest,
+  INDEX_PARTITION_EVIDENCE_ROOT: options.root,
+  INDEX_PARTITION_QUERY_OUTPUT: path.join(options.root, 'query.json'),
+  INDEX_PARTITION_MUTATION_OUTPUT: path.join(options.root, 'mutation.json'),
+  INDEX_PARTITION_MAINTENANCE_OUTPUT: path.join(options.root, 'maintenance.json'),
+  INDEX_PARTITION_CUTOVER_OUTPUT: path.join(options.root, 'cutover.json'),
+  INDEX_PARTITION_CAPTURE_OUTPUT: options.capture,
+});
+
+const buildStages = (options) => {
+  const baseEnvironment = buildBaseEnvironment(options);
+  const cargoCommand = process.env.CARGO ?? 'cargo';
+  const cargoStages = [
+    {
+      identifier: 'index-partition-snapshot-capture',
+      label: 'capture baseline and retained shadow snapshot',
+      outputs: ['baseline.json', 'shadow.json'],
+      environment: {
+        INDEX_PARTITION_QUERY_AUDIT: options.queryAudit,
+        INDEX_PARTITION_ALLOW_SHADOW_COPY: '1',
+      },
+    },
+    {
+      identifier: 'index-partition-query-evidence',
+      label: 'capture baseline/shadow query evidence',
+      outputs: ['query.json'],
+      environment: { INDEX_PARTITION_ALLOW_QUERY_EVIDENCE: '1' },
+    },
+    {
+      identifier: 'index-partition-mutation-evidence',
+      label: 'capture rollback-only mutation and WAL evidence',
+      outputs: ['mutation.json'],
+      environment: { INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE: '1' },
+    },
+    {
+      identifier: 'index-partition-maintenance-evidence',
+      label: 'capture ordinary-VACUUM maintenance evidence',
+      outputs: ['maintenance.json'],
+      environment: { INDEX_PARTITION_ALLOW_MAINTENANCE_EVIDENCE: '1' },
+    },
+    {
+      identifier: 'index-partition-cutover-evidence',
+      label: 'capture cutover lock and rollback rehearsal evidence',
+      outputs: ['cutover.json'],
+      environment: { INDEX_PARTITION_ALLOW_CUTOVER_EVIDENCE: '1' },
+    },
+    {
+      identifier: 'index-partition-capture-finalize',
+      label: 'bind raw artifacts to runner and PostgreSQL identity',
+      outputs: ['capture.json'],
+      environment: { INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE: '1' },
+    },
+  ].map((stage) => ({
+    kind: 'cargo',
+    identifier: stage.identifier,
+    label: stage.label,
+    command: cargoCommand,
+    args: ['run', '-p', 'rustok-benchmarks', '--bin', stage.identifier, '--release'],
+    environment: { ...baseEnvironment, ...stage.environment },
+    environmentOverrides: Object.keys(stage.environment),
+    outputs: stage.outputs.map((filename) => path.join(options.root, filename)),
+  }));
+
+  return [
+    ...cargoStages,
+    {
+      kind: 'node',
+      identifier: 'assemble-index-partition-evidence.mjs',
+      label: 'assemble exact-byte retained partition packet',
+      command: process.execPath,
+      args: [
+        scriptPath('assemble-index-partition-evidence.mjs'),
+        '--manifest', options.manifest,
+        '--capture', options.capture,
+        '--output', options.packet,
+      ],
+      environment: process.env,
+      environmentOverrides: [],
+      outputs: [options.packet],
+    },
+    {
+      kind: 'node',
+      identifier: 'validate-index-partition-evidence.mjs',
+      label: 'validate retained partition packet admission',
+      command: process.execPath,
+      args: [
+        scriptPath('validate-index-partition-evidence.mjs'),
+        '--input', options.packet,
+        '--output', options.admission,
+      ],
+      environment: process.env,
+      environmentOverrides: [],
+      outputs: [options.admission],
+    },
+  ];
+};
+
+const printPlan = (options, stages) => {
+  const plan = {
+    contract: 'index_partition_full_capture_plan_v1',
+    mode: 'plan',
+    preflight_completed: true,
+    database_connection_attempted: false,
+    writes_performed: false,
+    required_environment: [fullCaptureOptIn, 'DATABASE_URL'],
+    inputs: {
+      manifest: options.manifest,
+      query_audit: options.queryAudit,
+    },
+    root: options.root,
+    outputs: outputContract(options),
+    stages: stages.map((stage, index) => ({
+      order: index + 1,
+      kind: stage.kind,
+      identifier: stage.identifier,
+      command: [stage.command, ...stage.args],
+      environment_overrides: stage.environmentOverrides,
+      outputs: stage.outputs,
+    })),
+    limitations: [
+      'DATABASE_URL presence is checked, but no database connection is opened.',
+      'No Cargo or Node evidence stage is started.',
+      'No bundle directory or output file is created.',
+    ],
+  };
+  console.log(JSON.stringify(plan, null, 2));
+};
+
+const main = () => {
   const options = parseArgs(process.argv.slice(2));
   if (options === null) {
     usage();
-    process.exit(0);
+    return;
   }
   if (process.env[fullCaptureOptIn] !== '1') {
-    fail(`${fullCaptureOptIn}=1 is required because this command runs every owner-operated PostgreSQL evidence stage`);
+    fail(`${fullCaptureOptIn}=1 is required because this command covers every owner-operated PostgreSQL evidence stage`);
   }
   if (!process.env.DATABASE_URL) fail('DATABASE_URL is required');
   preflight(options);
 
-  const baseEnvironment = {
-    ...process.env,
-    INDEX_PARTITION_MANIFEST: options.manifest,
-    INDEX_PARTITION_EVIDENCE_ROOT: options.root,
-    INDEX_PARTITION_QUERY_OUTPUT: path.join(options.root, 'query.json'),
-    INDEX_PARTITION_MUTATION_OUTPUT: path.join(options.root, 'mutation.json'),
-    INDEX_PARTITION_MAINTENANCE_OUTPUT: path.join(options.root, 'maintenance.json'),
-    INDEX_PARTITION_CUTOVER_OUTPUT: path.join(options.root, 'cutover.json'),
-    INDEX_PARTITION_CAPTURE_OUTPUT: options.capture,
-  };
+  const stages = buildStages(options);
+  if (options.plan) {
+    printPlan(options, stages);
+    return;
+  }
 
-  cargoRun(
-    'index-partition-snapshot-capture',
-    'capture baseline and retained shadow snapshot',
-    {
-      ...baseEnvironment,
-      INDEX_PARTITION_QUERY_AUDIT: options.queryAudit,
-      INDEX_PARTITION_ALLOW_SHADOW_COPY: '1',
-    },
-  );
-  cargoRun(
-    'index-partition-query-evidence',
-    'capture baseline/shadow query evidence',
-    { ...baseEnvironment, INDEX_PARTITION_ALLOW_QUERY_EVIDENCE: '1' },
-  );
-  cargoRun(
-    'index-partition-mutation-evidence',
-    'capture rollback-only mutation and WAL evidence',
-    { ...baseEnvironment, INDEX_PARTITION_ALLOW_MUTATION_EVIDENCE: '1' },
-  );
-  cargoRun(
-    'index-partition-maintenance-evidence',
-    'capture ordinary-VACUUM maintenance evidence',
-    { ...baseEnvironment, INDEX_PARTITION_ALLOW_MAINTENANCE_EVIDENCE: '1' },
-  );
-  cargoRun(
-    'index-partition-cutover-evidence',
-    'capture cutover lock and rollback rehearsal evidence',
-    { ...baseEnvironment, INDEX_PARTITION_ALLOW_CUTOVER_EVIDENCE: '1' },
-  );
-  cargoRun(
-    'index-partition-capture-finalize',
-    'bind raw artifacts to runner and PostgreSQL identity',
-    { ...baseEnvironment, INDEX_PARTITION_ALLOW_CAPTURE_FINALIZE: '1' },
-  );
-
-  runCommand(
-    process.execPath,
-    [
-      scriptPath('assemble-index-partition-evidence.mjs'),
-      '--manifest', options.manifest,
-      '--capture', options.capture,
-      '--output', options.packet,
-    ],
-    'assemble exact-byte retained partition packet',
-  );
-  runCommand(
-    process.execPath,
-    [
-      scriptPath('validate-index-partition-evidence.mjs'),
-      '--input', options.packet,
-      '--output', options.admission,
-    ],
-    'validate retained partition packet admission',
-  );
+  for (const stage of stages) {
+    runCommand(stage.command, stage.args, stage.label, stage.environment);
+  }
   console.log(`${prefix} complete: bundle=${options.root}`);
+};
+
+try {
+  main();
 } catch (error) {
   console.error(`${prefix} ${error.message}`);
   process.exitCode = 1;

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -72,6 +72,9 @@ try {
     'preflight_completed: true',
     'database_connection_attempted: false',
     'writes_performed: false',
+    'baseEnvironmentOverrides',
+    'INDEX_PARTITION_MANIFEST',
+    'environment_overrides',
     'No Cargo or Node evidence stage is started.',
     'if (options.plan)',
     'JSON.stringify(plan, null, 2)',
@@ -99,6 +102,8 @@ try {
     'database_connection_attempted',
     'writes_performed',
     'secret-value-must-not-be-printed',
+    'plan.stages[0].environment_overrides',
+    'INDEX_PARTITION_QUERY_AUDIT',
     'plan refuses partial output reuse without starting Cargo',
   ], 'full capture plan fixture');
   requireMarkers(tooling, [

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -25,6 +25,7 @@ try {
   const cargo = read('ops/benches/Cargo.toml');
   const module = read('ops/benches/src/index_storage/mod.rs');
   const orchestrator = read('scripts/verify/run-index-partition-evidence.mjs');
+  const planTest = read('scripts/verify/index-partition-full-capture-plan.test.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
   const plan = read('crates/rustok-index/docs/implementation-plan.md');
@@ -66,6 +67,15 @@ try {
   ], 'index storage module exports');
   requireMarkers(orchestrator, [
     'INDEX_PARTITION_ALLOW_FULL_CAPTURE',
+    "'--plan'",
+    'index_partition_full_capture_plan_v1',
+    'preflight_completed: true',
+    'database_connection_attempted: false',
+    'writes_performed: false',
+    'No Cargo or Node evidence stage is started.',
+    'if (options.plan)',
+    'JSON.stringify(plan, null, 2)',
+    'for (const stage of stages)',
     'index-partition-snapshot-capture',
     'index-partition-query-evidence',
     'index-partition-mutation-evidence',
@@ -83,15 +93,29 @@ try {
     'ALTER TABLE index_links',
     'dual-write',
   ], 'full capture tooling');
+  requireMarkers(planTest, [
+    'prints a no-write eight-stage full-capture plan',
+    "CARGO: path.join(workspace, 'missing-cargo')",
+    'database_connection_attempted',
+    'writes_performed',
+    'secret-value-must-not-be-printed',
+    'plan refuses partial output reuse without starting Cargo',
+  ], 'full capture plan fixture');
   requireMarkers(tooling, [
     'partition-capture',
     'run-index-partition-evidence.mjs',
+    'index-partition-full-capture-plan.test.mjs',
     'verify-index-partition-full-capture.mjs',
   ], 'index storage tooling router');
   requireMarkers(runbook, [
     'M3 partition cutover rehearsal evidence runner: `complete`',
     'M3 retained packet owner orchestration: `complete`',
     'Real retained PostgreSQL packet execution: `open`',
+    'partition-capture --plan',
+    'does not open a PostgreSQL connection',
+    'does not start Cargo or Node evidence stages',
+    'does not create the bundle directory or any output file',
+    'does not print the `DATABASE_URL` value',
     'INDEX_PARTITION_ALLOW_FULL_CAPTURE=1',
     'index-partition-capture-finalize',
     'forbidden before one retained admitted packet',


### PR DESCRIPTION
## Summary

- add `--plan` to the full retained partition capture command;
- run the same owner opt-in, `DATABASE_URL` presence, input-file, path-confinement, and no-resume output preflight used by the real capture;
- print a machine-readable `index_partition_full_capture_plan_v1` document with all eight ordered stages, resolved inputs/outputs, command arrays, and environment override names;
- keep plan mode strictly no-write: it opens no PostgreSQL connection, starts no Cargo or Node evidence stage, and creates no bundle directory or output file;
- never print the `DATABASE_URL` value;
- drive real execution and plan output from the same stage definitions so their ordering cannot drift;
- add no-write/partial-output fixture coverage, static contract markers, router registration, and owner documentation.

## Root cause

The owner command previously moved directly from static files and environment variables into the first PostgreSQL/Cargo stage. Path mistakes or stale bundle outputs could be discovered only at execution time, and there was no machine-readable way to review the exact full-capture stage contract before starting an expensive retained run.

## Safety boundary

This PR changes only owner-operated evidence tooling, fixtures, guards, and documentation. It does not add production partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter behavior. Real retained PostgreSQL packet execution and admission remain open owner steps.

## Validation

Tests, fixture suites, contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run, per repository-owner instruction.

Only JavaScript syntax and static shape checks were performed locally:

```bash
node --check scripts/verify/run-index-partition-evidence.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
node --check scripts/verify/index-partition-full-capture-plan.test.mjs
```

Suggested owner checks:

```bash
node scripts/verify/verify-index-partition-full-capture.mjs
node --test scripts/verify/index-partition-full-capture-plan.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

## Next M3 step

Review a successful `partition-capture --plan`, then rerun the same fresh manifest/query-audit/root command without `--plan` against PostgreSQL 16. Retain all nine outputs and review `admission.json` before any production partition lifecycle design.