### PR TITLE
feat(index): add retained partition bundle report

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -52,6 +52,19 @@ The orchestration command runs, in order:
 
 The final retained directory contains `baseline.json`, `shadow.json`, `query.json`, `mutation.json`, `maintenance.json`, `cutover.json`, `capture.json`, `partition-packet.json`, and `admission.json`.
 
+## Owner review and archive report
+
+After a successful capture, render a read-only review of all nine retained files:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-report \
+  --root evidence/index-partition/retained-run
+```
+
+`partition-report` requires a regular non-symlink bundle and keeps `capture.json`, the packet, the admission file, and all six raw artifacts inside that bundle. It recalculates packet assembly and admission from the retained bytes, rejects raw-artifact, packet, or admission drift, checks that all nine files have distinct filesystem identities, and prints a stable Markdown inventory with exact-byte SHA-256 digests, PostgreSQL identity, provenance, calculated measurements, outcome, and typed reasons.
+
+The report command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save the derived report outside the immutable bundle, but the six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` remain the authoritative archive inputs. A report does not change admission and does not authorize production lifecycle work.
+
 A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
 
 This tooling does not authorize or implement production relation rename/drop, copy/replay, dual-write, cutover, cleanup, or query-adapter changes. Admission remains a measured owner decision based on the retained packet.

