### PR TITLE
Publish fulfillment lifecycle parity capture

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "generated_at": "2026-07-28",
   "status": "source_cutover_unvalidated",
-  "source_base_revision": "184ae1a7b413958bd06f2ea3fb66c2c266812991",
+  "source_base_revision": "75db491faebadac59440a705a4f201567466f3e9",
   "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
   "owner": {
     "crate": "rustok-fulfillment",
@@ -85,11 +85,23 @@
     "deadline_seconds": 2,
     "concrete_service_read_construction": false
   },
+  "runtime_capture": {
+    "contract": "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json",
+    "runner": "scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs",
+    "verifier": "scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs",
+    "runbook": "crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md",
+    "contract_published": true,
+    "capture_executed": false,
+    "transport_projection_parity_proven": false,
+    "deadline_failure_proven": false,
+    "restart_proven": false,
+    "remote_adapter_proven": false
+  },
   "consumer_cutover": {
     "graphql_compatibility_facade": true,
     "admin_rest_list_show": true,
     "concrete_delegate_removed": true,
-    "next_slice": "execute mounted GraphQL and REST lifecycle read parity, deadline, tenant, filter, optional-not-found, failure, restart, and remote-adapter evidence"
+    "next_slice": "run the mounted projection-parity capture, retain the immutable packet, then prove deadline/failure injection, process restart, and remote-adapter behavior separately"
   },
   "validation": {
     "tests_run": false,

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "module": "fulfillment",
+  "packet": "fulfillment-lifecycle-transport-parity-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_base_revision": "75db491faebadac59440a705a4f201567466f3e9",
+  "runner": "scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs",
+  "verifier": "scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs",
+  "evidence_path": "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution.json",
+  "evidence_status": "runtime_execution_pending",
+  "source_files": [
+    "apps/server/src/controllers/graphql.rs",
+    "crates/rustok-commerce/src/graphql/query.rs",
+    "crates/rustok-commerce/src/graphql/safe_query.rs",
+    "crates/rustok-commerce/src/graphql_runtime.rs",
+    "crates/rustok-commerce/src/controllers/admin/fulfillments.rs",
+    "crates/rustok-fulfillment/src/fulfillment_read.rs",
+    "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json"
+  ],
+  "required_environment": [
+    "RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL",
+    "RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL",
+    "RUSTOK_FULFILLMENT_PARITY_TENANT_ID",
+    "RUSTOK_FULFILLMENT_PARITY_AUTH_TOKEN",
+    "RUSTOK_FULFILLMENT_PARITY_DETAIL_ID",
+    "RUSTOK_FULFILLMENT_PARITY_ORDER_ID",
+    "RUSTOK_FULFILLMENT_PARITY_STATUS",
+    "RUSTOK_FULFILLMENT_PARITY_LATEST_ID",
+    "RUSTOK_FULFILLMENT_PARITY_MISSING_ID",
+    "RUSTOK_FULFILLMENT_PARITY_SOURCE_REVISION",
+    "RUSTOK_FULFILLMENT_PARITY_ADAPTER_PROFILE"
+  ],
+  "optional_environment": {
+    "RUSTOK_FULFILLMENT_PARITY_TENANT_HEADER": "X-Tenant-ID",
+    "RUSTOK_FULFILLMENT_PARITY_LOCALE": "en",
+    "RUSTOK_FULFILLMENT_PARITY_PAGE": "1",
+    "RUSTOK_FULFILLMENT_PARITY_PER_PAGE": "100",
+    "RUSTOK_FULFILLMENT_PARITY_TIMEOUT_MS": "10000",
+    "RUSTOK_FULFILLMENT_PARITY_RUNTIME_INSTANCE": "unreported"
+  },
+  "request_policy": {
+    "graphql_method": "POST",
+    "rest_method": "GET",
+    "graphql_mounted_path": "/api/graphql/",
+    "rest_list_path": "/admin/fulfillments",
+    "rest_detail_path_template": "/admin/fulfillments/{fulfillment_id}",
+    "maximum_response_bytes": 1048576,
+    "allow_http_for_local_capture": true,
+    "forbid_url_credentials_query_and_fragment": true
+  },
+  "scenarios": [
+    {
+      "id": "lookup_rest_detail_projection_parity",
+      "graphql_field": "fulfillment",
+      "rest_path": "/admin/fulfillments/{detail_id}",
+      "assertions": [
+        "both transports succeed",
+        "normalized fulfillment projections are identical"
+      ]
+    },
+    {
+      "id": "filtered_list_projection_parity",
+      "graphql_field": "fulfillments",
+      "rest_path": "/admin/fulfillments?status={status}&order_id={order_id}&page={page}&per_page={per_page}",
+      "assertions": [
+        "ordered normalized projections are identical",
+        "pagination total is identical",
+        "page and per-page are preserved"
+      ]
+    },
+    {
+      "id": "latest_by_order_projection_parity",
+      "graphql_field": "order.fulfillment",
+      "rest_path": "/admin/fulfillments/{latest_id}",
+      "assertions": [
+        "GraphQL latest fulfillment id matches the expected owner projection",
+        "GraphQL latest projection equals REST detail projection"
+      ]
+    },
+    {
+      "id": "optional_not_found_transport_policy",
+      "graphql_field": "fulfillment",
+      "rest_path": "/admin/fulfillments/{missing_id}",
+      "assertions": [
+        "GraphQL returns null without an error",
+        "REST returns 404 commerce_admin_not_found"
+      ]
+    }
+  ],
+  "retained_boundary": {
+    "bearer_token_retained": false,
+    "raw_response_bodies_retained": false,
+    "fulfillment_metadata_retained": false,
+    "normalized_projection_hashes_retained": true,
+    "source_hashes_retained": true,
+    "urls_retained_without_credentials_query_or_fragment": true,
+    "transport_projection_parity_requires_successful_capture": true,
+    "restart_deadline_failure_and_remote_adapter_evidence_separate": true
+  }
+}

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-port.md
@@ -1,6 +1,6 @@
 # Fulfillment lifecycle read port
 
-Status: source cutover, unvalidated.
+Status: source cutover, unvalidated; mounted projection-parity capture published.
 
 ## Scope
 
@@ -80,8 +80,8 @@ schemas.
 
 ## GraphQL cutover
 
-The existing mounted `CommerceShippingOptionReadScope` now scopes both read
-runtimes for each resolver task:
+The existing mounted `CommerceShippingOptionReadScope` scopes both read runtimes
+for each resolver task:
 
 - `CommerceShippingOptionReadRuntime`;
 - `CommerceFulfillmentLifecycleReadRuntime`.
@@ -136,6 +136,37 @@ retryability. Only technical database events retain the typed internal cause.
 The GraphQL and admin REST boundaries additionally retain transport operation,
 resource identity, public policy code, retryability, and deadline context.
 
+## Mounted projection-parity capture
+
+The locked execution contract is:
+
+`crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json`
+
+The maintainer-owned runner is:
+
+`scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs`
+
+It compares mounted GraphQL and admin REST behavior for:
+
+- single fulfillment lookup/detail projection equality;
+- filtered list projection order, pagination, and total equality;
+- latest fulfillment by order against REST detail;
+- GraphQL `null` versus REST `404 commerce_admin_not_found` for absence.
+
+The runner hashes normalized owner projections, source files, and the locked
+contract. It does not retain the bearer token, authorization header, raw response
+bodies, or fulfillment metadata. Output is written atomically and an existing
+packet is never overwritten implicitly.
+
+Publishing this contract does not prove runtime behavior. A successful future
+capture may prove bounded mounted projection parity, but wider
+`runtime_parity_proven` remains false until deadline/failure injection, process
+restart, external-adapter identity, and remote-adapter behavior are retained.
+
+The capture runbook is:
+
+`crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md`
+
 ## Evidence
 
 Source evidence is retained at:
@@ -144,18 +175,20 @@ Source evidence is retained at:
 
 Its status is `source_cutover_unvalidated`. It records completed default server
 composition, GraphQL lifecycle lookup/list/latest-by-order cutover, admin REST
