### PR TITLE
test(profiles): define retained PostgreSQL poison evidence

### DIFF
--- a/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
+++ b/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
@@ -43,6 +43,9 @@
     }
   ],
   "source_files": [
+    "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json",
+    "scripts/evidence/capture-iggy-consumer-poison-postgres.mjs",
+    "scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs",
     "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs",
     "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs",
     "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",

--- a/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
+++ b/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
@@ -43,9 +43,6 @@
     }
   ],
   "source_files": [
-    "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json",
-    "scripts/evidence/capture-iggy-consumer-poison-postgres.mjs",
-    "scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs",
     "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs",
     "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs",
     "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",

--- a/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
+++ b/crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": 1,
+  "module": "iggy-connector",
+  "packet": "consumer-poison-postgres-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "runner": "scripts/evidence/capture-iggy-consumer-poison-postgres.mjs",
+  "verifier": "scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs",
+  "evidence_path": "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution.json",
+  "execution_scope": "opt_in_postgresql_runtime_execution_pending",
+  "promotion_gate": "requires_clean_commit_and_all_required_cases_passed",
+  "database_url_env": "RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL",
+  "database_url_fallback_env": "DATABASE_URL",
+  "commands": [
+    {
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-iggy-connector",
+        "--features",
+        "migrations",
+        "--test",
+        "consumer_poison_receipt_postgres_environment",
+        "--",
+        "--nocapture",
+        "--test-threads=1"
+      ]
+    },
+    {
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-iggy-connector",
+        "--features",
+        "migrations",
+        "--test",
+        "consumer_poison_receipt_postgres",
+        "--",
+        "--nocapture",
+        "--test-threads=1"
+      ]
+    }
+  ],
+  "source_files": [
+    "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs",
+    "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs",
+    "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",
+    "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs",
+    "crates/rustok-iggy-connector/src/migrations.rs"
+  ],
+  "required_metadata": [
+    "git_commit",
+    "started_at",
+    "completed_at",
+    "postgres_server_version",
+    "postgres_server_version_num",
+    "cargo_version",
+    "rustc_version",
+    "test_output_sha256",
+    "source_sha256"
+  ],
+  "required_cases": [
+    {
+      "case": "concurrent_publishers_have_one_claim_owner",
+      "assertions": [
+        "exactly_one_publisher_claimed",
+        "other_publisher_busy",
+        "first_error_code_and_attempt_retained_as_one_atomic_pair"
+      ]
+    },
+    {
+      "case": "expired_lease_is_reclaimed_and_fences_the_previous_publisher",
+      "assertions": [
+        "empty_exact_payload_accepted",
+        "expired_publication_lease_reclaimed",
+        "previous_publisher_fenced_with_claim_lost",
+        "first_diagnostics_unchanged_after_reclaim"
+      ]
+    },
+    {
+      "case": "conflicts_roll_back_without_overwriting_original_identity",
+      "assertions": [
+        "delivery_uuid_source_collision_rejected",
+        "source_coordinate_payload_collision_rejected",
+        "original_receipt_unchanged",
+        "failed_conflicts_leave_one_receipt"
+      ]
+    },
+    {
+      "case": "terminal_states_and_aggregate_inspection_remain_consistent",
+      "assertions": [
+        "reserved_published_acknowledged_counts_consistent",
+        "expired_publishing_subset_consistent",
+        "published_redelivery_does_not_reopen_publication",
+        "acknowledged_redelivery_does_not_reopen_publication"
+      ]
+    }
+  ],
+  "evidence_status": "runtime_execution_pending"
+}

--- a/crates/rustok-iggy-connector/docs/consumer-poison-postgres-evidence.md
+++ b/crates/rustok-iggy-connector/docs/consumer-poison-postgres-evidence.md
@@ -21,11 +21,11 @@ Set one of:
 1. `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL`;
 2. `DATABASE_URL` as a fallback.
 
-The value must begin with `postgres://` or `postgresql://`. Without a PostgreSQL URL, every test reports a skip and returns successfully. The repository contains no default PostgreSQL credentials or localhost fallback.
+The value must begin with `postgres://` or `postgresql://`. Without a PostgreSQL URL, the direct test harness reports a skip and returns successfully. The retained-evidence runner rejects a missing or non-PostgreSQL URL and writes no packet. The repository contains no default PostgreSQL credentials or localhost fallback.
 
 ## Isolation
 
-Each test:
+Each scenario:
 
 1. creates a unique schema named `rustok_iggy_poison_<scenario>_<uuid>`;
 2. opens an isolated one-connection pool;
@@ -40,7 +40,7 @@ The concurrent claim test opens two additional one-connection pools and sets the
 
 ### Claim ownership
 
-Two publishers call `reserve_and_claim` concurrently for the same exact delivery. Exactly one result must be `Claimed`; the other must be `Busy`. The durable row remains `publishing` and retains whichever bounded diagnostic was observed first.
+Two publishers call `reserve_and_claim` concurrently for the same exact delivery. Exactly one result must be `Claimed`; the other must be `Busy`. The durable row remains `publishing` and retains one atomic first-observed error-code/attempt pair.
 
 ### Lease reclaim and fencing
 
@@ -61,18 +61,56 @@ Both fail as `IdentityConflict`. The original receipt remains unchanged and the 
 
 The harness creates one reserved, one published, and one acknowledged receipt. `ConsumerPoisonReceiptInspector` must report total `3` with exact per-state counts and no expired publishing claims. Redelivery must return `AlreadyPublished` or `AlreadyAcknowledged` without reopening publication.
 
