### PR TITLE
test(profiles): define Postgres Iggy poison ordering evidence

### DIFF
--- a/crates/rustok-profiles/docs/poison-postgres-iggy-ordering-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-postgres-iggy-ordering-checkpoint.md
@@ -1,0 +1,71 @@
+# Profiles checkpoint: raw poison PostgreSQL/Iggy ordering
+
+## Status
+
+Source-complete, runtime-pending.
+
+This checkpoint records the combined PostgreSQL + external Iggy evidence boundary added after the separate connector receipt, cursor lifecycle, physical header, dedup behavior, and retained dedup tooling slices.
+
+## Delivered source evidence
+
+`rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs` now defines two opt-in cases using the first approved raw-poison owner consumer:
+
+1. **Published before source acknowledgement**
+   - unique PostgreSQL schema with connector receipt migrations;
+   - unique external Iggy stream and one partition;
+   - production `SocialGraphIndexConsumer` typed receive;
+   - neutral receipt `Claimed`/`publishing`;
+   - exact-byte production DLQ publication;
+   - receipt remains `publishing` after broker success;
+   - durable `published` before source acknowledgement;
+   - source acknowledgement before best-effort `acknowledged` bookkeeping;
+   - next source offset becomes visible only afterward.
+
+2. **Acknowledgement-only redelivery**
+   - first process publishes and persists `published` but does not acknowledge the source;
+   - a new transport and the same fixed consumer group receive the same offset, bytes, and UUID;
+   - the receipt store returns `AlreadyPublished`;
+   - recovery performs no second DLQ publication;
+   - source acknowledgement and `acknowledged` bookkeeping complete;
+   - the next source offset becomes visible.
+
+The machine contract is:
+
+```text
+crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json
+```
+
+The static parity guard is:
+
+```text
+node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
+```
+
+It locks the harness order against `apps/server/src/services/social_graph_index_worker.rs`.
+
+## Profiles boundary
+
+This evidence never authorizes profile presentation.
+
+Profiles still:
+
+- never authorizes from an event, Index projection, broker offset, DLQ record, poison receipt, metric, or evidence packet;
+- resolves `followers_only` only through authoritative Social Graph owner ports;
+- evaluates privacy before localized/profile-media presentation;
+- treats restricted or unavailable public rows as absent;
+- keeps Media descriptors Media-owned.
+
+The combined harness proves only the raw delivery terminalization order. It does not prove profile visibility, storefront behavior, follower policy, or presentation correctness.
+
+## Remaining evidence
+
+- execute this harness on reviewed PostgreSQL and disposable external Iggy;
+- retain bounded toolchain, server artifact, source/output digest, and all-pass results;
+- exercise the broker-success/`mark_published` ambiguity window;
+- execute multi-replica claim ownership with the combined broker path;
+- prove bundled mode, TLS/auth/failover, and production recovery-window sufficiency;
+- retain independent Profiles privacy/storefront runtime evidence.
+
+## Verification status
+
+Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy, and multi-replica scenarios were not run while authoring this checkpoint.

--- a/crates/rustok-social-graph/Cargo.toml
+++ b/crates/rustok-social-graph/Cargo.toml
@@ -31,4 +31,5 @@ index = ["dep:rustok-index"]
 index-consumer = ["index", "dep:rustok-iggy"]
 
 [dev-dependencies]
+rustok-iggy-connector = { workspace = true, features = ["migrations"] }
 tokio.workspace = true