-list/detail cutover, and concrete GraphQL delegate removal. Runtime parity remains
-explicitly unproven.
+list/detail cutover, concrete GraphQL delegate removal, and publication of the
+mounted projection-parity capture contract. Capture execution and all runtime
+parity flags remain false.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
 node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs
+node scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs
 cargo check -p rustok-fulfillment --lib
 cargo check -p rustok-commerce --lib
 cargo check -p rustok-server --features mod-commerce
 ```
 
-Tests, Cargo commands, formatting, verifiers, workflows, and CI were not run by
-the implementation agent.
+Tests, Cargo commands, formatting, verifiers, capture execution, workflows, and CI
+were not run by the implementation agent.

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md
@@ -1,0 +1,132 @@
+# Fulfillment lifecycle transport parity capture
+
+Status: capture contract published, execution pending.
+
+## Purpose
+
+This capture proves mounted **projection parity** for fulfillment lifecycle reads
+that already consume `FulfillmentReadPort` through the application-host-composed
+runtime. It compares real GraphQL HTTP and admin REST responses without retaining
+credentials, raw bodies, or fulfillment metadata.
+
+The locked execution contract is:
+
+`crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json`
+
+The runner is:
+
+`scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs`
+
+The source guard is:
+
+`scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs`
+
+A successful maintainer-owned run writes one immutable packet to:
+
+`crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution.json`
+
+That output file is intentionally absent until the mounted capture succeeds.
+
+## Mounted inputs
+
+The runner requires full mounted URLs instead of assuming a server prefix:
+
+- `RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL`, normally ending in `/api/graphql/`;
+- `RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL`, the prefix immediately before
+  `/admin/fulfillments`.
+
+Remote mounted endpoints must use HTTPS. Plain HTTP is accepted only for
+`localhost`, `127.0.0.1`, or IPv6 loopback so the bearer token is not sent over an
+unencrypted remote connection. Redirect responses are rejected.
+
+The bearer token must carry both `fulfillments:read` and `orders:read`, because the
+latest-by-order scenario reads `order.fulfillment` as well as fulfillment roots.
+Tenant resolution uses the configured header, defaulting to `X-Tenant-ID`.
+Reserved transport headers cannot be selected as the tenant header.
+
+Required fixture identities:
+
+- one known fulfillment for detail parity;
+- its order id and current status for filtered-list parity;
+- the expected latest fulfillment id for that order;
+- one canonical UUID that does not exist for optional-not-found behavior.
+
+The mounted binary revision, selected adapter profile, and runtime-instance label
+are operator claims retained for review. The runner does not independently prove
+source revision, external-adapter identity, or process identity.
+
+## Scenarios
+
+1. GraphQL `fulfillment` and REST `GET /admin/fulfillments/{id}` must return
+   identical normalized owner projections.
+2. GraphQL `fulfillments` and REST `GET /admin/fulfillments` must preserve the same
+   ordered projections, total, page, per-page, and `has_next` result for the same
+   order/status filter.
+3. GraphQL `order.fulfillment` must return the configured latest fulfillment and
+   match its REST detail projection.
+4. A missing fulfillment must return GraphQL `null` without errors and REST
+   `404 commerce_admin_not_found`.
+
+Fulfillment items are sorted by id before hashing. Top-level list order remains
+transport-visible and must match. Equivalent RFC3339 timestamps are normalized to UTC millisecond form before comparison so `Z` and `+00:00` formatting do not create false mismatches. Metadata is excluded from the retained projection boundary.
+
+## Capture command
+
+```bash
+export RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL='http://127.0.0.1:3000/api/graphql/'
+export RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL='http://127.0.0.1:3000/api'
+export RUSTOK_FULFILLMENT_PARITY_TENANT_ID='<tenant-uuid>'
+export RUSTOK_FULFILLMENT_PARITY_AUTH_TOKEN='<bearer-token>'
+export RUSTOK_FULFILLMENT_PARITY_DETAIL_ID='<known-fulfillment-uuid>'
+export RUSTOK_FULFILLMENT_PARITY_ORDER_ID='<known-order-uuid>'
+export RUSTOK_FULFILLMENT_PARITY_STATUS='<current-status>'
+export RUSTOK_FULFILLMENT_PARITY_LATEST_ID='<latest-fulfillment-uuid>'
+export RUSTOK_FULFILLMENT_PARITY_MISSING_ID='<nonexistent-uuid>'
+export RUSTOK_FULFILLMENT_PARITY_SOURCE_REVISION='<mounted-40-char-git-sha>'
+export RUSTOK_FULFILLMENT_PARITY_ADAPTER_PROFILE='in_process'
+node scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs
+```
+
+Optional inputs control tenant header, locale, page, per-page, client timeout, and
+an operator-provided runtime-instance label. URLs containing credentials, query,
+or fragments are rejected. Existing evidence is never overwritten implicitly.
+
+## Retained packet
+
+The packet retains:
+
+- contract and source hashes;
+- operator-claimed mounted revision, adapter profile, and runtime instance;
+- sanitized endpoint paths;
+- fixture identifiers;
+- response status and duration facts;
+- normalized projection hashes and bounded pagination facts;
+- explicit scenario pass results.
+
+It does not retain the bearer token, authorization header, raw response bodies, or
+fulfillment metadata.
+
+A successful packet may set `transport_projection_parity_proven` to `true`.
+`runtime_parity_proven` remains `false` because this capture does not prove owner
+deadline/failure injection, process restart, external-adapter identity, or remote
+adapter behavior.
+
+## Remaining evidence
+
+After projection parity is retained, separate execution must prove:
+
+- owner deadline and typed failure behavior with a controllable adapter;
+- runtime selection across process restart;
+- external-adapter identity rather than an operator label;
+- remote-adapter projection and error parity.
+
+No FFA/FBA or production status is promoted by publishing this capture contract.
+
+## Intended source check
+
+```bash
+node scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs
+```
+
+The implementation agent did not run the source guard, capture runner, tests,
+Cargo commands, formatting, workflows, or CI.

--- a/crates/rustok-fulfillment/docs/implementation-plan.md
+++ b/crates/rustok-fulfillment/docs/implementation-plan.md
@@ -83,6 +83,15 @@ identity, stable service actor, resource correlation, and a two-second deadline.
 Lifecycle mutations remain on their existing concrete or orchestration owner
 paths.
 
+A locked mounted projection-parity execution contract and fail-closed capture
+runner are now published. The maintainer-owned runner compares GraphQL
+lookup/list/latest-by-order with admin REST list/detail, hashes normalized
+projections and source files, preserves transport-specific optional-not-found
+policy, and excludes credentials, raw bodies, and fulfillment metadata. No capture
+has run; `transport_projection_parity_proven` and `runtime_parity_proven` remain
+false. Deadline/failure injection, restart, external-adapter identity, and remote
+adapter execution are separate evidence gates.
+
 The native FFA surface remains seller/cart selection through
 `ShippingSelectionPort`; it does not publish complete projection list or lookup
 operations. No projection API should be added without a concrete consumer.
@@ -108,11 +117,15 @@ operations. No projection API should be added without a concrete consumer.
   `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-transport-parity-source.json`.
 - Fulfillment lifecycle read source evidence:
   `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json`.
-- Both files are unvalidated source evidence and do not promote status.
+- Fulfillment lifecycle mounted capture contract:
+  `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json`.
+- Source evidence and the capture contract are unvalidated and do not promote
+  status.
 - Focused guards cover owner boundaries, application-host runtime composition,
   shared GraphQL resolver scope, GraphQL/admin REST lifecycle consumer cutover,
-  typed public envelopes, and the separate native selection surface.
-- Compile, migrated database, mounted transport, restart, contention, and remote
+  typed public envelopes, the projection-parity capture boundary, and the separate
+  native selection surface.
+- Compile, migrated database, mounted capture, restart, contention, and remote
   evidence remain missing.
 
 ## Checkout execution source checklist
@@ -196,8 +209,11 @@ operations. No projection API should be added without a concrete consumer.
   from the private GraphQL compatibility facade.
 - [x] Retain source evidence and focused guards that record complete source cutover
   without claiming mounted runtime parity.
-- [ ] Execute compile, mounted GraphQL/REST lifecycle query, deadline, tenant,
-  filter, optional-not-found, failure, restart, and remote evidence.
+- [x] Publish the mounted lifecycle projection-parity execution contract and capture runner.
+- [ ] Execute the mounted GraphQL/REST projection-parity capture and retain its immutable packet.
+- [ ] Prove deadline/failure injection, process restart, and remote-adapter behavior separately.
+- [ ] Execute compile and remaining tenant/context/runtime evidence before any
+  status promotion.
 
 ## Open results
 
@@ -241,14 +257,16 @@ operations. No projection API should be added without a concrete consumer.
    envelopes, and no mounted projection transport constructs a concrete read
    service or provider.
 
-6. **Prove mounted lifecycle read parity.** Execute GraphQL lookup/list/latest-by-
-   order and admin REST list/detail through the host-selected
-   `CommerceFulfillmentLifecycleReadRuntime` against the same owner projections.
-   **Depends on:** compiled fulfillment/Commerce/server crates and mounted
-   transport fixtures.
-   **Done when:** GraphQL and REST preserve tenant, filters, pagination, optional
-   not-found, public error policy, deadline behavior, restart behavior, and remote
-   adapter selection with no concrete Commerce read construction.
+6. **Prove mounted lifecycle read parity.** Run the locked capture contract against
+   GraphQL lookup/list/latest-by-order and admin REST list/detail through the
+   host-selected `CommerceFulfillmentLifecycleReadRuntime`. Retain the immutable
+   projection-parity packet, then execute deadline/failure, restart, external-
+   adapter identity, and remote-adapter evidence as separate packets.
+   **Depends on:** compiled fulfillment/Commerce/server crates, mounted fixtures,
+   and tokens with `fulfillments:read` plus `orders:read`.
+   **Done when:** projection parity, tenant/filter/pagination and optional-not-found
+   policy are retained first, then wider runtime behavior is proven without
+   concrete Commerce read construction or secret/raw-payload retention.
 
 7. **Execute remote contracts.** Turn shipping-selection and checkout-execution
    matrices into provider execution before promoting beyond `boundary_ready`.
@@ -265,6 +283,8 @@ operations. No projection API should be added without a concrete consumer.
 - `node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
 - `node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-query-fulfillment-context.mjs`
