### PR TITLE
feat(index): add admitted archive manifest

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -65,6 +65,19 @@ node scripts/verify/index-storage-tooling.mjs partition-report \
 
 The report command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save the derived report outside the immutable bundle, but the six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` remain the authoritative archive inputs. A report does not change admission and does not authorize production lifecycle work.
 
+## Machine-readable admitted archive manifest
+
+After the report is reviewed and the retained outcome is `admitted`, print a deterministic machine-readable archive manifest:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-archive-manifest \
+  --root evidence/index-partition/retained-run
+```
+
+`partition-archive-manifest` runs the same retained-bundle inspection as `partition-report`, refuses any outcome other than `admitted`, and prints JSON containing the evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, byte counts, and total retained bytes. Its `manifest_digest` is the SHA-256 digest of canonical JSON for the manifest payload before the `manifest_digest` field is added, under `canonical_json_without_manifest_digest_v1`.
+
+The archive-manifest command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save this derived index outside the immutable bundle. The manifest does not replace or modify the nine authoritative retained files, does not change admission, and does not authorize production lifecycle work.
+
 A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
 
 This tooling does not authorize or implement production relation rename/drop, copy/replay, dual-write, cutover, cleanup, or query-adapter changes. Admission remains a measured owner decision based on the retained packet.

--- a/scripts/verify/index-partition-archive-manifest-core.mjs
+++ b/scripts/verify/index-partition-archive-manifest-core.mjs
@@ -1,0 +1,85 @@
+import {
+  canonicalJson,
+  sha256Hex,
+} from './index-partition-evidence-core.mjs';
+import { REVIEW_CONTRACT } from './index-partition-review-core.mjs';
+
+export const ARCHIVE_MANIFEST_CONTRACT = 'index_partition_retained_archive_manifest_v1';
+export const ARCHIVE_MANIFEST_DIGEST_CONTRACT = 'canonical_json_without_manifest_digest_v1';
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const requireObject = (value, label) => {
+  if (!isObject(value)) throw new Error(`${label} must be an object`);
+  return value;
+};
+
+const requireNonEmptyString = (value, label) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+const requireInteger = (value, label) => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+};
+
+const normalizeFiles = (files) => {
+  if (!Array.isArray(files) || files.length !== 9) {
+    throw new Error('inspection.files must contain exactly nine retained files');
+  }
+  const roles = new Set();
+  const paths = new Set();
+  return files.map((file, index) => {
+    requireObject(file, `inspection.files[${index}]`);
+    const role = requireNonEmptyString(file.role, `inspection.files[${index}].role`);
+    const retainedPath = requireNonEmptyString(file.path, `inspection.files[${index}].path`);
+    const bytes = requireInteger(file.bytes, `inspection.files[${index}].bytes`);
+    const sha256 = requireNonEmptyString(file.sha256, `inspection.files[${index}].sha256`);
+    if (!/^[0-9a-f]{64}$/u.test(sha256)) {
+      throw new Error(`inspection.files[${index}].sha256 must be a lowercase SHA-256 digest`);
+    }
+    if (roles.has(role)) throw new Error(`inspection.files contains duplicate role ${role}`);
+    if (paths.has(retainedPath)) throw new Error(`inspection.files contains duplicate path ${retainedPath}`);
+    roles.add(role);
+    paths.add(retainedPath);
+    return { role, path: retainedPath, bytes, sha256 };
+  });
+};
+
+export const buildRetainedPartitionArchiveManifest = (inspection) => {
+  requireObject(inspection, 'inspection');
+  if (inspection.contract !== REVIEW_CONTRACT) {
+    throw new Error(`inspection.contract must be ${REVIEW_CONTRACT}`);
+  }
+  const packet = requireObject(inspection.packet, 'inspection.packet');
+  const admission = requireObject(inspection.admission, 'inspection.admission');
+  if (admission.outcome !== 'admitted') {
+    throw new Error('retained archive manifest requires admission outcome admitted');
+  }
+  const files = normalizeFiles(inspection.files);
+  const totalBytes = files.reduce((total, file) => total + file.bytes, 0);
+  requireInteger(totalBytes, 'archive manifest total bytes');
+  const payload = {
+    contract: ARCHIVE_MANIFEST_CONTRACT,
+    digest_contract: ARCHIVE_MANIFEST_DIGEST_CONTRACT,
+    source_review_contract: REVIEW_CONTRACT,
+    evidence_id: requireNonEmptyString(admission.evidence_id, 'admission.evidence_id'),
+    completed_at: requireNonEmptyString(admission.completed_at, 'admission.completed_at'),
+    admission_outcome: admission.outcome,
+    packet_digest: requireNonEmptyString(admission.packet_digest, 'admission.packet_digest'),
+    run_provenance: structuredClone(requireObject(admission.run_provenance, 'admission.run_provenance')),
+    database: structuredClone(requireObject(packet.database, 'packet.database')),
+    file_count: files.length,
+    total_bytes: totalBytes,
+    files,
+  };
+  return {
+    ...payload,
+    manifest_digest: sha256Hex(Buffer.from(canonicalJson(payload), 'utf8')),
+  };
+};

