### PR TITLE
fix(index): fail closed on post-inspection drift

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -89,9 +89,11 @@ node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
   --manifest evidence/index-partition/retained-run.archive-manifest.json
 ```
 
-`partition-archive-verify` requires the saved manifest to be a non-empty regular non-symlink file outside the immutable bundle. It rejects lexical or canonical paths inside the bundle and rejects a hard-link alias to any of the nine retained files. It verifies the saved `manifest_digest`, reruns the full retained-bundle inspection, rebuilds the admitted archive manifest, and canonical-compares the complete saved manifest to the recalculated result.
+`partition-archive-verify` requires the saved manifest to be a non-empty regular non-symlink file outside the immutable bundle. It rejects lexical or canonical paths inside the bundle and rejects a hard-link alias to any of the nine retained files. It reads the saved manifest through one stable file descriptor, verifies the saved `manifest_digest`, reruns the full retained-bundle inspection, rebuilds the admitted archive manifest, and canonical-compares the complete saved manifest to the recalculated result.
 
-A successful verification prints a deterministic `index_partition_retained_archive_verification_v1` receipt with the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. The verifier writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
+Before publishing success, the verifier rereads all nine retained files through stable file descriptors and compares their current byte counts and exact-byte SHA-256 digests to the completed inspection. It fails closed on post-inspection exact-byte drift, current retained-file aliasing, or identity/content drift while a file is being read. This closes the gap where a bundle could change between inspection and receipt publication.
+
+A successful verification prints a deterministic `index_partition_retained_archive_verification_v1` receipt with `retained_files_rechecked: true`, the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. The verifier writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
 
 A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
 

--- a/scripts/verify/index-partition-archive-manifest-core.mjs
+++ b/scripts/verify/index-partition-archive-manifest-core.mjs
@@ -1,4 +1,11 @@
-import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import {
+  closeSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -13,6 +20,12 @@ export const ARCHIVE_VERIFICATION_CONTRACT = 'index_partition_retained_archive_v
 
 const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+const fingerprintOf = (stat) => [
+  identityOf(stat),
+  stat.size,
+  stat.mtimeNs,
+  stat.ctimeNs,
+].join(':');
 
 const requireObject = (value, label) => {
   if (!isObject(value)) throw new Error(`${label} must be an object`);
@@ -49,11 +62,54 @@ const parseJsonBytes = (bytes, label) => {
   }
 };
 
+const ensureInsideRoot = (root, filename, label) => {
+  const relative = path.relative(root, filename);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside the retained bundle root`);
+  }
+};
+
 const ensureOutsideRoot = (root, filename, label) => {
   const relative = path.relative(root, filename);
   const inside = relative === ''
     || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
   if (inside) throw new Error(`${label} must stay outside the retained bundle root`);
+};
+
+const readStableRegularFile = (filename, label) => {
+  const pathStatBefore = lstatSync(filename, { bigint: true });
+  if (pathStatBefore.isSymbolicLink() || !pathStatBefore.isFile()) {
+    throw new Error(`${label} must be a regular non-symlink file`);
+  }
+
+  const descriptor = openSync(filename, 'r');
+  try {
+    const descriptorStatBefore = fstatSync(descriptor, { bigint: true });
+    if (!descriptorStatBefore.isFile()
+        || identityOf(descriptorStatBefore) !== identityOf(pathStatBefore)) {
+      throw new Error(`${label} changed before it could be read`);
+    }
+
+    const bytes = readFileSync(descriptor);
+    const descriptorStatAfter = fstatSync(descriptor, { bigint: true });
+    const pathStatAfter = lstatSync(filename, { bigint: true });
+    if (pathStatAfter.isSymbolicLink()
+        || !pathStatAfter.isFile()
+        || identityOf(pathStatAfter) !== identityOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatBefore) !== fingerprintOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatAfter) !== fingerprintOf(pathStatAfter)) {
+      throw new Error(`${label} changed while it was being read`);
+    }
+    if (bytes.length === 0) throw new Error(`${label} must not be empty`);
+
+    return {
+      bytes,
+      identity: identityOf(descriptorStatAfter),
+      canonical: realpathSync.native(filename),
+    };
+  } finally {
+    closeSync(descriptor);
+  }
 };
 
 const normalizeFiles = (files) => {
@@ -74,6 +130,31 @@ const normalizeFiles = (files) => {
     paths.add(retainedPath);
     return { role, path: retainedPath, bytes, sha256 };
   });
