### PR TITLE
test(profiles): define physical Iggy DLQ header evidence

### DIFF
--- a/crates/rustok-iggy/Cargo.toml
+++ b/crates/rustok-iggy/Cargo.toml
@@ -26,5 +26,6 @@ default = ["iggy"]
 iggy = ["dep:iggy", "rustok-iggy-connector/iggy"]
 
 [dev-dependencies]
+futures-util.workspace = true
 tokio.workspace = true
 serde_yaml.workspace = true

--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-header-source.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-header-source.json
@@ -36,6 +36,7 @@
     "assert_received_partition_equals_expected_one_based_partition",
     "assert_physical_payload_is_exact",
     "commit_probe_header_offset_only",
+    "drop_probe_consumer_and_shutdown_probe_client",
     "shutdown_production_transport"
   ],
   "production_paths": [
@@ -55,7 +56,8 @@
       "read_header_id",
       "read_partition_id",
       "read_payload",
-      "store_probe_offset"
+      "store_probe_offset",
+      "shutdown"
     ],
     "forbidden_operations": [
       "publish",

--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-header-source.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-header-source.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "contract-poison-external-iggy-header-source",
+  "status": "source_complete_runtime_pending",
+  "scope": "external_real_iggy_physical_dlq_header_and_partition",
+  "test_target": "contract_poison_external_iggy_header",
+  "test_case": "deterministic_dlq_uuid_is_physical_iggy_header_and_selects_one_based_partition",
+  "source_path": "crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs",
+  "verifier": "scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs",
+  "required_environment": [
+    "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS"
+  ],
+  "optional_environment": [
+    "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+    "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD"
+  ],
+  "topology": {
+    "mode": "external",
+    "protocol": "tcp",
+    "unique_stream_per_run": true,
+    "domain_partitions": 3,
+    "replication_factor": 1,
+    "observed_topic": "dlq",
+    "broker_requirement": "disposable_or_operator_cleaned_external_iggy"
+  },
+  "required_sequence": [
+    "start_production_transport_and_topology",
+    "open_sdk_dlq_probe_group_before_publication",
+    "construct_nonempty_synthetic_decode_failure_with_production_type",
+    "derive_dlq_entry_and_expected_connector_uuid",
+    "derive_expected_one_based_partition_from_uuid_modulo_partition_count",
+    "publish_once_through_iggy_transport_move_to_dlq",
+    "receive_one_physical_dlq_message_through_sdk_probe",
+    "assert_physical_header_id_equals_uuid_as_u128",
+    "assert_received_partition_equals_expected_one_based_partition",
+    "assert_physical_payload_is_exact",
+    "commit_probe_header_offset_only",
+    "shutdown_production_transport"
+  ],
+  "production_paths": [
+    "ConsumedContractDecodeFailure::new",
+    "ConsumedContractDecodeFailure::to_dlq_entry",
+    "DlqEntry::broker_message_id",
+    "IggyTransport::new",
+    "IggyTransport::move_to_dlq",
+    "IggyTransport::shutdown"
+  ],
+  "sdk_probe_boundary": {
+    "purpose": "observe_physical_dlq_message_only",
+    "allowed_operations": [
+      "connect",
+      "open_dlq_consumer_group",
+      "receive_one_message",
+      "read_header_id",
+      "read_partition_id",
+      "read_payload",
+      "store_probe_offset"
+    ],
+    "forbidden_operations": [
+      "publish",
+      "create_source_fixture",
+      "mutate_production_receipt",
+      "acknowledge_source_cursor",
+      "delete_stream",
+      "change_broker_deduplication"
+    ]
+  },
+  "publication_count": 1,
+  "forbidden_claims": [
+    "source_cursor_lifecycle_proved_by_this_test",
+    "database_receipt_ordering_proved",
+    "broker_deduplication_runtime_proved",
+    "duplicate_suppression_window_proved",
+    "physical_exactly_once_proved",
+    "bundled_mode_proved",
+    "tls_or_auth_failure_proved",
+    "multi_replica_proved"
+  ],
+  "execution_status": "not_run"
+}

