### PR TITLE
test(profiles): define external Iggy dedup behavior

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-source.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-source.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "contract-poison-external-iggy-dedup-source",
+  "status": "source_complete_runtime_pending",
+  "scope": "external_real_iggy_message_id_deduplication_behavior",
+  "test_target": "contract_poison_external_iggy_dedup",
+  "source_path": "crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs",
+  "verifier": "scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs",
+  "shared_optional_environment": [
+    "RUSTOK_IGGY_DEDUP_TEST_USERNAME",
+    "RUSTOK_IGGY_DEDUP_TEST_PASSWORD"
+  ],
+  "scenarios": [
+    {
+      "case": "disabled_deduplication_persists_repeated_uuid_twice",
+      "address_env": "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS",
+      "required_reviewed_server_config": {
+        "system.message_deduplication.enabled": false
+      },
+      "publication_sequence": [
+        "A",
+        "A"
+      ],
+      "expected_partition_message_counts": [
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "case": "enabled_deduplication_suppresses_immediate_repeated_uuid",
+      "address_env": "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS",
+      "required_reviewed_server_config": {
+        "system.message_deduplication.enabled": true,
+        "system.message_deduplication.max_entries": "at_least_1",
+        "system.message_deduplication.expiry": "longer_than_scenario_horizon"
+      },
+      "publication_sequence": [
+        "A",
+        "A"
+      ],
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "case": "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+      "address_env": "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS",
+      "required_reviewed_server_config": {
+        "system.message_deduplication.enabled": true,
+        "system.message_deduplication.max_entries": 1,
+        "system.message_deduplication.expiry": "longer_than_scenario_horizon"
+      },
+      "publication_sequence": [
+        "A",
+        "A",
+        "B",
+        "A"
+      ],
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "case": "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+      "address_env": "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS",
+      "additional_env": "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS",
+      "required_reviewed_server_config": {
+        "system.message_deduplication.enabled": true,
+        "system.message_deduplication.max_entries": "at_least_1",
+        "system.message_deduplication.expiry": "shorter_than_RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS"
+      },
+      "publication_sequence": [
+        "A",
+        "A",
+        "wait",
+        "A"
+      ],
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1,
+        2
+      ]
+    }
+  ],
+  "topology": {
+    "mode": "external",
+    "protocol": "tcp",
+    "unique_stream_per_scenario": true,
+    "domain_partitions": 1,
+    "replication_factor": 1,
+    "observed_topic": "dlq",
+    "observed_partition": 1,
+    "broker_requirement": "four_separately_configured_disposable_or_operator_cleaned_external_iggy_instances"
+  },
+  "production_paths": [
+    "ConsumedContractDecodeFailure::new",
+    "ConsumedContractDecodeFailure::to_dlq_entry",
+    "IggyTransport::new",
+    "IggyTransport::move_to_dlq",
+    "IggyTransport::shutdown"
+  ],
+  "observer_boundary": {
+    "purpose": "read_partition_message_count_only",
+    "allowed_operations": [
+      "connect",
+      "get_dlq_topic",
+      "read_partition_1_messages_count",
+      "shutdown"
+    ],
+    "forbidden_operations": [
+      "publish",
+      "consume_payload",
+      "store_offset",
+      "modify_server_configuration",
+      "delete_stream",
+      "mutate_production_receipt"
+    ]
+  },
+  "forbidden_claims": [
+    "server_configuration_read_back_by_test",
+    "physical_exactly_once_proved",
+    "receipt_and_broker_transaction_proved",
+    "deduplication_window_sufficient_for_production_recovery_proved",
+    "bundled_mode_proved",
+    "tls_or_auth_failure_proved",
+    "multi_replica_proved"
+  ],
+  "execution_status": "not_run"
+}

