### PR TITLE
Use fulfillment owner port for admin reads

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
+++ b/crates/rustok-commerce/src/controllers/admin/fulfillments.rs
@@ -3,9 +3,14 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::Permission;
-use rustok_api::{AuthContext, TenantContext};
-use rustok_fulfillment::{FulfillmentError, FulfillmentService};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_fulfillment::{
+    FulfillmentError, FulfillmentService, ListFulfillmentProjectionsRequest,
+    ReadFulfillmentProjectionRequest,
+};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -18,7 +23,7 @@ use crate::{
     FulfillmentOrchestrationError, FulfillmentOrchestrationService,
     dto::{
         CancelFulfillmentInput, CreateFulfillmentInput, DeliverFulfillmentInput,
-        FulfillmentResponse, ListFulfillmentsInput, ReopenFulfillmentInput, ReshipFulfillmentInput,
+        FulfillmentResponse, ReopenFulfillmentInput, ReshipFulfillmentInput,
         ShipFulfillmentInput,
     },
 };
@@ -51,6 +56,95 @@ impl AdminFulfillmentErrorContext {
     }
 }
 
+fn admin_fulfillment_read_port_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    fulfillment_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = fulfillment_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-fulfillment:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_admin_fulfillment_port_error(
+    context: AdminFulfillmentErrorContext,
+    port_context: &PortContext,
+    owner_operation: &'static str,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_fulfillment_failed",
+            "Fulfillment operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_FULFILLMENT_OWNER,
+        owner_operation,
+        correlation_id = %port_context.correlation_id,
+        tenant_id = %context.tenant_id,
+        fulfillment_id = ?context.fulfillment_id,
+        order_id = ?context.order_id,
+        operation = %context.operation,
+        actor = ?port_context.actor,
+        channel = ?port_context.channel,
+        locale = %port_context.locale,
+        deadline_ms = ?port_context.deadline_ms,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_FULFILLMENT_BOUNDARY,
+        "commerce admin fulfillment owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
 /// List admin fulfillments
 #[utoipa::path(
     get,
@@ -66,6 +160,7 @@ pub async fn list_fulfillments(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Query(params): Query<ListFulfillmentsParams>,
 ) -> HttpResult<Json<PaginatedResponse<FulfillmentResponse>>> {
     ensure_permissions(
@@ -75,10 +170,18 @@ pub async fn list_fulfillments(
     )?;
 
     let pagination = params.pagination.unwrap_or_default();
-    let (fulfillments, total) = FulfillmentService::new(runtime.db_clone())
-        .list_fulfillments(
-            tenant.id,
-            ListFulfillmentsInput {
+    let read_context = admin_fulfillment_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        None,
+        "list_fulfillments",
+    );
+    let page = runtime
+        .fulfillment_read_port()
+        .list_fulfillment_projections(
+            read_context.clone(),
+            ListFulfillmentProjectionsRequest {
                 page: pagination.page,
                 per_page: pagination.limit(),
                 status: params.status,
@@ -88,15 +191,21 @@ pub async fn list_fulfillments(
         )
         .await
         .map_err(|error| {
-            map_admin_fulfillment_error(
+            map_admin_fulfillment_port_error(
                 AdminFulfillmentErrorContext::new(tenant.id, None, None, "list_fulfillments"),
+                &read_context,
+                "list_fulfillment_projections",
                 error,
             )
         })?;
 
     Ok(Json(PaginatedResponse {
-        data: fulfillments,
-        meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
+        data: page.items,
+        meta: super::super::common::PaginationMeta::new(
+            pagination.page,
+            pagination.limit(),
+            page.total,
+        ),
     }))
 }
 
@@ -160,6 +269,7 @@ pub async fn show_fulfillment(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<FulfillmentResponse>> {
     ensure_permissions(
@@ -168,12 +278,25 @@ pub async fn show_fulfillment(
         "Permission denied: fulfillments:read required",
     )?;
 
-    let fulfillment = FulfillmentService::new(runtime.db_clone())
-        .get_fulfillment(tenant.id, id)
+    let read_context = admin_fulfillment_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "get_fulfillment",
+    );
+    let fulfillment = runtime
+        .fulfillment_read_port()
+        .read_fulfillment_projection(
+            read_context.clone(),
+            ReadFulfillmentProjectionRequest { fulfillment_id: id },
+        )
         .await
         .map_err(|error| {
-            map_admin_fulfillment_error(
+            map_admin_fulfillment_port_error(
                 AdminFulfillmentErrorContext::new(tenant.id, Some(id), None, "get_fulfillment"),
+                &read_context,
+                "read_fulfillment_projection",
                 error,
             )
         })?;

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -61,7 +61,6 @@ impl CommerceHttpRuntime {
             .shipping_option_admin_read_port()
     }
 
-    #[allow(dead_code)]
     fn fulfillment_read_port(
         &self,
     ) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentReadPort> {

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-28",
-  "status": "source_composed_unvalidated",
-  "source_base_revision": "765b12129b500292c05d5f8a17f0e3902d345fb2",
+  "status": "source_rest_cutover_unvalidated",
+  "source_base_revision": "8a5e251eec95d7fcda54e0ba5c7df4560ef70935",
   "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
   "owner": {
     "crate": "rustok-fulfillment",
@@ -58,11 +58,22 @@
     "commerce_http_runtime_required": true,
     "external_adapter_preserved": true
   },
+  "admin_rest": {
+    "list_consumer": "list_fulfillment_projections",
+    "detail_consumer": "read_fulfillment_projection",
+    "pagination_total_preserved": true,
+    "filters_preserved": true,
+    "public_error_policy_preserved": true,
+    "tenant_actor_locale_channel_correlation_propagated": true,
+    "deadline_seconds": 2,
+    "concrete_service_read_construction": false,
+    "mutation_service_construction_unchanged": true
+  },
   "consumer_cutover": {
     "graphql_compatibility_facade": false,
-    "admin_rest_list_show": false,
+    "admin_rest_list_show": true,
     "concrete_delegate_removed": false,
-    "next_slice": "route admin REST list/show and GraphQL lookup/list/latest-by-order through the host-composed FulfillmentReadPort while preserving transport-specific optional-not-found and public error policy"
+    "next_slice": "add request-safe GraphQL lifecycle runtime scope and route fulfillment lookup/list/latest-by-order through FulfillmentReadPort while preserving optional-not-found and public error policy"
   },
   "validation": {
     "tests_run": false,

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
@@ -1,6 +1,6 @@
 # Fulfillment lifecycle read port
 
-Status: source-composed, unvalidated.
+Status: source REST cutover, unvalidated.
 
 ## Scope
 
@@ -14,8 +14,9 @@ projection reads used by Commerce query consumers. It is separate from:
 - fulfillment lifecycle mutation methods, which remain on `FulfillmentService`.
 
 The owner read boundary and Commerce runtime container are published. The default
-application host now composes and attaches that runtime, and `CommerceHttpRuntime`
-requires it. GraphQL/admin REST handlers have not yet been cut over to the port.
+application host composes and attaches that runtime, `CommerceHttpRuntime`
+requires it, and admin REST list/detail now consume its owner port. GraphQL
+lifecycle handlers have not yet been cut over.
 
 ## Operations
 
@@ -64,7 +65,7 @@ conflict outcomes retain stable owner codes.
 It remains separate from `CommerceShippingOptionReadRuntime`, allowing different
 adapters for lifecycle and shipping-option projections.
 
-The application server now:
+The application server:
 
 1. reuses a lifecycle runtime already installed in `ServerRuntimeContext`;
 2. otherwise constructs the deterministic in-process runtime once;
@@ -78,32 +79,45 @@ Commerce GraphQL runtime-data construction consumes the host-provided runtime.
 Its explicit in-process fallback remains for directly embedded compatibility
 schemas until the GraphQL facade cutover is complete.
 
-`CommerceHttpRuntime::from_host` now fails closed when
+`CommerceHttpRuntime::from_host` fails closed when
 `CommerceFulfillmentLifecycleReadRuntime` is absent and exposes the cloned
-`FulfillmentReadPort` for route handlers. No HTTP handler consumes it yet in this
-slice.
+`FulfillmentReadPort` for route handlers.
 
-## Consumer boundary
+## Admin REST cutover
 
-The current private Commerce GraphQL fulfillment facade still constructs one
-concrete `FulfillmentService` for:
+`GET /admin/fulfillments` now calls `list_fulfillment_projections` and preserves:
+
+- page and per-page values;
+- status, order, and customer filters;
+- the owner pagination total;
+- the existing `PaginatedResponse<FulfillmentResponse>` envelope.
+
+`GET /admin/fulfillments/{id}` now calls `read_fulfillment_projection` and keeps
+the existing detail envelope and not-found policy.
+
+Both handlers construct `PortContext` with tenant identity, authenticated user
+actor, request locale, optional request channel, a resource-scoped correlation
+id, and a two-second deadline. `PortErrorKind` maps to the existing public
+validation, not-found, conflict, permission, unavailable, and safe-failure HTTP
+policies without copying owner messages.
+
+Admin lifecycle create/ship/deliver/reopen/reship/cancel paths remain on their
+existing concrete or orchestration services. This read cutover does not change
+mutation ownership or behavior.
+
+## Remaining GraphQL boundary
+
+The private Commerce GraphQL fulfillment facade still constructs one concrete
+`FulfillmentService` for:
 
 - fulfillment lookup;
 - fulfillment list;
 - latest fulfillment by order.
 
-Admin REST also still constructs `FulfillmentService` for:
-
-- `GET /admin/fulfillments`;
-- `GET /admin/fulfillments/{id}`.
-
-Lifecycle mutations remain intentionally outside this read boundary.
-
-The next cutover slice must route the GraphQL and REST read consumers through the
-already host-composed `FulfillmentReadPort`, preserve each transport's
-optional-not-found and public error policy, add request-safe GraphQL scope, and
-remove only the private GraphQL concrete delegate. No mounted consumer is claimed
-in this slice.
+The next cutover slice must add request-safe GraphQL lifecycle runtime scope,
+route those three reads through the already host-composed `FulfillmentReadPort`,
+preserve optional-not-found and public error behavior, and remove only the
+private GraphQL concrete delegate. Lifecycle mutation services remain unchanged.
 
 ## Diagnostics
 
@@ -112,15 +126,19 @@ length, locale length, causation/trace presence, deadline, relevant fulfillment,
 order, customer, and status facts, stable owner code, error kind, and
 retryability. Only technical database events retain the typed internal cause.
 
+The admin REST boundary additionally records the public HTTP code/status and the
+stable owner code, retryability, actor, channel, locale, deadline, resource, and
+transport operation.
+
 ## Evidence
 
 Source evidence is retained at:
 
 `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`
 
-Its status is `source_composed_unvalidated`. It records completed default server
-cache/attachment and mandatory Commerce HTTP runtime injection while keeping
-GraphQL/admin REST consumer cutover and private concrete delegate removal false.
+Its status is `source_rest_cutover_unvalidated`. It records completed default
+server composition and admin REST list/detail cutover while keeping GraphQL
+facade cutover and private concrete delegate removal false.
 
 ## Intended checks
 

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -58,19 +58,24 @@ identity from `PortContext`, preserves existing filter and ordering semantics, a
 maps every current owner error to stable `PortError`.
 
 Commerce publishes a separate
-`CommerceFulfillmentLifecycleReadRuntime`. The default application host now
-reuses an externally installed runtime or constructs the in-process baseline once,
-caches it in `ServerRuntimeContext`, and attaches the same typed value to
-`HostRuntimeContext`. `CommerceHttpRuntime` requires that runtime and exposes the
-cloned owner port for route cutover. GraphQL runtime-data construction consumes
-the host value and retains an explicit in-process fallback only for directly
-embedded compatibility schemas.
+`CommerceFulfillmentLifecycleReadRuntime`. The default application host reuses an
+externally installed runtime or constructs the in-process baseline once, caches it
+in `ServerRuntimeContext`, and attaches the same typed value to
+`HostRuntimeContext`. `CommerceHttpRuntime` requires that runtime. Admin REST
+fulfillment list/detail consume its cloned owner port and no longer construct a
+concrete read service.
 
-Consumer cutover remains open. The private GraphQL compatibility facade still
-retains one concrete `FulfillmentService` for fulfillment lookup, list, and
-latest-by-order. Admin REST still constructs the service for fulfillment list and
-detail reads. Fulfillment lifecycle mutations remain on their existing
-concrete/orchestration owner paths and are outside this read boundary.
+The admin REST cutover preserves page/per-page, status/order/customer filters,
+owner pagination total, detail not-found behavior, public HTTP status/code/message
+policy, authenticated user actor, request locale/channel, resource correlation,
+and a two-second deadline. Lifecycle mutations remain on their existing concrete
+or orchestration owner paths.
+
+The private GraphQL compatibility facade still retains one concrete
+`FulfillmentService` for fulfillment lookup, list, and latest-by-order. GraphQL
+runtime-data construction consumes the host value and retains an explicit
+in-process fallback only for directly embedded compatibility schemas. Request-safe
+GraphQL lifecycle scope and consumer cutover remain open.
 
 The native FFA surface remains seller/cart selection through
 `ShippingSelectionPort`; it does not publish complete projection list or lookup
@@ -99,8 +104,9 @@ operations. No projection API should be added without a concrete consumer.
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`.
 - Both files are unvalidated source evidence and do not promote status.
 - Focused guards cover owner boundaries, application-host runtime composition,
-  Commerce HTTP injection, current mounted consumers, typed public envelopes, and
-  the separate native selection surface.
+  Commerce HTTP injection, admin REST lifecycle consumer cutover, typed public
+  envelopes, current GraphQL compatibility consumers, and the separate native
+  selection surface.
 - Compile, migrated database, mounted transport, restart, contention, and remote
   evidence remain missing.
 
@@ -165,14 +171,21 @@ operations. No projection API should be added without a concrete consumer.
   preserve externally installed adapters, and attach it to `HostRuntimeContext`.
 - [x] Require the typed lifecycle runtime in `CommerceHttpRuntime` and expose the
   cloned owner port for route handlers.
-- [x] Retain source evidence and a focused guard that record completed runtime
-  composition without claiming GraphQL/admin REST consumer cutover.
+- [x] Cut admin REST fulfillment list and detail reads over to the owner port while
+  preserving page/per-page, status/order/customer filters, owner total, and detail
+  not-found behavior.
+- [x] Preserve admin REST status/code/message policy through typed `PortErrorKind`
+  mapping without owner-message control flow.
+- [x] Propagate admin REST tenant, authenticated actor, locale, optional channel,
+  resource correlation, and two-second deadline context.
+- [x] Keep lifecycle mutation concrete/orchestration service construction
+  unchanged.
+- [x] Retain source evidence and a focused guard that record completed runtime and
+  admin REST cutover without claiming GraphQL consumer cutover.
 - [ ] Add resolver scope or equivalent request-safe injection for GraphQL.
 - [ ] Cut GraphQL fulfillment lookup, filtered list, and latest-by-order reads over
   to `FulfillmentReadPort` while preserving optional-not-found and public error
   behavior.
-- [ ] Cut admin REST fulfillment list and detail reads over to the same owner port
-  while preserving pagination and current HTTP status/code/message policy.
 - [ ] Remove the remaining concrete `FulfillmentService` field from the private
   GraphQL compatibility facade; lifecycle mutation services remain unchanged.
 - [ ] Execute compile, mounted GraphQL/REST lifecycle query, deadline, tenant,
@@ -220,16 +233,15 @@ operations. No projection API should be added without a concrete consumer.
    envelopes, and no mounted projection transport constructs a concrete read
    service or provider.
 
-6. **Cut mounted lifecycle reads over to the owner port.** Use the already
+6. **Complete mounted lifecycle GraphQL read cutover.** Use the already
    host-composed `CommerceFulfillmentLifecycleReadRuntime`, add request-safe
-   GraphQL injection, route GraphQL lookup/list/latest-by-order and admin REST
-   list/detail through `FulfillmentReadPort`, and remove the private GraphQL
-   concrete delegate.
-   **Depends on:** stable transport-specific optional-not-found/public error
-   contracts.
-   **Done when:** mounted GraphQL and REST lifecycle reads consume the host-selected
-   owner port, preserve their existing response policy, and no mounted lifecycle
-   read constructs `FulfillmentService` inside Commerce.
+   GraphQL injection, route GraphQL lookup/list/latest-by-order through
+   `FulfillmentReadPort`, and remove the private GraphQL concrete delegate. Admin
+   REST list/detail already consume the owner port.
+   **Depends on:** stable GraphQL optional-not-found and public error contracts.
+   **Done when:** mounted GraphQL lifecycle reads consume the host-selected owner
+   port, preserve existing response policy, and no mounted lifecycle read
+   constructs `FulfillmentService` inside the private Commerce query facade.
 
 7. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.

--- a/scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
@@ -33,6 +33,12 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
+const portMapper = between(
+  source,
+  'fn map_admin_fulfillment_port_error(',
+  '/// List admin fulfillments',
+  'admin fulfillment port mapper',
+);
 const ownerMapper = between(
   source,
   'fn map_admin_fulfillment_error(',
@@ -49,7 +55,9 @@ if (orchestrationStart < 0) {
 }
 
 for (const [value, label] of [
-  ['use rustok_fulfillment::{FulfillmentError, FulfillmentService};', 'typed fulfillment import'],
+  ['AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,', 'typed API imports'],
+  ['FulfillmentError, FulfillmentService, ListFulfillmentProjectionsRequest,', 'typed fulfillment imports'],
+  ['ReadFulfillmentProjectionRequest,', 'typed fulfillment detail request'],
   ['FulfillmentOrchestrationError, FulfillmentOrchestrationService,', 'typed orchestration import'],
   ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
   ['const ADMIN_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_routes";', 'owner constant'],
@@ -80,13 +88,19 @@ for (const [value, label] of [
   ['[Permission::FULFILLMENTS_READ]', 'read permission'],
   ['[Permission::FULFILLMENTS_CREATE]', 'create permission'],
   ['[Permission::FULFILLMENTS_UPDATE]', 'update permission'],
-  ['ListFulfillmentsInput {', 'list input contract'],
+  ['request_context: RequestContext', 'request context extraction'],
+  ['ListFulfillmentProjectionsRequest {', 'list port input contract'],
   ['page: pagination.page', 'page forwarding'],
   ['per_page: pagination.limit()', 'page-size forwarding'],
+  ['status: params.status', 'status forwarding'],
+  ['order_id: params.order_id', 'order forwarding'],
+  ['customer_id: params.customer_id', 'customer forwarding'],
+  ['.list_fulfillment_projections(', 'list owner-port contract'],
+  ['ReadFulfillmentProjectionRequest { fulfillment_id: id }', 'detail port input contract'],
+  ['.read_fulfillment_projection(', 'detail owner-port contract'],
   ['let order_id = input.order_id;', 'create order identity capture'],
   ['Some(order_id)', 'create order identity context'],
   ['.create_manual_fulfillment(tenant.id, input)', 'create service contract'],
-  ['.get_fulfillment(tenant.id, id)', 'show service contract'],
   ['.ship_fulfillment(tenant.id, id, input)', 'ship service contract'],
   ['.deliver_fulfillment(tenant.id, id, input)', 'deliver service contract'],
   ['.reopen_fulfillment(tenant.id, id, input)', 'reopen service contract'],
@@ -96,8 +110,10 @@ for (const [value, label] of [
 
 for (const [value, label] of [
   ['"list_fulfillments"', 'list operation'],
+  ['"list_fulfillment_projections"', 'list owner operation'],
   ['"create_manual_fulfillment"', 'create operation'],
   ['"get_fulfillment"', 'show operation'],
+  ['"read_fulfillment_projection"', 'show owner operation'],
   ['"ship_fulfillment"', 'ship operation'],
   ['"deliver_fulfillment"', 'deliver operation'],
   ['"reopen_fulfillment"', 'reopen operation'],
@@ -105,12 +121,19 @@ for (const [value, label] of [
   ['"cancel_fulfillment"', 'cancel operation'],
 ]) requireText(source, value, label);
 
+const portMapperUses =
+  source.match(
+    /map_admin_fulfillment_port_error\(\s+AdminFulfillmentErrorContext::new\(/g,
+  ) ?? [];
+if (portMapperUses.length !== 2) {
+  failures.push(`expected two context-aware port mapper callsites, found ${portMapperUses.length}`);
+}
 const ownerMapperUses =
   source.match(
     /map_admin_fulfillment_error\(\s+AdminFulfillmentErrorContext::new\(/g,
   ) ?? [];
-if (ownerMapperUses.length !== 4) {
-  failures.push(`expected four context-aware owner mapper callsites, found ${ownerMapperUses.length}`);
+if (ownerMapperUses.length !== 2) {
+  failures.push(`expected two context-aware mutation owner mapper callsites, found ${ownerMapperUses.length}`);
 }
 const orchestrationMapperUses =
   source.match(
@@ -121,6 +144,43 @@ if (orchestrationMapperUses.length !== 4) {
     `expected four context-aware orchestration mapper callsites, found ${orchestrationMapperUses.length}`,
   );
 }
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'port validation variant'],
+  ['PortErrorKind::NotFound', 'port not-found variant'],
+  ['PortErrorKind::Conflict', 'port conflict variant'],
+  ['PortErrorKind::Forbidden', 'port forbidden variant'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'port unavailable variant'],
+  ['PortErrorKind::InvariantViolation', 'port invariant variant'],
+  ['error = ?error', 'typed port cause'],
+  ['owner = ADMIN_FULFILLMENT_OWNER', 'port owner log'],
+  ['owner_operation,', 'owner operation log'],
+  ['correlation_id = %port_context.correlation_id', 'correlation log'],
+  ['tenant_id = %context.tenant_id', 'port tenant log'],
+  ['fulfillment_id = ?context.fulfillment_id', 'port fulfillment identity log'],
+  ['order_id = ?context.order_id', 'port order identity log'],
+  ['operation = %context.operation', 'port operation log'],
+  ['actor = ?port_context.actor', 'actor log'],
+  ['channel = ?port_context.channel', 'channel log'],
+  ['locale = %port_context.locale', 'locale log'],
+  ['deadline_ms = ?port_context.deadline_ms', 'deadline log'],
+  ['internal_code = %error.code', 'stable owner code log'],
+  ['retryable = error.retryable', 'retryability log'],
+  ['error_kind,', 'port error-kind log'],
+  ['public_code = code', 'port public code log'],
+  ['status = %status', 'port status log'],
+  ['boundary = ADMIN_FULFILLMENT_BOUNDARY', 'port boundary log'],
+  ['"Fulfillment request is invalid"', 'static validation envelope'],
+  ['"Commerce resource not found"', 'static not-found envelope'],
+  [
+    '"Fulfillment operation conflicts with the current state"',
+    'static conflict envelope',
+  ],
+  ['"Permission denied"', 'static permission envelope'],
+  ['"Fulfillment storage is temporarily unavailable"', 'static storage envelope'],
+  ['"Fulfillment operation could not be completed safely"', 'static safe-failure envelope'],
+  ['HttpError::new(status, code, message)', 'single port envelope constructor'],
+]) requireText(portMapper, value, label);
 
 for (const [value, label] of [
   ['FulfillmentError::Validation(_)', 'validation variant'],
@@ -189,6 +249,25 @@ for (const [ownerSource, value, label] of [
   [orchestrationErrors, 'PersistenceAfterProvider {', 'persistence-after-provider owner variant'],
 ]) requireText(ownerSource, value, label);
 
+const listBlock = between(
+  source,
+  'pub async fn list_fulfillments(',
+  '/// Create admin fulfillment',
+  'admin fulfillment list block',
+);
+const showBlock = between(
+  source,
+  'pub async fn show_fulfillment(',
+  '/// Ship admin fulfillment',
+  'admin fulfillment show block',
+);
+for (const [content, value, label] of [
+  [listBlock, 'FulfillmentService::new(', 'list concrete service'],
+  [listBlock, '.list_fulfillments(', 'list concrete operation'],
+  [showBlock, 'FulfillmentService::new(', 'show concrete service'],
+  [showBlock, '.get_fulfillment(', 'show concrete operation'],
+]) forbidText(content, value, label);
+
 for (const value of [
   '.map_err(super::map_fulfillment_error)',
   '.map_err(super::map_fulfillment_orchestration_error)',
@@ -204,5 +283,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin fulfillment routes retain typed causes and return static public envelopes',
+  '✔ Commerce admin fulfillment reads use typed owner-port errors while mutation routes retain typed causes and static public envelopes',
 );

--- a/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
@@ -180,11 +180,46 @@ const adminShow = between(
   'admin fulfillment show',
 );
 for (const [source, value, label] of [
-  [adminList, 'FulfillmentService::new(runtime.db_clone())', 'retained admin list service'],
-  [adminList, '.list_fulfillments(', 'retained admin list operation'],
-  [adminShow, 'FulfillmentService::new(runtime.db_clone())', 'retained admin show service'],
-  [adminShow, '.get_fulfillment(tenant.id, id)', 'retained admin show operation'],
+  [adminList, 'request_context: RequestContext', 'admin list request context'],
+  [adminList, '.fulfillment_read_port()', 'admin list runtime port'],
+  [adminList, '.list_fulfillment_projections(', 'admin list owner operation'],
+  [adminList, 'ListFulfillmentProjectionsRequest {', 'admin list typed request'],
+  [adminList, 'status: params.status', 'admin list status filter'],
+  [adminList, 'order_id: params.order_id', 'admin list order filter'],
+  [adminList, 'customer_id: params.customer_id', 'admin list customer filter'],
+  [adminList, 'data: page.items', 'admin list owner projection'],
+  [adminList, 'page.total', 'admin list owner total'],
+  [adminShow, 'request_context: RequestContext', 'admin show request context'],
+  [adminShow, '.fulfillment_read_port()', 'admin show runtime port'],
+  [adminShow, '.read_fulfillment_projection(', 'admin show owner operation'],
+  [adminShow, 'ReadFulfillmentProjectionRequest { fulfillment_id: id }', 'admin show typed request'],
 ]) requireText(source, value, label);
+
+for (const [source, value, label] of [
+  [adminList, 'FulfillmentService::new(', 'admin list concrete service'],
+  [adminList, '.list_fulfillments(', 'admin list concrete operation'],
+  [adminShow, 'FulfillmentService::new(', 'admin show concrete service'],
+  [adminShow, '.get_fulfillment(', 'admin show concrete operation'],
+]) forbidText(source, value, label);
+
+for (const [value, label] of [
+  ['fn admin_fulfillment_read_port_context(', 'admin read context builder'],
+  ['PortActor::user(auth.user_id.to_string())', 'admin user actor'],
+  ['request_context.locale.as_str()', 'admin locale propagation'],
+  ['request_context.channel_slug.as_deref()', 'admin channel propagation'],
+  ['commerce-admin-fulfillment:{operation}:{resource_id}', 'admin correlation id'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'admin read deadline'],
+  ['fn map_admin_fulfillment_port_error(', 'admin typed error mapper'],
+  ['PortErrorKind::Forbidden', 'admin forbidden mapping'],
+  ['PortErrorKind::Timeout', 'admin timeout mapping'],
+  ['PortErrorKind::InvariantViolation', 'admin invariant mapping'],
+  ['"commerce_admin_fulfillment_invalid"', 'admin validation public code'],
+  ['"commerce_admin_not_found"', 'admin not-found public code'],
+  ['"commerce_admin_fulfillment_state_conflict"', 'admin conflict public code'],
+  ['"commerce_admin_fulfillment_storage_unavailable"', 'admin unavailable public code'],
+  ['"commerce_admin_fulfillment_failed"', 'admin invariant public code'],
+  ['internal_code = %error.code', 'admin stable owner code logging'],
+]) requireText(adminRest, value, label);
 
 for (const value of [
   'error = %message',
@@ -192,9 +227,9 @@ for (const value of [
   'error.message',
 ]) forbidText(ownerSource, value, 'owner message exposure');
 
-if (evidence.status !== 'source_composed_unvalidated') {
+if (evidence.status !== 'source_rest_cutover_unvalidated') {
   failures.push(
-    `evidence status: expected source_composed_unvalidated, found ${evidence.status}`,
+    `evidence status: expected source_rest_cutover_unvalidated, found ${evidence.status}`,
   );
 }
 if (evidence.owner?.port !== 'FulfillmentReadPort') {
@@ -221,11 +256,26 @@ if (evidence.runtime_publication?.commerce_http_runtime_required !== true) {
 if (evidence.runtime_publication?.external_adapter_preserved !== true) {
   failures.push('evidence must record preservation of external adapters');
 }
+if (evidence.admin_rest?.pagination_total_preserved !== true) {
+  failures.push('evidence must record preserved admin pagination total');
+}
+if (evidence.admin_rest?.filters_preserved !== true) {
+  failures.push('evidence must record preserved admin list filters');
+}
+if (evidence.admin_rest?.public_error_policy_preserved !== true) {
+  failures.push('evidence must record preserved admin public error policy');
+}
+if (evidence.admin_rest?.concrete_service_read_construction !== false) {
+  failures.push('evidence must forbid concrete admin REST read construction');
+}
+if (evidence.admin_rest?.mutation_service_construction_unchanged !== true) {
+  failures.push('evidence must retain lifecycle mutation service construction');
+}
 if (evidence.consumer_cutover?.graphql_compatibility_facade !== false) {
   failures.push('evidence must retain GraphQL facade cutover as false');
 }
-if (evidence.consumer_cutover?.admin_rest_list_show !== false) {
-  failures.push('evidence must retain admin REST list/show cutover as false');
+if (evidence.consumer_cutover?.admin_rest_list_show !== true) {
+  failures.push('evidence must record admin REST list/show cutover');
 }
 if (evidence.consumer_cutover?.concrete_delegate_removed !== false) {
   failures.push('evidence must retain concrete delegate removal as false');
@@ -250,5 +300,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment lifecycle reads are owner-published, default-host composed, and injected into Commerce HTTP while GraphQL/admin consumer cutovers remain explicitly open',
+  '✔ fulfillment lifecycle reads are owner-published and host-composed; admin REST list/show consume the typed port while GraphQL cutover remains explicitly open',
 );


### PR DESCRIPTION
## Summary

- route `GET /admin/fulfillments` through the host-composed `FulfillmentReadPort::list_fulfillment_projections` operation;
- route `GET /admin/fulfillments/{id}` through `FulfillmentReadPort::read_fulfillment_projection`;
- preserve page/per-page, status/order/customer filters, owner pagination total, detail not-found behavior, and the existing JSON envelopes;
- construct admin read `PortContext` with tenant, authenticated user actor, request locale, optional channel, resource-scoped correlation, and a two-second deadline;
- map typed `PortErrorKind` values to the existing public validation, not-found, conflict, permission, unavailable, and safe-failure HTTP policies without owner-message control flow;
- keep create/ship/deliver/reopen/reship/cancel concrete and orchestration paths unchanged;
- update both fulfillment lifecycle guards, source evidence, boundary documentation, and the implementation roadmap.

## Boundary

This PR cuts over admin REST lifecycle reads only. It deliberately does **not**:

- add GraphQL lifecycle resolver scope;
- route GraphQL fulfillment lookup/list/latest-by-order through the port;
- remove the private GraphQL concrete `FulfillmentService` delegate;
- change lifecycle mutations or orchestration;
- promote FFA/FBA status;
- claim executed runtime parity.

Evidence status is `source_rest_cutover_unvalidated`. GraphQL cutover and concrete delegate removal remain false.

## Recheck

- confirmed PR #2359 host-composes and injects `CommerceFulfillmentLifecycleReadRuntime`;
- confirmed no open PR overlaps this lifecycle boundary;
- audited the existing shipping-option admin context and typed error mapping pattern;
- preserved every admin fulfillment list filter and the owner pagination total;
- found and updated the dependent admin fulfillment route error-context guard, which previously required concrete list/detail reads;
- retained two concrete mutation-owner mapper callsites and four orchestration mapper callsites;
- rebuilt the branch as one atomic commit over current `main` commit `8a5e251eec95d7fcda54e0ba5c7df4560ef70935`;
- confirmed one commit ahead, zero behind, with exactly seven intended files.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested maintainer checks:

```bash
node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
node scripts/verify/verify-commerce-admin-fulfillment-route-error-context.mjs
cargo check -p rustok-commerce --lib
cargo check -p rustok-server --features mod-commerce
```

## Next slice

Add request-safe GraphQL lifecycle runtime scope, cut lookup/list/latest-by-order over to `FulfillmentReadPort`, preserve optional-not-found and public error policy, and remove the private concrete read delegate.