### PR TITLE
test(profiles): retain Postgres Iggy poison ordering evidence

### DIFF
--- a/crates/rustok-profiles/docs/poison-postgres-iggy-retained-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-postgres-iggy-retained-checkpoint.md
@@ -1,0 +1,66 @@
+# Profiles checkpoint: retained raw poison PostgreSQL/Iggy evidence
+
+## Status
+
+Capture tooling is source-complete; runtime evidence is pending.
+
+The combined Social Graph raw-poison ordering harness now has a locked retained-execution path:
+
+- clean-commit runner;
+- two independent exact test commands;
+- current production/test source SHA-256 binding;
+- reviewed PostgreSQL and Iggy server artifact labels;
+- atomic canonical packet writing;
+- strict pending/executed verifier;
+- privacy-safe aggregate packet projection.
+
+The future canonical packet is:
+
+```text
+crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution.json
+```
+
+It remains absent until a maintainer successfully executes both cases.
+
+## Profiles authorization boundary
+
+Neither the source harness nor its retained packet authorizes presentation.
+
+Profiles never authorizes from:
+
+- broker delivery or DLQ state;
+- source offset, acknowledgement token, or deterministic delivery UUID;
+- neutral poison receipt state;
+- PostgreSQL/Iggy artifact labels;
+- source/output hashes;
+- metrics, health snapshots, or evidence packet results.
+
+`followers_only` continues to resolve only through authoritative Social Graph owner ports. Privacy is evaluated before localization, tags, summaries, and Media-backed descriptors. Restricted or unavailable public rows remain absent.
+
+## Packet privacy
+
+The retained packet omits database URLs, broker addresses, credentials, connection strings, schema/stream names, payloads, offsets, acknowledgement tokens, delivery UUIDs, and raw test output.
+
+It retains only bounded provenance and aggregate pass evidence:
+
+- commit and timestamps;
+- Cargo/Rust versions;
+- reviewed service artifact labels;
+- environment-variable names for service endpoints;
+- exact command arrays;
+- source/output digests and output sizes;
+- two all-pass ordering cases.
+
+## Remaining work
+
+- execute the clean-commit runner on reviewed PostgreSQL and disposable external Iggy;
+- review and commit the canonical packet;
+- repeat whenever a bound source hash changes;
+- exercise broker-success before `mark_published` process loss;
+- prove combined multi-replica claim ownership;
+- establish production dedup-window sufficiency or adopt a stronger outbox/transaction design;
+- retain independent Profiles privacy/storefront runtime evidence.
+
+## Verification status
+
+Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy, and retained capture were not run while authoring this checkpoint.