--- a/crates/rustok-iggy/docs/contract-poison-external-dedup-evidence.md
+++ b/crates/rustok-iggy/docs/contract-poison-external-dedup-evidence.md
@@ -1,0 +1,170 @@
+# External Iggy message-ID deduplication evidence
+
+## Purpose
+
+`contract_poison_external_iggy_dedup.rs` defines four opt-in behavior scenarios for Iggy's server-side message-ID deduplication. The production publisher is always `IggyTransport::move_to_dlq` with a deterministic raw-poison `broker_message_id`. A separate SDK observer reads only partition `messages_count` from the unique stream's `dlq` topic.
+
+The test does not read or mutate Iggy server configuration. A retained execution must therefore pair each run with a reviewed server configuration artifact and must not infer configuration values from test code alone.
+
+## Required disposable brokers
+
+Provide four separately configured external Iggy instances or four independently restarted disposable configurations.
+
+### Disabled
+
+```toml
+[system.message_deduplication]
+enabled = false
+```
+
+Address:
+
+```text
+RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS=host:port
+```
+
+Publishing the same immutable entry `A` twice must produce partition counts:
+
+```text
+0 -> 1 -> 2
+```
+
+### Enabled, entry retained
+
+```toml
+[system.message_deduplication]
+enabled = true
+max_entries = <at least 1>
+expiry = <longer than the scenario>
+```
+
+Address:
+
+```text
+RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS=host:port
+```
+
+Publishing `A` twice immediately must produce:
+
+```text
+0 -> 1 -> 1
+```
+
+### Capacity eviction
+
+```toml
+[system.message_deduplication]
+enabled = true
+max_entries = 1
+expiry = <longer than the scenario>
+```
+
+Address:
+
+```text
+RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS=host:port
+```
+
+The scenario publishes `A`, repeats `A`, publishes distinct `B`, then publishes `A` again:
+
+```text
+0 -> 1 -> 1 -> 2 -> 3
+```
+
+The immediate repeated `A` proves suppression is active before `B` is introduced. Acceptance of `A` after `B` is the capacity-eviction behavior expected from a one-entry per-partition cache.
+
+### Expiry
+
+```toml
+[system.message_deduplication]
+enabled = true
+max_entries = <at least 1>
+expiry = <shorter than the configured test wait>
+```
+
+Address and bounded wait:
+
+```text
+RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS=host:port
+RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS=<100..300000>
+```
+
+The scenario publishes `A`, repeats `A` immediately, waits, then publishes `A` again:
+
+```text
+0 -> 1 -> 1 -> 2
+```
+
+The immediate repeat establishes active suppression; acceptance after the reviewed wait establishes observed expiry behavior for that execution.
+
+## Shared credentials and transport
+
+Optional shared credentials must be supplied as a pair:
+
+```text
+RUSTOK_IGGY_DEDUP_TEST_USERNAME=...
+RUSTOK_IGGY_DEDUP_TEST_PASSWORD=...
+```
+
+Every scenario uses:
+
+- external TCP mode;
+- one unique stream;
+- one `domain` partition and one matching `dlq` partition;
+- replication factor `1`;
+- exact deterministic UUIDs derived through `ConsumedContractDecodeFailure::to_dlq_entry`;
+- explicit observer and production transport shutdown.
+
+There are no default addresses or credentials. Use disposable brokers or an operator-approved cleanup process; the tests do not delete streams.
+
+## Observation boundary
+
+The SDK observer may only:
+
+- connect;
+- call `get_topic` for the unique stream's `dlq` topic;
+- read partition `1` and its `messages_count`;
+- shut down.
+
+It does not consume payloads, publish, store offsets, modify configuration, delete streams, or mutate connector receipts.
+
+The test reads counts immediately after each successful production publish. It does not use an absence timeout to decide whether a duplicate was suppressed. The single sleep is bounded and belongs only to the expiry scenario.
+
+## Non-claims
+
+Even after successful execution, these scenarios do not prove:
+
+- that the test read back the active server configuration;
+- physical exactly-once publication;
+- a transaction between PostgreSQL receipt state and Iggy publication;
+- that the selected `max_entries`/`expiry` window covers the maximum production lease, restart, reconnect, and recovery horizon;
+- bundled mode;
+- TLS/authentication/failover behavior;
+- multi-replica behavior;
+- Profiles privacy or authorization.
+
+Production confirmation policy still requires reviewed retained configuration and recovery-window evidence, or a stronger database-owned outbox/broker transaction design.
+
+## Maintainer command
+
+Provide all four addresses to run the complete target:
+
+```bash
+RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='disabled.example:8090' \
+RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='enabled.example:8090' \
+RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='capacity.example:8090' \
+RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='expiry.example:8090' \
+RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' \
+RUSTOK_IGGY_DEDUP_TEST_USERNAME='...' \
+RUSTOK_IGGY_DEDUP_TEST_PASSWORD='...' \
+  cargo test -p rustok-iggy --features iggy \
+  --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1
+
+node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
+```
+
+A future retained runner must reject missing scenario addresses, record reviewed configuration digests without credentials, require all four named tests to execute rather than skip, and retain source/output hashes.
+
+## Evidence status
+
+The four behavior scenarios, versioned source contract, read-only observer boundary, and static verifier are source-complete. `execution_status` remains `not_run`. No Cargo command, verifier, external Iggy scenario, server restart, or configuration change was performed while authoring this slice.

--- a/crates/rustok-iggy/docs/implementation-plan.md
+++ b/crates/rustok-iggy/docs/implementation-plan.md
@@ -72,34 +72,53 @@ acknowledges it explicitly, and then requires the second offset to become visibl
 independent real DLQ cursor verifies both payloads byte-for-byte. The harness is
 source-complete and has not been executed.
 
-A separate physical-header harness now covers the publisher wire contract without
-repeating the lifecycle scenario. It creates a production `ConsumedContractDecodeFailure`,
-derives one `DlqEntry`, publishes exactly once through `IggyTransport::move_to_dlq`, and
-uses a probe-only SDK consumer on `dlq` to require:
+A separate physical-header harness covers the publisher wire contract without repeating
+the lifecycle scenario. It creates a production `ConsumedContractDecodeFailure`, derives
+one `DlqEntry`, publishes exactly once through `IggyTransport::move_to_dlq`, and uses a
+probe-only SDK consumer on `dlq` to require:
 
 - physical `message.header.id == broker_message_id.as_u128()`;
-- physical partition equals `(uuid_as_u128 mod partitions) + 1` and remains in the
-  one-based range;
+- physical partition equals `(uuid_as_u128 mod partitions) + 1` and remains one-based;
 - physical payload is exact;
 - only the probe message's physical header offset is committed.
 
-The SDK probe cannot publish, create source fixtures, acknowledge source cursors,
-modify receipts, delete streams, or change deduplication. The physical-header harness
-is source-complete and runtime-pending.
+The physical-header SDK probe cannot publish, create source fixtures, acknowledge
+source cursors, modify receipts, delete streams, or change deduplication. The harness is
+source-complete and runtime-pending.
 
-Neither external harness composes PostgreSQL receipt ordering, exercises broker
-suppression, or claims bundled/TLS/auth/multi-replica proof. Source cursor lifecycle,
-physical header observation, database ordering, and deduplication remain distinct
-evidence boundaries.
+A third external harness now defines observed server deduplication behavior against four
+separately configured disposable brokers. Every scenario creates a unique one-partition
+stream, publishes only through production `IggyTransport::move_to_dlq`, and uses a
+read-only SDK `get_topic` observer for partition `messages_count`:
+
+- disabled: repeated `A` produces `0 -> 1 -> 2`;
+- enabled: immediate repeated `A` produces `0 -> 1 -> 1`;
+- `max_entries = 1`: `A, A, B, A` produces `0 -> 1 -> 1 -> 2 -> 3`;
+- expiry: `A, A, wait, A` produces `0 -> 1 -> 1 -> 2`.
+
+The capacity sequence first proves immediate suppression, then introduces distinct `B`,
+then observes `A` accepted again. The expiry sequence also proves immediate suppression
+before one bounded operator-configured wait. The observer cannot publish, consume
+payloads, store offsets, modify configuration, delete streams, or mutate receipts.
+
+The dedup harness does not read back server configuration. A retained execution must
+pair each address with a reviewed configuration artifact for `enabled`, `max_entries`,
+and `expiry`, require every named test to execute rather than skip, and retain
+source/output/configuration digests without credentials. Source coverage exists; runtime
+execution and production-window sufficiency remain open.
+
+The lifecycle, physical-header, dedup behavior, PostgreSQL ordering, and production
+confirmation policy remain distinct evidence boundaries. None of the source harnesses
+claims a database/broker transaction or physical exactly-once.
 
 Replay remains intentionally unavailable. A production replay API requires bounded
 broker reads, republish, durable progress/idempotency evidence, and a real broker
 integration test. DLQ retry requires a complete `DlqEntry`; there is no ID-only API
 that can claim success without the original payload.
 