+## Retained execution contract
+
+`contracts/evidence/consumer-poison-postgres-execution-contract.json` locks:
+
+- the two exact Cargo commands;
+- the four required scenario names and assertions;
+- the source files whose SHA-256 values bind an executed packet;
+- required Git, toolchain, PostgreSQL, timestamp, and output-digest metadata;
+- the output path for retained evidence.
+
+`capture-iggy-consumer-poison-postgres.mjs` requires a clean working tree and a full Git commit SHA. It executes a small PostgreSQL environment test followed by the receipt scenarios with one test thread. The environment test reads `server_version` and `server_version_num` through the same SeaORM/PostgreSQL path; no `psql` installation is required.
+
+The runner writes `consumer-poison-postgres-execution.json` atomically only when both Cargo commands succeed, every required test reports `ok`, the Git commit remains unchanged, and source hashes remain stable throughout execution.
+
+The retained packet contains no database URL, host, database name, credentials, raw test log, delivery UUID, source coordinate, or payload. It stores only:
+
+- the environment variable name that supplied the URL;
+- bounded PostgreSQL and Rust toolchain versions;
+- start/end timestamps and Git commit;
+- exact command arrays;
+- source and combined-output SHA-256 values;
+- aggregate per-case `pass` results.
+
 ## Maintainer commands
+
+Diagnostic harness only:
 
 ```bash
 RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' \
   cargo test -p rustok-iggy-connector --features migrations \
   --test consumer_poison_receipt_postgres -- --nocapture
+```
 
+Create the retained packet from a clean commit:
+
+```bash
+RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' \
+  node scripts/evidence/capture-iggy-consumer-poison-postgres.mjs
+
+node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs
+```
+
+The existing source harness guard remains available:
+
+```bash
 node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
 ```
 
-For stronger concurrency evidence, run the test target repeatedly against the same PostgreSQL server while allowing each invocation to create its own schemas. Do not reuse a schema or replace the unique-schema setup with shared-table truncation.
+For stronger concurrency evidence, execute the retained runner repeatedly against the same PostgreSQL server on separate clean commits or retain separately reviewed packets outside the canonical repository path. Do not reuse a schema or replace the unique-schema setup with shared-table truncation.
 
 ## Evidence status
 
-The harness and source guard are source-complete. No PostgreSQL command, Cargo command, formatter, or source verifier was executed when this slice was authored. A successful maintainer run remains required before claiming runtime proof.
+The harness, execution contract, metadata test, runner, and source verifiers are source-complete. `consumer-poison-postgres-execution.json` is intentionally absent until a maintainer performs a successful PostgreSQL run. No PostgreSQL command, Cargo command, formatter, or source verifier was executed when this slice was authored.

--- a/crates/rustok-iggy-connector/docs/implementation-plan.md
+++ b/crates/rustok-iggy-connector/docs/implementation-plan.md
@@ -49,12 +49,17 @@ The explicit platform append-only migration tail includes both
 `m20260728_000001_create_consumer_poison_receipts`, preserving the previously published
 migration prefix.
 
-An opt-in PostgreSQL integration harness now creates a unique schema per scenario and
-applies connector migrations directly. It defines source evidence for independent
+An opt-in PostgreSQL integration harness creates a unique schema per scenario and
+applies connector migrations directly. Four source-complete scenarios cover independent
 concurrent claim connections, lease reclaim/fencing, collision rollback,
 first-diagnostic retention, empty payloads, terminal recognition, and aggregate
-inspection. The harness is source-complete but has not been executed; PostgreSQL runtime
-proof remains open.
+inspection.
+
+A retained execution contract now locks the exact Cargo commands, required cases,
+source-hash set, metadata fields, and canonical evidence path. A clean-commit runner
+collects bounded PostgreSQL/toolchain metadata and writes an evidence packet atomically
+only after every required case succeeds. The packet is intentionally absent until a
+maintainer executes the runner; PostgreSQL runtime proof remains open.
 
 ## FFA/FBA boundary
 
@@ -94,6 +99,11 @@ proof remains open.
   database creation/deletion.
 - Direct test SQL is limited to deterministic lease expiry and read-only diagnostics;
   production receipt transitions are exercised through the public store API.
+- Retained execution requires a clean commit, unchanged source hashes, exact contract
+  commands, one unambiguous PostgreSQL server version, and all required test cases.
+- Retained packets never store the database URL, host, database name, credentials, raw
+  test output, delivery identity, source coordinates, or payload. Raw output is reduced
+  to SHA-256 plus byte count.
 - The server enables feature `migrations` explicitly when it composes the neutral store;
   runtime availability does not rely on transitive feature unification.
 - Existing source guard: `node scripts/verify/verify-iggy-connector-source.mjs`.
@@ -103,8 +113,10 @@ proof remains open.
   `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`.
 - Owner observer/metrics guard:
   `node scripts/verify/verify-social-graph-index-poison-observer.mjs`.
-- PostgreSQL evidence guard:
+- PostgreSQL harness guard:
   `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`.
+- Retained execution guard:
+  `node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs`.
 
 ## Delivered results
 
@@ -131,6 +143,9 @@ proof remains open.
    ownership, lease reclaim/fencing, collision rollback, first-diagnostic retention,
    empty payloads, terminal redelivery, and aggregate consistency without claiming an
    executed runtime result.
+9. **Retained PostgreSQL execution contract.** An environment metadata test, clean-commit
+   runner, atomic evidence writer, source/output digests, and strict verifier define how
+   runtime proof becomes retainable without storing credentials or delivery-level facts.
 
 ## Next results
 
@@ -138,10 +153,11 @@ proof remains open.
    exact publish-before-ack ordering, acknowledgement-only redelivery, reconnect, exact
    commit, publication failure, restart, and multi-replica behavior in bundled and
    external environments.
