### PR TITLE
Use fulfillment owner port in GraphQL reads

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
+++ b/crates/rustok-commerce/docs/graphql-query-fulfillment-context.md
@@ -1,75 +1,84 @@
 # GraphQL query fulfillment owner context
 
-Status: `source_cutover_ready_unvalidated`
+Status: `source_cutover_unvalidated`
 
-## Shipping-option owner reads
+## Owner projection reads
 
-Mounted Commerce GraphQL and REST projection reads now consume the same
-application-host-composed fulfillment boundaries:
+Mounted Commerce GraphQL and REST projection reads consume application-host-
+composed fulfillment boundaries.
 
-- storefront active list uses
-  `ShippingOptionReadPort::list_shipping_option_projections`;
-- single shipping-option lookup uses
-  `ShippingOptionReadPort::read_shipping_option_projection`;
-- administrative list-all uses
-  `ShippingOptionAdminReadPort::list_all_shipping_option_projections`.
+Shipping-option reads use:
 
-The ports return fulfillment-owned `ShippingOptionResponse` projections. Commerce
-continues to apply transport-specific filtering and public error policy after the
-owner projection returns.
+- `ShippingOptionReadPort::list_shipping_option_projections`;
+- `ShippingOptionReadPort::read_shipping_option_projection`;
+- `ShippingOptionAdminReadPort::list_all_shipping_option_projections`.
 
-This remains a partial fulfillment-query topology result. The private GraphQL
-compatibility facade still retains one concrete `FulfillmentService` delegate for
-fulfillment lifecycle list/lookup and order-to-fulfillment reads that do not yet
-have published owner query ports.
+Fulfillment lifecycle reads use:
+
+- `FulfillmentReadPort::read_fulfillment_projection`;
+- `FulfillmentReadPort::list_fulfillment_projections`;
+- `FulfillmentReadPort::find_latest_fulfillment_by_order_projection`.
+
+The ports return fulfillment-owned response projections. Commerce continues to
+apply transport-specific filtering, optional-not-found, pagination, and public
+error policy after the owner projection returns.
 
 ## Application-host composition
 
-The server bootstrap constructs one `CommerceShippingOptionReadRuntime` from the
-storefront and administrative root factories, caches it in
-`ServerRuntimeContext`, and attaches it to `HostRuntimeContext`.
+The server bootstrap constructs and caches separate host-selectable runtimes:
 
-GraphQL consumes that runtime through manifest data and
-`CommerceShippingOptionReadScope`. The private query facade clones the scoped
-owner ports and does not construct read providers.
+- `CommerceShippingOptionReadRuntime`;
+- `CommerceFulfillmentLifecycleReadRuntime`.
 
-Commerce HTTP router construction consumes the same typed runtime from
-`HostRuntimeContext` and stores it in `CommerceHttpRuntime`. HTTP startup fails
-closed when the runtime is absent. The REST handlers clone the owner ports from
-that state; they do not construct `FulfillmentService` or root in-process read
-providers for shipping-option projection reads.
+Both typed values are attached to `HostRuntimeContext`. Existing external
+adapters are preserved; otherwise the root in-process factories provide the
+baseline implementation.
+
+GraphQL consumes both runtimes through manifest data and one mounted
+`CommerceShippingOptionReadScope`. The extension nests both task-local values for
+each resolver execution. The private query facade clones all three owner ports and
+does not construct `FulfillmentService` or root in-process read providers.
+
+Commerce HTTP router construction consumes the same typed runtimes from
+`HostRuntimeContext`. HTTP startup fails closed when either required runtime is
+absent.
 
 Directly embedded GraphQL schemas that do not mount the server extension retain
-an explicit `CommerceShippingOptionReadRuntime::in_process` compatibility
-fallback in the public GraphQL runtime module. This fallback is outside the
-private facade and is not mounted transport parity evidence.
+explicit in-process compatibility fallbacks in the public GraphQL runtime module.
+Those fallbacks are outside the private facade and are not mounted transport parity
+evidence.
+
+## GraphQL lifecycle source cutover
+
+The existing `query.rs` source remains facade-routed and unchanged.
+
+- `fulfillment` calls the compatibility facade, which delegates to
+  `read_fulfillment_projection`; owner not-found is adapted back to
+  `FulfillmentNotFound`, preserving `Ok(None)`.
+- `fulfillments` delegates to `list_fulfillment_projections`; page, per-page,
+  status, order, customer, owner total, and `GqlFulfillmentList` metadata are
+  preserved.
+- admin order detail delegates to
+  `find_latest_fulfillment_by_order_projection`; its optional latest fulfillment
+  remains unchanged.
+
+The private facade now stores `Arc<dyn FulfillmentReadPort>`. The former concrete
+lifecycle `FulfillmentService` field and constructor are removed.
 
 ## REST source cutover
 
-The source inventory at
-`crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`
-has status `source_cutover_ready_unvalidated`.
+Shipping-option REST retains its existing owner-port topology and transport
+filters.
 
-It records the following source topology:
+Admin fulfillment REST now delegates:
 
-- mounted GraphQL and Commerce REST obtain both read ports from the same
-  `CommerceShippingOptionReadRuntime`;
-- storefront REST delegates active-list loading to
-  `list_shipping_option_projections`, then retains its currency,
-  public-channel-visibility, and shipping-profile compatibility filters;
-- admin REST delegates complete list loading to
-  `list_all_shipping_option_projections`, preserving inactive options before
-  active, currency, provider, search, and pagination filters;
-- admin REST single lookup delegates to `read_shipping_option_projection`;
-- admin shipping-option create, update, deactivate, and reactivate remain
-  lifecycle mutations over the concrete owner service and are outside this read
-  cutover;
-- the native fulfillment storefront surface remains seller/cart selection through
-  `ShippingSelectionPort`; it does not publish complete projection list/lookup
-  operations without a consumer contract.
+- `GET /admin/fulfillments` to `list_fulfillment_projections`;
+- `GET /admin/fulfillments/{id}` to `read_fulfillment_projection`.
 
-The inventory is source evidence only. It does not claim compiled handlers,
-mounted request execution, GraphQL/REST result parity, or any FFA/FBA promotion.
+Page/per-page, status/order/customer filters, owner total, detail not-found,
+public status/code/message policy, and successful DTO envelopes remain unchanged.
+Admin fulfillment mutations continue to use their existing concrete or
+orchestration services and are outside the read cutover.
 
 ## Retained read context
 
@@ -81,28 +90,27 @@ GraphQL shipping-option reads construct `PortContext` with:
 - query-field and resource-scoped correlation id;
 - two-second deadline.
 
-The current GraphQL query signature does not carry public channel into every
-shipping-option read context, so that propagation remains open.
-
-REST shipping-option reads construct `PortContext` with:
+GraphQL fulfillment lifecycle reads construct `PortContext` with:
 
 - tenant identity;
-- authenticated user actor for admin reads;
-- authenticated user actor or storefront service actor for public reads;
-- request locale;
-- effective public channel when available, including cart-derived channel for
-  storefront list requests;
-- resource-scoped correlation id;
+- service actor `rustok-commerce.graphql-query-fulfillments`;
+- stable compatibility locale;
+- query-field, owner-operation, and resource-scoped correlation id;
 - two-second deadline.
 
-Requested and tenant-default locale values remain explicit owner request fields.
-Single lookup retains the shipping-option UUID.
+The current GraphQL query signature does not carry public channel into every read
+context, so complete GraphQL channel propagation remains open.
+
+REST reads construct `PortContext` with tenant identity, authenticated or
+storefront service actor as appropriate, request locale, effective channel when
+available, resource-scoped correlation id, and a two-second deadline.
 
 ## Typed public mapping
 
-GraphQL retains its existing typed `FULFILLMENT_*` boundary policy and optional
-single-lookup not-found behavior. No `PortError.message` is parsed or matched as
-control flow.
+GraphQL retains its established compatibility behavior. Lifecycle port failures
+are classified through `PortErrorKind`, logged with stable owner code and context,
+and adapted back to the existing fulfillment error classes used by unchanged
+`query.rs`. No `PortError.message` is parsed or matched as control flow.
 
 REST maps `PortErrorKind` directly to the existing static Commerce HTTP policy:
 
@@ -117,33 +125,30 @@ REST maps `PortErrorKind` directly to the existing static Commerce HTTP policy:
 
 These mappings use fixed transport-owned messages. Owner error code, kind,
 retryability, correlation, actor, locale, channel, resource identity, and deadline
-are retained in diagnostics without exposing the owner message.
+are retained in diagnostics without exposing owner messages.
 
 ## Preserved contracts
 
 - GraphQL `query.rs` remains facade-routed and successful GraphQL DTOs are
   unchanged.
-- Single GraphQL shipping-option not-found still returns `None`.
-- Storefront owner list remains active-only.
-- Storefront REST currency, channel visibility, and shipping-profile filters are
-  unchanged after owner projections return.
-- Administrative list-all still includes inactive options before local active,
-  currency, provider, search, and pagination filtering.
-- REST successful DTOs and route shapes are unchanged.
-- Admin shipping-option mutations retain their existing concrete lifecycle
-  service and typed `FulfillmentError` HTTP mapper.
-- Fulfillment lifecycle GraphQL reads remain on the isolated concrete delegate.
+- Single GraphQL shipping-option and fulfillment not-found still return `None`.
+- GraphQL fulfillment list filters, pagination total, and metadata are unchanged.
+- GraphQL admin order detail retains optional latest fulfillment.
+- Storefront owner shipping-option list remains active-only.
+- REST currency, channel visibility, shipping-profile, admin filtering, and
+  pagination behavior remain unchanged.
+- Admin shipping-option and fulfillment mutations retain their existing concrete
+  or orchestration services and typed error mappers.
 - Native seller/cart selection remains a separate contract.
 - Fulfillment FFA/FBA status is unchanged.
 
 ## Still open
 
