### PR TITLE
feat(profiles): expose count-only poison receipt health

### DIFF
--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -99,6 +99,8 @@ pub mod server_bootstrap;
 pub mod server_runtime_context;
 pub mod settings_service;
 #[cfg(feature = "mod-social_graph")]
+pub mod social_graph_index_poison_observer;
+#[cfg(feature = "mod-social_graph")]
 pub mod social_graph_index_position_observer;
 #[cfg(feature = "mod-social_graph")]
 pub mod social_graph_index_worker;

--- a/apps/server/src/services/runtime_guardrails.rs
+++ b/apps/server/src/services/runtime_guardrails.rs
@@ -12,6 +12,8 @@ use crate::services::seo_redirect_cache_reconciliation::{
 };
 use crate::services::server_runtime_context::ServerRuntimeContext;
 #[cfg(feature = "mod-social_graph")]
+use crate::services::social_graph_index_poison_observer::SocialGraphIndexPoisonObserverHandle;
+#[cfg(feature = "mod-social_graph")]
 use crate::services::social_graph_index_worker::{
     SocialGraphIndexWorkerHandle, social_graph_index_consumer_enabled,
 };
@@ -114,13 +116,22 @@ fn observe_social_graph_index_worker(
 ) {
     match social_graph_index_consumer_enabled() {
         Ok(false) => {}
-        Ok(true) => observe_worker(
-            snapshot,
-            "Social Graph Index durable consumer",
-            ctx.shared_get::<SocialGraphIndexWorkerHandle>()
-                .map(|handle| handle.is_ready()),
-            RuntimeGuardrailStatus::Critical,
-        ),
+        Ok(true) => {
+            observe_worker(
+                snapshot,
+                "Social Graph Index durable consumer",
+                ctx.shared_get::<SocialGraphIndexWorkerHandle>()
+                    .map(|handle| handle.is_ready()),
+                RuntimeGuardrailStatus::Critical,
+            );
+            observe_worker(
+                snapshot,
+                "Social Graph Index poison receipt observer",
+                ctx.shared_get::<SocialGraphIndexPoisonObserverHandle>()
+                    .map(|handle| handle.is_ready()),
+                RuntimeGuardrailStatus::Degraded,
+            );
+        }
         Err(error) => escalate_snapshot(
             snapshot,
             RuntimeGuardrailStatus::Critical,

--- a/apps/server/src/services/server_bootstrap.rs
+++ b/apps/server/src/services/server_bootstrap.rs
@@ -155,6 +155,12 @@ pub async fn bootstrap_application_router(
     )
     .await?;
 
+    #[cfg(feature = "mod-social_graph")]
+    crate::services::social_graph_index_poison_observer::start_social_graph_index_poison_observer_if_enabled(
+        &runtime_ctx,
+    )
+    .await?;
+
     connect_runtime_workers_with_runtime(runtime_ctx.clone()).await?;
     tracing::info!("RusTok runtime workers connected");
 

--- a/apps/server/src/services/social_graph_index_poison_observer.rs
+++ b/apps/server/src/services/social_graph_index_poison_observer.rs
@@ -56,7 +56,7 @@ pub async fn start_social_graph_index_poison_observer_if_enabled(
 
     let poll = match poison_poll_interval() {
         Ok(poll) => poll,
-        Err(error) => {
+        Err(_) => {
             consumer_poison_metrics::record_unavailable(METRICS_CONSUMER);
             runtime_consumer_metrics::record_failure(
                 METRICS_CONSUMER,
@@ -65,7 +65,7 @@ pub async fn start_social_graph_index_poison_observer_if_enabled(
             );
             tracing::warn!(
                 worker = METRICS_CONSUMER,
-                error = %error,
+                error_code = CONFIGURATION_ERROR,
                 "Consumer poison observer configuration is invalid; projection remains active"
             );
             return Ok(());
@@ -120,7 +120,6 @@ async fn poison_observer_loop(
                 tracing::warn!(
                     worker = METRICS_CONSUMER,
                     error_code = error.stable_code(),
-                    error = %error,
                     "Count-only poison receipt snapshot failed; projection remains active"
                 );
             }

--- a/apps/server/src/services/social_graph_index_poison_observer.rs
+++ b/apps/server/src/services/social_graph_index_poison_observer.rs
@@ -1,0 +1,201 @@
+use std::env;
+use std::time::Duration;
+
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonReceiptInspector, ConsumerPoisonReceiptSummary,
+};
+use rustok_social_graph::index_consumer::SOCIAL_GRAPH_INDEX_CONSUMER_GROUP;
+use rustok_telemetry::{consumer_poison_metrics, runtime_consumer_metrics};
+use tokio::task::JoinHandle;
+
+use crate::error::{Error, Result};
+use crate::services::app_lifecycle::StopHandle;
+use crate::services::server_runtime_context::ServerRuntimeContext;
+use crate::services::social_graph_index_worker::social_graph_index_consumer_enabled;
+
+const POLL_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_POLL_MS";
+const DEFAULT_POLL_MS: u64 = 5_000;
+const MAX_POLL_MS: u64 = 300_000;
+const METRICS_CONSUMER: &str = "social_graph_index";
+const STAGE_POISON_SNAPSHOT: &str = "poison_receipt_snapshot";
+const CONFIGURATION_ERROR: &str = "iggy.connector.poison_inspection_configuration_invalid";
+
+pub struct SocialGraphIndexPoisonObserverHandle {
+    handle: JoinHandle<()>,
+}
+
+impl SocialGraphIndexPoisonObserverHandle {
+    pub fn is_ready(&self) -> bool {
+        !self.handle.is_finished()
+    }
+}
+
+/// Starts a count-only observer for connector-owned neutral poison receipts.
+///
+/// The observer reads one aggregate row for the fixed Social Graph Index consumer group. It never
+/// claims, releases, publishes, acknowledges, repairs, retains, or deletes a receipt and never
+/// exposes delivery identifiers, source coordinates, payloads, error classifications, publisher
+/// identities, or timestamps as metric labels.
+pub async fn start_social_graph_index_poison_observer_if_enabled(
+    ctx: &ServerRuntimeContext,
+) -> Result<()> {
+    if !ctx.settings().runtime.runs_background_workers()
+        || ctx.shared_contains::<SocialGraphIndexPoisonObserverHandle>()
+        || !social_graph_index_consumer_enabled()?
+    {
+        return Ok(());
+    }
+
+    if let Err(error) = consumer_poison_metrics::ensure_registered() {
+        tracing::debug!(
+            worker = METRICS_CONSUMER,
+            error = %error,
+            "Consumer poison metrics are unavailable"
+        );
+    }
+
+    let poll = match poison_poll_interval() {
+        Ok(poll) => poll,
+        Err(error) => {
+            consumer_poison_metrics::record_unavailable(METRICS_CONSUMER);
+            runtime_consumer_metrics::record_failure(
+                METRICS_CONSUMER,
+                STAGE_POISON_SNAPSHOT,
+                CONFIGURATION_ERROR,
+            );
+            tracing::warn!(
+                worker = METRICS_CONSUMER,
+                error = %error,
+                "Consumer poison observer configuration is invalid; projection remains active"
+            );
+            return Ok(());
+        }
+    };
+
+    if !ctx.shared_contains::<StopHandle>() {
+        let (stop_handle, _stop_rx) = StopHandle::new();
+        ctx.shared_insert(stop_handle);
+    }
+    let stop_rx = ctx
+        .shared_get::<StopHandle>()
+        .expect("StopHandle must exist before poison observer startup")
+        .subscribe();
+    let inspector = ConsumerPoisonReceiptInspector::new(ctx.db_clone());
+
+    tracing::info!(
+        worker = METRICS_CONSUMER,
+        poll_ms = duration_millis(poll),
+        consumer_group = SOCIAL_GRAPH_INDEX_CONSUMER_GROUP,
+        "Starting count-only Social Graph Index poison receipt observer"
+    );
+    ctx.shared_insert(SocialGraphIndexPoisonObserverHandle {
+        handle: tokio::spawn(poison_observer_loop(inspector, poll, stop_rx)),
+    });
+    Ok(())
+}
+
+async fn poison_observer_loop(
+    inspector: ConsumerPoisonReceiptInspector,
+    poll: Duration,
+    mut stop_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        if *stop_rx.borrow() {
+            consumer_poison_metrics::record_unavailable(METRICS_CONSUMER);
+            return;
+        }
+
+        match inspector
+            .summarize(SOCIAL_GRAPH_INDEX_CONSUMER_GROUP)
+            .await
+        {
+            Ok(summary) => record_summary(&summary),
+            Err(error) => {
+                consumer_poison_metrics::record_unavailable(METRICS_CONSUMER);
+                runtime_consumer_metrics::record_failure(
+                    METRICS_CONSUMER,
+                    STAGE_POISON_SNAPSHOT,
+                    error.stable_code(),
+                );
+                tracing::warn!(
+                    worker = METRICS_CONSUMER,
+                    error_code = error.stable_code(),
+                    error = %error,
+                    "Count-only poison receipt snapshot failed; projection remains active"
+                );
+            }
+        }
+
+        if wait_or_stop(poll, &mut stop_rx).await {
+            consumer_poison_metrics::record_unavailable(METRICS_CONSUMER);
+            return;
+        }
+    }
+}
+
+fn record_summary(summary: &ConsumerPoisonReceiptSummary) {
+    consumer_poison_metrics::record_snapshot(
+        METRICS_CONSUMER,
+        summary.total(),
+        summary.reserved(),
+        summary.publishing(),
+        summary.expired_publishing(),
+        summary.published(),
+        summary.acknowledged(),
+    );
+    tracing::debug!(
+        worker = METRICS_CONSUMER,
+        total = summary.total(),
+        reserved = summary.reserved(),
+        publishing = summary.publishing(),
+        expired_publishing = summary.expired_publishing(),
+        published = summary.published(),
+        acknowledged = summary.acknowledged(),
+        "Recorded count-only neutral poison receipt snapshot"
+    );
+}
+
+fn poison_poll_interval() -> Result<Duration> {
+    let value = match env::var(POLL_ENV) {
+        Ok(value) => value
+            .parse::<u64>()
+            .map_err(|error| Error::Message(format!("{POLL_ENV} is invalid: {error}")))?,
+        Err(env::VarError::NotPresent) => DEFAULT_POLL_MS,
+        Err(error) => {
+            return Err(Error::Message(format!(
+                "failed to read {POLL_ENV}: {error}"
+            )));
+        }
+    };
+    if value == 0 || value > MAX_POLL_MS {
+        return Err(Error::Message(format!(
+            "{POLL_ENV} must be between 1 and {MAX_POLL_MS}"
+        )));
+    }
+    Ok(Duration::from_millis(value))
+}
+
+async fn wait_or_stop(
+    delay: Duration,
+    stop_rx: &mut tokio::sync::watch::Receiver<bool>,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => false,
+        changed = stop_rx.changed() => changed.is_err() || *stop_rx.borrow(),
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_interval_is_bounded() {
+        assert_eq!(duration_millis(Duration::from_secs(5)), 5_000);
+        assert_eq!(MAX_POLL_MS, 300_000);
+    }
+}

--- a/crates/rustok-iggy-connector/docs/implementation-plan.md
+++ b/crates/rustok-iggy-connector/docs/implementation-plan.md
@@ -28,7 +28,7 @@ Receipt states are `reserved`, leased `publishing`, terminal `published`, and
 post-source-commit `acknowledged`. The store performs no broker publication, DLQ routing,
 source acknowledgement, authorization, or policy selection.
 
-`ConsumerPoisonReceiptInspector` now provides one read-only aggregate snapshot for a
+`ConsumerPoisonReceiptInspector` provides one read-only aggregate snapshot for a
 validated consumer group. It exposes only total, reserved, publishing, expired-
 publishing, published, and acknowledged counts. Unknown/corrupt states fail closed when
 the known-state sum differs from total, and an expired-publishing count cannot exceed
@@ -36,13 +36,18 @@ publishing. The inspector never returns delivery identifiers, source coordinates
 payloads, classifications, publisher identities, or timestamps and performs no claim,
 repair, retention, deletion, publication, or acknowledgement action.
 
-The first approved consumer is now wired at the owner/server layer. The Social Graph
-Index worker constructs `ConsumerPoisonIdentity`, recognizes an existing receipt before
-applying current DLQ policy, reserves/claims new work, publishes exact bytes through
-`rustok-iggy`, persists `published`, commits the source cursor, and then records
-`acknowledged` as best-effort bookkeeping. This composition remains outside the
-connector store. Existing durable work continues recovery if new DLQ decisions are
-later disabled.
+The Social Graph Index owner/server path now composes both durable recovery and
+read-only observation. The worker constructs `ConsumerPoisonIdentity`, recognizes an
+existing receipt before applying current DLQ policy, reserves/claims new work, publishes
+exact bytes through `rustok-iggy`, persists `published`, commits the source cursor, and
+then records `acknowledged` as best-effort bookkeeping. A separate observer polls only
+the inspector aggregate and exports bounded Prometheus counts. Observer failure clears
+stale metrics and never stops projection.
+
+The explicit platform append-only migration tail now includes both
+`m20260727_000004_create_index_dlq_receipts` and
+`m20260728_000001_create_consumer_poison_receipts`, preserving the previously published
+migration prefix.
 
 ## FFA/FBA boundary
 
@@ -72,8 +77,10 @@ later disabled.
 - Aggregate inspection is consumer-group scoped, count-only, and read-only. Alert
   thresholds, reclaim decisions, repair, and retention remain operator policy outside
   this crate.
+- Telemetry consumes aggregate values only. It cannot call receipt transition methods or
+  derive labels from delivery-level facts.
 - Profiles and Social Graph must never authorize from this receipt, its aggregate
-  inspection, or any broker state.
+  inspection, metrics, or any broker state.
 - The server enables feature `migrations` explicitly when it composes the neutral store;
   runtime availability does not rely on transitive feature unification.
 - Existing source guard: `node scripts/verify/verify-iggy-connector-source.mjs`.
@@ -81,6 +88,8 @@ later disabled.
   `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`.
 - Aggregate inspection guard:
   `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`.
+- Owner observer/metrics guard:
+  `node scripts/verify/verify-social-graph-index-poison-observer.mjs`.
 
 ## Delivered results
 
@@ -98,29 +107,30 @@ later disabled.
 5. **Read-only operational inspection.** One bounded consumer-group query reports
    known-state and expired-lease counts, rejects corrupt aggregate state, and exposes no
    delivery-level facts or mutation side effects.
+6. **Append-only release order.** Both receipt migrations extend the explicit platform
+   tail without rewriting the previously published prefix.
+7. **Count-only owner observability.** A separate server observer exports fixed receipt
+   states, snapshot availability, and snapshot time; unavailable inspection clears stale
+   gauges and leaves recovery behavior unchanged.
 
 ## Next results
 
-1. **Reconcile the append-only migration tail.** Add the already-present Social Graph
-   Index DLQ migration and this connector poison migration to the explicit platform
-   release-order tail before migration compatibility validation. Do not rewrite the
-   previously published prefix; reconcile current `main` and refresh `Cargo.lock`.
-2. **Verify real Iggy SDK receive and commit.** Prove validated and malformed delivery,
+1. **Verify real Iggy SDK receive and commit.** Prove validated and malformed delivery,
    exact publish-before-ack ordering, acknowledgement-only redelivery, reconnect, exact
    commit, publication failure, restart, and multi-replica behavior in bundled and
    external environments.
-3. **Verify PostgreSQL receipt concurrency and inspection.** Prove claim ownership,
+2. **Verify PostgreSQL receipt concurrency and inspection.** Prove claim ownership,
    lease expiry and reclaim, UUID/source collisions, first-diagnostic retention,
-   rollback, terminal recognition, aggregate consistency, and read-only inspection under
-   multiple workers.
-4. **Harden lifecycle failure behavior.** Define reconnect/backoff, authentication, TLS,
+   rollback, terminal recognition, aggregate consistency, read-only inspection, and
+   observer behavior under multiple workers.
+3. **Harden lifecycle failure behavior.** Define reconnect/backoff, authentication, TLS,
    existing-topology validation, batching, and shutdown semantics without simulated
    fallback.
-5. **Publish operational guarantees.** Compose count-only health/metrics and an operator
-   runbook for disconnected/stalled subscribers, poison receipt claims, publication
-   ambiguity, and recovery. Keep alert thresholds, reclaim, repair, and retention as
-   explicit reviewed policy rather than storage side effects.
-6. **Complete packaging evidence.** Prove bundled distributions install the pinned
+4. **Retain operational evidence.** Exercise count-only metrics, unavailable snapshot
+   clearing, expired-lease diagnosis, publication ambiguity, and acknowledgement-only
+   recovery. Keep alert thresholds, reclaim, repair, and retention as explicit reviewed
+   policy rather than storage side effects.
+5. **Complete packaging evidence.** Prove bundled distributions install the pinned
    server artifact and external-only distributions omit it.
 
 ## Verification
@@ -130,20 +140,22 @@ later disabled.
 - `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
 - `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
+- `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
+- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`
 - Bundled/external Iggy integration evidence for receive, scoped ack, reconnect,
-  TLS/auth failure, poison publication/recovery, inspection, and shutdown.
+  TLS/auth failure, poison publication/recovery, inspection, metrics, and shutdown.
 
 Tests, Cargo commands, formatting, verifiers, database scenarios, and real-broker
-scenarios remain maintainer-run and were not executed in this slice. `Cargo.lock` must
-be refreshed after reconciliation with current `main`.
+scenarios remain maintainer-run and were not executed in this slice.
 
 ## References
 
 - [Crate README](../README.md)
 - [Module documentation](./README.md)
 - [Iggy transport plan](../../rustok-iggy/docs/implementation-plan.md)
+- [Poison observer runbook](../../rustok-social-graph/docs/index-poison-receipt-observer.md)
 - [Iggy integration reference](../../../docs/references/iggy/README.md)

--- a/crates/rustok-social-graph/docs/index-poison-receipt-observer.md
+++ b/crates/rustok-social-graph/docs/index-poison-receipt-observer.md
@@ -49,6 +49,16 @@ The `state` label is restricted to:
 
 Unix timestamp of the latest successful snapshot. It is reset to zero when inspection is unavailable or the observer stops.
 
+## Runtime health
+
+When the Social Graph Index consumer is enabled, runtime guardrails require the observer handle to exist and its task to remain active. A missing or stopped observer reports `Degraded`, not `Critical`:
+
+- projection and source acknowledgement continue independently;
+- receipt counts do not influence worker readiness;
+- the health signal exists only to prevent a dead observer from leaving stale metrics without an explicit operational symptom.
+
+Runtime rollout mode still controls whether an observed degraded condition is enforced or reported through observation mode.
+
 ## Cardinality and privacy boundary
 
 Metrics never expose or label by:
@@ -60,7 +70,7 @@ Metrics never expose or label by:
 - publisher identity or lease timestamp;
 - tenant, actor, relation, or event identity.
 
-Logs contain only the same aggregate counts plus a bounded stable error code when inspection fails.
+Successful logs contain only the same aggregate counts. Inspection failure logs contain a bounded stable error code and omit the underlying storage error text.
 
 ## Operator policy
 

--- a/crates/rustok-social-graph/docs/index-poison-receipt-observer.md
+++ b/crates/rustok-social-graph/docs/index-poison-receipt-observer.md
@@ -1,0 +1,89 @@
+# Social Graph Index poison receipt observer
+
+## Purpose
+
+The Social Graph Index worker can persist neutral connector receipts when broker bytes cannot be decoded into a trusted event. `social_graph_index_poison_observer` provides count-only operational visibility over those receipts without entering the delivery recovery path.
+
+The observer is read-only. It does not claim or release publication leases, publish a DLQ entry, acknowledge a source cursor, repair rows, choose retention, or delete receipts. Profiles privacy and Social Graph authorization remain independent of these metrics.
+
+## Startup
+
+The observer starts only when all of the following are true:
+
+- the server host runs background workers;
+- the Social Graph Index durable consumer is explicitly enabled;
+- an observer handle is not already registered in `ServerRuntimeContext`.
+
+The poll interval is controlled by `RUSTOK_SOCIAL_GRAPH_INDEX_POISON_POLL_MS`.
+
+- default: `5000` milliseconds;
+- minimum: `1` millisecond;
+- maximum: `300000` milliseconds.
+
+An invalid value records the snapshot as unavailable and leaves projection active.
+
+## Metrics
+
+All metrics use the fixed consumer label `social_graph_index`.
+
+### `rustok_runtime_consumer_poison_receipts`
+
+Gauge labels: `consumer`, `state`.
+
+The `state` label is restricted to:
+
+- `total`;
+- `reserved`;
+- `publishing`;
+- `expired_publishing`;
+- `published`;
+- `acknowledged`.
+
+`expired_publishing` is a subset of `publishing`. The connector inspector fails closed if known states do not sum to `total` or if expired claims exceed publishing receipts.
+
+### `rustok_runtime_consumer_poison_snapshot_available`
+
+`1` means the latest aggregate query succeeded. `0` means inspection is unavailable. On failure, all receipt count gauges are reset to zero so stale counts cannot appear current.
+
+### `rustok_runtime_consumer_poison_snapshot_timestamp_seconds`
+
+Unix timestamp of the latest successful snapshot. It is reset to zero when inspection is unavailable or the observer stops.
+
+## Cardinality and privacy boundary
+
+Metrics never expose or label by:
+
+- delivery UUID;
+- stream, topic, partition, or offset;
+- payload or payload hash;
+- decode error classification;
+- publisher identity or lease timestamp;
+- tenant, actor, relation, or event identity.
+
+Logs contain only the same aggregate counts plus a bounded stable error code when inspection fails.
+
+## Operator policy
+
+The repository does not prescribe universal alert thresholds. Operators must choose thresholds from deployment traffic, poll interval, retry policy, and broker deduplication retention.
+
+Useful conditions to evaluate externally include:
+
+- snapshot availability remaining zero beyond the expected database recovery window;
+- `expired_publishing` remaining non-zero across multiple polls;
+- `reserved` or `publishing` increasing while consumer lag also increases;
+- `published` remaining non-zero, which indicates acknowledgement-only recovery work;
+- sustained growth in `total` relative to the deployment's receipt retention policy.
+
+Metrics are diagnostic inputs only. An alert or dashboard must not trigger automatic reclaim, acknowledgement, deletion, authorization, or privacy decisions.
+
+## Maintainer verification
+
+```bash
+RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets
+RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets
+cargo test -p rustok-telemetry consumer_poison_metrics -- --nocapture
+cargo test -p rustok-server social_graph_index_poison_observer -- --nocapture
+node scripts/verify/verify-social-graph-index-poison-observer.mjs
+```
+
+These commands are maintainer-run. They were not executed when the source slice was authored.

--- a/crates/rustok-telemetry/docs/implementation-plan.md
+++ b/crates/rustok-telemetry/docs/implementation-plan.md
@@ -7,9 +7,9 @@ registry, and neutral instrumentation helpers. `apps/server` composes process-wi
 bootstrap; modules and runtime workers own metric meaning, bounded label values,
 alert thresholds, and runbooks.
 
-The shared runtime-consumer collector now covers throughput, terminal outcomes,
-retries, bounded failures, DLQ publication, processing duration, lifecycle,
-in-flight state/timestamps, last success, and broker-backed consumer lag.
+The shared runtime-consumer collector covers throughput, terminal outcomes, retries,
+bounded failures, DLQ publication, processing duration, lifecycle, in-flight
+state/timestamps, last success, and broker-backed consumer lag.
 
 Consumer lag is accepted only from a partition-qualified snapshot that reads every
 topic partition and its persistent group checkpoint. The collector publishes snapshot
@@ -17,9 +17,16 @@ time, partition count, completeness, and bounded `total`/`max` lag aggregations.
 Incomplete snapshots clear lag values and set completeness to zero so stale lag cannot
 be mistaken for a current observation.
 
-No runtime-consumer metric uses tenant, event, relation, partition, offset, payload,
-ack-token, credential, or raw error-message values as labels. Lag is never inferred
-from event age, processing duration, one delivered offset, or a local cursor counter.
+The separate `consumer_poison_metrics` collector now exposes one count-only neutral
+receipt snapshot for a bounded durable consumer. It publishes fixed states `total`,
+`reserved`, `publishing`, `expired_publishing`, `published`, and `acknowledged`, plus
+snapshot availability and timestamp. Inspection failure or observer shutdown clears
+all counts and timestamp so stale values cannot appear current.
+
+No runtime-consumer or poison-receipt metric uses tenant, event, relation, partition,
+offset, payload, delivery UUID, publisher identity, acknowledgement token, credential,
+or raw error-message values as labels. Lag is never inferred from event age,
+processing duration, one delivered offset, or a local cursor counter.
 
 ## Boundary
 
@@ -32,8 +39,10 @@ from event age, processing duration, one delivered offset, or a local cursor cou
   thresholds, and operational response.
 - Runtime collectors register through `register_runtime_collector`; a second global
   registry is forbidden.
-- Dynamic identities, raw positions, payloads, claims, credentials, and storage causes
-  are forbidden as metric labels.
+- Dynamic identities, raw positions, payloads, claims, credentials, storage causes,
+  and unbounded error values are forbidden as metric labels.
+- Metrics provide observations only. They never acknowledge, reclaim, repair, delete,
+  retain, authorize, or select delivery policy.
 
 ## Delivered result: bounded runtime consumer metrics
 
@@ -57,17 +66,37 @@ from event age, processing duration, one delivered offset, or a local cursor cou
 - Static verification guards names, label sets, completeness clearing, broker-backed
   snapshot origin, DLQ ordering, and acknowledgement-only recovery.
 
+## Delivered result: count-only poison receipt metrics
+
+- `consumer_poison_metrics::ensure_registered` installs a separate bounded collector in
+  the same process registry.
+- `rustok_runtime_consumer_poison_receipts{consumer,state}` reports only six fixed
+  aggregate states.
+- `rustok_runtime_consumer_poison_snapshot_available` distinguishes a real all-zero
+  snapshot from unavailable storage inspection.
+- `rustok_runtime_consumer_poison_snapshot_timestamp_seconds` identifies the latest
+  successful snapshot and resets to zero when unavailable.
+- Counts saturate at the Prometheus signed gauge range instead of wrapping.
+- The Social Graph Index owner observer supplies only connector-validated aggregates,
+  uses one fixed consumer label, logs bounded stable failure codes, and leaves
+  projection active on inspection failure.
+- Alert thresholds and any reclaim, repair, or retention response remain external
+  reviewed operator policy.
+
 ## Next results
 
 1. **Prove bootstrap and shutdown behavior in every host mode.** Cover native server,
    CLI compatibility, OTel enabled/disabled, metrics disabled, repeated initialization,
-   dynamic collector registration, and graceful exporter shutdown.
+   dynamic collector registration, poison observer shutdown, and graceful exporter
+   shutdown.
 2. **Harden the shared metrics contract.** Add focused coverage for duplicate/concurrent
    registration, disabled telemetry, collector rendering, bounded labels, incomplete
-   snapshot clearing, and worker termination with an unacknowledged delivery.
-3. **Retain live lag evidence.** Verify every-partition Iggy snapshots, concurrent broker
-   movement during capture, missing checkpoints, observer reconnect, TLS/auth failure,
-   and multi-replica group semantics before defining alerts.
+   snapshot clearing, poison snapshot unavailability, and worker termination with an
+   unacknowledged delivery.
+3. **Retain live lag and receipt evidence.** Verify every-partition Iggy snapshots,
+   concurrent broker movement, missing checkpoints, observer reconnect, PostgreSQL
+   aggregate consistency, expired leases, TLS/auth failure, and multi-replica semantics
+   before selecting alerts.
 4. **Align module instrumentation with operations.** Validate representative modules and
    `/metrics` against a small correlation/service-health convention without moving
    domain semantics or runbooks into this crate.
@@ -79,6 +108,7 @@ from event age, processing duration, one delivered offset, or a local cursor cou
 - `node scripts/verify/verify-runtime-consumer-metrics.mjs`
 - `node scripts/verify/verify-iggy-consumer-position.mjs`
 - `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
+- `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
 - `scripts/verify/verify-architecture.sh`
 - Targeted `/metrics`, bootstrap, registration, snapshot, and shutdown tests.
 

--- a/crates/rustok-telemetry/src/consumer_poison_metrics.rs
+++ b/crates/rustok-telemetry/src/consumer_poison_metrics.rs
@@ -1,0 +1,187 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use lazy_static::lazy_static;
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::MetricFamily;
+use prometheus::{IntGaugeVec, Opts};
+
+const STATES: [&str; 6] = [
+    "total",
+    "reserved",
+    "publishing",
+    "expired_publishing",
+    "published",
+    "acknowledged",
+];
+
+#[derive(Clone)]
+struct ConsumerPoisonMetrics {
+    receipts: IntGaugeVec,
+    snapshot_available: IntGaugeVec,
+    snapshot_timestamp_seconds: IntGaugeVec,
+}
+
+impl ConsumerPoisonMetrics {
+    fn new() -> Self {
+        Self {
+            receipts: IntGaugeVec::new(
+                Opts::new(
+                    "rustok_runtime_consumer_poison_receipts",
+                    "Count-only neutral poison receipts by bounded durable state",
+                ),
+                &["consumer", "state"],
+            )
+            .expect("Failed to create consumer poison receipt gauge"),
+            snapshot_available: IntGaugeVec::new(
+                Opts::new(
+                    "rustok_runtime_consumer_poison_snapshot_available",
+                    "Whether the latest count-only poison receipt snapshot is available",
+                ),
+                &["consumer"],
+            )
+            .expect("Failed to create consumer poison snapshot availability gauge"),
+            snapshot_timestamp_seconds: IntGaugeVec::new(
+                Opts::new(
+                    "rustok_runtime_consumer_poison_snapshot_timestamp_seconds",
+                    "Unix timestamp of the latest available count-only poison receipt snapshot",
+                ),
+                &["consumer"],
+            )
+            .expect("Failed to create consumer poison snapshot timestamp gauge"),
+        }
+    }
+}
+
+impl Collector for ConsumerPoisonMetrics {
+    fn desc(&self) -> Vec<&Desc> {
+        let mut descriptions = Vec::new();
+        descriptions.extend(self.receipts.desc());
+        descriptions.extend(self.snapshot_available.desc());
+        descriptions.extend(self.snapshot_timestamp_seconds.desc());
+        descriptions
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut families = Vec::new();
+        families.extend(self.receipts.collect());
+        families.extend(self.snapshot_available.collect());
+        families.extend(self.snapshot_timestamp_seconds.collect());
+        families
+    }
+}
+
+lazy_static! {
+    static ref CONSUMER_POISON_METRICS: ConsumerPoisonMetrics = ConsumerPoisonMetrics::new();
+}
+
+static CONSUMER_POISON_METRICS_REGISTERING: AtomicBool = AtomicBool::new(false);
+
+/// Registers the count-only neutral poison-receipt collector after telemetry initialization.
+///
+/// Metric names and state labels are fixed. Callers must use a bounded consumer identifier and
+/// must not derive labels from delivery identifiers, source coordinates, errors, or payloads.
+pub fn ensure_registered() -> Result<(), prometheus::Error> {
+    if CONSUMER_POISON_METRICS_REGISTERING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    match crate::register_runtime_collector(Box::new(CONSUMER_POISON_METRICS.clone())) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            CONSUMER_POISON_METRICS_REGISTERING.store(false, Ordering::Release);
+            Err(error)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn record_snapshot(
+    consumer: &str,
+    total: u64,
+    reserved: u64,
+    publishing: u64,
+    expired_publishing: u64,
+    published: u64,
+    acknowledged: u64,
+) {
+    for (state, value) in STATES.into_iter().zip([
+        total,
+        reserved,
+        publishing,
+        expired_publishing,
+        published,
+        acknowledged,
+    ]) {
+        CONSUMER_POISON_METRICS
+            .receipts
+            .with_label_values(&[consumer, state])
+            .set(metric_value(value));
+    }
+    CONSUMER_POISON_METRICS
+        .snapshot_available
+        .with_label_values(&[consumer])
+        .set(1);
+    CONSUMER_POISON_METRICS
+        .snapshot_timestamp_seconds
+        .with_label_values(&[consumer])
+        .set(unix_timestamp_seconds());
+}
+
+/// Clears count gauges when storage inspection is unavailable so stale values cannot look current.
+pub fn record_unavailable(consumer: &str) {
+    for state in STATES {
+        CONSUMER_POISON_METRICS
+            .receipts
+            .with_label_values(&[consumer, state])
+            .set(0);
+    }
+    CONSUMER_POISON_METRICS
+        .snapshot_available
+        .with_label_values(&[consumer])
+        .set(0);
+    CONSUMER_POISON_METRICS
+        .snapshot_timestamp_seconds
+        .with_label_values(&[consumer])
+        .set(0);
+}
+
+fn unix_timestamp_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| metric_value(duration.as_secs()))
+        .unwrap_or(0)
+}
+
+fn metric_value(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_labels_are_fixed_and_bounded() {
+        assert_eq!(
+            STATES,
+            [
+                "total",
+                "reserved",
+                "publishing",
+                "expired_publishing",
+                "published",
+                "acknowledged",
+            ]
+        );
+    }
+
+    #[test]
+    fn metric_values_saturate_instead_of_wrapping() {
+        assert_eq!(metric_value(1), 1);
+        assert_eq!(metric_value(u64::MAX), i64::MAX);
+    }
+}

--- a/crates/rustok-telemetry/src/lib.rs
+++ b/crates/rustok-telemetry/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod consumer_poison_metrics;
 pub mod metrics;
 pub mod otel;
 pub mod runtime_consumer_metrics;

--- a/scripts/verify/verify-social-graph-index-poison-observer.mjs
+++ b/scripts/verify/verify-social-graph-index-poison-observer.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const files = {
+  telemetryLib: readFileSync("crates/rustok-telemetry/src/lib.rs", "utf8"),
+  metrics: readFileSync(
+    "crates/rustok-telemetry/src/consumer_poison_metrics.rs",
+    "utf8",
+  ),
+  services: readFileSync("apps/server/src/services/mod.rs", "utf8"),
+  bootstrap: readFileSync(
+    "apps/server/src/services/server_bootstrap.rs",
+    "utf8",
+  ),
+  observer: readFileSync(
+    "apps/server/src/services/social_graph_index_poison_observer.rs",
+    "utf8",
+  ),
+};
+
+const failures = [];
+
+function requireText(name, source, text) {
+  if (!source.includes(text)) {
+    failures.push(`${name} is missing required marker: ${text}`);
+  }
+}
+
+function forbidText(name, source, text) {
+  if (source.includes(text)) {
+    failures.push(`${name} contains forbidden marker: ${text}`);
+  }
+}
+
+requireText(
+  "telemetry lib",
+  files.telemetryLib,
+  "pub mod consumer_poison_metrics;",
+);
+
+for (const marker of [
+  '"rustok_runtime_consumer_poison_receipts"',
+  '"rustok_runtime_consumer_poison_snapshot_available"',
+  '"rustok_runtime_consumer_poison_snapshot_timestamp_seconds"',
+  '&["consumer", "state"]',
+  '"total"',
+  '"reserved"',
+  '"publishing"',
+  '"expired_publishing"',
+  '"published"',
+  '"acknowledged"',
+  "pub fn record_snapshot(",
+  "pub fn record_unavailable(",
+  ".set(0);",
+  "metric_value(u64::MAX)",
+]) {
+  requireText("poison metrics", files.metrics, marker);
+}
+
+for (const marker of [
+  '#[cfg(feature = "mod-social_graph")]\npub mod social_graph_index_poison_observer;',
+  "start_social_graph_index_poison_observer_if_enabled",
+]) {
+  requireText("server composition", `${files.services}\n${files.bootstrap}`, marker);
+}
+
+for (const marker of [
+  "ConsumerPoisonReceiptInspector::new(ctx.db_clone())",
+  ".summarize(SOCIAL_GRAPH_INDEX_CONSUMER_GROUP)",
+  "consumer_poison_metrics::record_snapshot(",
+  "consumer_poison_metrics::record_unavailable(METRICS_CONSUMER)",
+  "error.stable_code()",
+  "projection remains active",
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_POLL_MS",
+  "MAX_POLL_MS: u64 = 300_000",
+]) {
+  requireText("poison observer", files.observer, marker);
+}
+
+const observerProduction = files.observer.split("#[cfg(test)]")[0];
+for (const forbidden of [
+  ".reserve_and_claim(",
+  ".release_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".acknowledge_decode_failure(",
+  ".move_to_dlq(",
+  "DELETE FROM",
+  "UPDATE iggy_consumer_poison_receipts",
+  "INSERT INTO iggy_consumer_poison_receipts",
+  "delivery_id =",
+  "source_offset =",
+  "publisher_id =",
+  "stable_error_code =",
+]) {
+  forbidText("read-only poison observer production code", observerProduction, forbidden);
+}
+
+for (const forbidden of [
+  '"delivery_id"',
+  '"source_stream"',
+  '"source_topic"',
+  '"source_partition"',
+  '"source_offset"',
+  '"payload"',
+  '"error_code"',
+  '"publisher_id"',
+  '"tenant_id"',
+  '"event_id"',
+]) {
+  forbidText("poison metric labels", files.metrics, forbidden);
+}
+
+if (failures.length > 0) {
+  console.error("Social Graph Index poison observer verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "Social Graph Index poison observer verification passed: count-only bounded states, stale-value clearing, fixed consumer scope, read-only inspection, and delivery/privacy isolation are locked.",
+);

--- a/scripts/verify/verify-social-graph-index-poison-observer.mjs
+++ b/scripts/verify/verify-social-graph-index-poison-observer.mjs
@@ -13,6 +13,10 @@ const files = {
     "apps/server/src/services/server_bootstrap.rs",
     "utf8",
   ),
+  runtimeGuardrails: readFileSync(
+    "apps/server/src/services/runtime_guardrails.rs",
+    "utf8",
+  ),
   observer: readFileSync(
     "apps/server/src/services/social_graph_index_poison_observer.rs",
     "utf8",
@@ -63,6 +67,14 @@ for (const marker of [
   "start_social_graph_index_poison_observer_if_enabled",
 ]) {
   requireText("server composition", `${files.services}\n${files.bootstrap}`, marker);
+}
+
+for (const marker of [
+  "SocialGraphIndexPoisonObserverHandle",
+  '"Social Graph Index poison receipt observer"',
+  "RuntimeGuardrailStatus::Degraded",
+]) {
+  requireText("runtime guardrails", files.runtimeGuardrails, marker);
 }
 
 for (const marker of [
@@ -142,5 +154,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Social Graph Index poison observer verification passed: count-only bounded states, stale-value clearing, fixed consumer scope, read-only inspection, bounded failure logging, and delivery/privacy isolation are locked.",
+  "Social Graph Index poison observer verification passed: count-only bounded states, stale-value clearing, fixed consumer scope, read-only inspection, bounded failure logging, degraded task health, and delivery/privacy isolation are locked.",
 );

--- a/scripts/verify/verify-social-graph-index-poison-observer.mjs
+++ b/scripts/verify/verify-social-graph-index-poison-observer.mjs
@@ -97,6 +97,27 @@ for (const forbidden of [
   forbidText("read-only poison observer production code", observerProduction, forbidden);
 }
 
+const snapshotFailureStart = observerProduction.indexOf("match inspector");
+const snapshotFailureEnd = observerProduction.indexOf("fn record_summary");
+if (snapshotFailureStart < 0 || snapshotFailureEnd <= snapshotFailureStart) {
+  failures.push("poison observer snapshot failure path could not be isolated");
+} else {
+  const snapshotFailurePath = observerProduction.slice(
+    snapshotFailureStart,
+    snapshotFailureEnd,
+  );
+  requireText(
+    "poison snapshot failure path",
+    snapshotFailurePath,
+    "error_code = error.stable_code()",
+  );
+  forbidText(
+    "poison snapshot failure path",
+    snapshotFailurePath,
+    "error = %error",
+  );
+}
+
 for (const forbidden of [
   '"delivery_id"',
   '"source_stream"',
@@ -121,5 +142,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Social Graph Index poison observer verification passed: count-only bounded states, stale-value clearing, fixed consumer scope, read-only inspection, and delivery/privacy isolation are locked.",
+  "Social Graph Index poison observer verification passed: count-only bounded states, stale-value clearing, fixed consumer scope, read-only inspection, bounded failure logging, and delivery/privacy isolation are locked.",
 );


### PR DESCRIPTION
## Summary

Add read-only operational health for neutral raw-contract poison receipts without entering the delivery recovery path.

- `rustok-telemetry` exports fixed count gauges for `total`, `reserved`, `publishing`, `expired_publishing`, `published`, and `acknowledged`;
- snapshot availability and timestamp distinguish a real all-zero result from unavailable inspection;
- unavailable inspection or observer shutdown clears counts and timestamp so stale values cannot look current;
- the Social Graph Index observer polls only `ConsumerPoisonReceiptInspector` for the fixed durable consumer group;
- snapshot failure records a bounded stable code and leaves projection active;
- runtime guardrails report a missing/stopped observer as `Degraded`, while receipt counts never affect worker readiness;
- no delivery UUID, broker coordinates, payload, error classification, publisher identity, tenant, relation, or event fact becomes a metric label;
- the observer performs no claim, release, DLQ publication, source acknowledgement, repair, retention, or deletion action.

## Documentation and guardrails

- added the Social Graph Index poison observer operator runbook;
- updated telemetry and connector live implementation plans;
- added `verify-social-graph-index-poison-observer.mjs` to lock bounded labels, stale-value clearing, read-only behavior, bounded failure logging, degraded task health, and privacy isolation.

## Verification

Tests, Cargo commands, formatting, source verifiers, PostgreSQL scenarios, and runtime metric rendering were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets
RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets
cargo test -p rustok-telemetry consumer_poison_metrics -- --nocapture
cargo test -p rustok-server social_graph_index_poison_observer -- --nocapture
node scripts/verify/verify-social-graph-index-poison-observer.mjs
```