### PR TITLE
test(profiles): define PostgreSQL poison receipt evidence

### DIFF
--- a/crates/rustok-iggy-connector/docs/consumer-poison-postgres-evidence.md
+++ b/crates/rustok-iggy-connector/docs/consumer-poison-postgres-evidence.md
@@ -1,0 +1,78 @@
+# Consumer poison receipt PostgreSQL evidence
+
+## Scope
+
+`consumer_poison_receipt_postgres.rs` is an opt-in PostgreSQL integration harness for the connector-owned neutral receipt store and count-only inspector. It exercises database behavior that SQLite source tests cannot establish:
+
+- concurrent publication claim ownership across independent PostgreSQL connections;
+- lease expiry, reclaim, and fencing of the previous publisher;
+- deterministic delivery UUID and source-coordinate collision rollback;
+- retention of the first bounded error classification and delivery-attempt diagnostic;
+- empty exact payload acceptance;
+- terminal `published` and `acknowledged` recognition;
+- aggregate inspector consistency across reserved and terminal states.
+
+The harness does not connect to Iggy, publish a DLQ entry, acknowledge a source cursor, choose retry policy, authorize a profile, or delete retained receipts.
+
+## Database selection
+
+Set one of:
+
+1. `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL`;
+2. `DATABASE_URL` as a fallback.
+
+The value must begin with `postgres://` or `postgresql://`. Without a PostgreSQL URL, every test reports a skip and returns successfully. The repository contains no default PostgreSQL credentials or localhost fallback.
+
+## Isolation
+
+Each test:
+
+1. creates a unique schema named `rustok_iggy_poison_<scenario>_<uuid>`;
+2. opens an isolated one-connection pool;
+3. sets `search_path` to the unique schema;
+4. applies connector migrations directly through `SchemaManager`;
+5. runs the scenario;
+6. drops the schema with `CASCADE`.
+
+The concurrent claim test opens two additional one-connection pools and sets the same isolated search path on both. This is deliberate: `SET search_path` is session-local, so a multi-connection pool configured through one session would not prove schema confinement.
+
+## Scenarios
+
+### Claim ownership
+
+Two publishers call `reserve_and_claim` concurrently for the same exact delivery. Exactly one result must be `Claimed`; the other must be `Busy`. The durable row remains `publishing` and retains whichever bounded diagnostic was observed first.
+
+### Lease reclaim and fencing
+
+The first publisher claims an empty payload. Test-only SQL expires its lease deterministically. A second publisher reclaims the row. The first publisher must receive `ClaimLost` when attempting `mark_published`; the second publisher can mark the receipt terminal. The first diagnostic remains unchanged.
+
+Direct SQL is limited to this deterministic lease-expiry operation and read-only count diagnostics. Production state transitions remain exercised through `ConsumerPoisonReceiptStore`.
+
+### Collision rollback
+
+The harness verifies both collision directions:
+
+- one deterministic delivery UUID reused for different source coordinates;
+- one source coordinate reused for different delivery UUID or bytes.
+
+Both fail as `IdentityConflict`. The original receipt remains unchanged and the table contains exactly one row.
+
+### Terminal aggregate consistency
+
+The harness creates one reserved, one published, and one acknowledged receipt. `ConsumerPoisonReceiptInspector` must report total `3` with exact per-state counts and no expired publishing claims. Redelivery must return `AlreadyPublished` or `AlreadyAcknowledged` without reopening publication.
+
+## Maintainer commands
+
+```bash
+RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' \
+  cargo test -p rustok-iggy-connector --features migrations \
+  --test consumer_poison_receipt_postgres -- --nocapture
+
+node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
+```
+
+For stronger concurrency evidence, run the test target repeatedly against the same PostgreSQL server while allowing each invocation to create its own schemas. Do not reuse a schema or replace the unique-schema setup with shared-table truncation.
+
+## Evidence status
+
+The harness and source guard are source-complete. No PostgreSQL command, Cargo command, formatter, or source verifier was executed when this slice was authored. A successful maintainer run remains required before claiming runtime proof.

--- a/crates/rustok-iggy-connector/docs/implementation-plan.md
+++ b/crates/rustok-iggy-connector/docs/implementation-plan.md
@@ -36,18 +36,25 @@ publishing. The inspector never returns delivery identifiers, source coordinates
 payloads, classifications, publisher identities, or timestamps and performs no claim,
 repair, retention, deletion, publication, or acknowledgement action.
 
-The Social Graph Index owner/server path now composes both durable recovery and
-read-only observation. The worker constructs `ConsumerPoisonIdentity`, recognizes an
-existing receipt before applying current DLQ policy, reserves/claims new work, publishes
-exact bytes through `rustok-iggy`, persists `published`, commits the source cursor, and
-then records `acknowledged` as best-effort bookkeeping. A separate observer polls only
-the inspector aggregate and exports bounded Prometheus counts. Observer failure clears
-stale metrics and never stops projection.
+The Social Graph Index owner/server path composes both durable recovery and read-only
+observation. The worker constructs `ConsumerPoisonIdentity`, recognizes an existing
+receipt before applying current DLQ policy, reserves/claims new work, publishes exact
+bytes through `rustok-iggy`, persists `published`, commits the source cursor, and then
+records `acknowledged` as best-effort bookkeeping. A separate observer polls only the
+inspector aggregate and exports bounded Prometheus counts. Observer failure clears stale
+metrics and never stops projection.
 
-The explicit platform append-only migration tail now includes both
+The explicit platform append-only migration tail includes both
 `m20260727_000004_create_index_dlq_receipts` and
 `m20260728_000001_create_consumer_poison_receipts`, preserving the previously published
 migration prefix.
+
+An opt-in PostgreSQL integration harness now creates a unique schema per scenario and
+applies connector migrations directly. It defines source evidence for independent
+concurrent claim connections, lease reclaim/fencing, collision rollback,
+first-diagnostic retention, empty payloads, terminal recognition, and aggregate
+inspection. The harness is source-complete but has not been executed; PostgreSQL runtime
+proof remains open.
 
 ## FFA/FBA boundary
 
@@ -81,6 +88,12 @@ migration prefix.
   derive labels from delivery-level facts.
 - Profiles and Social Graph must never authorize from this receipt, its aggregate
   inspection, metrics, or any broker state.
+- PostgreSQL evidence is opt-in through
+  `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL` with `DATABASE_URL` fallback. Tests use
+  unique schemas and contain no default credentials, shared-table truncation, or
+  database creation/deletion.
+- Direct test SQL is limited to deterministic lease expiry and read-only diagnostics;
+  production receipt transitions are exercised through the public store API.
 - The server enables feature `migrations` explicitly when it composes the neutral store;
   runtime availability does not rely on transitive feature unification.
 - Existing source guard: `node scripts/verify/verify-iggy-connector-source.mjs`.
@@ -90,6 +103,8 @@ migration prefix.
   `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`.
 - Owner observer/metrics guard:
   `node scripts/verify/verify-social-graph-index-poison-observer.mjs`.
+- PostgreSQL evidence guard:
+  `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`.
 
 ## Delivered results
 
