### PR TITLE
test(profiles): retain publish mark ambiguity evidence

### DIFF
--- a/crates/rustok-profiles/docs/poison-publish-mark-ambiguity-retained-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-publish-mark-ambiguity-retained-checkpoint.md
@@ -1,0 +1,89 @@
+# Profiles checkpoint: retained publish/mark ambiguity evidence
+
+Status: **retained tooling source-complete; runtime packet pending**.
+
+## Completed in this checkpoint
+
+The source-level publish/mark ambiguity harness now has a fail-closed retained execution path:
+
+```text
+crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json
+scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
+```
+
+The retained gate requires both exact PostgreSQL + external-Iggy scenarios from one clean commit:
+
+```text
+dedup enabled:  0 -> 1 -> 1
+dedup disabled: 0 -> 1 -> 2
+```
+
+## Configuration evidence
+
+The enabled scenario requires reviewed Iggy configuration with:
+
+- `enabled = true`;
+- `max_entries >= 1`;
+- a positive expiry strictly longer than the 1500 ms lease-recovery wait.
+
+The disabled scenario requires `enabled = false`.
+
+Only the canonical `[system.message_deduplication]` projection and its SHA-256 are retained. Full config files, paths, unrelated settings, and full-file hashes are excluded.
+
+## Runtime provenance
+
+The future packet must retain:
+
+- current Git commit;
+- clean-tree status before execution;
+- current source hashes for production code, tests, contracts, runner, and verifiers;
+- exact command arrays;
+- reviewed PostgreSQL and Iggy artifact labels;
+- expected physical count sequences;
+- two exact all-pass results;
+- bounded output hashes and byte counts.
+
+The runner rejects skipped or zero-test executions and writes the packet atomically only after both cases pass.
+
+## Privacy boundary
+
+The retained packet must not contain:
+
+- PostgreSQL URLs;
+- Iggy addresses;
+- usernames or passwords;
+- connection strings;
+- config paths or full config contents;
+- raw test logs;
+- malformed payloads;
+- source offsets;
+- delivery UUIDs;
+- acknowledgement tokens;
+- temporary schema or stream names.
+
+This evidence cannot be used as an authorization input. Profiles privacy, visibility, blocks, mutes, follows, and friendship policy continue to be decided by their authoritative owner ports before presentation.
+
+## Interpretation boundary
+
+A successful enabled case demonstrates physical duplicate suppression only for the exact isolated retry while the deterministic message ID remains in the reviewed dedup cache.
+
+It does not prove:
+
+- a PostgreSQL/Iggy transaction;
+- physical exactly-once when deduplication is disabled;
+- that production expiry and capacity cover every supported outage or load pattern;
+- active configuration readback from the running broker;
+- TLS, failover, bundled mode, or multi-replica ownership.
+
+The disabled case intentionally preserves the negative result: after broker success and before `mark_published`, lease recovery can produce a second physical DLQ entry even though receipt ownership remains fenced.
+
+## Remaining work
+
+1. execute both exact scenarios against reviewed external services;
+2. commit the canonical execution packet only after the retained verifier passes;
+3. review production dedup expiry/capacity against the maximum supported recovery interval and load;
+4. define operational handling for duplicate physical DLQ entries when dedup is disabled or exhausted;
+5. add separate failover and multi-replica evidence.
+
+`index-raw-poison-publish-mark-ambiguity-execution.json` is intentionally absent. Tests and verifiers were not run by the implementation agent.

--- a/crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json
+++ b/crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 1,
+  "module": "social-graph",
+  "packet": "index-raw-poison-publish-mark-ambiguity-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_contract": "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json",
+  "runner": "scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs",
+  "verifier": "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs",
+  "evidence_path": "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution.json",
+  "test_target": "index_raw_poison_publish_mark_ambiguity",
+  "database_environment": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+  "postgres_artifact_environment": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_POSTGRES_ARTIFACT",
+  "shared_optional_environment": [
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME",
+    "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD"
+  ],
+  "lease_reclaim_wait_milliseconds": 1500,
+  "scenarios": [
+    {
+      "case": "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+      "address_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS",
+      "config_path_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_SERVER_ARTIFACT",
+      "expected_configuration": {
+        "enabled": true,
+        "max_entries": "at_least_1",
+        "expiry": "longer_than_lease_reclaim_wait"
+      },
+      "expected_partition_message_counts": [0, 1, 1]
+    },
+    {
+      "case": "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+      "address_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS",
+      "config_path_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_CONFIG_PATH",
+      "server_artifact_env": "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_SERVER_ARTIFACT",
+      "expected_configuration": {
+        "enabled": false,
+        "max_entries": "optional",
+        "expiry": "optional"
+      },
+      "expected_partition_message_counts": [0, 1, 2]
+    }
+  ],
+  "command_template": {
+    "program": "cargo",
+    "args_before_case": [
+      "test",
+      "-p",
+      "rustok-social-graph",
+      "--features",
+      "index-consumer",
+      "--test",
+      "index_raw_poison_publish_mark_ambiguity",
+      "--"
+    ],
+    "args_after_case": ["--exact", "--nocapture", "--test-threads=1"]
+  },
+  "reviewed_configuration": {
+    "section": "system.message_deduplication",
+    "persisted_fields": [
+      "enabled",
+      "max_entries",
+      "expiry",
+      "expiry_milliseconds",
+      "canonical_sha256"
+    ],
+    "full_config_path_persisted": false,
+    "full_config_sha256_persisted": false,
+    "full_config_content_persisted": false
+  },
+  "source_files": [
+    "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json",
+    "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json",
+    "crates/rustok-social-graph/tests/index_raw_poison_publish_mark_ambiguity.rs",
+    "crates/rustok-social-graph/Cargo.toml",
+    "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",
+    "crates/rustok-iggy/src/transport.rs",
+    "apps/server/src/services/social_graph_index_worker.rs",
+    "scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs",
+    "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs",
+    "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs"
+  ],
+  "privacy_boundary": {
+    "forbidden_persisted_values": [
+      "database_url",
+      "broker_address",
+      "config_path",
+      "username",
+      "password",
+      "connection_string",
+      "full_config_content",
+      "full_config_sha256",
+      "raw_test_output",
+      "payload",
+      "source_offset",
+      "delivery_uuid",
+      "ack_token",
+      "schema_name",
+      "stream_name"
+    ]
+  },
+  "non_claims": [
+    "postgresql_iggy_transaction",
+    "physical_exactly_once_without_deduplication",
+    "production_dedup_window_sufficiency_beyond_reviewed_configuration",
+    "active_server_configuration_readback",
+    "bundled_iggy",
+    "tls_auth_failover",
+    "multi_replica_ownership",
+    "profiles_authorization"
+  ],
+  "evidence_status": "runtime_execution_pending"
+}