-Compilation, source-verifier execution, external-Iggy cursor/header execution,
-deduplication, receipt-plus-broker ordering, position/reconnect, persisted-offset,
-TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pending.
+Compilation, source-verifier execution, external-Iggy cursor/header/dedup execution,
+receipt-plus-broker ordering, position/reconnect, persisted-offset, TLS/auth,
+bundled-mode, and multi-replica evidence remain maintainer-run or pending.
 
 ## Boundary and dependencies
 
@@ -123,9 +142,14 @@ TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pend
   Production receive, classification, DLQ publication, reconnect, and source ack remain
   on `IggyTransport`/`PersistentContractConsumerGroup` APIs.
 - The physical-header SDK client is observation-only: connect, open a unique DLQ group,
-  receive one message, inspect header/partition/payload, and commit that probe offset.
+  receive one message, inspect header/partition/payload, commit that probe offset, and
+  shut down.
+- The dedup SDK client is count-only: connect, read `dlq` partition `1` through
+  `get_topic`, return `messages_count`, and shut down. It cannot consume or mutate.
 - External evidence creates unique streams but does not use an unreviewed deletion API.
-  It requires a disposable broker or operator-approved cleanup.
+  It requires disposable brokers or operator-approved cleanup.
+- Dedup addresses are configuration claims supplied by the operator; the source test
+  observes behavior and never presents those claims as server readback.
 - Consumers such as Outbox and Social Graph use public transport contracts rather than
   connector cursor internals.
 - Transport positions, tenant/event identities, broker IDs, credentials, raw payloads,
@@ -133,8 +157,8 @@ TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pend
 
 ## Delivered results
 
-1. **Persistent result-first consumer groups.** Root and sealed-family cursors retain
-   one remote cursor across receive and exact scoped acknowledgement.
+1. **Persistent result-first consumer groups.** Root and sealed-family cursors retain one
+   remote cursor across receive and exact scoped acknowledgement.
 2. **Exact-byte contract delivery.** Successfully decoded contract deliveries retain
    original broker bytes for lossless owner-directed DLQ publication.
 3. **Typed raw decode-failure delivery.** Deserialization and canonical-schema failures
@@ -169,21 +193,25 @@ TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pend
     broker-backed raw cursor evidence without claiming execution.
 12. **Physical header/partition harness.** A separate source contract and static guard
     define one production DLQ publication plus a probe-only SDK read that checks exact
-    UUID/u128 header mapping, one-based UUID partition routing, exact payload, and probe
-    offset commit without introducing deduplication claims.
+    UUID/u128 header mapping, one-based UUID partition routing, exact payload, explicit
+    probe shutdown, and no deduplication claims.
+13. **Deduplication behavior harness.** Four source scenarios and a static guard define
+    disabled, immediate suppression, capacity eviction, and expiry count sequences using
+    production publication and a read-only partition-count observer. Server configuration
+    review and runtime execution remain external retained evidence requirements.
 
 ## Next results
 
-1. **Execute external lifecycle and header evidence.** Run both harnesses on a disposable
-   external Iggy server, retain broker/version/configuration metadata and source/output
-   digests, and keep their runtime packets separate.
+1. **Execute external lifecycle, header, and dedup evidence.** Run the three harnesses on
+   disposable external Iggy instances and retain separate packets with broker version,
+   reviewed configuration digests, source/output hashes, and every required test result.
 2. **Compose receipt-plus-broker ordering evidence.** Add PostgreSQL receipt storage to a
    broker-backed scenario and prove reserve/claim -> exact publish -> durable `published`
    -> source ack -> best-effort `acknowledged`, including acknowledgement-only recovery.
-3. **Verify duplicate behavior separately.** Exercise publish failure reconnect and the
-   same deterministic UUID with deduplication disabled, enabled, capacity-evicted, and
-   expired. Do not infer these outcomes from the one-message header probe.
-4. **Verify bundled raw lifecycle.** Repeat the external scenario through the packaged
+3. **Prove recovery-window sufficiency.** Compare reviewed dedup `max_entries`/`expiry`
+   against maximum publication lease, process restart, reconnect, and operator recovery
+   horizons. Do not infer sufficiency from the four short behavior sequences.
+4. **Verify bundled raw lifecycle.** Repeat the external scenarios through the packaged
    bundled server and prove start, readiness, restart, durable data reuse, and shutdown.
 5. **Verify connector receipt concurrency.** Execute and retain the existing PostgreSQL
    claim ownership, lease expiry/reclaim, UUID/source collision, rollback,