--- a/crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution-contract.json
+++ b/crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution-contract.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 1,
+  "module": "social-graph",
+  "packet": "index-raw-poison-postgres-iggy-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_contract": "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json",
+  "runner": "scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs",
+  "verifier": "scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs",
+  "evidence_path": "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution.json",
+  "evidence_status": "runtime_execution_pending",
+  "test_target": "index_raw_poison_postgres_iggy",
+  "required_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_POSTGRES_ARTIFACT",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_SERVER_ARTIFACT"
+  ],
+  "optional_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD"
+  ],
+  "command_template": {
+    "program": "cargo",
+    "args_before_case": [
+      "test",
+      "-p",
+      "rustok-social-graph",
+      "--features",
+      "index-consumer",
+      "--test",
+      "index_raw_poison_postgres_iggy",
+      "--"
+    ],
+    "args_after_case": [
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
+  "required_cases": [
+    {
+      "case": "raw_poison_persists_published_before_source_acknowledgement",
+      "assertions": [
+        "receipt_publishing_after_claim",
+        "exact_dlq_bytes_observed",
+        "receipt_publishing_after_broker_success",
+        "receipt_published_before_source_ack",
+        "receipt_published_after_source_ack_before_bookkeeping",
+        "receipt_acknowledged_after_bookkeeping",
+        "next_source_offset_visible"
+      ]
+    },
+    {
+      "case": "published_redelivery_is_acknowledgement_only_without_republication",
+      "assertions": [
+        "published_receipt_survives_transport_shutdown",
+        "same_offset_bytes_and_uuid_redelivered",
+        "claim_returns_already_published",
+        "no_second_dlq_publication_after_reopen",
+        "receipt_acknowledged_after_source_ack",
+        "next_source_offset_visible"
+      ]
+    }
+  ],
+  "source_files": [
+    "crates/rustok-social-graph/tests/index_raw_poison_postgres_iggy.rs",
+    "apps/server/src/services/social_graph_index_worker.rs",
+    "crates/rustok-social-graph/src/index_consumer.rs",
+    "crates/rustok-iggy/src/contract_consumer.rs",
+    "crates/rustok-iggy/src/contract_decode_failure.rs",
+    "crates/rustok-iggy/src/dlq_publisher.rs",
+    "crates/rustok-iggy/src/transport.rs",
+    "crates/rustok-iggy-connector/src/migrations.rs"
+  ],
+  "retained_metadata": [
+    "git_commit",
+    "started_at",
+    "completed_at",
+    "cargo_version",
+    "rustc_version",
+    "postgres_artifact",
+    "iggy_server_artifact",
+    "source_sha256",
+    "combined_test_output_sha256",
+    "test_output_sha256",
+    "test_output_bytes",
+    "executed_cases"
+  ],
+  "privacy_boundary": {
+    "forbidden_persisted_values": [
+      "database_url",
+      "iggy_address",
+      "username",
+      "password",
+      "connection_string",
+      "raw_test_output",
+      "payload",
+      "delivery_uuid",
+      "source_offset",
+      "ack_token",
+      "schema_name",
+      "stream_name"
+    ]
+  },
+  "promotion_gate": "clean_commit_all_exact_cases_pass_current_source_hashes",
+  "forbidden_claims": [
+    "physical_exactly_once_proved",
+    "database_broker_transaction_proved",
+    "deduplication_window_sufficiency_proved",
+    "bundled_mode_proved",
+    "tls_or_auth_failure_proved",
+    "multi_replica_claim_ownership_proved",
+    "profiles_authorization_proved"
+  ]
+}

--- a/crates/rustok-social-graph/docs/index-raw-poison-postgres-iggy-retained-evidence.md
+++ b/crates/rustok-social-graph/docs/index-raw-poison-postgres-iggy-retained-evidence.md
@@ -1,0 +1,122 @@
+# Retaining Social Graph raw poison PostgreSQL/Iggy evidence
+
+## Status
+
+The retained execution contract, capture runner, and strict verifier are source-complete. The canonical execution packet is intentionally absent until a maintainer executes both combined ordering cases successfully.
+
+## Files
+
+- execution contract: `crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution-contract.json`
+- capture runner: `scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs`
+- retained verifier: `scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs`
+- future packet: `crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution.json`
+
+The source harness and its production-order guard remain documented in `index-raw-poison-postgres-iggy-evidence.md`.
+
+## Required inputs
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL=postgresql://...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS=host:8090
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_POSTGRES_ARTIFACT=<reviewed version/image label>
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_SERVER_ARTIFACT=<reviewed version/image label>
+```
+
+Optional Iggy credentials must be supplied together:
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME=...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD=...
+```
+
+The runner validates that the database URL uses PostgreSQL and that the Iggy endpoint is a bounded `host:port` value without embedded credentials or URL parameters. It stores only the names of the URL/address environment variables, never their values.
+
+Artifact labels are bounded one-line operator-reviewed metadata. They are not active server readback and must not be described as such.
+
+## Execution gates
+
+The runner requires:
+
+- a clean Git working tree before execution;
+- one full lowercase commit SHA;
+- current SHA-256 values for all bound production and test sources;
+- Cargo and Rust compiler version metadata;
+- both required services and both reviewed artifact labels;
+- paired optional Iggy credentials;
+- each named case to run independently through a libtest `--exact` filter;
+- `running 1 test` and `<case> ... ok` for each command;
+- no source-harness skip marker;
+- unchanged commit, source hashes, and clean tree after execution.
+
+The packet is written atomically only after both cases pass.
+
+## Exact commands
+
+The runner constructs these commands from the locked template:
+
+```bash
+cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_postgres_iggy -- \
+  raw_poison_persists_published_before_source_acknowledgement \
+  --exact --nocapture --test-threads=1
+
+cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_postgres_iggy -- \
+  published_redelivery_is_acknowledgement_only_without_republication \
+  --exact --nocapture --test-threads=1
+```
+
+## Retained packet
+
+The packet retains only:
+
+- commit and timestamps;
+- Cargo/Rust compiler versions;
+- bounded reviewed PostgreSQL and Iggy artifact labels;
+- environment-variable names for the database URL and Iggy address;
+- exact command arrays;
+- source SHA-256 values;
+- per-case and combined test-output SHA-256 values and byte counts;
+- two aggregate `pass` results and their locked assertion names.
+
+It does not retain:
+
+- the database URL or Iggy address;
+- usernames, passwords, or connection strings;
+- raw test output;
+- PostgreSQL schema or Iggy stream names;
+- payloads, source offsets, acknowledgement tokens, or delivery UUIDs.
+
+## Verifier modes
+
+Before execution JSON exists, the verifier checks the contract, runner, source-contract state, exact commands, clean-commit gates, hashing, atomic output, and packet privacy projection. It reports runtime pending.
+
+After execution JSON exists, it additionally requires:
+
+- packet commit equal to current `HEAD`;
+- current source SHA-256 values;
+- valid bounded timestamps, toolchain values, and artifact labels;
+- exactly two retained cases in contract order;
+- `pass` for both cases;
+- exact command and assertion arrays;
+- valid per-case and combined output hashes and positive byte counts;
+- no forbidden packet keys.
+
+## Maintainer flow
+
+```bash
+node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
+node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs
+
+# Supply the required inputs, then:
+node scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs
+node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs
+```
+
+Review the generated packet before committing it.
+
+## Non-claims
+
+A successful retained packet proves the two bounded ordering scenarios for the reviewed service artifacts and bound source commit. It does not prove a PostgreSQL/Iggy transaction, physical exactly-once, production dedup-window sufficiency, bundled mode, TLS/auth/failover, multi-replica ownership, or Profiles authorization.
+
+No Cargo command, verifier, database query, broker scenario, formatter, or retained capture was executed while authoring this tooling.

--- a/scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs
+++ b/scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution-contract.json";
+const expectedRunner =
+  "scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs";
+const expectedVerifier =
+  "scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs";
+const expectedEvidence =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution.json";
+const expectedCases = [
+  "raw_poison_persists_published_before_source_acknowledgement",
+  "published_redelivery_is_acknowledgement_only_without_republication",
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-social-graph",
+    "--features",
+    "index-consumer",
+    "--test",
+    "index_raw_poison_postgres_iggy",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) fail(`${program} could not start: ${result.error.message}`);
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function oneLine(value, field, maximumLength = 256) {
+  const line = value.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (!line || line.length > maximumLength || /[\u0000-\u001f\u007f]/u.test(line)) {
+    fail(`${field} is missing or outside the retained evidence boundary`);
+  }
+  return line;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function validateContract() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "social-graph" ||
+    contract.packet !== "index-raw-poison-postgres-iggy-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked"
+  ) {
+    fail("combined poison execution contract identity drift");
+  }
+  if (
+    contract.runner !== expectedRunner ||
+    contract.verifier !== expectedVerifier ||
+    contract.evidence_path !== expectedEvidence ||
+    contract.evidence_status !== "runtime_execution_pending"
+  ) {
+    fail("combined poison retained tooling boundary drift");
+  }
+  if (!sameValue(contract.command_template, expectedCommandTemplate)) {
+    fail("combined poison Cargo command allowlist drift");
+  }
+  const cases = contract.required_cases?.map((entry) => entry.case);
+  if (!sameValue(cases, expectedCases)) fail("combined poison exact case allowlist drift");
+}
+
+function validateDatabaseUrl() {
+  const envName = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL";
+  const value = process.env[envName];
+  if (!value) fail(`${envName} is required for retained execution`);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail(`${envName} is invalid`);
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    fail(`${envName} must use PostgreSQL`);
+  }
+  return envName;
+}
+
+function validateIggyAddress() {
+  const envName = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS";
+  const address = oneLine(process.env[envName] ?? "", envName, 255);
+  if (
+    address.includes("://") ||
+    address.includes("@") ||
+    address.includes("?") ||
+    address.includes("#")
+  ) {
+    fail(`${envName} must be host:port without credentials or URL delimiters`);
+  }
+  if (!/^\[[0-9a-f:]+\]:\d+$|^[A-Za-z0-9._-]+:\d+$/u.test(address)) {
+    fail(`${envName} must be a bounded host:port address`);
+  }
+  return envName;
+}
+
+function validateCredentialsPair() {
+  const usernameEnv = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_USERNAME";
+  const passwordEnv = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_PASSWORD";
+  const username = process.env[usernameEnv] ?? "";
+  const password = process.env[passwordEnv] ?? "";
+  if (username.trim() !== username || password.trim() !== password) {
+    fail("Iggy credentials must not have surrounding whitespace");
+  }
+  if (username.length > 191 || password.length > 191) {
+    fail("Iggy credentials exceed the retained execution boundary");
+  }
+  if (username.includes(":") || username.includes("@")) {
+    fail("Iggy username contains an unsupported delimiter");
+  }
+  if (password.includes(":") || password.includes("@")) {
+    fail("Iggy password contains an unsupported delimiter");
+  }
+  if ((username.length === 0) !== (password.length === 0)) {
+    fail("Iggy username and password must both be set or both be empty");
+  }
+}
+
+function scenarioCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function requirePassedCase(output, caseName) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail(`combined poison scenario did not execute exactly one test: ${caseName}`);
+  }
+  const marker = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(caseName)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!marker.test(output)) fail(`combined poison case did not report success: ${caseName}`);
+  if (/skipping Social Graph raw poison PostgreSQL\/Iggy evidence/iu.test(output)) {
+    fail(`combined poison case reported a skip: ${caseName}`);
+  }
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) fail("working tree must be clean before retained execution");
+  const commit = oneLine(runChecked("git", ["rev-parse", "HEAD"]).stdout, "git_commit");
+  if (!/^[0-9a-f]{40}$/u.test(commit)) fail("git commit must be a full lowercase SHA-1");
+  return commit;
+}
+
+function ensureOutputInsideRepository() {
+  const prefix = resolve(repoRoot) + sep;
+  if (!outputPath.startsWith(prefix)) fail("retained evidence output must stay inside repository");
+}
+
+function writeAtomically(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+try {
+  ensureOutputInsideRepository();
+  validateContract();
+  const databaseUrlSource = validateDatabaseUrl();
+  const iggyAddressSource = validateIggyAddress();
+  validateCredentialsPair();
+  const postgresArtifact = oneLine(
+    process.env.RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_POSTGRES_ARTIFACT ?? "",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_POSTGRES_ARTIFACT",
+  );
+  const iggyServerArtifact = oneLine(
+    process.env.RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_SERVER_ARTIFACT ?? "",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_SERVER_ARTIFACT",
+  );
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const startedAt = new Date().toISOString();
+  const executedCases = [];
+  const combinedOutputs = [];
+
+  for (const requiredCase of contract.required_cases) {
+    const command = scenarioCommand(requiredCase.case);
+    const result = runChecked(command.program, command.args);
+    const output = `${result.stdout}\n${result.stderr}`;
+    requirePassedCase(output, requiredCase.case);
+    combinedOutputs.push(`--- ${requiredCase.case} ---\n${output}`);
+    executedCases.push({
+      case: requiredCase.case,
+      result: "pass",
+      assertions: requiredCase.assertions,
+      command,
+      test_output_sha256: sha256(output),
+      test_output_bytes: Buffer.byteLength(output),
+    });
+  }
+
+  const finalCommit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+  );
+  if (finalCommit !== gitCommit) fail("git commit changed during retained execution");
+  const finalSourceSha256 = sourceHashes();
+  if (!sameValue(finalSourceSha256, initialSourceSha256)) {
+    fail("combined poison source files changed during retained execution");
+  }
+  if (workingTreeStatus().trim()) fail("working tree changed during retained execution");
+
+  const completedAt = new Date().toISOString();
+  const combinedOutput = combinedOutputs.join("\n");
+  writeAtomically({
+    schema_version: 1,
+    module: contract.module,
+    packet: "index-raw-poison-postgres-iggy-runtime-evidence",
+    status: "postgres_iggy_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    environment_sources: {
+      database_url: databaseUrlSource,
+      iggy_address: iggyAddressSource,
+    },
+    reviewed_artifacts: {
+      postgresql: postgresArtifact,
+      iggy_server: iggyServerArtifact,
+    },
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    source_sha256: finalSourceSha256,
+    combined_test_output_sha256: sha256(combinedOutput),
+    combined_test_output_bytes: Buffer.byteLength(combinedOutput),
+    executed_cases: executedCases,
+  });
+  console.log(`Retained Social Graph PostgreSQL/Iggy evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`Social Graph PostgreSQL/Iggy evidence capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution-contract.json";
+const sourceContractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-source.json";
+const runnerPath =
+  "scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs";
+const evidencePath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-postgres-iggy-execution.json";
+const expectedVerifier =
+  "scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs";
+const expectedCases = [
+  "raw_poison_persists_published_before_source_acknowledgement",
+  "published_redelivery_is_acknowledgement_only_without_republication",
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-social-graph",
+    "--features",
+    "index-consumer",
+    "--test",
+    "index_raw_poison_postgres_iggy",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const sourceContract = JSON.parse(
+  readFileSync(resolve(repoRoot, sourceContractPath), "utf8"),
+);
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function currentSourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fail("could not read current git commit");
+    return null;
+  }
+  const commit = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("current git commit is not a full lowercase SHA-1");
+    return null;
+  }
+  return commit;
+}
+
+function expectedCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function boundedLine(value, field) {
+  if (
+    typeof value !== "string" ||
+    value.trim() !== value ||
+    value.length === 0 ||
+    value.length > 256 ||
+    /[\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is outside the retained metadata boundary`);
+  }
+}
+
+function validTimestamp(value, field) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${field} is not a valid timestamp`);
+  }
+}
+
+function validSha256(value, field) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${field} is not a lowercase SHA-256`);
+  }
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectKeys(entry, keys);
+    return keys;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(entry, keys);
+    }
+  }
+  return keys;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "social-graph" ||
+  contract.packet !== "index-raw-poison-postgres-iggy-execution-contract" ||
+  contract.status !== "runtime_execution_contract_locked"
+) {
+  fail("combined poison execution contract identity drift");
+}
+if (
+  contract.source_contract !== sourceContractPath ||
+  contract.runner !== runnerPath ||
+  contract.verifier !== expectedVerifier ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== "runtime_execution_pending"
+) {
+  fail("combined poison retained path drift");
+}
+if (!sameValue(contract.command_template, expectedCommandTemplate)) {
+  fail("combined poison command template drift");
+}
+if (!sameValue(contract.required_cases?.map((entry) => entry.case), expectedCases)) {
+  fail("combined poison required case drift");
+}
+if (sourceContract.execution_status !== "not_run") {
+  fail("source contract must remain unexecuted independently of retained packet");
+}
+
+for (const marker of [
+  "validateDatabaseUrl()",
+  "validateIggyAddress()",
+  "validateCredentialsPair()",
+  "ensureCleanCommit()",
+  "sourceHashes()",
+  "requirePassedCase(output, requiredCase.case)",
+  '"--exact"',
+  "running 1 test",
+  "reported a skip",
+  "finalCommit !== gitCommit",
+  "workingTreeStatus().trim()",
+  "writeAtomically({",
+  "environment_sources",
+  "reviewed_artifacts",
+  "combined_test_output_sha256",
+  "executed_cases",
+]) {
+  requireText("combined poison evidence runner", runner, marker);
+}
+for (const marker of [
+  "database_url: value",
+  "iggy_address: address",
+  "username: username",
+  "password: password",
+  "raw_test_output",
+  "payload:",
+  "delivery_uuid",
+  "source_offset",
+  "ack_token",
+  "schema_name",
+  "stream_name",
+]) {
+  forbidText("retained packet projection", runner.slice(runner.indexOf("writeAtomically({")), marker);
+}
+
+if (failures.length === 0 && !existsSync(resolve(repoRoot, evidencePath))) {
+  console.log(
+    "Social Graph PostgreSQL/Iggy retained evidence verified: execution contract, clean-commit runner, exact-case gates, source hashing, privacy boundary, and runtime-pending status are locked; canonical execution JSON is absent.",
+  );
+  process.exit(0);
+}
+
+if (existsSync(resolve(repoRoot, evidencePath))) {
+  const evidenceText = readFileSync(resolve(repoRoot, evidencePath), "utf8");
+  let evidence;
+  try {
+    evidence = JSON.parse(evidenceText);
+  } catch {
+    fail("combined poison execution packet is not valid JSON");
+  }
+
+  if (evidence) {
+    if (
+      evidence.schema_version !== 1 ||
+      evidence.module !== "social-graph" ||
+      evidence.packet !== "index-raw-poison-postgres-iggy-runtime-evidence" ||
+      evidence.status !== "postgres_iggy_runtime_executed"
+    ) {
+      fail("combined poison execution packet identity drift");
+    }
+    if (
+      evidence.generated_from !== contractPath ||
+      evidence.runner !== runnerPath ||
+      evidence.verifier !== expectedVerifier ||
+      evidence.working_tree_clean_before_run !== true
+    ) {
+      fail("combined poison execution provenance drift");
+    }
+
+    const commit = currentCommit();
+    if (commit && evidence.git_commit !== commit) {
+      fail("combined poison execution packet was generated from another commit");
+    }
+    validTimestamp(evidence.started_at, "started_at");
+    validTimestamp(evidence.completed_at, "completed_at");
+    if (
+      typeof evidence.started_at === "string" &&
+      typeof evidence.completed_at === "string" &&
+      Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)
+    ) {
+      fail("combined poison completion precedes start");
+    }
+
+    if (
+      !sameValue(evidence.environment_sources, {
+        database_url: "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+        iggy_address: "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_IGGY_ADDRESS",
+      })
+    ) {
+      fail("combined poison environment source metadata drift");
+    }
+    boundedLine(evidence.reviewed_artifacts?.postgresql, "reviewed PostgreSQL artifact");
+    boundedLine(evidence.reviewed_artifacts?.iggy_server, "reviewed Iggy artifact");
+    boundedLine(evidence.toolchain?.cargo, "cargo toolchain");
+    boundedLine(evidence.toolchain?.rustc, "rustc toolchain");
+
+    const hashes = currentSourceHashes();
+    if (!sameValue(evidence.source_sha256, hashes)) {
+      fail("combined poison execution source hashes are stale");
+    }
+    for (const [path, digest] of Object.entries(evidence.source_sha256 ?? {})) {
+      validSha256(digest, `source hash ${path}`);
+    }
+    validSha256(evidence.combined_test_output_sha256, "combined test output hash");
+    if (
+      !Number.isSafeInteger(evidence.combined_test_output_bytes) ||
+      evidence.combined_test_output_bytes <= 0
+    ) {
+      fail("combined test output byte count is invalid");
+    }
+
+    if (!Array.isArray(evidence.executed_cases) || evidence.executed_cases.length !== 2) {
+      fail("combined poison execution must retain exactly two cases");
+    } else {
+      for (let index = 0; index < expectedCases.length; index += 1) {
+        const retained = evidence.executed_cases[index];
+        const required = contract.required_cases[index];
+        if (
+          retained.case !== expectedCases[index] ||
+          retained.result !== "pass" ||
+          !sameValue(retained.assertions, required.assertions) ||
+          !sameValue(retained.command, expectedCommand(expectedCases[index]))
+        ) {
+          fail(`combined poison retained case drift: ${expectedCases[index]}`);
+        }
+        validSha256(retained.test_output_sha256, `${expectedCases[index]} output hash`);
+        if (!Number.isSafeInteger(retained.test_output_bytes) || retained.test_output_bytes <= 0) {
+          fail(`${expectedCases[index]} output byte count is invalid`);
+        }
+      }
+    }
+
+    const forbiddenKeys = new Set([
+      "database_url_value",
+      "iggy_address_value",
+      "username",
+      "password",
+      "connection_string",
+      "raw_test_output",
+      "payload",
+      "delivery_uuid",
+      "source_offset",
+      "ack_token",
+      "schema_name",
+      "stream_name",
+    ]);
+    for (const key of collectKeys(evidence)) {
+      if (forbiddenKeys.has(key)) fail(`combined poison packet contains forbidden key: ${key}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Social Graph PostgreSQL/Iggy retained evidence verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Social Graph PostgreSQL/Iggy retained evidence verified: current clean-commit provenance, reviewed service artifacts, current source hashes, exact commands, two all-pass ordering cases, bounded output digests, and privacy-safe packet projection are locked.",
+);