-- Execute mounted GraphQL/REST active-list, list-all, and lookup parity fixtures.
-- Prove locale, effective channel, deadline, optional not-found, and typed failure
-  behavior through mounted requests.
-- Add public-channel propagation to every GraphQL shipping-option query context.
-- Publish owner ports for fulfillment lifecycle query reads and remove the
-  remaining concrete GraphQL facade delegate.
+- Execute mounted GraphQL/REST shipping-option and fulfillment lifecycle parity
+  fixtures.
+- Prove locale, effective channel, deadline, tenant, filter, optional not-found,
+  typed failure, restart, and external-adapter behavior through mounted requests.
+- Add public-channel propagation to every GraphQL fulfillment read context.
 - Continue converting remaining Commerce query boundaries that still use dynamic
   strings.
 - Add compile and remote-profile evidence before promoting any FFA/FBA status.
@@ -152,6 +157,7 @@ are retained in diagnostics without exposing the owner message.
 
 ```bash
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
 node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs
 node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
 node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs

--- a/crates/rustok-commerce/src/graphql/safe_query.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query.rs
@@ -411,10 +411,12 @@ mod source {
 
         use ::rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
         use ::rustok_fulfillment::{
-            FulfillmentError, FulfillmentResponse, FulfillmentResult,
-            ListAllShippingOptionProjectionsRequest, ListFulfillmentsInput,
-            ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
-            ShippingOptionAdminReadPort, ShippingOptionReadPort, ShippingOptionResponse,
+            FindLatestFulfillmentByOrderProjectionRequest, FulfillmentError, FulfillmentReadPort,
+            FulfillmentResponse, FulfillmentResult, ListAllShippingOptionProjectionsRequest,
+            ListFulfillmentProjectionsRequest, ListFulfillmentsInput,
+            ListShippingOptionProjectionsRequest, ReadFulfillmentProjectionRequest,
+            ReadShippingOptionProjectionRequest, ShippingOptionAdminReadPort,
+            ShippingOptionReadPort, ShippingOptionResponse,
         };
         use ::sea_orm::{DatabaseConnection, DbErr};
         use ::uuid::Uuid;
@@ -438,9 +440,9 @@ mod source {
         }
 
         pub struct FulfillmentService {
-            inner: ::rustok_fulfillment::FulfillmentService,
             shipping_option_reads: Arc<dyn ShippingOptionReadPort>,
             shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>,
+            fulfillment_reads: Arc<dyn FulfillmentReadPort>,
         }
 
         impl FulfillmentService {
@@ -449,11 +451,13 @@ mod source {
                     crate::graphql_runtime::shipping_option_read_runtime_for_current_graphql_scope(
                         db.clone(),
                     );
+                let fulfillment_lifecycle_runtime = crate::graphql_runtime::
+                    fulfillment_lifecycle_read_runtime_for_current_graphql_scope(db);
                 Self {
-                    inner: ::rustok_fulfillment::FulfillmentService::new(db),
                     shipping_option_reads: shipping_option_runtime.shipping_option_read_port(),
                     shipping_option_admin_reads: shipping_option_runtime
                         .shipping_option_admin_read_port(),
+                    fulfillment_reads: fulfillment_lifecycle_runtime.fulfillment_read_port(),
                 }
             }
 
@@ -569,20 +573,28 @@ mod source {
                 tenant_id: Uuid,
                 id: Uuid,
             ) -> FulfillmentResult<FulfillmentResponse> {
-                self.inner
-                    .get_fulfillment(tenant_id, id)
+                let context = fulfillment_query_context(
+                    tenant_id,
+                    "fulfillment",
+                    "read_fulfillment_projection",
+                    Some(id),
+                    None,
+                );
+                self.fulfillment_reads
+                    .read_fulfillment_projection(
+                        context.clone(),
+                        ReadFulfillmentProjectionRequest { fulfillment_id: id },
+                    )
                     .await
                     .map_err(|error| {
-                        log_fulfillment_query_error(
-                            &error,
-                            tenant_id,
+                        map_fulfillment_port_error(
+                            error,
+                            &context,
                             "fulfillment",
-                            "get_fulfillment",
+                            "read_fulfillment_projection",
+                            Some(id),
                             None,
-                            None,
-                            None,
-                        );
-                        error
+                        )
                     })
             }
 
@@ -591,21 +603,44 @@ mod source {
                 tenant_id: Uuid,
                 input: ListFulfillmentsInput,
             ) -> FulfillmentResult<(Vec<FulfillmentResponse>, u64)> {
-                self.inner
-                    .list_fulfillments(tenant_id, input)
+                let ListFulfillmentsInput {
+                    page,
+                    per_page,
+                    status,
+                    order_id,
+                    customer_id,
+                } = input;
+                let context = fulfillment_query_context(
+                    tenant_id,
+                    "fulfillments",
+                    "list_fulfillment_projections",
+                    None,
+                    order_id,
+                );
+                let page_result = self
+                    .fulfillment_reads
+                    .list_fulfillment_projections(
+                        context.clone(),
+                        ListFulfillmentProjectionsRequest {
+                            page,
+                            per_page,
+                            status,
+                            order_id,
+                            customer_id,
+                        },
+                    )
                     .await
                     .map_err(|error| {
-                        log_fulfillment_query_error(
-                            &error,
-                            tenant_id,
+                        map_fulfillment_port_error(
+                            error,
+                            &context,
                             "fulfillments",
-                            "list_fulfillments",
+                            "list_fulfillment_projections",
                             None,
-                            None,
-                            None,
-                        );
-                        error
-                    })
+                            order_id,
+                        )
+                    })?;
+                Ok((page_result.items, page_result.total))
             }
 
             pub async fn find_by_order(
@@ -613,20 +648,28 @@ mod source {
                 tenant_id: Uuid,
                 order_id: Uuid,
             ) -> FulfillmentResult<Option<FulfillmentResponse>> {
-                self.inner
-                    .find_by_order(tenant_id, order_id)
+                let context = fulfillment_query_context(
+                    tenant_id,
+                    "order",
+                    "find_latest_fulfillment_by_order_projection",
+                    None,
+                    Some(order_id),
+                );
+                self.fulfillment_reads
+                    .find_latest_fulfillment_by_order_projection(
+                        context.clone(),
+                        FindLatestFulfillmentByOrderProjectionRequest { order_id },
+                    )
                     .await
                     .map_err(|error| {
-                        log_fulfillment_query_error(
-                            &error,
-                            tenant_id,
+                        map_fulfillment_port_error(
+                            error,
+                            &context,
                             "order",
-                            "find_by_order",
+                            "find_latest_fulfillment_by_order_projection",
+                            None,
                             Some(order_id),
-                            None,
-                            None,
-                        );
-                        error
+                        )
                     })
             }
         }
@@ -647,6 +690,25 @@ mod source {
                 PortActor::service("rustok-commerce.graphql-query-shipping-options"),
                 locale,
                 format!("graphql-fulfillment:{query_field}:{resource}"),
+            )
+            .with_deadline(std::time::Duration::from_secs(2))
+        }
+
+        fn fulfillment_query_context(
+            tenant_id: Uuid,
+            query_field: &'static str,
+            operation: &'static str,
+            fulfillment_id: Option<Uuid>,
+            order_id: Option<Uuid>,
+        ) -> PortContext {
+            let resource = fulfillment_id
+                .or(order_id)
+                .unwrap_or(tenant_id);
+            PortContext::new(
+                tenant_id.to_string(),
+                PortActor::service("rustok-commerce.graphql-query-fulfillments"),
+                "en",
+                format!("graphql-fulfillment-lifecycle:{query_field}:{operation}:{resource}"),
             )
             .with_deadline(std::time::Duration::from_secs(2))
         }
@@ -692,12 +754,12 @@ mod source {
                 PortErrorKind::Unavailable | PortErrorKind::Timeout => FulfillmentError::Database(
                     DbErr::Custom("fulfillment storage is temporarily unavailable".to_string()),
                 ),
-                PortErrorKind::Validation => FulfillmentError::Validation(
-                    "fulfillment request is invalid".to_string(),
-                ),
-                PortErrorKind::Forbidden => FulfillmentError::Validation(
-                    "fulfillment query is not permitted".to_string(),
-                ),
+                PortErrorKind::Validation => {
+                    FulfillmentError::Validation("fulfillment request is invalid".to_string())
+                }
+                PortErrorKind::Forbidden => {
+                    FulfillmentError::Validation("fulfillment query is not permitted".to_string())
+                }
                 PortErrorKind::InvariantViolation => FulfillmentError::Validation(
                     "fulfillment query could not be completed safely".to_string(),
                 ),
@@ -714,7 +776,79 @@ mod source {
             requested_locale: Option<&str>,
             tenant_default_locale: Option<&str>,
         ) -> BoundaryError {
-            let (message, code, retryable) = match &error.kind {
+            let (message, code, retryable) = public_fulfillment_port_policy(&error.kind);
+            let error_kind = port_error_kind_name(&error.kind);
+            let technical = is_technical_port_error(&error.kind);
+            log_shipping_option_port_error(
+                &error,
+                context,
+                query_field,
+                operation,
+                shipping_option_id,
+                requested_locale,
+                tenant_default_locale,
+                error_kind,
+                code,
+                retryable,
+                technical,
+            );
+
+            BoundaryError::Public {
+                message,
+                code,
+                retryable,
+            }
+        }
+
+        fn map_fulfillment_port_error(
+            error: PortError,
+            context: &PortContext,
+            query_field: &'static str,
+            operation: &'static str,
+            fulfillment_id: Option<Uuid>,
+            order_id: Option<Uuid>,
+        ) -> FulfillmentError {
+            let (public_message, public_code, public_retryable) =
+                public_fulfillment_port_policy(&error.kind);
+            log_fulfillment_port_error(
+                &error,
+                context,
+                query_field,
+                operation,
+                fulfillment_id,
+                order_id,
+                public_message,
+                public_code,
+                public_retryable,
+            );
+
+            match error.kind {
+                PortErrorKind::NotFound => FulfillmentError::FulfillmentNotFound(
+                    fulfillment_id.or(order_id).unwrap_or_else(Uuid::nil),
+                ),
+                PortErrorKind::Conflict => FulfillmentError::InvalidTransition {
+                    from: "current".to_string(),
+                    to: "query".to_string(),
+                },
+                PortErrorKind::Unavailable | PortErrorKind::Timeout => FulfillmentError::Database(
+                    DbErr::Custom("fulfillment storage is temporarily unavailable".to_string()),
+                ),
+                PortErrorKind::Validation => {
+                    FulfillmentError::Validation("fulfillment request is invalid".to_string())
+                }
+                PortErrorKind::Forbidden => {
+                    FulfillmentError::Validation("fulfillment query is not permitted".to_string())
+                }
+                PortErrorKind::InvariantViolation => FulfillmentError::Validation(
+                    "fulfillment query could not be completed safely".to_string(),
+                ),
+            }
+        }
+
+        fn public_fulfillment_port_policy(
+            kind: &PortErrorKind,
+        ) -> (&'static str, &'static str, bool) {
+            match kind {
                 PortErrorKind::Validation => (
                     "Fulfillment query is invalid",
                     "FULFILLMENT_REQUEST_INVALID",
@@ -745,27 +879,6 @@ mod source {
                     "FULFILLMENT_OPERATION_FAILED",
                     false,
                 ),
-            };
-            let error_kind = port_error_kind_name(&error.kind);
-            let technical = is_technical_port_error(&error.kind);
-            log_shipping_option_port_error(
-                &error,
-                context,
-                query_field,
-                operation,
-                shipping_option_id,
-                requested_locale,
-                tenant_default_locale,
-                error_kind,
-                code,
-                retryable,
-                technical,
-            );
-
-            BoundaryError::Public {
-                message,
-                code,
-                retryable,
             }
         }
 
@@ -852,71 +965,63 @@ mod source {
         }
 
         #[allow(clippy::too_many_arguments)]
-        fn log_fulfillment_query_error(
-            error: &FulfillmentError,
-            tenant_id: Uuid,
+        fn log_fulfillment_port_error(
+            error: &PortError,
+            context: &PortContext,
             query_field: &'static str,
             operation: &'static str,
+            fulfillment_id: Option<Uuid>,
             order_id: Option<Uuid>,
-            requested_locale: Option<&str>,
-            tenant_default_locale: Option<&str>,
+            public_message: &'static str,
+            public_code: &'static str,
+            public_retryable: bool,
         ) {
-            let (owner_code, owner_kind, owner_retryable) = match error {
-                FulfillmentError::Validation(_) =>
-                    ("fulfillment.validation", "validation", false),
-                FulfillmentError::ShippingOptionNotFound(_) => (
-                    "fulfillment.shipping_option_not_found",
-                    "not_found",
-                    false,
-                ),
-                FulfillmentError::FulfillmentNotFound(_) => (
-                    "fulfillment.fulfillment_not_found",
-                    "not_found",
-                    false,
-                ),
-                FulfillmentError::InvalidTransition { .. } => (
-                    "fulfillment.invalid_transition",
-                    "conflict",
-                    false,
-                ),
-                FulfillmentError::Database(_) => (
-                    "fulfillment.database_unavailable",
-                    "unavailable",
-                    true,
-                ),
-            };
-
-            match error {
-                FulfillmentError::Database(_) => tracing::error!(
+            let error_kind = port_error_kind_name(&error.kind);
+            if is_technical_port_error(&error.kind) {
+                tracing::error!(
                     error = ?error,
                     owner = "rustok_fulfillment",
-                    tenant_id = %tenant_id,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    actor = ?context.actor,
+                    context_locale_length = context.locale.len(),
+                    deadline_ms = ?context.deadline_ms,
                     query_field,
                     operation,
+                    fulfillment_id = ?fulfillment_id,
                     order_id = ?order_id,
-                    requested_locale = ?requested_locale,
-                    tenant_default_locale = ?tenant_default_locale,
-                    owner_code,
-                    owner_kind,
-                    owner_retryable,
+                    error_kind,
+                    owner_code = %error.code,
+                    owner_kind = ?error.kind,
+                    owner_retryable = error.retryable,
+                    public_message,
+                    public_code,
+                    public_retryable,
                     boundary = GRAPHQL_QUERY_FULFILLMENT_BOUNDARY,
                     "commerce GraphQL query fulfillment owner read failed"
-                ),
-                _ => tracing::warn!(
-                    error = ?error,
+                );
+            } else {
+                tracing::warn!(
                     owner = "rustok_fulfillment",
-                    tenant_id = %tenant_id,
+                    correlation_id = %context.correlation_id,
+                    tenant_id = %context.tenant_id,
+                    actor = ?context.actor,
+                    context_locale_length = context.locale.len(),
+                    deadline_ms = ?context.deadline_ms,
                     query_field,
                     operation,
+                    fulfillment_id = ?fulfillment_id,
                     order_id = ?order_id,
-                    requested_locale = ?requested_locale,
-                    tenant_default_locale = ?tenant_default_locale,
-                    owner_code,
-                    owner_kind,
-                    owner_retryable,
+                    error_kind,
+                    owner_code = %error.code,
+                    owner_kind = ?error.kind,
+                    owner_retryable = error.retryable,
+                    public_message,
+                    public_code,
+                    public_retryable,
                     boundary = GRAPHQL_QUERY_FULFILLMENT_BOUNDARY,
                     "commerce GraphQL query fulfillment owner read was rejected"
-                ),
+                );
             }
         }
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -51,11 +51,11 @@ impl CommerceShippingOptionReadRuntime {
     }
 }
 
-/// Host-selectable fulfillment lifecycle projection read port.
+/// Host-selected fulfillment lifecycle projection read port.
 ///
 /// The runtime is separate from shipping-option reads so hosts can select different adapters.
-/// Until the mounted server and consumers are cut over, GraphQL runtime-data construction retains
-/// an explicit in-process fallback.
+/// Mounted GraphQL resolvers consume it through the shared resolver scope; directly embedded
+/// compatibility schemas retain an explicit in-process fallback.
 #[derive(Clone)]
 pub struct CommerceFulfillmentLifecycleReadRuntime {
     fulfillment_reads: Arc<dyn FulfillmentReadPort>,
@@ -77,9 +77,13 @@ impl CommerceFulfillmentLifecycleReadRuntime {
 
 tokio::task_local! {
     static CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME: CommerceShippingOptionReadRuntime;
+    static CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME: CommerceFulfillmentLifecycleReadRuntime;
 }
 
 /// Resolver-scoped bridge from schema runtime data to the private compatibility facade.
+///
+/// The mounted extension carries both shipping-option and fulfillment-lifecycle owner ports so
+/// every included Commerce query resolves the host-selected adapters for the current async task.
 #[derive(Default)]
 pub struct CommerceShippingOptionReadScope;
 
@@ -105,7 +109,10 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
         CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME
             .scope(
                 runtime_data.shipping_option_read_runtime(),
-                next.run(ctx, info),
+                CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME.scope(
+                    runtime_data.fulfillment_lifecycle_read_runtime(),
+                    next.run(ctx, info),
+                ),
             )
             .await
     }
@@ -119,12 +126,20 @@ pub(crate) fn shipping_option_read_runtime_for_current_graphql_scope(
         .unwrap_or_else(|_| CommerceShippingOptionReadRuntime::in_process(db))
 }
 
+pub(crate) fn fulfillment_lifecycle_read_runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+) -> CommerceFulfillmentLifecycleReadRuntime {
+    CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| CommerceFulfillmentLifecycleReadRuntime::in_process(db))
+}
+
 /// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual
-/// provider registries remain deterministic fallbacks. Mounted shipping-option reads require host
-/// data; fulfillment lifecycle reads retain an explicit in-process fallback until their consumer
-/// cutover is complete.
+/// provider registries remain deterministic fallbacks. Mounted shipping-option and fulfillment
+/// lifecycle reads consume host-selected runtime data; directly embedded compatibility schemas
+/// retain explicit in-process read fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-28",
-  "status": "source_rest_cutover_unvalidated",
-  "source_base_revision": "8a5e251eec95d7fcda54e0ba5c7df4560ef70935",
+  "status": "source_cutover_unvalidated",
+  "source_base_revision": "184ae1a7b413958bd06f2ea3fb66c2c266812991",
   "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
   "owner": {
     "crate": "rustok-fulfillment",
@@ -56,7 +56,9 @@
     "server_cache_composed": true,
     "default_server_attachment": true,
     "commerce_http_runtime_required": true,
-    "external_adapter_preserved": true
+    "external_adapter_preserved": true,
+    "graphql_task_local_scoped": true,
+    "shared_scope_extension": "CommerceShippingOptionReadScope"
   },
   "admin_rest": {
     "list_consumer": "list_fulfillment_projections",
@@ -69,11 +71,25 @@
     "concrete_service_read_construction": false,
     "mutation_service_construction_unchanged": true
   },
+  "graphql": {
+    "lookup_consumer": "read_fulfillment_projection",
+    "list_consumer": "list_fulfillment_projections",
+    "latest_by_order_consumer": "find_latest_fulfillment_by_order_projection",
+    "existing_query_source_unchanged": true,
+    "optional_lookup_not_found_preserved": true,
+    "optional_latest_by_order_preserved": true,
+    "pagination_total_and_filters_preserved": true,
+    "public_error_policy_preserved": true,
+    "service_actor_propagated": true,
+    "correlation_propagated": true,
+    "deadline_seconds": 2,
+    "concrete_service_read_construction": false
+  },
   "consumer_cutover": {
-    "graphql_compatibility_facade": false,
+    "graphql_compatibility_facade": true,
     "admin_rest_list_show": true,
-    "concrete_delegate_removed": false,
-    "next_slice": "add request-safe GraphQL lifecycle runtime scope and route fulfillment lookup/list/latest-by-order through FulfillmentReadPort while preserving optional-not-found and public error policy"
+    "concrete_delegate_removed": true,
+    "next_slice": "execute mounted GraphQL and REST lifecycle read parity, deadline, tenant, filter, optional-not-found, failure, restart, and remote-adapter evidence"
   },
   "validation": {
     "tests_run": false,
@@ -81,6 +97,7 @@
     "format_run": false,
     "verifiers_run": false,
     "workflow_checks_run": false,
-    "ci_run": false
+    "ci_run": false,
+    "runtime_parity_proven": false
   }
 }

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
@@ -1,6 +1,6 @@
 # Fulfillment lifecycle read port
 
-Status: source REST cutover, unvalidated.
+Status: source cutover, unvalidated.
 
 ## Scope
 
@@ -13,10 +13,9 @@ projection reads used by Commerce query consumers. It is separate from:
 - `ShippingSelectionPort`, which owns seller/cart shipping selection;
 - fulfillment lifecycle mutation methods, which remain on `FulfillmentService`.
 
-The owner read boundary and Commerce runtime container are published. The default
-application host composes and attaches that runtime, `CommerceHttpRuntime`
-requires it, and admin REST list/detail now consume its owner port. GraphQL
-lifecycle handlers have not yet been cut over.
+The owner read boundary, host-selected runtime, GraphQL compatibility facade, and
+admin REST list/detail consumers now use one typed owner port. No mounted Commerce
+lifecycle read constructs the concrete owner service.
 
 ## Operations
 
@@ -75,25 +74,47 @@ The application server:
 This preserves external adapter selection and gives GraphQL and HTTP composition
 the same owner-port instance.
 
-Commerce GraphQL runtime-data construction consumes the host-provided runtime.
-Its explicit in-process fallback remains for directly embedded compatibility
-schemas until the GraphQL facade cutover is complete.
+Commerce GraphQL runtime-data construction consumes the host-provided runtime and
+retains an explicit in-process fallback for directly embedded compatibility
+schemas.
 
-`CommerceHttpRuntime::from_host` fails closed when
-`CommerceFulfillmentLifecycleReadRuntime` is absent and exposes the cloned
-`FulfillmentReadPort` for route handlers.
+## GraphQL cutover
+
+The existing mounted `CommerceShippingOptionReadScope` now scopes both read
+runtimes for each resolver task:
+
+- `CommerceShippingOptionReadRuntime`;
+- `CommerceFulfillmentLifecycleReadRuntime`.
+
+The private compatibility facade resolves both runtimes from the same task-local
+bridge. Its lifecycle field is now `Arc<dyn FulfillmentReadPort>`; the previous
+concrete `FulfillmentService` field and constructor are removed.
+
+The unchanged `query.rs` source keeps its public compatibility behavior:
+
+- fulfillment lookup calls `read_fulfillment_projection` and still converts owner
+  not-found to `None`;
+- fulfillment list calls `list_fulfillment_projections`, preserving filters,
+  page/per-page values, owner total, and `GqlFulfillmentList` metadata;
+- admin order detail calls `find_latest_fulfillment_by_order_projection`,
+  preserving its optional latest fulfillment.
+
+The facade constructs a two-second read `PortContext` with tenant identity, a
+stable Commerce GraphQL service actor, and a resource-scoped correlation id.
+Typed `PortErrorKind` values are adapted back to the established compatibility
+error classes without parsing or exposing owner messages.
 
 ## Admin REST cutover
 
-`GET /admin/fulfillments` now calls `list_fulfillment_projections` and preserves:
+`GET /admin/fulfillments` calls `list_fulfillment_projections` and preserves:
 
 - page and per-page values;
 - status, order, and customer filters;
 - the owner pagination total;
 - the existing `PaginatedResponse<FulfillmentResponse>` envelope.
 
-`GET /admin/fulfillments/{id}` now calls `read_fulfillment_projection` and keeps
-the existing detail envelope and not-found policy.
+`GET /admin/fulfillments/{id}` calls `read_fulfillment_projection` and keeps the
+existing detail envelope and not-found policy.
 
 Both handlers construct `PortContext` with tenant identity, authenticated user
 actor, request locale, optional request channel, a resource-scoped correlation
@@ -105,20 +126,6 @@ Admin lifecycle create/ship/deliver/reopen/reship/cancel paths remain on their
 existing concrete or orchestration services. This read cutover does not change
 mutation ownership or behavior.
 
-## Remaining GraphQL boundary
-
-The private Commerce GraphQL fulfillment facade still constructs one concrete
-`FulfillmentService` for:
-
-- fulfillment lookup;
-- fulfillment list;
-- latest fulfillment by order.
-
-The next cutover slice must add request-safe GraphQL lifecycle runtime scope,
-route those three reads through the already host-composed `FulfillmentReadPort`,
-preserve optional-not-found and public error behavior, and remove only the
-private GraphQL concrete delegate. Lifecycle mutation services remain unchanged.
-
 ## Diagnostics
 
 The owner boundary records operation, correlation id, tenant, actor, channel
@@ -126,9 +133,8 @@ length, locale length, causation/trace presence, deadline, relevant fulfillment,
 order, customer, and status facts, stable owner code, error kind, and
 retryability. Only technical database events retain the typed internal cause.
 
-The admin REST boundary additionally records the public HTTP code/status and the
-stable owner code, retryability, actor, channel, locale, deadline, resource, and
-transport operation.
+The GraphQL and admin REST boundaries additionally retain transport operation,
+resource identity, public policy code, retryability, and deadline context.
 
 ## Evidence
 
@@ -136,14 +142,16 @@ Source evidence is retained at:
 
 `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`
 
-Its status is `source_rest_cutover_unvalidated`. It records completed default
-server composition and admin REST list/detail cutover while keeping GraphQL
-facade cutover and private concrete delegate removal false.
+Its status is `source_cutover_unvalidated`. It records completed default server
+composition, GraphQL lifecycle lookup/list/latest-by-order cutover, admin REST
+list/detail cutover, and concrete GraphQL delegate removal. Runtime parity remains
+explicitly unproven.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
 cargo check -p rustok-fulfillment --lib
 cargo check -p rustok-commerce --lib
 cargo check -p rustok-server --features mod-commerce

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -61,21 +61,27 @@ Commerce publishes a separate
 `CommerceFulfillmentLifecycleReadRuntime`. The default application host reuses an
 externally installed runtime or constructs the in-process baseline once, caches it
 in `ServerRuntimeContext`, and attaches the same typed value to
-`HostRuntimeContext`. `CommerceHttpRuntime` requires that runtime. Admin REST
-fulfillment list/detail consume its cloned owner port and no longer construct a
-concrete read service.
+`HostRuntimeContext`. `CommerceHttpRuntime` requires that runtime.
 
-The admin REST cutover preserves page/per-page, status/order/customer filters,
-owner pagination total, detail not-found behavior, public HTTP status/code/message
-policy, authenticated user actor, request locale/channel, resource correlation,
-and a two-second deadline. Lifecycle mutations remain on their existing concrete
-or orchestration owner paths.
+The mounted `CommerceShippingOptionReadScope` now carries both shipping-option and
+fulfillment-lifecycle runtimes for each GraphQL resolver task. The private
+compatibility facade resolves `Arc<dyn FulfillmentReadPort>` from that shared
+scope. Fulfillment lookup, filtered list, and latest-by-order now call the three
+owner operations while leaving `query.rs` signatures and optional-not-found
+behavior unchanged. The previous private concrete `FulfillmentService` field and
+constructor are removed.
 
-The private GraphQL compatibility facade still retains one concrete
-`FulfillmentService` for fulfillment lookup, list, and latest-by-order. GraphQL
-runtime-data construction consumes the host value and retains an explicit
-in-process fallback only for directly embedded compatibility schemas. Request-safe
-GraphQL lifecycle scope and consumer cutover remain open.
+Admin REST fulfillment list/detail consume the same host-selected owner port. The
+cutover preserves page/per-page, status/order/customer filters, owner pagination
+total, detail not-found behavior, public HTTP status/code/message policy,
+authenticated user actor, request locale/channel, resource correlation, and a
+two-second deadline.
+
+GraphQL lifecycle reads preserve the existing lookup `None`, list pagination and
+filters, optional latest-by-order projection, compatibility error classes, tenant
+identity, stable service actor, resource correlation, and a two-second deadline.
+Lifecycle mutations remain on their existing concrete or orchestration owner
+paths.
 
 The native FFA surface remains seller/cart selection through
 `ShippingSelectionPort`; it does not publish complete projection list or lookup
@@ -104,9 +110,8 @@ operations. No projection API should be added without a concrete consumer.
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`.
 - Both files are unvalidated source evidence and do not promote status.
 - Focused guards cover owner boundaries, application-host runtime composition,