-2. **Execute and retain PostgreSQL receipt evidence.** Run the isolated-schema harness
-   against PostgreSQL, retain command/environment/server-version evidence, repeat the
-   concurrent ownership scenario, and prove cleanup. Source coverage exists; runtime
-   execution remains owner work.
+2. **Execute and retain PostgreSQL receipt evidence.** Run
+   `capture-iggy-consumer-poison-postgres.mjs` from a clean commit, review the generated
+   packet, verify it, and commit the canonical evidence JSON. Repeat execution when any
+   bound source hash changes. Source coverage and capture tooling exist; runtime execution
+   remains owner work.
 3. **Extend PostgreSQL evidence to multi-replica observer behavior.** Prove aggregate
    consistency during concurrent claims, lease expiry, terminal transitions, and
    observer polling without adding mutation policy to inspection.
@@ -164,9 +180,11 @@ proof remains open.
 - `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
 - `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`
+- `node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
 - `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture`
+- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' node scripts/evidence/capture-iggy-consumer-poison-postgres.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`

--- a/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs
+++ b/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "migrations")]
+
+use std::error::Error;
+
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+
+const TEST_DATABASE_ENV: &str = "RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn reports_postgres_server_version_for_retained_evidence() -> TestResult<()> {
+    let Some(database_url) = postgres_database_url() else {
+        eprintln!(
+            "{TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping retained evidence metadata"
+        );
+        return Ok(());
+    };
+
+    let db = connect(&database_url).await?;
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT current_setting('server_version') AS server_version, current_setting('server_version_num') AS server_version_num".to_string(),
+        ))
+        .await?
+        .expect("PostgreSQL version query must return one row");
+    let server_version: String = row.try_get("", "server_version")?;
+    let server_version_num: String = row.try_get("", "server_version_num")?;
+    let server_version = bounded_metadata("server_version", &server_version)?;
+    let server_version_num = bounded_metadata("server_version_num", &server_version_num)?;
+
+    println!("RUSTOK_IGGY_POISON_EVIDENCE postgres_server_version={server_version}");
+    println!("RUSTOK_IGGY_POISON_EVIDENCE postgres_server_version_num={server_version_num}");
+    Ok(())
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+fn bounded_metadata<'a>(field: &'static str, value: &'a str) -> TestResult<&'a str> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(format!("{field} must not be empty").into());
+    }
+    if value.len() > 128 {
+        return Err(format!("{field} exceeds retained evidence limit").into());
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!("{field} contains control characters").into());
+    }
+    Ok(value)
+}

--- a/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs
+++ b/crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "migrations")]
 
 use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
 
 use sea_orm::{
     ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
@@ -53,16 +54,25 @@ async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
     Ok(Database::connect(options).await?)
 }
 
-fn bounded_metadata<'a>(field: &'static str, value: &'a str) -> TestResult<&'a str> {
+fn bounded_metadata<'a>(field: &'static str, value: &'a str) -> Result<&'a str, IoError> {
     let value = value.trim();
     if value.is_empty() {
-        return Err(format!("{field} must not be empty").into());
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{field} must not be empty"),
+        ));
     }
     if value.len() > 128 {
-        return Err(format!("{field} exceeds retained evidence limit").into());
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{field} exceeds retained evidence limit"),
+        ));
     }
     if value.chars().any(char::is_control) {
-        return Err(format!("{field} contains control characters").into());
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{field} contains control characters"),
+        ));
     }
     Ok(value)
 }

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -15,7 +15,8 @@ restricted or unavailable rows as absent.
 `followers_only` visibility resolves through authoritative Social Graph owner
 ports. Profiles never reads relation tables and never authorizes from an event,
 Index projection, decoded/raw DLQ receipt, neutral receipt aggregate, broker
-identifier, consumer offset, lag metric, or poison-receipt health signal.
+identifier, consumer offset, lag metric, poison-receipt health signal, or retained
+receipt evidence packet.
 
 Media descriptors remain Media-owned. Profiles validates tenant, uploader, and
 MIME constraints and exposes only Media-selected descriptors. Profiles does not
@@ -67,10 +68,14 @@ mutation retry.
   values; a missing/stopped observer is degraded health and never blocks projection.
 - The explicit append-only migration tail contains both receipt migrations, so the
   previously published migration prefix is preserved.
-- An opt-in PostgreSQL receipt harness now defines isolated-schema evidence for
+- An opt-in PostgreSQL receipt harness defines isolated-schema evidence for
   concurrent ownership, lease reclaim/fencing, collision rollback,
   first-diagnostic retention, empty payloads, terminal recognition, and aggregate
-  inspection. It has not been executed.
+  inspection.
+- A retained execution contract locks the exact Cargo commands, required cases,
+  bounded metadata, source hashes, and canonical packet path. Its clean-commit
+  runner and strict verifier are source-complete; the execution JSON is intentionally
+  absent until a maintainer runs PostgreSQL successfully.
 - Main also contains generic Index partition snapshot/query/mutation evidence.
   That strengthens the shared Index substrate but does not validate this Social
   Graph consumer, its schema registration, or Profiles presentation policy.
@@ -134,9 +139,10 @@ The Social Graph Index worker is wired to the typed result:
 - the raw path never invokes Index projection and never creates tenant/event facts.
 
 Migration-order reconciliation is complete. The remaining work is execution and
-retained proof: compile the current mainline, run PostgreSQL claim/lease/collision/
-inspection scenarios, run real-Iggy publication/ack/restart scenarios, and retain
-multi-replica/operator evidence without weakening privacy or exactly-once language.
+retained proof: compile the current mainline, run the clean-commit PostgreSQL
+capture runner, review and commit its canonical evidence JSON, run real-Iggy
+publication/ack/restart scenarios, and retain multi-replica/operator evidence
+without weakening privacy or exactly-once language.
 
 ## FFA/FBA boundary
 
@@ -194,19 +200,22 @@ multi-replica/operator evidence without weakening privacy or exactly-once langua
    deterministic DLQ broker identity, maintenance, events, replay, cleanup CLI,
    persisted schema registration, durable terminal recognition, default-off shared
    transport lifecycle, retries, shutdown, readiness, bounded metrics, complete
