### PR TITLE
test(profiles): define publish mark ambiguity evidence

### DIFF
--- a/crates/rustok-profiles/docs/poison-publish-mark-ambiguity-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-publish-mark-ambiguity-checkpoint.md
@@ -1,0 +1,105 @@
+# Profiles checkpoint: poison publish/mark ambiguity
+
+Status: **source-complete runtime evidence pending**.
+
+## Why this belongs in the Profiles improvement trail
+
+Profiles privacy and authorization remain owner-port concerns, but the Social Graph Index is one downstream consumer of privacy-relevant relationship facts. Its malformed-delivery terminalization must not silently lose a source offset or claim stronger broker guarantees than the infrastructure provides.
+
+The combined PostgreSQL/Iggy ordering harness already establishes:
+
+```text
+claim -> exact DLQ publish -> published -> source ack -> acknowledged bookkeeping
+```
+
+This checkpoint adds the missing cross-system ambiguity boundary: the broker may accept the deterministic DLQ message immediately before the process stops and before PostgreSQL records `published`.
+
+## Locked source scenarios
+
+Machine contract:
+
+```text
+crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json
+```
+
+Harness:
+
+```text
+crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+```
+
+Two distinct external-Iggy modes are required.
+
+### Dedup enabled
+
+The first publisher succeeds at the broker, remains `publishing` in PostgreSQL, and stops without source acknowledgement. After natural lease expiry, a recovery publisher receives the same source delivery and retries the same deterministic broker message ID.
+
+Required physical DLQ counts:
+
+```text
+0 -> 1 -> 1
+```
+
+### Dedup disabled
+
+The same sequence is repeated against a broker that accepts duplicate message IDs.
+
+Required physical DLQ counts:
+
+```text
+0 -> 1 -> 2
+```
+
+This negative case is important: PostgreSQL publisher fencing alone does not provide physical exactly-once across a successful broker write and a missing `mark_published` write.
+
+## Production implications
+
+The source contract preserves the current worker order:
+
+```text
+reserve_and_claim
+IggyTransport::move_to_dlq
+mark_raw_poison_published
+acknowledge_decode_failure
+best-effort mark_acknowledged
+```
+
+It also preserves these recovery rules:
+
+- a live lease returns `Busy`;
+- an expired lease can be reclaimed;
+- the old publisher is fenced with `ClaimLost`;
+- `published` redelivery is acknowledgement-only;
+- source acknowledgement never precedes the durable terminal result.
+
+Server-side message-ID deduplication is therefore a physical-duplicate mitigation for the publish/mark crash window, not a PostgreSQL/Iggy transaction.
+
+## Profiles authorization boundary
+
+No relationship, privacy, visibility, block, mute, follow, or friendship policy is inferred from:
+
+- poison receipt state;
+- Iggy deduplication state;
+- DLQ message count;
+- source acknowledgement state;
+- retained evidence metadata.
+
+Profiles presentation still consumes authorized owner-port results. Broker and receipt evidence only protects the reliability and auditability of downstream processing.
+
+## Remaining evidence
+
+The following work remains explicit:
+
+1. execute both ambiguity scenarios against reviewed PostgreSQL and two separately configured external-Iggy instances;
+2. retain current-commit evidence without database URLs, broker addresses, credentials, payloads, offsets, UUIDs, schema names, stream names, or raw logs;
+3. review whether production dedup expiry and capacity can contain the maximum supported publish-to-recovery interval;
+4. keep a documented operational response for dedup-disabled or dedup-window-exhausted duplicate DLQ entries;
+5. separately evaluate multi-replica lease ownership and broker failover.
+
+No canonical execution packet exists for this checkpoint. Tests and verifiers were not run by the implementation agent.

--- a/crates/rustok-social-graph/Cargo.toml
+++ b/crates/rustok-social-graph/Cargo.toml
@@ -31,5 +31,6 @@ index = ["dep:rustok-index"]
 index-consumer = ["index", "dep:rustok-iggy"]
 
 [dev-dependencies]
+iggy.workspace = true
 rustok-iggy-connector = { workspace = true, features = ["migrations"] }
 tokio.workspace = true

