### PR TITLE
feat(index): verify retained archive manifests

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -67,16 +67,31 @@ The report command writes no files, opens no PostgreSQL connection, and starts n
 
 ## Machine-readable admitted archive manifest
 
-After the report is reviewed and the retained outcome is `admitted`, print a deterministic machine-readable archive manifest:
+After the report is reviewed and the retained outcome is `admitted`, print a deterministic machine-readable archive manifest. Save the derived manifest outside the immutable bundle:
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-archive-manifest \
-  --root evidence/index-partition/retained-run
+  --root evidence/index-partition/retained-run \
+  > evidence/index-partition/retained-run.archive-manifest.json
 ```
 
 `partition-archive-manifest` runs the same retained-bundle inspection as `partition-report`, refuses any outcome other than `admitted`, and prints JSON containing the evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, byte counts, and total retained bytes. Its `manifest_digest` is the SHA-256 digest of canonical JSON for the manifest payload before the `manifest_digest` field is added, under `canonical_json_without_manifest_digest_v1`.
 
 The archive-manifest command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save this derived index outside the immutable bundle. The manifest does not replace or modify the nine authoritative retained files, does not change admission, and does not authorize production lifecycle work.
+
+## Verify a saved archive manifest
+
+Before moving or accepting an archived packet, verify the saved manifest against the current immutable bundle:
+
+```bash
+node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
+  --root evidence/index-partition/retained-run \
+  --manifest evidence/index-partition/retained-run.archive-manifest.json
+```
+
+`partition-archive-verify` requires the saved manifest to be a non-empty regular non-symlink file outside the immutable bundle. It rejects lexical or canonical paths inside the bundle and rejects a hard-link alias to any of the nine retained files. It verifies the saved `manifest_digest`, reruns the full retained-bundle inspection, rebuilds the admitted archive manifest, and canonical-compares the complete saved manifest to the recalculated result.
+
+A successful verification prints a deterministic `index_partition_retained_archive_verification_v1` receipt with the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. The verifier writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
 
 A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
 

--- a/scripts/verify/index-partition-archive-manifest-core.mjs
+++ b/scripts/verify/index-partition-archive-manifest-core.mjs
@@ -1,3 +1,6 @@
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
 import {
   canonicalJson,
   sha256Hex,
@@ -6,8 +9,10 @@ import { REVIEW_CONTRACT } from './index-partition-review-core.mjs';
 
 export const ARCHIVE_MANIFEST_CONTRACT = 'index_partition_retained_archive_manifest_v1';
 export const ARCHIVE_MANIFEST_DIGEST_CONTRACT = 'canonical_json_without_manifest_digest_v1';
+export const ARCHIVE_VERIFICATION_CONTRACT = 'index_partition_retained_archive_verification_v1';
 
 const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
 
 const requireObject = (value, label) => {
   if (!isObject(value)) throw new Error(`${label} must be an object`);
@@ -28,6 +33,29 @@ const requireInteger = (value, label) => {
   return value;
 };
 
+const requireDigest = (value, label) => {
+  const digest = requireNonEmptyString(value, label);
+  if (!/^[0-9a-f]{64}$/u.test(digest)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`);
+  }
+  return digest;
+};
+
+const parseJsonBytes = (bytes, label) => {
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${label} must contain valid UTF-8 JSON: ${error.message}`);
+  }
+};
+
+const ensureOutsideRoot = (root, filename, label) => {
+  const relative = path.relative(root, filename);
+  const inside = relative === ''
+    || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+  if (inside) throw new Error(`${label} must stay outside the retained bundle root`);
+};
+
 const normalizeFiles = (files) => {
   if (!Array.isArray(files) || files.length !== 9) {
     throw new Error('inspection.files must contain exactly nine retained files');
@@ -39,10 +67,7 @@ const normalizeFiles = (files) => {
     const role = requireNonEmptyString(file.role, `inspection.files[${index}].role`);
     const retainedPath = requireNonEmptyString(file.path, `inspection.files[${index}].path`);
     const bytes = requireInteger(file.bytes, `inspection.files[${index}].bytes`);
-    const sha256 = requireNonEmptyString(file.sha256, `inspection.files[${index}].sha256`);
-    if (!/^[0-9a-f]{64}$/u.test(sha256)) {
-      throw new Error(`inspection.files[${index}].sha256 must be a lowercase SHA-256 digest`);
-    }
+    const sha256 = requireDigest(file.sha256, `inspection.files[${index}].sha256`);
     if (roles.has(role)) throw new Error(`inspection.files contains duplicate role ${role}`);
     if (paths.has(retainedPath)) throw new Error(`inspection.files contains duplicate path ${retainedPath}`);
     roles.add(role);
@@ -81,5 +106,64 @@ export const buildRetainedPartitionArchiveManifest = (inspection) => {
   return {
     ...payload,
     manifest_digest: sha256Hex(Buffer.from(canonicalJson(payload), 'utf8')),
+  };
+};
+
+export const verifySavedRetainedPartitionArchiveManifest = ({
+  inspection,
+  root,
+  manifestPath,
+}) => {
+  const expected = buildRetainedPartitionArchiveManifest(inspection);
+  const resolvedRoot = path.resolve(requireNonEmptyString(root, 'root'));
+  const resolvedManifestPath = path.resolve(requireNonEmptyString(manifestPath, 'manifestPath'));
+  ensureOutsideRoot(resolvedRoot, resolvedManifestPath, 'saved archive manifest');
+
+  const manifestStat = lstatSync(resolvedManifestPath);
+  if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
+    throw new Error('saved archive manifest must be a regular non-symlink file');
+  }
+  const manifestBytes = readFileSync(resolvedManifestPath);
+  if (manifestBytes.length === 0) throw new Error('saved archive manifest must not be empty');
+
+  const canonicalRoot = realpathSync.native(resolvedRoot);
+  const canonicalManifestPath = realpathSync.native(resolvedManifestPath);
+  ensureOutsideRoot(canonicalRoot, canonicalManifestPath, 'saved archive manifest');
+
+  const manifestIdentity = identityOf(manifestStat);
+  for (const file of inspection.files) {
+    const retainedStat = lstatSync(path.resolve(resolvedRoot, file.path));
+    if (identityOf(retainedStat) === manifestIdentity) {
+      throw new Error('saved archive manifest aliases a retained bundle file');
+    }
+  }
+
+  const saved = requireObject(
+    parseJsonBytes(manifestBytes, 'saved archive manifest'),
+    'saved archive manifest',
+  );
+  const savedDigest = requireDigest(saved.manifest_digest, 'saved archive manifest.manifest_digest');
+  const { manifest_digest: ignoredManifestDigest, ...savedPayload } = saved;
+  void ignoredManifestDigest;
+  const calculatedDigest = sha256Hex(Buffer.from(canonicalJson(savedPayload), 'utf8'));
+  if (savedDigest !== calculatedDigest) {
+    throw new Error('saved archive manifest digest does not match canonical payload');
+  }
+  if (canonicalJson(saved) !== canonicalJson(expected)) {
+    throw new Error('saved archive manifest does not match recalculated retained bundle manifest');
+  }
+
+  return {
+    contract: ARCHIVE_VERIFICATION_CONTRACT,
+    verified: true,
+    source_manifest_contract: ARCHIVE_MANIFEST_CONTRACT,
+    source_digest_contract: ARCHIVE_MANIFEST_DIGEST_CONTRACT,
+    evidence_id: expected.evidence_id,
+    packet_digest: expected.packet_digest,
+    manifest_digest: expected.manifest_digest,
+    saved_manifest_sha256: sha256Hex(manifestBytes),
+    file_count: expected.file_count,
+    total_bytes: expected.total_bytes,
+    production_lifecycle_authorized: false,
   };
 };

--- a/scripts/verify/index-partition-review.test.mjs
+++ b/scripts/verify/index-partition-review.test.mjs
@@ -15,6 +15,7 @@ import {
 
 const reportScript = path.resolve('scripts/verify/render-index-partition-review.mjs');
 const archiveManifestScript = path.resolve('scripts/verify/render-index-partition-archive-manifest.mjs');
+const archiveVerifyScript = path.resolve('scripts/verify/verify-index-partition-archive-manifest.mjs');
 const digest = (character) => character.repeat(64);
 
 const writeJson = (filename, value) => writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
@@ -134,10 +135,33 @@ const runScript = (script, root) => spawnSync(
 
 const runReport = (root) => runScript(reportScript, root);
 const runArchiveManifest = (root) => runScript(archiveManifestScript, root);
+const runArchiveVerify = (root, manifestPath) => spawnSync(
+  process.execPath,
+  [archiveVerifyScript, '--root', root, '--manifest', manifestPath],
+  { encoding: 'utf8' },
+);
+
+const externalManifestPath = (root) => path.join(
+  path.dirname(root),
+  `${path.basename(root)}-archive-manifest.json`,
+);
+
+const saveArchiveManifest = (root) => {
+  const result = runArchiveManifest(root);
+  assert.equal(result.status, 0, result.stderr);
+  const filename = externalManifestPath(root);
+  writeFileSync(filename, result.stdout);
+  return filename;
+};
 
 const snapshot = (root) => Object.fromEntries(
   readdirSync(root).sort().map((filename) => [filename, readFileSync(path.join(root, filename))]),
 );
+
+const cleanup = (root, manifestPath) => {
+  if (manifestPath) rmSync(manifestPath, { force: true });
+  rmSync(root, { recursive: true, force: true });
+};
 
 test('renders a deterministic read-only nine-file retained bundle review', () => {
   const context = buildBundle();
@@ -156,7 +180,7 @@ test('renders a deterministic read-only nine-file retained bundle review', () =>
     assert.match(first.stdout, /Production partition copy\/replay/u);
     assert.deepEqual(snapshot(context.root), before);
   } finally {
-    rmSync(context.root, { recursive: true, force: true });
+    cleanup(context.root);
   }
 });
 
@@ -188,7 +212,91 @@ test('prints a deterministic read-only admitted archive manifest', () => {
     );
     assert.deepEqual(snapshot(context.root), before);
   } finally {
-    rmSync(context.root, { recursive: true, force: true });
+    cleanup(context.root);
+  }
+});
+
+test('verifies a saved admitted archive manifest without changing either input', () => {
+  const context = buildBundle();
+  let manifestPath;
+  try {
+    manifestPath = saveArchiveManifest(context.root);
+    const beforeBundle = snapshot(context.root);
+    const beforeManifest = readFileSync(manifestPath);
+    const first = runArchiveVerify(context.root, manifestPath);
+    const second = runArchiveVerify(context.root, manifestPath);
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(first.stderr, '');
+    assert.equal(first.stdout, second.stdout);
+    const receipt = JSON.parse(first.stdout);
+    assert.equal(receipt.contract, 'index_partition_retained_archive_verification_v1');
+    assert.equal(receipt.verified, true);
+    assert.equal(receipt.source_manifest_contract, 'index_partition_retained_archive_manifest_v1');
+    assert.equal(receipt.source_digest_contract, 'canonical_json_without_manifest_digest_v1');
+    assert.equal(receipt.file_count, 9);
+    assert.equal(receipt.production_lifecycle_authorized, false);
+    assert.equal(
+      receipt.saved_manifest_sha256,
+      createHash('sha256').update(beforeManifest).digest('hex'),
+    );
+    assert.deepEqual(snapshot(context.root), beforeBundle);
+    assert.deepEqual(readFileSync(manifestPath), beforeManifest);
+  } finally {
+    cleanup(context.root, manifestPath);
+  }
+});
+
+test('rejects saved archive manifest digest drift', () => {
+  const context = buildBundle();
+  let manifestPath;
+  try {
+    manifestPath = saveArchiveManifest(context.root);
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.manifest_digest = '0'.repeat(64);
+    writeJson(manifestPath, manifest);
+    const result = runArchiveVerify(context.root, manifestPath);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /digest does not match canonical payload/u);
+    assert.equal(result.stdout, '');
+  } finally {
+    cleanup(context.root, manifestPath);
+  }
+});
+
+test('rejects saved archive manifest semantic drift with a recalculated digest', () => {
+  const context = buildBundle();
+  let manifestPath;
+  try {
+    manifestPath = saveArchiveManifest(context.root);
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.total_bytes += 1;
+    const { manifest_digest: ignoredDigest, ...payload } = manifest;
+    void ignoredDigest;
+    manifest.manifest_digest = createHash('sha256').update(canonicalJson(payload)).digest('hex');
+    writeJson(manifestPath, manifest);
+    const result = runArchiveVerify(context.root, manifestPath);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /does not match recalculated retained bundle manifest/u);
+    assert.equal(result.stdout, '');
+  } finally {
+    cleanup(context.root, manifestPath);
+  }
+});
+
+test('requires the saved archive manifest to stay outside the retained bundle', () => {
+  const context = buildBundle();
+  try {
+    const result = runArchiveManifest(context.root);
+    assert.equal(result.status, 0, result.stderr);
+    const manifestPath = path.join(context.root, 'archive-manifest.json');
+    writeFileSync(manifestPath, result.stdout);
+    const verification = runArchiveVerify(context.root, manifestPath);
+    assert.notEqual(verification.status, 0);
+    assert.match(verification.stderr, /must stay outside the retained bundle root/u);
+    assert.equal(verification.stdout, '');
+  } finally {
+    cleanup(context.root);
   }
 });
 
@@ -206,7 +314,7 @@ test('refuses an archive manifest for a non-admitted retained bundle', () => {
     assert.match(result.stderr, /requires admission outcome admitted/u);
     assert.equal(result.stdout, '');
   } finally {
-    rmSync(context.root, { recursive: true, force: true });
+    cleanup(context.root);
   }
 });
 
@@ -222,7 +330,7 @@ test('rejects a saved admission that does not match recalculated packet admissio
     assert.match(result.stderr, /admission file does not match recalculated retained bundle content/u);
     assert.equal(result.stdout, '');
   } finally {
-    rmSync(context.root, { recursive: true, force: true });
+    cleanup(context.root);
   }
 });
 
@@ -238,6 +346,6 @@ test('rejects raw artifact drift from the retained packet', () => {
     assert.match(result.stderr, /packet file does not match recalculated retained bundle content/u);
     assert.equal(result.stdout, '');
   } finally {
-    rmSync(context.root, { recursive: true, force: true });
+    cleanup(context.root);
   }
 });

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -24,6 +24,7 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs partition-report --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs partition-archive-manifest --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
+  node scripts/verify/index-storage-tooling.mjs partition-archive-verify --root <bundle-directory> --manifest <archive-manifest.json> [--packet <packet.json>] [--admission <admission.json>]
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
   node scripts/verify/index-storage-tooling.mjs render --comparison <comparison.json> --decision <decision.json> --output <adr.md>
@@ -40,6 +41,7 @@ Commands:
   partition-validate          Validate a measured partition packet and publish calculated admission output.
   partition-report            Recalculate and render a read-only review of all nine retained bundle files.
   partition-archive-manifest  Print a deterministic JSON archive manifest for one admitted retained bundle.
+  partition-archive-verify    Verify a saved archive manifest against the current admitted retained bundle.
   hash                        Print the SHA-256 digest of the exact comparison.json bytes.
   prepare                     Create a non-overwriting manual decision draft bound to exact comparison bytes.
   render                      Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
@@ -221,6 +223,9 @@ switch (command) {
     break;
   case 'partition-archive-manifest':
     runScript('render-index-partition-archive-manifest.mjs', args);
+    break;
+  case 'partition-archive-verify':
+    runScript('verify-index-partition-archive-manifest.mjs', args);
     break;
   case 'hash':
     runScript('hash-index-storage-comparison.mjs', args);

--- a/scripts/verify/verify-index-partition-archive-manifest.mjs
+++ b/scripts/verify/verify-index-partition-archive-manifest.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+
+import { inspectRetainedPartitionBundle } from './index-partition-review-core.mjs';
+import { verifySavedRetainedPartitionArchiveManifest } from './index-partition-archive-manifest-core.mjs';
+
+const prefix = '[verify-index-partition-archive-manifest]';
+
+const usage = () => {
+  console.log(`Usage:
+  node scripts/verify/verify-index-partition-archive-manifest.mjs \
+    --root <retained-bundle-directory> \
+    --manifest <saved-archive-manifest.json> \
+    [--packet <partition-packet.json>] \
+    [--admission <admission.json>]
+
+The saved manifest must be a regular non-symlink file outside the retained bundle. The command writes no files.`);
+};
+
+const parseArgs = (args) => {
+  if (args.length === 1 && ['--help', '-h'].includes(args[0])) return null;
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!['--root', '--manifest', '--packet', '--admission'].includes(flag)
+        || !value || value.startsWith('--')) {
+      throw new Error('expected --root/--manifest and optional --packet/--admission pairs');
+    }
+    if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
+    values.set(flag, value);
+  }
+  if (!values.has('--root')) throw new Error('--root is required');
+  if (!values.has('--manifest')) throw new Error('--manifest is required');
+  return {
+    root: path.resolve(values.get('--root')),
+    manifestPath: path.resolve(values.get('--manifest')),
+    packetPath: values.has('--packet') ? path.resolve(values.get('--packet')) : undefined,
+    admissionPath: values.has('--admission') ? path.resolve(values.get('--admission')) : undefined,
+  };
+};
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options === null) {
+    usage();
+  } else {
+    const inspection = inspectRetainedPartitionBundle(options);
+    const receipt = verifySavedRetainedPartitionArchiveManifest({
+      inspection,
+      root: options.root,
+      manifestPath: options.manifestPath,
+    });
+    process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+  }
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -30,6 +30,7 @@ try {
   const reviewCli = read('scripts/verify/render-index-partition-review.mjs');
   const archiveCore = read('scripts/verify/index-partition-archive-manifest-core.mjs');
   const archiveCli = read('scripts/verify/render-index-partition-archive-manifest.mjs');
+  const archiveVerifyCli = read('scripts/verify/verify-index-partition-archive-manifest.mjs');
   const reviewTest = read('scripts/verify/index-partition-review.test.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
@@ -136,11 +137,17 @@ try {
   requireMarkers(archiveCore, [
     'index_partition_retained_archive_manifest_v1',
     'canonical_json_without_manifest_digest_v1',
+    'index_partition_retained_archive_verification_v1',
     'REVIEW_CONTRACT',
     "admission.outcome !== 'admitted'",
     'must contain exactly nine retained files',
     'total_bytes: totalBytes',
     "sha256Hex(Buffer.from(canonicalJson(payload), 'utf8'))",
+    'must stay outside the retained bundle root',
+    'saved archive manifest aliases a retained bundle file',
+    'saved archive manifest digest does not match canonical payload',
+    'saved archive manifest does not match recalculated retained bundle manifest',
+    'production_lifecycle_authorized: false',
   ], 'retained partition archive manifest core');
   requireMarkers(archiveCli, [
     "'--root'",
@@ -152,7 +159,19 @@ try {
     'process.stdout.write',
     'It writes no files.',
   ], 'retained partition archive manifest CLI');
-  forbidMarkers(`${reviewCore}\n${reviewCli}\n${archiveCore}\n${archiveCli}`, [
+  requireMarkers(archiveVerifyCli, [
+    "'--root'",
+    "'--manifest'",
+    "'--packet'",
+    "'--admission'",
+    'inspectRetainedPartitionBundle',
+    'verifySavedRetainedPartitionArchiveManifest',
+    'JSON.stringify(receipt, null, 2)',
+    'process.stdout.write',
+    'outside the retained bundle',
+    'The command writes no files.',
+  ], 'retained partition archive verifier CLI');
+  forbidMarkers(`${reviewCore}\n${reviewCli}\n${archiveCore}\n${archiveCli}\n${archiveVerifyCli}`, [
     'writeFileSync',
     'mkdirSync',
     'renameSync',
@@ -168,6 +187,12 @@ try {
     'index_partition_retained_archive_manifest_v1',
     'canonical_json_without_manifest_digest_v1',
     "createHash('sha256').update(canonicalJson(payload)).digest('hex')",
+    'verifies a saved admitted archive manifest without changing either input',
+    'index_partition_retained_archive_verification_v1',
+    'production_lifecycle_authorized',
+    'rejects saved archive manifest digest drift',
+    'rejects saved archive manifest semantic drift with a recalculated digest',
+    'requires the saved archive manifest to stay outside the retained bundle',
     'refuses an archive manifest for a non-admitted retained bundle',
     'assert.deepEqual(snapshot(context.root), before)',
     'saved admission that does not match recalculated packet admission',
@@ -181,6 +206,8 @@ try {
     'render-index-partition-review.mjs',
     'partition-archive-manifest',
     'render-index-partition-archive-manifest.mjs',
+    'partition-archive-verify',
+    'verify-index-partition-archive-manifest.mjs',
     'index-partition-review.test.mjs',
     'verify-index-partition-full-capture.mjs',
   ], 'index storage tooling router');
@@ -201,6 +228,10 @@ try {
     'partition-archive-manifest',
     'refuses any outcome other than `admitted`',
     'canonical_json_without_manifest_digest_v1',
+    'partition-archive-verify',
+    'outside the immutable bundle',
+    'index_partition_retained_archive_verification_v1',
+    'production_lifecycle_authorized',
     'writes no files',
     'forbidden before one retained admitted packet',
   ], 'full partition capture runbook');


### PR DESCRIPTION
## Summary

- add `partition-archive-verify`, a read-only owner command for a saved admitted archive manifest;
- require the saved manifest to be a non-empty regular non-symlink file outside the immutable retained bundle;
- reject lexical/canonical paths inside the bundle and hard-link aliases to any of the nine retained files;
- verify the saved manifest's `manifest_digest` against its canonical payload;
- rerun retained-bundle packet assembly and admission validation, rebuild the expected admitted archive manifest, and canonical-compare the complete saved manifest;
- print a deterministic `index_partition_retained_archive_verification_v1` receipt with evidence identity, packet/manifest digests, exact-byte saved-manifest SHA-256, retained byte totals, and `production_lifecycle_authorized: false`;
- register the command, extend fixture coverage, strengthen static no-write guards, and document the owner verification flow.

## Safety boundary

The verifier reads only the existing nine-file retained bundle and one derived saved manifest outside it. It writes no files, opens no PostgreSQL connection, starts no Cargo or evidence stage, does not change admission, and does not authorize or implement partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter work.

## Validation

Per repository-owner instruction, tests, fixture suites, contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run.

Only JavaScript syntax and local static marker inspection were performed:

```bash
node --check scripts/verify/index-partition-archive-manifest-core.mjs
node --check scripts/verify/verify-index-partition-archive-manifest.mjs
node --check scripts/verify/index-partition-review.test.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
```

Suggested owner checks:

```bash
node scripts/verify/verify-index-partition-full-capture.mjs
node --test scripts/verify/index-partition-review.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

## Owner usage

```bash
node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
  --root evidence/index-partition/retained-run \
  --manifest evidence/index-partition/retained-run.archive-manifest.json
```