+};
+
+const assertRetainedFilesUnchanged = ({
+  files,
+  resolvedRoot,
+  canonicalRoot,
+  manifestIdentity,
+}) => {
+  const retainedIdentities = new Set();
+  for (const file of files) {
+    const filename = path.resolve(resolvedRoot, file.path);
+    ensureInsideRoot(resolvedRoot, filename, `retained bundle file ${file.role}`);
+    const current = readStableRegularFile(filename, `retained bundle file ${file.role}`);
+    ensureInsideRoot(canonicalRoot, current.canonical, `retained bundle file ${file.role}`);
+    if (current.identity === manifestIdentity) {
+      throw new Error('saved archive manifest aliases a retained bundle file');
+    }
+    if (retainedIdentities.has(current.identity)) {
+      throw new Error(`retained bundle file ${file.role} aliases another retained bundle file after inspection`);
+    }
+    retainedIdentities.add(current.identity);
+    if (current.bytes.length !== file.bytes || sha256Hex(current.bytes) !== file.sha256) {
+      throw new Error(`retained bundle file ${file.role} changed after inspection`);
+    }
+  }
 };
 
 export const buildRetainedPartitionArchiveManifest = (inspection) => {
@@ -119,27 +200,12 @@ export const verifySavedRetainedPartitionArchiveManifest = ({
   const resolvedManifestPath = path.resolve(requireNonEmptyString(manifestPath, 'manifestPath'));
   ensureOutsideRoot(resolvedRoot, resolvedManifestPath, 'saved archive manifest');
 
-  const manifestStat = lstatSync(resolvedManifestPath);
-  if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
-    throw new Error('saved archive manifest must be a regular non-symlink file');
-  }
-  const manifestBytes = readFileSync(resolvedManifestPath);
-  if (manifestBytes.length === 0) throw new Error('saved archive manifest must not be empty');
-
+  const manifestFile = readStableRegularFile(resolvedManifestPath, 'saved archive manifest');
   const canonicalRoot = realpathSync.native(resolvedRoot);
-  const canonicalManifestPath = realpathSync.native(resolvedManifestPath);
-  ensureOutsideRoot(canonicalRoot, canonicalManifestPath, 'saved archive manifest');
-
-  const manifestIdentity = identityOf(manifestStat);
-  for (const file of inspection.files) {
-    const retainedStat = lstatSync(path.resolve(resolvedRoot, file.path));
-    if (identityOf(retainedStat) === manifestIdentity) {
-      throw new Error('saved archive manifest aliases a retained bundle file');
-    }
-  }
+  ensureOutsideRoot(canonicalRoot, manifestFile.canonical, 'saved archive manifest');
 
   const saved = requireObject(
-    parseJsonBytes(manifestBytes, 'saved archive manifest'),
+    parseJsonBytes(manifestFile.bytes, 'saved archive manifest'),
     'saved archive manifest',
   );
   const savedDigest = requireDigest(saved.manifest_digest, 'saved archive manifest.manifest_digest');
@@ -153,15 +219,23 @@ export const verifySavedRetainedPartitionArchiveManifest = ({
     throw new Error('saved archive manifest does not match recalculated retained bundle manifest');
   }
 
+  assertRetainedFilesUnchanged({
+    files: expected.files,
+    resolvedRoot,
+    canonicalRoot,
+    manifestIdentity: manifestFile.identity,
+  });
+
   return {
     contract: ARCHIVE_VERIFICATION_CONTRACT,
     verified: true,
+    retained_files_rechecked: true,
     source_manifest_contract: ARCHIVE_MANIFEST_CONTRACT,
     source_digest_contract: ARCHIVE_MANIFEST_DIGEST_CONTRACT,
     evidence_id: expected.evidence_id,
     packet_digest: expected.packet_digest,
     manifest_digest: expected.manifest_digest,
-    saved_manifest_sha256: sha256Hex(manifestBytes),
+    saved_manifest_sha256: sha256Hex(manifestFile.bytes),
     file_count: expected.file_count,
     total_bytes: expected.total_bytes,
     production_lifecycle_authorized: false,

--- a/scripts/verify/index-partition-post-inspection-drift.test.mjs
+++ b/scripts/verify/index-partition-post-inspection-drift.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildRetainedPartitionArchiveManifest,
+  verifySavedRetainedPartitionArchiveManifest,
+} from './index-partition-archive-manifest-core.mjs';
+import { sha256Hex } from './index-partition-evidence-core.mjs';
+import { REVIEW_CONTRACT } from './index-partition-review-core.mjs';
+
+const roles = [
+  'baseline',
+  'shadow',
+  'query',
+  'mutation',
+  'maintenance',
+  'cutover',
+  'capture',
+  'packet',
+  'admission',
+];
+
+const buildContext = () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'index-partition-post-inspection-'));
+  const files = roles.map((role, index) => {
+    const relativePath = `${role}.json`;
+    const bytes = Buffer.from(`${JSON.stringify({ role, index })}\n`, 'utf8');
+    writeFileSync(path.join(root, relativePath), bytes);
+    return {
+      role,
+      path: relativePath,
+      bytes: bytes.length,
+      sha256: sha256Hex(bytes),
+    };
+  });
+  const inspection = {
+    contract: REVIEW_CONTRACT,
+    packet: {
+      database: {
+        version: 'PostgreSQL 16.4',
+        server_version_num: '160004',
+        jit: 'off',
+        system_identifier: '7432859712345678901',
+        database_name: 'rustok_index_partition_fixture',
+      },
+    },
+    admission: {
+      outcome: 'admitted',
+      evidence_id: 'post-inspection-drift-fixture',
+      completed_at: '2026-07-28T12:00:00Z',
+      packet_digest: 'a'.repeat(64),
+      run_provenance: {
+        repository: 'RusTokRs/RusTok',
+        commit: '1'.repeat(40),
+        run_key: 'post-inspection-drift-fixture',
+        job: 'partition-evidence-fixture',
+        runner_os: 'Linux',
+        runner_arch: 'X64',
+      },
+    },
+    files,
+  };
+  const manifestPath = path.join(path.dirname(root), `${path.basename(root)}.archive-manifest.json`);
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(buildRetainedPartitionArchiveManifest(inspection), null, 2)}\n`,
+  );
+  return { root, manifestPath, inspection };
+};
+
+const cleanup = ({ root, manifestPath }) => {
+  rmSync(manifestPath, { force: true });
+  rmSync(root, { recursive: true, force: true });
+};
+
+test('rechecks all retained files before publishing an archive verification receipt', () => {
+  const context = buildContext();
+  try {
+    const manifestBefore = readFileSync(context.manifestPath);
+    const receipt = verifySavedRetainedPartitionArchiveManifest({
+      inspection: context.inspection,
+      root: context.root,
+      manifestPath: context.manifestPath,
+    });
+    assert.equal(receipt.verified, true);
+    assert.equal(receipt.retained_files_rechecked, true);
+    assert.equal(receipt.file_count, 9);
+    assert.equal(receipt.production_lifecycle_authorized, false);
+    assert.deepEqual(readFileSync(context.manifestPath), manifestBefore);
+  } finally {
+    cleanup(context);
+  }
+});
+
+test('fails closed when a retained file changes after inspection', () => {
+  const context = buildContext();
+  try {
+    writeFileSync(path.join(context.root, 'query.json'), '{"role":"query","drift":true}\n');
+    assert.throws(
+      () => verifySavedRetainedPartitionArchiveManifest({
+        inspection: context.inspection,
+        root: context.root,
+        manifestPath: context.manifestPath,
+      }),
+      /retained bundle file query changed after inspection/u,
+    );
+  } finally {
+    cleanup(context);
+  }
+});

--- a/scripts/verify/verify-index-partition-post-inspection-drift.mjs
+++ b/scripts/verify/verify-index-partition-post-inspection-drift.mjs
@@ -55,7 +55,7 @@ try {
 
   requireMarkers(runbook, [
     'rereads all nine retained files',
-    'post-inspection identity or exact-byte drift',
+    'post-inspection exact-byte drift',
     '`retained_files_rechecked: true`',
   ], 'full partition capture runbook');
 

--- a/scripts/verify/verify-index-partition-post-inspection-drift.mjs
+++ b/scripts/verify/verify-index-partition-post-inspection-drift.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const prefix = '[verify-index-partition-post-inspection-drift]';
+const read = (filename) => readFileSync(filename, 'utf8');
+
+const requireMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (!source.includes(marker)) throw new Error(`${label} is missing ${marker}`);
+  }
+};
+
+const forbidMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) throw new Error(`${label} must not contain ${marker}`);
+  }
+};
+
+try {
+  const core = read('scripts/verify/index-partition-archive-manifest-core.mjs');
+  const fixture = read('scripts/verify/index-partition-post-inspection-drift.test.mjs');
+  const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
+
+  requireMarkers(core, [
+    'readStableRegularFile',
+    'openSync',
+    'fstatSync',
+    'closeSync',
+    'fingerprintOf',
+    'assertRetainedFilesUnchanged',
+    'changed before it could be read',
+    'changed while it was being read',
+    'changed after inspection',
+    'retained_files_rechecked: true',
+    'saved archive manifest aliases a retained bundle file',
+    'production_lifecycle_authorized: false',
+  ], 'archive verifier core');
+  forbidMarkers(core, [
+    'writeFileSync',
+    'mkdirSync',
+    'renameSync',
+    'rmSync',
+    'spawnSync',
+    'DATABASE_URL',
+    'INDEX_PARTITION_ALLOW',
+  ], 'archive verifier core');
+
+  requireMarkers(fixture, [
+    'rechecks all retained files before publishing an archive verification receipt',
+    'retained_files_rechecked',
+    'fails closed when a retained file changes after inspection',
+    'retained bundle file query changed after inspection',
+  ], 'post-inspection drift fixture');
+
+  requireMarkers(runbook, [
+    'rereads all nine retained files',
+    'post-inspection identity or exact-byte drift',
+    '`retained_files_rechecked: true`',
+  ], 'full partition capture runbook');
+
+  console.log(`${prefix} contract satisfied`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- read the saved archive manifest through a stable file descriptor and reject path/descriptor identity drift before or during the read;
- after canonical saved-manifest verification, reread all nine retained files through stable descriptors;
- compare current byte counts and exact-byte SHA-256 digests to the completed retained-bundle inspection;
- fail closed on post-inspection exact-byte drift, current retained-file aliasing, saved-manifest aliasing, or identity/content drift while a file is being read;
- add `retained_files_rechecked: true` to successful verification receipts;
- add a focused standalone fixture and static contract guard, plus owner runbook wording.

## Safety boundary

This remains a read-only owner verifier. It writes no files, opens no PostgreSQL connection, starts no Cargo or evidence stage, does not change admission, and does not authorize or implement partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter work.

The new fixture and static guard are standalone focused checks and are not registered in the aggregate `index-storage-tooling.mjs` contract/fixture router in this slice.

## Validation

Per repository-owner instruction, tests, fixture suites, aggregate contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run.

Only JavaScript syntax checks and the new standalone static guard were run:

```bash
node --check scripts/verify/index-partition-archive-manifest-core.mjs
node --check scripts/verify/index-partition-post-inspection-drift.test.mjs
node --check scripts/verify/verify-index-partition-post-inspection-drift.mjs
node scripts/verify/verify-index-partition-post-inspection-drift.mjs
```

The standalone static guard completed with:

```text
[verify-index-partition-post-inspection-drift] contract satisfied
```

Suggested owner checks:

```bash
node scripts/verify/verify-index-partition-post-inspection-drift.mjs
node --test scripts/verify/index-partition-post-inspection-drift.test.mjs
node scripts/verify/verify-index-partition-full-capture.mjs
node --test scripts/verify/index-partition-review.test.mjs
```

## Owner behavior

The existing command is unchanged:

```bash
node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
  --root evidence/index-partition/retained-run \
  --manifest evidence/index-partition/retained-run.archive-manifest.json
```

A successful receipt now explicitly records `retained_files_rechecked: true`; it remains derived metadata and keeps `production_lifecycle_authorized: false`.