### PR TITLE
fix(index): bind retained verification to file identity

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -61,7 +61,7 @@ node scripts/verify/index-storage-tooling.mjs partition-report \
   --root evidence/index-partition/retained-run
 ```
 
-`partition-report` requires a regular non-symlink bundle and keeps `capture.json`, the packet, the admission file, and all six raw artifacts inside that bundle. It recalculates packet assembly and admission from the retained bytes, rejects raw-artifact, packet, or admission drift, checks that all nine files have distinct filesystem identities, and prints a stable Markdown inventory with exact-byte SHA-256 digests, PostgreSQL identity, provenance, calculated measurements, outcome, and typed reasons.
+`partition-report` requires a regular non-symlink bundle and keeps `capture.json`, the packet, the admission file, and all six raw artifacts inside that bundle. It reads every authoritative file through a stable file descriptor, binds the inspected bytes to an internal `dev:ino` identity, recalculates packet assembly and admission from the retained bytes, rejects raw-artifact, packet, or admission drift, checks that all nine files have distinct filesystem identities, and prints a stable Markdown inventory with exact-byte SHA-256 digests, PostgreSQL identity, provenance, calculated measurements, outcome, and typed reasons.
 
 The report command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save the derived report outside the immutable bundle, but the six raw artifacts, `capture.json`, `partition-packet.json`, and `admission.json` remain the authoritative archive inputs. A report does not change admission and does not authorize production lifecycle work.
 
@@ -77,7 +77,7 @@ node scripts/verify/index-storage-tooling.mjs partition-archive-manifest \
 
 `partition-archive-manifest` runs the same retained-bundle inspection as `partition-report`, refuses any outcome other than `admitted`, and prints JSON containing the evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, byte counts, and total retained bytes. Its `manifest_digest` is the SHA-256 digest of canonical JSON for the manifest payload before the `manifest_digest` field is added, under `canonical_json_without_manifest_digest_v1`.
 
-The archive-manifest command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save this derived index outside the immutable bundle. The manifest does not replace or modify the nine authoritative retained files, does not change admission, and does not authorize production lifecycle work.
+The archive-manifest command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save this derived index outside the immutable bundle. The manifest does not replace or modify the nine authoritative retained files, does not expose internal filesystem identities, does not change admission, and does not authorize production lifecycle work.
 
 ## Verify a saved archive manifest
 
@@ -91,7 +91,7 @@ node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
 
 `partition-archive-verify` requires the saved manifest to be a non-empty regular non-symlink file outside the immutable bundle. It rejects lexical or canonical paths inside the bundle and rejects a hard-link alias to any of the nine retained files. It reads the saved manifest through one stable file descriptor, verifies the saved `manifest_digest`, reruns the full retained-bundle inspection, rebuilds the admitted archive manifest, and canonical-compares the complete saved manifest to the recalculated result.
 
-Before publishing success, the verifier rereads all nine retained files through stable file descriptors and compares their current byte counts and exact-byte SHA-256 digests to the completed inspection. It fails closed on post-inspection exact-byte drift, current retained-file aliasing, or identity/content drift while a file is being read. This closes the gap where a bundle could change between inspection and receipt publication.
+Before publishing success, the verifier rereads all nine retained files through stable file descriptors and compares their current filesystem identities, byte counts, and exact-byte SHA-256 digests to the completed inspection. It fails closed on same-byte filesystem identity replacement, post-inspection exact-byte drift, current retained-file aliasing, or identity/content drift while a file is being read. This closes the gap where a bundle path could be replaced between inspection and receipt publication even when the replacement bytes are identical.
 
 A successful verification prints a deterministic `index_partition_retained_archive_verification_v1` receipt with `retained_files_rechecked: true`, the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. The verifier writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
 

--- a/scripts/verify/index-partition-archive-manifest-core.mjs
+++ b/scripts/verify/index-partition-archive-manifest-core.mjs
@@ -54,6 +54,14 @@ const requireDigest = (value, label) => {
   return digest;
 };
 
+const requireIdentity = (value, label) => {
+  const identity = requireNonEmptyString(value, label);
+  if (!/^\d+:\d+$/u.test(identity)) {
+    throw new Error(`${label} must be a decimal device:inode identity`);
+  }
+  return identity;
+};
+
 const parseJsonBytes = (bytes, label) => {
   try {
     return JSON.parse(bytes.toString('utf8'));
@@ -112,7 +120,7 @@ const readStableRegularFile = (filename, label) => {
   }
 };
 
-const normalizeFiles = (files) => {
+const normalizeFiles = (files, { requireInspectionIdentity = false } = {}) => {
   if (!Array.isArray(files) || files.length !== 9) {
     throw new Error('inspection.files must contain exactly nine retained files');
   }
@@ -128,7 +136,14 @@ const normalizeFiles = (files) => {
     if (paths.has(retainedPath)) throw new Error(`inspection.files contains duplicate path ${retainedPath}`);
     roles.add(role);
     paths.add(retainedPath);
-    return { role, path: retainedPath, bytes, sha256 };
+    const normalized = { role, path: retainedPath, bytes, sha256 };
+    if (requireInspectionIdentity) {
+      normalized.identity = requireIdentity(
+        file.identity,
+        `inspection.files[${index}].identity`,
+      );
+    }
+    return normalized;
   });
 };
 
@@ -151,6 +166,9 @@ const assertRetainedFilesUnchanged = ({
       throw new Error(`retained bundle file ${file.role} aliases another retained bundle file after inspection`);
     }
     retainedIdentities.add(current.identity);
+    if (current.identity !== file.identity) {
+      throw new Error(`retained bundle file ${file.role} identity changed after inspection`);
+    }
     if (current.bytes.length !== file.bytes || sha256Hex(current.bytes) !== file.sha256) {
       throw new Error(`retained bundle file ${file.role} changed after inspection`);
     }
@@ -196,6 +214,7 @@ export const verifySavedRetainedPartitionArchiveManifest = ({
   manifestPath,
 }) => {
   const expected = buildRetainedPartitionArchiveManifest(inspection);
+  const inspectedFiles = normalizeFiles(inspection.files, { requireInspectionIdentity: true });
   const resolvedRoot = path.resolve(requireNonEmptyString(root, 'root'));
   const resolvedManifestPath = path.resolve(requireNonEmptyString(manifestPath, 'manifestPath'));
   ensureOutsideRoot(resolvedRoot, resolvedManifestPath, 'saved archive manifest');
@@ -220,7 +239,7 @@ export const verifySavedRetainedPartitionArchiveManifest = ({
   }
 
   assertRetainedFilesUnchanged({
-    files: expected.files,
+    files: inspectedFiles,
     resolvedRoot,
     canonicalRoot,
     manifestIdentity: manifestFile.identity,

--- a/scripts/verify/index-partition-evidence-assembly-core.mjs
+++ b/scripts/verify/index-partition-evidence-assembly-core.mjs
@@ -1,4 +1,11 @@
-import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import {
+  closeSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -54,6 +61,48 @@ const parseJsonBytes = (bytes, label) => {
 };
 
 const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+const fingerprintOf = (stat) => [
+  identityOf(stat),
+  stat.size,
+  stat.mtimeNs,
+  stat.ctimeNs,
+].join(':');
+
+const readStableRegularFile = (filename, label) => {
+  const pathStatBefore = lstatSync(filename, { bigint: true });
+  if (pathStatBefore.isSymbolicLink() || !pathStatBefore.isFile()) {
+    throw new Error(`${label} must be a regular non-symlink file`);
+  }
+
+  const descriptor = openSync(filename, 'r');
+  try {
+    const descriptorStatBefore = fstatSync(descriptor, { bigint: true });
+    if (!descriptorStatBefore.isFile()
+        || identityOf(descriptorStatBefore) !== identityOf(pathStatBefore)) {
+      throw new Error(`${label} changed before it could be read`);
+    }
+
+    const bytes = readFileSync(descriptor);
+    const descriptorStatAfter = fstatSync(descriptor, { bigint: true });
+    const pathStatAfter = lstatSync(filename, { bigint: true });
+    if (pathStatAfter.isSymbolicLink()
+        || !pathStatAfter.isFile()
+        || identityOf(pathStatAfter) !== identityOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatBefore) !== fingerprintOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatAfter) !== fingerprintOf(pathStatAfter)) {
+      throw new Error(`${label} changed while it was being read`);
+    }
+    if (bytes.length === 0) throw new Error(`${label} must not be empty`);
+
+    return {
+      bytes,
+      identity: identityOf(descriptorStatAfter),
+      canonical: realpathSync.native(filename),
+    };
+  } finally {
+    closeSync(descriptor);
+  }
+};
 
 const resolveArtifactPath = (bundleRoot, canonicalBundleRoot, relative, label) => {
   requireNonEmptyString(relative, label);
@@ -102,32 +151,32 @@ export const readCaptureArtifacts = ({ capturePath, capture }) => {
   const canonicalBundleRoot = realpathSync.native(bundleRoot);
   const resolvedPaths = new Map();
   const identities = new Map();
+  const byteLengths = new Map();
   const seenIdentities = new Set();
   const rawArtifacts = {};
   const parsed = {};
 
   for (const role of RAW_ARTIFACT_ROLES) {
+    const label = `capture artifact ${role}`;
     const { resolved, canonical } = resolveArtifactPath(
       bundleRoot,
       canonicalBundleRoot,
       capture.artifacts[role],
       `capture.artifacts.${role}`,
     );
-    const stat = lstatSync(resolved);
-    if (stat.isSymbolicLink() || !stat.isFile()) {
-      throw new Error(`capture artifact ${role} must be a regular non-symlink file`);
+    const file = readStableRegularFile(resolved, label);
+    if (file.canonical !== canonical) {
+      throw new Error(`${label} changed before it could be read`);
     }
-    const identity = identityOf(stat);
-    if (seenIdentities.has(identity)) {
+    if (seenIdentities.has(file.identity)) {
       throw new Error(`capture artifact files must be unique; ${role} aliases another role`);
     }
-    seenIdentities.add(identity);
-    const bytes = readFileSync(resolved);
-    if (bytes.length === 0) throw new Error(`capture artifact ${role} must not be empty`);
-    resolvedPaths.set(role, canonical);
-    identities.set(role, identity);
-    rawArtifacts[role] = sha256Hex(bytes);
-    parsed[role] = parseJsonBytes(bytes, `capture artifact ${role}`);
+    seenIdentities.add(file.identity);
+    resolvedPaths.set(role, file.canonical);
+    identities.set(role, file.identity);
+    byteLengths.set(role, file.bytes.length);
+    rawArtifacts[role] = sha256Hex(file.bytes);
+    parsed[role] = parseJsonBytes(file.bytes, label);
   }
 
   requireObject(parsed.baseline, 'baseline artifact');
@@ -137,12 +186,24 @@ export const readCaptureArtifacts = ({ capturePath, capture }) => {
   requireArray(parsed.maintenance, 'maintenance artifact');
   requireArray(parsed.cutover, 'cutover artifact');
 
-  return { rawArtifacts, parsed, resolvedPaths, identities };
+  return {
+    rawArtifacts,
+    parsed,
+    resolvedPaths,
+    identities,
+    byteLengths,
+  };
 };
 
 export const assemblePartitionPacket = ({ manifest, capturePath, capture }) => {
   validatePreparedManifest(manifest);
-  const { rawArtifacts, parsed, resolvedPaths, identities } = readCaptureArtifacts({
+  const {
+    rawArtifacts,
+    parsed,
+    resolvedPaths,
+    identities,
+    byteLengths,
+  } = readCaptureArtifacts({
     capturePath,
     capture,
   });
@@ -161,5 +222,10 @@ export const assemblePartitionPacket = ({ manifest, capturePath, capture }) => {
     cutover_rehearsals: parsed.cutover,
   };
   validatePartitionPacket(packet);
-  return { packet, resolvedPaths, identities };
+  return {
+    packet,
+    resolvedPaths,
+    identities,
+    byteLengths,
+  };
 };

--- a/scripts/verify/index-partition-post-inspection-drift.test.mjs
+++ b/scripts/verify/index-partition-post-inspection-drift.test.mjs
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -23,17 +30,21 @@ const roles = [
   'admission',
 ];
 
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+
 const buildContext = () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'index-partition-post-inspection-'));
   const files = roles.map((role, index) => {
     const relativePath = `${role}.json`;
+    const filename = path.join(root, relativePath);
     const bytes = Buffer.from(`${JSON.stringify({ role, index })}\n`, 'utf8');
-    writeFileSync(path.join(root, relativePath), bytes);
+    writeFileSync(filename, bytes);
     return {
       role,
       path: relativePath,
       bytes: bytes.length,
       sha256: sha256Hex(bytes),
+      identity: identityOf(lstatSync(filename, { bigint: true })),
     };
   });
   const inspection = {
@@ -80,6 +91,7 @@ test('rechecks all retained files before publishing an archive verification rece
   const context = buildContext();
   try {
     const manifestBefore = readFileSync(context.manifestPath);
+    const savedManifest = JSON.parse(manifestBefore.toString('utf8'));
     const receipt = verifySavedRetainedPartitionArchiveManifest({
       inspection: context.inspection,
       root: context.root,
@@ -89,6 +101,7 @@ test('rechecks all retained files before publishing an archive verification rece
     assert.equal(receipt.retained_files_rechecked, true);
     assert.equal(receipt.file_count, 9);
     assert.equal(receipt.production_lifecycle_authorized, false);
+    assert.equal(Object.hasOwn(savedManifest.files[0], 'identity'), false);
     assert.deepEqual(readFileSync(context.manifestPath), manifestBefore);
   } finally {
     cleanup(context);
@@ -106,6 +119,31 @@ test('fails closed when a retained file changes after inspection', () => {
         manifestPath: context.manifestPath,
       }),
       /retained bundle file query changed after inspection/u,
+    );
+  } finally {
+    cleanup(context);
+  }
+});
+
+test('fails closed on a same-byte retained file identity replacement after inspection', () => {
+  const context = buildContext();
+  try {
+    const target = path.join(context.root, 'query.json');
+    const replacement = path.join(context.root, 'query.replacement');
+    const bytes = readFileSync(target);
+    const identityBefore = identityOf(lstatSync(target, { bigint: true }));
+    writeFileSync(replacement, bytes);
+    rmSync(target);
+    renameSync(replacement, target);
+    const identityAfter = identityOf(lstatSync(target, { bigint: true }));
+    assert.notEqual(identityAfter, identityBefore);
+    assert.throws(
+      () => verifySavedRetainedPartitionArchiveManifest({
+        inspection: context.inspection,
+        root: context.root,
+        manifestPath: context.manifestPath,
+      }),
+      /retained bundle file query identity changed after inspection/u,
     );
   } finally {
     cleanup(context);

--- a/scripts/verify/index-partition-review-core.mjs
+++ b/scripts/verify/index-partition-review-core.mjs
@@ -1,4 +1,11 @@
-import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import {
+  closeSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -21,6 +28,12 @@ const descriptorNames = Object.freeze({
 
 const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+const fingerprintOf = (stat) => [
+  identityOf(stat),
+  stat.size,
+  stat.mtimeNs,
+  stat.ctimeNs,
+].join(':');
 const portablePath = (value) => value.split(path.sep).join('/');
 
 const requireObject = (value, label) => {
@@ -43,19 +56,40 @@ const ensureInsideRoot = (root, filename, label) => {
   }
 };
 
-const readRegularFile = (filename, label) => {
-  const stat = lstatSync(filename);
-  if (stat.isSymbolicLink() || !stat.isFile()) {
+const readStableRegularFile = (filename, label) => {
+  const pathStatBefore = lstatSync(filename, { bigint: true });
+  if (pathStatBefore.isSymbolicLink() || !pathStatBefore.isFile()) {
     throw new Error(`${label} must be a regular non-symlink file`);
   }
-  const bytes = readFileSync(filename);
-  if (bytes.length === 0) throw new Error(`${label} must not be empty`);
-  return {
-    bytes,
-    stat,
-    identity: identityOf(stat),
-    canonical: realpathSync.native(filename),
-  };
+
+  const descriptor = openSync(filename, 'r');
+  try {
+    const descriptorStatBefore = fstatSync(descriptor, { bigint: true });
+    if (!descriptorStatBefore.isFile()
+        || identityOf(descriptorStatBefore) !== identityOf(pathStatBefore)) {
+      throw new Error(`${label} changed before it could be read`);
+    }
+
+    const bytes = readFileSync(descriptor);
+    const descriptorStatAfter = fstatSync(descriptor, { bigint: true });
+    const pathStatAfter = lstatSync(filename, { bigint: true });
+    if (pathStatAfter.isSymbolicLink()
+        || !pathStatAfter.isFile()
+        || identityOf(pathStatAfter) !== identityOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatBefore) !== fingerprintOf(descriptorStatAfter)
+        || fingerprintOf(descriptorStatAfter) !== fingerprintOf(pathStatAfter)) {
+      throw new Error(`${label} changed while it was being read`);
+    }
+    if (bytes.length === 0) throw new Error(`${label} must not be empty`);
+
+    return {
+      bytes,
+      identity: identityOf(descriptorStatAfter),
+      canonical: realpathSync.native(filename),
+    };
+  } finally {
+    closeSync(descriptor);
+  }
 };
 
 const assertDistinctIdentity = (seen, identity, label) => {
@@ -93,9 +127,9 @@ export const inspectRetainedPartitionBundle = ({ root, packetPath, admissionPath
     throw new Error('capture, packet, and admission files must be distinct');
   }
 
-  const captureFile = readRegularFile(capturePath, 'capture file');
-  const packetFile = readRegularFile(resolvedPacketPath, 'packet file');
-  const admissionFile = readRegularFile(resolvedAdmissionPath, 'admission file');
+  const captureFile = readStableRegularFile(capturePath, 'capture file');
+  const packetFile = readStableRegularFile(resolvedPacketPath, 'packet file');
+  const admissionFile = readStableRegularFile(resolvedAdmissionPath, 'admission file');
   for (const [label, file] of [
     ['capture file', captureFile],
     ['packet file', packetFile],
@@ -128,14 +162,18 @@ export const inspectRetainedPartitionBundle = ({ root, packetPath, admissionPath
   const files = [];
   for (const role of RAW_ARTIFACT_ROLES) {
     const canonical = assembled.resolvedPaths.get(role);
-    const stat = lstatSync(canonical);
     const identity = assembled.identities.get(role);
+    const stat = lstatSync(canonical, { bigint: true });
+    if (stat.isSymbolicLink() || !stat.isFile() || identityOf(stat) !== identity) {
+      throw new Error(`capture artifact ${role} changed after it was read`);
+    }
     assertDistinctIdentity(seenIdentities, identity, `capture artifact ${role}`);
     files.push({
       role,
       path: portablePath(path.relative(canonicalRoot, canonical)),
-      bytes: stat.size,
+      bytes: assembled.byteLengths.get(role),
       sha256: packet.raw_artifacts[role],
+      identity,
     });
   }
   for (const [role, filename, file] of [
@@ -148,6 +186,7 @@ export const inspectRetainedPartitionBundle = ({ root, packetPath, admissionPath
       path: portablePath(path.relative(resolvedRoot, filename)),
       bytes: file.bytes.length,
       sha256: sha256Hex(file.bytes),
+      identity: file.identity,
     });
   }
 

--- a/scripts/verify/verify-index-partition-post-inspection-drift.mjs
+++ b/scripts/verify/verify-index-partition-post-inspection-drift.mjs
@@ -18,9 +18,34 @@ const forbidMarkers = (source, markers, label) => {
 };
 
 try {
+  const assembly = read('scripts/verify/index-partition-evidence-assembly-core.mjs');
+  const review = read('scripts/verify/index-partition-review-core.mjs');
   const core = read('scripts/verify/index-partition-archive-manifest-core.mjs');
   const fixture = read('scripts/verify/index-partition-post-inspection-drift.test.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
+
+  requireMarkers(assembly, [
+    'readStableRegularFile',
+    'openSync',
+    'fstatSync',
+    'closeSync',
+    'fingerprintOf',
+    'changed before it could be read',
+    'changed while it was being read',
+    'byteLengths.set(role, file.bytes.length)',
+    'identities.set(role, file.identity)',
+  ], 'partition evidence assembly core');
+
+  requireMarkers(review, [
+    'readStableRegularFile',
+    'openSync',
+    'fstatSync',
+    'closeSync',
+    'fingerprintOf',
+    'capture artifact ${role} changed after it was read',
+    'bytes: assembled.byteLengths.get(role)',
+    'identity: file.identity',
+  ], 'retained partition review core');
 
   requireMarkers(core, [
     'readStableRegularFile',
@@ -29,6 +54,10 @@ try {
     'closeSync',
     'fingerprintOf',
     'assertRetainedFilesUnchanged',
+    'requireInspectionIdentity',
+    'must be a decimal device:inode identity',
+    'current.identity !== file.identity',
+    'identity changed after inspection',
     'changed before it could be read',
     'changed while it was being read',
     'changed after inspection',
@@ -36,7 +65,7 @@ try {
     'saved archive manifest aliases a retained bundle file',
     'production_lifecycle_authorized: false',
   ], 'archive verifier core');
-  forbidMarkers(core, [
+  forbidMarkers(`${assembly}\n${review}\n${core}`, [
     'writeFileSync',
     'mkdirSync',
     'renameSync',
@@ -44,17 +73,24 @@ try {
     'spawnSync',
     'DATABASE_URL',
     'INDEX_PARTITION_ALLOW',
-  ], 'archive verifier core');
+  ], 'partition inspection and archive verifier cores');
 
   requireMarkers(fixture, [
     'rechecks all retained files before publishing an archive verification receipt',
     'retained_files_rechecked',
+    "Object.hasOwn(savedManifest.files[0], 'identity')",
     'fails closed when a retained file changes after inspection',
     'retained bundle file query changed after inspection',
+    'fails closed on a same-byte retained file identity replacement after inspection',
+    'assert.notEqual(identityAfter, identityBefore)',
+    'retained bundle file query identity changed after inspection',
   ], 'post-inspection drift fixture');
 
   requireMarkers(runbook, [
+    'stable file descriptor',
+    'internal `dev:ino` identity',
     'rereads all nine retained files',
+    'same-byte filesystem identity replacement',
     'post-inspection exact-byte drift',
     '`retained_files_rechecked: true`',
   ], 'full partition capture runbook');


### PR DESCRIPTION
## Summary

- read the six raw artifacts and `capture.json`/`partition-packet.json`/`admission.json` through stable file descriptors during retained-bundle inspection;
- bind the inspected bytes to internal filesystem `dev:ino` identities;
- require the final archive-verification reread to observe the same identities, byte counts, and exact-byte SHA-256 digests;
- fail closed when a retained path is replaced by a different inode even when the replacement bytes are identical;
- add focused regression and static contract coverage for same-byte identity replacement;
- document the strengthened owner review/archive boundary.

## Compatibility and safety boundary

The internal inspection object now carries file identities, but `index_partition_retained_archive_manifest_v1` does not serialize them. The archive manifest schema, manifest digest contract, and `index_partition_retained_archive_verification_v1` receipt schema remain unchanged.

This does not change capture stages, admission thresholds, PostgreSQL access, packet formats, production partition copy/replay, dual-write, relation cutover, cleanup, rollback automation, or query-adapter behavior. Successful verification still emits `production_lifecycle_authorized: false`.

## Validation

Per repository-owner instruction, tests, fixture suites, aggregate contract suites, Rust builds, Cargo commands, database connections, and PostgreSQL evidence were not run.

Only JavaScript syntax checks and the standalone static guard were run:

```bash
node --check scripts/verify/index-partition-evidence-assembly-core.mjs
node --check scripts/verify/index-partition-review-core.mjs
node --check scripts/verify/index-partition-archive-manifest-core.mjs
node --check scripts/verify/index-partition-post-inspection-drift.test.mjs
node --check scripts/verify/verify-index-partition-post-inspection-drift.mjs
node scripts/verify/verify-index-partition-post-inspection-drift.mjs
```

Static guard output:

```text
[verify-index-partition-post-inspection-drift] contract satisfied
```

Suggested owner checks:

```bash
node --test scripts/verify/index-partition-post-inspection-drift.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```

The branch was created from `229a5d202e2bf751cb77436fc813abc6a6172a5b`. Current `main` advanced only through unrelated Iggy, Translation, module-registry, and xtask paths; none overlap the six Index files in this PR.