--- a/crates/rustok-iggy/docs/contract-poison-external-header-evidence.md
+++ b/crates/rustok-iggy/docs/contract-poison-external-header-evidence.md
@@ -1,0 +1,101 @@
+# External Iggy physical DLQ header evidence
+
+## Purpose
+
+`contract_poison_external_iggy_header.rs` is an opt-in source harness for one narrow runtime claim: a deterministic connector delivery UUID attached to a raw contract poison `DlqEntry` is physically written as the Iggy message header ID, and the same UUID selects the expected one-based DLQ partition.
+
+This is intentionally separate from `contract_poison_external_iggy.rs`:
+
+- the lifecycle harness proves production source receive, no-ack transport reconnect/redelivery, exact-byte DLQ, and explicit source cursor advancement;
+- the header harness proves one physical DLQ message's header ID, partition, and payload;
+- future deduplication scenarios must remain separate because a repeated publication can be accepted, suppressed, expired, or evicted depending on broker configuration.
+
+## Production and probe boundaries
+
+The production path is:
+
+1. construct `ConsumedContractDecodeFailure` with the production validated type;
+2. call `to_dlq_entry(1)`;
+3. read the explicit `broker_message_id` from that entry;
+4. publish exactly once through `IggyTransport::move_to_dlq`;
+5. shut down through `IggyTransport::shutdown`.
+
+The direct Iggy SDK is a probe only. It may:
+
+- connect to the reviewed external endpoint;
+- open one unique consumer group on the unique stream's `dlq` topic before publication;
+- receive one message;
+- read `message.header.id`, `partition_id`, and payload;
+- commit that probe message's physical header offset.
+
+The SDK probe must not publish, create a source fixture, acknowledge a production source cursor, modify connector receipts, delete a stream, or change broker deduplication.
+
+## Broker selection
+
+Set:
+
+```text
+RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=host:8090
+```
+
+Optional credentials must be supplied together:
+
+```text
+RUSTOK_IGGY_EXTERNAL_TEST_USERNAME=...
+RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD=...
+```
+
+There is no localhost or default-credential fallback. The address is `host:port` without scheme, embedded credentials, or query parameters. This slice is TCP/non-TLS only.
+
+Every run creates a unique three-partition stream and a unique DLQ probe group. Use a disposable external Iggy server or an operator-approved cleanup process; the harness does not call an unreviewed stream deletion API.
+
+## Assertions
+
+The harness creates one non-empty synthetic decode failure with stable source metadata and derives its production DLQ entry.
+
+For `N = 3`, the expected partition is:
+
+```text
+(uuid_as_u128 mod N) + 1
+```
+
+The source test requires this value to be in `1..=N`, then publishes one entry. The physical SDK message must satisfy all of the following:
+
+- `message.header.id == delivery_uuid.as_u128()`;
+- `partition_id == expected_partition`;
+- physical payload bytes equal the exact DLQ payload;
+- the probe commits `message.header.offset` for that same partition.
+
+The SDK polling cursor's `current_offset` is not treated as the physical delivery offset and is not compared to the message header offset.
+
+## Non-claims
+
+Even after successful execution, this harness does not prove:
+
+- source consumer receive, redelivery, or acknowledgement lifecycle;
+- PostgreSQL receipt ordering or durable `published` state;
+- duplicate suppression with deduplication disabled or enabled;
+- deduplication capacity or expiry windows;
+- physical exactly-once publication;
+- bundled mode;
+- TLS/authentication/failover behavior;
+- multi-replica behavior;
+- Profiles privacy or authorization.
+
+## Maintainer commands
+
+```bash
+RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='iggy.example:8090' \
+RUSTOK_IGGY_EXTERNAL_TEST_USERNAME='...' \
+RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD='...' \
+  cargo test -p rustok-iggy --features iggy \
+  --test contract_poison_external_iggy_header -- --nocapture --test-threads=1
+
+node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs
+```
+
+Username/password may both be omitted for a disposable anonymous broker. Never provide only one.
+
+## Evidence status
+
+The test, versioned source contract, probe boundary, and static verifier are source-complete. `execution_status` remains `not_run`. No Cargo command, source verifier, external Iggy scenario, or broker configuration change was executed while authoring this slice.

--- a/crates/rustok-iggy/docs/implementation-plan.md
+++ b/crates/rustok-iggy/docs/implementation-plan.md
@@ -63,28 +63,43 @@ consumer-group checkpoint for that partition. Aggregate lag is published only wh
 every partition is empty or has a coherent stored offset not ahead of the observed
 high-watermark. Missing checkpoints and inconsistent observations fail closed.
 
-An opt-in external-Iggy source harness now uses one unique stream and one partition to
-exercise the production raw-poison cursor path. It injects two malformed fixtures,
-receives the first through `PersistentContractConsumerGroup`, publishes exact bytes
-through `IggyTransport::move_to_dlq`, drops the source cursor without acknowledgement,
-requires same-offset/bytes/UUID redelivery after reopening the group, acknowledges it
-explicitly, and then requires the second offset to become visible. An independent real
-DLQ cursor verifies both payloads byte-for-byte. The harness is source-complete and has
-not been executed.
+The External raw-poison lifecycle harness uses one unique stream and one partition to
+exercise the production cursor path. It injects two malformed fixtures, receives the
+first through `PersistentContractConsumerGroup`, publishes exact bytes through
+`IggyTransport::move_to_dlq`, shuts down the transport without source acknowledgement,
+requires same-offset/bytes/UUID redelivery through a new transport and the same group,
+acknowledges it explicitly, and then requires the second offset to become visible. An
+independent real DLQ cursor verifies both payloads byte-for-byte. The harness is
+source-complete and has not been executed.
 
-The harness intentionally does not inspect the physical Iggy header, compose the
-PostgreSQL receipt store, exercise deduplication, or claim bundled/TLS/auth/multi-replica
-proof. Those remain separate retained evidence boundaries.
+A separate physical-header harness now covers the publisher wire contract without
+repeating the lifecycle scenario. It creates a production `ConsumedContractDecodeFailure`,
+derives one `DlqEntry`, publishes exactly once through `IggyTransport::move_to_dlq`, and
+uses a probe-only SDK consumer on `dlq` to require:
+
+- physical `message.header.id == broker_message_id.as_u128()`;
+- physical partition equals `(uuid_as_u128 mod partitions) + 1` and remains in the
+  one-based range;
+- physical payload is exact;
+- only the probe message's physical header offset is committed.
+
+The SDK probe cannot publish, create source fixtures, acknowledge source cursors,
+modify receipts, delete streams, or change deduplication. The physical-header harness
+is source-complete and runtime-pending.
+
+Neither external harness composes PostgreSQL receipt ordering, exercises broker
+suppression, or claims bundled/TLS/auth/multi-replica proof. Source cursor lifecycle,
+physical header observation, database ordering, and deduplication remain distinct
+evidence boundaries.
 
 Replay remains intentionally unavailable. A production replay API requires bounded
 broker reads, republish, durable progress/idempotency evidence, and a real broker
 integration test. DLQ retry requires a complete `DlqEntry`; there is no ID-only API
 that can claim success without the original payload.
 