--- a/scripts/verify/index-partition-review-core.mjs
+++ b/scripts/verify/index-partition-review-core.mjs
@@ -1,0 +1,268 @@
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  RAW_ARTIFACT_ROLES,
+  assemblePartitionPacket,
+} from './index-partition-evidence-assembly-core.mjs';
+import {
+  canonicalJson,
+  sha256Hex,
+  validatePartitionPacket,
+} from './index-partition-evidence-core.mjs';
+
+export const REVIEW_CONTRACT = 'index_partition_retained_bundle_review_v1';
+
+const descriptorNames = Object.freeze({
+  capture: 'capture.json',
+  packet: 'partition-packet.json',
+  admission: 'admission.json',
+});
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+const portablePath = (value) => value.split(path.sep).join('/');
+
+const requireObject = (value, label) => {
+  if (!isObject(value)) throw new Error(`${label} must be an object`);
+  return value;
+};
+
+const parseJsonBytes = (bytes, label) => {
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${label} must contain valid UTF-8 JSON: ${error.message}`);
+  }
+};
+
+const ensureInsideRoot = (root, filename, label) => {
+  const relative = path.relative(root, filename);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside the retained bundle root`);
+  }
+};
+
+const readRegularFile = (filename, label) => {
+  const stat = lstatSync(filename);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`${label} must be a regular non-symlink file`);
+  }
+  const bytes = readFileSync(filename);
+  if (bytes.length === 0) throw new Error(`${label} must not be empty`);
+  return {
+    bytes,
+    stat,
+    identity: identityOf(stat),
+    canonical: realpathSync.native(filename),
+  };
+};
+
+const assertDistinctIdentity = (seen, identity, label) => {
+  if (seen.has(identity)) throw new Error(`${label} aliases another retained bundle file`);
+  seen.add(identity);
+};
+
+const assertCanonicalMatch = (actual, expected, label) => {
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    throw new Error(`${label} does not match recalculated retained bundle content`);
+  }
+};
+
+export const inspectRetainedPartitionBundle = ({ root, packetPath, admissionPath }) => {
+  const resolvedRoot = path.resolve(root);
+  const rootStat = lstatSync(resolvedRoot);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error('retained bundle root must be a regular non-symlink directory');
+  }
+  const canonicalRoot = realpathSync.native(resolvedRoot);
+  const capturePath = path.join(resolvedRoot, descriptorNames.capture);
+  const resolvedPacketPath = path.resolve(packetPath ?? path.join(resolvedRoot, descriptorNames.packet));
+  const resolvedAdmissionPath = path.resolve(
+    admissionPath ?? path.join(resolvedRoot, descriptorNames.admission),
+  );
+
+  for (const [label, filename] of [
+    ['capture file', capturePath],
+    ['packet file', resolvedPacketPath],
+    ['admission file', resolvedAdmissionPath],
+  ]) {
+    ensureInsideRoot(resolvedRoot, filename, label);
+  }
+  if (new Set([capturePath, resolvedPacketPath, resolvedAdmissionPath]).size !== 3) {
+    throw new Error('capture, packet, and admission files must be distinct');
+  }
+
+  const captureFile = readRegularFile(capturePath, 'capture file');
+  const packetFile = readRegularFile(resolvedPacketPath, 'packet file');
+  const admissionFile = readRegularFile(resolvedAdmissionPath, 'admission file');
+  for (const [label, file] of [
+    ['capture file', captureFile],
+    ['packet file', packetFile],
+    ['admission file', admissionFile],
+  ]) {
+    ensureInsideRoot(canonicalRoot, file.canonical, label);
+  }
+
+  const capture = requireObject(parseJsonBytes(captureFile.bytes, 'capture file'), 'capture file');
+  const packet = requireObject(parseJsonBytes(packetFile.bytes, 'packet file'), 'packet file');
+  const admission = requireObject(parseJsonBytes(admissionFile.bytes, 'admission file'), 'admission file');
+  const assembled = assemblePartitionPacket({
+    manifest: packet.manifest,
+    capturePath,
+    capture,
+  });
+  assertCanonicalMatch(packet, assembled.packet, 'packet file');
+  const recalculatedAdmission = validatePartitionPacket(packet);
+  assertCanonicalMatch(admission, recalculatedAdmission, 'admission file');
+
+  const seenIdentities = new Set();
+  for (const [label, file] of [
+    ['capture file', captureFile],
+    ['packet file', packetFile],
+    ['admission file', admissionFile],
+  ]) {
+    assertDistinctIdentity(seenIdentities, file.identity, label);
+  }
+
+  const files = [];
+  for (const role of RAW_ARTIFACT_ROLES) {
+    const canonical = assembled.resolvedPaths.get(role);
+    const stat = lstatSync(canonical);
+    const identity = assembled.identities.get(role);
+    assertDistinctIdentity(seenIdentities, identity, `capture artifact ${role}`);
+    files.push({
+      role,
+      path: portablePath(path.relative(canonicalRoot, canonical)),
+      bytes: stat.size,
+      sha256: packet.raw_artifacts[role],
+    });
+  }
+  for (const [role, filename, file] of [
+    ['capture', capturePath, captureFile],
+    ['packet', resolvedPacketPath, packetFile],
+    ['admission', resolvedAdmissionPath, admissionFile],
+  ]) {
+    files.push({
+      role,
+      path: portablePath(path.relative(resolvedRoot, filename)),
+      bytes: file.bytes.length,
+      sha256: sha256Hex(file.bytes),
+    });
+  }
+
+  return {
+    contract: REVIEW_CONTRACT,
+    packet,
+    admission: recalculatedAdmission,
+    files,
+  };
+};
+
+const renderTable = (headers, rows) => [
+  `| ${headers.join(' | ')} |`,
+  `| ${headers.map(() => '---').join(' | ')} |`,
+  ...rows.map((row) => `| ${row.join(' | ')} |`),
+];
+
+const code = (value) => {
+  const escaped = String(value)
+    .replaceAll('\\', '\\\\')
+    .replaceAll('`', '\\`')
+    .replaceAll('|', '\\|')
+    .replaceAll('\r', ' ')
+    .replaceAll('\n', ' ');
+  return `\`${escaped}\``;
+};
+
+export const renderRetainedPartitionReview = (inspection) => {
+  requireObject(inspection, 'inspection');
+  if (inspection.contract !== REVIEW_CONTRACT) {
+    throw new Error(`inspection.contract must be ${REVIEW_CONTRACT}`);
+  }
+  const { packet, admission, files } = inspection;
+  const measurements = admission.measurements;
+  const lines = [
+    '# Index partition retained bundle review',
+    '',
+    `- Review contract: ${code(REVIEW_CONTRACT)}`,
+    `- Evidence ID: ${code(admission.evidence_id)}`,
+    `- Admission outcome: ${code(admission.outcome)}`,
+    `- Completed at: ${code(admission.completed_at)}`,
+    `- Packet canonical digest: ${code(admission.packet_digest)}`,
+    `- Recalculated admission matches saved admission: ${code(true)}`,
+    `- Retained file count: ${code(files.length)}`,
+    '',
+    '## Run provenance',
+    '',
+    ...renderTable(['Field', 'Value'], [
+      ['Repository', code(admission.run_provenance.repository)],
+      ['Commit', code(admission.run_provenance.commit)],
+      ['Run key', code(admission.run_provenance.run_key)],
+      ['Job', code(admission.run_provenance.job)],
+      ['Runner OS', code(admission.run_provenance.runner_os)],
+      ['Runner architecture', code(admission.run_provenance.runner_arch)],
+    ]),
+    '',
+    '## PostgreSQL identity',
+    '',
+    ...renderTable(['Field', 'Value'], [
+      ['Version', code(packet.database.version)],
+      ['Server version number', code(packet.database.server_version_num)],
+      ['JIT', code(packet.database.jit)],
+      ['System identifier', code(packet.database.system_identifier)],
+      ['Database name', code(packet.database.database_name)],
+    ]),
+    '',
+    '## Calculated measurements',
+    '',
+    ...renderTable(['Measurement', 'Value'], [
+      ['Total rows', code(measurements.total_rows)],
+      ['Total bytes', code(measurements.total_bytes)],
+      ['Distinct tenants', code(measurements.distinct_tenants)],
+      ['Tenant predicate coverage (bps)', code(measurements.tenant_predicate_coverage_bps)],
+      ['Query runs', code(measurements.query_runs)],
+      ['Mutation runs', code(measurements.mutation_runs)],
+      ['Maintenance runs', code(measurements.maintenance_runs)],
+      ['Cutover rehearsals', code(measurements.cutover_rehearsals)],
+      ['Query plan regressions', code(measurements.query_plan_regressions)],
+      ['Maximum query p95 regression (bps)', code(measurements.maximum_query_p95_regression_bps)],
+      ['Maximum mutation p95 regression (bps)', code(measurements.maximum_mutation_p95_regression_bps)],
+      ['Maximum WAL amplification (bps)', code(measurements.maximum_wal_amplification_bps)],
+      ['Maximum partition size/mean (bps)', code(measurements.maximum_partition_size_to_mean_bps)],
+      ['Maximum cutover lock (ms)', code(measurements.maximum_cutover_lock_ms)],
+      ['Entity digest matches', code(measurements.entity_digest_matches)],
+      ['Link digest matches', code(measurements.link_digest_matches)],
+      ['Shadow caught up', code(measurements.shadow_caught_up)],
+      ['Foreign keys validated', code(measurements.foreign_keys_validated)],
+      ['Orphan links', code(measurements.orphan_links)],
+    ]),
+    '',
+    '## Retained file inventory',
+    '',
+    ...renderTable(
+      ['Role', 'Relative path', 'Bytes', 'Exact-byte SHA-256'],
+      files.map((file) => [code(file.role), code(file.path), code(file.bytes), code(file.sha256)]),
+    ),
+    '',
+    '## Admission reasons',
+    '',
+  ];
+  if (admission.reasons.length === 0) {
+    lines.push('- None.');
+  } else {
+    for (const reason of admission.reasons) {
+      lines.push(`- ${code(reason.code)}: ${code(canonicalJson(reason))}`);
+    }
+  }
+  lines.push(
+    '',
+    '## Owner gate',
+    '',
+    '- This read-only report recalculates packet assembly and admission from the retained bundle; it does not create, edit, or admit evidence.',
+    '- Archive the six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` as the authoritative retained inputs.',
+    '- Production partition copy/replay, dual-write, relation cutover, cleanup, and query-adapter work remain forbidden until an owner reviews and archives one complete admitted real bundle.',
+    '',
+  );
+  return lines.join('\n');
+};