--- a/scripts/verify/index-partition-review.test.mjs
+++ b/scripts/verify/index-partition-review.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
@@ -6,9 +7,14 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { assemblePartitionPacket } from './index-partition-evidence-assembly-core.mjs';
-import { prepareManifest, validatePartitionPacket } from './index-partition-evidence-core.mjs';
+import {
+  canonicalJson,
+  prepareManifest,
+  validatePartitionPacket,
+} from './index-partition-evidence-core.mjs';
 
-const script = path.resolve('scripts/verify/render-index-partition-review.mjs');
+const reportScript = path.resolve('scripts/verify/render-index-partition-review.mjs');
+const archiveManifestScript = path.resolve('scripts/verify/render-index-partition-archive-manifest.mjs');
 const digest = (character) => character.repeat(64);
 
 const writeJson = (filename, value) => writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
@@ -120,11 +126,14 @@ const buildBundle = () => {
   return { root };
 };
 
-const runReport = (root) => spawnSync(
+const runScript = (script, root) => spawnSync(
   process.execPath,
   [script, '--root', root],
   { encoding: 'utf8' },
 );
+
+const runReport = (root) => runScript(reportScript, root);
+const runArchiveManifest = (root) => runScript(archiveManifestScript, root);
 
 const snapshot = (root) => Object.fromEntries(
   readdirSync(root).sort().map((filename) => [filename, readFileSync(path.join(root, filename))]),
@@ -146,6 +155,56 @@ test('renders a deterministic read-only nine-file retained bundle review', () =>
     assert.match(first.stdout, /Recalculated admission matches saved admission: `true`/u);
     assert.match(first.stdout, /Production partition copy\/replay/u);
     assert.deepEqual(snapshot(context.root), before);
+  } finally {
+    rmSync(context.root, { recursive: true, force: true });
+  }
+});
+
+test('prints a deterministic read-only admitted archive manifest', () => {
+  const context = buildBundle();
+  try {
+    const before = snapshot(context.root);
+    const first = runArchiveManifest(context.root);
+    const second = runArchiveManifest(context.root);
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(first.stderr, '');
+    assert.equal(first.stdout, second.stdout);
+    const manifest = JSON.parse(first.stdout);
+    const { manifest_digest: manifestDigest, ...payload } = manifest;
+    assert.equal(manifest.contract, 'index_partition_retained_archive_manifest_v1');
+    assert.equal(manifest.digest_contract, 'canonical_json_without_manifest_digest_v1');
+    assert.equal(manifest.source_review_contract, 'index_partition_retained_bundle_review_v1');
+    assert.equal(manifest.admission_outcome, 'admitted');
+    assert.equal(manifest.file_count, 9);
+    assert.equal(manifest.files.length, 9);
+    assert.equal(
+      manifest.total_bytes,
+      manifest.files.reduce((total, file) => total + file.bytes, 0),
+    );
+    assert.equal(
+      manifestDigest,
+      createHash('sha256').update(canonicalJson(payload)).digest('hex'),
+    );
+    assert.deepEqual(snapshot(context.root), before);
+  } finally {
+    rmSync(context.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses an archive manifest for a non-admitted retained bundle', () => {
+  const context = buildBundle();
+  try {
+    const packetPath = path.join(context.root, 'partition-packet.json');
+    const admissionPath = path.join(context.root, 'admission.json');
+    const packet = JSON.parse(readFileSync(packetPath, 'utf8'));
+    packet.manifest.thresholds.maximum_query_p95_regression_bps = 0;
+    writeJson(packetPath, packet);
+    writeJson(admissionPath, validatePartitionPacket(packet));
+    const result = runArchiveManifest(context.root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /requires admission outcome admitted/u);
+    assert.equal(result.stdout, '');
   } finally {
     rmSync(context.root, { recursive: true, force: true });
   }

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -23,25 +23,27 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs partition-report --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
+  node scripts/verify/index-storage-tooling.mjs partition-archive-manifest --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
   node scripts/verify/index-storage-tooling.mjs render --comparison <comparison.json> --decision <decision.json> --output <adr.md>
   node scripts/verify/index-storage-tooling.mjs verify-adr --comparison <comparison.json> --decision <decision.json> --adr <adr.md>
 
 Commands:
-  contract            Run static Index boundary, evidence, partition, standalone-tool, and ADR guards.
-  fixtures            Run standalone, evidence, comparator, decision, partition, and ADR fixture suites.
-  packet              Validate one smoke, 100k, or 1m storage evidence packet.
-  compare             Generate a cross-scale storage comparison.
-  partition-prepare   Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
-  partition-capture   Print a no-write preflight plan or run every owner-operated capture, assembly, and validation stage.
-  partition-assemble  Build one packet from six retained raw JSON artifacts and exact-byte hashes.
-  partition-validate  Validate a measured partition packet and publish calculated admission output.
-  partition-report    Recalculate and render a read-only review of all nine retained bundle files.
-  hash                Print the SHA-256 digest of the exact comparison.json bytes.
-  prepare             Create a non-overwriting manual decision draft bound to exact comparison bytes.
-  render              Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
-  verify-adr          Verify a saved ADR against exact comparison and decision bytes.`);
+  contract                    Run static Index boundary, evidence, partition, standalone-tool, and ADR guards.
+  fixtures                    Run standalone, evidence, comparator, decision, partition, and ADR fixture suites.
+  packet                      Validate one smoke, 100k, or 1m storage evidence packet.
+  compare                     Generate a cross-scale storage comparison.
+  partition-prepare           Bind an immutable partition evidence manifest and shadow-only bootstrap SQL.
+  partition-capture           Print a no-write preflight plan or run every owner-operated capture, assembly, and validation stage.
+  partition-assemble          Build one packet from six retained raw JSON artifacts and exact-byte hashes.
+  partition-validate          Validate a measured partition packet and publish calculated admission output.
+  partition-report            Recalculate and render a read-only review of all nine retained bundle files.
+  partition-archive-manifest  Print a deterministic JSON archive manifest for one admitted retained bundle.
+  hash                        Print the SHA-256 digest of the exact comparison.json bytes.
+  prepare                     Create a non-overwriting manual decision draft bound to exact comparison bytes.
+  render                      Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
+  verify-adr                  Verify a saved ADR against exact comparison and decision bytes.`);
 };
 
 const runNode = (args, label, environment = process.env) => {
@@ -216,6 +218,9 @@ switch (command) {
     break;
   case 'partition-report':
     runScript('render-index-partition-review.mjs', args);
+    break;
+  case 'partition-archive-manifest':
+    runScript('render-index-partition-archive-manifest.mjs', args);
     break;
   case 'hash':
     runScript('hash-index-storage-comparison.mjs', args);

--- a/scripts/verify/render-index-partition-archive-manifest.mjs
+++ b/scripts/verify/render-index-partition-archive-manifest.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+
+import { buildRetainedPartitionArchiveManifest } from './index-partition-archive-manifest-core.mjs';
+import { inspectRetainedPartitionBundle } from './index-partition-review-core.mjs';
+
+const prefix = '[render-index-partition-archive-manifest]';
+
+const usage = () => {
+  console.log(`Usage:
+  node scripts/verify/render-index-partition-archive-manifest.mjs \
+    --root <retained-bundle-directory> \
+    [--packet <partition-packet.json>] \
+    [--admission <admission.json>]
+
+The command validates one admitted retained bundle and prints a deterministic archive manifest to stdout. It writes no files.`);
+};
+
+const parseArgs = (args) => {
+  if (args.length === 1 && ['--help', '-h'].includes(args[0])) return null;
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--root', '--packet', '--admission'].includes(flag) || !value || value.startsWith('--')) {
+      throw new Error('expected --root and optional --packet/--admission pairs');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  if (!values.has('--root')) throw new Error('--root is required');
+  return {
+    root: path.resolve(values.get('--root')),
+    packetPath: values.has('--packet') ? path.resolve(values.get('--packet')) : undefined,
+    admissionPath: values.has('--admission') ? path.resolve(values.get('--admission')) : undefined,
+  };
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options === null) {
+    usage();
+  } else {
+    const inspection = inspectRetainedPartitionBundle(options);
+    const manifest = buildRetainedPartitionArchiveManifest(inspection);
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+  }
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -28,6 +28,8 @@ try {
   const planTest = read('scripts/verify/index-partition-full-capture-plan.test.mjs');
   const reviewCore = read('scripts/verify/index-partition-review-core.mjs');
   const reviewCli = read('scripts/verify/render-index-partition-review.mjs');
+  const archiveCore = read('scripts/verify/index-partition-archive-manifest-core.mjs');
+  const archiveCli = read('scripts/verify/render-index-partition-archive-manifest.mjs');
   const reviewTest = read('scripts/verify/index-partition-review.test.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
@@ -131,7 +133,26 @@ try {
     'process.stdout.write',
     'It writes no files.',
   ], 'retained partition review CLI');
-  forbidMarkers(`${reviewCore}\n${reviewCli}`, [
+  requireMarkers(archiveCore, [
+    'index_partition_retained_archive_manifest_v1',
+    'canonical_json_without_manifest_digest_v1',
+    'REVIEW_CONTRACT',
+    "admission.outcome !== 'admitted'",
+    'must contain exactly nine retained files',
+    'total_bytes: totalBytes',
+    "sha256Hex(Buffer.from(canonicalJson(payload), 'utf8'))",
+  ], 'retained partition archive manifest core');
+  requireMarkers(archiveCli, [
+    "'--root'",
+    "'--packet'",
+    "'--admission'",
+    'inspectRetainedPartitionBundle',
+    'buildRetainedPartitionArchiveManifest',
+    'JSON.stringify(manifest, null, 2)',
+    'process.stdout.write',
+    'It writes no files.',
+  ], 'retained partition archive manifest CLI');
+  forbidMarkers(`${reviewCore}\n${reviewCli}\n${archiveCore}\n${archiveCli}`, [
     'writeFileSync',
     'mkdirSync',
     'renameSync',
@@ -139,10 +160,15 @@ try {
     'spawnSync',
     'DATABASE_URL',
     'INDEX_PARTITION_ALLOW',
-  ], 'retained partition review tooling');
+  ], 'retained partition review and archive tooling');
   requireMarkers(reviewTest, [
     'renders a deterministic read-only nine-file retained bundle review',
     'Retained file count: `9`',
+    'prints a deterministic read-only admitted archive manifest',
+    'index_partition_retained_archive_manifest_v1',
+    'canonical_json_without_manifest_digest_v1',
+    "createHash('sha256').update(canonicalJson(payload)).digest('hex')",
+    'refuses an archive manifest for a non-admitted retained bundle',
     'assert.deepEqual(snapshot(context.root), before)',
     'saved admission that does not match recalculated packet admission',
     'rejects raw artifact drift from the retained packet',
@@ -153,6 +179,8 @@ try {
     'index-partition-full-capture-plan.test.mjs',
     'partition-report',
     'render-index-partition-review.mjs',
+    'partition-archive-manifest',
+    'render-index-partition-archive-manifest.mjs',
     'index-partition-review.test.mjs',
     'verify-index-partition-full-capture.mjs',
   ], 'index storage tooling router');
@@ -170,6 +198,9 @@ try {
     'partition-report',
     'all nine retained files',
     'recalculates packet assembly and admission',
+    'partition-archive-manifest',
+    'refuses any outcome other than `admitted`',
+    'canonical_json_without_manifest_digest_v1',
     'writes no files',
     'forbidden before one retained admitted packet',
   ], 'full partition capture runbook');


### PR DESCRIPTION
## Summary

- add `partition-archive-manifest`, a read-only owner command for one already admitted retained partition bundle;
- reuse the existing nine-file retained-bundle inspection, packet reassembly, and admission recalculation before emitting archive metadata;
- require the recalculated admission outcome to be exactly `admitted`;
- print deterministic JSON containing evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, per-file byte counts, and total retained bytes;
- bind the manifest with `manifest_digest`, calculated from canonical JSON before the digest field is added under `canonical_json_without_manifest_digest_v1`;
- reject duplicate roles/paths, invalid digests, unsafe byte counts, incomplete inventories, and non-admitted outcomes;
- keep the command stdout-only with no file writes, PostgreSQL connection, Cargo command, or evidence stage;
- register the command, extend the retained-bundle fixture, strengthen static no-write guards, and document the owner archive flow.

## Safety boundary

This PR creates only a derived machine-readable index for an already produced and admitted retained bundle. It does not replace or modify the six raw artifacts, `capture.json`, `partition-packet.json`, or `admission.json`. It does not create or change admission and does not add production partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter behavior.

## Validation

Tests, fixture suites, contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run, per repository-owner instruction.

Only JavaScript syntax and local static marker checks were performed before publication:

```bash
node --check scripts/verify/index-partition-archive-manifest-core.mjs
node --check scripts/verify/render-index-partition-archive-manifest.mjs
node --check scripts/verify/index-partition-review.test.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
```

Suggested owner checks:

```bash
node scripts/verify/verify-index-partition-full-capture.mjs
node --test scripts/verify/index-partition-review.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

## Owner usage

```bash
node scripts/verify/index-storage-tooling.mjs partition-archive-manifest \
  --root evidence/index-partition/retained-run
```

Shell redirection may save the derived manifest outside the immutable retained bundle. The nine retained evidence files remain the authoritative archive inputs.