@@ -207,6 +235,7 @@ TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pend
 - `cargo test -p rustok-iggy --test integration`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_header -- --nocapture --test-threads=1`
+- `RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='host:8090' RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='host:8091' RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='host:8092' RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='host:8093' RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
@@ -214,6 +243,7 @@ TLS/auth, bundled-mode, and multi-replica evidence remain maintainer-run or pend
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs`
 - `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
 - `node scripts/verify/verify-iggy-consumer-position.mjs`
 - `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
@@ -234,4 +264,5 @@ this slice.
 - [Connector plan](../../rustok-iggy-connector/docs/implementation-plan.md)
 - [External raw poison evidence guide](./contract-poison-external-evidence.md)
 - [External physical header evidence guide](./contract-poison-external-header-evidence.md)
+- [External dedup behavior evidence guide](./contract-poison-external-dedup-evidence.md)
 - [Iggy integration reference](../../../docs/references/iggy/README.md)

--- a/crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs
+++ b/crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs
@@ -1,0 +1,326 @@
+#![cfg(feature = "iggy")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::time::Duration;
+
+use iggy::prelude::{Client, Identifier, IggyClient, TopicClient};
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ContractDecodeFailureKind, DlqEntry, ExternalConfig, IggyConfig,
+    IggyMode, IggyTransport, SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::SubscriberMessageMetadata;
+use uuid::Uuid;
+
+const DISABLED_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS";
+const ENABLED_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS";
+const CAPACITY_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS";
+const EXPIRY_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_DEDUP_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_DEDUP_TEST_PASSWORD";
+const EXPIRY_WAIT_ENV: &str = "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS";
+const MIN_EXPIRY_WAIT_MS: u64 = 100;
+const MAX_EXPIRY_WAIT_MS: u64 = 300_000;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn disabled_deduplication_persists_repeated_uuid_twice() -> TestResult<()> {
+    let Some(harness) = ExternalDedupHarness::start(DISABLED_ADDRESS_ENV, "disabled").await? else {
+        eprintln!(
+            "{DISABLED_ADDRESS_ENV} is not set; skipping disabled Iggy deduplication evidence"
+        );
+        return Ok(());
+    };
+
+    let entry = poison_entry(&harness.stream, 10, vec![0x10, 0x20, 0x30])?;
+    harness.assert_message_count(0).await?;
+    harness.transport.move_to_dlq(entry.clone()).await?;
+    harness.assert_message_count(1).await?;
+    harness.transport.move_to_dlq(entry).await?;
+    harness.assert_message_count(2).await?;
+    harness.shutdown().await
+}
+
+#[tokio::test]
+async fn enabled_deduplication_suppresses_immediate_repeated_uuid() -> TestResult<()> {
+    let Some(harness) = ExternalDedupHarness::start(ENABLED_ADDRESS_ENV, "enabled").await? else {
+        eprintln!(
+            "{ENABLED_ADDRESS_ENV} is not set; skipping enabled Iggy deduplication evidence"
+        );
+        return Ok(());
+    };
+
+    let entry = poison_entry(&harness.stream, 20, vec![0x20, 0x30, 0x40])?;
+    harness.assert_message_count(0).await?;
+    harness.transport.move_to_dlq(entry.clone()).await?;
+    harness.assert_message_count(1).await?;
+    harness.transport.move_to_dlq(entry).await?;
+    harness.assert_message_count(1).await?;
+    harness.shutdown().await
+}
+
+#[tokio::test]
+async fn bounded_deduplication_capacity_eviction_accepts_old_uuid_again() -> TestResult<()> {
+    let Some(harness) = ExternalDedupHarness::start(CAPACITY_ADDRESS_ENV, "capacity").await? else {
+        eprintln!(
+            "{CAPACITY_ADDRESS_ENV} is not set; skipping capacity-eviction Iggy deduplication evidence"
+        );
+        return Ok(());
+    };
+
+    let first = poison_entry(&harness.stream, 30, vec![0x30, 0x40, 0x50])?;
+    let second = poison_entry(&harness.stream, 31, vec![0x31, 0x41, 0x51])?;
+    assert_ne!(first.broker_message_id(), second.broker_message_id());
+
+    harness.assert_message_count(0).await?;
+    harness.transport.move_to_dlq(first.clone()).await?;
+    harness.assert_message_count(1).await?;
+    harness.transport.move_to_dlq(first.clone()).await?;
+    harness.assert_message_count(1).await?;
+    harness.transport.move_to_dlq(second).await?;
+    harness.assert_message_count(2).await?;
+    harness.transport.move_to_dlq(first).await?;
+    harness.assert_message_count(3).await?;
+    harness.shutdown().await
+}
+
+#[tokio::test]
+async fn expired_deduplication_entry_accepts_same_uuid_after_bounded_wait() -> TestResult<()> {
+    let Some(harness) = ExternalDedupHarness::start(EXPIRY_ADDRESS_ENV, "expiry").await? else {
+        eprintln!(
+            "{EXPIRY_ADDRESS_ENV} is not set; skipping expiry Iggy deduplication evidence"
+        );
+        return Ok(());
+    };
+    let wait = expiry_wait()?;
+    let entry = poison_entry(&harness.stream, 40, vec![0x40, 0x50, 0x60])?;
+
+    harness.assert_message_count(0).await?;
+    harness.transport.move_to_dlq(entry.clone()).await?;
+    harness.assert_message_count(1).await?;
+    harness.transport.move_to_dlq(entry.clone()).await?;
+    harness.assert_message_count(1).await?;
+    tokio::time::sleep(wait).await;
+    harness.transport.move_to_dlq(entry).await?;
+    harness.assert_message_count(2).await?;
+    harness.shutdown().await
+}
+
+struct ExternalDedupHarness {
+    transport: IggyTransport,
+    client: IggyClient,
+    stream: String,
+    stream_id: Identifier,
+    topic_id: Identifier,
+}
+
+impl ExternalDedupHarness {
+    async fn start(address_env: &'static str, scope: &str) -> TestResult<Option<Self>> {
+        let Some(config) = external_test_config(address_env, scope)? else {
+            return Ok(None);
+        };
+        let stream = config.topology.stream_name.clone();
+        let stream_id: Identifier = stream.clone().try_into()?;
+        let topic_id: Identifier = "dlq".to_string().try_into()?;
+        let transport = IggyTransport::new(config.clone()).await?;
+        let client = connect_observer(&config).await?;
+        Ok(Some(Self {
+            transport,
+            client,
+            stream,
+            stream_id,
+            topic_id,
+        }))
+    }
+
+    async fn message_count(&self) -> TestResult<u64> {
+        let topic = self
+            .client
+            .get_topic(&self.stream_id, &self.topic_id)
+            .await?
+            .ok_or_else(|| invalid_data("external Iggy dedup evidence DLQ topic is missing"))?;
+        let partition = topic
+            .partitions
+            .iter()
+            .find(|partition| partition.id == 1)
+            .ok_or_else(|| invalid_data("external Iggy dedup evidence partition 1 is missing"))?;
+        Ok(partition.messages_count)
+    }
+
+    async fn assert_message_count(&self, expected: u64) -> TestResult<()> {
+        let observed = self.message_count().await?;
+        if observed != expected {
+            return Err(invalid_data(format!(
+                "external Iggy dedup evidence expected {expected} DLQ messages but observed {observed}"
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    async fn shutdown(self) -> TestResult<()> {
+        self.client.shutdown().await?;
+        self.transport.shutdown().await?;
+        Ok(())
+    }
+}
+
+fn poison_entry(stream: &str, offset: u64, payload: Vec<u8>) -> rustok_core::Result<DlqEntry> {
+    Ok(ConsumedContractDecodeFailure::new(
+        stream.to_string(),
+        "domain".to_string(),
+        SubscriberMessageMetadata::new(stream, "domain", 1)
+            .with_offset(offset)
+            .with_ack_token(format!("dedup-evidence-{offset}")),
+        payload,
+        ContractDecodeFailureKind::Deserialize,
+    )?
+    .to_dlq_entry(1))
+}
+
+fn external_test_config(
+    address_env: &'static str,
+    scope: &str,
+) -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(address_env) {
+        Ok(value) => bounded_env(address_env, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://") || address.contains('@') || address.contains('?') {
+        return Err(invalid_data(format!(
+            "{address_env} must be host:port without credentials or query parameters"
+        ))
+        .into());
+    }
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "Iggy dedup evidence username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name(scope),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+async fn connect_observer(config: &IggyConfig) -> TestResult<IggyClient> {
+    let connection_string = connection_string(&config.external)?;
+    let client = IggyClient::from_connection_string(&connection_string)?;
+    client.connect().await?;
+    Ok(client)
+}
+
+fn connection_string(config: &ExternalConfig) -> Result<String, IoError> {
+    let address = config
+        .addresses
+        .first()
+        .ok_or_else(|| invalid_data("external Iggy dedup evidence address is missing"))?;
+    if config.protocol != "tcp" {
+        return Err(invalid_data("Iggy dedup evidence requires TCP"));
+    }
+    if config.tls_enabled || config.tls_domain.is_some() || config.tls_ca_file.is_some() {
+        return Err(invalid_data("Iggy dedup evidence does not claim TLS coverage"));
+    }
+    validate_connection_component(address, "address", &['@', '?', '#'])?;
+    validate_connection_component(&config.username, "username", &[':', '@'])?;
+    validate_connection_component(&config.password, "password", &[':', '@'])?;
+
+    if config.username.is_empty() {
+        Ok(format!("iggy://{address}"))
+    } else {
+        Ok(format!(
+            "iggy://{}:{}@{address}",
+            config.username, config.password
+        ))
+    }
+}
+
+fn expiry_wait() -> TestResult<Duration> {
+    let value = env::var(EXPIRY_WAIT_ENV).map_err(|error| {
+        invalid_data(format!(
+            "{EXPIRY_WAIT_ENV} is required for expiry evidence: {error}"
+        ))
+    })?;
+    let millis = value.parse::<u64>().map_err(|error| {
+        invalid_data(format!("{EXPIRY_WAIT_ENV} is invalid: {error}"))
+    })?;
+    if !(MIN_EXPIRY_WAIT_MS..=MAX_EXPIRY_WAIT_MS).contains(&millis) {
+        return Err(invalid_data(format!(
+            "{EXPIRY_WAIT_ENV} must be between {MIN_EXPIRY_WAIT_MS} and {MAX_EXPIRY_WAIT_MS}"
+        ))
+        .into());
+    }
+    Ok(Duration::from_millis(millis))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_connection_component(
+    value: &str,
+    field: &'static str,
+    forbidden: &[char],
+) -> Result<(), IoError> {
+    if let Some(delimiter) = value
+        .chars()
+        .find(|character| forbidden.contains(character))
+    {
+        return Err(invalid_data(format!(
+            "Iggy {field} contains unsupported connection delimiter '{delimiter}'"
+        )));
+    }
+    Ok(())
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-poison-dedup-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -16,7 +16,7 @@ or unavailable rows as absent.
 never reads relation tables and never authorizes from an event, Index projection,
 decoded/raw DLQ receipt, neutral receipt aggregate, broker identifier, consumer
 offset, lag metric, poison health signal, PostgreSQL evidence packet, physical Iggy
-header observation, or any real-Iggy evidence harness.
+header observation, deduplication count observation, or any real-Iggy evidence harness.
 
 Media descriptors remain Media-owned. Profiles validates tenant, uploader, and MIME
 constraints and exposes only Media-selected descriptors. It does not know storage
@@ -137,7 +137,7 @@ External real-Iggy cursor evidence is source-complete and runtime-pending:
   offset;
 - an independent real DLQ cursor verifies both payloads byte-for-byte.
 
-A separate external physical-header harness is also source-complete and runtime-pending:
+External physical-header evidence is source-complete and runtime-pending:
 
 - one production `ConsumedContractDecodeFailure` creates one `DlqEntry`;
 - one production `IggyTransport::move_to_dlq` call publishes the entry;
@@ -146,13 +146,34 @@ A separate external physical-header harness is also source-complete and runtime-
 - physical `message.header.id` must equal the connector UUID as `u128`;
 - physical partition must equal `(uuid_as_u128 mod 3) + 1` and remain one-based;
 - physical payload must remain exact;
-- only the probe's physical header offset is committed.
+- only the probe's physical header offset is committed, then both probe and transport
+  shut down explicitly.
 
-The SDK probe cannot publish, acknowledge a source cursor, modify a receipt, delete a
-stream, or change deduplication. The lifecycle harness does not prove the physical
-header; the header harness does not prove source cursor lifecycle. Neither proves
-PostgreSQL ordering, deduplication, bundled mode, TLS/auth, multi-replica behavior, or
-physical exactly-once.
+External deduplication behavior evidence is now source-complete and runtime-pending.
+Four separately configured disposable brokers are required. Every scenario uses a
+unique one-partition stream, production `move_to_dlq`, and a count-only SDK
+`get_topic` observer:
+
+- disabled `A, A`: `0 -> 1 -> 2`;
+- enabled immediate `A, A`: `0 -> 1 -> 1`;
+- `max_entries = 1`, `A, A, B, A`: `0 -> 1 -> 1 -> 2 -> 3`;
+- expiry `A, A, wait, A`: `0 -> 1 -> 1 -> 2`.
+
+The capacity scenario proves immediate suppression before `B` and observed acceptance
+of `A` afterward. The expiry scenario proves immediate suppression before one bounded
+operator-configured wait. The observer can only read partition `messages_count` and
+shut down; it cannot publish, consume payloads, store offsets, modify configuration,
+delete streams, or mutate receipts.
+
+The test does not read back server configuration. Retained execution must include
+reviewed configuration digests for `enabled`, `max_entries`, and `expiry`, require all
+four named tests to execute rather than skip, and retain broker/toolchain/source/output
+metadata without credentials. The short behavior sequences do not prove that a chosen
+window covers the maximum production lease/restart/reconnect/recovery horizon.
+
+Cursor lifecycle, physical header, dedup behavior, PostgreSQL ordering, and production
+confirmation policy are separate evidence boundaries. None authorizes Profiles and none
+alone proves physical exactly-once.
 
 ## FFA/FBA boundary
 
@@ -193,18 +214,19 @@ physical exactly-once.
    Run the clean-commit capture runner, review the bounded packet, commit the canonical
    JSON, and repeat whenever a bound source hash changes.
 
-6. **Execute external cursor and header evidence.**
-   Run both harnesses on a disposable broker and retain separate packets for source
-   reconnect/redelivery and physical UUID/header/partition observation.
+6. **Execute external cursor, header, and dedup evidence.**
+   Run the three harnesses on reviewed disposable brokers and retain separate packets
+   for source reconnect/redelivery, physical UUID/header/partition, and the four dedup
+   count sequences plus reviewed configuration digests.
 
 7. **Compose receipt-plus-broker evidence.**
    Prove reserve/claim -> exact publish -> durable `published` -> source ack ->
    best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
    multi-replica claim ownership on PostgreSQL plus real Iggy.
 
-8. **Prove duplicate and confirmation behavior separately.**
-   Exercise publisher reconnect and the same deterministic UUID with deduplication
-   disabled, enabled, capacity-evicted, and expired. Choose an enforced dedup window or
+8. **Prove confirmation-window sufficiency.**
+   Compare dedup `max_entries`/`expiry` against maximum publication lease, restart,
+   reconnect, and operator recovery horizons. Choose an enforced monitored window or a
    stronger outbox/transaction mechanism before any stronger duplicate guarantee.
 
 9. **Retain production operations.**
@@ -226,14 +248,12 @@ physical exactly-once.
   health, and the operator runbook.
 - Added isolated PostgreSQL scenarios and clean-commit retained evidence tooling; the
   execution packet remains pending.
-- Added a versioned external-Iggy cursor contract, opt-in real cursor/DLQ harness,
-  no-ack transport reconnect/redelivery, exact-byte DLQ checks, explicit cursor
-  advancement, and a static verifier.
-- Added a separate physical-header contract and harness for one production publication,
-  exact UUID/u128 header mapping, one-based partition routing, exact payload, probe-only
-  SDK access, and probe offset commit.
-- Kept duplicate suppression, database ordering, bundled/TLS/auth, and multi-replica
-  claims explicitly open.
+- Added external-Iggy cursor reconnect/redelivery and exact-byte DLQ source evidence.
+- Added one-message physical UUID/u128 header and one-based partition source evidence.
+- Added four external dedup behavior scenarios for disabled, enabled, one-entry capacity
+  eviction, and expiry, with count-only observation and reviewed-config boundaries.
+- Kept server-config readback, retained external execution, production recovery-window
+  sufficiency, database ordering, bundled/TLS/auth, and multi-replica claims open.
 - Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy,
   and multi-replica scenarios were not run, per maintainer instruction.
 
@@ -248,9 +268,11 @@ physical exactly-once.
 - `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
 - `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_header -- --nocapture --test-threads=1`