-Compilation, source-verifier execution, external-Iggy raw cursor execution,
-deterministic-header/deduplication, receipt-plus-broker ordering, position/reconnect,
-persisted-offset, TLS/auth, bundled-mode, and multi-replica evidence remain
-maintainer-run or pending.
+Compilation, source-verifier execution, external-Iggy cursor/header execution,
+deduplication, receipt-plus-broker ordering, position/reconnect, persisted-offset,
+TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pending.
 
 ## Boundary and dependencies
 
@@ -104,11 +119,13 @@ maintainer-run or pending.
 - Consumer workers compose typed receive, connector receipt recognition/claim,
   exact-byte DLQ publication, durable `published`, source acknowledgement, and
   best-effort `acknowledged` in that order.
-- The external evidence fixture connector may publish arbitrary malformed bytes only.
-  Production receive, classification, DLQ publication, and source acknowledgement must
-  remain on `IggyTransport`/`PersistentContractConsumerGroup` APIs.
-- The external harness creates unique streams but does not use an unreviewed deletion
-  API. It requires a disposable broker or operator-approved cleanup.
+- The lifecycle fixture connector may publish arbitrary malformed bytes only.
+  Production receive, classification, DLQ publication, reconnect, and source ack remain
+  on `IggyTransport`/`PersistentContractConsumerGroup` APIs.
+- The physical-header SDK client is observation-only: connect, open a unique DLQ group,
+  receive one message, inspect header/partition/payload, and commit that probe offset.
+- External evidence creates unique streams but does not use an unreviewed deletion API.
+  It requires a disposable broker or operator-approved cleanup.
 - Consumers such as Outbox and Social Graph use public transport contracts rather than
   connector cursor internals.
 - Transport positions, tenant/event identities, broker IDs, credentials, raw payloads,
@@ -147,22 +164,25 @@ maintainer-run or pending.
     reviewed loopback endpoint already managed by `IggyTransport`; external clients reuse
     reviewed address/auth/TLS configuration.
 11. **External raw-poison lifecycle harness.** A versioned source contract, opt-in real
-    external broker test, bounded timeouts, exact-byte DLQ cursor, no-ack reopen/redelivery,
-    explicit source advancement, and static guard define the first broker-backed raw
-    decode-failure evidence without overclaiming unexecuted runtime proof.
+    external broker test, bounded timeouts, exact-byte DLQ cursor, no-ack transport
+    reconnect/redelivery, explicit source advancement, and static guard define the first
+    broker-backed raw cursor evidence without claiming execution.
+12. **Physical header/partition harness.** A separate source contract and static guard
+    define one production DLQ publication plus a probe-only SDK read that checks exact
+    UUID/u128 header mapping, one-based UUID partition routing, exact payload, and probe
+    offset commit without introducing deduplication claims.
 
 ## Next results
 
-1. **Execute external raw receive and acknowledgement evidence.** Run the new harness on
-   a disposable external Iggy server, retain broker/version/configuration metadata and
-   source/output digests, and repeat reopen/redelivery behavior. Source coverage exists;
-   runtime execution remains maintainer work.
+1. **Execute external lifecycle and header evidence.** Run both harnesses on a disposable
+   external Iggy server, retain broker/version/configuration metadata and source/output
+   digests, and keep their runtime packets separate.
 2. **Compose receipt-plus-broker ordering evidence.** Add PostgreSQL receipt storage to a
    broker-backed scenario and prove reserve/claim -> exact publish -> durable `published`
    -> source ack -> best-effort `acknowledged`, including acknowledgement-only recovery.
-3. **Verify deterministic DLQ header behavior.** Use a read-only SDK probe to prove the
-   outgoing header ID and one-based partition, then exercise publish failure reconnect and
-   duplicate behavior with deduplication disabled, enabled, capacity-evicted, and expired.
+3. **Verify duplicate behavior separately.** Exercise publish failure reconnect and the
+   same deterministic UUID with deduplication disabled, enabled, capacity-evicted, and
+   expired. Do not infer these outcomes from the one-message header probe.
 4. **Verify bundled raw lifecycle.** Repeat the external scenario through the packaged
    bundled server and prove start, readiness, restart, durable data reuse, and shutdown.
 5. **Verify connector receipt concurrency.** Execute and retain the existing PostgreSQL
@@ -186,12 +206,14 @@ maintainer-run or pending.
 - `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
 - `cargo test -p rustok-iggy --test integration`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
+- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_header -- --nocapture --test-threads=1`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `node scripts/verify/verify-iggy-connector-source.mjs`
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
 - `node scripts/verify/verify-iggy-consumer-position.mjs`
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
@@ -211,4 +233,5 @@ this slice.
 - [Module documentation](./README.md)
 - [Connector plan](../../rustok-iggy-connector/docs/implementation-plan.md)
 - [External raw poison evidence guide](./contract-poison-external-evidence.md)
+- [External physical header evidence guide](./contract-poison-external-header-evidence.md)
 - [Iggy integration reference](../../../docs/references/iggy/README.md)

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
@@ -68,6 +68,8 @@ async fn deterministic_dlq_uuid_is_physical_iggy_header_and_selects_one_based_pa
             Some(received.partition_id),
         )
         .await?;