-   lag, count-only poison health, and a PostgreSQL receipt evidence harness.
-   **Remaining:** execute PostgreSQL concurrency/retention/replay/rollback evidence,
-   approve deployment retention, prove real broker observer/reconnect/TLS/rebalance,
-   deterministic header and dedup disabled/enabled/expiry/capacity behavior,
-   confirmation policy, multi-replica behavior, and retained operator packets.
+   lag, count-only poison health, PostgreSQL scenarios, and retained capture tooling.
+   **Remaining:** execute and commit PostgreSQL evidence, prove retention/replay/
+   rollback, approve deployment retention, prove real broker observer/reconnect/
+   TLS/rebalance, deterministic header and dedup disabled/enabled/expiry/capacity
+   behavior, confirmation policy, multi-replica behavior, and retained operator
+   packets.
 
 6. **Handle undecodable sealed contract deliveries without invented ownership.**
    **Status:** source-complete for typed receive, immutable connector identity,
    neutral durable receipt, exact-byte DLQ publication, durable published-before-ack,
    existing-result recovery, best-effort post-ack bookkeeping, append-only migration
-   placement, count-only health, and opt-in PostgreSQL evidence scenarios.
-   **Next:** execute the PostgreSQL harness, retain database/server/cleanup evidence,
-   then execute real-Iggy failure/restart/dedup/multi-replica scenarios.
+   placement, count-only health, opt-in PostgreSQL scenarios, and a fail-closed
+   retained execution contract/runner/verifier.
+   **Next:** execute the clean-commit PostgreSQL runner, review and commit the
+   canonical packet, then execute real-Iggy failure/restart/dedup/multi-replica
+   scenarios.
    **Done when:** malformed bytes are retained, classified, durably terminalized,
    published/recovered, and acknowledged without fabricated tenant/event identity,
    implicit commits, duplicate authorization effects, or exactly-once claims, and
@@ -222,7 +231,7 @@ multi-replica/operator evidence without weakening privacy or exactly-once langua
   identity, readiness, telemetry, and position observation from PR #2317.
 - Reconfirmed privacy-before-presentation, bounded follower reads, owner-scoped
   writes, Media-owned descriptors, no automatic mutation retry, and the rule that
-  Index/broker/receipt/metric state never authorizes profile presentation.
+  Index/broker/receipt/metric/evidence state never authorizes profile presentation.
 - Added the typed exact-byte decode-failure contract with explicit acknowledgement.
 - Added connector-owned neutral receipt DDL/store with private immutable source
   identity, empty exact-byte support, collision detection, first-diagnostic
@@ -242,6 +251,9 @@ multi-replica/operator evidence without weakening privacy or exactly-once langua
 - Added an opt-in isolated-schema PostgreSQL harness for claim ownership, lease
   reclaim/fencing, collision rollback, atomic first-diagnostic retention, terminal
   recognition, and aggregate consistency.
+- Added a PostgreSQL metadata test, clean-commit capture runner, atomic canonical
+  packet writer, source/output SHA-256 binding, and strict retained-evidence verifier.
+- The canonical execution JSON remains absent until a maintainer runs PostgreSQL.
 - Tests, Cargo commands, formatters, source verifiers, PostgreSQL, real-broker, and
   multi-replica scenarios were not run, per maintainer instruction.
 
@@ -259,9 +271,11 @@ multi-replica/operator evidence without weakening privacy or exactly-once langua
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
 - `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture`
+- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' node scripts/evidence/capture-iggy-consumer-poison-postgres.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`
+- `node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-index --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets`
@@ -309,6 +323,8 @@ multi-replica/operator evidence without weakening privacy or exactly-once langua
     connector poison contract and acknowledge only after its terminal result exists.
 16. Existing durable poison choices remain recoverable across later policy disablement;
     new undecodable deliveries remain uncommitted without an enabled terminal policy.
-17. Count-only receipt health and PostgreSQL evidence never authorize, acknowledge,
-    reclaim, repair, retain, or delete production delivery state.
-18. Update Profiles and affected owner docs with every boundary change.
+17. Count-only receipt health and retained PostgreSQL evidence never authorize,
+    acknowledge, reclaim, repair, retain, or delete production delivery state.
+18. Retained packets must be generated from a clean commit, omit credentials and
+    delivery-level facts, and become stale when any bound source SHA-256 changes.
+19. Update Profiles and affected owner docs with every boundary change.