@@ -112,6 +127,10 @@ migration prefix.
 7. **Count-only owner observability.** A separate server observer exports fixed receipt
    states, snapshot availability, and snapshot time; unavailable inspection clears stale
    gauges and leaves recovery behavior unchanged.
+8. **PostgreSQL evidence harness.** Four opt-in isolated-schema scenarios cover concurrent
+   ownership, lease reclaim/fencing, collision rollback, first-diagnostic retention,
+   empty payloads, terminal redelivery, and aggregate consistency without claiming an
+   executed runtime result.
 
 ## Next results
 
@@ -119,18 +138,21 @@ migration prefix.
    exact publish-before-ack ordering, acknowledgement-only redelivery, reconnect, exact
    commit, publication failure, restart, and multi-replica behavior in bundled and
    external environments.
-2. **Verify PostgreSQL receipt concurrency and inspection.** Prove claim ownership,
-   lease expiry and reclaim, UUID/source collisions, first-diagnostic retention,
-   rollback, terminal recognition, aggregate consistency, read-only inspection, and
-   observer behavior under multiple workers.
-3. **Harden lifecycle failure behavior.** Define reconnect/backoff, authentication, TLS,
+2. **Execute and retain PostgreSQL receipt evidence.** Run the isolated-schema harness
+   against PostgreSQL, retain command/environment/server-version evidence, repeat the
+   concurrent ownership scenario, and prove cleanup. Source coverage exists; runtime
+   execution remains owner work.
+3. **Extend PostgreSQL evidence to multi-replica observer behavior.** Prove aggregate
+   consistency during concurrent claims, lease expiry, terminal transitions, and
+   observer polling without adding mutation policy to inspection.
+4. **Harden lifecycle failure behavior.** Define reconnect/backoff, authentication, TLS,
    existing-topology validation, batching, and shutdown semantics without simulated
    fallback.
-4. **Retain operational evidence.** Exercise count-only metrics, unavailable snapshot
+5. **Retain operational evidence.** Exercise count-only metrics, unavailable snapshot
    clearing, expired-lease diagnosis, publication ambiguity, and acknowledgement-only
    recovery. Keep alert thresholds, reclaim, repair, and retention as explicit reviewed
    policy rather than storage side effects.
-5. **Complete packaging evidence.** Prove bundled distributions install the pinned
+6. **Complete packaging evidence.** Prove bundled distributions install the pinned
    server artifact and external-only distributions omit it.
 
 ## Verification
@@ -141,8 +163,10 @@ migration prefix.
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
 - `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
 - `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
+- `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
+- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`
@@ -158,4 +182,5 @@ scenarios remain maintainer-run and were not executed in this slice.
 - [Module documentation](./README.md)
 - [Iggy transport plan](../../rustok-iggy/docs/implementation-plan.md)
 - [Poison observer runbook](../../rustok-social-graph/docs/index-poison-receipt-observer.md)
+- [PostgreSQL poison evidence guide](./consumer-poison-postgres-evidence.md)
 - [Iggy integration reference](../../../docs/references/iggy/README.md)

--- a/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
+++ b/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
@@ -135,12 +135,14 @@ async fn concurrent_publishers_have_one_claim_owner() -> TestResult<()> {
     assert_eq!(retained.state, ConsumerPoisonReceiptState::Publishing);
     assert!(
         matches!(
-            retained.stable_error_code.as_str(),
-            "iggy.contract.decode_invalid" | "iggy.contract.schema_invalid"
+            (
+                retained.stable_error_code.as_str(),
+                retained.first_delivery_attempt_count,
+            ),
+            ("iggy.contract.decode_invalid", 1) | ("iggy.contract.schema_invalid", 2)
         ),
-        "one first-observed bounded diagnostic must be retained"
+        "the winning reservation must retain one atomic first-observed diagnostic pair"
     );
-    assert!(matches!(retained.first_delivery_attempt_count, 1 | 2));
 
     test_db.cleanup().await
 }

--- a/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
+++ b/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
@@ -21,6 +21,7 @@ const CONSUMER_GROUP: &str = "rustok-social-graph-index";
 struct PostgresPoisonReceiptTestDb {
     control: DatabaseConnection,
     db: DatabaseConnection,
+    database_url: String,
     schema_name: String,
 }
 
