### PR TITLE
fix(migrations): append receipt migrations to release tail

### DIFF
--- a/crates/rustok-migrations/src/lib.rs
+++ b/crates/rustok-migrations/src/lib.rs
@@ -69,6 +69,8 @@ const APPEND_ONLY_MIGRATION_TAIL: &[&str] = &[
     "m20260723_000001_create_social_graph_relations",
     "m20260725_000002_add_follow_relation_kind",
     "m20260726_000003_create_command_receipts",
+    "m20260727_000004_create_index_dlq_receipts",
+    "m20260728_000001_create_consumer_poison_receipts",
 ];
 
 struct ModuleMigrationSource {


### PR DESCRIPTION
## Summary

Append the already-merged Social Graph Index DLQ receipt migration and connector neutral poison receipt migration to the explicit append-only platform migration tail:

1. `m20260727_000004_create_index_dlq_receipts`
2. `m20260728_000001_create_consumer_poison_receipts`

This preserves the previously published prefix instead of allowing lexical insertion to move the new receipt migrations before the established owner-migration tail.

## Verification

The 1030-line source file was reconstructed from one GitHub blob and verified against original blob SHA `03682e18769f63aee129401cbab8610cb1fb9609` before modification. The resulting commit patch contains exactly two added lines.

Tests, Cargo commands, formatting, migration export, and source verifiers were not run, per maintainer instruction.