--- a/crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json
+++ b/crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 1,
+  "module": "social-graph",
+  "packet": "index-raw-poison-postgres-iggy-source",
+  "status": "source_complete_runtime_pending",
+  "scope": "social_graph_index_raw_poison_postgres_iggy_ordering",
+  "test_target": "index_raw_poison_postgres_iggy",
+  "source_path": "crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs",
+  "worker_path": "apps/server/src/services/social_graph_index_worker.rs",
+  "verifier": "scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs",
+  "required_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS"
+  ],
+  "optional_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD"
+  ],
+  "database": {
+    "backend": "postgresql",
+    "unique_schema_per_case": true,
+    "connector_migrations_only": true,
+    "max_connections_per_pool": 1,
+    "cleanup": "drop_unique_schema_only"
+  },
+  "broker": {
+    "mode": "external",
+    "protocol": "tcp",
+    "unique_stream_per_case": true,
+    "domain_partitions": 1,
+    "replication_factor": 1,
+    "topics": [
+      "domain",
+      "dlq"
+    ],
+    "cleanup": "disposable_broker_or_operator_cleanup"
+  },
+  "cases": [
+    {
+      "case": "raw_poison_persists_published_before_source_acknowledgement",
+      "required_sequence": [
+        "open_source_and_dlq_groups_before_fixture_publication",
+        "publish_two_distinct_malformed_source_payloads",
+        "receive_first_decode_failure_without_source_ack",
+        "reserve_and_claim_neutral_receipt",
+        "assert_receipt_publishing",
+        "publish_exact_bytes_through_iggy_transport",
+        "observe_and_ack_physical_dlq_payload",
+        "assert_receipt_still_publishing_after_broker_publish",
+        "mark_receipt_published",
+        "assert_receipt_published_before_source_ack",
+        "acknowledge_source_decode_failure",
+        "assert_receipt_still_published_after_source_ack",
+        "mark_receipt_acknowledged",
+        "receive_second_source_offset"
+      ]
+    },
+    {
+      "case": "published_redelivery_is_acknowledgement_only_without_republication",
+      "required_sequence": [
+        "reserve_claim_publish_and_mark_published",
+        "shutdown_first_transport_without_source_ack",
+        "reopen_same_stream_and_consumer_group",
+        "receive_same_offset_bytes_and_delivery_uuid",
+        "reserve_and_claim_returns_already_published",
+        "acknowledge_redelivered_source_without_dlq_republish",
+        "mark_receipt_acknowledged",
+        "observe_no_second_dlq_message",
+        "receive_next_source_offset"
+      ]
+    }
+  ],
+  "production_paths": [
+    "SocialGraphIndexConsumer::open",
+    "SocialGraphIndexConsumer::receive_delivery",
+    "ConsumerPoisonReceiptStore::reserve_and_claim",
+    "ConsumedContractDecodeFailure::to_dlq_entry",
+    "IggyTransport::move_to_dlq",
+    "ConsumerPoisonReceiptStore::mark_published",
+    "SocialGraphIndexConsumer::acknowledge_decode_failure",
+    "ConsumerPoisonReceiptStore::mark_acknowledged"
+  ],
+  "worker_order": [
+    "reserve_and_claim",
+    "transport.move_to_dlq",
+    "mark_raw_poison_published",
+    "acknowledge_decode_failure",
+    "mark_acknowledged"
+  ],
+  "privacy_boundary": {
+    "forbidden_retained_values": [
+      "database_url",
+      "broker_address",
+      "username",
+      "password",
+      "connection_string",
+      "raw_payload",
+      "delivery_uuid",
+      "source_offset",
+      "ack_token"
+    ]
+  },
+  "forbidden_claims": [
+    "physical_exactly_once_proved",
+    "database_broker_transaction_proved",
+    "deduplication_window_sufficiency_proved",
+    "bundled_mode_proved",
+    "tls_or_auth_failure_proved",
+    "multi_replica_claim_ownership_proved",
+    "profiles_authorization_proved"
+  ],
+  "execution_status": "not_run"
+}