+    drop(probe);
+    client.shutdown().await?;
     transport.shutdown().await?;
     Ok(())
 }

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
@@ -1,0 +1,231 @@
+#![cfg(feature = "iggy")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use iggy::prelude::{Client, IggyClient};
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ContractDecodeFailureKind, ExternalConfig, IggyConfig, IggyMode,
+    IggyTransport, SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::SubscriberMessageMetadata;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+const ADDRESS_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";
+const PARTITIONS: u32 = 3;
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn deterministic_dlq_uuid_is_physical_iggy_header_and_selects_one_based_partition(
+) -> TestResult<()> {
+    let Some(config) = external_test_config()? else {
+        eprintln!(
+            "{ADDRESS_ENV} is not set; skipping external Iggy physical DLQ header evidence"
+        );
+        return Ok(());
+    };
+
+    let stream = config.topology.stream_name.clone();
+    let probe_group = unique_name("header-probe");
+    let transport = IggyTransport::new(config.clone()).await?;
+    let client = connect_sdk_probe(&config).await?;
+    let mut probe = client
+        .consumer_group(&probe_group, &stream, "dlq")?
+        .commit_failed_messages()
+        .build();
+    probe.init().await?;
+
+    let payload = vec![0xff, 0x00, 0x7f, 0x22, 0x01];
+    let failure = synthetic_decode_failure(&stream, payload.clone())?;
+    let entry = failure.to_dlq_entry(1);
+    let expected_id = entry
+        .broker_message_id()
+        .ok_or_else(|| invalid_data("decode failure DLQ entry has no deterministic broker ID"))?;
+    let expected_partition = expected_partition(expected_id, PARTITIONS)?;
+
+    transport.move_to_dlq(entry).await?;
+
+    let received = timeout(RECEIVE_TIMEOUT, probe.next())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for the physical Iggy DLQ message"))?
+        .ok_or_else(|| invalid_data("Iggy DLQ probe ended before receiving a message"))??;
+
+    assert_eq!(received.message.header.id, expected_id.as_u128());
+    assert_eq!(received.partition_id, expected_partition);
+    assert_eq!(received.message.payload.as_ref(), payload.as_slice());
+    assert_eq!(received.message.header.offset, received.current_offset);
+
+    probe
+        .store_offset(
+            received.message.header.offset,
+            Some(received.partition_id),
+        )
+        .await?;
+    transport.shutdown().await?;
+    Ok(())
+}
+
+fn synthetic_decode_failure(
+    stream: &str,
+    payload: Vec<u8>,
+) -> rustok_core::Result<ConsumedContractDecodeFailure> {
+    ConsumedContractDecodeFailure::new(
+        stream.to_string(),
+        "domain".to_string(),
+        SubscriberMessageMetadata::new(stream, "domain", 1)
+            .with_offset(42)
+            .with_ack_token("physical-header-evidence-only"),
+        payload,
+        ContractDecodeFailureKind::Deserialize,
+    )
+}
+
+fn expected_partition(message_id: Uuid, partitions: u32) -> Result<u32, IoError> {
+    if partitions == 0 {
+        return Err(invalid_data("physical header evidence requires at least one partition"));
+    }
+    let partition = (message_id.as_u128() % u128::from(partitions)) as u32 + 1;
+    if !(1..=partitions).contains(&partition) {
+        return Err(invalid_data("deterministic Iggy partition is outside the one-based range"));
+    }
+    Ok(partition)
+}
+
+async fn connect_sdk_probe(config: &IggyConfig) -> TestResult<IggyClient> {
+    let connection_string = connection_string(&config.external)?;
+    let client = IggyClient::from_connection_string(&connection_string)?;
+    client.connect().await?;
+    Ok(client)
+}
+
+fn connection_string(config: &ExternalConfig) -> Result<String, IoError> {
+    let address = config
+        .addresses
+        .first()
+        .ok_or_else(|| invalid_data("external Iggy evidence address is missing"))?;
+    if config.protocol != "tcp" {
+        return Err(invalid_data("physical Iggy header evidence requires TCP"));
+    }
+    if config.tls_enabled || config.tls_domain.is_some() || config.tls_ca_file.is_some() {
+        return Err(invalid_data(
+            "physical Iggy header evidence does not claim TLS coverage",
+        ));
+    }
+    if config.username.is_empty() != config.password.is_empty() {
+        return Err(invalid_data(
+            "external Iggy evidence username and password must both be set or both be empty",
+        ));
+    }
+    validate_connection_component(address, "address", &['@', '?', '#'])?;
+    validate_connection_component(&config.username, "username", &[':', '@'])?;
+    validate_connection_component(&config.password, "password", &[':', '@'])?;
+
+    if config.username.is_empty() {
+        Ok(format!("iggy://{address}"))
+    } else {
+        Ok(format!(
+            "iggy://{}:{}@{address}",
+            config.username, config.password
+        ))
+    }
+}
+
+fn external_test_config() -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(ADDRESS_ENV) {
+        Ok(value) => bounded_env(ADDRESS_ENV, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://") || address.contains('@') || address.contains('?') {
+        return Err(invalid_data(
+            "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS must be host:port without credentials or query parameters",
+        )
+        .into());
+    }
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "external Iggy evidence username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name("header-stream"),
+            domain_partitions: PARTITIONS,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_connection_component(
+    value: &str,
+    field: &'static str,
+    forbidden: &[char],
+) -> Result<(), IoError> {
+    if let Some(delimiter) = value
+        .chars()
+        .find(|character| forbidden.contains(character))
+    {
+        return Err(invalid_data(format!(
+            "Iggy {field} contains unsupported connection delimiter '{delimiter}'"
+        )));
+    }
+    Ok(())
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-poison-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs
@@ -61,7 +61,6 @@ async fn deterministic_dlq_uuid_is_physical_iggy_header_and_selects_one_based_pa
     assert_eq!(received.message.header.id, expected_id.as_u128());
     assert_eq!(received.partition_id, expected_partition);
     assert_eq!(received.message.payload.as_ref(), payload.as_slice());
-    assert_eq!(received.message.header.offset, received.current_offset);
 
     probe
         .store_offset(

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -15,8 +15,8 @@ or unavailable rows as absent.
 `followers_only` resolves through authoritative Social Graph owner ports. Profiles
 never reads relation tables and never authorizes from an event, Index projection,
 decoded/raw DLQ receipt, neutral receipt aggregate, broker identifier, consumer
-offset, lag metric, poison health signal, PostgreSQL evidence packet, or real-Iggy
-evidence harness.
+offset, lag metric, poison health signal, PostgreSQL evidence packet, physical Iggy
+header observation, or any real-Iggy evidence harness.
 
 Media descriptors remain Media-owned. Profiles validates tenant, uploader, and MIME
 constraints and exposes only Media-selected descriptors. It does not know storage
@@ -123,7 +123,7 @@ PostgreSQL evidence tooling is source-complete:
 The canonical PostgreSQL execution JSON remains absent until a maintainer executes the
 runner successfully.
 
-External real-Iggy source evidence is now defined:
+External real-Iggy cursor evidence is source-complete and runtime-pending:
 
 - one unique disposable/operator-cleaned stream and one partition;
 - two non-empty malformed payloads injected only through fixture-level
@@ -131,15 +131,28 @@ External real-Iggy source evidence is now defined:
 - production typed receive retains exact first bytes, offset, ack token, stable code,
   and deterministic UUID without source ack;
 - production `IggyTransport::move_to_dlq` publishes the exact first bytes;
-- dropping and reopening the same source group must redeliver the same offset, bytes,
-  and UUID;
+- first transport shutdown without source ack followed by a new transport and the same
+  group must redeliver the same offset, bytes, and UUID;
 - explicit source ack must then expose the second malformed payload at a greater
   offset;
 - an independent real DLQ cursor verifies both payloads byte-for-byte.
 
-This harness is source-complete and runtime-pending. It does not prove PostgreSQL
-receipt ordering, the physical Iggy header ID, deduplication, bundled mode, TLS/auth,
-reconnect, multi-replica behavior, or physical exactly-once.
+A separate external physical-header harness is also source-complete and runtime-pending:
+
+- one production `ConsumedContractDecodeFailure` creates one `DlqEntry`;
+- one production `IggyTransport::move_to_dlq` call publishes the entry;
+- a probe-only SDK consumer opened before publication reads exactly one physical DLQ
+  message;
+- physical `message.header.id` must equal the connector UUID as `u128`;
+- physical partition must equal `(uuid_as_u128 mod 3) + 1` and remain one-based;
+- physical payload must remain exact;
+- only the probe's physical header offset is committed.
+
+The SDK probe cannot publish, acknowledge a source cursor, modify a receipt, delete a
+stream, or change deduplication. The lifecycle harness does not prove the physical
+header; the header harness does not prove source cursor lifecycle. Neither proves
+PostgreSQL ordering, deduplication, bundled mode, TLS/auth, multi-replica behavior, or
+physical exactly-once.
 
 ## FFA/FBA boundary
 
@@ -180,21 +193,19 @@ reconnect, multi-replica behavior, or physical exactly-once.
    Run the clean-commit capture runner, review the bounded packet, commit the canonical
    JSON, and repeat whenever a bound source hash changes.
 
-6. **Execute external real-Iggy raw lifecycle evidence.**
-   Run the new harness on a disposable broker, retain broker/toolchain/configuration
-   metadata and output/source digests, and repeat no-ack reopen/redelivery plus explicit
-   cursor advancement.
+6. **Execute external cursor and header evidence.**
+   Run both harnesses on a disposable broker and retain separate packets for source
+   reconnect/redelivery and physical UUID/header/partition observation.
 
 7. **Compose receipt-plus-broker evidence.**
    Prove reserve/claim -> exact publish -> durable `published` -> source ack ->
    best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
    multi-replica claim ownership on PostgreSQL plus real Iggy.
 
-8. **Prove header and confirmation behavior.**
-   Inspect the physical UUID header, same-partition routing, publisher reconnect, and
-   duplicate behavior with deduplication disabled, enabled, capacity-evicted, and
-   expired. Choose an enforced dedup window or stronger outbox/transaction mechanism
-   before any stronger duplicate guarantee.
+8. **Prove duplicate and confirmation behavior separately.**
+   Exercise publisher reconnect and the same deterministic UUID with deduplication
+   disabled, enabled, capacity-evicted, and expired. Choose an enforced dedup window or
+   stronger outbox/transaction mechanism before any stronger duplicate guarantee.
 
 9. **Retain production operations.**
    Prove bundled mode, restart, TLS/auth/failover, position reconnect, rebalance,
@@ -215,10 +226,14 @@ reconnect, multi-replica behavior, or physical exactly-once.
   health, and the operator runbook.
 - Added isolated PostgreSQL scenarios and clean-commit retained evidence tooling; the
   execution packet remains pending.
-- Added a versioned external-Iggy source contract, opt-in real cursor/DLQ harness,
-  no-ack reopen/redelivery, exact-byte DLQ checks, explicit cursor advancement, and a
-  static verifier.
-- Removed the stale verifier claim that no Social Graph worker was wired.
+- Added a versioned external-Iggy cursor contract, opt-in real cursor/DLQ harness,
+  no-ack transport reconnect/redelivery, exact-byte DLQ checks, explicit cursor
+  advancement, and a static verifier.
+- Added a separate physical-header contract and harness for one production publication,
+  exact UUID/u128 header mapping, one-based partition routing, exact payload, probe-only
+  SDK access, and probe offset commit.
+- Kept duplicate suppression, database ordering, bundled/TLS/auth, and multi-replica
+  claims explicitly open.
 - Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy,
   and multi-replica scenarios were not run, per maintainer instruction.
 
@@ -232,8 +247,10 @@ reconnect, multi-replica behavior, or physical exactly-once.
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
 - `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
+- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_header -- --nocapture --test-threads=1`
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
@@ -294,6 +311,8 @@ reconnect, multi-replica behavior, or physical exactly-once.
     become stale when a bound source SHA-256 changes.
 18. Real-Iggy fixture injection may create malformed bytes, but production receive, DLQ,
     and acknowledgement must use reviewed transport APIs.
-19. Do not claim physical header, deduplication, database ordering, bundled, TLS/auth, or
-    multi-replica proof from the external cursor lifecycle harness.
-20. Update Profiles and affected owner docs with every boundary change.
+19. Direct SDK probes may only observe explicitly scoped broker facts and commit their
+    own probe offsets; they must not publish, choose policy, or mutate receipts.
+20. Do not claim deduplication, database ordering, bundled, TLS/auth, multi-replica, or
+    exactly-once proof from one-message physical-header evidence.
+21. Update Profiles and affected owner docs with every boundary change.

--- a/scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const contract = JSON.parse(
+  readFileSync(
+    "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-header-source.json",
+    "utf8",
+  ),
+);
+const cargo = readFileSync("crates/rustok-iggy/Cargo.toml", "utf8");
+const test = readFileSync(
+  "crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs",
+  "utf8",
+);
+const failures = [];
+
+const expectedSequence = [
+  "start_production_transport_and_topology",
+  "open_sdk_dlq_probe_group_before_publication",
+  "construct_nonempty_synthetic_decode_failure_with_production_type",
+  "derive_dlq_entry_and_expected_connector_uuid",
+  "derive_expected_one_based_partition_from_uuid_modulo_partition_count",
+  "publish_once_through_iggy_transport_move_to_dlq",
+  "receive_one_physical_dlq_message_through_sdk_probe",
+  "assert_physical_header_id_equals_uuid_as_u128",
+  "assert_received_partition_equals_expected_one_based_partition",
+  "assert_physical_payload_is_exact",
+  "commit_probe_header_offset_only",
+  "shutdown_production_transport",
+];
+const expectedProductionPaths = [
+  "ConsumedContractDecodeFailure::new",
+  "ConsumedContractDecodeFailure::to_dlq_entry",
+  "DlqEntry::broker_message_id",
+  "IggyTransport::new",
+  "IggyTransport::move_to_dlq",
+  "IggyTransport::shutdown",
+];
+const expectedProbeBoundary = {
+  purpose: "observe_physical_dlq_message_only",
+  allowed_operations: [
+    "connect",
+    "open_dlq_consumer_group",
+    "receive_one_message",
+    "read_header_id",
+    "read_partition_id",
+    "read_payload",
+    "store_probe_offset",
+  ],
+  forbidden_operations: [
+    "publish",
+    "create_source_fixture",
+    "mutate_production_receipt",
+    "acknowledge_source_cursor",
+    "delete_stream",
+    "change_broker_deduplication",
+  ],
+};
+const expectedForbiddenClaims = [
+  "source_cursor_lifecycle_proved_by_this_test",
+  "database_receipt_ordering_proved",
+  "broker_deduplication_runtime_proved",
+  "duplicate_suppression_window_proved",
+  "physical_exactly_once_proved",
+  "bundled_mode_proved",
+  "tls_or_auth_failure_proved",
+  "multi_replica_proved",
+];
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    failures.push(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) {
+    failures.push(`${name} contains forbidden marker: ${marker}`);
+  }
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireOrdered(name, source, markers) {
+  let previous = -1;
+  for (const marker of markers) {
+    const position = source.indexOf(marker, previous + 1);
+    if (position < 0) {
+      failures.push(`${name} is missing ordered marker: ${marker}`);
+      return;
+    }
+    if (position <= previous) {
+      failures.push(`${name} has invalid ordering at marker: ${marker}`);
+      return;
+    }
+    previous = position;
+  }
+}
+
+if (contract.schema_version !== 1) failures.push("physical header contract schema drift");
+if (contract.module !== "iggy") failures.push("physical header contract module drift");
+if (contract.packet !== "contract-poison-external-iggy-header-source") {
+  failures.push("physical header contract packet drift");
+}
+if (contract.status !== "source_complete_runtime_pending") {
+  failures.push("physical header contract must remain runtime pending");
+}
+if (contract.scope !== "external_real_iggy_physical_dlq_header_and_partition") {
+  failures.push("physical header contract scope drift");
+}
+if (contract.test_target !== "contract_poison_external_iggy_header") {
+  failures.push("physical header test target drift");
+}
+if (
+  contract.test_case !==
+  "deterministic_dlq_uuid_is_physical_iggy_header_and_selects_one_based_partition"
+) {
+  failures.push("physical header test case drift");
+}
+if (
+  contract.source_path !==
+  "crates/rustok-iggy/tests/contract_poison_external_iggy_header.rs"
+) {
+  failures.push("physical header source path drift");
+}
+if (
+  contract.verifier !==
+  "scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs"
+) {
+  failures.push("physical header verifier path drift");
+}
+if (!sameValue(contract.required_environment, ["RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS"])) {
+  failures.push("physical header required environment drift");
+}
+if (
+  !sameValue(contract.optional_environment, [
+    "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+    "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD",
+  ])
+) {
+  failures.push("physical header optional environment drift");
+}
+if (
+  !sameValue(contract.topology, {
+    mode: "external",
+    protocol: "tcp",
+    unique_stream_per_run: true,
+    domain_partitions: 3,
+    replication_factor: 1,
+    observed_topic: "dlq",
+    broker_requirement: "disposable_or_operator_cleaned_external_iggy",
+  })
+) {
+  failures.push("physical header topology drift");
+}
+if (!sameValue(contract.required_sequence, expectedSequence)) {
+  failures.push("physical header sequence drift");
+}
+if (!sameValue(contract.production_paths, expectedProductionPaths)) {
+  failures.push("physical header production path drift");
+}
+if (!sameValue(contract.sdk_probe_boundary, expectedProbeBoundary)) {
+  failures.push("physical header SDK probe boundary drift");
+}
+if (contract.publication_count !== 1) {
+  failures.push("physical header evidence must contain exactly one production publication");
+}
+if (!sameValue(contract.forbidden_claims, expectedForbiddenClaims)) {
+  failures.push("physical header forbidden claim drift");
+}
+if (contract.execution_status !== "not_run") {
+  failures.push("physical header source contract must not claim execution");
+}
+
+requireText("rustok-iggy dev dependencies", cargo, "futures-util.workspace = true");
+
+for (const marker of [
+  '#![cfg(feature = "iggy")]',
+  "use futures_util::StreamExt;",
+  "use iggy::prelude::{Client, IggyClient};",
+  'const ADDRESS_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS";',
+  'const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";',
+  'const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";',
+  "const PARTITIONS: u32 = 3;",
+  "IggyMode::External",
+  'protocol: "tcp".to_string()',
+  'stream_name: unique_name("header-stream")',
+  "domain_partitions: PARTITIONS",
+  'consumer_group(&probe_group, &stream, "dlq")',
+  ".commit_failed_messages()",
+  "probe.init().await?;",
+  "ConsumedContractDecodeFailure::new(",
+  ".with_offset(42)",
+  '.with_ack_token("physical-header-evidence-only")',
+  "let entry = failure.to_dlq_entry(1);",
+  ".broker_message_id()",
+  "expected_partition(expected_id, PARTITIONS)",
+  "transport.move_to_dlq(entry).await?;",
+  "timeout(RECEIVE_TIMEOUT, probe.next())",
+  "received.message.header.id, expected_id.as_u128()",
+  "received.partition_id, expected_partition",
+  "received.message.payload.as_ref(), payload.as_slice()",
+  "received.message.header.offset",
+  "Some(received.partition_id)",
+  "transport.shutdown().await?;",
+  "(message_id.as_u128() % u128::from(partitions)) as u32 + 1",
+  "(1..=partitions).contains(&partition)",
+]) {
+  requireText("physical Iggy header test", test, marker);
+}
+
+requireOrdered("physical header publication and observation", test, [
+  "let transport = IggyTransport::new(config.clone()).await?;",
+  "let client = connect_sdk_probe(&config).await?;",
+  "probe.init().await?;",
+  "let failure = synthetic_decode_failure(&stream, payload.clone())?;",
+  "let entry = failure.to_dlq_entry(1);",
+  "let expected_id = entry",
+  "let expected_partition = expected_partition(expected_id, PARTITIONS)?;",
+  "transport.move_to_dlq(entry).await?;",
+  "let received = timeout(RECEIVE_TIMEOUT, probe.next())",
+  "assert_eq!(received.message.header.id, expected_id.as_u128());",
+  "assert_eq!(received.partition_id, expected_partition);",
+  "assert_eq!(received.message.payload.as_ref(), payload.as_slice());",
+  ".store_offset(",
+  "transport.shutdown().await?;",
+]);
+
+const moveToDlqCount = [...test.matchAll(/\.move_to_dlq\(/gu)].length;
+if (moveToDlqCount !== 1) {
+  failures.push(
+    `physical header evidence must publish exactly once through move_to_dlq; found ${moveToDlqCount}`,
+  );
+}
+const probeNextCount = [...test.matchAll(/probe\.next\(\)/gu)].length;
+if (probeNextCount !== 1) {
+  failures.push(`physical header evidence must read exactly one probe message; found ${probeNextCount}`);
+}
+
+for (const forbidden of [
+  "127.0.0.1:8090",
+  'username: "iggy"',
+  'password: "iggy"',
+  "ExternalConnector",
+  "PublishRequest",
+  "IggyMessage::builder",
+  ".producer(",
+  ".send(",
+  "PersistentContractConsumerGroup",
+  "open_persistent_contract_consumer_group",
+  "acknowledge_decode_failure",
+  "ConsumerPoisonReceiptStore",
+  "mark_published",
+  "mark_acknowledged",
+  "dedup",
+  "duplicate",
+  "exactly_once",
+  "delete_stream",
+  "std::thread::sleep",
+  "tokio::time::sleep",
+  "DATABASE_URL",
+  "println!(connection_string",
+  "tracing::",
+]) {
+  forbidText("physical Iggy header test", test, forbidden);
+}
+
+const sdkProbeStart = test.indexOf("async fn connect_sdk_probe(");
+const configStart = test.indexOf("fn connection_string(", sdkProbeStart);
+const sdkProbe =
+  sdkProbeStart >= 0 && configStart > sdkProbeStart
+    ? test.slice(sdkProbeStart, configStart)
+    : "";
+for (const marker of [
+  "IggyClient::from_connection_string",
+  "client.connect().await?",
+]) {
+  requireText("physical Iggy SDK probe connector", sdkProbe, marker);
+}
+for (const forbidden of [
+  ".producer(",
+  ".send(",
+  "IggyMessage",
+  "move_to_dlq",
+  "store_offset",
+]) {
+  forbidText("physical Iggy SDK probe connector", sdkProbe, forbidden);
+}
+
+if (failures.length > 0) {
+  console.error("External Iggy physical header evidence verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "External Iggy physical header source evidence verified: one production DLQ publication, exact UUID u128 header, one-based deterministic partition, exact payload, probe-only SDK access, and bounded unexecuted claims are locked.",
+);

--- a/scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs
@@ -27,6 +27,7 @@ const expectedSequence = [
   "assert_received_partition_equals_expected_one_based_partition",
   "assert_physical_payload_is_exact",
   "commit_probe_header_offset_only",
+  "drop_probe_consumer_and_shutdown_probe_client",
   "shutdown_production_transport",
 ];
 const expectedProductionPaths = [
@@ -47,6 +48,7 @@ const expectedProbeBoundary = {
     "read_partition_id",
     "read_payload",
     "store_probe_offset",
+    "shutdown",
   ],
   forbidden_operations: [
     "publish",
@@ -205,6 +207,8 @@ for (const marker of [
   "received.message.payload.as_ref(), payload.as_slice()",
   "received.message.header.offset",
   "Some(received.partition_id)",
+  "drop(probe);",
+  "client.shutdown().await?;",
   "transport.shutdown().await?;",
   "(message_id.as_u128() % u128::from(partitions)) as u32 + 1",
   "(1..=partitions).contains(&partition)",
@@ -226,6 +230,8 @@ requireOrdered("physical header publication and observation", test, [
   "assert_eq!(received.partition_id, expected_partition);",
   "assert_eq!(received.message.payload.as_ref(), payload.as_slice());",
   ".store_offset(",
+  "drop(probe);",
+  "client.shutdown().await?;",
   "transport.shutdown().await?;",
 ]);
 
@@ -299,5 +305,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "External Iggy physical header source evidence verified: one production DLQ publication, exact UUID u128 header, one-based deterministic partition, exact payload, probe-only SDK access, and bounded unexecuted claims are locked.",
+  "External Iggy physical header source evidence verified: one production DLQ publication, exact UUID u128 header, one-based deterministic partition, exact payload, explicit probe shutdown, probe-only SDK access, and bounded unexecuted claims are locked.",
 );


### PR DESCRIPTION
## Summary

Define a separate opt-in external-Iggy source harness for the physical deterministic DLQ header and partition contract.

The scenario intentionally publishes exactly one message:

1. starts a production `IggyTransport` with one unique three-partition stream;
2. opens a unique direct-SDK consumer group on `dlq` before publication;
3. constructs a non-empty production `ConsumedContractDecodeFailure` and derives one `DlqEntry`;
4. reads the deterministic connector UUID from `broker_message_id`;
5. computes the expected one-based partition as `(uuid_as_u128 mod 3) + 1`;
6. publishes once through production `IggyTransport::move_to_dlq`;
7. receives one physical SDK message and requires exact UUID/u128 header, expected partition, and exact payload;
8. commits the physical message header offset for the probe partition;
9. drops the probe consumer and explicitly shuts down the SDK client and production transport.

## SDK probe boundary

The direct SDK may only connect, open the unique DLQ probe group, receive one message, read header/partition/payload, store its own probe offset, and shut down. It may not publish, create a source fixture, acknowledge a source cursor, modify connector receipts, delete streams, or change broker deduplication.

This harness is separate from the already-merged external cursor lifecycle harness. It does not claim source redelivery/ack lifecycle, PostgreSQL receipt ordering, broker deduplication, suppression-window behavior, physical exactly-once, bundled mode, TLS/auth failure, or multi-replica proof.

## Documentation and guardrails

- added a versioned source contract with `execution_status: not_run`;
- added the physical-header operator/evidence guide;
- added `verify-iggy-contract-poison-external-header-evidence.mjs` to lock one publication, probe-only SDK access, exact header/partition/payload assertions, exact physical offset commit, explicit shutdown, and bounded claims;
- updated Iggy and canonical Profiles live plans;
- added `futures-util` only as a `rustok-iggy` dev dependency for SDK stream polling.

## Verification

Tests, Cargo commands, formatters, source verifiers, external/bundled Iggy scenarios, broker configuration changes, PostgreSQL, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs

RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' \
RUSTOK_IGGY_EXTERNAL_TEST_USERNAME='...' \
RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD='...' \
  cargo test -p rustok-iggy --features iggy \
  --test contract_poison_external_iggy_header -- --nocapture --test-threads=1
```