-  Commerce HTTP injection, admin REST lifecycle consumer cutover, typed public
-  envelopes, current GraphQL compatibility consumers, and the separate native
-  selection surface.
+  shared GraphQL resolver scope, GraphQL/admin REST lifecycle consumer cutover,
+  typed public envelopes, and the separate native selection surface.
 - Compile, migrated database, mounted transport, restart, contention, and remote
   evidence remain missing.
 
@@ -180,16 +185,19 @@ operations. No projection API should be added without a concrete consumer.
   resource correlation, and two-second deadline context.
 - [x] Keep lifecycle mutation concrete/orchestration service construction
   unchanged.
-- [x] Retain source evidence and a focused guard that record completed runtime and
-  admin REST cutover without claiming GraphQL consumer cutover.
-- [ ] Add resolver scope or equivalent request-safe injection for GraphQL.
-- [ ] Cut GraphQL fulfillment lookup, filtered list, and latest-by-order reads over
-  to `FulfillmentReadPort` while preserving optional-not-found and public error
-  behavior.
-- [ ] Remove the remaining concrete `FulfillmentService` field from the private
-  GraphQL compatibility facade; lifecycle mutation services remain unchanged.
+- [x] Scope the host-selected lifecycle runtime through the existing mounted
+  Commerce GraphQL resolver extension.
+- [x] Cut GraphQL fulfillment lookup, filtered list, and latest-by-order reads over
+  to `FulfillmentReadPort` while preserving lookup `None`, list metadata, and
+  optional latest-by-order behavior.
+- [x] Preserve GraphQL compatibility error classes through typed `PortErrorKind`
+  mapping without owner-message control flow.
+- [x] Remove the remaining concrete `FulfillmentService` read field and constructor
+  from the private GraphQL compatibility facade.
+- [x] Retain source evidence and focused guards that record complete source cutover
+  without claiming mounted runtime parity.
 - [ ] Execute compile, mounted GraphQL/REST lifecycle query, deadline, tenant,