--- a/crates/rustok-social-graph/docs/index-raw-poison-postgres-iggy-evidence.md
+++ b/crates/rustok-social-graph/docs/index-raw-poison-postgres-iggy-evidence.md
@@ -1,0 +1,129 @@
+# Social Graph Index raw poison PostgreSQL/Iggy evidence
+
+## Purpose
+
+`index_raw_poison_postgres_iggy.rs` is an opt-in source harness for the first approved undecodable Social Graph Index consumer path. It composes a real external Iggy cursor with the production neutral `ConsumerPoisonReceiptStore` on PostgreSQL.
+
+The harness is intentionally narrower than the server worker. It proves the persistence and broker ordering with public production APIs while `verify-social-graph-index-raw-poison-postgres-iggy.mjs` locks parity with `apps/server/src/services/social_graph_index_worker.rs`.
+
+## Required services
+
+Provide an operator-approved PostgreSQL database and a disposable external Iggy broker:
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL=postgresql://...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS=host:8090
+```
+
+Optional Iggy credentials must be supplied together:
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME=...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD=...
+```
+
+There is no `DATABASE_URL`, localhost, or default-credential fallback. Missing required variables make a direct developer invocation report a skip; a future retained runner must reject that skip.
+
+This source slice is external TCP/non-TLS only. TLS, authentication failure, failover, bundled mode, and multi-replica behavior remain separate evidence.
+
+## Isolation
+
+Each case creates:
+
+- one unique PostgreSQL schema;
+- one connection per SeaORM pool so session-local `search_path` remains deterministic;
+- only the connector receipt migrations inside that schema;
+- one unique Iggy stream;
+- one `domain` partition and matching `dlq` partition;
+- one unique DLQ observer group.
+
+Cleanup drops only the unique PostgreSQL schema. The harness does not call an unreviewed Iggy stream deletion API, so use a disposable broker or an operator-approved cleanup process.
+
+## Case 1: published before source acknowledgement
+
+The first case publishes two distinct malformed source payloads and requires this order:
+
+1. Open the fixed production source group and unique DLQ group before fixture publication.
+2. Receive the first payload as `ConsumedContractDecodeFailure` without source acknowledgement.
+3. Build the neutral connector identity and obtain one `Claimed` publication lease.
+4. Observe receipt state `publishing`.
+5. Publish exact bytes through `IggyTransport::move_to_dlq`.
+6. Receive and acknowledge the physical DLQ payload through a real connector cursor.
+7. Re-read PostgreSQL and require the receipt to remain `publishing`; broker success alone must not invent durable `published` state.
+8. Call `mark_published` and require state `published`.
+9. Acknowledge the exact source decode failure.
+10. Re-read PostgreSQL and require the receipt to remain `published` until bookkeeping runs.
+11. Call `mark_acknowledged` and require state `acknowledged`.
+12. Receive the second malformed source payload at a greater offset.
+
+This proves the intended boundary:
+
+```text
+reserve/claim -> exact broker publish -> durable published -> source ack -> acknowledged bookkeeping
+```
+
+## Case 2: acknowledgement-only redelivery
+
+The second case persists `published` but deliberately shuts down the first transport without source acknowledgement.
+
+After reopening the same unique stream with the fixed Social Graph Index consumer group, it requires:
+
+- the same source offset;
+- the same exact bytes;
+- the same deterministic connector delivery UUID;
+- `reserve_and_claim` to return `AlreadyPublished`;
+- no second `move_to_dlq` call after reopen;
+- source acknowledgement followed by `mark_acknowledged`;
+- no second physical DLQ message during the bounded observation window;
+- the next source payload at a greater offset.
+
+The bounded absence check is supporting evidence only. The source verifier also requires that the recovery portion contains no DLQ publication call and that the production worker recognizes `AlreadyPublished`/`AlreadyAcknowledged` before acknowledgement-only recovery.
+
+## Production parity
+
+The verifier requires the production worker to retain this ordering:
+
+```text
+reserve_and_claim
+transport.move_to_dlq
+mark_raw_poison_published
+acknowledge_decode_failure
+mark_acknowledged
+```
+
+It also requires terminal receipt recognition to skip publication and retry source acknowledgement only.
+
+The harness does not replace the server worker and does not create a second production policy implementation. Fixture publication is the only low-level injection path; receive, decode failure, DLQ publication, receipt transitions, and source acknowledgement use public production APIs.
+
+## Non-claims
+
+Even after successful execution, this evidence does not prove:
+
+- a transaction between PostgreSQL and Iggy;
+- physical exactly-once publication;
+- that an Iggy deduplication window covers the full production recovery horizon;
+- crash behavior in the broker-success/`mark_published` ambiguity window;
+- concurrent multi-replica claim ownership in this combined scenario;
+- bundled mode, TLS, authentication failure, or failover;
+- Profiles visibility or authorization.
+
+Profiles continues to authorize only through owner policy and authoritative Social Graph ports. Broker, receipt, metric, and evidence state never authorizes presentation.
+
+## Maintainer commands
+
+```bash
+node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
+
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL='postgresql://...' \
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS='host:8090' \
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME='...' \
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD='...' \
+  cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_postgres_iggy -- --nocapture --test-threads=1
+```
+
+The username/password variables may both be omitted when the disposable broker permits anonymous access.
+
+## Evidence status
+
+The integration source, machine contract, production-order verifier, and this operator guide are source-complete. `execution_status` remains `not_run`. No Cargo command, source verifier, PostgreSQL query, external Iggy scenario, formatter, or multi-replica scenario was executed while authoring this slice.