--- a/crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-retained-evidence.md
+++ b/crates/rustok-social-graph/docs/index-raw-poison-publish-mark-ambiguity-retained-evidence.md
@@ -1,0 +1,172 @@
+# Retained publish/mark ambiguity evidence
+
+Status: **execution contract locked; canonical runtime packet absent**.
+
+This retained path promotes the source harness in `index_raw_poison_publish_mark_ambiguity.rs` only after both PostgreSQL + external-Iggy scenarios pass from one clean commit.
+
+## Required inputs
+
+### PostgreSQL
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL=postgresql://...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_POSTGRES_ARTIFACT=postgresql-16.4-reviewed-build
+```
+
+The artifact value is a bounded operator-reviewed version, image digest, or build label. It must not be an endpoint. The database URL is validated but never retained.
+
+### Dedup-enabled Iggy
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_ADDRESS=host:port
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_CONFIG_PATH=/outside/repository/enabled.toml
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_ENABLED_SERVER_ARTIFACT=iggy-server-reviewed-build
+```
+
+The reviewed configuration must contain:
+
+```toml
+[system.message_deduplication]
+enabled = true
+max_entries = 1 # or greater
+expiry = "2s"  # strictly greater than the 1500 ms recovery wait
+```
+
+A larger production value is expected. The retained gate only requires enough reviewed capacity and expiry for the exact isolated scenario.
+
+### Dedup-disabled Iggy
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_ADDRESS=host:port
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_CONFIG_PATH=/outside/repository/disabled.toml
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_DEDUP_DISABLED_SERVER_ARTIFACT=iggy-server-reviewed-build
+```
+
+The reviewed configuration must contain:
+
+```toml
+[system.message_deduplication]
+enabled = false
+```
+
+The two addresses and the two config paths must be distinct. Config paths must be absolute, must identify existing files, and must remain outside the repository.
+
+### Optional credentials
+
+```text
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_USERNAME=...
+RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_IGGY_PASSWORD=...
+```
+
+Both must be supplied together. Their values are validated for the source harness boundary and are never retained.
+
+## Reviewed configuration projection
+
+The runner reads only `[system.message_deduplication]` and stores the canonical non-secret projection:
+
+```text
+enabled
+max_entries
+expiry
+expiry_milliseconds
+canonical_sha256
+```
+
+It does not retain:
+
+- config paths;
+- full config contents;
+- full-file hashes;
+- unrelated Iggy settings;
+- addresses or credentials.
+
+## Exact execution
+
+Each scenario is run separately:
+
+```bash
+cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_publish_mark_ambiguity -- \
+  dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate \
+  --exact --nocapture --test-threads=1
+```
+
+```bash
+cargo test -p rustok-social-graph --features index-consumer \
+  --test index_raw_poison_publish_mark_ambiguity -- \
+  dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate \
+  --exact --nocapture --test-threads=1
+```
+
+For each command the runner requires:
+
+- exit status zero;
+- `running 1 test`;
+- the exact named case followed by `... ok`;
+- no source-harness skip message.
+
+## Clean-commit capture
+
+Run the static source and retained verifiers before capture:
+
+```bash
+node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
+```
+
+Then capture:
+
+```bash
+node scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+```
+
+Finally verify the generated packet:
+
+```bash
+node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
+```
+
+The runner requires a clean working tree before execution and rechecks:
+
+- full commit SHA;
+- current source SHA-256 values, including the contracts, runner, and verifiers;
+- unchanged working tree after both tests;
+- bounded toolchain metadata.
+
+The canonical packet is written atomically only after both exact cases pass.
+
+## Retained packet
+
+Canonical path:
+
+```text
+crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution.json
+```
+
+The packet retains:
+
+- commit and timestamps;
+- Cargo and Rust compiler versions;
+- environment-variable names for PostgreSQL and Iggy inputs;
+- reviewed PostgreSQL/Iggy artifact labels;
+- canonical dedup values and digests;
+- current source hashes;
+- exact command arrays;
+- expected physical count sequences;
+- per-case and combined output SHA-256 values and byte counts;
+- two aggregate `pass` results.
+
+The packet omits database URLs, broker addresses, config paths, credentials, connection strings, full configs, raw logs, payloads, offsets, delivery UUIDs, acknowledgement tokens, schema names, and stream names.
+
+## Interpretation
+
+A successful retained packet establishes the exact reviewed configuration and isolated runtime behavior:
+
+```text
+dedup enabled:  0 -> 1 -> 1
+dedup disabled: 0 -> 1 -> 2
+```
+
+It does not establish a PostgreSQL/Iggy transaction or universal production exactly-once behavior. The enabled result applies only while the deterministic ID remains inside the reviewed broker expiry and capacity window. Longer outages, capacity pressure, failover, and multi-replica operation require separate operational evidence.
+
+The execution JSON is intentionally absent until a maintainer runs the capture successfully. No tests, Cargo commands, formatters, verifiers, PostgreSQL, or Iggy scenarios were run while adding this retained path.

--- a/scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+++ b/scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
@@ -1,0 +1,531 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json";
+const expectedRunner =
+  "scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs";
+const expectedVerifier =
+  "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs";
+const expectedEvidence =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution.json";
+const expectedCases = [
+  "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+  "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-social-graph",
+    "--features",
+    "index-consumer",
+    "--test",
+    "index_raw_poison_publish_mark_ambiguity",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) fail(`${program} could not start: ${result.error.message}`);
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function oneLine(value, field, maximumLength = 256) {
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    normalized.length > maximumLength ||
+    /[\r\n]/u.test(normalized) ||
+    /[\u0000-\u001f\u007f]/u.test(normalized)
+  ) {
+    fail(`${field} is missing, multiline, or outside the retained evidence boundary`);
+  }
+  return normalized;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`source file is missing: ${relativePath}`);
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function validateContract() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "social-graph" ||
+    contract.packet !== "index-raw-poison-publish-mark-ambiguity-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked"
+  ) {
+    fail("publish/mark ambiguity execution contract identity drift");
+  }
+  if (
+    contract.runner !== expectedRunner ||
+    contract.verifier !== expectedVerifier ||
+    contract.evidence_path !== expectedEvidence ||
+    contract.evidence_status !== "runtime_execution_pending"
+  ) {
+    fail("publish/mark ambiguity retained tooling boundary drift");
+  }
+  if (!sameValue(contract.command_template, expectedCommandTemplate)) {
+    fail("publish/mark ambiguity Cargo command allowlist drift");
+  }
+  if (!sameValue(contract.scenarios?.map((scenario) => scenario.case), expectedCases)) {
+    fail("publish/mark ambiguity exact case allowlist drift");
+  }
+  if (contract.lease_reclaim_wait_milliseconds !== 1500) {
+    fail("publish/mark ambiguity lease reclaim wait drift");
+  }
+}
+
+function validateDatabaseUrl() {
+  const value = process.env[contract.database_environment];
+  if (!value) fail(`${contract.database_environment} is required`);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail(`${contract.database_environment} is invalid`);
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    fail(`${contract.database_environment} must use PostgreSQL`);
+  }
+  if (!parsed.hostname) fail(`${contract.database_environment} must include a host`);
+}
+
+function validateAddress(value, field) {
+  const address = oneLine(value, field, 255);
+  if (
+    address.includes("://") ||
+    address.includes("@") ||
+    address.includes("?") ||
+    address.includes("#")
+  ) {
+    fail(`${field} must be host:port without URL or credential delimiters`);
+  }
+  if (!/^\[[0-9a-fA-F:]+\]:\d+$|^[A-Za-z0-9._-]+:\d+$/u.test(address)) {
+    fail(`${field} must be a bounded host:port address`);
+  }
+  const portText = address.slice(address.lastIndexOf(":") + 1);
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    fail(`${field} port must be between 1 and 65535`);
+  }
+  return address;
+}
+
+function validateCredentialsPair() {
+  const [usernameEnv, passwordEnv] = contract.shared_optional_environment;
+  const username = process.env[usernameEnv] ?? "";
+  const password = process.env[passwordEnv] ?? "";
+  if (username.trim() !== username || password.trim() !== password) {
+    fail("Iggy credentials must not have surrounding whitespace");
+  }
+  if (username.length > 191 || password.length > 191) {
+    fail("Iggy credentials exceed the source harness boundary");
+  }
+  if (/[\r\n\u0000-\u001f\u007f]/u.test(username + password)) {
+    fail("Iggy credentials contain control characters");
+  }
+  if (username.includes(":") || username.includes("@")) {
+    fail("Iggy username contains an unsupported connection delimiter");
+  }
+  if (password.includes(":") || password.includes("@")) {
+    fail("Iggy password contains an unsupported connection delimiter");
+  }
+  if ((username.length === 0) !== (password.length === 0)) {
+    fail("Iggy username and password must both be set or both be empty");
+  }
+}
+
+function reviewedArtifact(value, field) {
+  const artifact = oneLine(value, field, 256);
+  if (
+    artifact.includes("://") ||
+    artifact.includes("@") ||
+    /^\[[0-9a-fA-F:]+\]:\d+$/u.test(artifact) ||
+    /^[A-Za-z0-9._-]+:\d+$/u.test(artifact)
+  ) {
+    fail(`${field} must be a version, digest, or operator-reviewed artifact label, not an endpoint`);
+  }
+  return artifact;
+}
+
+function externalConfigPath(value, field) {
+  const supplied = oneLine(value, field, 4096);
+  if (!isAbsolute(supplied)) fail(`${field} must be an absolute path outside the repository`);
+  const absolutePath = resolve(supplied);
+  const root = resolve(repoRoot);
+  const prefix = `${root}${sep}`;
+  if (absolutePath === root || absolutePath.startsWith(prefix)) {
+    fail(`${field} must point outside the repository`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${field} must point to an existing external configuration file`);
+  }
+  return absolutePath;
+}
+
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote !== null && character === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && (character === '"' || character === "'")) {
+      quote = character;
+      continue;
+    }
+    if (quote === null && character === "#") return line.slice(0, index);
+  }
+  return line;
+}
+
+function parseTomlString(value, field) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return oneLine(JSON.parse(value), field, 128);
+    } catch {
+      fail(`${field} contains an invalid quoted TOML string`);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return oneLine(value.slice(1, -1), field, 128);
+  }
+  return oneLine(value, field, 128);
+}
+
+function durationMilliseconds(value, field) {
+  const match = /^(\d+)(ms|s|m|h|d)$/u.exec(value);
+  if (!match) fail(`${field} must be a positive duration such as 500ms, 10s, 5m, 1h, or 1d`);
+  const multipliers = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+  const milliseconds = Number(match[1]) * multipliers[match[2]];
+  if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
+    fail(`${field} is outside the retained duration boundary`);
+  }
+  return milliseconds;
+}
+
+function parseDedupConfiguration(absolutePath, field) {
+  const lines = readFileSync(absolutePath, "utf8").split(/\r?\n/u);
+  let inSection = false;
+  let sectionFound = false;
+  const values = new Map();
+
+  for (const rawLine of lines) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      if (inSection) break;
+      inSection = section[1].trim() === "system.message_deduplication";
+      sectionFound ||= inSection;
+      continue;
+    }
+    if (!inSection) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) fail(`${field} contains an invalid message_deduplication assignment`);
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!["enabled", "max_entries", "expiry"].includes(key)) continue;
+    if (values.has(key)) fail(`${field} contains duplicate key: ${key}`);
+    values.set(key, value);
+  }
+
+  if (!sectionFound) fail(`${field} is missing [system.message_deduplication]`);
+  const enabledRaw = values.get("enabled");
+  if (enabledRaw !== "true" && enabledRaw !== "false") {
+    fail(`${field} must set message_deduplication.enabled to true or false`);
+  }
+  const enabled = enabledRaw === "true";
+
+  let maxEntries = null;
+  if (values.has("max_entries")) {
+    const raw = values.get("max_entries");
+    if (!/^\d+$/u.test(raw)) fail(`${field} max_entries must be an integer`);
+    maxEntries = Number(raw);
+    if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+      fail(`${field} max_entries must be positive`);
+    }
+  }
+
+  let expiry = null;
+  let expiryMilliseconds = null;
+  if (values.has("expiry")) {
+    expiry = parseTomlString(values.get("expiry"), `${field} expiry`);
+    expiryMilliseconds = durationMilliseconds(expiry, `${field} expiry`);
+  }
+
+  return {
+    section: "system.message_deduplication",
+    enabled,
+    max_entries: maxEntries,
+    expiry,
+    expiry_milliseconds: expiryMilliseconds,
+  };
+}
+
+function validateScenarioConfiguration(scenario, configuration) {
+  if (configuration.enabled !== scenario.expected_configuration.enabled) {
+    fail(`${scenario.case} reviewed configuration has an unexpected enabled value`);
+  }
+  if (scenario.expected_configuration.max_entries === "at_least_1") {
+    if (configuration.max_entries === null || configuration.max_entries < 1) {
+      fail(`${scenario.case} requires reviewed max_entries >= 1`);
+    }
+  }
+  if (scenario.expected_configuration.expiry === "longer_than_lease_reclaim_wait") {
+    if (
+      configuration.expiry_milliseconds === null ||
+      configuration.expiry_milliseconds <= contract.lease_reclaim_wait_milliseconds
+    ) {
+      fail(`${scenario.case} reviewed expiry must exceed the 1500 ms recovery wait`);
+    }
+  }
+  const canonical = {
+    section: configuration.section,
+    enabled: configuration.enabled,
+    max_entries: configuration.max_entries,
+    expiry: configuration.expiry,
+    expiry_milliseconds: configuration.expiry_milliseconds,
+  };
+  return {
+    ...canonical,
+    canonical_sha256: sha256(JSON.stringify(canonical)),
+  };
+}
+
+function scenarioCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function requirePassedCase(output, caseName) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail(`publish/mark ambiguity case did not execute exactly one test: ${caseName}`);
+  }
+  const marker = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(caseName)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!marker.test(output)) fail(`publish/mark ambiguity case did not report success: ${caseName}`);
+  if (/skipping Social Graph publish\/mark ambiguity evidence/iu.test(output)) {
+    fail(`publish/mark ambiguity case reported a skip: ${caseName}`);
+  }
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) fail("working tree must be clean before retained execution");
+  const commit = oneLine(runChecked("git", ["rev-parse", "HEAD"]).stdout, "git_commit");
+  if (!/^[0-9a-f]{40}$/u.test(commit)) fail("git commit must be a full lowercase SHA-1");
+  return commit;
+}
+
+function ensureOutputInsideRepository() {
+  const root = `${resolve(repoRoot)}${sep}`;
+  if (!outputPath.startsWith(root)) fail("retained evidence output must stay inside repository");
+}
+
+function writeAtomically(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+try {
+  ensureOutputInsideRepository();
+  validateContract();
+  validateDatabaseUrl();
+  validateCredentialsPair();
+
+  const postgresArtifact = reviewedArtifact(
+    process.env[contract.postgres_artifact_environment] ?? "",
+    contract.postgres_artifact_environment,
+  );
+  const addresses = new Set();
+  const configPaths = new Set();
+  const reviewedScenarios = contract.scenarios.map((scenario) => {
+    const address = validateAddress(process.env[scenario.address_env] ?? "", scenario.address_env);
+    if (addresses.has(address)) fail("ambiguity execution requires two distinct broker addresses");
+    addresses.add(address);
+
+    const configPath = externalConfigPath(
+      process.env[scenario.config_path_env] ?? "",
+      scenario.config_path_env,
+    );
+    if (configPaths.has(configPath)) {
+      fail("ambiguity execution requires two distinct reviewed config files");
+    }
+    configPaths.add(configPath);
+
+    const serverArtifact = reviewedArtifact(
+      process.env[scenario.server_artifact_env] ?? "",
+      scenario.server_artifact_env,
+    );
+    const reviewedConfiguration = validateScenarioConfiguration(
+      scenario,
+      parseDedupConfiguration(configPath, scenario.config_path_env),
+    );
+    return { scenario, serverArtifact, reviewedConfiguration };
+  });
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const startedAt = new Date().toISOString();
+  const executedScenarios = [];
+  const combinedOutputs = [];
+
+  for (const reviewed of reviewedScenarios) {
+    const command = scenarioCommand(reviewed.scenario.case);
+    const result = runChecked(command.program, command.args);
+    const output = `${result.stdout}\n${result.stderr}`;
+    requirePassedCase(output, reviewed.scenario.case);
+    combinedOutputs.push(`--- ${reviewed.scenario.case} ---\n${output}`);
+    executedScenarios.push({
+      case: reviewed.scenario.case,
+      result: "pass",
+      address_source_env: reviewed.scenario.address_env,
+      configuration_source_env: reviewed.scenario.config_path_env,
+      server_artifact_source_env: reviewed.scenario.server_artifact_env,
+      server_artifact: reviewed.serverArtifact,
+      reviewed_configuration: reviewed.reviewedConfiguration,
+      expected_partition_message_counts: reviewed.scenario.expected_partition_message_counts,
+      command,
+      test_output_sha256: sha256(output),
+      test_output_bytes: Buffer.byteLength(output),
+    });
+  }
+
+  const finalCommit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+  );
+  if (finalCommit !== gitCommit) fail("git commit changed during retained execution");
+  const finalSourceSha256 = sourceHashes();
+  if (!sameValue(finalSourceSha256, initialSourceSha256)) {
+    fail("publish/mark ambiguity source files changed during retained execution");
+  }
+  if (workingTreeStatus().trim()) fail("working tree changed during retained execution");
+
+  const completedAt = new Date().toISOString();
+  const combinedOutput = combinedOutputs.join("\n");
+  writeAtomically({
+    schema_version: 1,
+    module: contract.module,
+    packet: "index-raw-poison-publish-mark-ambiguity-runtime-evidence",
+    status: "postgres_iggy_ambiguity_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    lease_reclaim_wait_milliseconds: contract.lease_reclaim_wait_milliseconds,
+    environment_sources: {
+      database_url: contract.database_environment,
+      postgresql_artifact: contract.postgres_artifact_environment,
+    },
+    reviewed_artifacts: {
+      postgresql: postgresArtifact,
+    },
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    source_sha256: finalSourceSha256,
+    combined_test_output_sha256: sha256(combinedOutput),
+    combined_test_output_bytes: Buffer.byteLength(combinedOutput),
+    executed_scenarios: executedScenarios,
+  });
+  console.log(`Retained publish/mark ambiguity evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`Publish/mark ambiguity evidence capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
+++ b/scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
@@ -72,16 +72,16 @@ function runChecked(program, args, env = process.env) {
 }
 
 function oneLine(value, field, maximumLength = 256) {
-  const normalized = value.trim();
   if (
-    normalized.length === 0 ||
-    normalized.length > maximumLength ||
-    /[\r\n]/u.test(normalized) ||
-    /[\u0000-\u001f\u007f]/u.test(normalized)
+    value.trim() !== value ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    /[\r\n]/u.test(value) ||
+    /[\u0000-\u001f\u007f]/u.test(value)
   ) {
-    fail(`${field} is missing, multiline, or outside the retained evidence boundary`);
+    fail(`${field} is missing, padded, multiline, or outside the retained evidence boundary`);
   }
-  return normalized;
+  return value;
 }
 
 function sha256(value) {
@@ -139,8 +139,11 @@ function validateContract() {
 }
 
 function validateDatabaseUrl() {
-  const value = process.env[contract.database_environment];
-  if (!value) fail(`${contract.database_environment} is required`);
+  const value = oneLine(
+    process.env[contract.database_environment] ?? "",
+    contract.database_environment,
+    4096,
+  );
   let parsed;
   try {
     parsed = new URL(value);
@@ -397,7 +400,7 @@ function workingTreeStatus() {
 
 function ensureCleanCommit() {
   if (workingTreeStatus().trim()) fail("working tree must be clean before retained execution");
-  const commit = oneLine(runChecked("git", ["rev-parse", "HEAD"]).stdout, "git_commit");
+  const commit = oneLine(runChecked("git", ["rev-parse", "HEAD"]).stdout.trim(), "git_commit");
   if (!/^[0-9a-f]{40}$/u.test(commit)) fail("git commit must be a full lowercase SHA-1");
   return commit;
 }
@@ -455,8 +458,8 @@ try {
 
   const gitCommit = ensureCleanCommit();
   const initialSourceSha256 = sourceHashes();
-  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
-  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout.trim(), "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout.trim(), "rustc_version");
   const startedAt = new Date().toISOString();
   const executedScenarios = [];
   const combinedOutputs = [];
@@ -483,7 +486,7 @@ try {
   }
 
   const finalCommit = oneLine(
-    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    runChecked("git", ["rev-parse", "HEAD"]).stdout.trim(),
     "final_git_commit",
   );
   if (finalCommit !== gitCommit) fail("git commit changed during retained execution");

--- a/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
@@ -193,7 +193,9 @@ if (
 
 for (const marker of [
   "function oneLine(value, field, maximumLength = 256)",
-  "/[\\r\\n]/u.test(normalized)",
+  "value.trim() !== value",
+  "/[\\r\\n]/u.test(value)",
+  "process.env[contract.database_environment] ??",
   "validateDatabaseUrl();",
   "validateCredentialsPair();",
   "validateAddress(process.env[scenario.address_env]",

--- a/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
+++ b/scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution-contract.json";
+const sourceContractPath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-source.json";
+const runnerPath =
+  "scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs";
+const evidencePath =
+  "crates/rustok-social-graph/contracts/evidence/index-raw-poison-publish-mark-ambiguity-execution.json";
+const expectedVerifier =
+  "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs";
+const expectedCases = [
+  "dedup_enabled_closes_publish_mark_ambiguity_without_physical_duplicate",
+  "dedup_disabled_exposes_publish_mark_ambiguity_as_physical_duplicate",
+];
+const expectedCommandTemplate = {
+  program: "cargo",
+  args_before_case: [
+    "test",
+    "-p",
+    "rustok-social-graph",
+    "--features",
+    "index-consumer",
+    "--test",
+    "index_raw_poison_publish_mark_ambiguity",
+    "--",
+  ],
+  args_after_case: ["--exact", "--nocapture", "--test-threads=1"],
+};
+const expectedTopLevelKeys = [
+  "schema_version",
+  "module",
+  "packet",
+  "status",
+  "generated_from",
+  "runner",
+  "verifier",
+  "git_commit",
+  "working_tree_clean_before_run",
+  "started_at",
+  "completed_at",
+  "lease_reclaim_wait_milliseconds",
+  "environment_sources",
+  "reviewed_artifacts",
+  "toolchain",
+  "source_sha256",
+  "combined_test_output_sha256",
+  "combined_test_output_bytes",
+  "executed_scenarios",
+].sort();
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const sourceContract = JSON.parse(
+  readFileSync(resolve(repoRoot, sourceContractPath), "utf8"),
+);
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function currentSourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fail("could not read current git commit");
+    return null;
+  }
+  const commit = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("current git commit is not a full lowercase SHA-1");
+    return null;
+  }
+  return commit;
+}
+
+function expectedCommand(caseName) {
+  return {
+    program: expectedCommandTemplate.program,
+    args: [
+      ...expectedCommandTemplate.args_before_case,
+      caseName,
+      ...expectedCommandTemplate.args_after_case,
+    ],
+  };
+}
+
+function validSha256(value, field) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${field} is not a lowercase SHA-256`);
+  }
+}
+
+function validTimestamp(value, field) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${field} is not a valid timestamp`);
+  }
+}
+
+function boundedArtifact(value, field) {
+  if (
+    typeof value !== "string" ||
+    value.trim() !== value ||
+    value.length === 0 ||
+    value.length > 256 ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value) ||
+    value.includes("://") ||
+    value.includes("@") ||
+    /^\[[0-9a-fA-F:]+\]:\d+$/u.test(value) ||
+    /^[A-Za-z0-9._-]+:\d+$/u.test(value)
+  ) {
+    fail(`${field} is not a bounded reviewed artifact label`);
+  }
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectKeys(entry, keys);
+    return keys;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(entry, keys);
+    }
+  }
+  return keys;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "social-graph" ||
+  contract.packet !== "index-raw-poison-publish-mark-ambiguity-execution-contract" ||
+  contract.status !== "runtime_execution_contract_locked" ||
+  contract.source_contract !== sourceContractPath ||
+  contract.runner !== runnerPath ||
+  contract.verifier !== expectedVerifier ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== "runtime_execution_pending"
+) {
+  fail("publish/mark ambiguity execution contract identity or path drift");
+}
+if (!sameValue(contract.command_template, expectedCommandTemplate)) {
+  fail("publish/mark ambiguity command template drift");
+}
+if (!sameValue(contract.scenarios?.map((scenario) => scenario.case), expectedCases)) {
+  fail("publish/mark ambiguity exact case order drift");
+}
+if (contract.lease_reclaim_wait_milliseconds !== 1500) {
+  fail("publish/mark ambiguity lease reclaim wait drift");
+}
+if (
+  sourceContract.status !== "source_complete_runtime_pending" ||
+  sourceContract.execution_status !== "not_run" ||
+  sourceContract.verifier !==
+    "scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs"
+) {
+  fail("publish/mark ambiguity source contract must remain source-complete and unexecuted");
+}
+
+for (const marker of [
+  "function oneLine(value, field, maximumLength = 256)",
+  "/[\\r\\n]/u.test(normalized)",
+  "validateDatabaseUrl();",
+  "validateCredentialsPair();",
+  "validateAddress(process.env[scenario.address_env]",
+  "externalConfigPath(",
+  "must point outside the repository",
+  "reviewedArtifact(",
+  "system.message_deduplication",
+  "configuration.expiry_milliseconds <= contract.lease_reclaim_wait_milliseconds",
+  "ambiguity execution requires two distinct broker addresses",
+  "ambiguity execution requires two distinct reviewed config files",
+  "ensureCleanCommit()",
+  "sourceHashes()",
+  '"--exact"',
+  "running 1 test",
+  "reported a skip",
+  "finalCommit !== gitCommit",
+  "workingTreeStatus().trim()",
+  "writeAtomically({",
+  "environment_sources",
+  "reviewed_artifacts",
+  "combined_test_output_sha256",
+  "executed_scenarios",
+]) {
+  requireText("publish/mark ambiguity retained runner", runner, marker);
+}
+
+if (failures.length === 0 && !existsSync(resolve(repoRoot, evidencePath))) {
+  console.log(
+    "Social Graph publish/mark ambiguity retained evidence verified: execution contract, reviewed dedup configuration gates, strict one-line metadata, clean-commit runner, exact-case execution, current source hashing, privacy projection, and runtime-pending status are locked; canonical execution JSON is absent.",
+  );
+  process.exit(0);
+}
+
+if (existsSync(resolve(repoRoot, evidencePath))) {
+  let evidence;
+  try {
+    evidence = JSON.parse(readFileSync(resolve(repoRoot, evidencePath), "utf8"));
+  } catch {
+    fail("publish/mark ambiguity execution packet is not valid JSON");
+  }
+
+  if (evidence) {
+    if (!sameValue(Object.keys(evidence).sort(), expectedTopLevelKeys)) {
+      fail("publish/mark ambiguity execution packet top-level keys drifted");
+    }
+    if (
+      evidence.schema_version !== 1 ||
+      evidence.module !== "social-graph" ||
+      evidence.packet !== "index-raw-poison-publish-mark-ambiguity-runtime-evidence" ||
+      evidence.status !== "postgres_iggy_ambiguity_runtime_executed" ||
+      evidence.generated_from !== contractPath ||
+      evidence.runner !== runnerPath ||
+      evidence.verifier !== expectedVerifier ||
+      evidence.working_tree_clean_before_run !== true ||
+      evidence.lease_reclaim_wait_milliseconds !== 1500
+    ) {
+      fail("publish/mark ambiguity execution packet identity or provenance drift");
+    }
+
+    const commit = currentCommit();
+    if (commit && evidence.git_commit !== commit) {
+      fail("publish/mark ambiguity execution packet was generated from another commit");
+    }
+    validTimestamp(evidence.started_at, "started_at");
+    validTimestamp(evidence.completed_at, "completed_at");
+    if (
+      typeof evidence.started_at === "string" &&
+      typeof evidence.completed_at === "string" &&
+      Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)
+    ) {
+      fail("publish/mark ambiguity completion precedes start");
+    }
+
+    if (
+      !sameValue(evidence.environment_sources, {
+        database_url: "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_TEST_DATABASE_URL",
+        postgresql_artifact:
+          "RUSTOK_SOCIAL_GRAPH_INDEX_POISON_AMBIGUITY_POSTGRES_ARTIFACT",
+      })
+    ) {
+      fail("publish/mark ambiguity environment source metadata drift");
+    }
+    if (!sameValue(Object.keys(evidence.reviewed_artifacts ?? {}), ["postgresql"])) {
+      fail("publish/mark ambiguity reviewed artifact keys drift");
+    }
+    boundedArtifact(evidence.reviewed_artifacts?.postgresql, "reviewed PostgreSQL artifact");
+    boundedArtifact(evidence.toolchain?.cargo, "cargo toolchain");
+    boundedArtifact(evidence.toolchain?.rustc, "rustc toolchain");
+
+    const hashes = currentSourceHashes();
+    if (!sameValue(evidence.source_sha256, hashes)) {
+      fail("publish/mark ambiguity execution source hashes are stale");
+    }
+    for (const [path, digest] of Object.entries(evidence.source_sha256 ?? {})) {
+      validSha256(digest, `source hash ${path}`);
+    }
+    validSha256(evidence.combined_test_output_sha256, "combined test output hash");
+    if (
+      !Number.isSafeInteger(evidence.combined_test_output_bytes) ||
+      evidence.combined_test_output_bytes <= 0
+    ) {
+      fail("publish/mark ambiguity combined output byte count is invalid");
+    }
+
+    if (
+      !Array.isArray(evidence.executed_scenarios) ||
+      evidence.executed_scenarios.length !== 2
+    ) {
+      fail("publish/mark ambiguity execution must retain exactly two scenarios");
+    } else {
+      for (let index = 0; index < expectedCases.length; index += 1) {
+        const retained = evidence.executed_scenarios[index];
+        const required = contract.scenarios[index];
+        if (
+          retained.case !== expectedCases[index] ||
+          retained.result !== "pass" ||
+          retained.address_source_env !== required.address_env ||
+          retained.configuration_source_env !== required.config_path_env ||
+          retained.server_artifact_source_env !== required.server_artifact_env ||
+          !sameValue(
+            retained.expected_partition_message_counts,
+            required.expected_partition_message_counts,
+          ) ||
+          !sameValue(retained.command, expectedCommand(expectedCases[index]))
+        ) {
+          fail(`publish/mark ambiguity retained scenario drift: ${expectedCases[index]}`);
+        }
+
+        boundedArtifact(retained.server_artifact, `${expectedCases[index]} server artifact`);
+        const reviewed = retained.reviewed_configuration;
+        if (
+          !sameValue(Object.keys(reviewed ?? {}).sort(), [
+            "canonical_sha256",
+            "enabled",
+            "expiry",
+            "expiry_milliseconds",
+            "max_entries",
+            "section",
+          ]) ||
+          reviewed.section !== "system.message_deduplication"
+        ) {
+          fail(`${expectedCases[index]} reviewed configuration shape drift`);
+        } else {
+          const canonical = {
+            section: reviewed.section,
+            enabled: reviewed.enabled,
+            max_entries: reviewed.max_entries,
+            expiry: reviewed.expiry,
+            expiry_milliseconds: reviewed.expiry_milliseconds,
+          };
+          validSha256(reviewed.canonical_sha256, `${expectedCases[index]} config hash`);
+          if (reviewed.canonical_sha256 !== sha256(JSON.stringify(canonical))) {
+            fail(`${expectedCases[index]} canonical configuration digest mismatch`);
+          }
+          if (index === 0) {
+            if (
+              reviewed.enabled !== true ||
+              !Number.isSafeInteger(reviewed.max_entries) ||
+              reviewed.max_entries < 1 ||
+              !Number.isSafeInteger(reviewed.expiry_milliseconds) ||
+              reviewed.expiry_milliseconds <= 1500
+            ) {
+              fail("dedup-enabled reviewed configuration does not cover the recovery wait");
+            }
+          } else if (reviewed.enabled !== false) {
+            fail("dedup-disabled reviewed configuration must retain enabled=false");
+          }
+        }
+
+        validSha256(retained.test_output_sha256, `${expectedCases[index]} output hash`);
+        if (!Number.isSafeInteger(retained.test_output_bytes) || retained.test_output_bytes <= 0) {
+          fail(`${expectedCases[index]} output byte count is invalid`);
+        }
+      }
+    }
+
+    const forbiddenKeys = new Set([
+      "database_url_value",
+      "broker_address",
+      "address",
+      "config_path",
+      "username",
+      "password",
+      "connection_string",
+      "full_config_content",
+      "full_config_sha256",
+      "raw_test_output",
+      "payload",
+      "source_offset",
+      "delivery_uuid",
+      "ack_token",
+      "schema_name",
+      "stream_name",
+    ]);
+    for (const key of collectKeys(evidence)) {
+      if (forbiddenKeys.has(key)) {
+        fail(`publish/mark ambiguity packet contains forbidden key: ${key}`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Social Graph publish/mark ambiguity retained verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Social Graph publish/mark ambiguity retained evidence verified: current commit/source hashes, reviewed PostgreSQL and Iggy artifacts, enabled expiry coverage, disabled duplicate behavior, two exact all-pass cases, bounded output digests, and privacy-safe packet projection are locked.",
+);


### PR DESCRIPTION
## Summary

Add a fail-closed retained-execution path for the Social Graph raw-poison publish/mark ambiguity harness merged in #2379.

## Execution contract

The versioned contract locks:

- the two exact ambiguity cases and physical DLQ count sequences;
- the Cargo command template with per-case `--exact` execution;
- one PostgreSQL service input and reviewed artifact label;
- two distinct external-Iggy addresses and two distinct reviewed config files outside the repository;
- separately reviewed enabled/disabled Iggy server artifact labels;
- current production, test, contract, runner, and verifier source hashes;
- the canonical packet path and privacy boundary.

## Reviewed Iggy configuration

The runner extracts only `[system.message_deduplication]`.

The enabled scenario requires:

- `enabled = true`;
- `max_entries >= 1`;
- positive expiry strictly longer than the 1500 ms lease-recovery wait;
- expected physical counts `0 -> 1 -> 1`.

The disabled scenario requires:

- `enabled = false`;
- expected physical counts `0 -> 1 -> 2`.

Only the canonical non-secret values and their SHA-256 are retained. Config paths, full contents, unrelated settings, and full-file hashes are excluded.

## Capture runner

The clean-commit runner:

- rejects padded, multiline, or control-character metadata;
- validates a PostgreSQL URL without retaining it;
- validates two distinct bounded `host:port` Iggy addresses;
- validates paired optional credentials without retaining them;
- requires absolute existing config files outside the repository;
- rejects endpoint-shaped service artifact labels;
- captures full commit SHA, Cargo/Rust versions, and current source SHA-256 values;
- runs each exact test separately;
- requires `running 1 test`, exact `<case> ... ok`, and no skip marker;
- rechecks commit, sources, and working-tree cleanliness;
- writes the canonical JSON atomically only after both cases pass.

## Retained verifier

Pending mode validates the contract, source-contract state, runner gates, strict metadata boundary, reviewed-config constraints, exact commands, source hashing, atomic output, and privacy projection while the execution JSON is absent.

Executed mode additionally requires:

- packet commit equal to current `HEAD`;
- exact top-level packet shape;
- current source hashes;
- two scenarios in contract order, both `pass`;
- exact commands and physical count sequences;
- enabled expiry/capacity coverage and disabled `enabled=false`;
- recomputed canonical config digests;
- bounded service/toolchain metadata;
- valid per-case/combined output hashes and byte counts;
- no endpoint, config-path, credential, raw-log, payload, offset, UUID, token, schema, or stream keys.

## Privacy

The packet retains only environment-variable names, reviewed artifact labels, canonical dedup values/digests, commit/toolchain/timestamps, exact commands, source/output hashes, output sizes, count expectations, and aggregate pass results.

It omits database URLs, broker addresses, config paths, usernames, passwords, connection strings, full configs, raw logs, payloads, source offsets, delivery UUIDs, acknowledgement tokens, schema names, and stream names.

`index-raw-poison-publish-mark-ambiguity-execution.json` is intentionally absent until a maintainer executes both scenarios successfully from a clean commit.

## Non-claims

This tooling does not claim a PostgreSQL/Iggy transaction, physical exactly-once without deduplication, production dedup-window sufficiency beyond the reviewed isolated configuration, active server configuration readback, bundled mode, TLS/auth/failover, multi-replica ownership, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, retained verifiers, PostgreSQL, external/bundled Iggy, and capture were not run, per maintainer instruction.

Suggested maintainer flow:

```bash
node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs

node scripts/evidence/capture-social-graph-index-raw-poison-publish-mark-ambiguity.mjs
node scripts/verify/verify-social-graph-index-raw-poison-publish-mark-ambiguity-retained.mjs
```