-  filter, optional-not-found, failure, and remote evidence.
+  filter, optional-not-found, failure, restart, and remote evidence.
 
 ## Open results
 
@@ -233,15 +241,14 @@ operations. No projection API should be added without a concrete consumer.
    envelopes, and no mounted projection transport constructs a concrete read
    service or provider.
 
-6. **Complete mounted lifecycle GraphQL read cutover.** Use the already
-   host-composed `CommerceFulfillmentLifecycleReadRuntime`, add request-safe
-   GraphQL injection, route GraphQL lookup/list/latest-by-order through
-   `FulfillmentReadPort`, and remove the private GraphQL concrete delegate. Admin
-   REST list/detail already consume the owner port.
-   **Depends on:** stable GraphQL optional-not-found and public error contracts.
-   **Done when:** mounted GraphQL lifecycle reads consume the host-selected owner
-   port, preserve existing response policy, and no mounted lifecycle read
-   constructs `FulfillmentService` inside the private Commerce query facade.
+6. **Prove mounted lifecycle read parity.** Execute GraphQL lookup/list/latest-by-
+   order and admin REST list/detail through the host-selected
+   `CommerceFulfillmentLifecycleReadRuntime` against the same owner projections.
+   **Depends on:** compiled fulfillment/Commerce/server crates and mounted
+   transport fixtures.
+   **Done when:** GraphQL and REST preserve tenant, filters, pagination, optional
+   not-found, public error policy, deadline behavior, restart behavior, and remote
+   adapter selection with no concrete Commerce read construction.
 
 7. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.

