### PR TITLE
Publish fulfillment lifecycle read port

### DIFF
--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -6,8 +6,9 @@ use async_graphql::extensions::{
 use async_graphql::{Context, ServerResult, Value};
 use rustok_fulfillment::providers::FulfillmentProviderRegistry;
 use rustok_fulfillment::{
-    ShippingOptionAdminReadPort, ShippingOptionReadPort,
-    in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
+    FulfillmentReadPort, ShippingOptionAdminReadPort, ShippingOptionReadPort,
+    in_process_fulfillment_read_port, in_process_shipping_option_admin_read_port,
+    in_process_shipping_option_read_port,
 };
 use rustok_payment::providers::PaymentProviderRegistry;
 use sea_orm::DatabaseConnection;
@@ -47,6 +48,30 @@ impl CommerceShippingOptionReadRuntime {
 
     pub fn shipping_option_admin_read_port(&self) -> Arc<dyn ShippingOptionAdminReadPort> {
         self.shipping_option_admin_reads.clone()
+    }
+}
+
+/// Host-selectable fulfillment lifecycle projection read port.
+///
+/// The runtime is separate from shipping-option reads so hosts can select different adapters.
+/// Until the mounted server and consumers are cut over, GraphQL runtime-data construction retains
+/// an explicit in-process fallback.
+#[derive(Clone)]
+pub struct CommerceFulfillmentLifecycleReadRuntime {
+    fulfillment_reads: Arc<dyn FulfillmentReadPort>,
+}
+
+impl CommerceFulfillmentLifecycleReadRuntime {
+    pub fn new(fulfillment_reads: Arc<dyn FulfillmentReadPort>) -> Self {
+        Self { fulfillment_reads }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(in_process_fulfillment_read_port(db))
+    }
+
+    pub fn fulfillment_read_port(&self) -> Arc<dyn FulfillmentReadPort> {
+        self.fulfillment_reads.clone()
     }
 }
 
@@ -94,17 +119,19 @@ pub(crate) fn shipping_option_read_runtime_for_current_graphql_scope(
         .unwrap_or_else(|_| CommerceShippingOptionReadRuntime::in_process(db))
 }
 
-/// Provider registries and host-composed ports available to every commerce GraphQL resolver.
+/// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual
-/// provider registries remain deterministic fallbacks for tests and deployments that have not
-/// installed external providers. Mounted shipping-option reads are required host data.
+/// provider registries remain deterministic fallbacks. Mounted shipping-option reads require host
+/// data; fulfillment lifecycle reads retain an explicit in-process fallback until their consumer
+/// cutover is complete.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
+    fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
 }
 
 impl CommerceGraphqlRuntimeData {
@@ -122,6 +149,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
         self.shipping_option_read_runtime.clone()
+    }
+
+    pub fn fulfillment_lifecycle_read_runtime(&self) -> CommerceFulfillmentLifecycleReadRuntime {
+        self.fulfillment_lifecycle_read_runtime.clone()
     }
 }
 
@@ -148,6 +179,11 @@ pub fn attach_schema_data(
                 "commerce GraphQL requires CommerceShippingOptionReadRuntime in host composition"
                     .to_string()
             })?,