+- `node scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs`
+- `node scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs`
 - `node scripts/verify/verify-commerce-shipping-option-transport-parity-inventory.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
 - `node scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
@@ -281,7 +301,7 @@ operations. No projection API should be added without a concrete consumer.
 - Targeted shipping-option GraphQL/REST parity, context, error, and remote tests.
 - Targeted fulfillment lifecycle owner-port and mounted GraphQL/REST query tests.
 
-No verification command was executed in this source wave.
+No verification or capture command was executed in this source wave.
 
 ## Change rules
 

--- a/scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs
+++ b/scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs
@@ -1,0 +1,901 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const contractPath =
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json';
+const expectedRunnerPath =
+  'scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs';
+const expectedVerifierPath =
+  'scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs';
+const expectedEvidencePath =
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution.json';
+const expectedSourceFiles = [
+  'apps/server/src/controllers/graphql.rs',
+  'crates/rustok-commerce/src/graphql/query.rs',
+  'crates/rustok-commerce/src/graphql/safe_query.rs',
+  'crates/rustok-commerce/src/graphql_runtime.rs',
+  'crates/rustok-commerce/src/controllers/admin/fulfillments.rs',
+  'crates/rustok-fulfillment/src/fulfillment_read.rs',
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json',
+];
+const expectedScenarioIds = [
+  'lookup_rest_detail_projection_parity',
+  'filtered_list_projection_parity',
+  'latest_by_order_projection_parity',
+  'optional_not_found_transport_policy',
+];
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), 'utf8'));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+const maximumResponseBytes = contract.request_policy.maximum_response_bytes;
+
+const projectionSelection = `
+  id
+  tenantId
+  orderId
+  shippingOptionId
+  customerId
+  status
+  carrier
+  trackingNumber
+  deliveredNote
+  cancellationReason
+  createdAt
+  updatedAt
+  shippedAt
+  deliveredAt
+  cancelledAt
+  items {
+    id
+    fulfillmentId
+    orderLineItemId
+    quantity
+    shippedQuantity
+    deliveredQuantity
+    createdAt
+    updatedAt
+  }
+`;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sameRecord(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function repositoryPath(relativePath) {
+  const root = resolve(repoRoot) + sep;
+  const candidate = resolve(repoRoot, relativePath);
+  if (!candidate.startsWith(root)) fail(`repository path escapes capture root: ${relativePath}`);
+  return candidate;
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(repositoryPath(relativePath)));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    expectedSourceFiles.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function oneLine(value, field, maximumLength = 4096) {
+  if (typeof value !== 'string') fail(`${field} must be a string`);
+  const line = value.trim();
+  if (
+    line.length === 0 ||
+    line.length > maximumLength ||
+    /[\u0000-\u001f\u007f]/u.test(line)
+  ) {
+    fail(`${field} is missing or outside the capture boundary`);
+  }
+  return line;
+}
+
+function requiredEnvironment(name, maximumLength = 4096) {
+  return oneLine(process.env[name] ?? '', name, maximumLength);
+}
+
+function optionalEnvironment(name, maximumLength = 4096) {
+  return oneLine(
+    process.env[name] ?? contract.optional_environment[name],
+    name,
+    maximumLength,
+  );
+}
+
+function positiveInteger(value, field, maximum) {
+  if (!/^\d+$/u.test(value)) fail(`${field} must be a positive integer`);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    fail(`${field} must be between 1 and ${maximum}`);
+  }
+  return parsed;
+}
+
+function uuid(value, field) {
+  const parsed = oneLine(value, field, 36).toLowerCase();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(parsed)) {
+    fail(`${field} must be a canonical UUID`);
+  }
+  return parsed;
+}
+
+function gitRevision(value, field) {
+  const parsed = oneLine(value, field, 40).toLowerCase();
+  if (!/^[0-9a-f]{40}$/u.test(parsed)) {
+    fail(`${field} must be a 40-character Git revision`);
+  }
+  return parsed;
+}
+
+function headerName(value, field) {
+  const parsed = oneLine(value, field, 128);
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(parsed)) {
+    fail(`${field} must be a valid HTTP header name`);
+  }
+  return parsed;
+}
+
+function tenantHeaderName(value, field) {
+  const parsed = headerName(value, field);
+  const reserved = new Set([
+    'accept',
+    'accept-language',
+    'authorization',
+    'connection',
+    'content-length',
+    'content-type',
+    'cookie',
+    'host',
+    'proxy-authorization',
+    'transfer-encoding',
+  ]);
+  if (reserved.has(parsed.toLowerCase())) fail(`${field} must not override a reserved HTTP header`);
+  return parsed;
+}
+
+function isLocalCaptureHost(hostname) {
+  const normalized = hostname.toLowerCase();
+  return ['localhost', '127.0.0.1', '[::1]', '::1'].includes(normalized);
+}
+
+function endpoint(value, field) {
+  const parsed = new URL(oneLine(value, field));
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    fail(`${field} must use http or https`);
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    fail(`${field} must not contain credentials, query, or fragment`);
+  }
+  if (parsed.protocol === 'http:' && !isLocalCaptureHost(parsed.hostname)) {
+    fail(`${field} must use https unless the mounted endpoint is localhost or loopback`);
+  }
+  return parsed;
+}
+
+function sanitizedEndpoint(value) {
+  return `${value.origin}${value.pathname}`;
+}
+
+function authorizationHeader(value) {
+  const token = oneLine(value, 'RUSTOK_FULFILLMENT_PARITY_AUTH_TOKEN', 8192);
+  return /^Bearer\s+/iu.test(token) ? token : `Bearer ${token}`;
+}
+
+function assertObject(value, field) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${field} must be a JSON object`);
+  }
+  return value;
+}
+
+function assertArray(value, field) {
+  if (!Array.isArray(value)) fail(`${field} must be a JSON array`);
+  return value;
+}
+
+function requiredString(value, field) {
+  return oneLine(value, field, 4096);
+}
+
+function optionalString(value, field) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') fail(`${field} must be a string or null`);
+  const line = value.trim();
+  if (line.length > 4096 || /[\u0000-\u001f\u007f]/u.test(line)) {
+    fail(`${field} is outside the capture boundary`);
+  }
+  return line;
+}
+
+function timestamp(value, field) {
+  const raw = requiredString(value, field);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u.test(raw)) {
+    fail(`${field} must be an RFC3339 timestamp`);
+  }
+  const milliseconds = Date.parse(raw);
+  if (!Number.isFinite(milliseconds)) fail(`${field} must be an RFC3339 timestamp`);
+  return new Date(milliseconds).toISOString();
+}
+
+function optionalTimestamp(value, field) {
+  if (value === null || value === undefined) return null;
+  return timestamp(value, field);
+}
+
+function requiredInteger(value, field) {
+  if (!Number.isSafeInteger(value)) fail(`${field} must be an integer`);
+  return value;
+}
+
+function requiredBoolean(value, field) {
+  if (typeof value !== 'boolean') fail(`${field} must be a boolean`);
+  return value;
+}
+
+function sortedObject(value) {
+  if (Array.isArray(value)) return value.map(sortedObject);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sortedObject(value[key])]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return JSON.stringify(sortedObject(value));
+}
+
+function projectionHash(value) {
+  return sha256(stableJson(value));
+}
+
+function normalizeItems(items, flavor, field) {
+  return assertArray(items, field)
+    .map((item, index) => {
+      const source = assertObject(item, `${field}[${index}]`);
+      const camel = flavor === 'graphql';
+      return {
+        id: uuid(source.id, `${field}[${index}].id`),
+        fulfillment_id: uuid(
+          source[camel ? 'fulfillmentId' : 'fulfillment_id'],
+          `${field}[${index}].fulfillment_id`,
+        ),
+        order_line_item_id: uuid(
+          source[camel ? 'orderLineItemId' : 'order_line_item_id'],
+          `${field}[${index}].order_line_item_id`,
+        ),
+        quantity: requiredInteger(source.quantity, `${field}[${index}].quantity`),
+        shipped_quantity: requiredInteger(
+          source[camel ? 'shippedQuantity' : 'shipped_quantity'],
+          `${field}[${index}].shipped_quantity`,
+        ),
+        delivered_quantity: requiredInteger(
+          source[camel ? 'deliveredQuantity' : 'delivered_quantity'],
+          `${field}[${index}].delivered_quantity`,
+        ),
+        created_at: timestamp(
+          source[camel ? 'createdAt' : 'created_at'],
+          `${field}[${index}].created_at`,
+        ),
+        updated_at: timestamp(
+          source[camel ? 'updatedAt' : 'updated_at'],
+          `${field}[${index}].updated_at`,
+        ),
+      };
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function normalizeProjection(value, flavor, field) {
+  const source = assertObject(value, field);
+  const camel = flavor === 'graphql';
+  return {
+    id: uuid(source.id, `${field}.id`),
+    tenant_id: uuid(source[camel ? 'tenantId' : 'tenant_id'], `${field}.tenant_id`),
+    order_id: uuid(source[camel ? 'orderId' : 'order_id'], `${field}.order_id`),
+    shipping_option_id:
+      source[camel ? 'shippingOptionId' : 'shipping_option_id'] === null
+        ? null
+        : uuid(
+            source[camel ? 'shippingOptionId' : 'shipping_option_id'],
+            `${field}.shipping_option_id`,
+          ),
+    customer_id:
+      source[camel ? 'customerId' : 'customer_id'] === null
+        ? null
+        : uuid(source[camel ? 'customerId' : 'customer_id'], `${field}.customer_id`),
+    status: requiredString(source.status, `${field}.status`),
+    carrier: optionalString(source.carrier, `${field}.carrier`),
+    tracking_number: optionalString(
+      source[camel ? 'trackingNumber' : 'tracking_number'],
+      `${field}.tracking_number`,
+    ),
+    delivered_note: optionalString(
+      source[camel ? 'deliveredNote' : 'delivered_note'],
+      `${field}.delivered_note`,
+    ),
+    cancellation_reason: optionalString(
+      source[camel ? 'cancellationReason' : 'cancellation_reason'],
+      `${field}.cancellation_reason`,
+    ),
+    items: normalizeItems(source.items, flavor, `${field}.items`),
+    created_at: timestamp(
+      source[camel ? 'createdAt' : 'created_at'],
+      `${field}.created_at`,
+    ),
+    updated_at: timestamp(
+      source[camel ? 'updatedAt' : 'updated_at'],
+      `${field}.updated_at`,
+    ),
+    shipped_at: optionalTimestamp(
+      source[camel ? 'shippedAt' : 'shipped_at'],
+      `${field}.shipped_at`,
+    ),
+    delivered_at: optionalTimestamp(
+      source[camel ? 'deliveredAt' : 'delivered_at'],
+      `${field}.delivered_at`,
+    ),
+    cancelled_at: optionalTimestamp(
+      source[camel ? 'cancelledAt' : 'cancelled_at'],
+      `${field}.cancelled_at`,
+    ),
+  };
+}
+
+function requireEqual(left, right, label) {
+  if (stableJson(left) !== stableJson(right)) fail(`${label} mismatch`);
+}
+
+function validateContract() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== 'fulfillment' ||
+    contract.packet !== 'fulfillment-lifecycle-transport-parity-execution-contract' ||
+    contract.status !== 'runtime_execution_contract_locked'
+  ) {
+    fail('fulfillment lifecycle parity contract identity drift');
+  }
+  if (
+    contract.runner !== expectedRunnerPath ||
+    contract.verifier !== expectedVerifierPath ||
+    contract.evidence_path !== expectedEvidencePath ||
+    contract.evidence_status !== 'runtime_execution_pending'
+  ) {
+    fail('fulfillment lifecycle parity tooling boundary drift');
+  }
+  if (!sameRecord(contract.source_files, expectedSourceFiles)) {
+    fail('fulfillment lifecycle parity source allowlist drift');
+  }
+  if (!sameRecord(contract.scenarios.map((scenario) => scenario.id), expectedScenarioIds)) {
+    fail('fulfillment lifecycle parity scenario allowlist drift');
+  }
+  if (
+    maximumResponseBytes !== 1048576 ||
+    contract.request_policy.graphql_method !== 'POST' ||
+    contract.request_policy.rest_method !== 'GET' ||
+    contract.request_policy.allow_http_for_local_capture !== true
+  ) {
+    fail('fulfillment lifecycle parity request policy drift');
+  }
+  if (
+    contract.retained_boundary.bearer_token_retained !== false ||
+    contract.retained_boundary.raw_response_bodies_retained !== false ||
+    contract.retained_boundary.fulfillment_metadata_retained !== false ||
+    contract.retained_boundary.transport_projection_parity_requires_successful_capture !== true ||
+    contract.retained_boundary.restart_deadline_failure_and_remote_adapter_evidence_separate !== true
+  ) {
+    fail('fulfillment lifecycle parity retained boundary drift');
+  }
+}
+
+function ensureOutputBoundary() {
+  const root = resolve(repoRoot) + sep;
+  if (!outputPath.startsWith(root)) {
+    fail('parity evidence path must stay inside the repository');
+  }
+  if (existsSync(outputPath)) {
+    fail('parity evidence already exists; remove it explicitly before a new capture');
+  }
+}
+
+async function requestJson(url, options, timeoutMs, operation) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(url, {
+      ...options,
+      redirect: 'error',
+      signal: controller.signal,
+    });
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength && Number.parseInt(declaredLength, 10) > maximumResponseBytes) {
+      fail(`${operation} response exceeds the retained capture boundary`);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > maximumResponseBytes) {
+      fail(`${operation} response exceeds the retained capture boundary`);
+    }
+    let body;
+    try {
+      body = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      fail(`${operation} did not return JSON`);
+    }
+    return {
+      status: response.status,
+      duration_ms: Math.max(0, Math.round(performance.now() - startedAt)),
+      body,
+    };
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      fail(`${operation} exceeded the client capture timeout`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function graphqlErrors(body) {
+  const errors = body?.errors;
+  if (errors === undefined) return [];
+  return assertArray(errors, 'GraphQL errors').map((error, index) => ({
+    code: optionalString(error?.extensions?.code, `GraphQL errors[${index}].code`),
+  }));
+}
+
+async function graphqlRequest(graphqlUrl, headers, timeoutMs, operation, query, variables) {
+  const response = await requestJson(
+    graphqlUrl,
+    {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    },
+    timeoutMs,
+    operation,
+  );
+  if (response.status !== 200) fail(`${operation} returned HTTP ${response.status}`);
+  const body = assertObject(response.body, `${operation} response`);
+  const errors = graphqlErrors(body);
+  if (errors.length > 0) {
+    const codes = errors.map((error) => error.code ?? 'unclassified').join(',');
+    fail(`${operation} returned GraphQL errors: ${codes}`);
+  }
+  return { ...response, body };
+}
+
+function restUrl(restBaseUrl, path) {
+  const base = restBaseUrl.href.endsWith('/')
+    ? restBaseUrl.href.slice(0, -1)
+    : restBaseUrl.href;
+  return new URL(`${base}${path}`);
+}
+
+function publicErrorCode(body) {
+  if (typeof body?.code === 'string') return body.code;
+  if (typeof body?.error?.code === 'string') return body.error.code;
+  return null;
+}
+
+function writeEvidence(packet) {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, { flag: 'wx' });
+    renameSync(temporaryPath, outputPath);
+  } catch (error) {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    throw error;
+  }
+}
+
+async function main() {
+  validateContract();
+  ensureOutputBoundary();
+
+  const graphqlUrl = endpoint(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL'),
+    'RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL',
+  );
+  const restBaseUrl = endpoint(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL'),
+    'RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL',
+  );
+  const tenantId = uuid(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_TENANT_ID', 36),
+    'RUSTOK_FULFILLMENT_PARITY_TENANT_ID',
+  );
+  const detailId = uuid(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_DETAIL_ID', 36),
+    'RUSTOK_FULFILLMENT_PARITY_DETAIL_ID',
+  );
+  const orderId = uuid(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_ORDER_ID', 36),
+    'RUSTOK_FULFILLMENT_PARITY_ORDER_ID',
+  );
+  const latestId = uuid(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_LATEST_ID', 36),
+    'RUSTOK_FULFILLMENT_PARITY_LATEST_ID',
+  );
+  const missingId = uuid(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_MISSING_ID', 36),
+    'RUSTOK_FULFILLMENT_PARITY_MISSING_ID',
+  );
+  if ([detailId, latestId].includes(missingId)) {
+    fail('RUSTOK_FULFILLMENT_PARITY_MISSING_ID must differ from retained fulfillment ids');
+  }
+  const status = requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_STATUS', 64);
+  const sourceRevision = gitRevision(
+    requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_SOURCE_REVISION', 40),
+    'RUSTOK_FULFILLMENT_PARITY_SOURCE_REVISION',
+  );
+  const adapterProfile = requiredEnvironment(
+    'RUSTOK_FULFILLMENT_PARITY_ADAPTER_PROFILE',
+    128,
+  );
+  const tenantHeader = tenantHeaderName(
+    optionalEnvironment('RUSTOK_FULFILLMENT_PARITY_TENANT_HEADER', 128),
+    'RUSTOK_FULFILLMENT_PARITY_TENANT_HEADER',
+  );
+  const locale = optionalEnvironment('RUSTOK_FULFILLMENT_PARITY_LOCALE', 64);
+  const page = positiveInteger(
+    optionalEnvironment('RUSTOK_FULFILLMENT_PARITY_PAGE', 8),
+    'page',
+    1000000,
+  );
+  const perPage = positiveInteger(
+    optionalEnvironment('RUSTOK_FULFILLMENT_PARITY_PER_PAGE', 8),
+    'per_page',
+    100,
+  );
+  const timeoutMs = positiveInteger(
+    optionalEnvironment('RUSTOK_FULFILLMENT_PARITY_TIMEOUT_MS', 8),
+    'timeout_ms',
+    120000,
+  );
+  const runtimeInstance = optionalEnvironment(
+    'RUSTOK_FULFILLMENT_PARITY_RUNTIME_INSTANCE',
+    256,
+  );
+  const headers = {
+    accept: 'application/json',
+    'accept-language': locale,
+    authorization: authorizationHeader(
+      requiredEnvironment('RUSTOK_FULFILLMENT_PARITY_AUTH_TOKEN', 8192),
+    ),
+    [tenantHeader]: tenantId,
+  };
+
+  const lookupQuery = `
+    query FulfillmentLifecycleParityLookup($tenantId: UUID!, $id: UUID!) {
+      lookup: fulfillment(tenantId: $tenantId, id: $id) {${projectionSelection}}
+    }
+  `;
+  const listQuery = `
+    query FulfillmentLifecycleParityList($tenantId: UUID!, $filter: FulfillmentsFilter) {
+      list: fulfillments(tenantId: $tenantId, filter: $filter) {
+        items {${projectionSelection}}
+        total
+        page
+        perPage
+        hasNext
+      }
+    }
+  `;
+  const latestQuery = `
+    query FulfillmentLifecycleParityLatest($tenantId: UUID!, $id: UUID!) {
+      order(tenantId: $tenantId, id: $id) {
+        fulfillment {${projectionSelection}}
+      }
+    }
+  `;
+
+  const graphqlLookup = await graphqlRequest(
+    graphqlUrl,
+    headers,
+    timeoutMs,
+    'GraphQL fulfillment lookup',
+    lookupQuery,
+    { tenantId, id: detailId },
+  );
+  const graphqlLookupProjection = normalizeProjection(
+    graphqlLookup.body.data?.lookup,
+    'graphql',
+    'GraphQL fulfillment lookup',
+  );
+  const restDetail = await requestJson(
+    restUrl(restBaseUrl, `/admin/fulfillments/${detailId}`),
+    { method: 'GET', headers },
+    timeoutMs,
+    'REST fulfillment detail',
+  );
+  if (restDetail.status !== 200) {
+    fail(`REST fulfillment detail returned HTTP ${restDetail.status}`);
+  }
+  const restDetailProjection = normalizeProjection(
+    restDetail.body,
+    'rest',
+    'REST fulfillment detail',
+  );
+  requireEqual(
+    graphqlLookupProjection,
+    restDetailProjection,
+    'lookup/detail projection parity',
+  );
+  if (
+    graphqlLookupProjection.id !== detailId ||
+    graphqlLookupProjection.tenant_id !== tenantId ||
+    graphqlLookupProjection.order_id !== orderId
+  ) {
+    fail('lookup/detail projection does not match the configured tenant, order, and fulfillment');
+  }
+
+  const graphqlList = await graphqlRequest(
+    graphqlUrl,
+    headers,
+    timeoutMs,
+    'GraphQL fulfillment list',
+    listQuery,
+    { tenantId, filter: { status, orderId, page, perPage } },
+  );
+  const graphqlListBody = assertObject(
+    graphqlList.body.data?.list,
+    'GraphQL fulfillment list',
+  );
+  const graphqlListProjections = assertArray(
+    graphqlListBody.items,
+    'GraphQL fulfillment list items',
+  ).map((item, index) =>
+    normalizeProjection(item, 'graphql', `GraphQL list[${index}]`),
+  );
+
+  const restListUrl = restUrl(restBaseUrl, '/admin/fulfillments');
+  restListUrl.searchParams.set('status', status);
+  restListUrl.searchParams.set('order_id', orderId);
+  restListUrl.searchParams.set('page', String(page));
+  restListUrl.searchParams.set('per_page', String(perPage));
+  const restList = await requestJson(
+    restListUrl,
+    { method: 'GET', headers },
+    timeoutMs,
+    'REST fulfillment list',
+  );
+  if (restList.status !== 200) {
+    fail(`REST fulfillment list returned HTTP ${restList.status}`);
+  }
+  const restListBody = assertObject(restList.body, 'REST fulfillment list');
+  const restListProjections = assertArray(
+    restListBody.data,
+    'REST fulfillment list data',
+  ).map((item, index) => normalizeProjection(item, 'rest', `REST list[${index}]`));
+  requireEqual(
+    graphqlListProjections,
+    restListProjections,
+    'filtered list projection parity',
+  );
+
+  const restMeta = assertObject(restListBody.meta, 'REST fulfillment list meta');
+  const graphqlTotal = requiredInteger(graphqlListBody.total, 'GraphQL list total');
+  const graphqlPage = requiredInteger(graphqlListBody.page, 'GraphQL list page');
+  const graphqlPerPage = requiredInteger(
+    graphqlListBody.perPage,
+    'GraphQL list perPage',
+  );
+  const graphqlHasNext = requiredBoolean(
+    graphqlListBody.hasNext,
+    'GraphQL list hasNext',
+  );
+  const restHasNext = requiredBoolean(restMeta.has_next, 'REST list has_next');
+  requireEqual(
+    graphqlTotal,
+    requiredInteger(restMeta.total, 'REST list total'),
+    'list total parity',
+  );
+  requireEqual(
+    graphqlPage,
+    requiredInteger(restMeta.page, 'REST list page'),
+    'list page parity',
+  );
+  requireEqual(
+    graphqlPerPage,
+    requiredInteger(restMeta.per_page, 'REST list per_page'),
+    'list per-page parity',
+  );
+  requireEqual(graphqlHasNext, restHasNext, 'list has-next parity');
+  if (graphqlPage !== page || graphqlPerPage !== perPage) {
+    fail('configured list pagination was not retained');
+  }
+  if (!graphqlListProjections.some((projection) => projection.id === detailId)) {
+    fail('configured detail fulfillment is absent from the filtered parity list');
+  }
+
+  const graphqlLatest = await graphqlRequest(
+    graphqlUrl,
+    headers,
+    timeoutMs,
+    'GraphQL latest fulfillment by order',
+    latestQuery,
+    { tenantId, id: orderId },
+  );
+  const orderDetail = assertObject(
+    graphqlLatest.body.data?.order,
+    'GraphQL order detail',
+  );
+  const graphqlLatestProjection = normalizeProjection(
+    orderDetail.fulfillment,
+    'graphql',
+    'GraphQL latest fulfillment',
+  );
+  if (graphqlLatestProjection.id !== latestId) {
+    fail('GraphQL latest fulfillment id does not match RUSTOK_FULFILLMENT_PARITY_LATEST_ID');
+  }
+  const restLatest = await requestJson(
+    restUrl(restBaseUrl, `/admin/fulfillments/${latestId}`),
+    { method: 'GET', headers },
+    timeoutMs,
+    'REST latest fulfillment detail',
+  );
+  if (restLatest.status !== 200) {
+    fail(`REST latest fulfillment detail returned HTTP ${restLatest.status}`);
+  }
+  const restLatestProjection = normalizeProjection(
+    restLatest.body,
+    'rest',
+    'REST latest fulfillment detail',
+  );
+  requireEqual(
+    graphqlLatestProjection,
+    restLatestProjection,
+    'latest-by-order projection parity',
+  );
+
+  const graphqlMissing = await graphqlRequest(
+    graphqlUrl,
+    headers,
+    timeoutMs,
+    'GraphQL missing fulfillment lookup',
+    lookupQuery,
+    { tenantId, id: missingId },
+  );
+  if (graphqlMissing.body.data?.lookup !== null) {
+    fail('GraphQL missing fulfillment lookup must return null');
+  }
+  const restMissing = await requestJson(
+    restUrl(restBaseUrl, `/admin/fulfillments/${missingId}`),
+    { method: 'GET', headers },
+    timeoutMs,
+    'REST missing fulfillment detail',
+  );
+  const restMissingCode = publicErrorCode(restMissing.body);
+  if (restMissing.status !== 404 || restMissingCode !== 'commerce_admin_not_found') {
+    fail('REST missing fulfillment detail must return 404 commerce_admin_not_found');
+  }
+
+  const listIds = graphqlListProjections.map((projection) => projection.id);
+  const packet = {
+    schema_version: 1,
+    module: 'fulfillment',
+    packet: 'fulfillment-lifecycle-transport-parity-execution',
+    status: 'transport_projection_parity_captured_unreviewed',
+    captured_at: new Date().toISOString(),
+    contract: {
+      path: contractPath,
+      sha256: fileSha256(contractPath),
+      source_base_revision: contract.source_base_revision,
+    },
+    runtime_claims: {
+      claimed_source_revision: sourceRevision,
+      claimed_adapter_profile: adapterProfile,
+      claimed_runtime_instance: runtimeInstance,
+      claims_verified_by_runner: false,
+      graphql_endpoint: sanitizedEndpoint(graphqlUrl),
+      rest_base_endpoint: sanitizedEndpoint(restBaseUrl),
+      tenant_id: tenantId,
+      locale,
+      page,
+      per_page: perPage,
+      client_timeout_ms: timeoutMs,
+    },
+    source_hashes: sourceHashes(),
+    scenarios: {
+      lookup_rest_detail_projection_parity: {
+        status: 'passed',
+        fulfillment_id: detailId,
+        projection_sha256: projectionHash(graphqlLookupProjection),
+        graphql_http_status: graphqlLookup.status,
+        graphql_duration_ms: graphqlLookup.duration_ms,
+        rest_http_status: restDetail.status,
+        rest_duration_ms: restDetail.duration_ms,
+      },
+      filtered_list_projection_parity: {
+        status: 'passed',
+        order_id: orderId,
+        filter_status: status,
+        ordered_ids_sha256: sha256(JSON.stringify(listIds)),
+        projections_sha256: projectionHash(graphqlListProjections),
+        total: graphqlTotal,
+        page: graphqlPage,
+        per_page: graphqlPerPage,
+        has_next: graphqlHasNext,
+        graphql_http_status: graphqlList.status,
+        graphql_duration_ms: graphqlList.duration_ms,
+        rest_http_status: restList.status,
+        rest_duration_ms: restList.duration_ms,
+      },
+      latest_by_order_projection_parity: {
+        status: 'passed',
+        order_id: orderId,
+        fulfillment_id: latestId,
+        projection_sha256: projectionHash(graphqlLatestProjection),
+        graphql_http_status: graphqlLatest.status,
+        graphql_duration_ms: graphqlLatest.duration_ms,
+        rest_http_status: restLatest.status,
+        rest_duration_ms: restLatest.duration_ms,
+      },
+      optional_not_found_transport_policy: {
+        status: 'passed',
+        missing_fulfillment_id: missingId,
+        graphql_result: 'null_without_errors',
+        graphql_http_status: graphqlMissing.status,
+        graphql_duration_ms: graphqlMissing.duration_ms,
+        rest_http_status: restMissing.status,
+        rest_public_code: restMissingCode,
+        rest_duration_ms: restMissing.duration_ms,
+      },
+    },
+    retained_boundary: {
+      bearer_token_retained: false,
+      raw_response_bodies_retained: false,
+      fulfillment_metadata_retained: false,
+      normalized_projection_hashes_retained: true,
+      source_hashes_retained: true,
+    },
+    limitations: {
+      owner_deadline_failure_injection_proven: false,
+      process_restart_proven: false,
+      external_adapter_identity_proven: false,
+      remote_adapter_behavior_proven: false,
+    },
+    transport_projection_parity_proven: true,
+    runtime_parity_proven: false,
+    review: {
+      maintainer_reviewed: false,
+      production_promotion_authorized: false,
+    },
+  };
+
+  writeEvidence(packet);
+  console.log(
+    `✔ retained fulfillment lifecycle transport projection parity evidence at ${contract.evidence_path}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(`[capture-fulfillment-lifecycle-transport-parity] ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const contractPath =
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution-contract.json';
+const runnerPath = 'scripts/evidence/capture-fulfillment-lifecycle-transport-parity.mjs';
+const verifierPath =
+  'scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs';
+const evidencePath =
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-transport-parity-execution.json';
+const sourceEvidencePath =
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json';
+const runbookPath =
+  'crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md';
+const planPath = 'crates/rustok-fulfillment/docs/implementation-plan.md';
+
+const contract = JSON.parse(read(contractPath));
+const runner = read(runnerPath);
+const sourceEvidence = JSON.parse(read(sourceEvidencePath));
+const runbook = read(runbookPath);
+const plan = read(planPath);
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const sameRecord = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
+const expectedSourceFiles = [
+  'apps/server/src/controllers/graphql.rs',
+  'crates/rustok-commerce/src/graphql/query.rs',
+  'crates/rustok-commerce/src/graphql/safe_query.rs',
+  'crates/rustok-commerce/src/graphql_runtime.rs',
+  'crates/rustok-commerce/src/controllers/admin/fulfillments.rs',
+  'crates/rustok-fulfillment/src/fulfillment_read.rs',
+  'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json',
+];
+const expectedRequiredEnvironment = [
+  'RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL',
+  'RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL',
+  'RUSTOK_FULFILLMENT_PARITY_TENANT_ID',
+  'RUSTOK_FULFILLMENT_PARITY_AUTH_TOKEN',
+  'RUSTOK_FULFILLMENT_PARITY_DETAIL_ID',
+  'RUSTOK_FULFILLMENT_PARITY_ORDER_ID',
+  'RUSTOK_FULFILLMENT_PARITY_STATUS',
+  'RUSTOK_FULFILLMENT_PARITY_LATEST_ID',
+  'RUSTOK_FULFILLMENT_PARITY_MISSING_ID',
+  'RUSTOK_FULFILLMENT_PARITY_SOURCE_REVISION',
+  'RUSTOK_FULFILLMENT_PARITY_ADAPTER_PROFILE',
+];
+const expectedScenarios = [
+  'lookup_rest_detail_projection_parity',
+  'filtered_list_projection_parity',
+  'latest_by_order_projection_parity',
+  'optional_not_found_transport_policy',
+];
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== 'fulfillment' ||
+  contract.packet !== 'fulfillment-lifecycle-transport-parity-execution-contract' ||
+  contract.status !== 'runtime_execution_contract_locked'
+) {
+  failures.push('execution contract identity mismatch');
+}
+if (
+  contract.runner !== runnerPath ||
+  contract.verifier !== verifierPath ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== 'runtime_execution_pending'
+) {
+  failures.push('execution contract tooling or output boundary mismatch');
+}
+if (!sameRecord(contract.source_files, expectedSourceFiles)) {
+  failures.push('execution contract source allowlist mismatch');
+}
+if (!sameRecord(contract.required_environment, expectedRequiredEnvironment)) {
+  failures.push('execution contract required environment allowlist mismatch');
+}
+if (!sameRecord(contract.scenarios?.map((scenario) => scenario.id), expectedScenarios)) {
+  failures.push('execution contract scenario allowlist mismatch');
+}
+if (
+  contract.request_policy?.graphql_method !== 'POST' ||
+  contract.request_policy?.rest_method !== 'GET' ||
+  contract.request_policy?.graphql_mounted_path !== '/api/graphql/' ||
+  contract.request_policy?.rest_list_path !== '/admin/fulfillments' ||
+  contract.request_policy?.maximum_response_bytes !== 1048576 ||
+  contract.request_policy?.allow_http_for_local_capture !== true
+) {
+  failures.push('execution contract request policy mismatch');
+}
+for (const [value, label] of [
+  [contract.retained_boundary?.bearer_token_retained, 'bearer token retention'],
+  [contract.retained_boundary?.raw_response_bodies_retained, 'raw response retention'],
+  [contract.retained_boundary?.fulfillment_metadata_retained, 'metadata retention'],
+]) {
+  if (value !== false) failures.push(`execution contract must forbid ${label}`);
+}
+for (const [value, label] of [
+  [contract.retained_boundary?.normalized_projection_hashes_retained, 'normalized projection hashes'],
+  [contract.retained_boundary?.source_hashes_retained, 'source hashes'],
+  [
+    contract.retained_boundary?.transport_projection_parity_requires_successful_capture,
+    'successful projection-parity capture',
+  ],
+  [
+    contract.retained_boundary?.restart_deadline_failure_and_remote_adapter_evidence_separate,
+    'separate wider runtime evidence',
+  ],
+]) {
+  if (value !== true) failures.push(`execution contract must require ${label}`);
+}
+if ('runtime_parity_requires_successful_capture' in contract.retained_boundary) {
+  failures.push('execution contract must not alias bounded projection parity as runtime parity');
+}
+
+for (const [value, label] of [
+  ['const expectedSourceFiles = [', 'runner source allowlist'],
+  ['function repositoryPath(relativePath)', 'repository path boundary'],
+  ['repository path escapes capture root', 'source path traversal rejection'],
+  ['const maximumResponseBytes = contract.request_policy.maximum_response_bytes;', 'bounded responses'],
+  ['function tenantHeaderName(value, field)', 'tenant header boundary'],
+  ['must not override a reserved HTTP header', 'reserved header rejection'],
+  ['function isLocalCaptureHost(hostname)', 'local HTTP host boundary'],
+  ["['localhost', '127.0.0.1', '[::1]', '::1']", 'local HTTP host allowlist'],
+  ['function endpoint(value, field)', 'URL validation'],
+  ['parsed.username || parsed.password || parsed.search || parsed.hash', 'URL credential/query rejection'],
+  ["parsed.protocol === 'http:' && !isLocalCaptureHost(parsed.hostname)", 'remote HTTPS requirement'],
+  ['must use https unless the mounted endpoint is localhost or loopback', 'remote HTTP rejection'],
+  ["redirect: 'error'", 'redirect rejection'],
+  ['function authorizationHeader(value)', 'authorization construction'],
+  ['function optionalString(value, field)', 'optional string normalization'],
+  ['function timestamp(value, field)', 'timestamp normalization'],
+  ['must be an RFC3339 timestamp', 'timestamp format boundary'],
+  ['new Date(milliseconds).toISOString()', 'UTC timestamp canonicalization'],
+  ['function normalizeProjection(value, flavor, field)', 'projection normalization'],
+  ['function normalizeItems(items, flavor, field)', 'item normalization'],
+  ['.sort((left, right) => left.id.localeCompare(right.id))', 'stable item ordering'],
+  ['function projectionHash(value)', 'projection hashing'],
+  ['function sourceHashes()', 'source hashing'],
+  ['parity evidence already exists; remove it explicitly before a new capture', 'immutable output'],
+  ['writeFileSync(temporaryPath', 'atomic temporary write'],
+  ['renameSync(temporaryPath, outputPath)', 'atomic publish'],
+  ['lookup: fulfillment(tenantId: $tenantId, id: $id)', 'GraphQL lookup'],
+  ['list: fulfillments(tenantId: $tenantId, filter: $filter)', 'GraphQL filtered list'],
+  ['order(tenantId: $tenantId, id: $id)', 'GraphQL latest by order'],
+  ["restUrl(restBaseUrl, '/admin/fulfillments')", 'REST list'],
+  ['`/admin/fulfillments/${detailId}`', 'REST detail'],
+  ["restMissing.status !== 404 || restMissingCode !== 'commerce_admin_not_found'", 'REST optional not-found'],
+  ['GraphQL missing fulfillment lookup must return null', 'GraphQL optional not-found'],
+  ['lookup/detail projection parity', 'detail projection equality'],
+  ['filtered list projection parity', 'list projection equality'],
+  ['latest-by-order projection parity', 'latest projection equality'],
+  ["status: 'transport_projection_parity_captured_unreviewed'", 'bounded packet status'],
+  ['claimed_source_revision: sourceRevision', 'claimed source revision'],
+  ['claimed_adapter_profile: adapterProfile', 'claimed adapter profile'],
+  ['claims_verified_by_runner: false', 'unverified runtime claims'],
+  ['bearer_token_retained: false', 'packet token boundary'],
+  ['raw_response_bodies_retained: false', 'packet response boundary'],
+  ['fulfillment_metadata_retained: false', 'packet metadata boundary'],
+  ['transport_projection_parity_proven: true', 'bounded projection parity result'],
+  ['runtime_parity_proven: false', 'wider runtime parity remains open'],
+  ['owner_deadline_failure_injection_proven: false', 'deadline/failure remains open'],
+  ['process_restart_proven: false', 'restart remains open'],
+  ['external_adapter_identity_proven: false', 'external identity remains open'],
+  ['remote_adapter_behavior_proven: false', 'remote adapter remains open'],
+]) {
+  requireText(runner, value, label);
+}
+for (const value of [
+  'auth_token:',
+  'raw_response_body',
+  'metadata: source.metadata',
+  'runtime_parity_proven: true',
+  "external_adapter_identity_proven: adapterProfile !== 'in_process'",
+]) {
+  forbidText(runner, value, 'capture runner must not over-retain or overclaim');
+}
+
+if (sourceEvidence.status !== 'source_cutover_unvalidated') {
+  failures.push('source evidence status must remain source_cutover_unvalidated');
+}
+if (sourceEvidence.validation?.runtime_parity_proven !== false) {
+  failures.push('source evidence runtime parity must remain false');
+}
+if (sourceEvidence.runtime_capture?.contract !== contractPath) {
+  failures.push('source evidence must reference the execution contract');
+}
+if (sourceEvidence.runtime_capture?.runner !== runnerPath) {
+  failures.push('source evidence must reference the capture runner');
+}
+if (sourceEvidence.runtime_capture?.verifier !== verifierPath) {
+  failures.push('source evidence must reference the capture verifier');
+}
+if (sourceEvidence.runtime_capture?.contract_published !== true) {
+  failures.push('source evidence must record the published capture contract');
+}
+for (const [value, label] of [
+  [sourceEvidence.runtime_capture?.capture_executed, 'capture execution'],
+  [sourceEvidence.runtime_capture?.transport_projection_parity_proven, 'projection parity'],
+  [sourceEvidence.runtime_capture?.deadline_failure_proven, 'deadline/failure evidence'],
+  [sourceEvidence.runtime_capture?.restart_proven, 'restart evidence'],
+  [sourceEvidence.runtime_capture?.remote_adapter_proven, 'remote adapter evidence'],
+]) {
+  if (value !== false) failures.push(`source evidence must retain ${label} as false`);
+}
+
+for (const [value, label] of [
+  ['Status: capture contract published, execution pending.', 'runbook status'],
+  [contractPath, 'runbook contract path'],
+  [runnerPath, 'runbook runner path'],
+  [verifierPath, 'runbook verifier path'],
+  ['RUSTOK_FULFILLMENT_PARITY_GRAPHQL_URL', 'runbook GraphQL input'],
+  ['RUSTOK_FULFILLMENT_PARITY_REST_BASE_URL', 'runbook REST input'],
+  ['Remote mounted endpoints must use HTTPS.', 'runbook transport security'],
+  ['timestamps are normalized to UTC millisecond form', 'runbook timestamp normalization'],
+  ['transport_projection_parity_proven', 'runbook bounded result'],
+  ['runtime_parity_proven` remains `false`', 'runbook non-promotion rule'],
+  ['does not retain the bearer token', 'runbook secret boundary'],
+]) {
+  requireText(runbook, value, label);
+}
+for (const [value, label] of [
+  ['Publish the mounted lifecycle projection-parity execution contract and capture runner.', 'plan contract checklist'],
+  ['Execute the mounted GraphQL/REST projection-parity capture and retain its immutable packet.', 'plan execution checklist'],
+  ['Prove deadline/failure injection, process restart, and remote-adapter behavior separately.', 'plan wider runtime checklist'],
+]) {
+  requireText(plan, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Fulfillment lifecycle transport parity capture verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Fulfillment lifecycle mounted projection-parity capture is contract-locked, fail-closed, secret-safe, and does not claim wider runtime parity',
+);


### PR DESCRIPTION
## Summary

- publish a locked execution contract for mounted fulfillment lifecycle GraphQL/admin REST projection parity;
- add a maintainer-owned capture runner for GraphQL `fulfillment`, filtered `fulfillments`, `order.fulfillment`, REST list/detail, and transport-specific optional-not-found behavior;
- normalize fulfillment DTOs across GraphQL camelCase and REST snake_case while excluding metadata;
- canonicalize equivalent RFC3339 timestamps to UTC millisecond form and sort fulfillment items by id before hashing;
- compare ordered list projections, owner total, page, per-page, and `has_next`;
- retain contract/source hashes, normalized projection hashes, fixture ids, HTTP statuses, and durations;
- reject URL credentials/query/fragment, remote plain HTTP, redirects, reserved tenant headers, source path traversal, oversized responses, and implicit evidence overwrite;
- retain mounted revision, adapter profile, and runtime-instance values only as unverified operator claims;
- add a source verifier, runbook, evidence pointers, and roadmap updates.

## Boundary

This PR publishes capture tooling only. It deliberately does **not**:

- execute the mounted capture;
- add the future execution packet;
- claim `transport_projection_parity_proven` in source evidence;
- claim full `runtime_parity_proven`;
- prove that separate gateway origins resolve the same process/runtime instance;
- prove deadline/failure injection, process restart, external-adapter identity, or remote-adapter behavior;
- modify GraphQL/REST runtime code or lifecycle mutations;
- promote fulfillment FFA/FBA status.

The future runner may set only `transport_projection_parity_proven: true`; it always retains `runtime_parity_proven: false` and all wider runtime limitations as false. GraphQL and REST full URLs stay independently configurable because valid deployments may expose them through different gateway origins; runtime/source/adapter identity remains an explicit unverified claim.

## Recheck

- confirmed PR #2371 completed the lifecycle GraphQL source cutover and PR #2364 completed admin REST list/detail cutover;
- confirmed no open PR overlaps this lifecycle parity capture boundary;
- verified the mounted GraphQL endpoint, REST pagination names, and REST error envelope from current source;
- kept route prefixes configurable through full endpoint/base URL inputs instead of guessing deployment topology;
- locked the exact seven application/source files hashed by the runner;
- reviewed token retention, redirect, transport security, tenant-header, UUID, timestamp, response-size, path, and immutable-output boundaries;
- normalized GraphQL `to_rfc3339()` and REST chrono-serde timestamps before projection comparison;
- confirmed the original lifecycle read-port guard tolerates the new pending-capture fields while continuing to require unvalidated runtime status;
- reviewed the final runner and guard patches without executing them;
- rebuilt the branch as one atomic commit over current `main` commit `75db491faebadac59440a705a4f201567466f3e9`;
- confirmed one commit ahead, zero behind, with exactly seven intended files;
- confirmed intervening `main` changes are unrelated social-graph/profile evidence files.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, capture execution, workflow checks, and CI were not run, per maintainer instruction.

Suggested maintainer source check:

```bash
node scripts/verify/verify-fulfillment-lifecycle-transport-parity-capture.mjs
```

The mounted capture command and required environment are documented in `crates/rustok-fulfillment/docs/fulfillment-lifecycle-transport-parity-capture.md`.

## Next slice

Run the capture against compiled mounted GraphQL/admin REST fixtures and retain the immutable projection-parity packet in a new PR. Deadline/failure injection, restart, external-adapter identity, and remote-adapter behavior remain separate subsequent evidence slices.