--- a/crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs
+++ b/crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs
@@ -1,0 +1,480 @@
+#![cfg(feature = "index-consumer")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ExternalConfig, IggyConfig, IggyMode, IggyTransport,
+    PersistentContractDelivery, SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceiptState,
+    ConsumerPoisonReceiptStore,
+};
+use rustok_iggy_connector::{
+    ConnectorConfig, ConsumerCursor, ExternalConnector, IggyConnector, PublishRequest,
+    SubscriberMessage,
+};
+use rustok_social_graph::index_consumer::{
+    SOCIAL_GRAPH_INDEX_CONSUMER_GROUP, SocialGraphIndexConsumer,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL";
+const ADDRESS_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const NO_SECOND_DLQ_TIMEOUT: Duration = Duration::from_millis(750);
+const PUBLISH_LEASE: Duration = Duration::from_secs(30);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct PostgresIggyEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+    config: IggyConfig,
+    fixture: ExternalConnector,
+}
+
+impl PostgresIggyEvidence {
+    async fn setup(scope: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Social Graph raw poison PostgreSQL/Iggy evidence"
+            );
+            return Ok(None);
+        };
+        let Some(config) = external_iggy_config(scope)? else {
+            eprintln!(
+                "{ADDRESS_ENV} is not set; skipping Social Graph raw poison PostgreSQL/Iggy evidence"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_sg_poison_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name).await?;
+        let migration_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in rustok_iggy_connector::migrations::migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = migration_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        let fixture = ExternalConnector::new();
+        if let Err(error) = fixture.connect(&ConnectorConfig::from(&config)).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+            config,
+            fixture,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.fixture.shutdown().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn raw_poison_persists_published_before_source_acknowledgement() -> TestResult<()> {
+    let Some(evidence) = PostgresIggyEvidence::setup("published_before_ack").await? else {
+        return Ok(());
+    };
+
+    let stream = evidence.config.topology.stream_name.clone();
+    let dlq_group = unique_name("ordering-dlq");
+    let transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);
+    let consumer = SocialGraphIndexConsumer::open(Arc::clone(&transport), evidence.db.clone()).await?;
+    let mut dlq_cursor = evidence
+        .fixture
+        .open_consumer_group(&stream, "dlq", &dlq_group)
+        .await?;
+
+    let first_payload = vec![0xff, 0x00, 0x31, 0x01];
+    let second_payload = vec![0xff, 0x00, 0x31, 0x02];
+    publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;
+    publish_fixture(&evidence.fixture, &stream, second_payload.clone()).await?;
+
+    let failure = receive_decode_failure(&consumer).await?;
+    assert_eq!(failure.raw_payload(), first_payload.as_slice());
+    let first_offset = failure.offset();
+    let identity = poison_identity(&failure)?;
+    let store = ConsumerPoisonReceiptStore::new(evidence.db.clone());
+    let publisher_id = Uuid::new_v4();
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                failure.stable_error_code(),
+                1,
+                publisher_id,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+
+    transport.move_to_dlq(failure.to_dlq_entry(1)).await?;
+    let physical_dlq = receive_cursor_message(&mut dlq_cursor).await?;
+    assert_eq!(physical_dlq.payload.as_slice(), first_payload.as_slice());
+    acknowledge_cursor_message(&mut dlq_cursor, &physical_dlq).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+
+    store.mark_published(&identity, publisher_id).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Published).await?;
+
+    consumer.acknowledge_decode_failure(&failure).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Published).await?;
+    store.mark_acknowledged(&identity).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Acknowledged).await?;
+
+    let next_failure = receive_decode_failure(&consumer).await?;
+    assert_eq!(next_failure.raw_payload(), second_payload.as_slice());
+    assert!(next_failure.offset() > first_offset);
+
+    drop(consumer);
+    transport.shutdown().await?;
+    evidence.cleanup().await
+}
+
+#[tokio::test]
+async fn published_redelivery_is_acknowledgement_only_without_republication() -> TestResult<()> {
+    let Some(evidence) = PostgresIggyEvidence::setup("ack_only_redelivery").await? else {
+        return Ok(());
+    };
+
+    let stream = evidence.config.topology.stream_name.clone();
+    let dlq_group = unique_name("recovery-dlq");
+    let first_transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);
+    let first_consumer =
+        SocialGraphIndexConsumer::open(Arc::clone(&first_transport), evidence.db.clone()).await?;
+    let mut dlq_cursor = evidence
+        .fixture
+        .open_consumer_group(&stream, "dlq", &dlq_group)
+        .await?;
+
+    let first_payload = vec![0xff, 0x00, 0x41, 0x01];
+    let second_payload = vec![0xff, 0x00, 0x41, 0x02];
+    publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;
+    publish_fixture(&evidence.fixture, &stream, second_payload.clone()).await?;
+
+    let first_failure = receive_decode_failure(&first_consumer).await?;
+    let first_offset = first_failure.offset();
+    let first_delivery_id = first_failure.delivery_id();
+    let identity = poison_identity(&first_failure)?;
+    let store = ConsumerPoisonReceiptStore::new(evidence.db.clone());
+    let publisher_id = Uuid::new_v4();
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                first_failure.stable_error_code(),
+                1,
+                publisher_id,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    first_transport
+        .move_to_dlq(first_failure.to_dlq_entry(1))
+        .await?;
+    let physical_dlq = receive_cursor_message(&mut dlq_cursor).await?;
+    assert_eq!(physical_dlq.payload.as_slice(), first_payload.as_slice());
+    acknowledge_cursor_message(&mut dlq_cursor, &physical_dlq).await?;
+    store.mark_published(&identity, publisher_id).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Published).await?;
+
+    drop(first_consumer);
+    first_transport.shutdown().await?;
+
+    let reopened_transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);
+    let reopened_consumer =
+        SocialGraphIndexConsumer::open(Arc::clone(&reopened_transport), evidence.db.clone()).await?;
+    let redelivered = receive_decode_failure(&reopened_consumer).await?;
+    assert_eq!(redelivered.offset(), first_offset);
+    assert_eq!(redelivered.delivery_id(), first_delivery_id);
+    assert_eq!(redelivered.raw_payload(), first_payload.as_slice());
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &poison_identity(&redelivered)?,
+                redelivered.stable_error_code(),
+                9,
+                Uuid::new_v4(),
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::AlreadyPublished
+    );
+    reopened_consumer
+        .acknowledge_decode_failure(&redelivered)
+        .await?;
+    store.mark_acknowledged(&identity).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Acknowledged).await?;
+
+    assert_no_second_dlq_message(&mut dlq_cursor).await?;
+    let next_failure = receive_decode_failure(&reopened_consumer).await?;
+    assert_eq!(next_failure.raw_payload(), second_payload.as_slice());
+    assert!(next_failure.offset() > first_offset);
+
+    drop(reopened_consumer);
+    reopened_transport.shutdown().await?;
+    evidence.cleanup().await
+}
+
+async fn publish_fixture(
+    connector: &ExternalConnector,
+    stream: &str,
+    payload: Vec<u8>,
+) -> TestResult<()> {
+    connector
+        .publish(PublishRequest::new(
+            stream,
+            "domain",
+            "raw-poison-ordering-fixture",
+            payload,
+            Uuid::new_v4().to_string(),
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn receive_decode_failure(
+    consumer: &SocialGraphIndexConsumer,
+) -> TestResult<ConsumedContractDecodeFailure> {
+    let delivery = timeout(RECEIVE_TIMEOUT, consumer.receive_delivery())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for a Social Graph raw poison delivery"))??
+        .ok_or_else(|| invalid_data("Social Graph source cursor ended before a delivery"))?;
+    match delivery {
+        PersistentContractDelivery::DecodeFailure(failure) => Ok(failure),
+        PersistentContractDelivery::Event(_) => Err(invalid_data(
+            "malformed ordering fixture unexpectedly decoded as a registered contract event",
+        )
+        .into()),
+    }
+}
+
+async fn receive_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+) -> TestResult<SubscriberMessage> {
+    timeout(RECEIVE_TIMEOUT, cursor.receive())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for a raw poison DLQ message"))??
+        .ok_or_else(|| invalid_data("raw poison DLQ cursor ended before a message").into())
+}
+
+async fn acknowledge_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+    message: &SubscriberMessage,
+) -> TestResult<()> {
+    let token = message
+        .metadata
+        .ack_token
+        .as_deref()
+        .ok_or_else(|| invalid_data("raw poison DLQ message has no acknowledgement token"))?;
+    cursor.acknowledge(token).await?;
+    Ok(())
+}
+
+async fn assert_no_second_dlq_message(cursor: &mut Box<dyn ConsumerCursor>) -> TestResult<()> {
+    match timeout(NO_SECOND_DLQ_TIMEOUT, cursor.receive()).await {
+        Err(_) | Ok(Ok(None)) => Ok(()),
+        Ok(Ok(Some(_))) => Err(invalid_data(
+            "acknowledgement-only recovery unexpectedly published another DLQ message",
+        )
+        .into()),
+        Ok(Err(error)) => Err(error.into()),
+    }
+}
+
+async fn assert_receipt_state(
+    store: &ConsumerPoisonReceiptStore,
+    identity: &ConsumerPoisonIdentity,
+    expected: ConsumerPoisonReceiptState,
+) -> TestResult<()> {
+    let receipt = store
+        .find(identity)
+        .await?
+        .ok_or_else(|| invalid_data("expected neutral poison receipt was not found"))?;
+    assert_eq!(receipt.state, expected);
+    Ok(())
+}
+
+fn poison_identity(
+    failure: &ConsumedContractDecodeFailure,
+) -> Result<ConsumerPoisonIdentity, rustok_iggy_connector::migrations::ConsumerPoisonReceiptError> {
+    ConsumerPoisonIdentity::new(
+        failure.delivery_id(),
+        SOCIAL_GRAPH_INDEX_CONSUMER_GROUP,
+        failure.stream(),
+        failure.topic(),
+        failure.partition(),
+        failure.offset(),
+        failure.raw_payload().to_vec(),
+    )
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+fn external_iggy_config(scope: &str) -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(ADDRESS_ENV) {
+        Ok(value) => bounded_env(ADDRESS_ENV, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://") || address.contains('@') || address.contains('?') {
+        return Err(invalid_data(format!(
+            "{ADDRESS_ENV} must be host:port without scheme, credentials, or query"
+        ))
+        .into());
+    }
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "raw poison PostgreSQL/Iggy username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name(scope),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(db)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-sg-poison-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs
+++ b/crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs
@@ -302,10 +302,12 @@ async fn receive_decode_failure(
 async fn receive_cursor_message(
     cursor: &mut Box<dyn ConsumerCursor>,
 ) -> TestResult<SubscriberMessage> {
-    timeout(RECEIVE_TIMEOUT, cursor.receive())
+    let message = timeout(RECEIVE_TIMEOUT, cursor.receive())
         .await
-        .map_err(|_| invalid_data("timed out waiting for a raw poison DLQ message"))??
-        .ok_or_else(|| invalid_data("raw poison DLQ cursor ended before a message").into())
+        .map_err(|_| invalid_data("timed out waiting for a raw poison DLQ message"))??;
+    message.ok_or_else(|| Box::<dyn Error + Send + Sync>::from(invalid_data(
+        "raw poison DLQ cursor ended before a message",
+    )))
 }
 
 async fn acknowledge_cursor_message(

--- a/scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json";
+const cargoPath = "crates/rustok-social-graph/Cargo.toml";
+const testPath = "crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs";
+const workerPath = "apps/server/src/services/social_graph_index_worker.rs";
+
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+const cargo = readFileSync(cargoPath, "utf8");
+const test = readFileSync(testPath, "utf8");
+const worker = readFileSync(workerPath, "utf8");
+const failures = [];
+
+const expectedCases = [
+  {
+    case: "raw_poison_persists_published_before_source_acknowledgement",
+    required_sequence: [
+      "open_source_and_dlq_groups_before_fixture_publication",
+      "publish_two_distinct_malformed_source_payloads",
+      "receive_first_decode_failure_without_source_ack",
+      "reserve_and_claim_neutral_receipt",
+      "assert_receipt_publishing",
+      "publish_exact_bytes_through_iggy_transport",
+      "observe_and_ack_physical_dlq_payload",
+      "assert_receipt_still_publishing_after_broker_publish",
+      "mark_receipt_published",
+      "assert_receipt_published_before_source_ack",
+      "acknowledge_source_decode_failure",
+      "assert_receipt_still_published_after_source_ack",
+      "mark_receipt_acknowledged",
+      "receive_second_source_offset",
+    ],
+  },
+  {
+    case: "published_redelivery_is_acknowledgement_only_without_republication",
+    required_sequence: [
+      "reserve_claim_publish_and_mark_published",
+      "shutdown_first_transport_without_source_ack",
+      "reopen_same_stream_and_consumer_group",
+      "receive_same_offset_bytes_and_delivery_uuid",
+      "reserve_and_claim_returns_already_published",
+      "acknowledge_redelivered_source_without_dlq_republish",
+      "mark_receipt_acknowledged",
+      "observe_no_second_dlq_message",
+      "receive_next_source_offset",
+    ],
+  },
+];
+const expectedProductionPaths = [
+  "SocialGraphIndexConsumer::open",
+  "SocialGraphIndexConsumer::receive_delivery",
+  "ConsumerPoisonReceiptStore::reserve_and_claim",
+  "ConsumedContractDecodeFailure::to_dlq_entry",
+  "IggyTransport::move_to_dlq",
+  "ConsumerPoisonReceiptStore::mark_published",
+  "SocialGraphIndexConsumer::acknowledge_decode_failure",
+  "ConsumerPoisonReceiptStore::mark_acknowledged",
+];
+const expectedWorkerOrder = [
+  "reserve_and_claim",
+  "transport.move_to_dlq",
+  "mark_raw_poison_published",
+  "acknowledge_decode_failure",
+  "mark_acknowledged",
+];
+const expectedForbiddenClaims = [
+  "physical_exactly_once_proved",
+  "database_broker_transaction_proved",
+  "deduplication_window_sufficiency_proved",
+  "bundled_mode_proved",
+  "tls_or_auth_failure_proved",
+  "multi_replica_claim_ownership_proved",
+  "profiles_authorization_proved",
+];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function requireOrdered(name, source, markers) {
+  let previous = -1;
+  for (const marker of markers) {
+    const position = source.indexOf(marker, previous + 1);
+    if (position < 0) {
+      fail(`${name} is missing ordered marker: ${marker}`);
+      return;
+    }
+    if (position <= previous) {
+      fail(`${name} has invalid ordering at marker: ${marker}`);
+      return;
+    }
+    previous = position;
+  }
+}
+
+function functionSlice(source, startMarker, nextMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) {
+    fail(`missing function marker: ${startMarker}`);
+    return "";
+  }
+  const end = source.indexOf(nextMarker, start + startMarker.length);
+  if (end < 0) {
+    fail(`missing following function marker: ${nextMarker}`);
+    return source.slice(start);
+  }
+  return source.slice(start, end);
+}
+
+if (contract.schema_version !== 1) fail("ordering contract schema drift");
+if (contract.module !== "social-graph") fail("ordering contract module drift");
+if (contract.packet !== "index-raw-poison-postgres-iggy-source") {
+  fail("ordering contract packet drift");
+}
+if (contract.status !== "source_complete_runtime_pending") {
+  fail("ordering contract must remain runtime pending until execution");
+}
+if (contract.scope !== "social_graph_index_raw_poison_postgres_iggy_ordering") {
+  fail("ordering contract scope drift");
+}
+if (contract.test_target !== "index_raw_poison_postgres_iggy") {
+  fail("ordering test target drift");
+}
+if (contract.source_path !== testPath || contract.worker_path !== workerPath) {
+  fail("ordering source or worker path drift");
+}
+if (contract.verifier !== "scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs") {
+  fail("ordering verifier path drift");
+}
+if (
+  !sameValue(contract.required_environment, [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS",
+  ])
+) {
+  fail("ordering required environment drift");
+}
+if (
+  !sameValue(contract.optional_environment, [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD",
+  ])
+) {
+  fail("ordering optional environment drift");
+}
+if (
+  !sameValue(contract.database, {
+    backend: "postgresql",
+    unique_schema_per_case: true,
+    connector_migrations_only: true,
+    max_connections_per_pool: 1,
+    cleanup: "drop_unique_schema_only",
+  })
+) {
+  fail("ordering database boundary drift");
+}
+if (
+  !sameValue(contract.broker, {
+    mode: "external",
+    protocol: "tcp",
+    unique_stream_per_case: true,
+    domain_partitions: 1,
+    replication_factor: 1,
+    topics: ["domain", "dlq"],
+    cleanup: "disposable_broker_or_operator_cleanup",
+  })
+) {
+  fail("ordering broker boundary drift");
+}
+if (!sameValue(contract.cases, expectedCases)) fail("ordering case contract drift");
+if (!sameValue(contract.production_paths, expectedProductionPaths)) {
+  fail("ordering production path drift");
+}
+if (!sameValue(contract.worker_order, expectedWorkerOrder)) fail("worker order contract drift");
+if (!sameValue(contract.forbidden_claims, expectedForbiddenClaims)) {
+  fail("ordering forbidden claims drift");
+}
+if (contract.execution_status !== "not_run") {
+  fail("ordering source contract must not claim runtime execution");
+}
+
+requireText(
+  "social-graph test dependency",
+  cargo,
+  'rustok-iggy-connector = { workspace = true, features = ["migrations"] }',
+);
+for (const marker of [
+  '#![cfg(feature = "index-consumer")]',
+  'const DATABASE_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL";',
+  'const ADDRESS_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS";',
+  'const USERNAME_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME";',
+  'const PASSWORD_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD";',
+  "max_connections(1)",
+  "min_connections(1)",
+  'format!(r#"CREATE SCHEMA "{schema_name}""#)',
+  'format!(r#"SET search_path TO "{schema_name}", public"#)',
+  'DROP SCHEMA IF EXISTS "{}" CASCADE',
+  "rustok_iggy_connector::migrations::migrations()",
+  "SocialGraphIndexConsumer::open",
+  "ConsumerPoisonReceiptStore::new",
+  "ConsumerPoisonPublishClaim::Claimed",
+  "ConsumerPoisonPublishClaim::AlreadyPublished",
+  "ConsumerPoisonReceiptState::Publishing",
+  "ConsumerPoisonReceiptState::Published",
+  "ConsumerPoisonReceiptState::Acknowledged",
+  "failure.to_dlq_entry(1)",
+  "first_failure.to_dlq_entry(1)",
+  "acknowledge_decode_failure",
+  "assert_no_second_dlq_message",
+  "next_failure.offset() > first_offset",
+  "timeout(RECEIVE_TIMEOUT",
+]) {
+  requireText("PostgreSQL/Iggy ordering harness", test, marker);
+}
+
+const firstCase = functionSlice(
+  test,
+  "async fn raw_poison_persists_published_before_source_acknowledgement()",
+  "#[tokio::test]\nasync fn published_redelivery_is_acknowledgement_only_without_republication()",
+);
+requireOrdered("published-before-ack evidence", firstCase, [
+  "SocialGraphIndexConsumer::open",
+  'open_consumer_group(&stream, "dlq", &dlq_group)',
+  "publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;",
+  "let failure = receive_decode_failure(&consumer).await?;",
+  ".reserve_and_claim(",
+  "ConsumerPoisonReceiptState::Publishing",
+  "transport.move_to_dlq(failure.to_dlq_entry(1)).await?;",
+  "let physical_dlq = receive_cursor_message(&mut dlq_cursor).await?;",
+  "acknowledge_cursor_message(&mut dlq_cursor, &physical_dlq).await?;",
+  "ConsumerPoisonReceiptState::Publishing",
+  "store.mark_published(&identity, publisher_id).await?;",
+  "ConsumerPoisonReceiptState::Published",
+  "consumer.acknowledge_decode_failure(&failure).await?;",
+  "ConsumerPoisonReceiptState::Published",
+  "store.mark_acknowledged(&identity).await?;",
+  "ConsumerPoisonReceiptState::Acknowledged",
+  "let next_failure = receive_decode_failure(&consumer).await?;",
+]);
+
+const secondCase = functionSlice(
+  test,
+  "async fn published_redelivery_is_acknowledgement_only_without_republication()",
+  "async fn publish_fixture(",
+);
+requireOrdered("acknowledgement-only redelivery evidence", secondCase, [
+  "SocialGraphIndexConsumer::open",
+  ".reserve_and_claim(",
+  ".move_to_dlq(first_failure.to_dlq_entry(1))",
+  "store.mark_published(&identity, publisher_id).await?;",
+  "drop(first_consumer);",
+  "first_transport.shutdown().await?;",
+  "let reopened_transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);",
+  "let redelivered = receive_decode_failure(&reopened_consumer).await?;",
+  "redelivered.offset(), first_offset",
+  "redelivered.delivery_id(), first_delivery_id",
+  "ConsumerPoisonPublishClaim::AlreadyPublished",
+  ".acknowledge_decode_failure(&redelivered)",
+  "store.mark_acknowledged(&identity).await?;",
+  "assert_no_second_dlq_message(&mut dlq_cursor).await?;",
+  "let next_failure = receive_decode_failure(&reopened_consumer).await?;",
+]);
+const secondCasePublishCount = [...secondCase.matchAll(/\.move_to_dlq\(/gu)].length;
+if (secondCasePublishCount !== 1) {
+  fail(`acknowledgement-only case must contain one initial DLQ publication; found ${secondCasePublishCount}`);
+}
+const reopenPosition = secondCase.indexOf("let reopened_transport");
+if (reopenPosition >= 0 && secondCase.slice(reopenPosition).includes(".move_to_dlq(")) {
+  fail("acknowledgement-only recovery must not republish after transport reopen");
+}
+
+const workerProcess = functionSlice(
+  worker,
+  "async fn process_decode_failure(",
+  "async fn mark_raw_poison_published(",
+);
+requireOrdered("production raw poison worker", workerProcess, [
+  ".reserve_and_claim(",
+  "transport.move_to_dlq(failure.to_dlq_entry(1)).await",
+  "mark_raw_poison_published(",
+  "acknowledge_raw_poison_result(",
+]);
+const workerAcknowledge = functionSlice(
+  worker,
+  "async fn acknowledge_raw_poison_result(",
+  "async fn acknowledge_terminal_result(",
+);
+requireOrdered("production raw poison acknowledgement", workerAcknowledge, [
+  "consumer.acknowledge_decode_failure(failure).await",
+  "poison_receipts.mark_acknowledged(identity).await",
+]);
+for (const marker of [
+  "Ok(ConsumerPoisonPublishClaim::AlreadyPublished)",
+  "Ok(ConsumerPoisonPublishClaim::AlreadyAcknowledged)",
+  "break true;",
+  "durable neutral receipt remains published and redelivery retries acknowledgement only",
+]) {
+  requireText("production acknowledgement-only recovery", worker, marker);
+}
+
+for (const forbidden of [
+  "127.0.0.1:8090",
+  'username: "iggy"',
+  'password: "iggy"',
+  'env::var("DATABASE_URL")',
+  "IggyClient",
+  "use iggy::",
+  ".producer(",
+  ".send(",
+  "tokio::time::sleep",
+  "std::thread::sleep",
+  "DELETE FROM iggy_consumer_poison_receipts",
+  "TRUNCATE",
+  "delete_stream",
+  "CREATE DATABASE",
+  "tenant_id",
+  "event_id()",
+  "authorization",
+  "exactly_once",
+]) {
+  forbidText("PostgreSQL/Iggy ordering harness", test, forbidden);
+}
+
+if (failures.length > 0) {
+  console.error("Social Graph raw poison PostgreSQL/Iggy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Social Graph raw poison PostgreSQL/Iggy source evidence verified: isolated PostgreSQL receipts, real external broker bytes, durable published-before-source-ack ordering, transport restart redelivery, acknowledgement-only recovery, worker-order parity, and bounded unexecuted claims are locked.",
+);


### PR DESCRIPTION
## Summary

Define the first combined PostgreSQL + real external-Iggy source harness for the approved Social Graph Index raw-poison terminalization order.

Two opt-in cases are added under `rustok-social-graph`:

1. **Published before source acknowledgement**
   - creates one unique PostgreSQL schema and applies only connector receipt migrations;
   - creates one unique external Iggy stream with one `domain`/`dlq` partition;
   - opens the production `SocialGraphIndexConsumer` and a real DLQ cursor before fixture publication;
   - receives malformed bytes as a typed decode failure without source acknowledgement;
   - reserves/claims the neutral receipt and requires `publishing`;
   - publishes exact bytes through production `IggyTransport::move_to_dlq`;
   - observes and acknowledges the physical DLQ payload;
   - re-reads PostgreSQL and requires the receipt to remain `publishing` after broker success;
   - persists `published`, then acknowledges the source, then performs `acknowledged` bookkeeping;
   - requires the next malformed source offset to become visible.

2. **Acknowledgement-only redelivery**
   - publishes and persists `published`, then shuts down the first transport without source acknowledgement;
   - reopens the same unique stream with the fixed Social Graph Index consumer group;
   - requires the same offset, exact bytes, and deterministic connector UUID;
   - requires `reserve_and_claim` to return `AlreadyPublished`;
   - acknowledges the source without a second `move_to_dlq` call;
   - persists `acknowledged`, observes no second physical DLQ message in a bounded supporting window, and requires the next source offset.

## Production parity

A machine contract and source verifier lock the harness against the actual server worker order:

```text
reserve_and_claim
transport.move_to_dlq
mark_raw_poison_published
acknowledge_decode_failure
mark_acknowledged
```

The verifier also requires terminal `AlreadyPublished`/`AlreadyAcknowledged` recognition and acknowledgement-only recovery in `apps/server/src/services/social_graph_index_worker.rs`.

## Isolation and boundaries

- no `DATABASE_URL`, localhost, or default credential fallback;
- unique PostgreSQL schema per case, one connection per pool, schema-only cleanup;
- unique Iggy stream per case; disposable broker or operator cleanup required;
- fixture connector only injects malformed source bytes;
- receive, receipt transitions, exact DLQ publication, restart/redelivery, and source acknowledgement use public production APIs;
- no direct Iggy SDK producer, receipt SQL mutation, sleeps, stream deletion, or authorization logic.

This source slice does **not** claim a PostgreSQL/Iggy transaction, physical exactly-once, dedup-window sufficiency, bundled mode, TLS/auth/failover, multi-replica ownership, or Profiles authorization.

## Documentation

- added the versioned source contract;
- added the Social Graph operator/evidence guide;
- added a Profiles checkpoint preserving privacy-before-presentation and owner-port authorization boundaries;
- added the connector migration dev dependency only to the Social Graph test target.

## Verification

Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs

RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL='postgresql://...' \
RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS='host:8090' \
  cargo test -p rustok-social-graph --features index-consumer \
  --test index_raw_poison_postgres_iggy -- --nocapture --test-threads=1
```