--- a/crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json
+++ b/crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 1,
+  "module": "social-graph",
+  "packet": "index-raw-poison-publish-mark-ambiguity-source",
+  "status": "source_complete_runtime_pending",
+  "test_target": "index_raw_poison_publish_mark_ambiguity",
+  "feature": "index-consumer",
+  "database_environment": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+  "shared_optional_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD"
+  ],
+  "scenarios": [
+    {
+      "case": "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+      "address_environment": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS",
+      "required_observed_dlq_counts": [
+        0,
+        1,
+        1
+      ],
+      "meaning": "the recovery publisher retries the same deterministic broker message ID after the first publish succeeded but before PostgreSQL reached published; enabled server-side deduplication suppresses the physical duplicate"
+    },
+    {
+      "case": "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+      "address_environment": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS",
+      "required_observed_dlq_counts": [
+        0,
+        1,
+        2
+      ],
+      "meaning": "the same recovery retry is accepted as a second physical DLQ message when server-side deduplication is disabled"
+    }
+  ],
+  "required_sequence": [
+    "receive_malformed_source_without_acknowledgement",
+    "reserve_and_claim_first_publisher_with_one_second_lease",
+    "publish_exact_bytes_through_production_iggy_transport",
+    "observe_one_physical_dlq_message",
+    "retain_postgresql_receipt_in_publishing",
+    "reject_live_second_claim_as_busy",
+    "shutdown_first_transport_without_source_acknowledgement_or_mark_published",
+    "wait_bounded_time_for_natural_lease_expiry",
+    "reopen_same_stream_and_fixed_consumer_group",
+    "receive_same_offset_delivery_uuid_and_exact_bytes",
+    "reclaim_receipt_with_second_publisher",
+    "fence_first_publisher_mark_published_as_claim_lost",
+    "retry_same_deterministic_broker_message_id_through_production_transport",
+    "observe_mode_specific_physical_dlq_count",
+    "persist_published_with_recovery_publisher",
+    "acknowledge_source_offset",
+    "persist_acknowledged_bookkeeping",
+    "receive_next_source_offset"
+  ],
+  "lease_boundary": {
+    "duration_seconds": 1,
+    "wait_milliseconds": 1500,
+    "direct_receipt_sql_mutation": false,
+    "clock_source": "postgresql_current_timestamp"
+  },
+  "broker_observer": {
+    "implementation": "read_only_iggy_sdk_topic_metadata",
+    "allowed_operation": "get_topic_partition_messages_count",
+    "direct_sdk_producer": false,
+    "unique_stream_per_case": true,
+    "domain_partitions": 1,
+    "replication_factor": 1
+  },
+  "production_paths": {
+    "source_consumer": "rustok_social_graph::index_consumer::SocialGraphIndexConsumer",
+    "dlq_publisher": "rustok_iggy::IggyTransport::move_to_dlq",
+    "receipt_store": "rustok_iggy_connector::migrations::ConsumerPoisonReceiptStore",
+    "worker": "apps/server/src/services/social_graph_index_worker.rs"
+  },
+  "required_production_order": [
+    "reserve_and_claim",
+    "transport.move_to_dlq",
+    "mark_raw_poison_published",
+    "acknowledge_decode_failure",
+    "mark_acknowledged"
+  ],
+  "isolation": {
+    "postgresql_schema": "unique_per_case",
+    "postgresql_pool_max_connections": 1,
+    "iggy_stream": "unique_per_case",
+    "enabled_and_disabled_addresses_must_be_distinct_when_both_are_present": true,
+    "localhost_fallback": false,
+    "database_url_fallback": false,
+    "default_credentials": false,
+    "stream_deletion_claim": false
+  },
+  "source_files": [
+    "crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs",
+    "crates/rustok-social-graph/Cargo.toml",
+    "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",
+    "crates/rustok-iggy/src/transport.rs",
+    "apps/server/src/services/social_graph_index_worker.rs"
+  ],
+  "verifier": "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs",
+  "documentation": "crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-evidence.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-publish-mark-ambiguity-checkpoint.md",
+  "non_claims": [
+    "postgresql_iggy_transaction",
+    "physical_exactly_once_without_deduplication",
+    "production_dedup_window_sufficiency",
+    "dedup_configuration_readback",
+    "bundled_iggy",
+    "tls_auth_failover",
+    "multi_replica_ownership",
+    "profiles_authorization"
+  ],
+  "execution_status": "not_run"
+}

