### PR TITLE
Compose fulfillment lifecycle read runtime

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -59,6 +59,20 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-fulfillment"))]
+    let host = {
+        let runtime = server
+            .shared_get::<rustok_commerce::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()
+            .unwrap_or_else(|| {
+                let runtime = rustok_commerce::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(
+                    server.db_clone(),
+                );
+                server.shared_insert(runtime.clone());
+                runtime
+            });
+        host.with_shared_value(runtime)
+    };
+
     #[cfg(feature = "mod-commerce")]
     let host = {
         let runtime = server

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -22,6 +22,8 @@ pub struct CommerceHttpRuntime {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
     shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime,
+    fulfillment_lifecycle_read_runtime:
+        crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
 
@@ -59,6 +61,14 @@ impl CommerceHttpRuntime {
             .shipping_option_admin_read_port()
     }
 
+    #[allow(dead_code)]
+    fn fulfillment_read_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentReadPort> {
+        self.fulfillment_lifecycle_read_runtime
+            .fulfillment_read_port()
+    }
+
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
             .operator_service(self.db_clone(), self.event_bus())
@@ -86,6 +96,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceShippingOptionReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let fulfillment_lifecycle_read_runtime = runtime
+            .shared_get::<crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require CommerceFulfillmentLifecycleReadRuntime in HostRuntimeContext"
+                )
+            })?;
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
@@ -103,6 +120,7 @@ impl CommerceHttpRuntime {
                 .shared_get::<FulfillmentProviderRegistry>()
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
             shipping_option_read_runtime,
+            fulfillment_lifecycle_read_runtime,
             marketplace_financial_runtime,
         })
     }

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-28",
-  "status": "source_ready_unvalidated",
-  "source_base_revision": "41b24915663848a77467a00e99ebbc92acecaf73",
+  "status": "source_composed_unvalidated",
+  "source_base_revision": "765b12129b500292c05d5f8a17f0e3902d345fb2",
   "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
   "owner": {
     "crate": "rustok-fulfillment",
@@ -53,14 +53,16 @@
     "runtime": "CommerceFulfillmentLifecycleReadRuntime",
     "graphql_host_override_supported": true,
     "graphql_manifest_fallback": "in_process",
-    "server_cache_composed": false,
-    "default_server_attachment": false
+    "server_cache_composed": true,
+    "default_server_attachment": true,
+    "commerce_http_runtime_required": true,
+    "external_adapter_preserved": true
   },
   "consumer_cutover": {
     "graphql_compatibility_facade": false,
     "admin_rest_list_show": false,
     "concrete_delegate_removed": false,
-    "next_slice": "compose the lifecycle runtime in ServerRuntimeContext and HostRuntimeContext, inject it into GraphQL and Commerce HTTP, and route GraphQL lookup/list/latest-by-order plus admin REST list/show through FulfillmentReadPort while preserving transport-specific optional-not-found and public error policy"
+    "next_slice": "route admin REST list/show and GraphQL lookup/list/latest-by-order through the host-composed FulfillmentReadPort while preserving transport-specific optional-not-found and public error policy"
   },
   "validation": {
     "tests_run": false,

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
@@ -1,6 +1,6 @@
 # Fulfillment lifecycle read port
 
-Status: source-ready, unvalidated.
+Status: source-composed, unvalidated.
 
 ## Scope
 
@@ -13,9 +13,9 @@ projection reads used by Commerce query consumers. It is separate from:
 - `ShippingSelectionPort`, which owns seller/cart shipping selection;
 - fulfillment lifecycle mutation methods, which remain on `FulfillmentService`.
 
-This slice publishes the owner read boundary and a host-selectable Commerce
-runtime container. It does not yet compose that runtime in the default server or
-cut GraphQL/admin REST consumers over to the port.
+The owner read boundary and Commerce runtime container are published. The default
+application host now composes and attaches that runtime, and `CommerceHttpRuntime`
+requires it. GraphQL/admin REST handlers have not yet been cut over to the port.
 
 ## Operations
 
@@ -52,7 +52,7 @@ The adapter does not parse, match, or expose owner error messages as control
 flow. Database failures are retryable `Unavailable`; validation, not-found, and
 conflict outcomes retain stable owner codes.
 
-## Commerce runtime publication
+## Commerce runtime composition
 
 `CommerceFulfillmentLifecycleReadRuntime` holds an
 `Arc<dyn FulfillmentReadPort>` and exposes:
@@ -64,14 +64,24 @@ conflict outcomes retain stable owner codes.
 It remains separate from `CommerceShippingOptionReadRuntime`, allowing different
 adapters for lifecycle and shipping-option projections.
 
-Commerce GraphQL runtime-data construction consumes a host-provided lifecycle
-runtime when one is already present in `HostRuntimeContext`. Until the default
-server and mounted consumers are cut over, it retains an explicit in-process
-fallback from `GraphqlRuntimeInputs::db_clone()`.
+The application server now:
 
-This fallback is compatibility source, not evidence that the default server has
-cached or attached the runtime. `ServerRuntimeContext` composition and
-`CommerceHttpRuntime` injection remain open.
+1. reuses a lifecycle runtime already installed in `ServerRuntimeContext`;
+2. otherwise constructs the deterministic in-process runtime once;
+3. caches that runtime in `ServerRuntimeContext`;
+4. attaches the same typed value to `HostRuntimeContext`.
+
+This preserves external adapter selection and gives GraphQL and HTTP composition
+the same owner-port instance.
+
+Commerce GraphQL runtime-data construction consumes the host-provided runtime.
+Its explicit in-process fallback remains for directly embedded compatibility
+schemas until the GraphQL facade cutover is complete.
+
+`CommerceHttpRuntime::from_host` now fails closed when
+`CommerceFulfillmentLifecycleReadRuntime` is absent and exposes the cloned
+`FulfillmentReadPort` for route handlers. No HTTP handler consumes it yet in this
+slice.
 
 ## Consumer boundary
 
@@ -89,11 +99,11 @@ Admin REST also still constructs `FulfillmentService` for:
 
 Lifecycle mutations remain intentionally outside this read boundary.
 
-The next cutover slice must compose/cache the runtime in the default application
-host, inject it into GraphQL and `CommerceHttpRuntime`, route the GraphQL and REST
-read consumers through `FulfillmentReadPort`, preserve each transport's
-optional-not-found and public error policy, and remove only the private GraphQL
-concrete delegate. No mounted consumer is claimed in this slice.
+The next cutover slice must route the GraphQL and REST read consumers through the
+already host-composed `FulfillmentReadPort`, preserve each transport's
+optional-not-found and public error policy, add request-safe GraphQL scope, and
+remove only the private GraphQL concrete delegate. No mounted consumer is claimed
+in this slice.
 
 ## Diagnostics
 
@@ -108,9 +118,9 @@ Source evidence is retained at:
 
 `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`
 
-Its status is `source_ready_unvalidated`. It explicitly records that default
-server composition, GraphQL/admin REST consumer cutover, and private concrete
-delegate removal remain incomplete.
+Its status is `source_composed_unvalidated`. It records completed default server
+cache/attachment and mandatory Commerce HTTP runtime injection while keeping
+GraphQL/admin REST consumer cutover and private concrete delegate removal false.
 
 ## Intended checks
 
@@ -118,6 +128,7 @@ delegate removal remain incomplete.
 node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
 cargo check -p rustok-fulfillment --lib
 cargo check -p rustok-commerce --lib
+cargo check -p rustok-server --features mod-commerce
 ```
 
 Tests, Cargo commands, formatting, verifiers, workflows, and CI were not run by

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -52,24 +52,25 @@ envelopes, context/deadline propagation, and the absence of concrete read
 construction. It explicitly records `runtime_parity_proven: false`.
 
 Fulfillment lifecycle projection lookup, filtered list, and latest-by-order are
-now published through `FulfillmentReadPort`. `InProcessFulfillmentReadPort` owns
+published through `FulfillmentReadPort`. `InProcessFulfillmentReadPort` owns
 concrete `FulfillmentService` construction, requires read policy, parses tenant
 identity from `PortContext`, preserves existing filter and ordering semantics, and
 maps every current owner error to stable `PortError`.
 
-Commerce now publishes a separate host-selectable
-`CommerceFulfillmentLifecycleReadRuntime`. GraphQL runtime-data construction uses
-a runtime already present in `HostRuntimeContext` and otherwise retains an
-explicit in-process fallback from the host database. This keeps the owner
-contract injectable without claiming that the default server has cached or
-attached the runtime.
+Commerce publishes a separate
+`CommerceFulfillmentLifecycleReadRuntime`. The default application host now
+reuses an externally installed runtime or constructs the in-process baseline once,
+caches it in `ServerRuntimeContext`, and attaches the same typed value to
+`HostRuntimeContext`. `CommerceHttpRuntime` requires that runtime and exposes the
+cloned owner port for route cutover. GraphQL runtime-data construction consumes
+the host value and retains an explicit in-process fallback only for directly
+embedded compatibility schemas.
 
-Default `ServerRuntimeContext` composition, resolver/HTTP injection, and consumer
-cutover remain open. The private GraphQL compatibility facade still retains one
-concrete `FulfillmentService` for fulfillment lookup, list, and latest-by-order.
-Admin REST still constructs the service for fulfillment list and detail reads.
-Fulfillment lifecycle mutations remain on their existing concrete/orchestration
-owner paths and are outside this read boundary.
+Consumer cutover remains open. The private GraphQL compatibility facade still
+retains one concrete `FulfillmentService` for fulfillment lookup, list, and
+latest-by-order. Admin REST still constructs the service for fulfillment list and
+detail reads. Fulfillment lifecycle mutations remain on their existing
+concrete/orchestration owner paths and are outside this read boundary.
 
 The native FFA surface remains seller/cart selection through
 `ShippingSelectionPort`; it does not publish complete projection list or lookup
@@ -97,9 +98,9 @@ operations. No projection API should be added without a concrete consumer.
 - Fulfillment lifecycle read source evidence:
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`.
 - Both files are unvalidated source evidence and do not promote status.
-- Focused guards cover owner boundaries, published Commerce runtime containers,
-  current mounted consumers, typed public envelopes, and the separate native
-  selection surface.
+- Focused guards cover owner boundaries, application-host runtime composition,
+  Commerce HTTP injection, current mounted consumers, typed public envelopes, and
+  the separate native selection surface.
 - Compile, migrated database, mounted transport, restart, contention, and remote
   evidence remain missing.
 
@@ -160,11 +161,12 @@ operations. No projection API should be added without a concrete consumer.
   and in-process constructors plus a clone getter.
 - [x] Allow Commerce GraphQL runtime-data construction to consume a host-provided
   lifecycle runtime while retaining an explicit in-process compatibility fallback.
-- [x] Retain source evidence and a focused guard that explicitly record default
-  server composition plus GraphQL/admin REST consumer cutovers as incomplete.
-- [ ] Compose/cache the lifecycle runtime once in the default application host,
-  preserve externally installed adapters, and expose it to both GraphQL and
-  `CommerceHttpRuntime`.
+- [x] Compose/cache the lifecycle runtime once in the default application host,
+  preserve externally installed adapters, and attach it to `HostRuntimeContext`.
+- [x] Require the typed lifecycle runtime in `CommerceHttpRuntime` and expose the
+  cloned owner port for route handlers.
+- [x] Retain source evidence and a focused guard that record completed runtime
+  composition without claiming GraphQL/admin REST consumer cutover.
 - [ ] Add resolver scope or equivalent request-safe injection for GraphQL.
 - [ ] Cut GraphQL fulfillment lookup, filtered list, and latest-by-order reads over
   to `FulfillmentReadPort` while preserving optional-not-found and public error
@@ -218,13 +220,13 @@ operations. No projection API should be added without a concrete consumer.
    envelopes, and no mounted projection transport constructs a concrete read
    service or provider.
 
-6. **Cut mounted lifecycle reads over to the owner port.** Compose/cache the
-   host-selectable `CommerceFulfillmentLifecycleReadRuntime`, inject it into
-   GraphQL and Commerce HTTP, route GraphQL lookup/list/latest-by-order and admin
-   REST list/detail through `FulfillmentReadPort`, and remove the private GraphQL
+6. **Cut mounted lifecycle reads over to the owner port.** Use the already
+   host-composed `CommerceFulfillmentLifecycleReadRuntime`, add request-safe
+   GraphQL injection, route GraphQL lookup/list/latest-by-order and admin REST
+   list/detail through `FulfillmentReadPort`, and remove the private GraphQL
    concrete delegate.
-   **Depends on:** the published owner port/runtime and stable transport-specific
-   optional-not-found/public error contracts.
+   **Depends on:** stable transport-specific optional-not-found/public error
+   contracts.
    **Done when:** mounted GraphQL and REST lifecycle reads consume the host-selected
    owner port, preserve their existing response policy, and no mounted lifecycle
    read constructs `FulfillmentService` inside Commerce.

--- a/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
@@ -14,6 +14,7 @@ const ownerRoot = read('crates/rustok-fulfillment/src/lib.rs');
 const ownerSource = read('crates/rustok-fulfillment/src/fulfillment_read.rs');
 const commerceRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
 const hostRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
+const commerceHttp = read('crates/rustok-commerce/src/controllers/mod.rs');
 const compatibilityFacade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
 const adminRest = read('crates/rustok-commerce/src/controllers/admin/fulfillments.rs');
 const evidence = JSON.parse(
@@ -116,11 +117,35 @@ for (const [value, label] of [
   ],
 ]) requireText(commerceRuntime, value, label);
 
-forbidText(
-  hostRuntime,
-  'CommerceFulfillmentLifecycleReadRuntime',
-  'default server lifecycle runtime composition before consumer cutover',
-);
+for (const [value, label] of [
+  [
+    '.shared_get::<rustok_commerce::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()',
+    'default server lifecycle runtime reuse',
+  ],
+  [
+    'rustok_commerce::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(',
+    'default server in-process composition',
+  ],
+  ['server.shared_insert(runtime.clone());', 'default server runtime cache'],
+  ['host.with_shared_value(runtime)', 'default host runtime attachment'],
+]) requireText(hostRuntime, value, label);
+
+for (const [value, label] of [
+  [
+    'fulfillment_lifecycle_read_runtime:\n        crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime',
+    'Commerce HTTP runtime field',
+  ],
+  ['fn fulfillment_read_port(', 'Commerce HTTP port getter'],
+  [
+    '.shared_get::<crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()',
+    'Commerce HTTP host lookup',
+  ],
+  [
+    'Commerce HTTP routes require CommerceFulfillmentLifecycleReadRuntime in HostRuntimeContext',
+    'Commerce HTTP fail-closed message',
+  ],
+  ['fulfillment_lifecycle_read_runtime,', 'Commerce HTTP runtime initialization'],
+]) requireText(commerceHttp, value, label);
 
 for (const [value, label] of [
   ['inner: ::rustok_fulfillment::FulfillmentService,', 'retained concrete facade field'],
@@ -167,8 +192,10 @@ for (const value of [
   'error.message',
 ]) forbidText(ownerSource, value, 'owner message exposure');
 
-if (evidence.status !== 'source_ready_unvalidated') {
-  failures.push(`evidence status: expected source_ready_unvalidated, found ${evidence.status}`);
+if (evidence.status !== 'source_composed_unvalidated') {
+  failures.push(
+    `evidence status: expected source_composed_unvalidated, found ${evidence.status}`,
+  );
 }
 if (evidence.owner?.port !== 'FulfillmentReadPort') {
   failures.push('evidence owner port must be FulfillmentReadPort');
@@ -182,11 +209,17 @@ if (evidence.runtime_publication?.graphql_host_override_supported !== true) {
 if (evidence.runtime_publication?.graphql_manifest_fallback !== 'in_process') {
   failures.push('evidence must record the GraphQL in-process fallback');
 }
-if (evidence.runtime_publication?.server_cache_composed !== false) {
-  failures.push('evidence must retain default server cache composition as false');
+if (evidence.runtime_publication?.server_cache_composed !== true) {
+  failures.push('evidence must record default server cache composition');
 }
-if (evidence.runtime_publication?.default_server_attachment !== false) {
-  failures.push('evidence must retain default server attachment as false');
+if (evidence.runtime_publication?.default_server_attachment !== true) {
+  failures.push('evidence must record default server attachment');
+}
+if (evidence.runtime_publication?.commerce_http_runtime_required !== true) {
+  failures.push('evidence must record mandatory Commerce HTTP runtime injection');
+}
+if (evidence.runtime_publication?.external_adapter_preserved !== true) {
+  failures.push('evidence must record preservation of external adapters');
 }
 if (evidence.consumer_cutover?.graphql_compatibility_facade !== false) {
   failures.push('evidence must retain GraphQL facade cutover as false');
@@ -217,5 +250,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment lifecycle reads are owner-published with a host-selectable Commerce runtime while default server and consumer cutovers remain explicitly open',
+  '✔ fulfillment lifecycle reads are owner-published, default-host composed, and injected into Commerce HTTP while GraphQL/admin consumer cutovers remain explicitly open',
 );


### PR DESCRIPTION
## Summary

- compose `CommerceFulfillmentLifecycleReadRuntime` once in the default application host;
- preserve a lifecycle runtime already installed in `ServerRuntimeContext`, otherwise construct the canonical in-process baseline and cache it;
- attach the same typed runtime to `HostRuntimeContext` for mounted transports;
- require the lifecycle runtime in `CommerceHttpRuntime::from_host` and expose its cloned `FulfillmentReadPort` for route handlers;
- update source evidence, owner documentation, the fulfillment implementation plan, and the focused source guard.

## Preserved behavior

- GraphQL lifecycle lookup/list/latest-by-order still use the current compatibility facade;
- admin REST fulfillment list/detail handlers still use their current concrete read path;
- lifecycle mutations and orchestration paths are unchanged;
- GraphQL runtime-data retains its explicit in-process fallback for directly embedded compatibility schemas;
- externally installed lifecycle adapters are preserved by the default server composition;
- no FFA/FBA status is promoted.

## Boundary

This PR completes runtime plumbing only. It deliberately does **not**:

- route admin REST list/show through `FulfillmentReadPort`;
- add request-safe GraphQL lifecycle scope;
- route GraphQL lookup/list/latest-by-order through the port;
- remove the private GraphQL concrete `FulfillmentService` delegate;
- claim mounted execution or runtime parity evidence.

Evidence status is `source_composed_unvalidated`; all consumer-cutover and validation flags remain false.

## Recheck

- audited the current default server composition, Commerce HTTP runtime, GraphQL compatibility facade, and admin fulfillment routes;
- confirmed the owner read port/runtime from PR #2353 is present on `main`;
- rebuilt the branch as one atomic commit over current `main` commit `765b12129b500292c05d5f8a17f0e3902d345fb2`;
- confirmed the branch is one commit ahead, zero behind, with exactly six intended files;
- confirmed intervening `main` changes were unrelated test-only files.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested maintainer checks:

```bash
node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
cargo check -p rustok-server --features mod-commerce
```

## Next slice

Use the now host-composed runtime to cut admin REST fulfillment list/detail and GraphQL fulfillment lookup/list/latest-by-order over to `FulfillmentReadPort`, preserving each transport's current optional-not-found and public error policy.