+        fulfillment_lifecycle_read_runtime: inputs
+            .shared_get::<CommerceFulfillmentLifecycleReadRuntime>()
+            .unwrap_or_else(|| {
+                CommerceFulfillmentLifecycleReadRuntime::in_process(inputs.db_clone())
+            }),
     })
 }
 

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-28",
+  "status": "source_ready_unvalidated",
+  "source_base_revision": "41b24915663848a77467a00e99ebbc92acecaf73",
+  "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
+  "owner": {
+    "crate": "rustok-fulfillment",
+    "port": "FulfillmentReadPort",
+    "adapter": "InProcessFulfillmentReadPort",
+    "factory": "in_process_fulfillment_read_port"
+  },
+  "operations": [
+    {
+      "name": "read_fulfillment_projection",
+      "request": "ReadFulfillmentProjectionRequest",
+      "result": "FulfillmentResponse",
+      "optional_not_found": false
+    },
+    {
+      "name": "list_fulfillment_projections",
+      "request": "ListFulfillmentProjectionsRequest",
+      "result": "FulfillmentProjectionPage",
+      "filters": [
+        "status",
+        "order_id",
+        "customer_id",
+        "page",
+        "per_page"
+      ]
+    },
+    {
+      "name": "find_latest_fulfillment_by_order_projection",
+      "request": "FindLatestFulfillmentByOrderProjectionRequest",
+      "result": "Option<FulfillmentResponse>",
+      "optional_not_found": true,
+      "ordering": "latest_created_at"
+    }
+  ],
+  "context": {
+    "read_policy_required": true,
+    "tenant_parsed_from_port_context": true,
+    "deadline_required_by_policy": true,
+    "diagnostics_retain_actor_channel_locale_correlation": true
+  },
+  "errors": {
+    "type": "PortError",
+    "owner_message_control_flow": false,
+    "database_retryable": true,
+    "all_current_fulfillment_error_variants_mapped": true
+  },
+  "runtime_publication": {
+    "runtime": "CommerceFulfillmentLifecycleReadRuntime",
+    "graphql_host_override_supported": true,
+    "graphql_manifest_fallback": "in_process",
+    "server_cache_composed": false,
+    "default_server_attachment": false
+  },
+  "consumer_cutover": {
+    "graphql_compatibility_facade": false,
+    "admin_rest_list_show": false,
+    "concrete_delegate_removed": false,
+    "next_slice": "compose the lifecycle runtime in ServerRuntimeContext and HostRuntimeContext, inject it into GraphQL and Commerce HTTP, and route GraphQL lookup/list/latest-by-order plus admin REST list/show through FulfillmentReadPort while preserving transport-specific optional-not-found and public error policy"
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
@@ -1,0 +1,124 @@
+# Fulfillment lifecycle read port
+
+Status: source-ready, unvalidated.
+
+## Scope
+
+`FulfillmentReadPort` is the fulfillment-owned boundary for complete lifecycle
+projection reads used by Commerce query consumers. It is separate from:
+
+- `ShippingOptionReadPort` and `ShippingOptionAdminReadPort`, which own
+  shipping-option projections;
+- `CheckoutFulfillmentExecutionPort`, which owns checkout create/adopt/recovery;
+- `ShippingSelectionPort`, which owns seller/cart shipping selection;
+- fulfillment lifecycle mutation methods, which remain on `FulfillmentService`.
+
+This slice publishes the owner read boundary and a host-selectable Commerce
+runtime container. It does not yet compose that runtime in the default server or
+cut GraphQL/admin REST consumers over to the port.
+
+## Operations
+
+The owner publishes three read-only operations:
+
+- `read_fulfillment_projection` returns one `FulfillmentResponse` by fulfillment
+  id and reports absence as owner `NotFound`;
+- `list_fulfillment_projections` preserves page, per-page, status, order, and
+  customer filters and returns `FulfillmentProjectionPage`;
+- `find_latest_fulfillment_by_order_projection` preserves the current
+  latest-created fulfillment lookup and returns `Option<FulfillmentResponse>`.
+
+The existing owner DTO is returned unchanged. Commerce does not define a partial
+copy of fulfillment lifecycle state.
+
+## In-process adapter
+
+`InProcessFulfillmentReadPort` owns concrete `FulfillmentService` construction.
+The root factory is:
+
+```rust
+in_process_fulfillment_read_port(db)
+```
+
+Every operation:
+
+1. requires `PortCallPolicy::read()`;
+2. parses tenant identity from `PortContext`;
+3. delegates to the existing fulfillment owner service;
+4. maps every current `FulfillmentError` variant to a stable `PortError`;
+5. preserves the owner projection and pagination total on success.
+
+The adapter does not parse, match, or expose owner error messages as control
+flow. Database failures are retryable `Unavailable`; validation, not-found, and
+conflict outcomes retain stable owner codes.
+
+## Commerce runtime publication
+
+`CommerceFulfillmentLifecycleReadRuntime` holds an
+`Arc<dyn FulfillmentReadPort>` and exposes:
+
+- a public constructor for a host-selected adapter;
+- an explicit `in_process` constructor;
+- a clone getter for consumer injection.
+
+It remains separate from `CommerceShippingOptionReadRuntime`, allowing different
+adapters for lifecycle and shipping-option projections.
+
+Commerce GraphQL runtime-data construction consumes a host-provided lifecycle
+runtime when one is already present in `HostRuntimeContext`. Until the default
+server and mounted consumers are cut over, it retains an explicit in-process
+fallback from `GraphqlRuntimeInputs::db_clone()`.
+
+This fallback is compatibility source, not evidence that the default server has
+cached or attached the runtime. `ServerRuntimeContext` composition and
+`CommerceHttpRuntime` injection remain open.
+
+## Consumer boundary
+
+The current private Commerce GraphQL fulfillment facade still constructs one
+concrete `FulfillmentService` for:
+
+- fulfillment lookup;
+- fulfillment list;
+- latest fulfillment by order.
+
+Admin REST also still constructs `FulfillmentService` for:
+
+- `GET /admin/fulfillments`;
+- `GET /admin/fulfillments/{id}`.
+
+Lifecycle mutations remain intentionally outside this read boundary.
+
+The next cutover slice must compose/cache the runtime in the default application
+host, inject it into GraphQL and `CommerceHttpRuntime`, route the GraphQL and REST
+read consumers through `FulfillmentReadPort`, preserve each transport's
+optional-not-found and public error policy, and remove only the private GraphQL
+concrete delegate. No mounted consumer is claimed in this slice.
+
+## Diagnostics
+
+The owner boundary records operation, correlation id, tenant, actor, channel
+length, locale length, causation/trace presence, deadline, relevant fulfillment,
+order, customer, and status facts, stable owner code, error kind, and
+retryability. Only technical database events retain the typed internal cause.
+
+## Evidence
+
+Source evidence is retained at:
+
+`crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`
+
+Its status is `source_ready_unvalidated`. It explicitly records that default
+server composition, GraphQL/admin REST consumer cutover, and private concrete
+delegate removal remain incomplete.
+
+## Intended checks
+
+```bash
+node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+cargo check -p rustok-fulfillment --lib
+cargo check -p rustok-commerce --lib
+```
+
+Tests, Cargo commands, formatting, verifiers, workflows, and CI were not run by
+the implementation agent.

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -46,17 +46,30 @@ service or in-process read provider inside Commerce:
 - REST storefront active-list;
 - REST admin list-all and single lookup.
 
-The GraphQL facade retains one concrete `FulfillmentService` only for fulfillment
-lifecycle and order-to-fulfillment compatibility reads. Admin REST
-shipping-option mutations continue to use the concrete lifecycle owner and are
-outside the projection-read cutover. Directly embedded GraphQL schemas retain an
-explicit in-process compatibility fallback outside the private facade.
+The source transport inventory has status `source_cutover_ready_unvalidated`. It
+records host-composed GraphQL/REST source topology, retained filters and HTTP
+envelopes, context/deadline propagation, and the absence of concrete read
+construction. It explicitly records `runtime_parity_proven: false`.
 
-The source transport inventory now has status
-`source_cutover_ready_unvalidated`. It records host-composed GraphQL/REST source
-topology, retained filters and HTTP envelopes, context/deadline propagation, and
-the absence of concrete read construction. It explicitly records
-`runtime_parity_proven: false`.
+Fulfillment lifecycle projection lookup, filtered list, and latest-by-order are
+now published through `FulfillmentReadPort`. `InProcessFulfillmentReadPort` owns
+concrete `FulfillmentService` construction, requires read policy, parses tenant
+identity from `PortContext`, preserves existing filter and ordering semantics, and
+maps every current owner error to stable `PortError`.
+
+Commerce now publishes a separate host-selectable
+`CommerceFulfillmentLifecycleReadRuntime`. GraphQL runtime-data construction uses
+a runtime already present in `HostRuntimeContext` and otherwise retains an
+explicit in-process fallback from the host database. This keeps the owner
+contract injectable without claiming that the default server has cached or
+attached the runtime.
+
+Default `ServerRuntimeContext` composition, resolver/HTTP injection, and consumer
+cutover remain open. The private GraphQL compatibility facade still retains one
+concrete `FulfillmentService` for fulfillment lookup, list, and latest-by-order.
+Admin REST still constructs the service for fulfillment list and detail reads.
+Fulfillment lifecycle mutations remain on their existing concrete/orchestration
+owner paths and are outside this read boundary.
 
 The native FFA surface remains seller/cart selection through
 `ShippingSelectionPort`; it does not publish complete projection list or lookup
@@ -74,15 +87,19 @@ operations. No projection API should be added without a concrete consumer.
 - Published checkout execution port: `CheckoutFulfillmentExecutionPort`.
 - Mounted checkout provider: `TypedCheckoutFulfillmentExecutionPort` over the
   owner execution adapter.
-- Source-ready internal read boundaries: `ShippingOptionReadPort` and
-  `ShippingOptionAdminReadPort`; these are not new FBA provider contracts.
+- Source-ready internal read boundaries: `ShippingOptionReadPort`,
+  `ShippingOptionAdminReadPort`, and `FulfillmentReadPort`; these are not new FBA
+  provider contracts.
 - Contract/provider evidence remains in the existing fulfillment evidence
   matrices and live-adapter files.
 - Shipping-option source evidence:
   `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`.
-  It is unvalidated source evidence and does not promote status.
-- Focused guards cover owner boundaries, GraphQL host composition, REST host
-  composition, typed HTTP envelopes, and the separate native selection surface.
+- Fulfillment lifecycle read source evidence:
+  `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`.
+- Both files are unvalidated source evidence and do not promote status.
+- Focused guards cover owner boundaries, published Commerce runtime containers,
+  current mounted consumers, typed public envelopes, and the separate native
+  selection surface.
 - Compile, migrated database, mounted transport, restart, contention, and remote
   evidence remain missing.
 
@@ -129,6 +146,36 @@ operations. No projection API should be added without a concrete consumer.
 - [ ] Execute compile, mounted GraphQL/REST active-list/list-all/lookup parity,
   deadline, locale, channel, optional-not-found, failure, and remote evidence.
 
+## Fulfillment lifecycle read source checklist
+
+- [x] Publish one owner `FulfillmentReadPort` for single projection, filtered list,
+  and latest-by-order reads.
+- [x] Preserve the existing `FulfillmentResponse`, list filters, pagination total,
+  latest-created ordering, and optional latest-by-order result.
+- [x] Require read policy and parse tenant identity from `PortContext`.
+- [x] Map every current `FulfillmentError` variant to stable owner `PortError`
+  values without owner-message control flow.
+- [x] Export the canonical `in_process_fulfillment_read_port` factory.
+- [x] Publish `CommerceFulfillmentLifecycleReadRuntime` with public host-selected
+  and in-process constructors plus a clone getter.
+- [x] Allow Commerce GraphQL runtime-data construction to consume a host-provided
+  lifecycle runtime while retaining an explicit in-process compatibility fallback.
+- [x] Retain source evidence and a focused guard that explicitly record default
+  server composition plus GraphQL/admin REST consumer cutovers as incomplete.
+- [ ] Compose/cache the lifecycle runtime once in the default application host,
+  preserve externally installed adapters, and expose it to both GraphQL and
+  `CommerceHttpRuntime`.
+- [ ] Add resolver scope or equivalent request-safe injection for GraphQL.
+- [ ] Cut GraphQL fulfillment lookup, filtered list, and latest-by-order reads over
+  to `FulfillmentReadPort` while preserving optional-not-found and public error
+  behavior.
+- [ ] Cut admin REST fulfillment list and detail reads over to the same owner port
+  while preserving pagination and current HTTP status/code/message policy.
+- [ ] Remove the remaining concrete `FulfillmentService` field from the private
+  GraphQL compatibility facade; lifecycle mutation services remain unchanged.
+- [ ] Execute compile, mounted GraphQL/REST lifecycle query, deadline, tenant,
+  filter, optional-not-found, failure, and remote evidence.
+
 ## Open results
 
 1. **Prove checkout fulfillment identity and replay.** Execute create/adopt/read,
@@ -171,12 +218,16 @@ operations. No projection API should be added without a concrete consumer.
    envelopes, and no mounted projection transport constructs a concrete read
    service or provider.
 
-6. **Publish remaining fulfillment query read ports.** Add owner boundaries for
-   fulfillment lifecycle list/lookup and order-to-fulfillment reads, then remove
-   the remaining concrete delegate from the GraphQL compatibility facade.
-   **Depends on:** stable projection and optional-not-found contracts.
-   **Done when:** all mounted fulfillment query reads consume host-composed owner
-   ports and lifecycle ownership remains in fulfillment.
+6. **Cut mounted lifecycle reads over to the owner port.** Compose/cache the
+   host-selectable `CommerceFulfillmentLifecycleReadRuntime`, inject it into
+   GraphQL and Commerce HTTP, route GraphQL lookup/list/latest-by-order and admin
+   REST list/detail through `FulfillmentReadPort`, and remove the private GraphQL
+   concrete delegate.
+   **Depends on:** the published owner port/runtime and stable transport-specific
+   optional-not-found/public error contracts.
+   **Done when:** mounted GraphQL and REST lifecycle reads consume the host-selected
+   owner port, preserve their existing response policy, and no mounted lifecycle
+   read constructs `FulfillmentService` inside Commerce.
 
 7. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.
@@ -191,6 +242,7 @@ operations. No projection API should be added without a concrete consumer.
 - `node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`
 - `node scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs`
 - `node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
+- `node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
 - `node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
@@ -206,6 +258,7 @@ operations. No projection API should be added without a concrete consumer.
 - `cargo check -p rustok-commerce --all-features`
 - Targeted checkout fulfillment identity/lifecycle/restart/contention tests.
 - Targeted shipping-option GraphQL/REST parity, context, error, and remote tests.
+- Targeted fulfillment lifecycle owner-port and mounted GraphQL/REST query tests.
 
 No verification command was executed in this source wave.
 

--- a/crates/rustok-fulfillment/src/fulfillment_read.rs
+++ b/crates/rustok-fulfillment/src/fulfillment_read.rs
@@ -1,0 +1,294 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    FulfillmentError, FulfillmentResponse, FulfillmentService, ListFulfillmentsInput,
+};
+
+/// Transport-neutral owner boundary for fulfillment lifecycle projection reads.
+#[async_trait]
+pub trait FulfillmentReadPort: Send + Sync {
+    async fn read_fulfillment_projection(
+        &self,
+        context: PortContext,
+        request: ReadFulfillmentProjectionRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+
+    async fn list_fulfillment_projections(
+        &self,
+        context: PortContext,
+        request: ListFulfillmentProjectionsRequest,
+    ) -> Result<FulfillmentProjectionPage, PortError>;
+
+    async fn find_latest_fulfillment_by_order_projection(
+        &self,
+        context: PortContext,
+        request: FindLatestFulfillmentByOrderProjectionRequest,
+    ) -> Result<Option<FulfillmentResponse>, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadFulfillmentProjectionRequest {
+    pub fulfillment_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListFulfillmentProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub status: Option<String>,
+    pub order_id: Option<Uuid>,
+    pub customer_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FulfillmentProjectionPage {
+    pub items: Vec<FulfillmentResponse>,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindLatestFulfillmentByOrderProjectionRequest {
+    pub order_id: Uuid,
+}
+
+pub struct InProcessFulfillmentReadPort {
+    inner: FulfillmentService,
+}
+
+impl InProcessFulfillmentReadPort {
+    pub fn new(db: sea_orm::DatabaseConnection) -> Self {
+        Self {
+            inner: FulfillmentService::new(db),
+        }
+    }
+
+    pub fn from_service(inner: FulfillmentService) -> Self {
+        Self { inner }
+    }
+}
+
+pub fn in_process_fulfillment_read_port(
+    db: sea_orm::DatabaseConnection,
+) -> Arc<dyn FulfillmentReadPort> {
+    Arc::new(InProcessFulfillmentReadPort::new(db))
+}
+
+#[async_trait]
+impl FulfillmentReadPort for InProcessFulfillmentReadPort {
+    async fn read_fulfillment_projection(
+        &self,
+        context: PortContext,
+        request: ReadFulfillmentProjectionRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, "read_fulfillment_projection")?;
+
+        self.inner
+            .get_fulfillment(tenant_id, request.fulfillment_id)
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    "read_fulfillment_projection",
+                    Some(request.fulfillment_id),
+                    None,
+                    None,
+                    None,
+                    error,
+                )
+            })
+    }
+
+    async fn list_fulfillment_projections(
+        &self,
+        context: PortContext,
+        request: ListFulfillmentProjectionsRequest,
+    ) -> Result<FulfillmentProjectionPage, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, "list_fulfillment_projections")?;
+        let status_length = request.status.as_deref().map(str::len);
+        let order_id = request.order_id;
+        let customer_id = request.customer_id;
+        let (items, total) = self
+            .inner
+            .list_fulfillments(
+                tenant_id,
+                ListFulfillmentsInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    status: request.status,
+                    order_id,
+                    customer_id,
+                },
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    "list_fulfillment_projections",
+                    None,
+                    order_id,
+                    status_length,
+                    customer_id,
+                    error,
+                )
+            })?;
+
+        Ok(FulfillmentProjectionPage { items, total })
+    }
+
+    async fn find_latest_fulfillment_by_order_projection(
+        &self,
+        context: PortContext,
+        request: FindLatestFulfillmentByOrderProjectionRequest,
+    ) -> Result<Option<FulfillmentResponse>, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(
+            &context,
+            "find_latest_fulfillment_by_order_projection",
+        )?;
+
+        self.inner
+            .find_by_order(tenant_id, request.order_id)
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    "find_latest_fulfillment_by_order_projection",
+                    None,
+                    Some(request.order_id),
+                    None,
+                    None,
+                    error,
+                )
+            })
+    }
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+        tracing::warn!(
+            error = ?error,
+            owner = "rustok_fulfillment",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            code = "fulfillment.context_invalid",
+            boundary = "fulfillment_lifecycle_read_port",
+            "fulfillment lifecycle read context is invalid"
+        );
+        PortError::validation(
+            "fulfillment.context_invalid",
+            "fulfillment request context is invalid",
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_owner_error(
+    context: &PortContext,
+    operation: &'static str,
+    fulfillment_id: Option<Uuid>,
+    order_id: Option<Uuid>,
+    status_length: Option<usize>,
+    customer_id: Option<Uuid>,
+    error: FulfillmentError,
+) -> PortError {
+    let (kind, code, message, retryable, error_kind) = match &error {
+        FulfillmentError::Validation(_) => (
+            PortErrorKind::Validation,
+            "fulfillment.validation",
+            "fulfillment request is invalid",
+            false,
+            "validation",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_) => (
+            PortErrorKind::NotFound,
+            "fulfillment.shipping_option_not_found",
+            "shipping option was not found",
+            false,
+            "shipping_option_not_found",
+        ),
+        FulfillmentError::FulfillmentNotFound(_) => (
+            PortErrorKind::NotFound,
+            "fulfillment.fulfillment_not_found",
+            "fulfillment was not found",
+            false,
+            "fulfillment_not_found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            PortErrorKind::Conflict,
+            "fulfillment.invalid_transition",
+            "fulfillment lifecycle transition conflicts with the current state",
+            false,
+            "invalid_transition",
+        ),
+        FulfillmentError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "fulfillment.database_unavailable",
+            "fulfillment storage is temporarily unavailable",
+            true,
+            "database",
+        ),
+    };
+
+    if matches!(&error, FulfillmentError::Database(_)) {
+        tracing::error!(
+            error = ?error,
+            owner = "rustok_fulfillment",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            fulfillment_id = ?fulfillment_id,
+            order_id = ?order_id,
+            customer_id = ?customer_id,
+            status_length = ?status_length,
+            error_kind,
+            code,
+            retryable,
+            boundary = "fulfillment_lifecycle_read_port",
+            "fulfillment lifecycle read failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = "rustok_fulfillment",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            fulfillment_id = ?fulfillment_id,
+            order_id = ?order_id,
+            customer_id = ?customer_id,
+            status_length = ?status_length,
+            error_kind,
+            code,
+            retryable,
+            boundary = "fulfillment_lifecycle_read_port",
+            "fulfillment lifecycle read was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -8,6 +8,7 @@ mod checkout_execution_typed;
 pub mod dto;
 pub mod entities;
 pub mod error;
+mod fulfillment_read;
 pub mod migrations;
 pub mod ports;
 pub mod providers;
@@ -25,6 +26,11 @@ pub use checkout_execution_typed::{
 };
 pub use dto::*;
 pub use entities::*;
+pub use fulfillment_read::{
+    FindLatestFulfillmentByOrderProjectionRequest, FulfillmentProjectionPage, FulfillmentReadPort,
+    InProcessFulfillmentReadPort, ListFulfillmentProjectionsRequest,
+    ReadFulfillmentProjectionRequest, in_process_fulfillment_read_port,
+};
 pub use ports::*;
 pub use providers::*;
 pub use shipping_option_read::{

--- a/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const ownerRoot = read('crates/rustok-fulfillment/src/lib.rs');
+const ownerSource = read('crates/rustok-fulfillment/src/fulfillment_read.rs');
+const commerceRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const hostRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
+const compatibilityFacade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
+const adminRest = read('crates/rustok-commerce/src/controllers/admin/fulfillments.rs');
+const evidence = JSON.parse(
+  read('crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json'),
+);
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+for (const [source, value, label] of [
+  [ownerRoot, 'mod fulfillment_read;', 'private owner module'],
+  [ownerRoot, 'FulfillmentReadPort,', 'owner port export'],
+  [ownerRoot, 'InProcessFulfillmentReadPort,', 'in-process adapter export'],
+  [ownerRoot, 'FulfillmentProjectionPage,', 'page export'],
+  [ownerRoot, 'ReadFulfillmentProjectionRequest,', 'read request export'],
+  [ownerRoot, 'ListFulfillmentProjectionsRequest,', 'list request export'],
+  [
+    ownerRoot,
+    'FindLatestFulfillmentByOrderProjectionRequest,',
+    'latest-by-order request export',
+  ],
+  [ownerRoot, 'in_process_fulfillment_read_port,', 'root factory export'],
+  [ownerSource, 'pub trait FulfillmentReadPort: Send + Sync {', 'owner trait'],
+  [ownerSource, 'pub struct InProcessFulfillmentReadPort {', 'in-process adapter'],
+  [
+    ownerSource,
+    'impl FulfillmentReadPort for InProcessFulfillmentReadPort',
+    'adapter implementation',
+  ],
+  [ownerSource, 'pub fn in_process_fulfillment_read_port(', 'root factory'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['async fn read_fulfillment_projection(', 'single read operation'],
+  ['async fn list_fulfillment_projections(', 'list operation'],
+  [
+    'async fn find_latest_fulfillment_by_order_projection(',
+    'latest-by-order operation',
+  ],
+  ['pub fulfillment_id: Uuid', 'fulfillment identity request'],
+  ['pub page: u64', 'page request'],
+  ['pub per_page: u64', 'per-page request'],
+  ['pub status: Option<String>', 'status request'],
+  ['pub order_id: Option<Uuid>', 'list order request'],
+  ['pub customer_id: Option<Uuid>', 'customer request'],
+  ['pub items: Vec<FulfillmentResponse>', 'page items'],
+  ['pub total: u64', 'page total'],
+  ['context.require_policy(PortCallPolicy::read())?', 'read policy'],
+  ['.get_fulfillment(tenant_id, request.fulfillment_id)', 'single owner delegation'],
+  ['.list_fulfillments(', 'list owner delegation'],
+  ['.find_by_order(tenant_id, request.order_id)', 'latest owner delegation'],
+  ['FulfillmentError::Validation(_)', 'validation mapping'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option mapping'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment mapping'],
+  ['FulfillmentError::InvalidTransition { .. }', 'conflict mapping'],
+  ['FulfillmentError::Database(_)', 'database mapping'],
+  ['PortErrorKind::Validation', 'validation kind'],
+  ['PortErrorKind::NotFound', 'not-found kind'],
+  ['PortErrorKind::Conflict', 'conflict kind'],
+  ['PortErrorKind::Unavailable', 'unavailable kind'],
+  ['"fulfillment_lifecycle_read_port"', 'owner boundary'],
+  ['PortError::new(kind, code, message, retryable)', 'stable error construction'],
+]) requireText(ownerSource, value, label);
+
+for (const [value, label] of [
+  ['pub struct CommerceFulfillmentLifecycleReadRuntime {', 'Commerce runtime'],
+  ['fulfillment_reads: Arc<dyn FulfillmentReadPort>', 'runtime port field'],
+  ['pub fn new(fulfillment_reads: Arc<dyn FulfillmentReadPort>)', 'runtime constructor'],
+  ['Self::new(in_process_fulfillment_read_port(db))', 'runtime in-process factory'],
+  ['pub fn fulfillment_read_port(&self)', 'runtime getter'],
+  [
+    'fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime',
+    'GraphQL runtime-data field',
+  ],
+  [
+    'pub fn fulfillment_lifecycle_read_runtime(&self)',
+    'GraphQL runtime-data getter',
+  ],
+  [
+    '.shared_get::<CommerceFulfillmentLifecycleReadRuntime>()',
+    'GraphQL host override',
+  ],
+  [
+    'CommerceFulfillmentLifecycleReadRuntime::in_process(inputs.db_clone())',
+    'GraphQL in-process compatibility fallback',
+  ],
+]) requireText(commerceRuntime, value, label);
+
+forbidText(
+  hostRuntime,
+  'CommerceFulfillmentLifecycleReadRuntime',
+  'default server lifecycle runtime composition before consumer cutover',
+);
+
+for (const [value, label] of [
+  ['inner: ::rustok_fulfillment::FulfillmentService,', 'retained concrete facade field'],
+  [
+    'inner: ::rustok_fulfillment::FulfillmentService::new(db)',
+    'retained concrete facade construction',
+  ],
+  [
+    'self.inner\n                    .get_fulfillment(',
+    'retained GraphQL single-read consumer',
+  ],
+  [
+    'self.inner\n                    .list_fulfillments(',
+    'retained GraphQL list consumer',
+  ],
+  [
+    'self.inner\n                    .find_by_order(',
+    'retained GraphQL latest-by-order consumer',
+  ],
+]) requireText(compatibilityFacade, value, label);
+
+const adminList = between(
+  adminRest,
+  'pub async fn list_fulfillments(',
+  '/// Create admin fulfillment',
+  'admin fulfillment list',
+);
+const adminShow = between(
+  adminRest,
+  'pub async fn show_fulfillment(',
+  '/// Ship admin fulfillment',
+  'admin fulfillment show',
+);
+for (const [source, value, label] of [
+  [adminList, 'FulfillmentService::new(runtime.db_clone())', 'retained admin list service'],
+  [adminList, '.list_fulfillments(', 'retained admin list operation'],
+  [adminShow, 'FulfillmentService::new(runtime.db_clone())', 'retained admin show service'],
+  [adminShow, '.get_fulfillment(tenant.id, id)', 'retained admin show operation'],
+]) requireText(source, value, label);
+
+for (const value of [
+  'error = %message',
+  'message = %',
+  'error.message',
+]) forbidText(ownerSource, value, 'owner message exposure');
+
+if (evidence.status !== 'source_ready_unvalidated') {
+  failures.push(`evidence status: expected source_ready_unvalidated, found ${evidence.status}`);
+}
+if (evidence.owner?.port !== 'FulfillmentReadPort') {
+  failures.push('evidence owner port must be FulfillmentReadPort');
+}
+if (evidence.runtime_publication?.runtime !== 'CommerceFulfillmentLifecycleReadRuntime') {
+  failures.push('evidence runtime publication mismatch');
+}
+if (evidence.runtime_publication?.graphql_host_override_supported !== true) {
+  failures.push('evidence must record GraphQL host override support');
+}
+if (evidence.runtime_publication?.graphql_manifest_fallback !== 'in_process') {
+  failures.push('evidence must record the GraphQL in-process fallback');
+}
+if (evidence.runtime_publication?.server_cache_composed !== false) {
+  failures.push('evidence must retain default server cache composition as false');
+}
+if (evidence.runtime_publication?.default_server_attachment !== false) {
+  failures.push('evidence must retain default server attachment as false');
+}
+if (evidence.consumer_cutover?.graphql_compatibility_facade !== false) {
+  failures.push('evidence must retain GraphQL facade cutover as false');
+}
+if (evidence.consumer_cutover?.admin_rest_list_show !== false) {
+  failures.push('evidence must retain admin REST list/show cutover as false');
+}
+if (evidence.consumer_cutover?.concrete_delegate_removed !== false) {
+  failures.push('evidence must retain concrete delegate removal as false');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must be false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Fulfillment lifecycle read-port source verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ fulfillment lifecycle reads are owner-published with a host-selectable Commerce runtime while default server and consumer cutovers remain explicitly open',
+);


### PR DESCRIPTION
## Summary

- continue fulfillment plan item 6 after shipping-option GraphQL/REST source cutover;
- publish fulfillment-owned `FulfillmentReadPort` for one lifecycle projection, filtered/paginated list, and latest-created projection by order;
- preserve existing `FulfillmentResponse`, status/order/customer filters, pagination total, and optional latest-by-order semantics;
- add `InProcessFulfillmentReadPort` and canonical `in_process_fulfillment_read_port` factory as the only concrete lifecycle read provider in this slice;
- require `PortCallPolicy::read()`, parse tenant identity from `PortContext`, and map every current `FulfillmentError` variant to stable `PortError` values without owner-message control flow;
- publish separately injectable `CommerceFulfillmentLifecycleReadRuntime` so hosts may select lifecycle and shipping-option adapters independently;
- allow Commerce GraphQL runtime-data construction to consume a host-provided lifecycle runtime, with an explicit in-process compatibility fallback until default server and consumer cutover;
- add source evidence, focused source guard, owner documentation, and update the fulfillment implementation plan without promoting FFA/FBA status.

## Recheck

- audited current GraphQL fulfillment lookup/list/latest-by-order consumers and admin REST fulfillment list/detail reads;
- confirmed lifecycle mutations remain separate owner/orchestration paths and are outside this read contract;
- confirmed the mounted parity item still requires maintainer-run fixtures, so this PR advances the next source-contract item instead of claiming runtime evidence;
- `main` advanced substantially during implementation; checked intervening changes and rebuilt the branch twice as `main` moved;
- patch review found and removed an unintended stale full-file replacement of fresh server runtime tests;
- final branch is one atomic commit over current `main` commit `41b24915663848a77467a00e99ebbc92acecaf73`;
- confirmed the branch is one commit ahead, zero behind, with exactly seven intended files.

## Preserved behavior

- single fulfillment absence remains owner `NotFound` for later transport-specific optional mapping;
- list page/per-page behavior and status/order/customer filtering remain delegated to `FulfillmentService`;
- latest-by-order retains the current newest-created projection and `Option` result;
- owner projections are returned unchanged;
- database failures remain retryable unavailable errors; validation, not-found, and lifecycle conflict use stable owner codes;
- a lifecycle runtime already supplied through `HostRuntimeContext` is consumed by Commerce GraphQL runtime data;
- shipping-option read runtime, checkout execution, shipping selection, provider registries, server runtime tests, and lifecycle mutation behavior are unchanged.

## Boundary

This PR publishes the owner read boundary and host-selectable Commerce runtime container only. It deliberately does **not**:

- compose/cache the lifecycle runtime in the default `ServerRuntimeContext`;
- attach the runtime by default to application `HostRuntimeContext`;
- cut the private GraphQL compatibility facade over to `FulfillmentReadPort`;
- cut admin REST `GET /admin/fulfillments` or `GET /admin/fulfillments/{id}` over to the port;
- remove the private GraphQL concrete `FulfillmentService` delegate;
- change fulfillment lifecycle mutations;
- claim mounted execution, transport parity, remote evidence, or any FFA/FBA promotion.

The retained evidence status is `source_ready_unvalidated`; default server composition and all consumer-cutover flags remain false.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested focused checks:

```bash
node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
```

## Next slice

Compose/cache the lifecycle runtime in the default application host, inject it into GraphQL and Commerce HTTP consumers, route GraphQL lookup/list/latest-by-order plus admin REST list/detail through `FulfillmentReadPort`, preserve each transport's optional-not-found and public error policy, and remove only the private GraphQL concrete delegate.