--- a/crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-evidence.md
+++ b/crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-evidence.md
@@ -1,0 +1,164 @@
+# Social Graph raw-poison publish/mark ambiguity evidence
+
+Status: **source complete; external PostgreSQL/Iggy execution pending**.
+
+## Boundary under test
+
+The Social Graph Index worker cannot atomically commit an Iggy DLQ publish and a PostgreSQL poison-receipt transition. Its approved order is:
+
+```text
+reserve_and_claim
+IggyTransport::move_to_dlq
+mark_published
+acknowledge source offset
+best-effort mark_acknowledged
+```
+
+A process may stop after Iggy accepted the deterministic DLQ message but before PostgreSQL reached `published`. PostgreSQL then still reports `publishing`, the source offset is uncommitted, and a later publisher may reclaim the receipt after the durable lease expires.
+
+This harness isolates that ambiguity window. It does not describe it as a PostgreSQL/Iggy transaction.
+
+## Source harness
+
+Test target:
+
+```text
+crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs
+```
+
+Feature:
+
+```text
+index-consumer
+```
+
+Each case creates:
+
+- one unique PostgreSQL schema;
+- one connection per SeaORM pool;
+- one unique external-Iggy stream;
+- one `domain` partition and one `dlq` partition;
+- one production `SocialGraphIndexConsumer` at a time;
+- one read-only Iggy SDK observer that calls only `get_topic` and reads partition `messages_count`.
+
+The connector fixture only injects malformed source bytes. All source receive/redelivery, deterministic DLQ publication, receipt transitions, and source acknowledgement use public production APIs.
+
+## Shared PostgreSQL input
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL=postgresql://...
+```
+
+There is no `DATABASE_URL` fallback. The test creates and drops only its own unique schema.
+
+## Dedup-enabled case
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS=host:port
+```
+
+Exact case:
+
+```text
+dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate
+```
+
+The external broker must exhibit enabled message-ID deduplication for the bounded scenario. The physical DLQ counts must be:
+
+```text
+0 -> 1 -> 1
+```
+
+The first publisher:
+
+1. receives malformed bytes without acknowledging the source;
+2. claims a one-second PostgreSQL lease;
+3. publishes through `IggyTransport::move_to_dlq`;
+4. leaves the receipt in `publishing`;
+5. shuts down before `mark_published` and source acknowledgement.
+
+After a bounded 1.5-second wait, the recovery publisher receives the same source offset, deterministic delivery UUID, and exact raw bytes. It reclaims the expired receipt and retries the same deterministic broker message ID. The broker retains one physical DLQ message.
+
+The recovery publisher then persists `published`, acknowledges the source, records `acknowledged`, and receives the next source offset.
+
+## Dedup-disabled case
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS=host:port
+```
+
+Exact case:
+
+```text
+dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate
+```
+
+The physical DLQ counts must be:
+
+```text
+0 -> 1 -> 2
+```
+
+The PostgreSQL and source-cursor sequence is identical to the enabled case. The same deterministic message ID is retried after lease recovery, but a broker without deduplication accepts a second physical DLQ message.
+
+This is an intentional negative proof: durable receipt fencing prevents two live publishers from owning the lease simultaneously, but it cannot erase the cross-system ambiguity after the broker has succeeded and PostgreSQL has not yet recorded `published`.
+
+## Credentials
+
+Optional shared credentials must be supplied as a pair:
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME=...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD=...
+```
+
+The two mode addresses must be distinct when both are present. Addresses must be bounded `host:port` values without schemes, embedded credentials, query strings, or fragments.
+
+TLS, failover, and bundled-Iggy behavior are outside this source slice.
+
+## Suggested maintainer execution
+
+Run the source verifier first:
+
+```bash
+node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+```
+
+Then run both external cases serially:
+
+```bash
+cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_publish_mark_ambiguity \
+  -- --nocapture --test-threads=1
+```
+
+The harness is opt-in. Missing PostgreSQL or scenario-specific Iggy inputs produce an explicit skip message; a future retained runner must reject those skips.
+
+## What the source proves when executed successfully
+
+- a live second publisher observes `Busy` before the first lease expires;
+- natural PostgreSQL time expiry permits a new publisher to reclaim the receipt;
+- the old publisher is fenced with `ClaimLost`;
+- source redelivery preserves offset, deterministic delivery UUID, and exact malformed bytes;
+- both attempts use the same deterministic DLQ broker message ID;
+- enabled broker deduplication produces `0 -> 1 -> 1` physical counts;
+- disabled broker deduplication produces `0 -> 1 -> 2` physical counts;
+- `published` precedes source acknowledgement;
+- `acknowledged` remains bookkeeping after the source commit;
+- the source cursor advances to the next offset only after the terminal result is durable.
+
+## Non-claims
+
+This source does not claim:
+
+- a PostgreSQL/Iggy transaction;
+- physical exactly-once delivery without server-side deduplication;
+- that any production dedup expiry/capacity window is sufficient for every outage;
+- active server-configuration readback;
+- bundled mode, TLS, authentication coverage, or failover;
+- multi-replica ownership proof;
+- any Profiles authorization decision.
+
+A production dedup window must remain large enough to contain the actual publish-to-recovery interval and must avoid capacity eviction of the deterministic message ID. Those deployment properties require separate reviewed configuration and retained runtime evidence.
+
+No tests, Cargo commands, formatters, verifiers, PostgreSQL scenarios, or Iggy scenarios were run while defining this source contract.