--- a/scripts/evidence/capture-iggy-consumer-poison-postgres.mjs
+++ b/scripts/evidence/capture-iggy-consumer-poison-postgres.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json";
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.error) {
+    fail(`${program} could not start: ${result.error.message}`);
+  }
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function oneLine(value, field) {
+  const line = value.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (!line || line.length > 256 || /[\u0000-\u001f\u007f]/u.test(line)) {
+    fail(`${field} is missing or outside the retained evidence boundary`);
+  }
+  return line;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function sameRecord(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function requirePassedCase(output, caseName) {
+  const pattern = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(caseName)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!pattern.test(output)) {
+    fail(`required PostgreSQL case did not report success: ${caseName}`);
+  }
+}
+
+function markerValues(output, marker) {
+  const prefix = `RUSTOK_IGGY_POISON_EVIDENCE ${marker}=`;
+  return output
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(prefix))
+    .map((line) => line.slice(prefix.length).trim())
+    .filter(Boolean);
+}
+
+function requireOneMarker(output, marker) {
+  const values = [...new Set(markerValues(output, marker))];
+  if (values.length !== 1) {
+    fail(`expected exactly one retained evidence marker for ${marker}`);
+  }
+  return oneLine(values[0], marker);
+}
+
+function ensureOutputInsideRepository() {
+  const root = resolve(repoRoot) + sep;
+  if (!outputPath.startsWith(root)) {
+    fail("retained evidence output path must stay inside the repository");
+  }
+}
+
+function validateDatabaseUrl() {
+  const primary = process.env[contract.database_url_env];
+  const fallback = process.env[contract.database_url_fallback_env];
+  const value = primary || fallback;
+  if (!value) {
+    fail(
+      `${contract.database_url_env} or ${contract.database_url_fallback_env} must provide an opt-in PostgreSQL URL`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail("the opt-in PostgreSQL URL is invalid");
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    fail("the retained evidence runner accepts PostgreSQL URLs only");
+  }
+  return primary ? contract.database_url_env : contract.database_url_fallback_env;
+}
+
+function ensureCleanCommit() {
+  const status = runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]);
+  if (status.stdout.trim()) {
+    fail("working tree must be clean before retained evidence execution");
+  }
+  const commit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "git_commit",
+  );
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("git commit must be a full lowercase SHA-1");
+  }
+  return commit;
+}
+
+function executeContractCommand(command) {
+  return runChecked(command.program, command.args);
+}
+
+function writeAtomically(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  if (existsSync(temporaryPath)) {
+    unlinkSync(temporaryPath);
+  }
+  writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+try {
+  ensureOutputInsideRepository();
+  const databaseUrlSource = validateDatabaseUrl();
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const startedAt = new Date().toISOString();
+
+  if (!Array.isArray(contract.commands) || contract.commands.length !== 2) {
+    fail("retained evidence contract must contain exactly two commands");
+  }
+  const environmentResult = executeContractCommand(contract.commands[0]);
+  const scenarioResult = executeContractCommand(contract.commands[1]);
+  const environmentOutput = `${environmentResult.stdout}\n${environmentResult.stderr}`;
+  const scenarioOutput = `${scenarioResult.stdout}\n${scenarioResult.stderr}`;
+
+  const postgresServerVersion = requireOneMarker(
+    environmentOutput,
+    "postgres_server_version",
+  );
+  const postgresServerVersionNum = requireOneMarker(
+    environmentOutput,
+    "postgres_server_version_num",
+  );
+  if (!/^\d+$/u.test(postgresServerVersionNum)) {
+    fail("postgres_server_version_num must contain digits only");
+  }
+
+  for (const requiredCase of contract.required_cases) {
+    requirePassedCase(scenarioOutput, requiredCase.case);
+  }
+  if (scenarioOutput.includes("skipping consumer poison receipt PostgreSQL evidence")) {
+    fail("scenario tests reported a skip instead of PostgreSQL execution");
+  }
+
+  const finalCommit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+  );
+  if (finalCommit !== gitCommit) {
+    fail("git commit changed during retained evidence execution");
+  }
+  const finalSourceSha256 = sourceHashes();
+  if (!sameRecord(finalSourceSha256, initialSourceSha256)) {
+    fail("retained evidence source files changed during execution");
+  }
+  const completedAt = new Date().toISOString();
+  const combinedOutput = `${environmentOutput}\n--- consumer poison scenarios ---\n${scenarioOutput}`;
+
+  const packet = {
+    schema_version: 1,
+    module: contract.module,
+    packet: "consumer-poison-postgres-runtime-evidence",
+    status: "postgres_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    database_url_source: databaseUrlSource,
+    database: {
+      backend: "postgresql",
+      server_version: postgresServerVersion,
+      server_version_num: postgresServerVersionNum,
+    },
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    commands: contract.commands,
+    source_sha256: finalSourceSha256,
+    test_output_sha256: sha256(combinedOutput),
+    test_output_bytes: Buffer.byteLength(combinedOutput),
+    executed_cases: contract.required_cases.map((requiredCase) => ({
+      case: requiredCase.case,
+      result: "pass",
+      assertions: requiredCase.assertions,
+    })),
+  };
+
+  writeAtomically(packet);
+  console.log(`Retained PostgreSQL evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`PostgreSQL poison receipt evidence capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/evidence/capture-iggy-consumer-poison-postgres.mjs
+++ b/scripts/evidence/capture-iggy-consumer-poison-postgres.mjs
@@ -16,6 +16,49 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json";
+const expectedRunnerPath = "scripts/evidence/capture-iggy-consumer-poison-postgres.mjs";
+const expectedVerifierPath =
+  "scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs";
+const expectedEvidencePath =
+  "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution.json";
+const expectedCommands = [
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-iggy-connector",
+      "--features",
+      "migrations",
+      "--test",
+      "consumer_poison_receipt_postgres_environment",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-iggy-connector",
+      "--features",
+      "migrations",
+      "--test",
+      "consumer_poison_receipt_postgres",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+];
+const expectedCaseNames = [
+  "concurrent_publishers_have_one_claim_owner",
+  "expired_lease_is_reclaimed_and_fences_the_previous_publisher",
+  "conflicts_roll_back_without_overwriting_original_identity",
+  "terminal_states_and_aggregate_inspection_remain_consistent",
+];
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
 const outputPath = resolve(repoRoot, contract.evidence_path);
 
@@ -112,6 +155,32 @@ function ensureOutputInsideRepository() {
   }
 }
 
+function validateContractBoundary() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "iggy-connector" ||
+    contract.packet !== "consumer-poison-postgres-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked"
+  ) {
+    fail("retained evidence contract identity drift");
+  }
+  if (
+    contract.runner !== expectedRunnerPath ||
+    contract.verifier !== expectedVerifierPath ||
+    contract.evidence_path !== expectedEvidencePath ||
+    contract.evidence_status !== "runtime_execution_pending"
+  ) {
+    fail("retained evidence tooling or output boundary drift");
+  }
+  if (!sameRecord(contract.commands, expectedCommands)) {
+    fail("retained evidence command allowlist drift");
+  }
+  const caseNames = contract.required_cases?.map((requiredCase) => requiredCase.case);
+  if (!sameRecord(caseNames, expectedCaseNames)) {
+    fail("retained evidence required case allowlist drift");
+  }
+}
+
 function validateDatabaseUrl() {
   const primary = process.env[contract.database_url_env];
   const fallback = process.env[contract.database_url_fallback_env];
@@ -133,9 +202,13 @@ function validateDatabaseUrl() {
   return primary ? contract.database_url_env : contract.database_url_fallback_env;
 }
 
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"])
+    .stdout;
+}
+
 function ensureCleanCommit() {
-  const status = runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]);
-  if (status.stdout.trim()) {
+  if (workingTreeStatus().trim()) {
     fail("working tree must be clean before retained evidence execution");
   }
   const commit = oneLine(
@@ -146,6 +219,12 @@ function ensureCleanCommit() {
     fail("git commit must be a full lowercase SHA-1");
   }
   return commit;
+}
+
+function ensureCleanAfterExecution() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during retained evidence execution");
+  }
 }
 
 function executeContractCommand(command) {
@@ -165,6 +244,7 @@ function writeAtomically(packet) {
 
 try {
   ensureOutputInsideRepository();
+  validateContractBoundary();
   const databaseUrlSource = validateDatabaseUrl();
   const gitCommit = ensureCleanCommit();
   const initialSourceSha256 = sourceHashes();
@@ -172,11 +252,8 @@ try {
   const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
   const startedAt = new Date().toISOString();
 
-  if (!Array.isArray(contract.commands) || contract.commands.length !== 2) {
-    fail("retained evidence contract must contain exactly two commands");
-  }
-  const environmentResult = executeContractCommand(contract.commands[0]);
-  const scenarioResult = executeContractCommand(contract.commands[1]);
+  const environmentResult = executeContractCommand(expectedCommands[0]);
+  const scenarioResult = executeContractCommand(expectedCommands[1]);
   const environmentOutput = `${environmentResult.stdout}\n${environmentResult.stderr}`;
   const scenarioOutput = `${scenarioResult.stdout}\n${scenarioResult.stderr}`;
 
@@ -210,6 +287,7 @@ try {
   if (!sameRecord(finalSourceSha256, initialSourceSha256)) {
     fail("retained evidence source files changed during execution");
   }
+  ensureCleanAfterExecution();
   const completedAt = new Date().toISOString();
   const combinedOutput = `${environmentOutput}\n--- consumer poison scenarios ---\n${scenarioOutput}`;
 
@@ -235,7 +313,7 @@ try {
       cargo: cargoVersion,
       rustc: rustcVersion,
     },
-    commands: contract.commands,
+    commands: expectedCommands,
     source_sha256: finalSourceSha256,
     test_output_sha256: sha256(combinedOutput),
     test_output_bytes: Buffer.byteLength(combinedOutput),

--- a/scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs
+++ b/scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution-contract.json";
+const runnerPath = "scripts/evidence/capture-iggy-consumer-poison-postgres.mjs";
+const environmentTestPath =
+  "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres_environment.rs";
+const scenarioTestPath =
+  "crates/rustok-iggy-connector/tests/consumer_poison_receipt_postgres.rs";
+
+const contract = readJson(contractPath);
+const runner = readText(runnerPath);
+const environmentTest = readText(environmentTestPath);
+const scenarioTest = readText(scenarioTestPath);
+
+const expectedCommands = [
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-iggy-connector",
+      "--features",
+      "migrations",
+      "--test",
+      "consumer_poison_receipt_postgres_environment",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-iggy-connector",
+      "--features",
+      "migrations",
+      "--test",
+      "consumer_poison_receipt_postgres",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+];
+const expectedSourceFiles = [
+  environmentTestPath,
+  scenarioTestPath,
+  "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",
+  "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs",
+  "crates/rustok-iggy-connector/src/migrations.rs",
+];
+const expectedCases = [
+  {
+    case: "concurrent_publishers_have_one_claim_owner",
+    assertions: [
+      "exactly_one_publisher_claimed",
+      "other_publisher_busy",
+      "first_error_code_and_attempt_retained_as_one_atomic_pair",
+    ],
+  },
+  {
+    case: "expired_lease_is_reclaimed_and_fences_the_previous_publisher",
+    assertions: [
+      "empty_exact_payload_accepted",
+      "expired_publication_lease_reclaimed",
+      "previous_publisher_fenced_with_claim_lost",
+      "first_diagnostics_unchanged_after_reclaim",
+    ],
+  },
+  {
+    case: "conflicts_roll_back_without_overwriting_original_identity",
+    assertions: [
+      "delivery_uuid_source_collision_rejected",
+      "source_coordinate_payload_collision_rejected",
+      "original_receipt_unchanged",
+      "failed_conflicts_leave_one_receipt",
+    ],
+  },
+  {
+    case: "terminal_states_and_aggregate_inspection_remain_consistent",
+    assertions: [
+      "reserved_published_acknowledged_counts_consistent",
+      "expired_publishing_subset_consistent",
+      "published_redelivery_does_not_reopen_publication",
+      "acknowledged_redelivery_does_not_reopen_publication",
+    ],
+  },
+];
+const expectedMetadata = [
+  "git_commit",
+  "started_at",
+  "completed_at",
+  "postgres_server_version",
+  "postgres_server_version_num",
+  "cargo_version",
+  "rustc_version",
+  "test_output_sha256",
+  "source_sha256",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readText(relativePath) {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function sameSet(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    expected.every((value) => actual.includes(value))
+  );
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    fail(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function sha256File(relativePath) {
+  return createHash("sha256")
+    .update(readFileSync(resolve(repoRoot, relativePath)))
+    .digest("hex");
+}
+
+function requireExactKeys(name, value, expectedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  if (!sameSet(Object.keys(value), expectedKeys)) {
+    fail(`${name} contains missing or unexpected fields`);
+  }
+}
+
+function requireIsoTimestamp(name, value) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${name} must be an ISO-8601 timestamp`);
+  }
+}
+
+function verifyContract() {
+  if (contract.schema_version !== 1) fail("retained evidence contract schema_version drift");
+  if (contract.module !== "iggy-connector") fail("retained evidence contract module drift");
+  if (contract.packet !== "consumer-poison-postgres-execution-contract") {
+    fail("retained evidence contract packet drift");
+  }
+  if (contract.status !== "runtime_execution_contract_locked") {
+    fail("retained evidence contract status drift");
+  }
+  if (contract.runner !== runnerPath) fail("retained evidence runner path drift");
+  if (contract.verifier !== "scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs") {
+    fail("retained evidence verifier path drift");
+  }
+  if (
+    contract.evidence_path !==
+    "crates/rustok-iggy-connector/contracts/evidence/consumer-poison-postgres-execution.json"
+  ) {
+    fail("retained evidence output path drift");
+  }
+  if (contract.execution_scope !== "opt_in_postgresql_runtime_execution_pending") {
+    fail("retained evidence execution scope must remain explicitly pending until execution");
+  }
+  if (contract.promotion_gate !== "requires_clean_commit_and_all_required_cases_passed") {
+    fail("retained evidence promotion gate drift");
+  }
+  if (contract.database_url_env !== "RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL") {
+    fail("retained evidence database env drift");
+  }
+  if (contract.database_url_fallback_env !== "DATABASE_URL") {
+    fail("retained evidence fallback database env drift");
+  }
+  if (!sameValue(contract.commands, expectedCommands)) {
+    fail("retained evidence commands drift");
+  }
+  if (!sameValue(contract.source_files, expectedSourceFiles)) {
+    fail("retained evidence source file set drift");
+  }
+  if (!sameSet(contract.required_metadata, expectedMetadata)) {
+    fail("retained evidence metadata contract drift");
+  }
+  if (!sameValue(contract.required_cases, expectedCases)) {
+    fail("retained evidence required case contract drift");
+  }
+  if (contract.evidence_status !== "runtime_execution_pending") {
+    fail("retained evidence contract must not claim unexecuted runtime proof");
+  }
+}
+
+function verifySourceBoundaries() {
+  for (const marker of [
+    'const contractPath =',
+    'validateDatabaseUrl()',
+    'ensureCleanCommit()',
+    '["status", "--porcelain=v1", "--untracked-files=all"]',
+    '["rev-parse", "HEAD"]',
+    'const initialSourceSha256 = sourceHashes();',
+    'const finalSourceSha256 = sourceHashes();',
+    'requireOneMarker(',
+    'requirePassedCase(scenarioOutput, requiredCase.case)',
+    'test_output_sha256: sha256(combinedOutput)',
+    'writeAtomically(packet)',
+    'renameSync(temporaryPath, outputPath)',
+    'working_tree_clean_before_run: true',
+  ]) {
+    requireText("retained evidence runner", runner, marker);
+  }
+  for (const forbidden of [
+    "database_url: value",
+    "connection_string:",
+    "raw_log:",
+    "stdout: environmentOutput",
+    "stderr: scenarioOutput",
+    "payload:",
+    "delivery_id:",
+    "source_offset:",
+  ]) {
+    if (runner.includes(forbidden)) {
+      fail(`retained evidence runner contains forbidden persisted field: ${forbidden}`);
+    }
+  }
+
+  for (const marker of [
+    '#![cfg(feature = "migrations")]',
+    'RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL',
+    "current_setting('server_version') AS server_version",
+    "current_setting('server_version_num') AS server_version_num",
+    'RUSTOK_IGGY_POISON_EVIDENCE postgres_server_version=',
+    'RUSTOK_IGGY_POISON_EVIDENCE postgres_server_version_num=',
+    '.max_connections(1)',
+    'sqlx_logging(false)',
+  ]) {
+    requireText("PostgreSQL environment evidence test", environmentTest, marker);
+  }
+  for (const requiredCase of expectedCases) {
+    requireText(
+      "PostgreSQL scenario evidence test",
+      scenarioTest,
+      `async fn ${requiredCase.case}()`,
+    );
+  }
+}
+
+function verifyExecutedEvidence() {
+  const evidencePath = contract.evidence_path;
+  const absoluteEvidencePath = resolve(repoRoot, evidencePath);
+  if (!existsSync(absoluteEvidencePath)) {
+    console.log(
+      "Iggy consumer poison retained evidence contract verified; PostgreSQL runtime execution remains pending.",
+    );
+    return;
+  }
+
+  const evidenceText = readText(evidencePath);
+  const evidence = JSON.parse(evidenceText);
+  requireExactKeys("retained evidence packet", evidence, [
+    "schema_version",
+    "module",
+    "packet",
+    "status",
+    "generated_from",
+    "runner",
+    "verifier",
+    "git_commit",
+    "working_tree_clean_before_run",
+    "started_at",
+    "completed_at",
+    "database_url_source",
+    "database",
+    "toolchain",
+    "commands",
+    "source_sha256",
+    "test_output_sha256",
+    "test_output_bytes",
+    "executed_cases",
+  ]);
+  if (evidence.schema_version !== 1) fail("retained evidence schema_version drift");
+  if (evidence.module !== contract.module) fail("retained evidence module drift");
+  if (evidence.packet !== "consumer-poison-postgres-runtime-evidence") {
+    fail("retained evidence packet identity drift");
+  }
+  if (evidence.status !== "postgres_runtime_executed") {
+    fail("retained evidence must record successful PostgreSQL runtime execution");
+  }
+  if (evidence.generated_from !== contractPath) fail("retained evidence source contract drift");
+  if (evidence.runner !== contract.runner) fail("retained evidence runner drift");
+  if (evidence.verifier !== contract.verifier) fail("retained evidence verifier drift");
+  if (!/^[0-9a-f]{40}$/u.test(evidence.git_commit)) fail("retained evidence git commit is invalid");
+  if (evidence.working_tree_clean_before_run !== true) {
+    fail("retained evidence must come from a clean working tree");
+  }
+  requireIsoTimestamp("retained evidence started_at", evidence.started_at);
+  requireIsoTimestamp("retained evidence completed_at", evidence.completed_at);
+  if (Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)) {
+    fail("retained evidence completed_at precedes started_at");
+  }
+  if (
+    evidence.database_url_source !== contract.database_url_env &&
+    evidence.database_url_source !== contract.database_url_fallback_env
+  ) {
+    fail("retained evidence database URL source drift");
+  }
+
+  requireExactKeys("retained evidence database", evidence.database, [
+    "backend",
+    "server_version",
+    "server_version_num",
+  ]);
+  if (evidence.database.backend !== "postgresql") fail("retained evidence backend drift");
+  if (
+    typeof evidence.database.server_version !== "string" ||
+    !evidence.database.server_version.trim() ||
+    evidence.database.server_version.length > 128
+  ) {
+    fail("retained evidence PostgreSQL server version is invalid");
+  }
+  if (!/^\d+$/u.test(evidence.database.server_version_num)) {
+    fail("retained evidence PostgreSQL numeric version is invalid");
+  }
+
+  requireExactKeys("retained evidence toolchain", evidence.toolchain, ["cargo", "rustc"]);
+  if (!/^cargo\s/u.test(evidence.toolchain.cargo)) fail("retained evidence Cargo version is invalid");
+  if (!/^rustc\s/u.test(evidence.toolchain.rustc)) fail("retained evidence Rust version is invalid");
+  if (!sameValue(evidence.commands, expectedCommands)) fail("retained evidence command drift");
+  if (!/^[0-9a-f]{64}$/u.test(evidence.test_output_sha256)) {
+    fail("retained evidence output SHA-256 is invalid");
+  }
+  if (!Number.isSafeInteger(evidence.test_output_bytes) || evidence.test_output_bytes <= 0) {
+    fail("retained evidence output byte count is invalid");
+  }
+
+  requireExactKeys("retained evidence source hashes", evidence.source_sha256, expectedSourceFiles);
+  for (const relativePath of expectedSourceFiles) {
+    const retainedHash = evidence.source_sha256[relativePath];
+    if (!/^[0-9a-f]{64}$/u.test(retainedHash)) {
+      fail(`retained evidence source hash is invalid: ${relativePath}`);
+    }
+    if (retainedHash !== sha256File(relativePath)) {
+      fail(`retained evidence is stale for source file: ${relativePath}`);
+    }
+  }
+
+  if (!Array.isArray(evidence.executed_cases) || evidence.executed_cases.length !== expectedCases.length) {
+    fail("retained evidence executed case count drift");
+  }
+  for (const requiredCase of expectedCases) {
+    const executedCase = evidence.executed_cases.find(
+      (candidate) => candidate.case === requiredCase.case,
+    );
+    requireExactKeys(`retained evidence case ${requiredCase.case}`, executedCase, [
+      "case",
+      "result",
+      "assertions",
+    ]);
+    if (executedCase.result !== "pass") {
+      fail(`retained evidence case did not pass: ${requiredCase.case}`);
+    }
+    if (!sameValue(executedCase.assertions, requiredCase.assertions)) {
+      fail(`retained evidence assertions drift: ${requiredCase.case}`);
+    }
+  }
+
+  if (/postgres(?:ql)?:\/\//iu.test(evidenceText)) {
+    fail("retained evidence must not contain a PostgreSQL connection URL");
+  }
+  console.log(
+    "Iggy consumer poison retained PostgreSQL evidence verified: clean commit, bounded metadata, current source hashes, and all required cases passed.",
+  );
+}
+
+try {
+  verifyContract();
+  verifySourceBoundaries();
+  verifyExecutedEvidence();
+} catch (error) {
+  console.error(`Iggy consumer poison retained evidence verification failed: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Define a fail-closed retained-evidence path for the connector-owned neutral poison receipt PostgreSQL harness.

- added a versioned execution contract with the exact two Cargo commands, four required scenarios, source hash set, metadata boundary, and canonical output path;
- added a small opt-in PostgreSQL environment test that reports bounded `server_version` and `server_version_num` through SeaORM without requiring `psql`;
- added a clean-commit capture runner that validates a fixed command/case allowlist, requires a PostgreSQL URL, executes the environment and scenario targets, verifies every required `ok` result, checks commit/source/worktree stability, and writes the packet atomically only after success;
- added a strict verifier that validates the source contract while execution is pending and, once a packet exists, requires current source SHA-256 values, exact commands/cases, bounded metadata, clean-tree evidence, and all-pass results;
- updated the connector evidence guide, connector implementation plan, and canonical Profiles plan.

## Evidence privacy boundary

The retained packet does not contain the database URL, host, database name, credentials, raw test output, delivery UUID, source coordinates, error payload, or broker payload. It retains only the URL environment variable name, bounded PostgreSQL/toolchain versions, timestamps, Git commit, exact command arrays, source/output digests, output byte count, and aggregate case results.

`consumer-poison-postgres-execution.json` is intentionally absent until a maintainer executes the runner successfully from a clean commit.

## Verification

Tests, Cargo commands, formatters, source verifiers, PostgreSQL scenarios, and real-Iggy scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features migrations --all-targets
node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs
node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs

RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' \
  node scripts/evidence/capture-iggy-consumer-poison-postgres.mjs

node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs
```