### PR TITLE
test(profiles): retain external Iggy dedup evidence

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution-contract.json
+++ b/crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution-contract.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "contract-poison-external-iggy-dedup-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "runner": "scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs",
+  "verifier": "scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs",
+  "evidence_path": "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution.json",
+  "execution_scope": "four_external_iggy_dedup_modes_runtime_pending",
+  "promotion_gate": "requires_clean_commit_distinct_brokers_reviewed_configs_and_all_cases_passed",
+  "test_target": "contract_poison_external_iggy_dedup",
+  "shared_optional_environment": [
+    "RUSTOK_IGGY_DEDUP_TEST_USERNAME",
+    "RUSTOK_IGGY_DEDUP_TEST_PASSWORD"
+  ],
+  "scenarios": [
+    {
+      "case": "disabled_deduplication_persists_repeated_uuid_twice",
+      "address_env": "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS",
+      "config_path_env": "RUSTOK_IGGY_DEDUP_DISABLED_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_IGGY_DEDUP_DISABLED_SERVER_ARTIFACT",
+      "expected_configuration": {
+        "enabled": false,
+        "max_entries": "optional",
+        "expiry": "optional"
+      },
+      "expected_partition_message_counts": [
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "case": "enabled_deduplication_suppresses_immediate_repeated_uuid",
+      "address_env": "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS",
+      "config_path_env": "RUSTOK_IGGY_DEDUP_ENABLED_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_IGGY_DEDUP_ENABLED_SERVER_ARTIFACT",
+      "expected_configuration": {
+        "enabled": true,
+        "max_entries": "at_least_1",
+        "expiry": "positive_duration"
+      },
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1
+      ]
+    },
+    {
+      "case": "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+      "address_env": "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS",
+      "config_path_env": "RUSTOK_IGGY_DEDUP_CAPACITY_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_IGGY_DEDUP_CAPACITY_SERVER_ARTIFACT",
+      "expected_configuration": {
+        "enabled": true,
+        "max_entries": 1,
+        "expiry": "positive_duration"
+      },
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "case": "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+      "address_env": "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS",
+      "config_path_env": "RUSTOK_IGGY_DEDUP_EXPIRY_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_IGGY_DEDUP_EXPIRY_SERVER_ARTIFACT",
+      "additional_env": "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS",
+      "expected_configuration": {
+        "enabled": true,
+        "max_entries": "at_least_1",
+        "expiry": "positive_duration_shorter_than_wait"
+      },
+      "expected_partition_message_counts": [
+        0,
+        1,
+        1,
+        2
+      ]
+    }
+  ],
+  "command_template": {
+    "program": "cargo",
+    "args_before_case": [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--features",
+      "iggy",
+      "--test",
+      "contract_poison_external_iggy_dedup",
+      "--"
+    ],
+    "args_after_case": [
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
+  "reviewed_configuration": {
+    "section": "system.message_deduplication",
+    "persisted_fields": [
+      "enabled",
+      "max_entries",
+      "expiry",
+      "expiry_milliseconds",
+      "canonical_sha256"
+    ],
+    "full_config_path_persisted": false,
+    "full_config_sha256_persisted": false,
+    "full_config_content_persisted": false
+  },
+  "source_files": [
+    "crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs",
+    "crates/rustok-iggy/src/contract_decode_failure.rs",
+    "crates/rustok-iggy/src/dlq.rs",
+    "crates/rustok-iggy/src/dlq_publisher.rs",
+    "crates/rustok-iggy/src/partitioning.rs",
+    "crates/rustok-iggy/src/transport.rs"
+  ],
+  "required_metadata": [
+    "git_commit",
+    "started_at",
+    "completed_at",
+    "cargo_version",
+    "rustc_version",
+    "source_sha256",
+    "combined_test_output_sha256",
+    "server_artifact",
+    "reviewed_configuration",
+    "test_output_sha256",
+    "test_output_bytes"
+  ],
+  "privacy_boundary": {
+    "forbidden_persisted_values": [
+      "broker_address",
+      "config_path",
+      "username",
+      "password",
+      "connection_string",
+      "raw_test_output",
+      "delivery_uuid",
+      "payload",
+      "source_coordinates"
+    ]
+  },
+  "evidence_status": "runtime_execution_pending"
+}

--- a/crates/rustok-iggy/docs/contract-poison-external-dedup-evidence.md
+++ b/crates/rustok-iggy/docs/contract-poison-external-dedup-evidence.md
@@ -4,11 +4,11 @@
 
 `contract_poison_external_iggy_dedup.rs` defines four opt-in behavior scenarios for Iggy's server-side message-ID deduplication. The production publisher is always `IggyTransport::move_to_dlq` with a deterministic raw-poison `broker_message_id`. A separate SDK observer reads only partition `messages_count` from the unique stream's `dlq` topic.
 
-The test does not read or mutate Iggy server configuration. A retained execution must therefore pair each run with a reviewed server configuration artifact and must not infer configuration values from test code alone.
+The test does not read or mutate Iggy server configuration. A retained execution therefore pairs each run with an externally reviewed configuration file and a bounded server artifact/version label. The capture runner extracts only `[system.message_deduplication]`, validates the expected mode, canonicalizes its non-secret values, and stores a SHA-256 of that canonical section. It never persists the full configuration file, its path, or its full-file digest.
 
 ## Required disposable brokers
 
-Provide four separately configured external Iggy instances or four independently restarted disposable configurations.
+Provide four distinct external Iggy addresses backed by separately reviewed disposable configurations. The retained runner rejects duplicate addresses and duplicate config-file paths.
 
 ### Disabled
 
@@ -17,34 +17,40 @@ Provide four separately configured external Iggy instances or four independently
 enabled = false
 ```
 
-Address:
+Required inputs:
 
 ```text
 RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS=host:port
+RUSTOK_IGGY_DEDUP_DISABLED_CONFIG_PATH=/outside/repository/disabled.toml
+RUSTOK_IGGY_DEDUP_DISABLED_SERVER_ARTIFACT=iggy-server-0.10.0-or-reviewed-image-digest
 ```
 
-Publishing the same immutable entry `A` twice must produce partition counts:
+Publishing immutable entry `A` twice must produce partition counts:
 
 ```text
 0 -> 1 -> 2
 ```
+
+`max_entries` and `expiry` may be omitted in the disabled configuration. When present, they are parsed and retained in the canonical non-secret section.
 
 ### Enabled, entry retained
 
 ```toml
 [system.message_deduplication]
 enabled = true
-max_entries = <at least 1>
-expiry = <longer than the scenario>
+max_entries = 1000
+expiry = "10s"
 ```
 
-Address:
+Required inputs:
 
 ```text
 RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS=host:port
+RUSTOK_IGGY_DEDUP_ENABLED_CONFIG_PATH=/outside/repository/enabled.toml
+RUSTOK_IGGY_DEDUP_ENABLED_SERVER_ARTIFACT=iggy-server-0.10.0-or-reviewed-image-digest
 ```
 
-Publishing `A` twice immediately must produce:
+`max_entries` must be at least `1`; `expiry` must be a positive duration. Publishing `A` twice immediately must produce:
 
 ```text
 0 -> 1 -> 1
@@ -56,13 +62,15 @@ Publishing `A` twice immediately must produce:
 [system.message_deduplication]
 enabled = true
 max_entries = 1
-expiry = <longer than the scenario>
+expiry = "10s"
 ```
 
-Address:
+Required inputs:
 
 ```text
 RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS=host:port
+RUSTOK_IGGY_DEDUP_CAPACITY_CONFIG_PATH=/outside/repository/capacity.toml
+RUSTOK_IGGY_DEDUP_CAPACITY_SERVER_ARTIFACT=iggy-server-0.10.0-or-reviewed-image-digest
 ```
 
 The scenario publishes `A`, repeats `A`, publishes distinct `B`, then publishes `A` again:
@@ -71,25 +79,27 @@ The scenario publishes `A`, repeats `A`, publishes distinct `B`, then publishes 
 0 -> 1 -> 1 -> 2 -> 3
 ```
 
-The immediate repeated `A` proves suppression is active before `B` is introduced. Acceptance of `A` after `B` is the capacity-eviction behavior expected from a one-entry per-partition cache.
+The immediate repeated `A` establishes suppression before `B` is introduced. Acceptance of `A` after `B` is the observed capacity-eviction behavior for the reviewed one-entry per-partition configuration.
 
 ### Expiry
 
 ```toml
 [system.message_deduplication]
 enabled = true
-max_entries = <at least 1>
-expiry = <shorter than the configured test wait>
+max_entries = 1000
+expiry = "1s"
 ```
 
-Address and bounded wait:
+Required inputs:
 
 ```text
 RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS=host:port
+RUSTOK_IGGY_DEDUP_EXPIRY_CONFIG_PATH=/outside/repository/expiry.toml
+RUSTOK_IGGY_DEDUP_EXPIRY_SERVER_ARTIFACT=iggy-server-0.10.0-or-reviewed-image-digest
 RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS=<100..300000>
 ```
 
-The scenario publishes `A`, repeats `A` immediately, waits, then publishes `A` again:
+The runner supports positive TOML duration strings with units `ms`, `s`, `m`, `h`, or `d` and requires the reviewed expiry to be strictly shorter than the configured wait. The scenario publishes `A`, repeats it immediately, waits, then publishes `A` again:
 
 ```text
 0 -> 1 -> 1 -> 2
@@ -112,10 +122,38 @@ Every scenario uses:
 - one unique stream;
 - one `domain` partition and one matching `dlq` partition;
 - replication factor `1`;
-- exact deterministic UUIDs derived through `ConsumedContractDecodeFailure::to_dlq_entry`;
+- deterministic UUIDs derived through `ConsumedContractDecodeFailure::to_dlq_entry`;
 - explicit observer and production transport shutdown.
 
-There are no default addresses or credentials. Use disposable brokers or an operator-approved cleanup process; the tests do not delete streams.
+There are no default addresses or credentials. Use disposable brokers or an operator-approved cleanup process; neither the test nor the retained runner deletes streams.
+
+## Reviewed configuration boundary
+
+Each `*_CONFIG_PATH` must point to an existing file outside the repository. The runner locates exactly one `[system.message_deduplication]` section, parses `enabled`, `max_entries`, and `expiry`, and rejects duplicate keys or a mismatched scenario configuration.
+
+Only this canonical object is retained:
+
+```json
+{
+  "section": "system.message_deduplication",
+  "enabled": true,
+  "max_entries": 1,
+  "expiry": "10s",
+  "expiry_milliseconds": 10000,
+  "canonical_sha256": "..."
+}
+```
+
+The packet does not contain:
+
+- broker addresses;
+- configuration paths;
+- full configuration contents or full-file digests;
+- usernames, passwords, or connection strings;
+- raw test output;
+- delivery UUIDs, payloads, or source coordinates.
+
+The `server_artifact` value is an operator-reviewed bounded version/image identifier supplied through the scenario-specific `*_SERVER_ARTIFACT` environment variable. It is not server readback.
 
 ## Observation boundary
 
@@ -130,11 +168,45 @@ It does not consume payloads, publish, store offsets, modify configuration, dele
 
 The test reads counts immediately after each successful production publish. It does not use an absence timeout to decide whether a duplicate was suppressed. The single sleep is bounded and belongs only to the expiry scenario.
 
+## Retained execution
+
+`contract-poison-external-iggy-dedup-execution-contract.json` locks:
+
+- the four required scenario/address/config/artifact environment sets;
+- exact per-case Cargo command construction using a libtest `--exact` filter;
+- expected count sequences;
+- reviewed configuration fields and privacy boundary;
+- production source files whose SHA-256 values bind the packet;
+- the canonical evidence path.
+
+`capture-iggy-contract-poison-external-dedup.mjs` requires:
+
+1. a clean Git working tree and full commit SHA;
+2. all four distinct addresses;
+3. all four distinct external config files;
+4. all four bounded server artifact labels;
+5. valid optional credential pairing;
+6. a bounded expiry wait longer than the reviewed expiry;
+7. one exact named test per Cargo invocation;
+8. `running 1 test` and `<case> ... ok` for each invocation;
+9. no skip output;
+10. unchanged commit, source hashes, and clean working tree after all commands.
+
+Only after all checks pass does it atomically write:
+
+```text
+crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution.json
+```
+
+The packet contains bounded toolchain/timestamp metadata, source hashes, canonical reviewed configuration digests, server artifact labels, exact command arrays, expected count sequences, and per-case/combined output hashes and byte counts.
+
+`verify-iggy-contract-poison-external-dedup-retained-evidence.mjs` verifies the source contract while the packet is absent. Once a packet exists, it additionally requires current source hashes, exact fields and commands, valid canonical configuration digests, four all-pass cases, bounded metadata, and no forbidden persisted fields.
+
 ## Non-claims
 
 Even after successful execution, these scenarios do not prove:
 
-- that the test read back the active server configuration;
+- that the active server configuration was read back through Iggy;
 - physical exactly-once publication;
 - a transaction between PostgreSQL receipt state and Iggy publication;
 - that the selected `max_entries`/`expiry` window covers the maximum production lease, restart, reconnect, and recovery horizon;
@@ -143,28 +215,40 @@ Even after successful execution, these scenarios do not prove:
 - multi-replica behavior;
 - Profiles privacy or authorization.
 
-Production confirmation policy still requires reviewed retained configuration and recovery-window evidence, or a stronger database-owned outbox/broker transaction design.
+Production confirmation policy still requires reviewed recovery-window evidence, or a stronger database-owned outbox/broker transaction design.
 
-## Maintainer command
+## Maintainer commands
 
-Provide all four addresses to run the complete target:
+Source-only checks:
+
+```bash
+node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
+node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
+```
+
+Create the retained packet from a clean commit:
 
 ```bash
 RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='disabled.example:8090' \
+RUSTOK_IGGY_DEDUP_DISABLED_CONFIG_PATH='/secure/reviewed/disabled.toml' \
+RUSTOK_IGGY_DEDUP_DISABLED_SERVER_ARTIFACT='iggy-server-0.10.0' \
 RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='enabled.example:8090' \
+RUSTOK_IGGY_DEDUP_ENABLED_CONFIG_PATH='/secure/reviewed/enabled.toml' \
+RUSTOK_IGGY_DEDUP_ENABLED_SERVER_ARTIFACT='iggy-server-0.10.0' \
 RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='capacity.example:8090' \
+RUSTOK_IGGY_DEDUP_CAPACITY_CONFIG_PATH='/secure/reviewed/capacity.toml' \
+RUSTOK_IGGY_DEDUP_CAPACITY_SERVER_ARTIFACT='iggy-server-0.10.0' \
 RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='expiry.example:8090' \
+RUSTOK_IGGY_DEDUP_EXPIRY_CONFIG_PATH='/secure/reviewed/expiry.toml' \
+RUSTOK_IGGY_DEDUP_EXPIRY_SERVER_ARTIFACT='iggy-server-0.10.0' \
 RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' \
-RUSTOK_IGGY_DEDUP_TEST_USERNAME='...' \
-RUSTOK_IGGY_DEDUP_TEST_PASSWORD='...' \
-  cargo test -p rustok-iggy --features iggy \
-  --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1
+  node scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs
 
-node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
+node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
 ```
 
-A future retained runner must reject missing scenario addresses, record reviewed configuration digests without credentials, require all four named tests to execute rather than skip, and retain source/output hashes.
+Optional shared username/password may be added to the runner environment as a pair.
 
 ## Evidence status
 
-The four behavior scenarios, versioned source contract, read-only observer boundary, and static verifier are source-complete. `execution_status` remains `not_run`. No Cargo command, verifier, external Iggy scenario, server restart, or configuration change was performed while authoring this slice.
+The four behavior scenarios, versioned source and execution contracts, reviewed-config parser, clean-commit runner, read-only observer boundary, and static/persistent verifiers are source-complete. The canonical execution JSON is intentionally absent until a maintainer completes all four external-Iggy runs. No Cargo command, verifier, external Iggy scenario, server restart, or configuration change was performed while authoring this slice.

--- a/crates/rustok-profiles/docs/poison-dedup-retained-evidence-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-dedup-retained-evidence-checkpoint.md
@@ -1,0 +1,63 @@
+# Profiles checkpoint: retained external-Iggy dedup evidence
+
+## Status
+
+The external-Iggy dedup behavior source scenarios are already defined for four separately reviewed broker modes:
+
+- disabled: repeated immutable `A` produces `0 -> 1 -> 2`;
+- enabled: immediate repeated `A` produces `0 -> 1 -> 1`;
+- one-entry capacity: `A, A, B, A` produces `0 -> 1 -> 1 -> 2 -> 3`;
+- expiry: `A, A, bounded wait, A` produces `0 -> 1 -> 1 -> 2`.
+
+This checkpoint adds the retained-execution layer. The following are source-complete:
+
+- versioned execution contract;
+- four exact per-case Cargo commands;
+- required distinct broker addresses and reviewed external configuration files;
+- parser for `[system.message_deduplication]` with scenario-specific validation;
+- canonical non-secret configuration SHA-256;
+- clean-commit, unchanged-source, and post-run clean-tree gates;
+- skip/zero-test rejection;
+- atomic evidence packet writing;
+- strict verifier with pending and executed modes.
+
+The canonical execution JSON is intentionally absent. External-Iggy runtime execution remains maintainer work.
+
+## Privacy and ownership boundary
+
+Profiles never authorizes presentation from:
+
+- Iggy deduplication configuration or observed message counts;
+- broker addresses or server artifact labels;
+- deterministic delivery UUIDs;
+- DLQ state or receipt state;
+- retained execution packets or their digests.
+
+`followers_only` remains resolved exclusively through authoritative Social Graph owner ports. Index, broker, receipt, metric, and evidence state never authorize visibility.
+
+The retained packet omits broker addresses, configuration paths, full config contents and full-file hashes, credentials, connection strings, raw test logs, delivery UUIDs, payloads, and source coordinates. It stores only bounded environment-variable names, reviewed server artifact labels, canonical non-secret dedup settings/digests, source/output hashes, exact command arrays, timestamps, toolchain versions, and aggregate per-case pass results.
+
+## Remaining evidence
+
+This checkpoint does not prove:
+
+- server configuration readback through Iggy;
+- that the reviewed dedup window covers maximum publication lease, process restart, reconnect, or operator recovery horizons;
+- a PostgreSQL receipt/Iggy publication transaction;
+- physical exactly-once publication;
+- bundled mode, TLS/authentication/failover, or multi-replica behavior.
+
+Next evidence must execute the clean-commit runner against four reviewed disposable brokers, review and commit the generated packet, then compare `max_entries` and `expiry` with the maximum production recovery horizon. If that horizon cannot be guaranteed and monitored, production requires a stronger database-owned outbox or broker-transaction design before claiming stronger duplicate suppression.
+
+## Maintainer commands
+
+```bash
+node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
+node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
+
+# After supplying all required address/config/artifact environment variables:
+node scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs
+node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
+```
+
+Tests, Cargo commands, source verifiers, external Iggy scenarios, and server configuration changes were not executed while authoring this checkpoint.

--- a/scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs
+++ b/scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs
@@ -1,0 +1,564 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution-contract.json";
+const expectedRunnerPath =
+  "scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs";
+const expectedVerifierPath =
+  "scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs";
+const expectedEvidencePath =
+  "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution.json";
+const expectedCaseNames = [
+  "disabled_deduplication_persists_repeated_uuid_twice",
+  "enabled_deduplication_suppresses_immediate_repeated_uuid",
+  "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+  "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "contract_poison_external_iggy_dedup",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+const expiryWaitEnv = "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS";
+const minimumExpiryWaitMs = 100;
+const maximumExpiryWaitMs = 300_000;
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) {
+    fail(`${program} could not start: ${result.error.message}`);
+  }
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function oneLine(value, field, maximumLength = 256) {
+  const line = value.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (
+    !line ||
+    line.length > maximumLength ||
+    /[\u0000-\u001f\u007f]/u.test(line)
+  ) {
+    fail(`${field} is missing or outside the retained evidence boundary`);
+  }
+  return line;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function sameRecord(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function requirePassedCase(output, caseName) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail(`dedup scenario did not execute exactly one test: ${caseName}`);
+  }
+  const pattern = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(caseName)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!pattern.test(output)) {
+    fail(`required external Iggy dedup case did not report success: ${caseName}`);
+  }
+  if (/skipping .*Iggy deduplication evidence/iu.test(output)) {
+    fail(`dedup scenario reported a skip instead of execution: ${caseName}`);
+  }
+}
+
+function ensureOutputInsideRepository() {
+  const root = resolve(repoRoot) + sep;
+  if (!outputPath.startsWith(root)) {
+    fail("retained dedup evidence output path must stay inside the repository");
+  }
+}
+
+function validateContractBoundary() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "iggy" ||
+    contract.packet !== "contract-poison-external-iggy-dedup-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked"
+  ) {
+    fail("retained dedup execution contract identity drift");
+  }
+  if (
+    contract.runner !== expectedRunnerPath ||
+    contract.verifier !== expectedVerifierPath ||
+    contract.evidence_path !== expectedEvidencePath ||
+    contract.evidence_status !== "runtime_execution_pending"
+  ) {
+    fail("retained dedup tooling or output boundary drift");
+  }
+  if (!sameRecord(contract.command_template, expectedCommandTemplate)) {
+    fail("retained dedup Cargo command allowlist drift");
+  }
+  const caseNames = contract.scenarios?.map((scenario) => scenario.case);
+  if (!sameRecord(caseNames, expectedCaseNames)) {
+    fail("retained dedup case allowlist drift");
+  }
+}
+
+function validateAddress(value, field) {
+  const address = oneLine(value, field, 255);
+  if (
+    address.includes("://") ||
+    address.includes("@") ||
+    address.includes("?") ||
+    address.includes("#")
+  ) {
+    fail(`${field} must be host:port without scheme, credentials, query, or fragment`);
+  }
+  if (!/^\[[0-9a-f:]+\]:\d+$|^[A-Za-z0-9._-]+:\d+$/u.test(address)) {
+    fail(`${field} must be a bounded host:port address`);
+  }
+  return address;
+}
+
+function validateCredentialsPair() {
+  const [usernameEnv, passwordEnv] = contract.shared_optional_environment;
+  const username = process.env[usernameEnv] ?? "";
+  const password = process.env[passwordEnv] ?? "";
+  if (username.trim() !== username || password.trim() !== password) {
+    fail("dedup evidence credentials must not have surrounding whitespace");
+  }
+  if (username.length > 191 || password.length > 191) {
+    fail("dedup evidence credentials exceed the test boundary");
+  }
+  if (username.includes(":") || username.includes("@")) {
+    fail("dedup evidence username contains an unsupported connection delimiter");
+  }
+  if (password.includes(":") || password.includes("@")) {
+    fail("dedup evidence password contains an unsupported connection delimiter");
+  }
+  if (username.length === 0 !== (password.length === 0)) {
+    fail("dedup evidence username and password must both be set or both be empty");
+  }
+}
+
+function absoluteExternalConfigPath(value, field) {
+  const pathValue = oneLine(value, field, 4096);
+  const absolutePath = resolve(pathValue);
+  const repositoryPrefix = resolve(repoRoot) + sep;
+  if (absolutePath === resolve(repoRoot) || absolutePath.startsWith(repositoryPrefix)) {
+    fail(`${field} must point outside the repository`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${field} must point to an existing external configuration file`);
+  }
+  return absolutePath;
+}
+
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote !== null && character === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && (character === '"' || character === "'")) {
+      quote = character;
+      continue;
+    }
+    if (quote === null && character === "#") {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}
+
+function parseTomlString(value, field) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(value);
+      return oneLine(parsed, field, 128);
+    } catch {
+      fail(`${field} contains an invalid quoted TOML string`);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return oneLine(value.slice(1, -1), field, 128);
+  }
+  return oneLine(value, field, 128);
+}
+
+function durationMilliseconds(value, field) {
+  const match = /^(\d+)(ms|s|m|h|d)$/u.exec(value);
+  if (!match) {
+    fail(`${field} must be a positive duration such as 500ms, 10s, 5m, 1h, or 1d`);
+  }
+  const amount = Number(match[1]);
+  const multipliers = {
+    ms: 1,
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  const milliseconds = amount * multipliers[match[2]];
+  if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
+    fail(`${field} is outside the retained evidence duration boundary`);
+  }
+  return milliseconds;
+}
+
+function parseDedupConfiguration(absolutePath, field) {
+  const text = readFileSync(absolutePath, "utf8");
+  const lines = text.split(/\r?\n/u);
+  let inSection = false;
+  let sectionFound = false;
+  const values = new Map();
+
+  for (const rawLine of lines) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      if (inSection) break;
+      inSection = section[1].trim() === "system.message_deduplication";
+      sectionFound ||= inSection;
+      continue;
+    }
+    if (!inSection) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) {
+      fail(`${field} contains an invalid message_deduplication assignment`);
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!["enabled", "max_entries", "expiry"].includes(key)) continue;
+    if (values.has(key)) {
+      fail(`${field} contains duplicate message_deduplication key: ${key}`);
+    }
+    values.set(key, value);
+  }
+
+  if (!sectionFound) {
+    fail(`${field} is missing [system.message_deduplication]`);
+  }
+  const enabledRaw = values.get("enabled");
+  if (enabledRaw !== "true" && enabledRaw !== "false") {
+    fail(`${field} must set message_deduplication.enabled to true or false`);
+  }
+  const enabled = enabledRaw === "true";
+
+  let maxEntries = null;
+  if (values.has("max_entries")) {
+    const raw = values.get("max_entries");
+    if (!/^\d+$/u.test(raw)) {
+      fail(`${field} message_deduplication.max_entries must be an integer`);
+    }
+    maxEntries = Number(raw);
+    if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+      fail(`${field} message_deduplication.max_entries must be positive`);
+    }
+  }
+
+  let expiry = null;
+  let expiryMs = null;
+  if (values.has("expiry")) {
+    expiry = parseTomlString(values.get("expiry"), `${field} expiry`);
+    expiryMs = durationMilliseconds(expiry, `${field} expiry`);
+  }
+
+  return {
+    section: "system.message_deduplication",
+    enabled,
+    max_entries: maxEntries,
+    expiry,
+    expiry_milliseconds: expiryMs,
+  };
+}
+
+function expiryWaitMilliseconds() {
+  const value = oneLine(process.env[expiryWaitEnv] ?? "", expiryWaitEnv, 16);
+  if (!/^\d+$/u.test(value)) {
+    fail(`${expiryWaitEnv} must be an integer`);
+  }
+  const milliseconds = Number(value);
+  if (
+    !Number.isSafeInteger(milliseconds) ||
+    milliseconds < minimumExpiryWaitMs ||
+    milliseconds > maximumExpiryWaitMs
+  ) {
+    fail(
+      `${expiryWaitEnv} must be between ${minimumExpiryWaitMs} and ${maximumExpiryWaitMs}`,
+    );
+  }
+  return milliseconds;
+}
+
+function validateExpectedConfiguration(scenario, configuration, waitMs) {
+  const expected = scenario.expected_configuration;
+  if (configuration.enabled !== expected.enabled) {
+    fail(`${scenario.case} reviewed configuration has unexpected enabled value`);
+  }
+  if (expected.max_entries === "at_least_1") {
+    if (configuration.max_entries === null || configuration.max_entries < 1) {
+      fail(`${scenario.case} reviewed configuration requires max_entries >= 1`);
+    }
+  } else if (Number.isInteger(expected.max_entries)) {
+    if (configuration.max_entries !== expected.max_entries) {
+      fail(`${scenario.case} reviewed configuration requires max_entries=${expected.max_entries}`);
+    }
+  }
+  if (expected.expiry === "positive_duration") {
+    if (configuration.expiry_milliseconds === null) {
+      fail(`${scenario.case} reviewed configuration requires a positive expiry`);
+    }
+  }
+  if (expected.expiry === "positive_duration_shorter_than_wait") {
+    if (
+      configuration.expiry_milliseconds === null ||
+      configuration.expiry_milliseconds >= waitMs
+    ) {
+      fail(`${scenario.case} reviewed expiry must be shorter than ${expiryWaitEnv}`);
+    }
+  }
+
+  const canonical = {
+    section: configuration.section,
+    enabled: configuration.enabled,
+    max_entries: configuration.max_entries,
+    expiry: configuration.expiry,
+    expiry_milliseconds: configuration.expiry_milliseconds,
+  };
+  return {
+    ...canonical,
+    canonical_sha256: sha256(JSON.stringify(canonical)),
+  };
+}
+
+function scenarioCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"])
+    .stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree must be clean before retained dedup execution");
+  }
+  const commit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "git_commit",
+  );
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("git commit must be a full lowercase SHA-1");
+  }
+  return commit;
+}
+
+function ensureCleanAfterExecution() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during retained dedup execution");
+  }
+}
+
+function writeAtomically(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+try {
+  ensureOutputInsideRepository();
+  validateContractBoundary();
+  validateCredentialsPair();
+  const waitMs = expiryWaitMilliseconds();
+
+  const addresses = new Set();
+  const configPaths = new Set();
+  const reviewedScenarios = contract.scenarios.map((scenario) => {
+    const address = validateAddress(
+      process.env[scenario.address_env] ?? "",
+      scenario.address_env,
+    );
+    if (addresses.has(address)) {
+      fail("retained dedup execution requires four distinct broker addresses");
+    }
+    addresses.add(address);
+
+    const configPath = absoluteExternalConfigPath(
+      process.env[scenario.config_path_env] ?? "",
+      scenario.config_path_env,
+    );
+    if (configPaths.has(configPath)) {
+      fail("retained dedup execution requires four distinct reviewed config files");
+    }
+    configPaths.add(configPath);
+
+    const serverArtifact = oneLine(
+      process.env[scenario.server_artifact_env] ?? "",
+      scenario.server_artifact_env,
+      256,
+    );
+    const configuration = validateExpectedConfiguration(
+      scenario,
+      parseDedupConfiguration(configPath, scenario.config_path_env),
+      waitMs,
+    );
+    return {
+      scenario,
+      serverArtifact,
+      configuration,
+    };
+  });
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const startedAt = new Date().toISOString();
+  const executedScenarios = [];
+  const combinedOutputs = [];
+
+  for (const reviewed of reviewedScenarios) {
+    const command = scenarioCommand(reviewed.scenario.case);
+    const result = runChecked(command.program, command.args);
+    const output = `${result.stdout}\n${result.stderr}`;
+    requirePassedCase(output, reviewed.scenario.case);
+    combinedOutputs.push(`--- ${reviewed.scenario.case} ---\n${output}`);
+    executedScenarios.push({
+      case: reviewed.scenario.case,
+      result: "pass",
+      address_source_env: reviewed.scenario.address_env,
+      configuration_source_env: reviewed.scenario.config_path_env,
+      server_artifact_source_env: reviewed.scenario.server_artifact_env,
+      server_artifact: reviewed.serverArtifact,
+      reviewed_configuration: reviewed.configuration,
+      expected_partition_message_counts:
+        reviewed.scenario.expected_partition_message_counts,
+      command,
+      test_output_sha256: sha256(output),
+      test_output_bytes: Buffer.byteLength(output),
+    });
+  }
+
+  const finalCommit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+  );
+  if (finalCommit !== gitCommit) {
+    fail("git commit changed during retained dedup execution");
+  }
+  const finalSourceSha256 = sourceHashes();
+  if (!sameRecord(finalSourceSha256, initialSourceSha256)) {
+    fail("retained dedup source files changed during execution");
+  }
+  ensureCleanAfterExecution();
+  const completedAt = new Date().toISOString();
+  const combinedOutput = combinedOutputs.join("\n");
+
+  writeAtomically({
+    schema_version: 1,
+    module: contract.module,
+    packet: "contract-poison-external-iggy-dedup-runtime-evidence",
+    status: "external_iggy_dedup_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    expiry_wait_milliseconds: waitMs,
+    source_sha256: finalSourceSha256,
+    combined_test_output_sha256: sha256(combinedOutput),
+    combined_test_output_bytes: Buffer.byteLength(combinedOutput),
+    executed_scenarios: executedScenarios,
+  });
+  console.log(`Retained external Iggy dedup evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`External Iggy dedup evidence capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
+++ b/scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution-contract.json";
+const runnerPath =
+  "scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs";
+const verifierPath =
+  "scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-execution.json";
+const sourceContractPath =
+  "crates/rustok-iggy/contracts/evidence/contract-poison-external-iggy-dedup-source.json";
+const testPath =
+  "crates/rustok-iggy/tests/contract_poison_external_iggy_dedup.rs";
+
+const contract = readJson(contractPath);
+const sourceContract = readJson(sourceContractPath);
+const runner = readText(runnerPath);
+const test = readText(testPath);
+
+const expectedScenarios = [
+  {
+    case: "disabled_deduplication_persists_repeated_uuid_twice",
+    address_env: "RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS",
+    config_path_env: "RUSTOK_IGGY_DEDUP_DISABLED_CONFIG_PATH",
+    server_artifact_env: "RUSTOK_IGGY_DEDUP_DISABLED_SERVER_ARTIFACT",
+    expected_configuration: {
+      enabled: false,
+      max_entries: "optional",
+      expiry: "optional",
+    },
+    expected_partition_message_counts: [0, 1, 2],
+  },
+  {
+    case: "enabled_deduplication_suppresses_immediate_repeated_uuid",
+    address_env: "RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS",
+    config_path_env: "RUSTOK_IGGY_DEDUP_ENABLED_CONFIG_PATH",
+    server_artifact_env: "RUSTOK_IGGY_DEDUP_ENABLED_SERVER_ARTIFACT",
+    expected_configuration: {
+      enabled: true,
+      max_entries: "at_least_1",
+      expiry: "positive_duration",
+    },
+    expected_partition_message_counts: [0, 1, 1],
+  },
+  {
+    case: "bounded_deduplication_capacity_eviction_accepts_old_uuid_again",
+    address_env: "RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS",
+    config_path_env: "RUSTOK_IGGY_DEDUP_CAPACITY_CONFIG_PATH",
+    server_artifact_env: "RUSTOK_IGGY_DEDUP_CAPACITY_SERVER_ARTIFACT",
+    expected_configuration: {
+      enabled: true,
+      max_entries: 1,
+      expiry: "positive_duration",
+    },
+    expected_partition_message_counts: [0, 1, 1, 2, 3],
+  },
+  {
+    case: "expired_deduplication_entry_accepts_same_uuid_after_bounded_wait",
+    address_env: "RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS",
+    config_path_env: "RUSTOK_IGGY_DEDUP_EXPIRY_CONFIG_PATH",
+    server_artifact_env: "RUSTOK_IGGY_DEDUP_EXPIRY_SERVER_ARTIFACT",
+    additional_env: "RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS",
+    expected_configuration: {
+      enabled: true,
+      max_entries: "at_least_1",
+      expiry: "positive_duration_shorter_than_wait",
+    },
+    expected_partition_message_counts: [0, 1, 1, 2],
+  },
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "contract_poison_external_iggy_dedup",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+const expectedSourceFiles = [
+  testPath,
+  "crates/rustok-iggy/src/contract_decode_failure.rs",
+  "crates/rustok-iggy/src/dlq.rs",
+  "crates/rustok-iggy/src/dlq_publisher.rs",
+  "crates/rustok-iggy/src/partitioning.rs",
+  "crates/rustok-iggy/src/transport.rs",
+];
+const expectedMetadata = [
+  "git_commit",
+  "started_at",
+  "completed_at",
+  "cargo_version",
+  "rustc_version",
+  "source_sha256",
+  "combined_test_output_sha256",
+  "server_artifact",
+  "reviewed_configuration",
+  "test_output_sha256",
+  "test_output_bytes",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readText(relativePath) {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function sameSet(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    expected.every((value) => actual.includes(value))
+  );
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    fail(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) {
+    fail(`${name} contains forbidden marker: ${marker}`);
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sha256File(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function requireExactKeys(name, value, expectedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  if (!sameSet(Object.keys(value), expectedKeys)) {
+    fail(`${name} contains missing or unexpected fields`);
+  }
+}
+
+function requireIsoTimestamp(name, value) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${name} must be an ISO-8601 timestamp`);
+  }
+}
+
+function scenarioCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function validateConfiguration(name, configuration, expected, waitMs) {
+  requireExactKeys(name, configuration, [
+    "section",
+    "enabled",
+    "max_entries",
+    "expiry",
+    "expiry_milliseconds",
+    "canonical_sha256",
+  ]);
+  if (configuration.section !== "system.message_deduplication") {
+    fail(`${name} section drift`);
+  }
+  if (configuration.enabled !== expected.enabled) {
+    fail(`${name} enabled value drift`);
+  }
+  if (
+    configuration.max_entries !== null &&
+    (!Number.isSafeInteger(configuration.max_entries) || configuration.max_entries <= 0)
+  ) {
+    fail(`${name} max_entries is invalid`);
+  }
+  if (expected.max_entries === "at_least_1") {
+    if (configuration.max_entries === null || configuration.max_entries < 1) {
+      fail(`${name} requires max_entries >= 1`);
+    }
+  } else if (Number.isInteger(expected.max_entries)) {
+    if (configuration.max_entries !== expected.max_entries) {
+      fail(`${name} max_entries drift`);
+    }
+  }
+  if (configuration.expiry === null) {
+    if (configuration.expiry_milliseconds !== null) {
+      fail(`${name} has expiry milliseconds without expiry text`);
+    }
+  } else {
+    if (
+      typeof configuration.expiry !== "string" ||
+      !configuration.expiry ||
+      configuration.expiry.length > 128 ||
+      !Number.isSafeInteger(configuration.expiry_milliseconds) ||
+      configuration.expiry_milliseconds <= 0
+    ) {
+      fail(`${name} expiry metadata is invalid`);
+    }
+  }
+  if (
+    expected.expiry === "positive_duration" &&
+    configuration.expiry_milliseconds === null
+  ) {
+    fail(`${name} requires a positive expiry`);
+  }
+  if (expected.expiry === "positive_duration_shorter_than_wait") {
+    if (
+      configuration.expiry_milliseconds === null ||
+      configuration.expiry_milliseconds >= waitMs
+    ) {
+      fail(`${name} expiry must be shorter than retained wait`);
+    }
+  }
+  const canonical = {
+    section: configuration.section,
+    enabled: configuration.enabled,
+    max_entries: configuration.max_entries,
+    expiry: configuration.expiry,
+    expiry_milliseconds: configuration.expiry_milliseconds,
+  };
+  if (configuration.canonical_sha256 !== sha256(JSON.stringify(canonical))) {
+    fail(`${name} canonical configuration digest drift`);
+  }
+}
+
+function verifyContract() {
+  if (contract.schema_version !== 1) fail("retained dedup contract schema drift");
+  if (contract.module !== "iggy") fail("retained dedup contract module drift");
+  if (contract.packet !== "contract-poison-external-iggy-dedup-execution-contract") {
+    fail("retained dedup contract packet drift");
+  }
+  if (contract.status !== "runtime_execution_contract_locked") {
+    fail("retained dedup contract status drift");
+  }
+  if (contract.runner !== runnerPath) fail("retained dedup runner path drift");
+  if (contract.verifier !== verifierPath) fail("retained dedup verifier path drift");
+  if (contract.evidence_path !== evidencePath) fail("retained dedup output path drift");
+  if (contract.execution_scope !== "four_external_iggy_dedup_modes_runtime_pending") {
+    fail("retained dedup execution scope drift");
+  }
+  if (
+    contract.promotion_gate !==
+    "requires_clean_commit_distinct_brokers_reviewed_configs_and_all_cases_passed"
+  ) {
+    fail("retained dedup promotion gate drift");
+  }
+  if (contract.test_target !== "contract_poison_external_iggy_dedup") {
+    fail("retained dedup target drift");
+  }
+  if (
+    !sameValue(contract.shared_optional_environment, [
+      "RUSTOK_IGGY_DEDUP_TEST_USERNAME",
+      "RUSTOK_IGGY_DEDUP_TEST_PASSWORD",
+    ])
+  ) {
+    fail("retained dedup credential environment drift");
+  }
+  if (!sameValue(contract.scenarios, expectedScenarios)) {
+    fail("retained dedup scenario contract drift");
+  }
+  if (!sameValue(contract.command_template, expectedCommandTemplate)) {
+    fail("retained dedup command template drift");
+  }
+  if (
+    !sameValue(contract.reviewed_configuration, {
+      section: "system.message_deduplication",
+      persisted_fields: [
+        "enabled",
+        "max_entries",
+        "expiry",
+        "expiry_milliseconds",
+        "canonical_sha256",
+      ],
+      full_config_path_persisted: false,
+      full_config_sha256_persisted: false,
+      full_config_content_persisted: false,
+    })
+  ) {
+    fail("retained dedup reviewed configuration boundary drift");
+  }
+  if (!sameValue(contract.source_files, expectedSourceFiles)) {
+    fail("retained dedup source file set drift");
+  }
+  if (!sameSet(contract.required_metadata, expectedMetadata)) {
+    fail("retained dedup metadata contract drift");
+  }
+  if (
+    !sameValue(contract.privacy_boundary, {
+      forbidden_persisted_values: [
+        "broker_address",
+        "config_path",
+        "username",
+        "password",
+        "connection_string",
+        "raw_test_output",
+        "delivery_uuid",
+        "payload",
+        "source_coordinates",
+      ],
+    })
+  ) {
+    fail("retained dedup privacy boundary drift");
+  }
+  if (contract.evidence_status !== "runtime_execution_pending") {
+    fail("retained dedup contract must not claim unexecuted evidence");
+  }
+  if (sourceContract.execution_status !== "not_run") {
+    fail("dedup source contract must remain unexecuted in source-only changes");
+  }
+}
+
+function verifyRunnerAndSource() {
+  for (const marker of [
+    "validateContractBoundary()",
+    "validateCredentialsPair()",
+    "expiryWaitMilliseconds()",
+    "absoluteExternalConfigPath(",
+    "must point outside the repository",
+    "parseDedupConfiguration(",
+    'section: "system.message_deduplication"',
+    "canonical_sha256: sha256(JSON.stringify(canonical))",
+    "retained dedup execution requires four distinct broker addresses",
+    "retained dedup execution requires four distinct reviewed config files",
+    '["status", "--porcelain=v1", "--untracked-files=all"]',
+    '["rev-parse", "HEAD"]',
+    "requirePassedCase(output, reviewed.scenario.case)",
+    "running 1 test",
+    "scenarioCommand(reviewed.scenario.case)",
+    "ensureCleanAfterExecution()",
+    "writeAtomically({",
+    "renameSync(temporaryPath, outputPath)",
+    "combined_test_output_sha256: sha256(combinedOutput)",
+  ]) {
+    requireText("retained dedup runner", runner, marker);
+  }
+  for (const forbidden of [
+    "broker_address:",
+    "config_path:",
+    "username:",
+    "password:",
+    "connection_string:",
+    "raw_test_output:",
+    "delivery_uuid:",
+    "payload:",
+    "source_coordinates:",
+    "full_config_sha256",
+    "full_config_content",
+  ]) {
+    forbidText("retained dedup packet projection", runner, forbidden);
+  }
+  for (const scenario of expectedScenarios) {
+    requireText("dedup source test", test, `async fn ${scenario.case}()`);
+  }
+}
+
+function verifyExecutedEvidence() {
+  const absoluteEvidencePath = resolve(repoRoot, evidencePath);
+  if (!existsSync(absoluteEvidencePath)) {
+    console.log(
+      "External Iggy dedup retained evidence contract verified; four-mode runtime execution remains pending.",
+    );
+    return;
+  }
+
+  const evidenceText = readText(evidencePath);
+  const evidence = JSON.parse(evidenceText);
+  requireExactKeys("retained dedup evidence", evidence, [
+    "schema_version",
+    "module",
+    "packet",
+    "status",
+    "generated_from",
+    "runner",
+    "verifier",
+    "git_commit",
+    "working_tree_clean_before_run",
+    "started_at",
+    "completed_at",
+    "toolchain",
+    "expiry_wait_milliseconds",
+    "source_sha256",
+    "combined_test_output_sha256",
+    "combined_test_output_bytes",
+    "executed_scenarios",
+  ]);
+  if (evidence.schema_version !== 1) fail("retained dedup evidence schema drift");
+  if (evidence.module !== "iggy") fail("retained dedup evidence module drift");
+  if (evidence.packet !== "contract-poison-external-iggy-dedup-runtime-evidence") {
+    fail("retained dedup evidence packet drift");
+  }
+  if (evidence.status !== "external_iggy_dedup_runtime_executed") {
+    fail("retained dedup evidence status drift");
+  }
+  if (evidence.generated_from !== contractPath) fail("retained dedup generated_from drift");
+  if (evidence.runner !== runnerPath) fail("retained dedup runner drift");
+  if (evidence.verifier !== verifierPath) fail("retained dedup verifier drift");
+  if (!/^[0-9a-f]{40}$/u.test(evidence.git_commit)) {
+    fail("retained dedup git commit is invalid");
+  }
+  if (evidence.working_tree_clean_before_run !== true) {
+    fail("retained dedup evidence must originate from a clean tree");
+  }
+  requireIsoTimestamp("retained dedup started_at", evidence.started_at);
+  requireIsoTimestamp("retained dedup completed_at", evidence.completed_at);
+  if (Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)) {
+    fail("retained dedup completed_at precedes started_at");
+  }
+  requireExactKeys("retained dedup toolchain", evidence.toolchain, ["cargo", "rustc"]);
+  if (!/^cargo\s/u.test(evidence.toolchain.cargo)) fail("retained dedup Cargo version invalid");
+  if (!/^rustc\s/u.test(evidence.toolchain.rustc)) fail("retained dedup Rust version invalid");
+  if (
+    !Number.isSafeInteger(evidence.expiry_wait_milliseconds) ||
+    evidence.expiry_wait_milliseconds < 100 ||
+    evidence.expiry_wait_milliseconds > 300_000
+  ) {
+    fail("retained dedup expiry wait is invalid");
+  }
+  if (!/^[0-9a-f]{64}$/u.test(evidence.combined_test_output_sha256)) {
+    fail("retained dedup combined output digest invalid");
+  }
+  if (
+    !Number.isSafeInteger(evidence.combined_test_output_bytes) ||
+    evidence.combined_test_output_bytes <= 0
+  ) {
+    fail("retained dedup combined output byte count invalid");
+  }
+
+  requireExactKeys("retained dedup source hashes", evidence.source_sha256, expectedSourceFiles);
+  for (const relativePath of expectedSourceFiles) {
+    const retainedHash = evidence.source_sha256[relativePath];
+    if (!/^[0-9a-f]{64}$/u.test(retainedHash)) {
+      fail(`retained dedup source hash invalid: ${relativePath}`);
+    }
+    if (retainedHash !== sha256File(relativePath)) {
+      fail(`retained dedup evidence is stale for source file: ${relativePath}`);
+    }
+  }
+
+  if (
+    !Array.isArray(evidence.executed_scenarios) ||
+    evidence.executed_scenarios.length !== expectedScenarios.length
+  ) {
+    fail("retained dedup executed scenario count drift");
+  }
+  for (const expected of expectedScenarios) {
+    const scenario = evidence.executed_scenarios.find(
+      (candidate) => candidate.case === expected.case,
+    );
+    requireExactKeys(`retained dedup scenario ${expected.case}`, scenario, [
+      "case",
+      "result",
+      "address_source_env",
+      "configuration_source_env",
+      "server_artifact_source_env",
+      "server_artifact",
+      "reviewed_configuration",
+      "expected_partition_message_counts",
+      "command",
+      "test_output_sha256",
+      "test_output_bytes",
+    ]);
+    if (scenario.result !== "pass") fail(`retained dedup scenario failed: ${expected.case}`);
+    if (scenario.address_source_env !== expected.address_env) {
+      fail(`retained dedup address env drift: ${expected.case}`);
+    }
+    if (scenario.configuration_source_env !== expected.config_path_env) {
+      fail(`retained dedup config env drift: ${expected.case}`);
+    }
+    if (scenario.server_artifact_source_env !== expected.server_artifact_env) {
+      fail(`retained dedup artifact env drift: ${expected.case}`);
+    }
+    if (
+      typeof scenario.server_artifact !== "string" ||
+      !scenario.server_artifact.trim() ||
+      scenario.server_artifact.length > 256 ||
+      /[\u0000-\u001f\u007f]/u.test(scenario.server_artifact)
+    ) {
+      fail(`retained dedup server artifact invalid: ${expected.case}`);
+    }
+    validateConfiguration(
+      `retained dedup configuration ${expected.case}`,
+      scenario.reviewed_configuration,
+      expected.expected_configuration,
+      evidence.expiry_wait_milliseconds,
+    );
+    if (
+      !sameValue(
+        scenario.expected_partition_message_counts,
+        expected.expected_partition_message_counts,
+      )
+    ) {
+      fail(`retained dedup count sequence drift: ${expected.case}`);
+    }
+    if (!sameValue(scenario.command, scenarioCommand(expected.case))) {
+      fail(`retained dedup command drift: ${expected.case}`);
+    }
+    if (!/^[0-9a-f]{64}$/u.test(scenario.test_output_sha256)) {
+      fail(`retained dedup scenario output digest invalid: ${expected.case}`);
+    }
+    if (!Number.isSafeInteger(scenario.test_output_bytes) || scenario.test_output_bytes <= 0) {
+      fail(`retained dedup scenario output byte count invalid: ${expected.case}`);
+    }
+  }
+
+  for (const forbiddenKey of contract.privacy_boundary.forbidden_persisted_values) {
+    const pattern = new RegExp(`"${forbiddenKey}"\\s*:`, "u");
+    if (pattern.test(evidenceText)) {
+      fail(`retained dedup evidence contains forbidden persisted field: ${forbiddenKey}`);
+    }
+  }
+  if (/iggy:\/\//iu.test(evidenceText)) {
+    fail("retained dedup evidence must not contain an Iggy connection string");
+  }
+  console.log(
+    "External Iggy dedup retained evidence verified: clean commit, reviewed non-secret configuration digests, current source hashes, exact per-case commands, and all four behavior scenarios passed.",
+  );
+}
+
+try {
+  verifyContract();
+  verifyRunnerAndSource();
+  verifyExecutedEvidence();
+} catch (error) {
+  console.error(`External Iggy dedup retained evidence verification failed: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Add a fail-closed retained-execution path for the four external-Iggy message-ID deduplication behavior scenarios.

- added a versioned execution contract with four exact per-case Cargo commands, scenario-specific address/config/artifact environment variables, source hashes, privacy boundaries, and the canonical packet path;
- added a clean-commit runner that requires four distinct broker addresses and four distinct reviewed config files outside the repository;
- the runner extracts only `[system.message_deduplication]`, validates `enabled`, `max_entries`, and `expiry` against the scenario, converts the duration to milliseconds, and stores only a canonical non-secret SHA-256;
- the expiry configuration must be strictly shorter than the bounded `RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS`;
- each named test runs separately through a libtest `--exact` filter and must report `running 1 test` plus `<case> ... ok`; skips and zero-test runs fail closed;
- commit, source hashes, and working-tree cleanliness are checked before and after execution;
- the evidence JSON is written atomically only after all four scenarios pass;
- added a strict verifier that validates contract/runner/source while execution is pending and, once a packet exists, requires current source hashes, exact commands, reviewed config digests, bounded metadata, and four all-pass results;
- updated the dedup operator guide and added a Profiles retained-evidence checkpoint.

## Retained packet privacy

The packet does not contain broker addresses, config paths, full config contents or full-file hashes, usernames, passwords, connection strings, raw test logs, delivery UUIDs, payloads, or source coordinates.

It retains only environment-variable names, bounded reviewed server artifact labels, canonical non-secret dedup values/digests, exact command arrays, Git/toolchain/timestamp metadata, source/output SHA-256 values, output byte counts, expected message-count sequences, and aggregate pass results.

`contract-poison-external-iggy-dedup-execution.json` is intentionally absent until a maintainer executes all four modes successfully from a clean commit.

## Non-claims

This slice does not claim active server configuration readback, production recovery-window sufficiency, a PostgreSQL/Iggy transaction, physical exactly-once, bundled mode, TLS/auth/failover, or multi-replica proof. Profiles authorization remains independent of all broker and evidence state.

## Verification

Tests, Cargo commands, formatters, source verifiers, external/bundled Iggy scenarios, server configuration changes, PostgreSQL, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs
node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs

# After supplying all four address/config/artifact groups and expiry wait:
node scripts/evidence/capture-iggy-contract-poison-external-dedup.mjs
node scripts/verify/verify-iggy-contract-poison-external-dedup-retained-evidence.mjs
```