--- a/crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs
+++ b/crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs
@@ -1,0 +1,550 @@
+#![cfg(feature = "index-consumer")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::sync::Arc;
+use std::time::Duration;
+
+use iggy::prelude::{Client, Identifier, IggyClient, TopicClient};
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ExternalConfig, IggyConfig, IggyMode, IggyTransport,
+    PersistentContractDelivery, SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceiptError,
+    ConsumerPoisonReceiptState, ConsumerPoisonReceiptStore,
+};
+use rustok_iggy_connector::{
+    ConnectorConfig, ExternalConnector, IggyConnector, PublishRequest,
+};
+use rustok_social_graph::index_consumer::{
+    SOCIAL_GRAPH_INDEX_CONSUMER_GROUP, SocialGraphIndexConsumer,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL";
+const DEDUP_ENABLED_ADDRESS_ENV: &str =
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS";
+const DEDUP_DISABLED_ADDRESS_ENV: &str =
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const PUBLISH_LEASE: Duration = Duration::from_secs(1);
+const LEASE_RECLAIM_WAIT: Duration = Duration::from_millis(1_500);
+
+const DEDUP_ENABLED_RETRY_COUNT: u64 = 1;
+const DEDUP_DISABLED_RETRY_COUNT: u64 = 2;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct PostgresIggyAmbiguityEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+    config: IggyConfig,
+    fixture: ExternalConnector,
+}
+
+impl PostgresIggyAmbiguityEvidence {
+    async fn setup(address_env: &'static str, scope: &str) -> TestResult<Option<Self>> {
+        ensure_distinct_mode_addresses()?;
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Social Graph publish/mark ambiguity evidence"
+            );
+            return Ok(None);
+        };
+        let Some(config) = external_iggy_config(address_env, scope)? else {
+            eprintln!(
+                "{address_env} is not set; skipping Social Graph publish/mark ambiguity evidence"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_sg_poison_ambiguity_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name).await?;
+        let migration_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in rustok_iggy_connector::migrations::migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = migration_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        let fixture = ExternalConnector::new();
+        if let Err(error) = fixture.connect(&ConnectorConfig::from(&config)).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+            config,
+            fixture,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.fixture.shutdown().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate() -> TestResult<()> {
+    exercise_publish_mark_ambiguity(
+        DEDUP_ENABLED_ADDRESS_ENV,
+        "dedup_enabled",
+        DEDUP_ENABLED_RETRY_COUNT,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate() -> TestResult<()> {
+    exercise_publish_mark_ambiguity(
+        DEDUP_DISABLED_ADDRESS_ENV,
+        "dedup_disabled",
+        DEDUP_DISABLED_RETRY_COUNT,
+    )
+    .await
+}
+
+async fn exercise_publish_mark_ambiguity(
+    address_env: &'static str,
+    scope: &str,
+    expected_retry_count: u64,
+) -> TestResult<()> {
+    let Some(evidence) = PostgresIggyAmbiguityEvidence::setup(address_env, scope).await? else {
+        return Ok(());
+    };
+
+    let stream = evidence.config.topology.stream_name.clone();
+    let first_transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);
+    let first_consumer =
+        SocialGraphIndexConsumer::open(Arc::clone(&first_transport), evidence.db.clone()).await?;
+    let observer = connect_observer(&evidence.config).await?;
+
+    let first_payload = match expected_retry_count {
+        DEDUP_ENABLED_RETRY_COUNT => vec![0xff, 0x00, 0x51, 0x01],
+        DEDUP_DISABLED_RETRY_COUNT => vec![0xff, 0x00, 0x52, 0x01],
+        other => return Err(invalid_data(format!("unsupported retry count {other}")).into()),
+    };
+    let second_payload = match expected_retry_count {
+        DEDUP_ENABLED_RETRY_COUNT => vec![0xff, 0x00, 0x51, 0x02],
+        DEDUP_DISABLED_RETRY_COUNT => vec![0xff, 0x00, 0x52, 0x02],
+        _ => unreachable!("validated retry count"),
+    };
+    publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;
+    publish_fixture(&evidence.fixture, &stream, second_payload.clone()).await?;
+
+    let first_failure = receive_decode_failure(&first_consumer).await?;
+    assert_eq!(first_failure.raw_payload(), first_payload.as_slice());
+    let first_offset = first_failure.offset();
+    let first_delivery_id = first_failure.delivery_id();
+    let identity = poison_identity(&first_failure)?;
+    let store = ConsumerPoisonReceiptStore::new(evidence.db.clone());
+    let first_publisher = Uuid::new_v4();
+    let recovery_publisher = Uuid::new_v4();
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                first_failure.stable_error_code(),
+                1,
+                first_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+    assert_message_count(&observer, &stream, 0).await?;
+
+    let first_entry = first_failure.to_dlq_entry(1);
+    let first_broker_message_id = first_entry
+        .broker_message_id()
+        .ok_or_else(|| invalid_data("raw poison ambiguity entry has no deterministic message ID"))?;
+    first_transport.move_to_dlq(first_entry).await?;
+    assert_message_count(&observer, &stream, 1).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                first_failure.stable_error_code(),
+                2,
+                recovery_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Busy
+    );
+
+    drop(first_consumer);
+    first_transport.shutdown().await?;
+    tokio::time::sleep(LEASE_RECLAIM_WAIT).await;
+
+    let recovery_transport = Arc::new(IggyTransport::new(evidence.config.clone()).await?);
+    let recovery_consumer =
+        SocialGraphIndexConsumer::open(Arc::clone(&recovery_transport), evidence.db.clone()).await?;
+    let redelivered = receive_decode_failure(&recovery_consumer).await?;
+    assert_eq!(redelivered.offset(), first_offset);
+    assert_eq!(redelivered.delivery_id(), first_delivery_id);
+    assert_eq!(redelivered.raw_payload(), first_payload.as_slice());
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &poison_identity(&redelivered)?,
+                redelivered.stable_error_code(),
+                2,
+                recovery_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert!(matches!(
+        store.mark_published(&identity, first_publisher).await,
+        Err(ConsumerPoisonReceiptError::ClaimLost)
+    ));
+
+    let retry_entry = redelivered.to_dlq_entry(2);
+    assert_eq!(retry_entry.broker_message_id(), Some(first_broker_message_id));
+    recovery_transport.move_to_dlq(retry_entry).await?;
+    assert_message_count(&observer, &stream, expected_retry_count).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+
+    store
+        .mark_published(&identity, recovery_publisher)
+        .await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Published).await?;
+    recovery_consumer
+        .acknowledge_decode_failure(&redelivered)
+        .await?;
+    store.mark_acknowledged(&identity).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Acknowledged).await?;
+
+    let next_failure = receive_decode_failure(&recovery_consumer).await?;
+    assert_eq!(next_failure.raw_payload(), second_payload.as_slice());
+    assert!(next_failure.offset() > first_offset);
+
+    drop(recovery_consumer);
+    observer.shutdown().await?;
+    recovery_transport.shutdown().await?;
+    evidence.cleanup().await
+}
+
+async fn publish_fixture(
+    connector: &ExternalConnector,
+    stream: &str,
+    payload: Vec<u8>,
+) -> TestResult<()> {
+    connector
+        .publish(PublishRequest::new(
+            stream,
+            "domain",
+            "raw-poison-publish-mark-ambiguity-fixture",
+            payload,
+            Uuid::new_v4().to_string(),
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn receive_decode_failure(
+    consumer: &SocialGraphIndexConsumer,
+) -> TestResult<ConsumedContractDecodeFailure> {
+    let delivery = timeout(RECEIVE_TIMEOUT, consumer.receive_delivery())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for publish/mark ambiguity delivery"))??
+        .ok_or_else(|| invalid_data("source cursor ended before publish/mark ambiguity delivery"))?;
+    match delivery {
+        PersistentContractDelivery::DecodeFailure(failure) => Ok(failure),
+        PersistentContractDelivery::Event(_) => Err(invalid_data(
+            "malformed publish/mark ambiguity fixture unexpectedly decoded as a contract event",
+        )
+        .into()),
+    }
+}
+
+async fn connect_observer(config: &IggyConfig) -> TestResult<IggyClient> {
+    let client = IggyClient::from_connection_string(&connection_string(&config.external)?)?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn message_count(client: &IggyClient, stream: &str) -> TestResult<u64> {
+    let stream_id: Identifier = stream.to_string().try_into()?;
+    let topic_id: Identifier = "dlq".to_string().try_into()?;
+    let topic = client
+        .get_topic(&stream_id, &topic_id)
+        .await?
+        .ok_or_else(|| invalid_data("publish/mark ambiguity DLQ topic is missing"))?;
+    let partition = topic
+        .partitions
+        .iter()
+        .find(|partition| partition.id == 1)
+        .ok_or_else(|| invalid_data("publish/mark ambiguity DLQ partition 1 is missing"))?;
+    Ok(partition.messages_count)
+}
+
+async fn assert_message_count(client: &IggyClient, stream: &str, expected: u64) -> TestResult<()> {
+    let observed = message_count(client, stream).await?;
+    if observed != expected {
+        return Err(invalid_data(format!(
+            "publish/mark ambiguity expected {expected} physical DLQ messages but observed {observed}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+async fn assert_receipt_state(
+    store: &ConsumerPoisonReceiptStore,
+    identity: &ConsumerPoisonIdentity,
+    expected: ConsumerPoisonReceiptState,
+) -> TestResult<()> {
+    let receipt = store
+        .find(identity)
+        .await?
+        .ok_or_else(|| invalid_data("expected publish/mark ambiguity receipt was not found"))?;
+    assert_eq!(receipt.state, expected);
+    Ok(())
+}
+
+fn poison_identity(
+    failure: &ConsumedContractDecodeFailure,
+) -> Result<ConsumerPoisonIdentity, ConsumerPoisonReceiptError> {
+    ConsumerPoisonIdentity::new(
+        failure.delivery_id(),
+        SOCIAL_GRAPH_INDEX_CONSUMER_GROUP,
+        failure.stream(),
+        failure.topic(),
+        failure.partition(),
+        failure.offset(),
+        failure.raw_payload().to_vec(),
+    )
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+fn external_iggy_config(
+    address_env: &'static str,
+    scope: &str,
+) -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(address_env) {
+        Ok(value) => bounded_env(address_env, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    validate_address(address_env, &address)?;
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "publish/mark ambiguity Iggy username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name(scope),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn ensure_distinct_mode_addresses() -> TestResult<()> {
+    let enabled = env::var(DEDUP_ENABLED_ADDRESS_ENV).ok();
+    let disabled = env::var(DEDUP_DISABLED_ADDRESS_ENV).ok();
+    if let (Some(enabled), Some(disabled)) = (enabled, disabled) {
+        let enabled = bounded_env(DEDUP_ENABLED_ADDRESS_ENV, enabled, 255)?;
+        let disabled = bounded_env(DEDUP_DISABLED_ADDRESS_ENV, disabled, 255)?;
+        validate_address(DEDUP_ENABLED_ADDRESS_ENV, &enabled)?;
+        validate_address(DEDUP_DISABLED_ADDRESS_ENV, &disabled)?;
+        if enabled == disabled {
+            return Err(invalid_data(
+                "dedup-enabled and dedup-disabled ambiguity evidence require distinct Iggy addresses",
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_address(name: &'static str, address: &str) -> Result<(), IoError> {
+    if address.contains("://") || address.contains('@') || address.contains('?') || address.contains('#') {
+        return Err(invalid_data(format!(
+            "{name} must be host:port without credentials or URL delimiters"
+        )));
+    }
+    Ok(())
+}
+
+fn connection_string(config: &ExternalConfig) -> Result<String, IoError> {
+    let address = config
+        .addresses
+        .first()
+        .ok_or_else(|| invalid_data("publish/mark ambiguity Iggy address is missing"))?;
+    if config.protocol != "tcp" {
+        return Err(invalid_data("publish/mark ambiguity evidence requires TCP"));
+    }
+    if config.tls_enabled || config.tls_domain.is_some() || config.tls_ca_file.is_some() {
+        return Err(invalid_data(
+            "publish/mark ambiguity source harness does not claim TLS coverage",
+        ));
+    }
+    validate_connection_component(address, "address", &['@', '?', '#'])?;
+    validate_connection_component(&config.username, "username", &[':', '@'])?;
+    validate_connection_component(&config.password, "password", &[':', '@'])?;
+
+    if config.username.is_empty() {
+        Ok(format!("iggy://{address}"))
+    } else {
+        Ok(format!(
+            "iggy://{}:{}@{address}",
+            config.username, config.password
+        ))
+    }
+}
+
+fn validate_connection_component(
+    value: &str,
+    field: &'static str,
+    forbidden: &[char],
+) -> Result<(), IoError> {
+    if let Some(delimiter) = value
+        .chars()
+        .find(|character| forbidden.contains(character))
+    {
+        return Err(invalid_data(format!(
+            "Iggy {field} contains unsupported connection delimiter '{delimiter}'"
+        )));
+    }
+    Ok(())
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(db)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-sg-poison-ambiguity-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json";
+const testPath =
+  "crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs";
+const cargoPath = "crates/rustok-social-graph/Cargo.toml";
+const receiptPath = "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs";
+const transportPath = "crates/rustok-iggy/src/transport.rs";
+const workerPath = "apps/server/src/services/social_graph_index_worker.rs";
+const expectedVerifier =
+  "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs";
+const expectedDocumentation =
+  "crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-evidence.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-publish-mark-ambiguity-checkpoint.md";
+const expectedScenarios = [
+  {
+    case: "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+    address_environment:
+      "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS",
+    required_observed_dlq_counts: [0, 1, 1],
+  },
+  {
+    case: "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+    address_environment:
+      "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS",
+    required_observed_dlq_counts: [0, 1, 2],
+  },
+];
+const expectedProductionOrder = [
+  "reserve_and_claim",
+  "transport.move_to_dlq",
+  "mark_raw_poison_published",
+  "acknowledge_decode_failure",
+  "mark_acknowledged",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const test = readFileSync(resolve(repoRoot, testPath), "utf8");
+const cargo = readFileSync(resolve(repoRoot, cargoPath), "utf8");
+const receipt = readFileSync(resolve(repoRoot, receiptPath), "utf8");
+const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
+const worker = readFileSync(resolve(repoRoot, workerPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, source, marker) {
+  if (source.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+function requireOrder(name, source, markers) {
+  let cursor = -1;
+  for (const marker of markers) {
+    const next = source.indexOf(marker, cursor + 1);
+    if (next < 0) {
+      fail(`${name} is missing ordered marker: ${marker}`);
+      return;
+    }
+    if (next <= cursor) {
+      fail(`${name} marker order drifted at: ${marker}`);
+      return;
+    }
+    cursor = next;
+  }
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "social-graph" ||
+  contract.packet !== "index-raw-poison-publish-mark-ambiguity-source" ||
+  contract.status !== "source_complete_runtime_pending" ||
+  contract.test_target !== "index_raw_poison_publish_mark_ambiguity" ||
+  contract.feature !== "index-consumer" ||
+  contract.execution_status !== "not_run"
+) {
+  fail("publish/mark ambiguity contract identity or runtime-pending status drift");
+}
+
+if (
+  contract.database_environment !==
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL" ||
+  !sameValue(contract.shared_optional_environment, [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD",
+  ])
+) {
+  fail("publish/mark ambiguity environment boundary drift");
+}
+
+const retainedScenarios = contract.scenarios?.map((scenario) => ({
+  case: scenario.case,
+  address_environment: scenario.address_environment,
+  required_observed_dlq_counts: scenario.required_observed_dlq_counts,
+}));
+if (!sameValue(retainedScenarios, expectedScenarios)) {
+  fail("publish/mark ambiguity scenario or physical count contract drift");
+}
+
+if (
+  contract.lease_boundary?.duration_seconds !== 1 ||
+  contract.lease_boundary?.wait_milliseconds !== 1500 ||
+  contract.lease_boundary?.direct_receipt_sql_mutation !== false ||
+  contract.lease_boundary?.clock_source !== "postgresql_current_timestamp"
+) {
+  fail("publish/mark ambiguity lease boundary drift");
+}
+
+if (
+  contract.broker_observer?.implementation !==
+    "read_only_iggy_sdk_topic_metadata" ||
+  contract.broker_observer?.allowed_operation !==
+    "get_topic_partition_messages_count" ||
+  contract.broker_observer?.direct_sdk_producer !== false ||
+  contract.broker_observer?.unique_stream_per_case !== true ||
+  contract.broker_observer?.domain_partitions !== 1 ||
+  contract.broker_observer?.replication_factor !== 1
+) {
+  fail("publish/mark ambiguity read-only broker observer boundary drift");
+}
+
+if (!sameValue(contract.required_production_order, expectedProductionOrder)) {
+  fail("publish/mark ambiguity production order contract drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("publish/mark ambiguity verifier or documentation path drift");
+}
+
+const expectedSources = [
+  testPath,
+  cargoPath,
+  receiptPath,
+  transportPath,
+  workerPath,
+];
+if (!sameValue(contract.source_files, expectedSources)) {
+  fail("publish/mark ambiguity source file allowlist drift");
+}
+
+for (const marker of [
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS",
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS",
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME",
+  "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD",
+  "const PUBLISH_LEASE: Duration = Duration::from_secs(1);",
+  "const LEASE_RECLAIM_WAIT: Duration = Duration::from_millis(1_500);",
+  "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+  "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+  "ensure_distinct_mode_addresses()?",
+  "ConsumerPoisonPublishClaim::Busy",
+  "tokio::time::sleep(LEASE_RECLAIM_WAIT).await;",
+  "assert_eq!(redelivered.offset(), first_offset);",
+  "assert_eq!(redelivered.delivery_id(), first_delivery_id);",
+  "assert_eq!(redelivered.raw_payload(), first_payload.as_slice());",
+  "Err(ConsumerPoisonReceiptError::ClaimLost)",
+  "assert_eq!(retry_entry.broker_message_id(), Some(first_broker_message_id));",
+  "assert_message_count(&observer, &stream, expected_retry_count).await?;",
+  "ConsumerPoisonReceiptState::Published",
+  "acknowledge_decode_failure(&redelivered)",
+  "store.mark_acknowledged(&identity).await?;",
+  "ConsumerPoisonReceiptState::Acknowledged",
+  "assert!(next_failure.offset() > first_offset);",
+  ".get_topic(&stream_id, &topic_id)",
+  "partition.messages_count",
+  ".max_connections(1)",
+  "DROP SCHEMA IF EXISTS",
+]) {
+  requireText("publish/mark ambiguity source harness", test, marker);
+}
+
+if (countText(test, ".move_to_dlq(") !== 2) {
+  fail("publish/mark ambiguity harness must contain exactly two production DLQ publishes");
+}
+if (countText(test, ".reserve_and_claim(") !== 3) {
+  fail("publish/mark ambiguity harness must contain first, busy, and recovery claims");
+}
+if (countText(test, "assert_message_count(") < 4) {
+  fail("publish/mark ambiguity harness has insufficient physical count observations");
+}
+
+requireOrder("publish/mark ambiguity recovery helper", test, [
+  "ConsumerPoisonPublishClaim::Claimed",
+  "first_transport.move_to_dlq(first_entry).await?;",
+  "ConsumerPoisonPublishClaim::Busy",
+  "first_transport.shutdown().await?;",
+  "tokio::time::sleep(LEASE_RECLAIM_WAIT).await;",
+  "let redelivered = receive_decode_failure(&recovery_consumer).await?;",
+  "Err(ConsumerPoisonReceiptError::ClaimLost)",
+  "recovery_transport.move_to_dlq(retry_entry).await?;",
+  "mark_published(&identity, recovery_publisher)",
+  "acknowledge_decode_failure(&redelivered)",
+  "store.mark_acknowledged(&identity).await?;",
+]);
+
+for (const marker of [
+  "DATABASE_URL",
+  "localhost",
+  "127.0.0.1",
+  "UPDATE iggy_consumer_poison_receipts",
+  "lease_expires_at =",
+  "Statement::from_sql",
+  ".send_messages(",
+  ".send_message(",
+  "delete_stream",
+  "remove_stream",
+]) {
+  forbidText("publish/mark ambiguity source harness", test, marker);
+}
+
+requireText("Social Graph Cargo dev dependencies", cargo, "iggy.workspace = true");
+requireText(
+  "Social Graph Cargo dev dependencies",
+  cargo,
+  'rustok-iggy-connector = { workspace = true, features = ["migrations"] }',
+);
+
+for (const marker of [
+  "must be a whole number of seconds",
+  "lease_expires_at <= CURRENT_TIMESTAMP",
+  "ConsumerPoisonReceiptError::ClaimLost",
+  "WHERE publisher_id =",
+  "state = 'publishing'",
+]) {
+  requireText("consumer poison receipt store", receipt, marker);
+}
+
+for (const marker of [
+  "if entry.broker_message_id().is_some()",
+  "IggyDlqPublisher::connect",
+  ".publish(&entry)",
+]) {
+  requireText("production Iggy transport", transport, marker);
+}
+
+requireOrder("production Social Graph raw poison worker", worker, [
+  ".reserve_and_claim(",
+  "transport.move_to_dlq(failure.to_dlq_entry(1)).await",
+  "mark_raw_poison_published(",
+  "consumer.acknowledge_decode_failure(failure).await",
+  "poison_receipts.mark_acknowledged(identity).await",
+]);
+for (const marker of [
+  "Raw poison bytes were published but durable published state failed; retrying persistence only",
+  "source offset committed but receipt acknowledgement bookkeeping failed",
+  "redelivery retries acknowledgement only",
+]) {
+  requireText("production Social Graph raw poison worker", worker, marker);
+}
+
+const requiredNonClaims = new Set([
+  "postgresql_iggy_transaction",
+  "physical_exactly_once_without_deduplication",
+  "production_dedup_window_sufficiency",
+  "dedup_configuration_readback",
+  "bundled_iggy",
+  "tls_auth_failover",
+  "multi_replica_ownership",
+  "profiles_authorization",
+]);
+for (const claim of contract.non_claims ?? []) requiredNonClaims.delete(claim);
+if (requiredNonClaims.size > 0) {
+  fail(`publish/mark ambiguity non-claims are incomplete: ${[...requiredNonClaims].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Social Graph publish/mark ambiguity source verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Social Graph publish/mark ambiguity source verified: PostgreSQL lease recovery, deterministic retry identity, dedup-enabled 0→1→1 behavior, dedup-disabled 0→1→2 behavior, production worker ordering, and bounded non-claims are locked; runtime execution remains pending.",
+);

--- a/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
@@ -218,7 +218,8 @@ requireOrder("publish/mark ambiguity recovery helper", test, [
 ]);
 
 for (const marker of [
-  "DATABASE_URL",
+  'env::var("DATABASE_URL")',
+  'std::env::var("DATABASE_URL")',
   "localhost",
   "127.0.0.1",
   "UPDATE iggy_consumer_poison_receipts",
@@ -242,7 +243,7 @@ requireText(
 for (const marker of [
   "must be a whole number of seconds",
   "lease_expires_at <= CURRENT_TIMESTAMP",
-  "ConsumerPoisonReceiptError::ClaimLost",
+  "Self::ClaimLost",
   "WHERE publisher_id =",
   "state = 'publishing'",
 ]) {


### PR DESCRIPTION
## Summary

Define a combined PostgreSQL + external-Iggy source harness for the crash/ambiguity window after a deterministic raw-poison DLQ publish succeeds but before the PostgreSQL receipt reaches `published`.

## Scenarios

Two exact opt-in cases use distinct externally configured brokers.

### Dedup enabled

`dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate`

- receive malformed source bytes without acknowledgement;
- claim a one-second PostgreSQL publishing lease;
- publish through production `IggyTransport::move_to_dlq`;
- require physical DLQ counts `0 -> 1` while the receipt remains `publishing`;
- require a live recovery claim to return `Busy`;
- shut down the first transport without `mark_published` or source acknowledgement;
- wait 1.5 seconds for natural PostgreSQL lease expiry;
- reopen the same stream and fixed Social Graph consumer group;
- require the same source offset, deterministic delivery UUID, and exact bytes;
- reclaim with a second publisher and fence the old publisher with `ClaimLost`;
- retry the same deterministic broker message ID through production transport;
- require the physical DLQ count to remain `1`;
- persist `published`, acknowledge the source, persist `acknowledged`, and receive the next offset.

### Dedup disabled

`dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate`

The same sequence is repeated against a broker that accepts duplicate message IDs. The required physical DLQ counts are `0 -> 1 -> 2`.

This is an explicit negative proof: PostgreSQL lease fencing prevents concurrent live ownership but cannot provide physical exactly-once across a successful broker write and a missing `mark_published` write.

## Evidence boundaries

- unique PostgreSQL schema and unique Iggy stream per case;
- one connection per database pool;
- no `DATABASE_URL` or localhost fallback;
- enabled and disabled addresses must be distinct when both are supplied;
- fixture connector only injects malformed source bytes;
- source receive/redelivery, receipt transitions, DLQ publication, and source acknowledgement use public production APIs;
- read-only Iggy SDK observer only calls `get_topic` and reads partition `messages_count`;
- no direct SDK producer, receipt SQL mutation, stream deletion, or authorization logic.

## Production parity

The machine contract and verifier preserve the server worker order:

```text
reserve_and_claim
transport.move_to_dlq
mark_raw_poison_published
acknowledge_decode_failure
mark_acknowledged
```

The verifier also locks whole-second PostgreSQL leases, natural `lease_expires_at <= CURRENT_TIMESTAMP` reclaim, old-publisher fencing, deterministic Iggy publication, and acknowledgement-only terminal recovery markers.

## Documentation

- added the versioned source contract;
- added a static source verifier;
- added the Social Graph operator/evidence guide;
- added a Profiles checkpoint preserving the owner-port authorization boundary;
- added the read-only Iggy observer as a Social Graph dev dependency.

## Non-claims

This slice does not claim a PostgreSQL/Iggy transaction, physical exactly-once without deduplication, production dedup-window sufficiency, active configuration readback, bundled mode, TLS/auth/failover, multi-replica ownership, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy, and multi-replica scenarios were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs

cargo test -p rustok-social-graph --features index-consumer \
  --test index_raw_poison_publish_mark_ambiguity \
  -- --nocapture --test-threads=1
```