@@ -43,8 +44,7 @@ impl PostgresPoisonReceiptTestDb {
             .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
             .await?;
 
-        let db = connect(&database_url).await?;
-        set_search_path(&db, &schema_name).await?;
+        let db = connect_in_schema(&database_url, &schema_name).await?;
         let setup_result = async {
             let manager = SchemaManager::new(&db);
             for migration in rustok_iggy_connector::migrations::migrations() {
@@ -64,8 +64,13 @@ impl PostgresPoisonReceiptTestDb {
         Ok(Some(Self {
             control,
             db,
+            database_url,
             schema_name,
         }))
+    }
+
+    async fn connect_worker(&self) -> TestResult<DatabaseConnection> {
+        connect_in_schema(&self.database_url, &self.schema_name).await
     }
 
     async fn cleanup(self) -> TestResult<()> {
@@ -88,8 +93,8 @@ async fn concurrent_publishers_have_one_claim_owner() -> TestResult<()> {
     let identity = identity(Uuid::new_v4(), 1, 42, vec![1, 2, 3])?;
     let first_publisher = Uuid::new_v4();
     let second_publisher = Uuid::new_v4();
-    let first_store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
-    let second_store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+    let first_store = ConsumerPoisonReceiptStore::new(test_db.connect_worker().await?);
+    let second_store = ConsumerPoisonReceiptStore::new(test_db.connect_worker().await?);
 
     let (first, second) = tokio::join!(
         first_store.reserve_and_claim(
@@ -400,10 +405,19 @@ fn postgres_database_url() -> Option<String> {
 async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
     let mut options = ConnectOptions::new(database_url.to_owned());
     options
-        .max_connections(4)
+        .max_connections(1)
         .min_connections(1)
         .sqlx_logging(false);
     Ok(Database::connect(options).await?)
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    set_search_path(&db, schema_name).await?;
+    Ok(db)
 }
 
 async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {

--- a/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
+++ b/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs
@@ -1,0 +1,432 @@
+#![cfg(feature = "migrations")]
+
+use std::error::Error;
+use std::time::Duration;
+
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceiptError,
+    ConsumerPoisonReceiptInspector, ConsumerPoisonReceiptState, ConsumerPoisonReceiptStore,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const TEST_DATABASE_ENV: &str = "RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL";
+const CONSUMER_GROUP: &str = "rustok-social-graph-index";
+
+struct PostgresPoisonReceiptTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresPoisonReceiptTestDb {
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping consumer poison receipt PostgreSQL evidence"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_iggy_poison_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+        let setup_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in rustok_iggy_connector::migrations::migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn concurrent_publishers_have_one_claim_owner() -> TestResult<()> {
+    let Some(test_db) = PostgresPoisonReceiptTestDb::setup("claim_owner").await? else {
+        return Ok(());
+    };
+
+    let identity = identity(Uuid::new_v4(), 1, 42, vec![1, 2, 3])?;
+    let first_publisher = Uuid::new_v4();
+    let second_publisher = Uuid::new_v4();
+    let first_store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+    let second_store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+
+    let (first, second) = tokio::join!(
+        first_store.reserve_and_claim(
+            &identity,
+            "iggy.contract.decode_invalid",
+            1,
+            first_publisher,
+            Duration::from_secs(30),
+        ),
+        second_store.reserve_and_claim(
+            &identity,
+            "iggy.contract.schema_invalid",
+            2,
+            second_publisher,
+            Duration::from_secs(30),
+        )
+    );
+    let first = first?;
+    let second = second?;
+    assert!(
+        matches!(
+            (first, second),
+            (
+                ConsumerPoisonPublishClaim::Claimed,
+                ConsumerPoisonPublishClaim::Busy
+            ) | (
+                ConsumerPoisonPublishClaim::Busy,
+                ConsumerPoisonPublishClaim::Claimed
+            )
+        ),
+        "exactly one concurrent publisher must own the publication claim: {first:?}, {second:?}"
+    );
+
+    let retained = first_store
+        .find(&identity)
+        .await?
+        .expect("concurrent reservation must retain one receipt");
+    assert_eq!(retained.state, ConsumerPoisonReceiptState::Publishing);
+    assert!(
+        matches!(
+            retained.stable_error_code.as_str(),
+            "iggy.contract.decode_invalid" | "iggy.contract.schema_invalid"
+        ),
+        "one first-observed bounded diagnostic must be retained"
+    );
+    assert!(matches!(retained.first_delivery_attempt_count, 1 | 2));
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn expired_lease_is_reclaimed_and_fences_the_previous_publisher() -> TestResult<()> {
+    let Some(test_db) = PostgresPoisonReceiptTestDb::setup("lease_reclaim").await? else {
+        return Ok(());
+    };
+
+    let identity = identity(Uuid::new_v4(), 1, 43, Vec::new())?;
+    let first_publisher = Uuid::new_v4();
+    let second_publisher = Uuid::new_v4();
+    let store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                "iggy.contract.decode_invalid",
+                1,
+                first_publisher,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    expire_publishing_lease(&test_db.db, identity.delivery_id()).await?;
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                "iggy.contract.schema_invalid",
+                9,
+                second_publisher,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert!(matches!(
+        store.mark_published(&identity, first_publisher).await,
+        Err(ConsumerPoisonReceiptError::ClaimLost)
+    ));
+
+    store.mark_published(&identity, second_publisher).await?;
+    let retained = store
+        .find(&identity)
+        .await?
+        .expect("reclaimed receipt must remain durable");
+    assert_eq!(retained.state, ConsumerPoisonReceiptState::Published);
+    assert_eq!(retained.stable_error_code, "iggy.contract.decode_invalid");
+    assert_eq!(retained.first_delivery_attempt_count, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn conflicts_roll_back_without_overwriting_original_identity() -> TestResult<()> {
+    let Some(test_db) = PostgresPoisonReceiptTestDb::setup("identity_conflict").await? else {
+        return Ok(());
+    };
+
+    let delivery_id = Uuid::new_v4();
+    let original = identity(delivery_id, 1, 44, vec![7, 8, 9])?;
+    let conflicting_source = identity(delivery_id, 2, 45, vec![7, 8, 9])?;
+    let conflicting_bytes = identity(Uuid::new_v4(), 1, 44, vec![9, 8, 7])?;
+    let publisher = Uuid::new_v4();
+    let store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &original,
+                "iggy.contract.decode_invalid",
+                1,
+                publisher,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert!(matches!(
+        store
+            .reserve_and_claim(
+                &conflicting_source,
+                "iggy.contract.schema_invalid",
+                2,
+                Uuid::new_v4(),
+                Duration::from_secs(30),
+            )
+            .await,
+        Err(ConsumerPoisonReceiptError::IdentityConflict)
+    ));
+    assert!(matches!(
+        store.find(&conflicting_bytes).await,
+        Err(ConsumerPoisonReceiptError::IdentityConflict)
+    ));
+
+    let retained = store
+        .find(&original)
+        .await?
+        .expect("identity conflict must not remove or rewrite the original receipt");
+    assert_eq!(retained.state, ConsumerPoisonReceiptState::Publishing);
+    assert_eq!(retained.stable_error_code, "iggy.contract.decode_invalid");
+    assert_eq!(retained.first_delivery_attempt_count, 1);
+    assert_eq!(count_receipts(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn terminal_states_and_aggregate_inspection_remain_consistent() -> TestResult<()> {
+    let Some(test_db) = PostgresPoisonReceiptTestDb::setup("terminal_summary").await? else {
+        return Ok(());
+    };
+
+    let published_identity = identity(Uuid::new_v4(), 1, 46, vec![1])?;
+    let acknowledged_identity = identity(Uuid::new_v4(), 1, 47, vec![2])?;
+    let reserved_identity = identity(Uuid::new_v4(), 1, 48, vec![3])?;
+    let store = ConsumerPoisonReceiptStore::new(test_db.db.clone());
+    let inspector = ConsumerPoisonReceiptInspector::new(test_db.db.clone());
+
+    let published_owner = Uuid::new_v4();
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &published_identity,
+                "iggy.contract.decode_invalid",
+                1,
+                published_owner,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    store
+        .mark_published(&published_identity, published_owner)
+        .await?;
+
+    let acknowledged_owner = Uuid::new_v4();
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &acknowledged_identity,
+                "iggy.contract.decode_invalid",
+                1,
+                acknowledged_owner,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    store
+        .mark_published(&acknowledged_identity, acknowledged_owner)
+        .await?;
+    store.mark_acknowledged(&acknowledged_identity).await?;
+
+    let reserved_owner = Uuid::new_v4();
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &reserved_identity,
+                "iggy.contract.decode_invalid",
+                1,
+                reserved_owner,
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    store
+        .release_claim(&reserved_identity, reserved_owner)
+        .await?;
+
+    let summary = inspector.summarize(CONSUMER_GROUP).await?;
+    assert_eq!(summary.total(), 3);
+    assert_eq!(summary.reserved(), 1);
+    assert_eq!(summary.publishing(), 0);
+    assert_eq!(summary.expired_publishing(), 0);
+    assert_eq!(summary.published(), 1);
+    assert_eq!(summary.acknowledged(), 1);
+    assert!(summary.has_recovery_work());
+    assert!(!summary.has_expired_claims());
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &published_identity,
+                "iggy.contract.schema_invalid",
+                8,
+                Uuid::new_v4(),
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::AlreadyPublished
+    );
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &acknowledged_identity,
+                "iggy.contract.schema_invalid",
+                8,
+                Uuid::new_v4(),
+                Duration::from_secs(30),
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::AlreadyAcknowledged
+    );
+
+    test_db.cleanup().await
+}
+
+fn identity(
+    delivery_id: Uuid,
+    source_partition: u32,
+    source_offset: u64,
+    payload: Vec<u8>,
+) -> Result<ConsumerPoisonIdentity, ConsumerPoisonReceiptError> {
+    ConsumerPoisonIdentity::new(
+        delivery_id,
+        CONSUMER_GROUP,
+        "rustok",
+        "domain",
+        source_partition,
+        source_offset,
+        payload,
+    )
+}
+
+async fn expire_publishing_lease(
+    db: &DatabaseConnection,
+    delivery_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "UPDATE iggy_consumer_poison_receipts SET lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second' WHERE delivery_id = $1 AND state = 'publishing'",
+        vec![delivery_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn count_receipts(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM iggy_consumer_poison_receipts".to_string(),
+        ))
+        .await?
+        .expect("count query must return one row");
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(4)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -14,8 +14,8 @@ restricted or unavailable rows as absent.
 
 `followers_only` visibility resolves through authoritative Social Graph owner
 ports. Profiles never reads relation tables and never authorizes from an event,
-Index projection, decoded/raw DLQ receipt, broker identifier, consumer offset, or
-lag metric.
+Index projection, decoded/raw DLQ receipt, neutral receipt aggregate, broker
+identifier, consumer offset, lag metric, or poison-receipt health signal.
 
 Media descriptors remain Media-owned. Profiles validates tenant, uploader, and
 MIME constraints and exposes only Media-selected descriptors. Profiles does not
@@ -62,6 +62,15 @@ mutation retry.
 - A read-only observer reads every `domain` partition plus the persistent group
   checkpoint. Complete total/max lag is published only when every partition is
   coherent; missing/inconsistent checkpoints clear lag gauges.
+- A separate count-only poison observer publishes fixed receipt-state aggregates,
+  snapshot availability, and snapshot time. Unavailable inspection clears stale
+  values; a missing/stopped observer is degraded health and never blocks projection.
+- The explicit append-only migration tail contains both receipt migrations, so the
+  previously published migration prefix is preserved.
+- An opt-in PostgreSQL receipt harness now defines isolated-schema evidence for
+  concurrent ownership, lease reclaim/fencing, collision rollback,
+  first-diagnostic retention, empty payloads, terminal recognition, and aggregate
+  inspection. It has not been executed.
 - Main also contains generic Index partition snapshot/query/mutation evidence.
   That strengthens the shared Index substrate but does not validate this Social
   Graph consumer, its schema registration, or Profiles presentation policy.
@@ -105,9 +114,11 @@ owner worker, and the offset remained uncommitted.
 - states are `reserved`, leased `publishing`, `published`, and `acknowledged`;
 - expired publication leases may be reclaimed, while terminal states are
   recognized idempotently;
-- the store performs no publish, DLQ routing, source commit, or authorization.
+- the store performs no publish, DLQ routing, source commit, or authorization;
+- read-only inspection exposes only fixed consumer-group counts and performs no
+  receipt transition, repair, retention, or deletion action.
 
-The Social Graph Index worker is now wired to the typed result:
+The Social Graph Index worker is wired to the typed result:
 
 - `SocialGraphIndexConsumer::receive_delivery` exposes events and decode failures
   without committing either;
@@ -122,9 +133,10 @@ The Social Graph Index worker is now wired to the typed result:
 - source ack precedes best-effort `mark_acknowledged` bookkeeping;
 - the raw path never invokes Index projection and never creates tenant/event facts.
 
-The remaining blocker is migration-order reconciliation: both the existing Social
-Graph Index DLQ migration and the connector poison migration must be appended to
-the explicit platform release-order tail without rewriting its published prefix.
+Migration-order reconciliation is complete. The remaining work is execution and
+retained proof: compile the current mainline, run PostgreSQL claim/lease/collision/
+inspection scenarios, run real-Iggy publication/ack/restart scenarios, and retain
+multi-replica/operator evidence without weakening privacy or exactly-once language.
 
 ## FFA/FBA boundary
 
@@ -152,7 +164,8 @@ the explicit platform release-order tail without rewriting its published prefix.
    transactional events, cleanup CLI, bounded replay, schema registration,
    result-first Index apply/ack, durable decoded-event and raw-delivery DLQ receipt
    recovery, deterministic broker identity, shared-transport lifecycle, readiness,
-   delivery telemetry, and broker-backed complete lag observation.
+   delivery telemetry, broker-backed complete lag observation, and count-only
+   neutral receipt health.
    **Remaining:** prove bounded replay/rescan repair and retain compiled/runtime
    evidence for privacy, receipts, cleanup, event relay/replay, schema concurrency,
    broker restart/redelivery/DLQ receipt/header/dedup/position observation,
@@ -180,20 +193,20 @@ the explicit platform release-order tail without rewriting its published prefix.
    telemetry, durable command/decoded-event/raw-delivery DLQ receipts,
    deterministic DLQ broker identity, maintenance, events, replay, cleanup CLI,
    persisted schema registration, durable terminal recognition, default-off shared
-   transport lifecycle, retries, shutdown, readiness, bounded metrics, and complete
-   lag.
-   **Remaining:** deployment retention approval, PostgreSQL concurrency/retention/
-   replay/rollback, real broker observer/reconnect/TLS/rebalance, deterministic
-   header and dedup disabled/enabled/expiry/capacity evidence, confirmation-policy
-   decision, multi-replica evidence, and retained operator packets.
+   transport lifecycle, retries, shutdown, readiness, bounded metrics, complete
+   lag, count-only poison health, and a PostgreSQL receipt evidence harness.
+   **Remaining:** execute PostgreSQL concurrency/retention/replay/rollback evidence,
+   approve deployment retention, prove real broker observer/reconnect/TLS/rebalance,
+   deterministic header and dedup disabled/enabled/expiry/capacity behavior,
+   confirmation policy, multi-replica behavior, and retained operator packets.
 
 6. **Handle undecodable sealed contract deliveries without invented ownership.**
    **Status:** source-complete for typed receive, immutable connector identity,
    neutral durable receipt, exact-byte DLQ publication, durable published-before-ack,
-   existing-result recovery, and best-effort post-ack bookkeeping.
-   **Next:** append both pending receipt migrations to the platform release-order
-   tail, reconcile with current `main`, refresh `Cargo.lock`, and execute PostgreSQL
-   plus real-Iggy failure/restart/multi-replica evidence.
+   existing-result recovery, best-effort post-ack bookkeeping, append-only migration
+   placement, count-only health, and opt-in PostgreSQL evidence scenarios.
+   **Next:** execute the PostgreSQL harness, retain database/server/cleanup evidence,
+   then execute real-Iggy failure/restart/dedup/multi-replica scenarios.
    **Done when:** malformed bytes are retained, classified, durably terminalized,
    published/recovered, and acknowledged without fabricated tenant/event identity,
    implicit commits, duplicate authorization effects, or exactly-once claims, and
@@ -202,13 +215,14 @@ the explicit platform release-order tail without rewriting its published prefix.
 ## Recheck checkpoint — 2026-07-28
 
 - Rechecked the canonical Profiles plan, superseded PR #2237, draft PR #2317,
-  replacement PR #2338, current `main`, and generic Index partition evidence.
+  replacement PR #2338, and current `main` while using short merge/new-branch cycles
+  to reduce conflicts with parallel agents.
 - Preserved receipts, cleanup, sealed events, replay, schema registration,
   persistent worker, durable decoded-event DLQ receipts, deterministic broker
   identity, readiness, telemetry, and position observation from PR #2317.
 - Reconfirmed privacy-before-presentation, bounded follower reads, owner-scoped
   writes, Media-owned descriptors, no automatic mutation retry, and the rule that
-  Index/broker state never authorizes profile presentation.
+  Index/broker/receipt/metric state never authorizes profile presentation.
 - Added the typed exact-byte decode-failure contract with explicit acknowledgement.
 - Added connector-owned neutral receipt DDL/store with private immutable source
   identity, empty exact-byte support, collision detection, first-diagnostic
@@ -221,11 +235,13 @@ the explicit platform release-order tail without rewriting its published prefix.
 - Enabled connector migration/storage API explicitly in the server dependency rather
   than relying on transitive feature unification.
 - Registered the connector migration in the truthful `mode: none` backfill ledger.
-- Found that `m20260727_000004_create_index_dlq_receipts` is absent from the current
-  explicit append-only migration tail; the connector receipt migration must be
-  appended with it before compatibility validation.
-- The replacement branch still descends from PR #2317 and must be synchronized with
-  current `main`; `Cargo.lock` must be refreshed by Cargo afterward.
+- Appended both receipt migrations to the explicit platform release-order tail
+  without rewriting its published prefix.
+- Added count-only receipt inspection, Prometheus metrics, stale-snapshot clearing,
+  bounded failure logging, degraded observer-task health, and an operator runbook.
+- Added an opt-in isolated-schema PostgreSQL harness for claim ownership, lease
+  reclaim/fencing, collision rollback, atomic first-diagnostic retention, terminal
+  recognition, and aggregate consistency.
 - Tests, Cargo commands, formatters, source verifiers, PostgreSQL, real-broker, and
   multi-replica scenarios were not run, per maintainer instruction.
 
@@ -241,7 +257,11 @@ the explicit platform release-order tail without rewriting its published prefix.
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
+- `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
+- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture`
 - `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
+- `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`
+- `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-index --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets`
@@ -252,6 +272,7 @@ the explicit platform release-order tail without rewriting its published prefix.
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
 - `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
 - `node scripts/verify/verify-social-graph-index-dlq-receipts.mjs`
+- `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
 - `node scripts/verify/verify-runtime-consumer-metrics.mjs`
 - `node scripts/verify/verify-social-graph-command-receipts.mjs`
 - `node scripts/verify/verify-social-graph-receipt-cleanup.mjs`
@@ -288,4 +309,6 @@ the explicit platform release-order tail without rewriting its published prefix.
     connector poison contract and acknowledge only after its terminal result exists.
 16. Existing durable poison choices remain recoverable across later policy disablement;
     new undecodable deliveries remain uncommitted without an enabled terminal policy.
-17. Update Profiles and affected owner docs with every boundary change.
+17. Count-only receipt health and PostgreSQL evidence never authorize, acknowledge,
+    reclaim, repair, retain, or delete production delivery state.
+18. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-social-graph/docs/implementation-plan.md
+++ b/crates/rustok-social-graph/docs/implementation-plan.md
@@ -19,14 +19,20 @@ persistent Iggy consumption, typed exact-byte decode failures, connector-owned n
 poison receipts, one shared EventRuntime Iggy transport, default-off server lifecycle,
 bounded projection/DLQ/receipt/ack retry, decoded-event and raw-delivery durable DLQ
 recovery, deterministic UUIDv8 broker message IDs, graceful shutdown, enabled-worker
-readiness, bounded per-consumer Prometheus telemetry, and a read-only
-partition-qualified consumer-position observer with completeness-gated total/max lag.
+readiness, bounded per-consumer Prometheus telemetry, a read-only partition-qualified
+consumer-position observer with completeness-gated total/max lag, and a count-only
+neutral poison-receipt observer with stale-snapshot clearing.
 
-Compilation, source-verifier execution, append-only migration-tail reconciliation,
-PostgreSQL receipt/concurrency evidence, real-broker deterministic-ID/deduplication and
-publish-confirmation behavior, observer reconnect/TLS/auth, multi-replica
-position/receipt semantics, and retained runtime evidence remain maintainer-run or
-pending.
+The append-only migration tail now contains both decoded and neutral receipt
+migrations. An opt-in PostgreSQL harness defines isolated-schema evidence for
+concurrent neutral claim ownership, lease reclaim/fencing, collision rollback,
+first-diagnostic retention, empty payloads, terminal recognition, and aggregate
+inspection.
+
+Compilation, source-verifier execution, PostgreSQL runtime execution, real-broker
+deterministic-ID/deduplication and publish-confirmation behavior, observer reconnect/
+TLS/auth, multi-replica position/receipt semantics, retention policy, and retained
+runtime evidence remain maintainer-run or pending.
 
 ## Delivered owner relation contract
 
@@ -91,82 +97,41 @@ pending.
 
 - Migration `m20260727_000004_create_index_dlq_receipts` owns immutable source identity
   and exact payload bytes for poison deliveries that already have trusted tenant and
-  event identity. The key is tenant, consumer group, and event ID; stored source
-  coordinates must match on every retry.
+  event identity.
 - States are `reserved`, leased `publishing`, terminal `published`, and post-source-ack
   `acknowledged`. Publisher leases are bounded and reclaimable after process loss.
 - `project_consumed` checks receipts before Index projection. Published receipts enter
-  acknowledgement-only recovery; unfinished receipts remain retryable DLQ work and do
-  not cross back into mutation apply.
-- A versioned SHA-256 construction derives one RFC 9562 UUIDv8 from tenant, consumer
-  group, event ID, source stream/topic/partition/offset, and exact retained payload.
-  Every variable-length field is length-framed.
-- Retry count, time, publisher/lease identity, and random state are excluded, so retries
-  for one immutable receipt retain the same broker message ID.
-- `publish_consumed_to_dlq` returns success only after exact-byte broker publication and
-  the durable `published` transition. Repeated calls recognize a terminal receipt and
-  skip broker publication.
-- The UUIDv8 is attached separately from the source event ID. `IggyTransport` lazily
-  opens one SDK publisher connection to the same configured endpoint and existing
-  `dlq` topic, then maps the UUID to Iggy's `u128` message header.
-- Publisher connection/configuration failures leave the source unacknowledged, clear the
-  cached client, and are retried through the existing bounded DLQ retry path.
-- Ack failure after successful publication leaves the terminal receipt intact. On
-  redelivery the consumer skips projection and DLQ publication and retries source ack.
-- A previously created unfinished receipt continues to completion even if policy for
-  creating new DLQ decisions is later disabled.
-- Source-ack success is the transport boundary. Updating the receipt to `acknowledged`
-  afterward is best-effort bookkeeping and cannot convert a committed source offset
-  back into failure.
-- Broker success followed by process/DB failure before the `published` transition is a
-  separate explicit confirmation ambiguity. A retry carries the same UUIDv8, but Iggy
-  duplicate suppression applies only when the deployment enables it and the relevant
-  per-partition cache/expiry still covers the recovery interval.
-- Durable receipt state remains authoritative. Physical broker exactly-once is not
-  claimed from a deterministic ID or bounded optional deduplication; production must
-  retain evidence for its configured window or select a stronger transaction/outbox
-  mechanism.
-- Historical rows are intentionally not fabricated; the migration backfill contract is
-  `none`.
+  acknowledgement-only recovery; unfinished receipts remain retryable DLQ work.
+- A versioned length-framed SHA-256 construction derives one RFC 9562 UUIDv8 from the
+  immutable trusted receipt identity and exact payload.
+- Retry count, time, publisher/lease identity, and random state are excluded.
+- Exact-byte publication and durable `published` precede source acknowledgement.
+- Ack failure after publication leaves a terminal receipt; redelivery retries ack only.
+- Broker success followed by process/DB failure before `published` remains explicit
+  confirmation ambiguity. A deterministic ID does not establish physical exactly-once.
+- Historical rows are not fabricated; the migration backfill contract is `none`.
 
 ## Delivered typed raw poison terminalization boundary
 
 - `PersistentContractConsumerGroup::receive_delivery` returns either a validated
-  `ConsumedContractEvent` or `ConsumedContractDecodeFailure`; neither receive branch
-  commits the cursor.
-- `SocialGraphIndexConsumer::receive_delivery` exposes that typed transport result to
-  the owner worker. `receive_next` remains a compatibility event-only path, and
-  `acknowledge_decode_failure` is an isolated exact-cursor commit adapter with no
-  projection or publication behavior.
+  `ConsumedContractEvent` or `ConsumedContractDecodeFailure`; neither branch commits.
+- `SocialGraphIndexConsumer::receive_delivery` exposes that typed result to the owner
+  worker; raw acknowledgement is an isolated exact-cursor adapter.
 - Decode/schema failures retain exact bytes, stream, topic, partition, offset, opaque
   acknowledgement metadata, bounded classification, and a deterministic connector
-  delivery UUID. They do not create or infer tenant, actor, relation, or domain event
-  identity.
+  delivery UUID without inventing tenant, actor, relation, or event identity.
 - Connector migration `m20260728_000001_create_consumer_poison_receipts` owns the neutral
-  result store. One deterministic delivery UUID and one consumer-group/stream/topic/
-  partition/offset coordinate set bind the exact payload; collisions fail closed.
-- Empty payload is valid exact broker input. Error classification and observed retry
-  count are retained as first diagnostics but do not alter immutable delivery identity.
+  result store. Delivery UUID/source-coordinate/payload collisions fail closed.
+- Empty payload is valid. Error classification and observed attempt are retained as one
+  first-observed diagnostic pair but are not immutable identity.
 - Receipt states are `reserved`, leased `publishing`, `published`, and `acknowledged`.
-  The store performs no broker publish, source ack, authorization, or policy choice.
-- The server worker checks for an existing receipt before applying current DLQ policy.
-  A previously chosen raw-poison result continues publish/ack recovery even if creating
-  new DLQ decisions is later disabled; a new undecodable delivery remains uncommitted
-  while DLQ is disabled.
-- For a claimed receipt, the worker publishes `ConsumedContractDecodeFailure::to_dlq_entry`
-  with exact bytes and deterministic broker message ID, then retries only the durable
-  `mark_published` transition. Source acknowledgement is attempted only after published
-  is durable or already recognized.
-- After source commit, `mark_acknowledged` is best-effort bookkeeping. Failure cannot
-  make the committed offset uncommitted.
-- If source acknowledgement fails, the durable published receipt remains and redelivery
-  enters acknowledgement-only recovery without projection or another selected terminal
-  result.
-- Broker success followed by loss before `mark_published` remains an explicit duplicate
-  ambiguity; retry uses the same deterministic broker message ID and makes no exactly-once
-  claim without broker deduplication evidence.
-- Profiles privacy never reads or authorizes from this neutral receipt or any raw broker
-  state.
+- The worker checks an existing receipt before current DLQ policy. Existing selected
+  work remains recoverable if creation of new DLQ decisions is later disabled.
+- New undecodable deliveries remain uncommitted while no terminal policy is enabled.
+- Exact-byte DLQ publication and durable `mark_published` precede source ack.
+- Published redelivery is acknowledgement-only; post-ack `mark_acknowledged` is
+  best-effort bookkeeping.
+- Profiles privacy never reads or authorizes from this neutral receipt or broker state.
 
 ## Delivered persistent consumer, host lifecycle, and readiness
 
@@ -177,96 +142,92 @@ pending.
 - `receive_delivery`, `project_consumed`, `acknowledge_consumed`, and
   `acknowledge_decode_failure` retain one outstanding cursor delivery and expose
   result-first decoded and raw paths.
-- `process_next` remains the direct serialized validated-event register/apply/ack
-  compatibility path. The server worker owns typed raw-poison composition.
 - Execution is default-off until
   `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED=true` and then requires a worker host
   plus effective `outbox_iggy` delivery.
-- `EventRuntime` publishes the exact configured `Arc<IggyTransport>` into shared
-  context; relay and consumer reuse it, and the worker never starts or stops a second
-  bundled broker process.
-- Identified DLQ publication may open one additional lazy SDK client owned by that same
-  transport. It connects to the existing endpoint and does not create another transport
-  or bundled process.
-- `SocialGraphIndexWorkerHandle` exposes task state and observes shared `StopHandle`.
+- `EventRuntime` publishes the configured shared `Arc<IggyTransport>`; relay and
+  consumer reuse it and never start a second bundled broker process.
 - Projection, decoded DLQ, neutral receipt, raw DLQ, and source acknowledgement use
   bounded exponential backoff from reviewed event settings.
-- New permanent/exhausted failures may choose DLQ only while policy is enabled. Existing
-  decoded or raw durable receipts continue regardless of later policy changes.
-- After any durable Index or DLQ result, only acknowledgement is retried; projection and
-  terminal publication selection are not repeated in-process.
-- Missing/stopped/invalid enabled worker state is critical in `runtime_guardrails`,
-  reaches `/health/ready`, and changes aggregate guardrail metrics. Disabled execution
-  is not degraded.
+- After a durable Index or DLQ result, only acknowledgement is retried.
+- Missing/stopped/invalid enabled worker state is critical in `runtime_guardrails` and
+  reaches `/health/ready`. Disabled execution is not degraded.
+- A missing/stopped count-only poison observer is degraded, not critical, and does not
+  stop projection or source acknowledgement.
 
 ## Delivered durable-consumer observability
 
 - `rustok-telemetry::runtime_consumer_metrics` registers one bounded shared collector
   in the process Prometheus registry rendered by `/metrics`.
-- Delivery metrics cover received/terminal outcomes, projection/DLQ/receipt/ack retries,
-  bounded stage/error failures, DLQ `published`, `already_published`, and `failure`
-  results, receive-to-ack duration, worker lifecycle, in-flight state/timestamp, and
-  last success.
+- Delivery metrics cover terminal outcomes, bounded retries/failures, DLQ results,
+  receive-to-ack duration, lifecycle, in-flight state, last success, and complete lag.
 - Raw outcomes are bounded to `decode_dead_lettered` and
-  `decode_dead_letter_recovered`; payload, delivery UUID, coordinates, and ack token are
-  not metric labels.
-- A separate `SocialGraphIndexPositionObserver` starts only when the durable consumer
-  is explicitly enabled. It uses the shared transport configuration to open a read-only
-  SDK client to the already-running endpoint; it never starts/stops a broker or mutates
-  offsets.
-- Every poll reads all `domain` topic partitions and persistent group checkpoints.
-  Empty partitions contribute zero; missing or incoherent checkpoints make the
-  snapshot incomplete.
-- Metrics expose snapshot timestamp, partition count, completeness, and exact
-  `rustok_runtime_consumer_lag{aggregation="total|max"}` only from complete snapshots.
-  Incomplete snapshots clear lag gauges and set completeness to zero.
-- Labels remain bounded to consumer, stage, outcome, result, reason, aggregation, and
-  stable error code. Tenant, event, relation, partition, offset, payload, broker ID,
-  ack token, credentials, and raw error text are not labels.
-- Observer configuration/connection/snapshot failures are recorded by stable code,
-  retried independently, and do not stop projection or enter readiness guardrails.
-- Lag is never inferred from event age, processing duration, a delivered offset, or a
-  local cursor counter.
+  `decode_dead_letter_recovered`; delivery-level facts are not labels.
+- `SocialGraphIndexPositionObserver` reads all topic partitions and persistent group
+  checkpoints without mutating offsets. Incomplete snapshots clear lag gauges.
+- `SocialGraphIndexPoisonObserver` reads only
+  `ConsumerPoisonReceiptInspector::summarize` for the fixed consumer group.
+- Poison metrics expose fixed `total`, `reserved`, `publishing`,
+  `expired_publishing`, `published`, and `acknowledged` states plus availability and
+  snapshot time. Unavailable inspection and shutdown clear stale values.
+- Failure logs contain bounded stable codes and omit storage error text.
+- Tenant, event, relation, partition, offset, payload, broker ID, publisher identity,
+  acknowledgement token, credentials, and raw error text are not metric labels.
+- Metrics and observers never authorize, acknowledge, reclaim, repair, retain, or
+  delete receipt state.
 
-## Migration-order reconciliation blocker
+## Migration-order reconciliation
 
-The platform migrator already discovers both receipt migrations, and their backfill
-contracts are `none`. The explicit append-only release-order tail still ends at
-`m20260726_000003_create_command_receipts`. Before compatibility validation and merge,
-append these entries without rewriting the published prefix:
+The platform migrator discovers both receipt migrations, their truthful backfill
+contracts remain `none`, and the explicit append-only release-order tail now ends with:
 
 1. `m20260727_000004_create_index_dlq_receipts`
 2. `m20260728_000001_create_consumer_poison_receipts`
 
-This branch also requires reconciliation with current `main` and a Cargo-managed
-`Cargo.lock` refresh.
+This preserves the previously published migration prefix. The reconciliation was
+merged separately before the later health/evidence slices.
+
+## PostgreSQL poison receipt evidence
+
+The opt-in `consumer_poison_receipt_postgres` target:
+
+- selects `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL` with `DATABASE_URL` fallback;
+- skips without a PostgreSQL URL and contains no default credentials;
+- creates and drops one unique schema per scenario;
+- uses one connection per pool so session-local `search_path` is deterministic;
+- uses independent pools for concurrent claim ownership;
+- verifies one `Claimed` and one `Busy` result;
+- verifies lease reclaim fences the previous publisher with `ClaimLost`;
+- verifies UUID/source/payload conflicts roll back without rewriting the original row;
+- verifies the winning reservation retains one atomic first-observed diagnostic pair;
+- verifies reserved/published/acknowledged aggregate consistency and terminal redelivery.
+
+Direct test SQL is limited to deterministic lease expiry and read-only diagnostics.
+The harness and source guard are source-complete; no PostgreSQL run has been executed.
 
 ## Remaining Social Graph scope
 
-1. Reconcile the append-only migration tail, current `main`, and `Cargo.lock`.
-2. Execute PostgreSQL concurrent schema-registration, decoded/raw receipt claim,
-   publish/mark/ack, collision, lease expiry, rollback, and retention evidence.
+1. Execute and retain the PostgreSQL neutral receipt harness, including server version,
+   command/environment evidence, repeated concurrent ownership, and schema cleanup.
+2. Execute decoded receipt and schema-registration concurrency/rollback/retention
+   scenarios against PostgreSQL.
 3. Prove real-Iggy validated and undecodable receive, deterministic UUID header
    publication, same-partition retry, connection loss/reconnect, ack failure, restart,
-   graceful shutdown, observer snapshot/reconnect, and multi-replica cursor/receipt
-   ownership.
+   graceful shutdown, observer snapshot/reconnect, and multi-replica ownership.
 4. Exercise broker success followed by receipt-mark loss with deduplication disabled,
-   enabled, capacity-evicted, and expired. Verify the configured window covers the
-   maximum lease/restart/recovery horizon before relying on duplicate suppression.
-5. Decide whether production requires an enforced and monitored Iggy deduplication
-   contract, a broker transaction, or a DB-owned DLQ/outbox relay before claiming any
-   stronger physical duplicate guarantee.
-6. Validate lag under concurrent publication, empty/missing checkpoints, TLS/auth
-   failures, rebalancing, and multiple worker replicas before defining alerts.
+   enabled, capacity-evicted, and expired.
+5. Decide whether production requires monitored Iggy deduplication, a broker
+   transaction, or a DB-owned DLQ/outbox relay before stronger duplicate guarantees.
+6. Validate lag and poison aggregates under concurrent publication, missing checkpoints,
+   expired claims, TLS/auth failures, rebalancing, and multiple replicas before alerts.
 7. Corrupt/delete projection state and prove bounded owner replay/rescan repair while
    Profiles privacy remains on authoritative owner ports.
-8. Define decoded and raw DLQ receipt retention/reconciliation before permitting
-   deletion; configure command-receipt retention cadence and retain cleanup CLI
-   dry-run/live evidence.
+8. Define decoded/raw receipt retention and reconciliation before deletion; retain
+   cleanup CLI dry-run/live evidence.
 9. Retain receipt/event concurrency, replay-window, rollback, telemetry, storefront,
    privacy, and operational packets.
-10. Continue friendship lifecycle, broader directory/follow UX, lists, block/mute
-    management, and moderation/admin repair.
+10. Continue friendship lifecycle, directory/follow UX, lists, block/mute management,
+    and moderation/admin repair.
 
 ## Verification
 
@@ -284,7 +245,11 @@ cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture
 node scripts/verify/verify-iggy-contract-decode-failure.mjs
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets
 cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture
+cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture
+RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture
 node scripts/verify/verify-iggy-consumer-poison-receipts.mjs
+node scripts/verify/verify-iggy-consumer-poison-inspection.mjs
+node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
 node scripts/verify/verify-iggy-consumer-position.mjs
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets
 cargo test -p rustok-social-graph --features index-consumer index_consumer::tests -- --nocapture
@@ -297,6 +262,7 @@ node scripts/verify/verify-social-graph-index-consumer.mjs
 node scripts/verify/verify-social-graph-index-runtime-consumer.mjs
 node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs
 node scripts/verify/verify-social-graph-index-dlq-receipts.mjs
+node scripts/verify/verify-social-graph-index-poison-observer.mjs
 node scripts/verify/verify-runtime-consumer-metrics.mjs
 node scripts/verify/verify-social-graph-command-receipts.mjs
 node scripts/verify/verify-social-graph-receipt-cleanup.mjs
@@ -308,4 +274,4 @@ rustok-cli social_graph receipt-cleanup --tenant-id <uuid> --retention-days 30 -
 ```
 
 These commands remain maintainer-run and were not executed manually while publishing
-this slice. `Cargo.lock` must be refreshed after synchronization with `main`.
+this slice.

--- a/scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
+++ b/scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const test = readFileSync(
+  "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs",
+  "utf8",
+);
+const failures = [];
+
+function requireText(text) {
+  if (!test.includes(text)) {
+    failures.push(`PostgreSQL poison receipt evidence is missing: ${text}`);
+  }
+}
+
+function forbidText(text) {
+  if (test.includes(text)) {
+    failures.push(`PostgreSQL poison receipt evidence contains forbidden marker: ${text}`);
+  }
+}
+
+for (const marker of [
+  '#![cfg(feature = "migrations")]',
+  'RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL',
+  '.or_else(|_| std::env::var("DATABASE_URL"))',
+  'CREATE SCHEMA "{schema_name}"',
+  'DROP SCHEMA IF EXISTS "{}" CASCADE',
+  'SET search_path TO "{schema_name}", public',
+  '.max_connections(1)',
+  'async fn connect_worker(&self)',
+  'ConsumerPoisonReceiptStore::new(test_db.connect_worker().await?)',
+  'tokio::join!(',
+  'concurrent_publishers_have_one_claim_owner',
+  'expired_lease_is_reclaimed_and_fences_the_previous_publisher',
+  'conflicts_roll_back_without_overwriting_original_identity',
+  'terminal_states_and_aggregate_inspection_remain_consistent',
+  'ConsumerPoisonPublishClaim::Busy',
+  'ConsumerPoisonReceiptError::ClaimLost',
+  'ConsumerPoisonReceiptError::IdentityConflict',
+  'CURRENT_TIMESTAMP - INTERVAL \'1 second\'',
+  'retained.stable_error_code, "iggy.contract.decode_invalid"',
+  'retained.first_delivery_attempt_count, 1',
+  'assert_eq!(count_receipts(&test_db.db).await?, 1)',
+  'ConsumerPoisonReceiptInspector::new(test_db.db.clone())',
+  'assert_eq!(summary.reserved(), 1)',
+  'assert_eq!(summary.published(), 1)',
+  'assert_eq!(summary.acknowledged(), 1)',
+  'ConsumerPoisonPublishClaim::AlreadyPublished',
+  'ConsumerPoisonPublishClaim::AlreadyAcknowledged',
+]) {
+  requireText(marker);
+}
+
+for (const marker of [
+  'postgres://localhost',
+  'postgresql://localhost',
+  'DROP DATABASE',
+  'CREATE DATABASE',
+  'TRUNCATE ',
+  'DELETE FROM iggy_consumer_poison_receipts',
+  'std::thread::sleep',
+  'tokio::time::sleep',
+  '.max_connections(4)',
+]) {
+  forbidText(marker);
+}
+
+const directUpdates = [...test.matchAll(/UPDATE iggy_consumer_poison_receipts/g)].length;
+if (directUpdates !== 1) {
+  failures.push(
+    `PostgreSQL poison receipt evidence must contain exactly one direct receipt UPDATE for deterministic lease expiry; found ${directUpdates}`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error("Iggy consumer poison PostgreSQL evidence verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "Iggy consumer poison PostgreSQL evidence verification passed: opt-in isolated schemas, independent claim connections, ownership fencing, collision rollback, first-diagnostic retention, and aggregate terminal consistency are locked.",
+);

--- a/scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
+++ b/scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
@@ -39,6 +39,8 @@ for (const marker of [
   'ConsumerPoisonReceiptError::ClaimLost',
   'ConsumerPoisonReceiptError::IdentityConflict',
   'CURRENT_TIMESTAMP - INTERVAL \'1 second\'',
+  '("iggy.contract.decode_invalid", 1) | ("iggy.contract.schema_invalid", 2)',
+  'the winning reservation must retain one atomic first-observed diagnostic pair',
   'retained.stable_error_code, "iggy.contract.decode_invalid"',
   'retained.first_delivery_attempt_count, 1',
   'assert_eq!(count_receipts(&test_db.db).await?, 1)',
@@ -82,5 +84,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy consumer poison PostgreSQL evidence verification passed: opt-in isolated schemas, independent claim connections, ownership fencing, collision rollback, first-diagnostic retention, and aggregate terminal consistency are locked.",
+  "Iggy consumer poison PostgreSQL evidence verification passed: opt-in isolated schemas, independent claim connections, ownership fencing, collision rollback, atomic first-diagnostic retention, and aggregate terminal consistency are locked.",
 );


### PR DESCRIPTION
## Summary

Add an opt-in PostgreSQL evidence harness for connector-owned neutral poison receipts and actualize the Profiles, Social Graph, and connector live plans.

The harness uses one unique schema per scenario and one connection per pool so session-local `search_path` remains deterministic. The concurrent ownership scenario uses two independent pools.

Covered source scenarios:

- exactly one concurrent publisher receives `Claimed`; the other receives `Busy`;
- the winning reservation retains one atomic first-observed error-code/attempt pair;
- an expired publication lease can be reclaimed and the previous publisher is fenced with `ClaimLost`;
- deterministic UUID/source-coordinate/payload conflicts fail as `IdentityConflict` and roll back without rewriting the original receipt;
- an empty exact payload remains valid;
- reserved, published, and acknowledged states produce consistent count-only inspection;
- terminal redelivery returns `AlreadyPublished` or `AlreadyAcknowledged` without reopening publication.

## Isolation and safety

- opt-in via `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL`, with `DATABASE_URL` fallback;
- no default PostgreSQL credentials or localhost fallback;
- unique schema creation and cleanup per test;
- no database creation, shared-table truncation, or receipt deletion;
- direct test SQL is limited to deterministic lease expiry and read-only diagnostics;
- production transitions are exercised through `ConsumerPoisonReceiptStore`;
- no Iggy publication, source acknowledgement, retention decision, repair, or Profiles authorization occurs in the harness.

## Documentation and guardrail

- added a PostgreSQL evidence guide;
- updated connector, Social Graph, and Profiles plans to remove the closed migration-tail blocker and distinguish source-complete scenarios from unexecuted runtime proof;
- added `verify-iggy-consumer-poison-postgres-evidence.mjs` to lock database opt-in, schema isolation, independent connections, ownership fencing, collision rollback, atomic diagnostics, and aggregate terminal consistency.

## Verification

Tests, Cargo commands, formatting, source verifiers, PostgreSQL scenarios, and real-Iggy scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features migrations --all-targets
RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' \
  cargo test -p rustok-iggy-connector --features migrations \
  --test consumer_poison_receipt_postgres -- --nocapture
node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
```