### PR TITLE
test(profiles): define external Iggy raw poison lifecycle

### DIFF
--- a/crates/rustok-iggy/Cargo.toml
+++ b/crates/rustok-iggy/Cargo.toml
@@ -26,6 +26,5 @@ default = ["iggy"]
 iggy = ["dep:iggy", "rustok-iggy-connector/iggy"]
 
 [dev-dependencies]
-futures-util.workspace = true
 tokio.workspace = true
 serde_yaml.workspace = true

--- a/crates/rustok-iggy/Cargo.toml
+++ b/crates/rustok-iggy/Cargo.toml
@@ -26,5 +26,6 @@ default = ["iggy"]
 iggy = ["dep:iggy", "rustok-iggy-connector/iggy"]
 
 [dev-dependencies]
+futures-util.workspace = true
 tokio.workspace = true
 serde_yaml.workspace = true

--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-source.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "contract-poison-external-iggy-source",
+  "status": "source_complete_runtime_pending",
+  "scope": "external_real_iggy_raw_poison_cursor_lifecycle",
+  "test_target": "contract_poison_external_iggy",
+  "test_case": "malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_bytes",
+  "source_path": "crates/rustok-iggy/tests/contract_poison_external_iggy.rs",
+  "verifier": "scripts/verify/verify-iggy-contract-poison-external-evidence.mjs",
+  "required_environment": [
+    "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS"
+  ],
+  "optional_environment": [
+    "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+    "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD"
+  ],
+  "topology": {
+    "mode": "external",
+    "protocol": "tcp",
+    "unique_stream_per_run": true,
+    "domain_partitions": 1,
+    "replication_factor": 1,
+    "topics": [
+      "domain",
+      "dlq"
+    ],
+    "broker_requirement": "disposable_or_operator_cleaned_external_iggy"
+  },
+  "required_sequence": [
+    "open_source_and_dlq_consumer_groups_before_fixture_publish",
+    "publish_two_distinct_nonempty_malformed_payloads_to_one_domain_partition",
+    "receive_first_payload_through_persistent_contract_consumer_without_ack",
+    "classify_first_payload_as_decode_invalid_and_retain_exact_bytes_offset_ack_token",
+    "publish_first_failure_through_iggy_transport_move_to_dlq",
+    "receive_and_ack_exact_first_dlq_payload",
+    "drop_source_cursor_without_ack",
+    "reopen_same_source_group_and_receive_same_offset_payload_and_delivery_uuid",
+    "explicitly_acknowledge_redelivered_failure",
+    "receive_second_payload_at_a_greater_offset",
+    "publish_and_verify_exact_second_dlq_payload",
+    "explicitly_acknowledge_second_failure",
+    "shutdown_fixture_connector_and_transport"
+  ],
+  "production_paths": [
+    "IggyTransport::new",
+    "IggyTransport::open_persistent_contract_consumer_group",
+    "PersistentContractConsumerGroup::receive_delivery",
+    "ConsumedContractDecodeFailure::to_dlq_entry",
+    "IggyTransport::move_to_dlq",
+    "PersistentContractConsumerGroup::acknowledge_decode_failure",
+    "ExternalConnector::open_consumer_group"
+  ],
+  "fixture_only_path": "ExternalConnector::publish(PublishRequest) injects arbitrary malformed broker bytes",
+  "forbidden_claims": [
+    "database_receipt_ordering_proved",
+    "deterministic_iggy_header_runtime_proved",
+    "broker_deduplication_runtime_proved",
+    "physical_exactly_once_proved",
+    "bundled_mode_proved",
+    "tls_or_auth_failure_proved",
+    "multi_replica_proved"
+  ],
+  "execution_status": "not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-source.json
@@ -35,15 +35,18 @@
     "publish_first_failure_through_iggy_transport_move_to_dlq",
     "receive_and_ack_exact_first_dlq_payload",
     "drop_source_cursor_without_ack",
-    "reopen_same_source_group_and_receive_same_offset_payload_and_delivery_uuid",
+    "shutdown_first_transport_without_source_ack",
+    "connect_new_transport_with_same_stream_and_source_group",
+    "receive_same_offset_payload_and_delivery_uuid_after_reconnect",
     "explicitly_acknowledge_redelivered_failure",
     "receive_second_payload_at_a_greater_offset",
     "publish_and_verify_exact_second_dlq_payload",
     "explicitly_acknowledge_second_failure",
