### PR TITLE
test(index): integrate post-inspection integrity checks

### DIFF
--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -79,6 +79,7 @@ const runContract = (args) => {
     'verify-index-partition-maintenance-evidence.mjs',
     'verify-index-partition-cutover-evidence.mjs',
     'verify-index-partition-full-capture.mjs',
+    'verify-index-partition-post-inspection-drift.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',
     'verify-index-storage-standalone-tools.mjs',
@@ -120,6 +121,7 @@ const runFixtures = (args) => {
     scriptPath('index-partition-evidence-assembly.test.mjs'),
     scriptPath('index-partition-full-capture-plan.test.mjs'),
     scriptPath('index-partition-review.test.mjs'),
+    scriptPath('index-partition-post-inspection-drift.test.mjs'),
   ], 'Index storage fixture suites');
 };
 

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -32,6 +32,8 @@ try {
   const archiveCli = read('scripts/verify/render-index-partition-archive-manifest.mjs');
   const archiveVerifyCli = read('scripts/verify/verify-index-partition-archive-manifest.mjs');
   const reviewTest = read('scripts/verify/index-partition-review.test.mjs');
+  const postInspectionGuard = read('scripts/verify/verify-index-partition-post-inspection-drift.mjs');
+  const postInspectionTest = read('scripts/verify/index-partition-post-inspection-drift.test.mjs');
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
   const plan = read('crates/rustok-index/docs/implementation-plan.md');
@@ -147,6 +149,7 @@ try {
     'saved archive manifest aliases a retained bundle file',
     'saved archive manifest digest does not match canonical payload',
     'saved archive manifest does not match recalculated retained bundle manifest',
+    'retained_files_rechecked: true',
     'production_lifecycle_authorized: false',
   ], 'retained partition archive manifest core');
   requireMarkers(archiveCli, [
@@ -198,6 +201,19 @@ try {
     'saved admission that does not match recalculated packet admission',
     'rejects raw artifact drift from the retained packet',
   ], 'retained partition review fixture');
+  requireMarkers(postInspectionGuard, [
+    '[verify-index-partition-post-inspection-drift]',
+    'readStableRegularFile',
+    'assertRetainedFilesUnchanged',
+    'changed after inspection',
+    'retained_files_rechecked: true',
+    'production_lifecycle_authorized: false',
+  ], 'post-inspection drift guard');
+  requireMarkers(postInspectionTest, [
+    'rechecks all retained files before publishing an archive verification receipt',
+    'fails closed when a retained file changes after inspection',
+    'retained bundle file query changed after inspection',
+  ], 'post-inspection drift fixture');
   requireMarkers(tooling, [
     'partition-capture',
     'run-index-partition-evidence.mjs',
@@ -210,6 +226,8 @@ try {
     'verify-index-partition-archive-manifest.mjs',
     'index-partition-review.test.mjs',
     'verify-index-partition-full-capture.mjs',
+    'verify-index-partition-post-inspection-drift.mjs',
+    'index-partition-post-inspection-drift.test.mjs',
   ], 'index storage tooling router');
   requireMarkers(runbook, [
     'M3 partition cutover rehearsal evidence runner: `complete`',


### PR DESCRIPTION
## Summary

- register `verify-index-partition-post-inspection-drift.mjs` in the aggregate `index-storage-tooling.mjs contract` command;
- register `index-partition-post-inspection-drift.test.mjs` in the aggregate `index-storage-tooling.mjs fixtures` command;
- extend the existing full-capture static guard so it requires both aggregate registrations;
- require the focused guard and fixture to retain their key stable-read, post-inspection drift, receipt, and production-boundary markers.

## Safety boundary

This changes only aggregate verification coverage. It does not change `partition-archive-verify`, evidence formats, admission, PostgreSQL access, capture stages, production partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter behavior.

## Validation

Per repository-owner instruction, tests, fixture suites, aggregate contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run.

Only JavaScript syntax checks were run:

```bash
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-full-capture.mjs
```

Suggested owner checks:

```bash
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

The branch was created from Index merge commit `6bb412eb1728f17df5e2f0e1fd37ab391f672a9b`. Current `main` advanced only through unrelated Commerce, Fulfillment, Iggy, and Profiles paths; the two Index paths in this PR do not overlap those base changes.