--- a/scripts/verify/index-partition-review.test.mjs
+++ b/scripts/verify/index-partition-review.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { assemblePartitionPacket } from './index-partition-evidence-assembly-core.mjs';
+import { prepareManifest, validatePartitionPacket } from './index-partition-evidence-core.mjs';
+
+const script = path.resolve('scripts/verify/render-index-partition-review.mjs');
+const digest = (character) => character.repeat(64);
+
+const writeJson = (filename, value) => writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
+
+const manifestInput = () => ({
+  contract: 'index_partition_evidence_manifest_v1',
+  repository: 'RusTokRs/RusTok',
+  commit: '1'.repeat(40),
+  run_key: 'retained-review-fixture',
+  postgres_image: 'postgres:16',
+  strategy: 'tenant_hash',
+  plan_digest_contract: 'normalized_partition_plan_v1',
+  modulus: 4,
+  locales: ['en-US', 'ru-RU'],
+  repetitions: { query: 1, mutation: 1, maintenance: 1, cutover: 1 },
+  thresholds: {
+    minimum_total_rows: 100,
+    minimum_total_bytes: 1_000,
+    minimum_distinct_tenants: 4,
+    maximum_query_p95_regression_bps: 500,
+    maximum_mutation_p95_regression_bps: 500,
+    maximum_wal_amplification_bps: 11_000,
+    maximum_partition_size_to_mean_bps: 13_000,
+    maximum_cutover_lock_ms: 250,
+  },
+});
+
+const buildBundle = () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'index-partition-review-'));
+  const manifest = prepareManifest(manifestInput());
+  const artifacts = {
+    baseline: {
+      generated_at: '2026-07-27T13:00:00Z',
+      distinct_tenants: 8,
+      tenant_predicate_audit: { total_templates: 12, tenant_scoped_templates: 12 },
+      entities: { rows: 1_000, bytes: 80_000, digest: digest('a') },
+      links: { rows: 2_000, bytes: 120_000, digest: digest('b') },
+    },
+    shadow: {
+      generated_at: '2026-07-27T13:30:00Z',
+      caught_up: true,
+      foreign_keys_validated: true,
+      orphan_links: 0,
+      entities: {
+        rows: 1_000,
+        bytes: 82_000,
+        digest: digest('a'),
+        partition_bytes: [20_000, 20_500, 20_500, 21_000],
+      },
+      links: {
+        rows: 2_000,
+        bytes: 123_000,
+        digest: digest('b'),
+        partition_bytes: [30_000, 30_500, 31_000, 31_500],
+      },
+    },
+    query: [{
+      name: 'filter-sort-1',
+      baseline_p95_ms: 10,
+      shadow_p95_ms: 10.2,
+      baseline_plan_digest: digest('c'),
+      shadow_plan_digest: digest('c'),
+    }],
+    mutation: [{
+      name: 'upsert-1',
+      baseline_p95_ms: 20,
+      shadow_p95_ms: 20.4,
+      baseline_wal_bytes: 1_000,
+      shadow_wal_bytes: 1_040,
+    }],
+    maintenance: [{
+      name: 'vacuum-1',
+      baseline_vacuum_ms: 100,
+      shadow_vacuum_ms: 104,
+      baseline_dead_tuples: 20,
+      shadow_dead_tuples: 18,
+    }],
+    cutover: [{ lock_ms: 50, rollback_verified: true, production_relations_unchanged: true }],
+  };
+  for (const [role, value] of Object.entries(artifacts)) {
+    writeJson(path.join(root, `${role}.json`), value);
+  }
+  const capture = {
+    contract: 'index_partition_capture_v1',
+    completed_at: '2026-07-27T14:00:00Z',
+    run_provenance: {
+      repository: manifest.repository,
+      commit: manifest.commit,
+      run_key: manifest.run_key,
+      job: 'partition-evidence-fixture',
+      runner_os: 'Linux',
+      runner_arch: 'X64',
+    },
+    database: {
+      version: 'PostgreSQL 16.4',
+      server_version_num: '160004',
+      jit: 'off',
+      system_identifier: '7432859712345678901',
+      database_name: 'rustok_index_partition_fixture',
+    },
+    artifacts: Object.fromEntries(Object.keys(artifacts).map((role) => [role, `${role}.json`])),
+  };
+  const capturePath = path.join(root, 'capture.json');
+  writeJson(capturePath, capture);
+  const { packet } = assemblePartitionPacket({ manifest, capturePath, capture });
+  const admission = validatePartitionPacket(packet);
+  writeJson(path.join(root, 'partition-packet.json'), packet);
+  writeJson(path.join(root, 'admission.json'), admission);
+  return { root };
+};
+
+const runReport = (root) => spawnSync(
+  process.execPath,
+  [script, '--root', root],
+  { encoding: 'utf8' },
+);
+
+const snapshot = (root) => Object.fromEntries(
+  readdirSync(root).sort().map((filename) => [filename, readFileSync(path.join(root, filename))]),
+);
+
+test('renders a deterministic read-only nine-file retained bundle review', () => {
+  const context = buildBundle();
+  try {
+    const before = snapshot(context.root);
+    const first = runReport(context.root);
+    const second = runReport(context.root);
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(first.stderr, '');
+    assert.equal(first.stdout, second.stdout);
+    assert.match(first.stdout, /index_partition_retained_bundle_review_v1/u);
+    assert.match(first.stdout, /Admission outcome: `admitted`/u);
+    assert.match(first.stdout, /Retained file count: `9`/u);
+    assert.match(first.stdout, /Recalculated admission matches saved admission: `true`/u);
+    assert.match(first.stdout, /Production partition copy\/replay/u);
+    assert.deepEqual(snapshot(context.root), before);
+  } finally {
+    rmSync(context.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a saved admission that does not match recalculated packet admission', () => {
+  const context = buildBundle();
+  try {
+    const filename = path.join(context.root, 'admission.json');
+    const admission = JSON.parse(readFileSync(filename, 'utf8'));
+    admission.outcome = 'keep_unpartitioned';
+    writeJson(filename, admission);
+    const result = runReport(context.root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /admission file does not match recalculated retained bundle content/u);
+    assert.equal(result.stdout, '');
+  } finally {
+    rmSync(context.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects raw artifact drift from the retained packet', () => {
+  const context = buildBundle();
+  try {
+    const filename = path.join(context.root, 'query.json');
+    const query = JSON.parse(readFileSync(filename, 'utf8'));
+    query[0].shadow_p95_ms = 12;
+    writeJson(filename, query);
+    const result = runReport(context.root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /packet file does not match recalculated retained bundle content/u);
+    assert.equal(result.stdout, '');
+  } finally {
+    rmSync(context.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -22,6 +22,7 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs partition-capture [--plan] --manifest <manifest.json> --query-audit <query-audit.json> --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
+  node scripts/verify/index-storage-tooling.mjs partition-report --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
   node scripts/verify/index-storage-tooling.mjs render --comparison <comparison.json> --decision <decision.json> --output <adr.md>
@@ -36,6 +37,7 @@ Commands:
   partition-capture   Print a no-write preflight plan or run every owner-operated capture, assembly, and validation stage.
   partition-assemble  Build one packet from six retained raw JSON artifacts and exact-byte hashes.
   partition-validate  Validate a measured partition packet and publish calculated admission output.
+  partition-report    Recalculate and render a read-only review of all nine retained bundle files.
   hash                Print the SHA-256 digest of the exact comparison.json bytes.
   prepare             Create a non-overwriting manual decision draft bound to exact comparison bytes.
   render              Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
@@ -113,6 +115,7 @@ const runFixtures = (args) => {
     scriptPath('index-partition-evidence.test.mjs'),
     scriptPath('index-partition-evidence-assembly.test.mjs'),
     scriptPath('index-partition-full-capture-plan.test.mjs'),
+    scriptPath('index-partition-review.test.mjs'),
   ], 'Index storage fixture suites');
 };
 
@@ -210,6 +213,9 @@ switch (command) {
     break;
   case 'partition-validate':
     runScript('validate-index-partition-evidence.mjs', args);
+    break;
+  case 'partition-report':
+    runScript('render-index-partition-review.mjs', args);
     break;
   case 'hash':
     runScript('hash-index-storage-comparison.mjs', args);

--- a/scripts/verify/render-index-partition-review.mjs
+++ b/scripts/verify/render-index-partition-review.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+
+import {
+  inspectRetainedPartitionBundle,
+  renderRetainedPartitionReview,
+} from './index-partition-review-core.mjs';
+
+const prefix = '[render-index-partition-review]';
+
+const usage = () => {
+  console.log(`Usage:
+  node scripts/verify/render-index-partition-review.mjs \\
+    --root <retained-bundle-directory> \\
+    [--packet <partition-packet.json>] \\
+    [--admission <admission.json>]
+
+The command validates and renders the retained bundle to stdout. It writes no files.`);
+};
+
+const parseArgs = (args) => {
+  if (args.length === 1 && ['--help', '-h'].includes(args[0])) return null;
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--root', '--packet', '--admission'].includes(flag) || !value || value.startsWith('--')) {
+      throw new Error('expected --root and optional --packet/--admission pairs');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  if (!values.has('--root')) throw new Error('--root is required');
+  return {
+    root: path.resolve(values.get('--root')),
+    packetPath: values.has('--packet') ? path.resolve(values.get('--packet')) : undefined,
+    admissionPath: values.has('--admission') ? path.resolve(values.get('--admission')) : undefined,
+  };
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options === null) {
+    usage();
+  } else {
+    const inspection = inspectRetainedPartitionBundle(options);
+    process.stdout.write(renderRetainedPartitionReview(inspection));
+  }
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -26,6 +26,9 @@ try {
   const module = read('ops/benches/src/index_storage/mod.rs');
   const orchestrator = read('scripts/verify/run-index-partition-evidence.mjs');
   const planTest = read('scripts/verify/index-partition-full-capture-plan.test.mjs');
+  const reviewCore = read('scripts/verify/index-partition-review-core.mjs');
+  const reviewCli = read('scripts/verify/render-index-partition-review.mjs');
+  const reviewTest = read('scripts/verify/index-partition-review.test.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
   const plan = read('crates/rustok-index/docs/implementation-plan.md');
@@ -106,10 +109,51 @@ try {
     'INDEX_PARTITION_QUERY_AUDIT',
     'plan refuses partial output reuse without starting Cargo',
   ], 'full capture plan fixture');
+  requireMarkers(reviewCore, [
+    'index_partition_retained_bundle_review_v1',
+    'RAW_ARTIFACT_ROLES',
+    'assemblePartitionPacket',
+    'assertCanonicalMatch(packet, assembled.packet',
+    'validatePartitionPacket(packet)',
+    'assertCanonicalMatch(admission, recalculatedAdmission',
+    'aliases another retained bundle file',
+    'sha256Hex(file.bytes)',
+    'Exact-byte SHA-256',
+    'does not create, edit, or admit evidence',
+    'Production partition copy/replay',
+  ], 'retained partition review core');
+  requireMarkers(reviewCli, [
+    "'--root'",
+    "'--packet'",
+    "'--admission'",
+    'inspectRetainedPartitionBundle',
+    'renderRetainedPartitionReview',
+    'process.stdout.write',
+    'It writes no files.',
+  ], 'retained partition review CLI');
+  forbidMarkers(`${reviewCore}\n${reviewCli}`, [
+    'writeFileSync',
+    'mkdirSync',
+    'renameSync',
+    'rmSync',
+    'spawnSync',
+    'DATABASE_URL',
+    'INDEX_PARTITION_ALLOW',
+  ], 'retained partition review tooling');
+  requireMarkers(reviewTest, [
+    'renders a deterministic read-only nine-file retained bundle review',
+    'Retained file count: `9`',
+    'assert.deepEqual(snapshot(context.root), before)',
+    'saved admission that does not match recalculated packet admission',
+    'rejects raw artifact drift from the retained packet',
+  ], 'retained partition review fixture');
   requireMarkers(tooling, [
     'partition-capture',
     'run-index-partition-evidence.mjs',
     'index-partition-full-capture-plan.test.mjs',
+    'partition-report',
+    'render-index-partition-review.mjs',
+    'index-partition-review.test.mjs',
     'verify-index-partition-full-capture.mjs',
   ], 'index storage tooling router');
   requireMarkers(runbook, [
@@ -123,6 +167,10 @@ try {
     'does not print the `DATABASE_URL` value',
     'INDEX_PARTITION_ALLOW_FULL_CAPTURE=1',
     'index-partition-capture-finalize',
+    'partition-report',
+    'all nine retained files',
+    'recalculates packet assembly and admission',
+    'writes no files',
     'forbidden before one retained admitted packet',
   ], 'full partition capture runbook');
   requireMarkers(plan, [


### PR DESCRIPTION
## Summary

- add `partition-report`, a read-only owner command for reviewing a completed retained partition bundle;
- require all six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` to remain regular, non-symlink files inside one retained root;
- reuse the existing packet assembler to recalculate the packet from retained bytes and reject raw-artifact or packet drift;
- reuse the existing admission validator to recalculate admission and reject stale or edited `admission.json`;
- require all nine retained files to have distinct filesystem identities;
- print a deterministic Markdown review with exact-byte SHA-256 inventory, provenance, PostgreSQL identity, calculated measurements, outcome, and typed reasons;
- keep report mode strictly read-only: no file writes, PostgreSQL connection, Cargo command, or evidence stage;
- register the command and fixture, add static no-write guards, and document the owner review/archive step.

## Safety boundary

This PR only adds inspection and reporting around already-produced evidence. It does not create or admit evidence and does not add production partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter behavior. Production lifecycle work remains forbidden until an owner executes, reviews, and archives one complete admitted real bundle.

## Validation

Tests, fixture suites, contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run, per repository-owner instruction.

Only JavaScript syntax checks were performed on the local draft before publication:

```bash
node --check scripts/verify/index-partition-review-core.mjs
node --check scripts/verify/render-index-partition-review.mjs
node --check scripts/verify/index-partition-review.test.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
```

Suggested owner checks:

```bash
node scripts/verify/verify-index-partition-full-capture.mjs
node --test scripts/verify/index-partition-review.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

## Owner usage

```bash
node scripts/verify/index-storage-tooling.mjs partition-report \
  --root evidence/index-partition/retained-run
```

The Markdown report is derived output. The six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` remain the authoritative archive inputs.