### PR DESCRIPTION
## Summary

Add a fail-closed retained-execution path for the combined Social Graph raw-poison PostgreSQL + external-Iggy ordering harness merged in #2373.

## Execution contract

The versioned contract locks:

- two exact test cases and their assertion sets;
- the Cargo command template with per-case libtest `--exact` filtering;
- required PostgreSQL URL, external Iggy address, and reviewed service artifact labels;
- paired optional Iggy credentials;
- current production/test source hashes;
- the canonical execution packet path;
- packet privacy and bounded non-claims.

## Capture runner

The clean-commit runner:

- accepts PostgreSQL URLs only;
- accepts a bounded `host:port` Iggy endpoint without embedded credentials or URL parameters;
- validates paired optional credentials but never retains them;
- requires bounded reviewed PostgreSQL and Iggy server artifact/version labels;
- requires a clean working tree and full commit SHA before execution;
- captures Cargo/Rust compiler versions and source SHA-256 values;
- runs each of the two named tests separately through `--exact`;
- requires `running 1 test`, `<case> ... ok`, and no source-harness skip marker;
- rechecks commit, source hashes, and working-tree cleanliness afterward;
- writes the canonical JSON atomically only after both cases pass.

## Retained verifier

Before the execution JSON exists, the verifier locks the contract, runner, source-contract state, exact commands, hashing, atomic output, and packet projection while reporting runtime pending.