--- a/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
@@ -14,7 +14,8 @@ const query = read('crates/rustok-commerce/src/graphql/query.rs');
 const facade = read('crates/rustok-commerce/src/graphql/safe_query.rs');
 const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
 const commerceCargo = read('crates/rustok-commerce/Cargo.toml');
-const owner = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const shippingOwner = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const lifecycleOwner = read('crates/rustok-fulfillment/src/fulfillment_read.rs');
 const serverComposition = read('apps/server/src/services/commerce_provider_runtime.rs');
 const serverSchema = read('apps/server/src/graphql/schema.rs');
 const failures = [];
@@ -65,6 +66,24 @@ const optionAdminList = between(
   'pub async fn get_fulfillment(',
   'administrative shipping option list facade',
 );
+const fulfillmentLookup = between(
+  shim,
+  'pub async fn get_fulfillment(',
+  'pub async fn list_fulfillments(',
+  'fulfillment lookup facade',
+);
+const fulfillmentList = between(
+  shim,
+  'pub async fn list_fulfillments(',
+  'pub async fn find_by_order(',
+  'fulfillment list facade',
+);
+const fulfillmentLatest = between(
+  shim,
+  'pub async fn find_by_order(',
+  'fn shipping_option_query_context(',
+  'fulfillment latest-by-order facade',
+);
 const adminQuery = between(
   query,
   'async fn shipping_options(',
@@ -74,84 +93,112 @@ const adminQuery = between(
 const portBoundary = between(
   shim,
   'fn map_shipping_option_lookup_port_error(',
-  '#[allow(clippy::too_many_arguments)]\n        fn log_fulfillment_query_error(',
-  'shipping option port boundary',
+  '    }\n\n    use self::rustok_api_shim as rustok_api;',
+  'fulfillment port boundary',
 );
 
 for (const [value, label] of [
   ['mod rustok_fulfillment_shim {', 'private fulfillment facade'],
   ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'safe fulfillment routing'],
-  ['inner: ::rustok_fulfillment::FulfillmentService', 'legacy lifecycle delegate'],
   ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'storefront read port field'],
   [
     'shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>',
     'administrative read port field',
   ],
+  ['fulfillment_reads: Arc<dyn FulfillmentReadPort>', 'lifecycle read port field'],
   ['pub async fn list_all_shipping_options(', 'administrative all-options facade'],
+  ['pub async fn get_fulfillment(', 'fulfillment lookup facade'],
+  ['pub async fn list_fulfillments(', 'fulfillment list facade'],
   ['pub async fn find_by_order(', 'order fulfillment facade'],
   ['FulfillmentResult<Option<FulfillmentResponse>>', 'order fulfillment typed result'],
-]) {
-  requireText(facade, value, label);
-}
+]) requireText(facade, value, label);
 
 for (const [value, label] of [
   [
     'shipping_option_read_runtime_for_current_graphql_scope(',
-    'resolver-scoped runtime resolution',
+    'shipping resolver-scoped runtime resolution',
   ],
   ['shipping_option_runtime.shipping_option_read_port()', 'host storefront read port'],
   [
     'shipping_option_runtime\n                        .shipping_option_admin_read_port()',
     'host administrative read port',
   ],
-  ['::rustok_fulfillment::FulfillmentService::new(db)', 'isolated lifecycle constructor'],
-]) {
-  requireText(constructor, value, label);
-}
+  [
+    'fulfillment_lifecycle_read_runtime_for_current_graphql_scope(db)',
+    'lifecycle resolver-scoped runtime resolution',
+  ],
+  [
+    'fulfillment_lifecycle_runtime.fulfillment_read_port()',
+    'host lifecycle read port',
+  ],
+]) requireText(constructor, value, label);
 for (const value of [
+  '::rustok_fulfillment::FulfillmentService::new(db)',
   'in_process_shipping_option_read_port',
   'in_process_shipping_option_admin_read_port',
-]) {
-  forbidText(shim, value, 'private facade must not construct shipping-option ports');
-}
+  'in_process_fulfillment_read_port',
+]) forbidText(shim, value, 'private facade must not construct concrete read implementations');
 
 for (const [source, value, label] of [
-  [optionLookup, 'FulfillmentResult<ShippingOptionResponse>', 'optional lookup result'],
+  [optionLookup, 'FulfillmentResult<ShippingOptionResponse>', 'optional option lookup result'],
   [optionLookup, '.read_shipping_option_projection(', 'owner option lookup'],
-  [optionLookup, 'ReadShippingOptionProjectionRequest {', 'typed lookup request'],
-  [optionLookup, 'map_shipping_option_lookup_port_error(', 'lookup compatibility adapter'],
-  [optionList, 'Result<Vec<ShippingOptionResponse>, BoundaryError>', 'storefront list result'],
-  [optionList, '.list_shipping_option_projections(', 'owner storefront list'],
-  [optionList, 'ListShippingOptionProjectionsRequest {', 'typed storefront request'],
-  [optionList, 'map_shipping_option_port_error(', 'storefront boundary mapper'],
+  [optionLookup, 'ReadShippingOptionProjectionRequest {', 'typed option lookup request'],
+  [optionLookup, 'map_shipping_option_lookup_port_error(', 'option lookup adapter'],
+  [optionList, 'Result<Vec<ShippingOptionResponse>, BoundaryError>', 'storefront option list result'],
+  [optionList, '.list_shipping_option_projections(', 'owner storefront option list'],
+  [optionList, 'ListShippingOptionProjectionsRequest {', 'typed storefront option request'],
+  [optionList, 'map_shipping_option_port_error(', 'storefront option boundary mapper'],
   [
     optionAdminList,
     'Result<Vec<ShippingOptionResponse>, ShippingOptionAdminQueryError>',
-    'typed admin adapter result',
+    'typed admin option result',
   ],
-  [optionAdminList, '.list_all_shipping_option_projections(', 'owner admin list'],
-  [optionAdminList, 'ListAllShippingOptionProjectionsRequest {', 'typed admin request'],
+  [optionAdminList, '.list_all_shipping_option_projections(', 'owner admin option list'],
+  [optionAdminList, 'ListAllShippingOptionProjectionsRequest {', 'typed admin option request'],
   [
     optionAdminList,
     'ShippingOptionAdminQueryError(map_shipping_option_port_error(',
-    'admin boundary adapter',
+    'admin option boundary adapter',
   ],
-]) {
-  requireText(source, value, label);
-}
+  [fulfillmentLookup, 'FulfillmentResult<FulfillmentResponse>', 'fulfillment lookup result'],
+  [fulfillmentLookup, '.read_fulfillment_projection(', 'owner fulfillment lookup'],
+  [
+    fulfillmentLookup,
+    'ReadFulfillmentProjectionRequest { fulfillment_id: id }',
+    'typed fulfillment lookup request',
+  ],
+  [fulfillmentLookup, 'map_fulfillment_port_error(', 'fulfillment lookup adapter'],
+  [fulfillmentList, 'ListFulfillmentsInput {', 'compatibility list input destructuring'],
+  [fulfillmentList, '.list_fulfillment_projections(', 'owner fulfillment list'],
+  [fulfillmentList, 'ListFulfillmentProjectionsRequest {', 'typed fulfillment list request'],
+  [fulfillmentList, 'Ok((page_result.items, page_result.total))', 'list result compatibility'],
+  [
+    fulfillmentLatest,
+    '.find_latest_fulfillment_by_order_projection(',
+    'owner latest fulfillment by order',
+  ],
+  [
+    fulfillmentLatest,
+    'FindLatestFulfillmentByOrderProjectionRequest { order_id }',
+    'typed latest fulfillment request',
+  ],
+]) requireText(source, value, label);
 
 for (const [value, label] of [
-  ['pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);', 'typed admin error'],
+  ['pub(crate) struct ShippingOptionAdminQueryError(BoundaryError);', 'typed admin option error'],
   ['pub(crate) fn to_string(self) -> BoundaryError', 'non-string source bridge'],
   ['self.0', 'boundary preservation'],
-]) {
-  requireText(shim, value, label);
-}
-for (const value of ['impl std::fmt::Display', 'impl Display', 'format!("{}", self.0)']) {
-  forbidText(shim, value, 'admin boundary must not serialize through text');
-}
-
-for (const [value, label] of [
+  ['fn fulfillment_query_context(', 'lifecycle context builder'],
+  [
+    'PortActor::service("rustok-commerce.graphql-query-fulfillments")',
+    'lifecycle service actor',
+  ],
+  [
+    'graphql-fulfillment-lifecycle:{query_field}:{operation}:{resource}',
+    'lifecycle correlation context',
+  ],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline context'],
+  ['fn map_fulfillment_port_error(', 'lifecycle compatibility mapper'],
   ['PortErrorKind::Validation', 'validation classification'],
   ['PortErrorKind::NotFound', 'not-found classification'],
   ['PortErrorKind::Conflict', 'conflict classification'],
@@ -164,87 +211,90 @@ for (const [value, label] of [
   ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'unavailable code'],
   ['"FULFILLMENT_ACCESS_DENIED"', 'forbidden code'],
   ['"FULFILLMENT_OPERATION_FAILED"', 'invariant code'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['correlation_id = %context.correlation_id', 'correlation logging'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline logging'],
   ['owner_code = %error.code', 'stable owner code'],
   ['BoundaryError::Public {', 'typed public boundary'],
-]) {
-  requireText(portBoundary, value, label);
+]) requireText(portBoundary, value, label);
+for (const value of ['impl std::fmt::Display', 'impl Display', 'format!("{}", self.0)']) {
+  forbidText(shim, value, 'admin boundary must not serialize through text');
 }
 
 for (const [value, label] of [
-  ['pub struct CommerceShippingOptionReadRuntime {', 'host read runtime'],
-  ['shipping_option_reads: Arc<dyn ShippingOptionReadPort>', 'runtime storefront port'],
-  [
-    'shipping_option_admin_reads: Arc<dyn ShippingOptionAdminReadPort>',
-    'runtime administrative port',
-  ],
-  ['pub fn new(', 'host-injectable runtime constructor'],
-  ['pub fn in_process(db: DatabaseConnection) -> Self', 'standalone compatibility factory'],
-  ['in_process_shipping_option_read_port(db.clone())', 'standalone storefront factory'],
-  ['in_process_shipping_option_admin_read_port(db)', 'standalone admin factory'],
+  ['pub struct CommerceShippingOptionReadRuntime {', 'host shipping runtime'],
+  ['pub struct CommerceFulfillmentLifecycleReadRuntime {', 'host lifecycle runtime'],
   ['tokio::task_local! {', 'async task-local scope'],
-  ['CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME', 'scoped runtime identity'],
-  ['pub struct CommerceShippingOptionReadScope;', 'GraphQL scope extension'],
+  ['CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME', 'shipping scoped runtime identity'],
+  [
+    'CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME',
+    'lifecycle scoped runtime identity',
+  ],
+  ['pub struct CommerceShippingOptionReadScope;', 'shared GraphQL scope extension'],
   ['impl ExtensionFactory for CommerceShippingOptionReadScope', 'extension factory'],
   ['ctx.data_opt::<CommerceGraphqlRuntimeData>()', 'schema runtime lookup'],
-  ['.scope(', 'resolver task scope'],
+  ['runtime_data.shipping_option_read_runtime()', 'shipping runtime scope value'],
+  [
+    'runtime_data.fulfillment_lifecycle_read_runtime()',
+    'lifecycle runtime scope value',
+  ],
   ['.try_with(Clone::clone)', 'facade runtime lookup'],
-  ['CommerceShippingOptionReadRuntime::in_process(db)', 'standalone fallback'],
+  ['CommerceShippingOptionReadRuntime::in_process(db)', 'shipping standalone fallback'],
+  [
+    'CommerceFulfillmentLifecycleReadRuntime::in_process(db)',
+    'lifecycle standalone fallback',
+  ],
   [
     '.shared_get::<CommerceShippingOptionReadRuntime>()',
-    'manifest runtime-data host requirement',
+    'manifest shipping runtime host requirement',
   ],
-]) {
-  requireText(graphqlRuntime, value, label);
-}
+  [
+    '.shared_get::<CommerceFulfillmentLifecycleReadRuntime>()',
+    'manifest lifecycle runtime host selection',
+  ],
+]) requireText(graphqlRuntime, value, label);
 
 for (const [value, label] of [
   [
     'shared_get::<rustok_commerce::graphql_runtime::CommerceShippingOptionReadRuntime>()',
-    'server runtime reuse',
+    'server shipping runtime reuse',
   ],
   [
-    'CommerceShippingOptionReadRuntime::in_process(',
-    'server in-process baseline composition',
+    'shared_get::<rustok_commerce::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()',
+    'server lifecycle runtime reuse',
   ],
   ['server.shared_insert(runtime.clone());', 'server runtime cache'],
   ['host.with_shared_value(runtime)', 'host runtime attachment'],
-]) {
-  requireText(serverComposition, value, label);
-}
+]) requireText(serverComposition, value, label);
 
 for (const [value, label] of [
   [
     'use rustok_commerce::graphql_runtime::CommerceShippingOptionReadScope;',
-    'server extension import',
+    'server shared extension import',
   ],
   [
     'let builder = builder.extension(CommerceShippingOptionReadScope);',
-    'server extension mount',
+    'server shared extension mount',
   ],
-]) {
-  requireText(serverSchema, value, label);
-}
+]) requireText(serverSchema, value, label);
 requireText(commerceCargo, 'tokio.workspace = true', 'task-local runtime dependency');
 
 for (const [value, label] of [
-  ['use rustok_fulfillment::FulfillmentService;', 'unchanged query import'],
-  ['let mut options = FulfillmentService::new(db.clone())', 'storefront facade constructor'],
-  ['let fulfillment = FulfillmentService::new(db.clone())', 'lifecycle facade constructor'],
-  ['Err(rustok_fulfillment::error::FulfillmentError::ShippingOptionNotFound(_))', 'optional none'],
+  ['use rustok_fulfillment::FulfillmentService;', 'unchanged query facade import'],
+  ['.get_fulfillment(tenant_id, id)', 'query fulfillment lookup facade call'],
+  ['.list_fulfillments(', 'query fulfillment list facade call'],
+  ['.find_by_order(tenant_id, id)', 'query latest-by-order facade call'],
+  [
+    'Err(rustok_fulfillment::error::FulfillmentError::FulfillmentNotFound(_))',
+    'optional fulfillment lookup none',
+  ],
   ['Err(err) => return Err(err.to_string().into())', 'lookup fail-closed conversion'],
-]) {
-  requireText(query, value, label);
-}
+]) requireText(query, value, label);
 for (const [value, label] of [
-  ['.list_all_shipping_options(', 'admin facade call'],
+  ['.list_all_shipping_options(', 'admin option facade call'],
   ['.map_err(|err| async_graphql::Error::new(err.to_string()))?', 'typed admin source bridge'],
-  ['active: None,', 'admin active filter'],
-  ['items.retain(|option| option.active == active);', 'admin active filtering'],
-]) {
-  requireText(adminQuery, value, label);
-}
+  ['active: None,', 'admin option active filter'],
+  ['items.retain(|option| option.active == active);', 'admin option filtering'],
+]) requireText(adminQuery, value, label);
 forbidText(
   query,
   '::rustok_fulfillment::FulfillmentService',
@@ -253,29 +303,40 @@ forbidText(
 
 const concreteConstructors =
   facade.match(/::rustok_fulfillment::FulfillmentService::new\(db\)/g) ?? [];
-if (concreteConstructors.length !== 1) {
-  failures.push(`expected one remaining lifecycle constructor, found ${concreteConstructors.length}`);
+if (concreteConstructors.length !== 0) {
+  failures.push(`expected zero concrete lifecycle constructors, found ${concreteConstructors.length}`);
 }
-const runtimeReadFactories =
+const shippingRuntimeFactories =
   graphqlRuntime.match(/in_process_shipping_option_read_port\(db\.clone\(\)\)/g) ?? [];
-if (runtimeReadFactories.length !== 1) {
-  failures.push(`expected one standalone storefront factory, found ${runtimeReadFactories.length}`);
+if (shippingRuntimeFactories.length !== 1) {
+  failures.push(`expected one standalone storefront factory, found ${shippingRuntimeFactories.length}`);
 }
-const runtimeAdminFactories =
+const adminRuntimeFactories =
   graphqlRuntime.match(/in_process_shipping_option_admin_read_port\(db\)/g) ?? [];
-if (runtimeAdminFactories.length !== 1) {
-  failures.push(`expected one standalone admin factory, found ${runtimeAdminFactories.length}`);
+if (adminRuntimeFactories.length !== 1) {
+  failures.push(`expected one standalone admin factory, found ${adminRuntimeFactories.length}`);
+}
+const lifecycleRuntimeFactories =
+  graphqlRuntime.match(/in_process_fulfillment_read_port\(db\)/g) ?? [];
+if (lifecycleRuntimeFactories.length !== 1) {
+  failures.push(`expected one standalone lifecycle factory, found ${lifecycleRuntimeFactories.length}`);
 }
 
-for (const [value, label] of [
-  ['pub trait ShippingOptionReadPort: Send + Sync {', 'owner storefront read port'],
-  ['pub trait ShippingOptionAdminReadPort: Send + Sync {', 'owner admin read port'],
-  ['async fn list_all_shipping_option_projections(', 'owner admin operation'],
-  ['context.require_policy(PortCallPolicy::read())?', 'owner read policy'],
-  ['PortError::new(kind, code, message, retryable)', 'owner stable error'],
-]) {
-  requireText(owner, value, label);
-}
+for (const [source, value, label] of [
+  [shippingOwner, 'pub trait ShippingOptionReadPort: Send + Sync {', 'owner storefront read port'],
+  [shippingOwner, 'pub trait ShippingOptionAdminReadPort: Send + Sync {', 'owner admin read port'],
+  [shippingOwner, 'async fn list_all_shipping_option_projections(', 'owner admin operation'],
+  [lifecycleOwner, 'pub trait FulfillmentReadPort: Send + Sync {', 'owner lifecycle read port'],
+  [lifecycleOwner, 'async fn read_fulfillment_projection(', 'owner lifecycle lookup'],
+  [lifecycleOwner, 'async fn list_fulfillment_projections(', 'owner lifecycle list'],
+  [
+    lifecycleOwner,
+    'async fn find_latest_fulfillment_by_order_projection(',
+    'owner lifecycle latest-by-order',
+  ],
+  [lifecycleOwner, 'context.require_policy(PortCallPolicy::read())?', 'owner lifecycle read policy'],
+  [lifecycleOwner, 'PortError::new(kind, code, message, retryable)', 'owner lifecycle stable error'],
+]) requireText(source, value, label);
 
 if (failures.length > 0) {
   console.error('Commerce GraphQL query fulfillment context verification failed:');
@@ -284,5 +345,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Mounted Commerce GraphQL shipping-option reads use host-composed fulfillment ports with resolver-scoped runtime data, retained typed envelopes, standalone compatibility, and isolated lifecycle reads',
+  '✔ Mounted Commerce GraphQL shipping-option and fulfillment lifecycle reads use host-composed owner ports through one resolver-scoped runtime bridge with retained compatibility envelopes',
 );

--- a/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
@@ -115,6 +115,22 @@ for (const [value, label] of [
     'CommerceFulfillmentLifecycleReadRuntime::in_process(inputs.db_clone())',
     'GraphQL in-process compatibility fallback',
   ],
+  [
+    'CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME',
+    'GraphQL lifecycle task-local identity',
+  ],
+  [
+    'runtime_data.fulfillment_lifecycle_read_runtime()',
+    'GraphQL lifecycle resolver scope value',
+  ],
+  [
+    'pub(crate) fn fulfillment_lifecycle_read_runtime_for_current_graphql_scope(',
+    'GraphQL lifecycle facade resolver',
+  ],
+  [
+    'CommerceFulfillmentLifecycleReadRuntime::in_process(db)',
+    'GraphQL lifecycle standalone fallback',
+  ],
 ]) requireText(commerceRuntime, value, label);
 
 for (const [value, label] of [
@@ -147,25 +163,93 @@ for (const [value, label] of [
   ['fulfillment_lifecycle_read_runtime,', 'Commerce HTTP runtime initialization'],
 ]) requireText(commerceHttp, value, label);
 
+const facadeConstructor = between(
+  compatibilityFacade,
+  'pub fn new(db: DatabaseConnection) -> Self {',
+  'pub async fn get_shipping_option(',
+  'GraphQL fulfillment facade constructor',
+);
+const facadeLookup = between(
+  compatibilityFacade,
+  'pub async fn get_fulfillment(',
+  'pub async fn list_fulfillments(',
+  'GraphQL fulfillment lookup',
+);
+const facadeList = between(
+  compatibilityFacade,
+  'pub async fn list_fulfillments(',
+  'pub async fn find_by_order(',
+  'GraphQL fulfillment list',
+);
+const facadeLatest = between(
+  compatibilityFacade,
+  'pub async fn find_by_order(',
+  'fn shipping_option_query_context(',
+  'GraphQL latest fulfillment by order',
+);
+
+for (const [source, value, label] of [
+  [compatibilityFacade, 'fulfillment_reads: Arc<dyn FulfillmentReadPort>', 'facade lifecycle port'],
+  [
+    facadeConstructor,
+    'fulfillment_lifecycle_read_runtime_for_current_graphql_scope(db)',
+    'facade scoped lifecycle runtime',
+  ],
+  [
+    facadeConstructor,
+    'fulfillment_reads: fulfillment_lifecycle_runtime.fulfillment_read_port()',
+    'facade injected lifecycle port',
+  ],
+  [facadeLookup, '.read_fulfillment_projection(', 'GraphQL owner lookup'],
+  [facadeLookup, 'ReadFulfillmentProjectionRequest { fulfillment_id: id }', 'typed lookup request'],
+  [facadeLookup, 'map_fulfillment_port_error(', 'lookup compatibility error mapping'],
+  [facadeList, '.list_fulfillment_projections(', 'GraphQL owner list'],
+  [facadeList, 'ListFulfillmentProjectionsRequest {', 'typed list request'],
+  [facadeList, 'status,', 'status filter forwarding'],
+  [facadeList, 'order_id,', 'order filter forwarding'],
+  [facadeList, 'customer_id,', 'customer filter forwarding'],
+  [facadeList, 'Ok((page_result.items, page_result.total))', 'list envelope compatibility'],
+  [
+    facadeLatest,
+    '.find_latest_fulfillment_by_order_projection(',
+    'GraphQL owner latest-by-order',
+  ],
+  [
+    facadeLatest,
+    'FindLatestFulfillmentByOrderProjectionRequest { order_id }',
+    'typed latest-by-order request',
+  ],
+]) requireText(source, value, label);
+
 for (const [value, label] of [
-  ['inner: ::rustok_fulfillment::FulfillmentService,', 'retained concrete facade field'],
+  ['fn fulfillment_query_context(', 'GraphQL lifecycle context builder'],
   [
-    'inner: ::rustok_fulfillment::FulfillmentService::new(db)',
-    'retained concrete facade construction',
+    'PortActor::service("rustok-commerce.graphql-query-fulfillments")',
+    'GraphQL lifecycle service actor',
   ],
   [
-    'self.inner\n                    .get_fulfillment(',
-    'retained GraphQL single-read consumer',
+    'graphql-fulfillment-lifecycle:{query_field}:{operation}:{resource}',
+    'GraphQL lifecycle correlation',
   ],
-  [
-    'self.inner\n                    .list_fulfillments(',
-    'retained GraphQL list consumer',
-  ],
-  [
-    'self.inner\n                    .find_by_order(',
-    'retained GraphQL latest-by-order consumer',
-  ],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'GraphQL lifecycle deadline'],
+  ['fn map_fulfillment_port_error(', 'GraphQL lifecycle port mapper'],
+  ['PortErrorKind::Forbidden', 'GraphQL forbidden mapping'],
+  ['PortErrorKind::Timeout', 'GraphQL timeout mapping'],
+  ['PortErrorKind::InvariantViolation', 'GraphQL invariant mapping'],
+  ['"FULFILLMENT_REQUEST_INVALID"', 'GraphQL validation code'],
+  ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'GraphQL not-found code'],
+  ['"FULFILLMENT_STATE_CONFLICT"', 'GraphQL conflict code'],
+  ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'GraphQL unavailable code'],
+  ['"FULFILLMENT_ACCESS_DENIED"', 'GraphQL forbidden code'],
+  ['"FULFILLMENT_OPERATION_FAILED"', 'GraphQL invariant code'],
+  ['owner_code = %error.code', 'GraphQL stable owner code logging'],
 ]) requireText(compatibilityFacade, value, label);
+
+for (const value of [
+  'inner: ::rustok_fulfillment::FulfillmentService',
+  '::rustok_fulfillment::FulfillmentService::new(db)',
+  'self.inner',
+]) forbidText(compatibilityFacade, value, 'GraphQL concrete lifecycle delegate');
 
 const adminList = between(
   adminRest,
@@ -202,34 +286,13 @@ for (const [source, value, label] of [
   [adminShow, '.get_fulfillment(', 'admin show concrete operation'],
 ]) forbidText(source, value, label);
 
-for (const [value, label] of [
-  ['fn admin_fulfillment_read_port_context(', 'admin read context builder'],
-  ['PortActor::user(auth.user_id.to_string())', 'admin user actor'],
-  ['request_context.locale.as_str()', 'admin locale propagation'],
-  ['request_context.channel_slug.as_deref()', 'admin channel propagation'],
-  ['commerce-admin-fulfillment:{operation}:{resource_id}', 'admin correlation id'],
-  ['with_deadline(std::time::Duration::from_secs(2))', 'admin read deadline'],
-  ['fn map_admin_fulfillment_port_error(', 'admin typed error mapper'],
-  ['PortErrorKind::Forbidden', 'admin forbidden mapping'],
-  ['PortErrorKind::Timeout', 'admin timeout mapping'],
-  ['PortErrorKind::InvariantViolation', 'admin invariant mapping'],
-  ['"commerce_admin_fulfillment_invalid"', 'admin validation public code'],
-  ['"commerce_admin_not_found"', 'admin not-found public code'],
-  ['"commerce_admin_fulfillment_state_conflict"', 'admin conflict public code'],
-  ['"commerce_admin_fulfillment_storage_unavailable"', 'admin unavailable public code'],
-  ['"commerce_admin_fulfillment_failed"', 'admin invariant public code'],
-  ['internal_code = %error.code', 'admin stable owner code logging'],
-]) requireText(adminRest, value, label);
+for (const value of ['error = %message', 'message = %', 'error.message']) {
+  forbidText(ownerSource, value, 'owner message exposure');
+}
 
-for (const value of [
-  'error = %message',
-  'message = %',
-  'error.message',
-]) forbidText(ownerSource, value, 'owner message exposure');
-
-if (evidence.status !== 'source_rest_cutover_unvalidated') {
+if (evidence.status !== 'source_cutover_unvalidated') {
   failures.push(
-    `evidence status: expected source_rest_cutover_unvalidated, found ${evidence.status}`,
+    `evidence status: expected source_cutover_unvalidated, found ${evidence.status}`,
   );
 }
 if (evidence.owner?.port !== 'FulfillmentReadPort') {
@@ -238,47 +301,39 @@ if (evidence.owner?.port !== 'FulfillmentReadPort') {
 if (evidence.runtime_publication?.runtime !== 'CommerceFulfillmentLifecycleReadRuntime') {
   failures.push('evidence runtime publication mismatch');
 }
-if (evidence.runtime_publication?.graphql_host_override_supported !== true) {
-  failures.push('evidence must record GraphQL host override support');
+for (const [value, label] of [
+  [evidence.runtime_publication?.graphql_host_override_supported, 'GraphQL host override'],
+  [evidence.runtime_publication?.server_cache_composed, 'server cache composition'],
+  [evidence.runtime_publication?.default_server_attachment, 'default server attachment'],
+  [evidence.runtime_publication?.commerce_http_runtime_required, 'Commerce HTTP injection'],
+  [evidence.runtime_publication?.external_adapter_preserved, 'external adapter preservation'],
+  [evidence.runtime_publication?.graphql_task_local_scoped, 'GraphQL task-local scope'],
+  [evidence.admin_rest?.pagination_total_preserved, 'admin pagination total'],
+  [evidence.admin_rest?.filters_preserved, 'admin filters'],
+  [evidence.admin_rest?.public_error_policy_preserved, 'admin public error policy'],
+  [evidence.admin_rest?.mutation_service_construction_unchanged, 'mutation service preservation'],
+  [evidence.graphql?.existing_query_source_unchanged, 'unchanged query source'],
+  [evidence.graphql?.optional_lookup_not_found_preserved, 'optional lookup not-found'],
+  [evidence.graphql?.optional_latest_by_order_preserved, 'optional latest-by-order'],
+  [evidence.graphql?.pagination_total_and_filters_preserved, 'GraphQL pagination and filters'],
+  [evidence.graphql?.public_error_policy_preserved, 'GraphQL public error policy'],
+  [evidence.consumer_cutover?.graphql_compatibility_facade, 'GraphQL facade cutover'],
+  [evidence.consumer_cutover?.admin_rest_list_show, 'admin REST cutover'],
+  [evidence.consumer_cutover?.concrete_delegate_removed, 'concrete delegate removal'],
+]) {
+  if (value !== true) failures.push(`evidence must record ${label}`);
 }
 if (evidence.runtime_publication?.graphql_manifest_fallback !== 'in_process') {
   failures.push('evidence must record the GraphQL in-process fallback');
 }
-if (evidence.runtime_publication?.server_cache_composed !== true) {
-  failures.push('evidence must record default server cache composition');
-}
-if (evidence.runtime_publication?.default_server_attachment !== true) {
-  failures.push('evidence must record default server attachment');
-}
-if (evidence.runtime_publication?.commerce_http_runtime_required !== true) {
-  failures.push('evidence must record mandatory Commerce HTTP runtime injection');
-}
-if (evidence.runtime_publication?.external_adapter_preserved !== true) {
-  failures.push('evidence must record preservation of external adapters');
-}
-if (evidence.admin_rest?.pagination_total_preserved !== true) {
-  failures.push('evidence must record preserved admin pagination total');
-}
-if (evidence.admin_rest?.filters_preserved !== true) {
-  failures.push('evidence must record preserved admin list filters');
-}
-if (evidence.admin_rest?.public_error_policy_preserved !== true) {
-  failures.push('evidence must record preserved admin public error policy');
-}
 if (evidence.admin_rest?.concrete_service_read_construction !== false) {
   failures.push('evidence must forbid concrete admin REST read construction');
 }
-if (evidence.admin_rest?.mutation_service_construction_unchanged !== true) {
-  failures.push('evidence must retain lifecycle mutation service construction');
+if (evidence.graphql?.concrete_service_read_construction !== false) {
+  failures.push('evidence must forbid concrete GraphQL read construction');
 }
-if (evidence.consumer_cutover?.graphql_compatibility_facade !== false) {
-  failures.push('evidence must retain GraphQL facade cutover as false');
-}
-if (evidence.consumer_cutover?.admin_rest_list_show !== true) {
-  failures.push('evidence must record admin REST list/show cutover');
-}
-if (evidence.consumer_cutover?.concrete_delegate_removed !== false) {
-  failures.push('evidence must retain concrete delegate removal as false');
+if (evidence.validation?.runtime_parity_proven !== false) {
+  failures.push('evidence must retain runtime parity as unproven');
 }
 for (const key of [
   'tests_run',
@@ -300,5 +355,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment lifecycle reads are owner-published and host-composed; admin REST list/show consume the typed port while GraphQL cutover remains explicitly open',
+  '✔ fulfillment lifecycle reads are owner-published, host-composed, and consumed through typed GraphQL and admin REST boundaries without concrete Commerce read delegates',
 );


### PR DESCRIPTION
## Summary

- scope `CommerceFulfillmentLifecycleReadRuntime` through the existing mounted `CommerceShippingOptionReadScope` for every Commerce GraphQL resolver task;
- resolve the host-selected lifecycle runtime in the private compatibility facade, with the public runtime module retaining the explicit in-process fallback for directly embedded schemas;
- replace the private concrete `FulfillmentService` read delegate with `Arc<dyn FulfillmentReadPort>`;
- route fulfillment lookup through `read_fulfillment_projection`;
- route filtered fulfillment list through `list_fulfillment_projections`;
- route admin order latest-fulfillment enrichment through `find_latest_fulfillment_by_order_projection`;
- preserve the unchanged `query.rs` compatibility signatures, lookup `None`, optional latest-by-order, list filters, pagination total, DTO envelopes, and public error classes;
- retain tenant, stable service actor, resource correlation, and a two-second deadline in GraphQL lifecycle read context;
- leave admin REST cutover and all lifecycle mutations/orchestration unchanged;
- update source evidence, both focused guards, owner documentation, Commerce GraphQL boundary documentation, and the fulfillment roadmap.

## Boundary

This PR completes the fulfillment lifecycle **source** read cutover. It deliberately does **not**:

- change `crates/rustok-commerce/src/graphql/query.rs`;
- change lifecycle create/ship/deliver/reopen/reship/cancel paths;
- claim compiled or mounted GraphQL/REST parity;
- claim restart or external-adapter execution evidence;
- promote fulfillment FFA/FBA status;
- close the canonical Commerce plan's broader Product/Order/Payment/Fulfillment owner-port task, because the other owner domains remain open.

Evidence status is `source_cutover_unvalidated`; `runtime_parity_proven` remains false.

## Recheck

- confirmed PR #2359 composes the lifecycle runtime and PR #2364 cuts admin REST list/detail over to the owner port;
- confirmed no open PR overlaps the lifecycle GraphQL boundary;
- preserved the existing single mounted scope extension instead of adding a second resolver extension;
- confirmed the private facade has zero concrete lifecycle read constructors and three typed lifecycle owner-port consumers;
- confirmed `query.rs` is unchanged and continues to provide optional-not-found and list-envelope compatibility;
- refreshed both dependent guards that previously expected the isolated concrete lifecycle delegate;
- reviewed the final Rust patches and confirmed the large facade diff is restricted to the private fulfillment shim;
- rebuilt the branch as one atomic commit over current `main` commit `184ae1a7b413958bd06f2ea3fb66c2c266812991`;
- confirmed one commit ahead, zero behind, with exactly eight intended files;
- confirmed intervening `main` changes are unrelated Iggy/Profile evidence files.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested maintainer checks:

```bash
node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
cargo check -p rustok-server --features mod-commerce
```

## Next slice

Execute mounted GraphQL lookup/list/latest-by-order and admin REST list/detail parity through the host-selected runtime, including tenant, filter, pagination, optional-not-found, deadline, failure, restart, and external-adapter evidence.