-    "shutdown_fixture_connector_and_transport"
+    "shutdown_fixture_connector_and_reopened_transport"
   ],
   "production_paths": [
     "IggyTransport::new",
+    "IggyTransport::shutdown",
     "IggyTransport::open_persistent_contract_consumer_group",
     "PersistentContractConsumerGroup::receive_delivery",
     "ConsumedContractDecodeFailure::to_dlq_entry",

--- a/crates/rustok-iggy/docs/contract-poison-external-evidence.md
+++ b/crates/rustok-iggy/docs/contract-poison-external-evidence.md
@@ -1,0 +1,96 @@
+# External Iggy raw contract poison evidence
+
+## Scope
+
+`contract_poison_external_iggy.rs` is an opt-in integration harness for the real external Iggy cursor and DLQ path. It proves the transport-level boundary around broker bytes that cannot decode into a trusted contract envelope.
+
+The harness uses production APIs for:
+
+- topology startup through `IggyTransport::new`;
+- persistent typed receive through `open_persistent_contract_consumer_group` and `receive_delivery`;
+- exact-byte raw failure conversion through `ConsumedContractDecodeFailure`;
+- deterministic DLQ entry construction through `to_dlq_entry`;
+- DLQ publication through `IggyTransport::move_to_dlq`;
+- source commit through `acknowledge_decode_failure`;
+- DLQ receive/commit through a real `ExternalConnector` consumer-group cursor.
+
+A separate `ExternalConnector::publish(PublishRequest)` is fixture-only. It injects arbitrary malformed bytes because the typed event publisher correctly refuses to create an invalid contract envelope. It does not implement receive, decode, DLQ, or acknowledgement behavior.
+
+## Broker selection
+
+Set:
+
+```text
+RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=host:8090
+```
+
+Optional credentials must be supplied as a pair:
+
+```text
+RUSTOK_IGGY_EXTERNAL_TEST_USERNAME=...
+RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD=...
+```
+
+The address contains no scheme, credentials, or query string. The harness has no localhost/default-credential fallback. If the address is absent, the direct test reports a skip and returns successfully.
+
+This first slice is TCP/non-TLS only. TLS, authentication failures, address failover, and certificate validation remain separate runtime evidence.
+
+## Isolation and cleanup
+
+Every execution creates:
+
+- one unique stream;
+- one unique source consumer group;
+- one unique DLQ consumer group;
+- one `domain` partition and one matching `dlq` partition.
+
+Use a disposable external Iggy server or an operator-approved cleanup process. The test intentionally does not call an unreviewed stream deletion API. A failed run may therefore leave a uniquely named stream that is safe to identify and remove later.
+
+The test uses bounded receive timeouts but no sleeps. It opens both consumer groups before fixture publication so evidence does not depend on an implicit latest/earliest subscription default.
+
+## Scenario
+
+Two distinct non-empty malformed payloads are published to the single `domain` partition.
+
+1. The production contract cursor receives the first payload as `DecodeFailure` without committing it.
+2. Exact bytes, offset, ack token, stable `decode_invalid` classification, and deterministic connector delivery UUID are retained.
+3. The failure is published to `dlq` through `IggyTransport::move_to_dlq`.
+4. The independent DLQ cursor receives the exact first payload and explicitly acknowledges it.
+5. The source cursor is dropped without source acknowledgement.
+6. Reopening the same source group must redeliver the same offset, bytes, and delivery UUID.
+7. Explicit source acknowledgement then permits the cursor to receive the second payload at a greater offset.
+8. The second payload is also published to DLQ, verified byte-for-byte, and explicitly acknowledged on both DLQ and source cursors.
+9. The fixture connector and transport shut down explicitly.
+
+## Evidence boundary
+
+This scenario proves only the real external broker cursor and transport path described above. It does **not** prove:
+
+- connector database receipt ordering or `published` persistence;
+- the deterministic UUID being present in the physical Iggy message header;
+- broker duplicate suppression, cache capacity, or expiry;
+- physical exactly-once publication;
+- bundled mode;
+- TLS/authentication/failover behavior;
+- multi-replica ownership or rebalance behavior;
+- Profiles privacy, which remains owner-port based and independent of broker evidence.
+
+Those claims require separate retained evidence.
+
+## Maintainer commands
+
+```bash
+RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='iggy.example:8090' \
+RUSTOK_IGGY_EXTERNAL_TEST_USERNAME='...' \
+RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD='...' \
+  cargo test -p rustok-iggy --features iggy \
+  --test contract_poison_external_iggy -- --nocapture --test-threads=1
+
+node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs
+```
+
+The username/password variables may both be omitted when the disposable broker permits anonymous access. Never pass only one of the pair.
+
+## Evidence status
+
+The source contract, opt-in harness, and static verifier are source-complete. The contract remains `source_complete_runtime_pending`, and no Cargo command, source verifier, or external Iggy scenario was executed while authoring this slice.

--- a/crates/rustok-iggy/docs/contract-poison-external-evidence.md
+++ b/crates/rustok-iggy/docs/contract-poison-external-evidence.md
@@ -2,11 +2,12 @@
 
 ## Scope
 
-`contract_poison_external_iggy.rs` is an opt-in integration harness for the real external Iggy cursor and DLQ path. It proves the transport-level boundary around broker bytes that cannot decode into a trusted contract envelope.
+`contract_poison_external_iggy.rs` is an opt-in integration harness for the real external Iggy cursor and DLQ path. It defines the transport-level evidence boundary around broker bytes that cannot decode into a trusted contract envelope.
 
 The harness uses production APIs for:
 
-- topology startup through `IggyTransport::new`;
+- topology startup and reconnect through `IggyTransport::new`;
+- transport shutdown through `IggyTransport::shutdown`;
 - persistent typed receive through `open_persistent_contract_consumer_group` and `receive_delivery`;
 - exact-byte raw failure conversion through `ConsumedContractDecodeFailure`;
 - deterministic DLQ entry construction through `to_dlq_entry`;
@@ -56,15 +57,16 @@ Two distinct non-empty malformed payloads are published to the single `domain` p
 2. Exact bytes, offset, ack token, stable `decode_invalid` classification, and deterministic connector delivery UUID are retained.
 3. The failure is published to `dlq` through `IggyTransport::move_to_dlq`.
 4. The independent DLQ cursor receives the exact first payload and explicitly acknowledges it.
-5. The source cursor is dropped without source acknowledgement.
-6. Reopening the same source group must redeliver the same offset, bytes, and delivery UUID.
-7. Explicit source acknowledgement then permits the cursor to receive the second payload at a greater offset.
-8. The second payload is also published to DLQ, verified byte-for-byte, and explicitly acknowledged on both DLQ and source cursors.
-9. The fixture connector and transport shut down explicitly.
+5. The source cursor is dropped without source acknowledgement, and the first external transport is shut down.
+6. A newly connected `IggyTransport` opens the same stream and source consumer group.
+7. The new cursor must redeliver the same offset, bytes, and delivery UUID.
+8. Explicit source acknowledgement then permits that cursor to receive the second payload at a greater offset.
+9. The second payload is published through the reopened transport, verified byte-for-byte on DLQ, and explicitly acknowledged on both cursors.
+10. The fixture connector and reopened transport shut down explicitly.
 
 ## Evidence boundary
 
-This scenario proves only the real external broker cursor and transport path described above. It does **not** prove:
+This scenario proves only the real external broker cursor and transport path described above after it is actually executed. It does **not** prove:
 
 - connector database receipt ordering or `published` persistence;
 - the deterministic UUID being present in the physical Iggy message header;
@@ -93,4 +95,4 @@ The username/password variables may both be omitted when the disposable broker p
 
 ## Evidence status
 
-The source contract, opt-in harness, and static verifier are source-complete. The contract remains `source_complete_runtime_pending`, and no Cargo command, source verifier, or external Iggy scenario was executed while authoring this slice.
+The source contract, opt-in harness, transport reconnect scenario, and static verifier are source-complete. The contract remains `source_complete_runtime_pending`, and no Cargo command, source verifier, or external Iggy scenario was executed while authoring this slice.

--- a/crates/rustok-iggy/docs/implementation-plan.md
+++ b/crates/rustok-iggy/docs/implementation-plan.md
@@ -63,14 +63,27 @@ consumer-group checkpoint for that partition. Aggregate lag is published only wh
 every partition is empty or has a coherent stored offset not ahead of the observed
 high-watermark. Missing checkpoints and inconsistent observations fail closed.
 
+An opt-in external-Iggy source harness now uses one unique stream and one partition to
+exercise the production raw-poison cursor path. It injects two malformed fixtures,
+receives the first through `PersistentContractConsumerGroup`, publishes exact bytes
+through `IggyTransport::move_to_dlq`, drops the source cursor without acknowledgement,
+requires same-offset/bytes/UUID redelivery after reopening the group, acknowledges it
+explicitly, and then requires the second offset to become visible. An independent real
+DLQ cursor verifies both payloads byte-for-byte. The harness is source-complete and has
+not been executed.
+
+The harness intentionally does not inspect the physical Iggy header, compose the
+PostgreSQL receipt store, exercise deduplication, or claim bundled/TLS/auth/multi-replica
+proof. Those remain separate retained evidence boundaries.
+
 Replay remains intentionally unavailable. A production replay API requires bounded
 broker reads, republish, durable progress/idempotency evidence, and a real broker
 integration test. DLQ retry requires a complete `DlqEntry`; there is no ID-only API
 that can claim success without the original payload.
 
-Compilation, source-verifier execution, migration-tail reconciliation, real-Iggy
-deterministic-ID/deduplication, raw decode-failure publication/acknowledgement,
-snapshot/reconnect, persisted-offset, TLS/auth, and multi-replica evidence remain
+Compilation, source-verifier execution, external-Iggy raw cursor execution,
+deterministic-header/deduplication, receipt-plus-broker ordering, position/reconnect,
+persisted-offset, TLS/auth, bundled-mode, and multi-replica evidence remain
 maintainer-run or pending.
 
 ## Boundary and dependencies
@@ -91,6 +104,11 @@ maintainer-run or pending.
 - Consumer workers compose typed receive, connector receipt recognition/claim,
   exact-byte DLQ publication, durable `published`, source acknowledgement, and
   best-effort `acknowledged` in that order.
+- The external evidence fixture connector may publish arbitrary malformed bytes only.
+  Production receive, classification, DLQ publication, and source acknowledgement must
+  remain on `IggyTransport`/`PersistentContractConsumerGroup` APIs.
+- The external harness creates unique streams but does not use an unreviewed deletion
+  API. It requires a disposable broker or operator-approved cleanup.
 - Consumers such as Outbox and Social Graph use public transport contracts rather than
   connector cursor internals.
 - Transport positions, tenant/event identities, broker IDs, credentials, raw payloads,
@@ -128,46 +146,52 @@ maintainer-run or pending.
 10. **Shared-endpoint composition.** Bundled publisher/observation clients connect to the
     reviewed loopback endpoint already managed by `IggyTransport`; external clients reuse
     reviewed address/auth/TLS configuration.
+11. **External raw-poison lifecycle harness.** A versioned source contract, opt-in real
+    external broker test, bounded timeouts, exact-byte DLQ cursor, no-ack reopen/redelivery,
+    explicit source advancement, and static guard define the first broker-backed raw
+    decode-failure evidence without overclaiming unexecuted runtime proof.
 
 ## Next results
 
-1. **Reconcile migration release order.** Append the existing decoded-event DLQ receipt
-   migration and the connector raw-poison migration to the explicit platform tail
-   without rewriting the published prefix; then reconcile current `main` and refresh
-   `Cargo.lock`.
-2. **Verify real consumption and acknowledgement.** Prove validated and raw-failure
-   receive, no implicit commit, exact-byte publish, durable published-before-ack,
-   acknowledgement-only recovery, and reconnect in bundled and external modes.
-3. **Verify deterministic DLQ behavior.** Prove the outgoing header ID, same-partition
-   retry, publish failure reconnect, broker-success/result-mark crash, and duplicate
-   behavior with deduplication disabled, enabled, capacity-evicted, and expired.
-4. **Verify connector receipt concurrency.** Prove PostgreSQL claim ownership, lease
-   expiry/reclaim, UUID/source collision handling, rollback, first-diagnostic retention,
-   and multi-replica redelivery.
-5. **Verify consumer-position observation.** Prove every-partition topic/offset reads,
+1. **Execute external raw receive and acknowledgement evidence.** Run the new harness on
+   a disposable external Iggy server, retain broker/version/configuration metadata and
+   source/output digests, and repeat reopen/redelivery behavior. Source coverage exists;
+   runtime execution remains maintainer work.
+2. **Compose receipt-plus-broker ordering evidence.** Add PostgreSQL receipt storage to a
+   broker-backed scenario and prove reserve/claim -> exact publish -> durable `published`
+   -> source ack -> best-effort `acknowledged`, including acknowledgement-only recovery.
+3. **Verify deterministic DLQ header behavior.** Use a read-only SDK probe to prove the
+   outgoing header ID and one-based partition, then exercise publish failure reconnect and
+   duplicate behavior with deduplication disabled, enabled, capacity-evicted, and expired.
+4. **Verify bundled raw lifecycle.** Repeat the external scenario through the packaged
+   bundled server and prove start, readiness, restart, durable data reuse, and shutdown.
+5. **Verify connector receipt concurrency.** Execute and retain the existing PostgreSQL
+   claim ownership, lease expiry/reclaim, UUID/source collision, rollback,
+   first-diagnostic, and aggregate inspection packet.
+6. **Verify consumer-position observation.** Prove every-partition topic/offset reads,
    empty/missing checkpoint behavior, concurrent publication during a snapshot,
    reconnect, TLS/auth failure, and multi-replica consumer-group semantics.
-6. **Choose production confirmation policy.** Require and verify a dedup window covering
+7. **Choose production confirmation policy.** Require and verify a dedup window covering
    the maximum recovery horizon, or move DLQ publication behind a database-owned outbox
    relay/broker transaction before claiming stronger duplicate suppression.
-7. **Execute broker-backed replay.** Prove real DLQ retry, then design bounded replay
+8. **Execute broker-backed replay.** Prove real DLQ retry, then design bounded replay
    with durable progress and idempotency.
-8. **Harden production operation.** Retain reconnect, backpressure, topology, health,
-   lag alert, decode-failure, receipt, dedup configuration, and recovery evidence with
-   operator runbooks.
+9. **Harden production operation.** Retain reconnect, backpressure, topology, health,
+   lag alert, decode-failure, receipt, dedup configuration, cleanup, and recovery evidence
+   with operator runbooks.
 
 ## Verification
 
 - `cargo test -p rustok-iggy --lib`
 - `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
 - `cargo test -p rustok-iggy --test integration`
+- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`
 - `node scripts/verify/verify-iggy-connector-source.mjs`
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
 - `node scripts/verify/verify-iggy-consumer-position.mjs`
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
@@ -179,11 +203,12 @@ maintainer-run or pending.
   behavior.
 
 These commands and scenarios remain maintainer-run and were not executed manually in
-this slice. `Cargo.lock` requires refresh after synchronization with `main`.
+this slice.
 
 ## References
 
 - [Crate README](../README.md)
 - [Module documentation](./README.md)
 - [Connector plan](../../rustok-iggy-connector/docs/implementation-plan.md)
+- [External raw poison evidence guide](./contract-poison-external-evidence.md)
 - [Iggy integration reference](../../../docs/references/iggy/README.md)

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
@@ -1,0 +1,239 @@
+#![cfg(feature = "iggy")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::time::Duration;
+
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ContractDecodeFailureKind, ExternalConfig, IggyConfig, IggyMode,
+    IggyTransport, PersistentContractConsumerGroup, PersistentContractDelivery,
+    SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::{
+    ConnectorConfig, ConsumerCursor, ExternalConnector, IggyConnector, PublishRequest,
+};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+const ADDRESS_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_bytes(
+) -> TestResult<()> {
+    let Some(config) = external_test_config()? else {
+        eprintln!(
+            "{ADDRESS_ENV} is not set; skipping external Iggy raw poison lifecycle evidence"
+        );
+        return Ok(());
+    };
+
+    let stream = config.topology.stream_name.clone();
+    let source_group = unique_name("source");
+    let dlq_group = unique_name("dlq");
+    let first_payload = vec![0xff, 0x00, 0x7f, 0x01];
+    let second_payload = br#"{"incomplete":true"#.to_vec();
+
+    let transport = IggyTransport::new(config.clone()).await?;
+    let fixture_connector = ExternalConnector::new();
+    fixture_connector
+        .connect(&ConnectorConfig::from(&config))
+        .await?;
+
+    let first_source_cursor = transport
+        .open_persistent_contract_consumer_group(&source_group, "domain")
+        .await?;
+    let mut dlq_cursor = fixture_connector
+        .open_consumer_group(&stream, "dlq", &dlq_group)
+        .await?;
+
+    publish_fixture(&fixture_connector, &stream, first_payload.clone()).await?;
+    publish_fixture(&fixture_connector, &stream, second_payload.clone()).await?;
+
+    let first_failure = receive_decode_failure(&first_source_cursor).await?;
+    assert_eq!(first_failure.raw_payload(), first_payload.as_slice());
+    assert_eq!(
+        first_failure.kind(),
+        ContractDecodeFailureKind::Deserialize
+    );
+    assert_eq!(
+        first_failure.stable_error_code(),
+        "iggy.contract.decode_invalid"
+    );
+    assert!(first_failure.ack_token().is_some());
+    let first_offset = first_failure.offset();
+    let first_delivery_id = first_failure.delivery_id();
+
+    transport.move_to_dlq(first_failure.to_dlq_entry(1)).await?;
+    let first_dlq = receive_cursor_message(&mut dlq_cursor).await?;
+    assert_eq!(first_dlq.payload, first_payload);
+    acknowledge_cursor_message(&mut dlq_cursor, &first_dlq).await?;
+
+    drop(first_source_cursor);
+
+    let reopened_source_cursor = transport
+        .open_persistent_contract_consumer_group(&source_group, "domain")
+        .await?;
+    let redelivered = receive_decode_failure(&reopened_source_cursor).await?;
+    assert_eq!(redelivered.offset(), first_offset);
+    assert_eq!(redelivered.delivery_id(), first_delivery_id);
+    assert_eq!(redelivered.raw_payload(), first_dlq.payload.as_slice());
+
+    reopened_source_cursor
+        .acknowledge_decode_failure(&redelivered)
+        .await?;
+
+    let second_failure = receive_decode_failure(&reopened_source_cursor).await?;
+    assert_eq!(second_failure.raw_payload(), second_payload.as_slice());
+    assert!(second_failure.offset() > first_offset);
+    assert_ne!(second_failure.delivery_id(), first_delivery_id);
+
+    transport.move_to_dlq(second_failure.to_dlq_entry(1)).await?;
+    let second_dlq = receive_cursor_message(&mut dlq_cursor).await?;
+    assert_eq!(second_dlq.payload, second_payload);
+    acknowledge_cursor_message(&mut dlq_cursor, &second_dlq).await?;
+    reopened_source_cursor
+        .acknowledge_decode_failure(&second_failure)
+        .await?;
+
+    fixture_connector.shutdown().await?;
+    transport.shutdown().await?;
+    Ok(())
+}
+
+async fn publish_fixture(
+    connector: &ExternalConnector,
+    stream: &str,
+    payload: Vec<u8>,
+) -> TestResult<()> {
+    connector
+        .publish(PublishRequest::new(
+            stream,
+            "domain",
+            "raw-poison-fixture",
+            payload,
+            Uuid::new_v4().to_string(),
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn receive_decode_failure(
+    consumer: &PersistentContractConsumerGroup,
+) -> TestResult<ConsumedContractDecodeFailure> {
+    let delivery = timeout(RECEIVE_TIMEOUT, consumer.receive_delivery())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for an external Iggy source delivery"))??
+        .ok_or_else(|| invalid_data("external Iggy source cursor ended before a delivery"))?;
+
+    match delivery {
+        PersistentContractDelivery::DecodeFailure(failure) => Ok(failure),
+        PersistentContractDelivery::Event(_) => Err(invalid_data(
+            "malformed fixture unexpectedly decoded as a registered contract event",
+        )
+        .into()),
+    }
+}
+
+async fn receive_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+) -> TestResult<rustok_iggy_connector::SubscriberMessage> {
+    timeout(RECEIVE_TIMEOUT, cursor.receive())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for an external Iggy DLQ delivery"))??
+        .ok_or_else(|| invalid_data("external Iggy DLQ cursor ended before a delivery").into())
+}
+
+async fn acknowledge_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+    message: &rustok_iggy_connector::SubscriberMessage,
+) -> TestResult<()> {
+    let ack_token = message
+        .metadata
+        .ack_token
+        .as_deref()
+        .ok_or_else(|| invalid_data("external Iggy DLQ delivery has no acknowledgement token"))?;
+    cursor.acknowledge(ack_token).await?;
+    Ok(())
+}
+
+fn external_test_config() -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(ADDRESS_ENV) {
+        Ok(value) => bounded_env(ADDRESS_ENV, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://") || address.contains('@') || address.contains('?') {
+        return Err(invalid_data(
+            "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS must be an address such as host:8090 without credentials or query parameters",
+        )
+        .into());
+    }
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "external Iggy evidence username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name("stream"),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-poison-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
@@ -71,7 +71,7 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
 
     transport.move_to_dlq(first_failure.to_dlq_entry(1)).await?;
     let first_dlq = receive_cursor_message(&mut dlq_cursor).await?;
-    assert_eq!(first_dlq.payload, first_payload);
+    assert_eq!(first_dlq.payload.as_slice(), first_payload.as_slice());
     acknowledge_cursor_message(&mut dlq_cursor, &first_dlq).await?;
 
     drop(first_source_cursor);
@@ -95,7 +95,7 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
 
     transport.move_to_dlq(second_failure.to_dlq_entry(1)).await?;
     let second_dlq = receive_cursor_message(&mut dlq_cursor).await?;
-    assert_eq!(second_dlq.payload, second_payload);
+    assert_eq!(second_dlq.payload.as_slice(), second_payload.as_slice());
     acknowledge_cursor_message(&mut dlq_cursor, &second_dlq).await?;
     reopened_source_cursor
         .acknowledge_decode_failure(&second_failure)
@@ -143,10 +143,11 @@ async fn receive_decode_failure(
 async fn receive_cursor_message(
     cursor: &mut Box<dyn ConsumerCursor>,
 ) -> TestResult<rustok_iggy_connector::SubscriberMessage> {
-    timeout(RECEIVE_TIMEOUT, cursor.receive())
+    let message = timeout(RECEIVE_TIMEOUT, cursor.receive())
         .await
         .map_err(|_| invalid_data("timed out waiting for an external Iggy DLQ delivery"))??
-        .ok_or_else(|| invalid_data("external Iggy DLQ cursor ended before a delivery").into())
+        .ok_or_else(|| invalid_data("external Iggy DLQ cursor ended before a delivery"))?;
+    Ok(message)
 }
 
 async fn acknowledge_cursor_message(

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy.rs
@@ -41,9 +41,8 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
 
     let transport = IggyTransport::new(config.clone()).await?;
     let fixture_connector = ExternalConnector::new();
-    fixture_connector
-        .connect(&ConnectorConfig::from(&config))
-        .await?;
+    let fixture_config = ConnectorConfig::from(&config);
+    fixture_connector.connect(&fixture_config).await?;
 
     let first_source_cursor = transport
         .open_persistent_contract_consumer_group(&source_group, "domain")
@@ -75,8 +74,10 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
     acknowledge_cursor_message(&mut dlq_cursor, &first_dlq).await?;
 
     drop(first_source_cursor);
+    transport.shutdown().await?;
 
-    let reopened_source_cursor = transport
+    let reopened_transport = IggyTransport::new(config.clone()).await?;
+    let reopened_source_cursor = reopened_transport
         .open_persistent_contract_consumer_group(&source_group, "domain")
         .await?;
     let redelivered = receive_decode_failure(&reopened_source_cursor).await?;
@@ -93,7 +94,9 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
     assert!(second_failure.offset() > first_offset);
     assert_ne!(second_failure.delivery_id(), first_delivery_id);
 
-    transport.move_to_dlq(second_failure.to_dlq_entry(1)).await?;
+    reopened_transport
+        .move_to_dlq(second_failure.to_dlq_entry(1))
+        .await?;
     let second_dlq = receive_cursor_message(&mut dlq_cursor).await?;
     assert_eq!(second_dlq.payload.as_slice(), second_payload.as_slice());
     acknowledge_cursor_message(&mut dlq_cursor, &second_dlq).await?;
@@ -102,7 +105,7 @@ async fn malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_by
         .await?;
 
     fixture_connector.shutdown().await?;
-    transport.shutdown().await?;
+    reopened_transport.shutdown().await?;
     Ok(())
 }
 

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -2,260 +2,225 @@
 
 ## Current state
 
-`rustok-profiles` owns public profile storage/translations, tags, handles,
+`rustok-profiles` owns public profile storage and translations, tags, handles,
 visibility policy, owner reads, audience-bound presentation, summary batching,
 GraphQL self-service, `profile.updated`, owner-local backfill, Media-backed image
-presentation, and the first module-owned storefront profile surface.
+presentation, and the module-owned profile storefront.
 
 Profiles is not an auth, customer, seller, staff, Social Graph, Index, search, or
-broker aggregate. Public GraphQL, Customer Admin enrichment, Blog/Forum author
-cards, and storefront reads share privacy-before-presentation ordering and hide
-restricted or unavailable rows as absent.
+broker aggregate. Public GraphQL, Customer Admin enrichment, Blog/Forum author cards,
+and storefront reads share privacy-before-presentation ordering and hide restricted
+or unavailable rows as absent.
 
-`followers_only` visibility resolves through authoritative Social Graph owner
-ports. Profiles never reads relation tables and never authorizes from an event,
-Index projection, decoded/raw DLQ receipt, neutral receipt aggregate, broker
-identifier, consumer offset, lag metric, poison-receipt health signal, or retained
-receipt evidence packet.
+`followers_only` resolves through authoritative Social Graph owner ports. Profiles
+never reads relation tables and never authorizes from an event, Index projection,
+decoded/raw DLQ receipt, neutral receipt aggregate, broker identifier, consumer
+offset, lag metric, poison health signal, PostgreSQL evidence packet, or real-Iggy
+evidence harness.
 
-Media descriptors remain Media-owned. Profiles validates tenant, uploader, and
-MIME constraints and exposes only Media-selected descriptors. Profiles does not
-know storage keys, provider endpoints, or ingress construction.
+Media descriptors remain Media-owned. Profiles validates tenant, uploader, and MIME
+constraints and exposes only Media-selected descriptors. It does not know storage
+keys, provider endpoints, or ingress construction.
 
-The module-owned storefront mounts `/modules/profiles?handle=<handle>`, supports
-SSR-first native and explicit GraphQL transports, renders approved avatar/banner
-descriptors, and exposes authenticated follow/unfollow with unique idempotency
-keys, optimistic revisions, and one read-only conflict refresh without automatic
-mutation retry.
+The storefront mounts `/modules/profiles?handle=<handle>`, supports SSR-first native
+and explicit GraphQL transports, renders approved avatar/banner descriptors, and
+exposes authenticated follow/unfollow with unique idempotency keys, optimistic
+revisions, and one read-only conflict refresh without automatic mutation retry.
 
-## Social Graph, Index, and broker status
+## Delivered Social Graph and Index boundary
 
-- Durable Social Graph command receipts bind a tenant-scoped normalized
-  idempotency key to one complete command identity and share a transaction with
-  relation mutation, optional event append, response snapshot, and completion.
-- `social_graph.relation.state_changed` is a sealed persisted-revision fact; no-op
-  and receipt replay emit nothing, and event failure rolls owner state back.
-- Historical replay is service/system-only, bounded, page-atomic, and remains the
+- Durable Social Graph command receipts bind a tenant-scoped normalized idempotency
+  key to one complete command identity and share a transaction with relation mutation,
+  optional event append, response snapshot, and completion.
+- `social_graph.relation.state_changed` is a sealed persisted-revision fact. No-op and
+  receipt replay emit nothing; event failure rolls owner state back.
+- Bounded relation-event replay is service/system-only, tenant-scoped, page-atomic,
+  and driven by an exclusive UUID cursor. Social Graph persistence remains the
   authoritative drift-repair source.
-- The generic Index adapter maps active revisions to non-localized upserts,
-  inactive revisions to tombstones, relation id to entity id, and revision to
-  monotonic `source_version`.
+- The generic Index adapter maps active revisions to non-localized upserts, inactive
+  revisions to tombstones, relation id to entity id, and relation revision to
+  monotonic revision/source-version semantics.
 - `SocialGraphIndexProjector` registers the tenant schema through Index-owned
-  persistence before Index inbox apply.
+  persistence before durable inbox apply.
 - `Applied`, `Duplicate`, and `StaleIgnored` are terminal durable results.
-- The persistent consumer retains one outstanding delivery and acknowledges only
-  after schema/mutation or durable decoded/raw DLQ results exist.
 - Runtime execution is default-off through
-  `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED`; explicit enablement requires a
-  worker host and `outbox_iggy`.
-- Relay and consumer reuse the single `Arc<IggyTransport>` owned by `EventRuntime`.
-- Projection, decoded/raw DLQ publication, neutral receipt, and acknowledgement
-  failures use bounded retry.
-- Migration `m20260727_000004_create_index_dlq_receipts` stores immutable poison
-  source coordinates and exact broker bytes under trusted tenant/consumer/event
-  identity.
-- Decoded receipt states reserve and lease publication, then persist `published`
-  before source acknowledgement. Existing `published`/`acknowledged` receipts are
-  recognized before projection and enter acknowledgement-only recovery.
-- A versioned length-framed SHA-256 construction derives one UUIDv8 from the
-  immutable trusted receipt identity and exact payload. Retry count, time,
-  publisher identity, and random values are excluded.
-- A read-only observer reads every `domain` partition plus the persistent group
-  checkpoint. Complete total/max lag is published only when every partition is
-  coherent; missing/inconsistent checkpoints clear lag gauges.
-- A separate count-only poison observer publishes fixed receipt-state aggregates,
-  snapshot availability, and snapshot time. Unavailable inspection clears stale
-  values; a missing/stopped observer is degraded health and never blocks projection.
-- The explicit append-only migration tail contains both receipt migrations, so the
-  previously published migration prefix is preserved.
-- An opt-in PostgreSQL receipt harness defines isolated-schema evidence for
-  concurrent ownership, lease reclaim/fencing, collision rollback,
-  first-diagnostic retention, empty payloads, terminal recognition, and aggregate
-  inspection.
-- A retained execution contract locks the exact Cargo commands, required cases,
-  bounded metadata, source hashes, and canonical packet path. Its clean-commit
-  runner and strict verifier are source-complete; the execution JSON is intentionally
-  absent until a maintainer runs PostgreSQL successfully.
-- Main also contains generic Index partition snapshot/query/mutation evidence.
-  That strengthens the shared Index substrate but does not validate this Social
-  Graph consumer, its schema registration, or Profiles presentation policy.
+  `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED`; explicit enablement requires a worker
+  host and `outbox_iggy`.
+- Relay, worker, and observers reuse the single `Arc<IggyTransport>` owned by
+  `EventRuntime`; no worker starts another bundled broker.
+- Decoded-event and raw-delivery receipt state is recognized before projection or a
+  new terminal-policy choice. Existing durable work remains recoverable when creation
+  of new DLQ decisions is later disabled.
+- The explicit append-only platform tail contains both
+  `m20260727_000004_create_index_dlq_receipts` and
+  `m20260728_000001_create_consumer_poison_receipts` without rewriting its published
+  prefix.
 
-## Raw contract decode-failure checkpoint
+## Delivered raw contract decode-failure boundary
 
-The previous consumer path deserialized before returning a delivery. Malformed
-JSON/MessagePack or a registered-schema failure therefore surfaced only as a
-receive error: exact bytes and connector coordinates were unavailable to the
-owner worker, and the offset remained uncommitted.
+`PersistentContractConsumerGroup::receive_delivery` returns either a validated event
+or `ConsumedContractDecodeFailure` without committing the cursor.
 
-`rustok-iggy` now defines the source contract:
-
-- `PersistentContractConsumerGroup::receive_delivery()` returns either a
-  validated event or `ConsumedContractDecodeFailure`;
-- stream/topic metadata is checked before decoding;
-- decode/schema failures retain exact bytes, partition, offset, and opaque ack
-  token without inventing tenant or domain event identity;
-- stable codes are limited to `iggy.contract.decode_invalid` and
+- stream/topic metadata is validated before deserialization;
+- malformed or schema-invalid deliveries retain exact bytes, partition, offset, and
+  opaque acknowledgement token;
+- stable classifications are limited to `iggy.contract.decode_invalid` and
   `iggy.contract.schema_invalid`;
-- a versioned UUIDv8 is derived from stream/topic/partition/offset/exact payload;
-  error kind, retry count, time, process identity, connector message identity,
-  acknowledgement token, credentials, and randomness are excluded;
-- acknowledgement remains a separate explicit call after an approved terminal
-  poison result exists;
-- compatibility `receive()` still returns a bounded error and performs no
-  implicit acknowledgement.
+- a versioned RFC 9562 UUIDv8 derives only from stream, topic, partition, offset, and
+  exact payload;
+- retry count, classification, time, process identity, credentials, connector message
+  identity, acknowledgement token, and randomness cannot drift the delivery identity;
+- no tenant, actor, relation, or domain event identity is invented;
+- compatibility `receive()` returns a bounded error and performs no implicit ack.
 
-`rustok-iggy-connector` owns the neutral durable result boundary:
+`rustok-iggy-connector` owns the neutral durable result:
 
-- migration `m20260728_000001_create_consumer_poison_receipts` is registered
-  through the existing connector migration hook;
-- source coordinates `(consumer_group, stream, topic, partition, offset)` are
-  unique and bind one deterministic connector delivery UUID plus exact bytes;
-- empty payload is valid exact broker input;
-- reuse with another UUID, coordinate set, or exact payload fails closed as an
-  identity conflict;
-- the first stable error code and observed delivery attempt are retained as
-  diagnostics, while later decoder classification or retry-count drift does not
-  redefine the connector delivery identity;
-- states are `reserved`, leased `publishing`, `published`, and `acknowledged`;
-- expired publication leases may be reclaimed, while terminal states are
-  recognized idempotently;
-- the store performs no publish, DLQ routing, source commit, or authorization;
-- read-only inspection exposes only fixed consumer-group counts and performs no
-  receipt transition, repair, retention, or deletion action.
+- source coordinates and deterministic delivery UUID bind exact payload, including an
+  empty payload;
+- UUID/source/payload reuse with different facts fails closed;
+- first error code and observed attempt are retained as one diagnostic pair;
+- states are `reserved`, leased `publishing`, terminal `published`, and
+  post-source-commit `acknowledged`;
+- the store performs no broker publication, source commit, authorization, reclaim
+  policy, retention, repair, or deletion choice;
+- read-only inspection exposes fixed consumer-group counts only.
 
-The Social Graph Index worker is wired to the typed result:
+The Social Graph Index worker composes the approved order:
 
-- `SocialGraphIndexConsumer::receive_delivery` exposes events and decode failures
-  without committing either;
-- the worker checks for an existing neutral receipt before applying current DLQ
-  policy, so a previously selected result continues recovery even when new DLQ
-  decisions are later disabled;
-- a new undecodable delivery remains uncommitted while DLQ is disabled;
-- a claimed receipt publishes `failure.to_dlq_entry(1)` with exact bytes and the
-  deterministic connector UUID, then persists `published` before source ack;
-- `published`/`acknowledged` redelivery skips publication and enters ack-only
-  recovery;
-- source ack precedes best-effort `mark_acknowledged` bookkeeping;
-- the raw path never invokes Index projection and never creates tenant/event facts.
+1. recognize or reserve the neutral receipt;
+2. claim publication ownership;
+3. publish `failure.to_dlq_entry(1)` with exact bytes;
+4. persist `published`;
+5. acknowledge the exact source cursor;
+6. record `acknowledged` as best-effort bookkeeping.
 
-Migration-order reconciliation is complete. The remaining work is execution and
-retained proof: compile the current mainline, run the clean-commit PostgreSQL
-capture runner, review and commit its canonical evidence JSON, run real-Iggy
-publication/ack/restart scenarios, and retain multi-replica/operator evidence
-without weakening privacy or exactly-once language.
+A terminal receipt enters acknowledgement-only recovery. The raw path never invokes
+Index projection and never affects Profiles privacy.
+
+## Operational and evidence checkpoint
+
+Source-complete operational visibility includes:
+
+- bounded delivery/retry/failure/DLQ/lifecycle metrics;
+- complete-partition consumer lag only when every broker checkpoint is coherent;
+- count-only poison receipt gauges for `total`, `reserved`, `publishing`,
+  `expired_publishing`, `published`, and `acknowledged`;
+- stale count clearing and snapshot availability/timestamp;
+- degraded health when the read-only observer task is missing or stopped, without
+  making receipt counts a readiness or authorization decision.
+
+PostgreSQL evidence tooling is source-complete:
+
+- unique schema per scenario and independent one-connection pools;
+- concurrent claim ownership and `Busy` loser;
+- lease reclaim with old-publisher `ClaimLost` fencing;
+- collision rollback and unchanged original row;
+- atomic first-diagnostic retention;
+- terminal aggregate consistency;
+- clean-commit runner, bounded PostgreSQL/toolchain metadata, source/output SHA-256,
+  atomic packet writing, and strict current-source verification.
+
+The canonical PostgreSQL execution JSON remains absent until a maintainer executes the
+runner successfully.
+
+External real-Iggy source evidence is now defined:
+
+- one unique disposable/operator-cleaned stream and one partition;
+- two non-empty malformed payloads injected only through fixture-level
+  `ExternalConnector::publish`;
+- production typed receive retains exact first bytes, offset, ack token, stable code,
+  and deterministic UUID without source ack;
+- production `IggyTransport::move_to_dlq` publishes the exact first bytes;
+- dropping and reopening the same source group must redeliver the same offset, bytes,
+  and UUID;
+- explicit source ack must then expose the second malformed payload at a greater
+  offset;
+- an independent real DLQ cursor verifies both payloads byte-for-byte.
+
+This harness is source-complete and runtime-pending. It does not prove PostgreSQL
+receipt ordering, the physical Iggy header ID, deduplication, bundled mode, TLS/auth,
+reconnect, multi-replica behavior, or physical exactly-once.
 
 ## FFA/FBA boundary
 
-- FFA status: `in_progress`
-- FBA status: `not_started`
-- Structural shape: `core_transport_ui`
-- The module has a module-owned Leptos storefront package with native/GraphQL
-  transports, package i18n, fail-closed transport selection, optimistic recovery,
-  and Media/Social Graph owner composition.
-- FBA remains `not_started` until compiled/live transport, Media isolation,
-  provider identity, public ingress, storage delivery, and retained runtime
-  evidence exist.
+- FFA status: `in_progress`.
+- FBA status: `not_started`.
+- Structural shape: `core_transport_ui`.
+- The Leptos storefront has native/GraphQL transports, package i18n, fail-closed
+  transport selection, Media/Social Graph owner composition, and optimistic conflict
+  recovery.
+- FBA remains blocked on compiled/live transport, Media isolation, provider identity,
+  public ingress/storage delivery, and retained runtime evidence.
 
 ## Results and next work
 
 1. **Keep owner reads separate from audience-bound presentation.**
    **Status:** source-complete for current consumers. Privacy is evaluated before
-   localized summary/tag loading and foreign modules do not read profile tables.
-   **Revisit when:** retained production telemetry proves another bounded owner
-   projection is necessary.
+   localized summary/tag loading; foreign modules do not read profile tables.
 
 2. **Finish followers-only and downstream presentation policy.**
-   **Status:** source-complete for owner privacy ports, public GraphQL lookups,
-   author cards, storefront, Customer Admin enrichment, receipt-aware commands,
-   transactional events, cleanup CLI, bounded replay, schema registration,
-   result-first Index apply/ack, durable decoded-event and raw-delivery DLQ receipt
-   recovery, deterministic broker identity, shared-transport lifecycle, readiness,
-   delivery telemetry, broker-backed complete lag observation, and count-only
-   neutral receipt health.
-   **Remaining:** prove bounded replay/rescan repair and retain compiled/runtime
-   evidence for privacy, receipts, cleanup, event relay/replay, schema concurrency,
-   broker restart/redelivery/DLQ receipt/header/dedup/position observation,
-   storefront, Customer Admin, Blog/Forum, and Media.
+   **Status:** source-complete for owner privacy ports, public GraphQL, author cards,
+   storefront, Customer Admin enrichment, command receipts, transactional events,
+   cleanup, replay, schema registration, result-first Index apply/ack, durable decoded
+   and raw DLQ recovery, shared-transport lifecycle, metrics, lag, and count-only poison
+   health.
+   **Remaining:** compiled/runtime evidence for privacy, schema concurrency, replay
+   repair, storefront, Customer Admin, Blog/Forum, and Media.
 
-3. **Publish module-owned profile storefront UI.**
-   **Status:** source-complete for the first Leptos slice, native/GraphQL transport
-   selection, Media presentation, authenticated follow control, and read-only
-   conflict recovery.
-   **Directory/search decision:** directory/search must use Profiles-owned public
-   profile records plus generic Index query contracts. Social Graph relation
-   projection may support discovery/ranking inputs but must not replace
-   audience-bound profile authorization.
-   **Remaining:** execute SSR/hydrate/GraphQL route, auth, i18n, Media
-   direct/proxy/fallback, mutation conflict, durable receipt, relation-event, and
-   accessibility evidence.
+3. **Publish and retain storefront evidence.**
+   Execute SSR/hydrate/GraphQL route, auth, i18n, Media direct/proxy/fallback, follow
+   conflict, durable receipt, relation-event, and accessibility scenarios.
 
 4. **Keep profile backfill owner-local.**
-   **Status:** source-complete; compiled/runtime verification pending. The CLI uses
-   owner auth/tenant/customer reads and optional Outbox publication while
-   preserving dry-run semantics and aggregate telemetry.
+   The CLI remains source-complete and uses owner auth/tenant/customer reads plus
+   optional Outbox publication while preserving dry-run semantics and aggregate
+   telemetry. Compiled/runtime proof remains open.
 
-5. **Complete audit and operational evidence.**
-   **Status:** source-complete for Profiles operations, Social Graph command
-   telemetry, durable command/decoded-event/raw-delivery DLQ receipts,
-   deterministic DLQ broker identity, maintenance, events, replay, cleanup CLI,
-   persisted schema registration, durable terminal recognition, default-off shared
-   transport lifecycle, retries, shutdown, readiness, bounded metrics, complete
-   lag, count-only poison health, PostgreSQL scenarios, and retained capture tooling.
-   **Remaining:** execute and commit PostgreSQL evidence, prove retention/replay/
-   rollback, approve deployment retention, prove real broker observer/reconnect/
-   TLS/rebalance, deterministic header and dedup disabled/enabled/expiry/capacity
-   behavior, confirmation policy, multi-replica behavior, and retained operator
-   packets.
+5. **Execute retained PostgreSQL poison evidence.**
+   Run the clean-commit capture runner, review the bounded packet, commit the canonical
+   JSON, and repeat whenever a bound source hash changes.
 
-6. **Handle undecodable sealed contract deliveries without invented ownership.**
-   **Status:** source-complete for typed receive, immutable connector identity,
-   neutral durable receipt, exact-byte DLQ publication, durable published-before-ack,
-   existing-result recovery, best-effort post-ack bookkeeping, append-only migration
-   placement, count-only health, opt-in PostgreSQL scenarios, and a fail-closed
-   retained execution contract/runner/verifier.
-   **Next:** execute the clean-commit PostgreSQL runner, review and commit the
-   canonical packet, then execute real-Iggy failure/restart/dedup/multi-replica
-   scenarios.
-   **Done when:** malformed bytes are retained, classified, durably terminalized,
-   published/recovered, and acknowledged without fabricated tenant/event identity,
-   implicit commits, duplicate authorization effects, or exactly-once claims, and
-   the behavior is retained by compiled/database/broker evidence.
+6. **Execute external real-Iggy raw lifecycle evidence.**
+   Run the new harness on a disposable broker, retain broker/toolchain/configuration
+   metadata and output/source digests, and repeat no-ack reopen/redelivery plus explicit
+   cursor advancement.
+
+7. **Compose receipt-plus-broker evidence.**
+   Prove reserve/claim -> exact publish -> durable `published` -> source ack ->
+   best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
+   multi-replica claim ownership on PostgreSQL plus real Iggy.
+
+8. **Prove header and confirmation behavior.**
+   Inspect the physical UUID header, same-partition routing, publisher reconnect, and
+   duplicate behavior with deduplication disabled, enabled, capacity-evicted, and
+   expired. Choose an enforced dedup window or stronger outbox/transaction mechanism
+   before any stronger duplicate guarantee.
+
+9. **Retain production operations.**
+   Prove bundled mode, restart, TLS/auth/failover, position reconnect, rebalance,
+   retention/reconciliation, operator cleanup, and bounded replay/rescan repair.
 
 ## Recheck checkpoint — 2026-07-28
 
-- Rechecked the canonical Profiles plan, superseded PR #2237, draft PR #2317,
-  replacement PR #2338, and current `main` while using short merge/new-branch cycles
-  to reduce conflicts with parallel agents.
-- Preserved receipts, cleanup, sealed events, replay, schema registration,
-  persistent worker, durable decoded-event DLQ receipts, deterministic broker
-  identity, readiness, telemetry, and position observation from PR #2317.
-- Reconfirmed privacy-before-presentation, bounded follower reads, owner-scoped
-  writes, Media-owned descriptors, no automatic mutation retry, and the rule that
+- Rechecked the canonical plan and current `main` using short merge/new-branch cycles
+  because multiple agents change the repository in parallel.
+- Reconfirmed privacy-before-presentation, bounded follower reads, owner-scoped writes,
+  Media-owned descriptors, no automatic mutation retry, and the rule that
   Index/broker/receipt/metric/evidence state never authorizes profile presentation.
-- Added the typed exact-byte decode-failure contract with explicit acknowledgement.
-- Added connector-owned neutral receipt DDL/store with private immutable source
-  identity, empty exact-byte support, collision detection, first-diagnostic
-  retention, leased publication, terminal recognition, and bounded stable errors.
-- Wired the Social Graph Index owner adapter and server worker to typed raw delivery.
-- Added exact-byte reserve/publish/mark-published/source-ack ordering and ack-only
-  redelivery recovery without tenant/event synthesis or Index projection.
-- Preserved an existing durable raw result across later DLQ policy disablement while
-  leaving a new undecodable delivery uncommitted when no terminal policy is enabled.
-- Enabled connector migration/storage API explicitly in the server dependency rather
-  than relying on transitive feature unification.
-- Registered the connector migration in the truthful `mode: none` backfill ledger.
-- Appended both receipt migrations to the explicit platform release-order tail
-  without rewriting its published prefix.
-- Added count-only receipt inspection, Prometheus metrics, stale-snapshot clearing,
-  bounded failure logging, degraded observer-task health, and an operator runbook.
-- Added an opt-in isolated-schema PostgreSQL harness for claim ownership, lease
-  reclaim/fencing, collision rollback, atomic first-diagnostic retention, terminal
-  recognition, and aggregate consistency.
-- Added a PostgreSQL metadata test, clean-commit capture runner, atomic canonical
-  packet writer, source/output SHA-256 binding, and strict retained-evidence verifier.
-- The canonical execution JSON remains absent until a maintainer runs PostgreSQL.
-- Tests, Cargo commands, formatters, source verifiers, PostgreSQL, real-broker, and
-  multi-replica scenarios were not run, per maintainer instruction.
+- Preserved command receipts, transactional sealed events, bounded replay, Index schema
+  registration, result-first consumption, decoded/raw DLQ receipts, deterministic
+  delivery identity, shared transport, readiness, metrics, and position observation.
+- Closed append-only migration-tail reconciliation.
+- Added count-only receipt inspection/metrics, stale clearing, degraded observer-task
+  health, and the operator runbook.
+- Added isolated PostgreSQL scenarios and clean-commit retained evidence tooling; the
+  execution packet remains pending.
+- Added a versioned external-Iggy source contract, opt-in real cursor/DLQ harness,
+  no-ack reopen/redelivery, exact-byte DLQ checks, explicit cursor advancement, and a
+  static verifier.
+- Removed the stale verifier claim that no Social Graph worker was wired.
+- Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy,
+  and multi-replica scenarios were not run, per maintainer instruction.
 
 ## Verification
 
@@ -266,7 +231,9 @@ without weakening privacy or exactly-once language.
 - `cargo test -p rustok-profiles-storefront`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
 - `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
+- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
@@ -307,24 +274,26 @@ without weakening privacy or exactly-once language.
 6. Profile media resolves through Media owner ports only.
 7. Module UI stays package-owned with explicit transports and package i18n.
 8. Follow controls use owner ports, unique idempotency, optimistic revision, and no automatic retry.
-9. Operational telemetry excludes presentation copy, email, provider details, identities,
-   idempotency keys, cursors, payloads, broker IDs, claims, roles, and channels.
+9. Operational telemetry excludes presentation copy, identities, idempotency keys,
+   cursors, payloads, broker IDs, claims, roles, credentials, and provider details.
 10. Index/search projections may use sealed owner events, generic Index contracts,
     monotonic source versions, and bounded replay, but never authorize visibility.
-11. Durable workers persist/recognize the owner result before ack; exact-byte broker
-    DLQ publication and terminal receipt persistence precede source ack.
+11. Durable workers persist/recognize the owner result before ack; exact-byte DLQ
+    publication and terminal receipt persistence precede source ack.
 12. Deterministic IDs bind immutable source identity and exact payload but never
     authorize presentation or imply exactly-once without retained broker evidence.
-13. Optional enabled workers participate in readiness and bounded telemetry; disabled
-    workers do not degrade presentation availability.
-14. Publish lag only from a complete partition-qualified broker snapshot; never use
-    partition or offset as metric labels.
-15. Undecodable bytes must not invent tenant or domain event identity. Use a neutral
-    connector poison contract and acknowledge only after its terminal result exists.
-16. Existing durable poison choices remain recoverable across later policy disablement;
-    new undecodable deliveries remain uncommitted without an enabled terminal policy.
-17. Count-only receipt health and retained PostgreSQL evidence never authorize,
-    acknowledge, reclaim, repair, retain, or delete production delivery state.
-18. Retained packets must be generated from a clean commit, omit credentials and
-    delivery-level facts, and become stale when any bound source SHA-256 changes.
-19. Update Profiles and affected owner docs with every boundary change.
+13. Publish lag only from a complete partition-qualified broker snapshot; partition and
+    offset are values, never metric labels.
+14. Undecodable bytes must not invent tenant or domain event identity; acknowledge only
+    after an approved terminal result exists.
+15. Existing durable poison choices remain recoverable across later policy disablement;
+    new undecodable deliveries remain uncommitted without enabled terminal policy.
+16. Count-only health and PostgreSQL/Iggy evidence never authorize, acknowledge, reclaim,
+    repair, retain, or delete production delivery state.
+17. Retained packets require a clean commit, omit credentials/delivery-level facts, and
+    become stale when a bound source SHA-256 changes.
+18. Real-Iggy fixture injection may create malformed bytes, but production receive, DLQ,
+    and acknowledgement must use reviewed transport APIs.
+19. Do not claim physical header, deduplication, database ordering, bundled, TLS/auth, or
+    multi-replica proof from the external cursor lifecycle harness.
+20. Update Profiles and affected owner docs with every boundary change.

--- a/scripts/verify/verify-iggy-contract-decode-failure.mjs
+++ b/scripts/verify/verify-iggy-contract-decode-failure.mjs
@@ -109,8 +109,9 @@ for (const forbidden of [
 
 for (const marker of [
   "does not invent a tenant or domain event id",
-  "No Social Graph or other runtime worker is wired",
-  "Choose durable connector poison confirmation",
+  "The first approved owner worker is wired",
+  "Choose production confirmation policy",
+  "External raw-poison lifecycle harness",
 ]) {
   requireText("Iggy decode-failure plan", files.plan, marker);
 }
@@ -131,5 +132,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy contract decode-failure verification passed: metadata-before-decode, immutable exact raw bytes and source coordinates, bounded failure codes, stable UUIDv8 connector identity, explicit post-result acknowledgement, compatibility no-ack behavior, and no invented tenant/event identity are locked.",
+  "Iggy contract decode-failure verification passed: metadata-before-decode, immutable exact raw bytes and source coordinates, bounded failure codes, stable UUIDv8 connector identity, explicit post-result acknowledgement, compatibility no-ack behavior, current owner-worker composition, and no invented tenant/event identity are locked.",
 );

--- a/scripts/verify/verify-iggy-contract-poison-external-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-evidence.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const contract = JSON.parse(
+  readFileSync(
+    "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-source.json",
+    "utf8",
+  ),
+);
+const test = readFileSync(
+  "crates/rustok-iggy/tests/contract_poison_external_iggy.rs",
+  "utf8",
+);
+const failures = [];
+
+const expectedSequence = [
+  "open_source_and_dlq_consumer_groups_before_fixture_publish",
+  "publish_two_distinct_nonempty_malformed_payloads_to_one_domain_partition",
+  "receive_first_payload_through_persistent_contract_consumer_without_ack",
+  "classify_first_payload_as_decode_invalid_and_retain_exact_bytes_offset_ack_token",
+  "publish_first_failure_through_iggy_transport_move_to_dlq",
+  "receive_and_ack_exact_first_dlq_payload",
+  "drop_source_cursor_without_ack",
+  "reopen_same_source_group_and_receive_same_offset_payload_and_delivery_uuid",
+  "explicitly_acknowledge_redelivered_failure",
+  "receive_second_payload_at_a_greater_offset",
+  "publish_and_verify_exact_second_dlq_payload",
+  "explicitly_acknowledge_second_failure",
+  "shutdown_fixture_connector_and_transport",
+];
+const expectedProductionPaths = [
+  "IggyTransport::new",
+  "IggyTransport::open_persistent_contract_consumer_group",
+  "PersistentContractConsumerGroup::receive_delivery",
+  "ConsumedContractDecodeFailure::to_dlq_entry",
+  "IggyTransport::move_to_dlq",
+  "PersistentContractConsumerGroup::acknowledge_decode_failure",
+  "ExternalConnector::open_consumer_group",
+];
+const expectedForbiddenClaims = [
+  "database_receipt_ordering_proved",
+  "deterministic_iggy_header_runtime_proved",
+  "broker_deduplication_runtime_proved",
+  "physical_exactly_once_proved",
+  "bundled_mode_proved",
+  "tls_or_auth_failure_proved",
+  "multi_replica_proved",
+];
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    failures.push(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) {
+    failures.push(`${name} contains forbidden marker: ${marker}`);
+  }
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireOrdered(name, source, markers) {
+  let previous = -1;
+  for (const marker of markers) {
+    const position = source.indexOf(marker, previous + 1);
+    if (position < 0) {
+      failures.push(`${name} is missing ordered marker: ${marker}`);
+      return;
+    }
+    if (position <= previous) {
+      failures.push(`${name} has invalid ordering at marker: ${marker}`);
+      return;
+    }
+    previous = position;
+  }
+}
+
+if (contract.schema_version !== 1) failures.push("source contract schema_version drift");
+if (contract.module !== "iggy") failures.push("source contract module drift");
+if (contract.packet !== "contract-poison-external-iggy-source") {
+  failures.push("source contract packet drift");
+}
+if (contract.status !== "source_complete_runtime_pending") {
+  failures.push("source contract must remain runtime-pending until execution");
+}
+if (contract.scope !== "external_real_iggy_raw_poison_cursor_lifecycle") {
+  failures.push("source contract scope drift");
+}
+if (contract.test_target !== "contract_poison_external_iggy") {
+  failures.push("source contract test target drift");
+}
+if (
+  contract.test_case !==
+  "malformed_delivery_redelivers_until_explicit_ack_and_dlq_keeps_exact_bytes"
+) {
+  failures.push("source contract test case drift");
+}
+if (
+  contract.source_path !==
+  "crates/rustok-iggy/tests/contract_poison_external_iggy.rs"
+) {
+  failures.push("source contract path drift");
+}
+if (
+  contract.verifier !==
+  "scripts/verify/verify-iggy-contract-poison-external-evidence.mjs"
+) {
+  failures.push("source contract verifier drift");
+}
+if (!sameValue(contract.required_environment, ["RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS"])) {
+  failures.push("source contract required environment drift");
+}
+if (
+  !sameValue(contract.optional_environment, [
+    "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+    "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD",
+  ])
+) {
+  failures.push("source contract optional environment drift");
+}
+if (
+  !sameValue(contract.topology, {
+    mode: "external",
+    protocol: "tcp",
+    unique_stream_per_run: true,
+    domain_partitions: 1,
+    replication_factor: 1,
+    topics: ["domain", "dlq"],
+    broker_requirement: "disposable_or_operator_cleaned_external_iggy",
+  })
+) {
+  failures.push("source contract topology drift");
+}
+if (!sameValue(contract.required_sequence, expectedSequence)) {
+  failures.push("source contract required sequence drift");
+}
+if (!sameValue(contract.production_paths, expectedProductionPaths)) {
+  failures.push("source contract production path drift");
+}
+if (
+  contract.fixture_only_path !==
+  "ExternalConnector::publish(PublishRequest) injects arbitrary malformed broker bytes"
+) {
+  failures.push("source contract fixture boundary drift");
+}
+if (!sameValue(contract.forbidden_claims, expectedForbiddenClaims)) {
+  failures.push("source contract forbidden claim drift");
+}
+if (contract.execution_status !== "not_run") {
+  failures.push("source contract must not claim an unexecuted real-Iggy result");
+}
+
+for (const marker of [
+  '#![cfg(feature = "iggy")]',
+  'const ADDRESS_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS";',
+  'const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";',
+  'const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";',
+  "IggyMode::External",
+  'protocol: "tcp".to_string()',
+  'stream_name: unique_name("stream")',
+  "domain_partitions: 1",
+  "replication_factor: 1",
+  'open_persistent_contract_consumer_group(&source_group, "domain")',
+  'open_consumer_group(&stream, "dlq", &dlq_group)',
+  "PersistentContractDelivery::DecodeFailure(failure)",
+  "ContractDecodeFailureKind::Deserialize",
+  '"iggy.contract.decode_invalid"',
+  "first_failure.ack_token().is_some()",
+  "transport.move_to_dlq(first_failure.to_dlq_entry(1))",
+  "drop(first_source_cursor)",
+  "redelivered.offset(), first_offset",
+  "redelivered.delivery_id(), first_delivery_id",
+  "redelivered.raw_payload(), first_dlq.payload.as_slice()",
+  ".acknowledge_decode_failure(&redelivered)",
+  "second_failure.offset() > first_offset",
+  "second_failure.delivery_id(), first_delivery_id",
+  "transport.move_to_dlq(second_failure.to_dlq_entry(1))",
+  ".acknowledge_decode_failure(&second_failure)",
+  "fixture_connector.shutdown().await?",
+  "transport.shutdown().await?",
+  "timeout(RECEIVE_TIMEOUT",
+]) {
+  requireText("external Iggy raw poison test", test, marker);
+}
+
+requireOrdered("first raw poison lifecycle", test, [
+  "let first_failure = receive_decode_failure(&first_source_cursor).await?;",
+  "transport.move_to_dlq(first_failure.to_dlq_entry(1)).await?;",
+  "let first_dlq = receive_cursor_message(&mut dlq_cursor).await?;",
+  "acknowledge_cursor_message(&mut dlq_cursor, &first_dlq).await?;",
+  "drop(first_source_cursor);",
+  "let redelivered = receive_decode_failure(&reopened_source_cursor).await?;",
+  ".acknowledge_decode_failure(&redelivered)",
+  "let second_failure = receive_decode_failure(&reopened_source_cursor).await?;",
+]);
+requireOrdered("second raw poison lifecycle", test, [
+  "let second_failure = receive_decode_failure(&reopened_source_cursor).await?;",
+  "transport.move_to_dlq(second_failure.to_dlq_entry(1)).await?;",
+  "let second_dlq = receive_cursor_message(&mut dlq_cursor).await?;",
+  "acknowledge_cursor_message(&mut dlq_cursor, &second_dlq).await?;",
+  ".acknowledge_decode_failure(&second_failure)",
+]);
+
+for (const forbidden of [
+  "127.0.0.1:8090",
+  'username: "iggy"',
+  'password: "iggy"',
+  "IggyClient",
+  "IggyConsumer",
+  "use iggy::",
+  ".store_offset(",
+  "std::thread::sleep",
+  "tokio::time::sleep",
+  "DELETE STREAM",
+  "delete_stream",
+  "DATABASE_URL",
+  "ConsumerPoisonReceiptStore",
+  "mark_published",
+  "mark_acknowledged",
+]) {
+  forbidText("external Iggy raw poison test", test, forbidden);
+}
+
+const publishFixtureStart = test.indexOf("async fn publish_fixture(");
+const receiveHelperStart = test.indexOf("async fn receive_decode_failure(");
+const publishFixture =
+  publishFixtureStart >= 0 && receiveHelperStart > publishFixtureStart
+    ? test.slice(publishFixtureStart, receiveHelperStart)
+    : "";
+for (const marker of [
+  "ExternalConnector",
+  ".publish(PublishRequest::new(",
+  '"domain"',
+  '"raw-poison-fixture"',
+]) {
+  requireText("malformed fixture injector", publishFixture, marker);
+}
+for (const forbidden of [
+  "move_to_dlq",
+  "acknowledge_decode_failure",
+  "ConsumerPoisonReceiptStore",
+  "tenant_id",
+  "event_id()",
+]) {
+  forbidText("malformed fixture injector", publishFixture, forbidden);
+}
+
+if (failures.length > 0) {
+  console.error("External Iggy raw poison evidence verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "External Iggy raw poison source evidence verified: unique external topology, production typed receive and DLQ paths, no-ack redelivery, explicit cursor advancement, exact-byte DLQ, and bounded unexecuted claims are locked.",
+);

--- a/scripts/verify/verify-iggy-contract-poison-external-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-evidence.mjs
@@ -22,15 +22,18 @@ const expectedSequence = [
   "publish_first_failure_through_iggy_transport_move_to_dlq",
   "receive_and_ack_exact_first_dlq_payload",
   "drop_source_cursor_without_ack",
-  "reopen_same_source_group_and_receive_same_offset_payload_and_delivery_uuid",
+  "shutdown_first_transport_without_source_ack",
+  "connect_new_transport_with_same_stream_and_source_group",
+  "receive_same_offset_payload_and_delivery_uuid_after_reconnect",
   "explicitly_acknowledge_redelivered_failure",
   "receive_second_payload_at_a_greater_offset",
   "publish_and_verify_exact_second_dlq_payload",
   "explicitly_acknowledge_second_failure",
-  "shutdown_fixture_connector_and_transport",
+  "shutdown_fixture_connector_and_reopened_transport",
 ];
 const expectedProductionPaths = [
   "IggyTransport::new",
+  "IggyTransport::shutdown",
   "IggyTransport::open_persistent_contract_consumer_group",
   "PersistentContractConsumerGroup::receive_delivery",
   "ConsumedContractDecodeFailure::to_dlq_entry",
@@ -173,37 +176,50 @@ for (const marker of [
   "first_failure.ack_token().is_some()",
   "transport.move_to_dlq(first_failure.to_dlq_entry(1))",
   "drop(first_source_cursor)",
+  "transport.shutdown().await?",
+  "let reopened_transport = IggyTransport::new(config.clone()).await?;",
   "redelivered.offset(), first_offset",
   "redelivered.delivery_id(), first_delivery_id",
   "redelivered.raw_payload(), first_dlq.payload.as_slice()",
   ".acknowledge_decode_failure(&redelivered)",
   "second_failure.offset() > first_offset",
   "second_failure.delivery_id(), first_delivery_id",
-  "transport.move_to_dlq(second_failure.to_dlq_entry(1))",
+  ".move_to_dlq(second_failure.to_dlq_entry(1))",
   ".acknowledge_decode_failure(&second_failure)",
   "fixture_connector.shutdown().await?",
-  "transport.shutdown().await?",
+  "reopened_transport.shutdown().await?",
   "timeout(RECEIVE_TIMEOUT",
 ]) {
   requireText("external Iggy raw poison test", test, marker);
 }
 
-requireOrdered("first raw poison lifecycle", test, [
+requireOrdered("consumer groups precede fixture publication", test, [
+  "let first_source_cursor = transport",
+  "let mut dlq_cursor = fixture_connector",
+  "publish_fixture(&fixture_connector, &stream, first_payload.clone()).await?;",
+  "publish_fixture(&fixture_connector, &stream, second_payload.clone()).await?;",
+]);
+requireOrdered("first raw poison lifecycle and reconnect", test, [
   "let first_failure = receive_decode_failure(&first_source_cursor).await?;",
   "transport.move_to_dlq(first_failure.to_dlq_entry(1)).await?;",
   "let first_dlq = receive_cursor_message(&mut dlq_cursor).await?;",
   "acknowledge_cursor_message(&mut dlq_cursor, &first_dlq).await?;",
   "drop(first_source_cursor);",
+  "transport.shutdown().await?;",
+  "let reopened_transport = IggyTransport::new(config.clone()).await?;",
+  "let reopened_source_cursor = reopened_transport",
   "let redelivered = receive_decode_failure(&reopened_source_cursor).await?;",
   ".acknowledge_decode_failure(&redelivered)",
   "let second_failure = receive_decode_failure(&reopened_source_cursor).await?;",
 ]);
 requireOrdered("second raw poison lifecycle", test, [
   "let second_failure = receive_decode_failure(&reopened_source_cursor).await?;",
-  "transport.move_to_dlq(second_failure.to_dlq_entry(1)).await?;",
+  "reopened_transport\n        .move_to_dlq(second_failure.to_dlq_entry(1))",
   "let second_dlq = receive_cursor_message(&mut dlq_cursor).await?;",
   "acknowledge_cursor_message(&mut dlq_cursor, &second_dlq).await?;",
   ".acknowledge_decode_failure(&second_failure)",
+  "fixture_connector.shutdown().await?;",
+  "reopened_transport.shutdown().await?;",
 ]);
 
 for (const forbidden of [
@@ -259,5 +275,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "External Iggy raw poison source evidence verified: unique external topology, production typed receive and DLQ paths, no-ack redelivery, explicit cursor advancement, exact-byte DLQ, and bounded unexecuted claims are locked.",
+  "External Iggy raw poison source evidence verified: unique external topology, production typed receive and DLQ paths, no-ack transport reconnect/redelivery, explicit cursor advancement, exact-byte DLQ, and bounded unexecuted claims are locked.",
 );


### PR DESCRIPTION
## Summary

Define the first opt-in real external-Iggy lifecycle harness for undecodable contract bytes without claiming unexecuted runtime proof.

The scenario uses one unique stream and one partition:

1. opens production source and real DLQ consumer groups before fixture publication;
2. injects two distinct non-empty malformed payloads through a fixture-only `ExternalConnector::publish` path;
3. receives the first payload through `PersistentContractConsumerGroup::receive_delivery` as an exact-byte `DecodeFailure` without source acknowledgement;
4. verifies offset, ack token, stable `decode_invalid` classification, and deterministic connector UUID;
5. publishes the exact bytes through `IggyTransport::move_to_dlq` and verifies them through an independent real DLQ cursor;
6. drops the source cursor and shuts down the first external transport without acknowledging the source;
7. creates a new transport for the same stream/group and requires the same offset, bytes, and UUID to redeliver;
8. explicitly acknowledges that redelivery and requires the second malformed payload at a greater offset;
9. publishes/verifies the second exact DLQ payload, acknowledges both cursors, and shuts down explicitly.

## Boundaries

- no localhost or default credential fallback;
- optional username/password must be supplied together;
- TCP/non-TLS only in this first slice;
- unique streams require a disposable broker or operator-approved cleanup;
- no direct Iggy SDK client, `store_offset`, sleeps, database receipt store, or production stream deletion in the harness;
- fixture publication only injects malformed bytes; production receive, classification, DLQ publication, reconnect, and acknowledgement stay on reviewed transport APIs.

This source contract does **not** claim PostgreSQL receipt ordering, physical Iggy header verification, broker deduplication, exactly-once, bundled mode, TLS/auth failure, or multi-replica proof.

## Documentation and guards

- added a versioned machine-readable source contract with `execution_status: not_run`;
- added an external-Iggy operator/evidence guide;
- updated the Iggy and canonical Profiles plans;
- updated the stale decode-failure verifier that incorrectly required the old “no worker is wired” state;
- added `verify-iggy-contract-poison-external-evidence.mjs` to lock topology, environment, production API usage, exact ordering, transport reconnect, exact-byte DLQ, and bounded claims.

## Verification

Tests, Cargo commands, formatters, source verifiers, external/bundled Iggy scenarios, PostgreSQL, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
node scripts/verify/verify-iggy-contract-decode-failure.mjs
node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs

RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' \
RUSTOK_IGGY_EXTERNAL_TEST_USERNAME='...' \
RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD='...' \
  cargo test -p rustok-iggy --features iggy \
  --test contract_poison_external_iggy -- --nocapture --test-threads=1
```