After a packet exists it additionally requires:

- packet commit equal to current `HEAD`;
- current source SHA-256 values;
- valid timestamps, toolchain metadata, and reviewed artifact labels;
- exactly two cases in contract order, both `pass`;
- exact commands and assertion arrays;
- valid per-case/combined output hashes and positive byte counts;
- no forbidden endpoint, credential, payload, UUID, offset, token, schema, stream, or raw-log keys.

## Privacy

The packet retains only environment-variable names for the service endpoints, bounded reviewed artifact labels, commit/toolchain/timestamps, exact commands, source/output digests, output sizes, and aggregate pass results.

It omits database URLs, broker addresses, usernames, passwords, connection strings, raw logs, schema/stream names, payloads, offsets, acknowledgement tokens, and delivery UUIDs.

`index-raw-poison-postgres-iggy-execution.json` is intentionally absent until a maintainer executes both scenarios successfully.

## Non-claims

This tooling does not claim a PostgreSQL/Iggy transaction, physical exactly-once, production dedup-window sufficiency, bundled mode, TLS/auth/failover, multi-replica ownership, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy, and retained capture were not run, per maintainer instruction.

Suggested maintainer flow:

```bash
node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy.mjs
node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs

# After supplying required inputs:
node scripts/evidence/capture-social-graph-index-raw-poison-postgres-iggy.mjs
node scripts/verify/verify-social-graph-index-raw-poison-postgres-iggy-retained.mjs
```