+- `RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='host:8090' RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='host:8091' RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='host:8092' RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='host:8093' RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1`
 - `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
 - `node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs`
+- `node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs`
 - `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
 - `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
@@ -311,8 +333,10 @@ physical exactly-once.
     become stale when a bound source SHA-256 changes.
 18. Real-Iggy fixture injection may create malformed bytes, but production receive, DLQ,
     and acknowledgement must use reviewed transport APIs.
-19. Direct SDK probes may only observe explicitly scoped broker facts and commit their
-    own probe offsets; they must not publish, choose policy, or mutate receipts.
-20. Do not claim deduplication, database ordering, bundled, TLS/auth, multi-replica, or
-    exactly-once proof from one-message physical-header evidence.
-21. Update Profiles and affected owner docs with every boundary change.
+19. Direct SDK probes may only observe explicitly scoped broker facts and shut down;
+    they must not publish, choose policy, modify configuration, or mutate receipts.
+20. Dedup behavior tests require separately reviewed server configs and cannot present
+    operator claims as server readback.
+21. Do not claim production-window sufficiency or exactly-once from short disabled,
+    enabled, capacity, or expiry sequences.
+22. Update Profiles and affected owner docs with every boundary change.

--- a/scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const contract = JSON.parse(
+  readFileSync(
+    "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-source.json",
+    "utf8",
+  ),
+);
+const test = readFileSync(
+  "crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs",
+  "utf8",
+);
+const failures = [];
+
+const expectedScenarios = [
+  {
+    case: "disabled_deduplication_persists_repeated_uuid_twice",
+    address_env: "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS",
+    required_reviewed_server_config: {
+      "system.message_deduplication.enabled": false,
+    },
+    publication_sequence: ["A", "A"],
+    expected_partition_message_counts: [0, 1, 2],
+  },
+  {
+    case: "enabled_deduplication_suppresses_immediate_repeated_uuid",
+    address_env: "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS",
+    required_reviewed_server_config: {
+      "system.message_deduplication.enabled": true,
+      "system.message_deduplication.max_entries": "at_least_1",
+      "system.message_deduplication.expiry": "longer_than_scenario_horizon",
+    },
+    publication_sequence: ["A", "A"],
+    expected_partition_message_counts: [0, 1, 1],
+  },
+  {
+    case: "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+    address_env: "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS",
+    required_reviewed_server_config: {
+      "system.message_deduplication.enabled": true,
+      "system.message_deduplication.max_entries": 1,
+      "system.message_deduplication.expiry": "longer_than_scenario_horizon",
+    },
+    publication_sequence: ["A", "A", "B", "A"],
+    expected_partition_message_counts: [0, 1, 1, 2, 3],
+  },
+  {
+    case: "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+    address_env: "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS",
+    additional_env: "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS",
+    required_reviewed_server_config: {
+      "system.message_deduplication.enabled": true,
+      "system.message_deduplication.max_entries": "at_least_1",
+      "system.message_deduplication.expiry":
+        "shorter_than_RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS",
+    },
+    publication_sequence: ["A", "A", "wait", "A"],
+    expected_partition_message_counts: [0, 1, 1, 2],
+  },
+];
+const expectedProductionPaths = [
+  "ConsumedContractDecodeFailure::new",
+  "ConsumedContractDecodeFailure::to_dlq_entry",
+  "IggyTransport::new",
+  "IggyTransport::move_to_dlq",
+  "IggyTransport::shutdown",
+];
+const expectedObserverBoundary = {
+  purpose: "read_partition_message_count_only",
+  allowed_operations: [
+    "connect",
+    "get_dlq_topic",
+    "read_partition_1_messages_count",
+    "shutdown",
+  ],
+  forbidden_operations: [
+    "publish",
+    "consume_payload",
+    "store_offset",
+    "modify_server_configuration",
+    "delete_stream",
+    "mutate_production_receipt",
+  ],
+};
+const expectedForbiddenClaims = [
+  "server_configuration_read_back_by_test",
+  "physical_exactly_once_proved",
+  "receipt_and_broker_transaction_proved",
+  "deduplication_window_sufficient_for_production_recovery_proved",
+  "bundled_mode_proved",
+  "tls_or_auth_failure_proved",
+  "multi_replica_proved",
+];
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    failures.push(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) {
+    failures.push(`${name} contains forbidden marker: ${marker}`);
+  }
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function functionBody(source, functionName, nextFunctionName) {
+  const start = source.indexOf(`async fn ${functionName}(`);
+  const end = source.indexOf(`async fn ${nextFunctionName}(`, start + 1);
+  return start >= 0 && end > start ? source.slice(start, end) : "";
+}
+
+function requireOrdered(name, source, markers) {
+  let previous = -1;
+  for (const marker of markers) {
+    const position = source.indexOf(marker, previous + 1);
+    if (position < 0) {
+      failures.push(`${name} is missing ordered marker: ${marker}`);
+      return;
+    }
+    previous = position;
+  }
+}
+
+if (contract.schema_version !== 1) failures.push("dedup contract schema drift");
+if (contract.module !== "iggy") failures.push("dedup contract module drift");
+if (contract.packet !== "contract-poison-external-iggy-dedup-source") {
+  failures.push("dedup contract packet drift");
+}
+if (contract.status !== "source_complete_runtime_pending") {
+  failures.push("dedup contract must remain runtime pending");
+}
+if (contract.scope !== "external_real_iggy_message_id_deduplication_behavior") {
+  failures.push("dedup contract scope drift");
+}
+if (contract.test_target !== "contract_poison_external_iggy_dedup") {
+  failures.push("dedup test target drift");
+}
+if (
+  contract.source_path !==
+  "crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs"
+) {
+  failures.push("dedup source path drift");
+}
+if (
+  contract.verifier !==
+  "scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs"
+) {
+  failures.push("dedup verifier path drift");
+}
+if (
+  !sameValue(contract.shared_optional_environment, [
+    "RUSTOK_IGGY_DEDUP_TEST_USERNAME",
+    "RUSTOK_IGGY_DEDUP_TEST_PASSWORD",
+  ])
+) {
+  failures.push("dedup credential environment drift");
+}
+if (!sameValue(contract.scenarios, expectedScenarios)) {
+  failures.push("dedup scenario contract drift");
+}
+if (
+  !sameValue(contract.topology, {
+    mode: "external",
+    protocol: "tcp",
+    unique_stream_per_scenario: true,
+    domain_partitions: 1,
+    replication_factor: 1,
+    observed_topic: "dlq",
+    observed_partition: 1,
+    broker_requirement:
+      "four_separately_configured_disposable_or_operator_cleaned_external_iggy_instances",
+  })
+) {
+  failures.push("dedup topology drift");
+}
+if (!sameValue(contract.production_paths, expectedProductionPaths)) {
+  failures.push("dedup production path drift");
+}
+if (!sameValue(contract.observer_boundary, expectedObserverBoundary)) {
+  failures.push("dedup observer boundary drift");
+}
+if (!sameValue(contract.forbidden_claims, expectedForbiddenClaims)) {
+  failures.push("dedup forbidden claim drift");
+}
+if (contract.execution_status !== "not_run") {
+  failures.push("dedup contract must not claim execution");
+}
+
+for (const marker of [
+  '#![cfg(feature = "iggy")]',
+  "use iggy::prelude::{Client, Identifier, IggyClient, TopicClient};",
+  'const DISABLED_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS";',
+  'const ENABLED_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS";',
+  'const CAPACITY_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS";',
+  'const EXPIRY_ADDRESS_ENV: &str = "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS";',
+  'const USERNAME_ENV: &str = "RUSTOK_IGGY_DEDUP_TEST_USERNAME";',
+  'const PASSWORD_ENV: &str = "RUSTOK_IGGY_DEDUP_TEST_PASSWORD";',
+  'const EXPIRY_WAIT_ENV: &str = "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS";',
+  "const MIN_EXPIRY_WAIT_MS: u64 = 100;",
+  "const MAX_EXPIRY_WAIT_MS: u64 = 300_000;",
+  "IggyMode::External",
+  'protocol: "tcp".to_string()',
+  "domain_partitions: 1",
+  "replication_factor: 1",
+  "ConsumedContractDecodeFailure::new(",
+  ".to_dlq_entry(1)",
+  ".get_topic(&self.stream_id, &self.topic_id)",
+  "partition.id == 1",
+  "partition.messages_count",
+  "self.client.shutdown().await?;",
+  "self.transport.shutdown().await?;",
+  "tokio::time::sleep(wait).await;",
+  "(MIN_EXPIRY_WAIT_MS..=MAX_EXPIRY_WAIT_MS).contains(&millis)",
+]) {
+  requireText("external Iggy dedup test", test, marker);
+}
+
+const disabled = functionBody(
+  test,
+  "disabled_deduplication_persists_repeated_uuid_twice",
+  "enabled_deduplication_suppresses_immediate_repeated_uuid",
+);
+requireOrdered("disabled dedup scenario", disabled, [
+  "assert_message_count(0)",
+  "move_to_dlq(entry.clone())",
+  "assert_message_count(1)",
+  "move_to_dlq(entry)",
+  "assert_message_count(2)",
+]);
+
+const enabled = functionBody(
+  test,
+  "enabled_deduplication_suppresses_immediate_repeated_uuid",
+  "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+);
+requireOrdered("enabled dedup scenario", enabled, [
+  "assert_message_count(0)",
+  "move_to_dlq(entry.clone())",
+  "assert_message_count(1)",
+  "move_to_dlq(entry)",
+  "assert_message_count(1)",
+]);
+
+const capacity = functionBody(
+  test,
+  "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+  "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+);
+for (const marker of [
+  "assert_ne!(first.broker_message_id(), second.broker_message_id())",
+  "assert_message_count(0)",
+  "move_to_dlq(first.clone())",
+  "assert_message_count(1)",
+  "move_to_dlq(second)",
+  "assert_message_count(2)",
+  "move_to_dlq(first)",
+  "assert_message_count(3)",
+]) {
+  requireText("capacity eviction scenario", capacity, marker);
+}
+const capacityFirstPublishCount = [
+  ...capacity.matchAll(/move_to_dlq\(first\.clone\(\)\)/gu),
+].length;
+if (capacityFirstPublishCount !== 2) {
+  failures.push(
+    `capacity eviction scenario must immediately publish A twice before B; found ${capacityFirstPublishCount}`,
+  );
+}
+
+const expiryStart = test.indexOf(
+  "async fn expired_deduplication_entry_accepts_same_uuid_after_bounded_wait(",
+);
+const harnessStart = test.indexOf("struct ExternalDedupHarness", expiryStart);
+const expiry =
+  expiryStart >= 0 && harnessStart > expiryStart
+    ? test.slice(expiryStart, harnessStart)
+    : "";
+requireOrdered("expiry dedup scenario", expiry, [
+  "assert_message_count(0)",
+  "move_to_dlq(entry.clone())",
+  "assert_message_count(1)",
+  "move_to_dlq(entry.clone())",
+  "assert_message_count(1)",
+  "tokio::time::sleep(wait).await;",
+  "move_to_dlq(entry)",
+  "assert_message_count(2)",
+]);
+
+const moveToDlqCount = [...test.matchAll(/\.move_to_dlq\(/gu)].length;
+if (moveToDlqCount !== 11) {
+  failures.push(`dedup evidence must contain exactly 11 production publications; found ${moveToDlqCount}`);
+}
+const sleepCount = [...test.matchAll(/tokio::time::sleep\(/gu)].length;
+if (sleepCount !== 1) {
+  failures.push(`dedup evidence must contain one bounded expiry sleep; found ${sleepCount}`);
+}
+
+const observerStart = test.indexOf("async fn message_count(&self)");
+const assertCountStart = test.indexOf("async fn assert_message_count", observerStart);
+const observerBody =
+  observerStart >= 0 && assertCountStart > observerStart
+    ? test.slice(observerStart, assertCountStart)
+    : "";
+for (const marker of [
+  ".get_topic(&self.stream_id, &self.topic_id)",
+  "partition.id == 1",
+  "partition.messages_count",
+]) {
+  requireText("dedup read-only observer", observerBody, marker);
+}
+for (const forbidden of [
+  ".producer(",
+  ".send(",
+  ".consumer_group(",
+  ".store_offset(",
+  "IggyMessage",
+  "payload",
+  "move_to_dlq",
+]) {
+  forbidText("dedup read-only observer", observerBody, forbidden);
+}
+
+for (const forbidden of [
+  "127.0.0.1:8090",
+  'username: "iggy"',
+  'password: "iggy"',
+  "ExternalConnector",
+  "PublishRequest",
+  "IggyMessage::builder",
+  ".producer(",
+  ".send(",
+  ".consumer_group(",
+  ".store_offset(",
+  "ConsumerPoisonReceiptStore",
+  "mark_published",
+  "mark_acknowledged",
+  "delete_stream",
+  "DATABASE_URL",
+  "println!(connection_string",
+  "tracing::",
+]) {
+  forbidText("external Iggy dedup test", test, forbidden);
+}
+
+if (failures.length > 0) {
+  console.error("External Iggy dedup evidence verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "External Iggy dedup source evidence verified: disabled, immediate suppression, capacity eviction, expiry, production DLQ publication, read-only partition counts, reviewed external config boundaries, and bounded unexecuted claims are locked.",
+);


### PR DESCRIPTION
## Summary

Define four opt-in external-Iggy behavior scenarios for deterministic message-ID deduplication, while keeping server configuration review and runtime execution separate.

Each scenario creates one unique one-partition stream, publishes immutable raw-poison DLQ entries only through production `IggyTransport::move_to_dlq`, and observes only partition `messages_count` through a read-only SDK `get_topic` client.

Expected sequences:

- dedup disabled, `A, A`: `0 -> 1 -> 2`;
- dedup enabled, immediate `A, A`: `0 -> 1 -> 1`;
- enabled with `max_entries = 1`, `A, A, B, A`: `0 -> 1 -> 1 -> 2 -> 3`;
- enabled with short expiry, `A, A, wait, A`: `0 -> 1 -> 1 -> 2`.

The capacity scenario first proves immediate suppression, then introduces distinct `B`, then observes `A` accepted again. The expiry scenario first proves immediate suppression and uses one bounded operator-configured wait.

## Configuration and observation boundary

- four separately configured disposable or operator-cleaned external Iggy instances are required;
- address variables are scenario-specific; optional shared username/password must be provided together;
- the test never reads or modifies server configuration;
- a retained execution must pair each address with a reviewed configuration artifact for `enabled`, `max_entries`, and `expiry`;
- the SDK observer may only connect, read `dlq` partition `1` through `get_topic`, return `messages_count`, and shut down;
- the observer cannot publish, consume payloads, store offsets, delete streams, mutate receipts, or change deduplication;
- there are no default addresses or credentials.

## Non-claims

This source slice does not claim that configuration was read back from the server, physical exactly-once, a PostgreSQL/Iggy transaction, production recovery-window sufficiency, bundled mode, TLS/auth failure behavior, or multi-replica proof.

## Documentation and guardrails

- added a versioned machine-readable source contract with `execution_status: not_run`;
- added the external dedup behavior operator guide;
- added `verify-iggy-contract-poison-external-dedup-evidence.mjs` to lock all four cases, exact count sequences, exactly 11 production publications, one bounded expiry sleep, and the count-only observer boundary;
- updated Iggy and canonical Profiles live plans.

## Verification

Tests, Cargo commands, formatters, source verifiers, external/bundled Iggy scenarios, server configuration changes, PostgreSQL, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs

RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='disabled.example:8090' \
RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='enabled.example:8090' \
RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='capacity.example:8090' \
RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='expiry.example:8090' \
RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' \
  cargo test -p rustok-iggy --features iggy \
  --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1
```