### PR TITLE
feat(profiles): inspect physical DLQ duplicates safely

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-inspection-source",
+  "status": "source_complete_runtime_adapter_pending",
+  "owner": "rustok-iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "public_exports": [
+    "DlqDuplicateObservation",
+    "DlqDuplicateSummary",
+    "DlqDuplicateInspectionError",
+    "summarize_dlq_duplicates"
+  ],
+  "identity": {
+    "input": "non_nil_deterministic_iggy_message_header_uuid",
+    "payload_comparison": "domain_separated_sha256_in_memory_only",
+    "empty_payload_valid": true,
+    "nil_uuid_rejected": true
+  },
+  "summary_fields": [
+    "total_messages",
+    "unique_message_ids",
+    "duplicate_messages",
+    "duplicate_groups",
+    "conflicting_payload_groups",
+    "max_copies_per_message_id"
+  ],
+  "semantics": {
+    "duplicate_message_formula": "total_messages_minus_unique_message_ids",
+    "ordinary_duplicate": "same_non_nil_message_id_and_same_exact_payload_digest",
+    "identity_conflict": "same_non_nil_message_id_with_more_than_one_exact_payload_digest",
+    "manual_review_required_for_identity_conflict": true,
+    "empty_scan_returns_zero_summary": true
+  },
+  "privacy_boundary": {
+    "summary_excludes": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "error_code",
+      "publisher_identity",
+      "timestamp",
+      "credential"
+    ],
+    "observation_exposes_digest": false,
+    "summary_exposes_identifiers": false
+  },
+  "mutation_boundary": {
+    "acknowledge": false,
+    "delete": false,
+    "replay": false,
+    "repair": false,
+    "claim_receipt": false,
+    "release_receipt": false,
+    "mark_receipt": false,
+    "choose_operator_policy": false
+  },
+  "stable_errors": {
+    "invalid_broker_message_id": "iggy.dlq_duplicate.identity_invalid",
+    "count_overflow": "iggy.dlq_duplicate.count_overflow"
+  },
+  "required_source_tests": [
+    "repeated_id_and_exact_bytes_are_counted_as_physical_duplicates",
+    "one_id_with_distinct_exact_bytes_requires_manual_review",
+    "empty_scan_and_empty_payload_are_valid",
+    "nil_message_id_is_rejected_with_stable_code"
+  ],
+  "production_relationship": {
+    "raw_poison_delivery_id": "ConsumedContractDecodeFailure::delivery_id",
+    "dlq_broker_message_id": "ConsumedContractDecodeFailure::to_dlq_entry",
+    "physical_publisher": "IggyTransport::move_to_dlq",
+    "receipt_summary": "ConsumerPoisonReceiptInspector",
+    "receipt_and_physical_duplicate_summaries_are_independent": true
+  },
+  "remaining_work": [
+    "bounded_read_only_iggy_dlq_scan_adapter",
+    "retained_external_iggy_duplicate_scan_evidence",
+    "operator_alert_threshold_policy",
+    "operator_ack_delete_replay_workflow_outside_inspector",
+    "correlation_with_count_only_receipt_health_without_identifier_export"
+  ],
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-inspection.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md",
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,0 +1,174 @@
+# Count-only physical DLQ duplicate inspection
+
+Status: **transport-neutral source complete; bounded external-Iggy scan adapter pending**.
+
+## Purpose
+
+The neutral poison receipt store answers whether a source delivery is reserved, publishing, published, or acknowledged. It does not answer how many physical copies currently exist in the Iggy `dlq` topic.
+
+Physical copies can exceed one when:
+
+- server-side message-ID deduplication is disabled;
+- the deterministic ID expired from the dedup window;
+- capacity pressure evicted the ID;
+- a failover or unsupported broker path did not preserve the expected dedup state.
+
+`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations.
+
+## Input boundary
+
+Each observation accepts:
+
+```text
+non-nil deterministic Iggy message header UUID
+exact physical payload bytes
+```
+
+The exact bytes are immediately reduced to a domain-separated SHA-256 value in memory. The observation exposes neither the bytes nor their digest. Empty payloads are valid because empty raw poison bytes are already valid at the receipt boundary.
+
+A nil UUID fails closed with:
+
+```text
+iggy.dlq_duplicate.identity_invalid
+```
+
+## Count-only result
+
+`DlqDuplicateSummary` exposes only:
+
+```text
+total_messages
+unique_message_ids
+duplicate_messages
+duplicate_groups
+conflicting_payload_groups
+max_copies_per_message_id
+```
+
+Where:
+
+```text
+duplicate_messages = total_messages - unique_message_ids
+```
+
+A duplicate group has more than one physical observation for the same deterministic message ID.
+
+## Ordinary duplicate versus identity conflict
+
+### Ordinary physical duplicate
+
+```text
+same non-nil message header UUID
+same exact payload digest
+```
+
+This is the expected shape of a publish/mark ambiguity retry when the broker accepts the same deterministic ID more than once.
+
+### Identity conflict
+
+```text
+same non-nil message header UUID
+different exact payload digests
+```
+
+This must not be silently collapsed into an ordinary duplicate. It indicates header corruption, an invalid producer, an unsupported reuse of the deterministic ID, or an extraordinary hash/identity failure.
+
+The summary increments `conflicting_payload_groups` and `requires_manual_review()` returns `true`.
+
+## Privacy boundary
+
+The summary does not expose:
+
+- broker address;
+- stream, topic, partition, or offset;
+- deterministic message UUID;
+- payload or payload digest;
+- receipt identity or state;
+- error classification;
+- publisher identity;
+- timestamps;
+- credentials.
+
+The classifier does not implement serialization. A future operator endpoint must preserve the same count-only projection unless a separately authorized forensic workflow is explicitly designed.
+
+## Mutation boundary
+
+The classifier cannot:
+
+- acknowledge a DLQ cursor;
+- delete a physical message;
+- replay or retry a message;
+- repair broker state;
+- claim or release a poison receipt;
+- mark a receipt published or acknowledged;
+- choose alert thresholds or operator policy.
+
+This separation is deliberate. Observation must not accidentally become destructive reconciliation.
+
+## Relationship to deterministic raw poison identity
+
+`ConsumedContractDecodeFailure::delivery_id` derives one UUID from immutable source stream/topic/partition/offset and exact raw bytes. Failure kind, retry count, process identity, time, and random values are excluded.
+
+`to_dlq_entry` attaches that UUID as the Iggy broker message ID. `IggyTransport::move_to_dlq` uses the deterministic publisher path when this ID is present.
+
+The duplicate classifier therefore groups physical Iggy messages by the same identity used for server-side deduplication.
+
+## Relationship to receipt health
+
+`ConsumerPoisonReceiptInspector` remains an independent count-only view of PostgreSQL receipt progress:
+
+```text
+reserved
+publishing
+expired_publishing
+published
+acknowledged
+```
+
+Neither summary contains identifiers, so they cannot be joined message-by-message. An operator may compare aggregate trends, for example:
+
+- rising `expired_publishing` with rising physical duplicates suggests lease recovery outside the effective dedup window;
+- zero receipt recovery work with growing duplicates suggests historic or downstream DLQ duplication;
+- `conflicting_payload_groups > 0` always requires direct forensic escalation.
+
+These are operator interpretations, not storage-layer decisions.
+
+## Safe operational sequence
+
+A future bounded external-Iggy adapter should:
+
+1. open a read-only scan cursor or metadata reader over an explicitly selected DLQ scope;
+2. enforce a maximum message count and bounded time window;
+3. extract only the physical header UUID and exact bytes into in-memory observations;
+4. call `summarize_dlq_duplicates`;
+5. publish only the count-only summary;
+6. close the observer without acknowledging, deleting, replaying, or moving messages.
+
+Any destructive action must be a separate, explicitly authorized workflow with its own preview, selection, audit, and retained evidence.
+
+## Source tests
+
+The focused unit cases define:
+
+- same ID and exact bytes counted as ordinary physical duplicates;
+- same ID and different bytes escalated as an identity conflict;
+- empty scan and empty payload behavior;
+- nil ID rejection and stable error code.
+
+Suggested maintainer commands:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+cargo test -p rustok-iggy dlq_duplicate_inspection -- --nocapture
+```
+
+No tests, Cargo commands, formatters, verifiers, or external-Iggy scans were run while defining this source slice.
+
+## Remaining work
+
+1. add a bounded read-only external-Iggy scan adapter;
+2. prove physical header extraction and count-only projection against a disposable broker;
+3. retain runtime evidence without identifiers, payloads, addresses, credentials, or raw logs;
+4. define alert thresholds outside the inspector;
+5. design any acknowledgement/delete/replay workflow as a separate authorized operation;
+6. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_inspection.rs
@@ -1,0 +1,250 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+const DLQ_PAYLOAD_DIGEST_DOMAIN: &[u8] = b"rustok.iggy.dlq.physical_payload.v1";
+
+/// One read-only physical DLQ observation reduced to a deterministic message ID
+/// and an in-memory payload digest.
+///
+/// Exact bytes are accepted only by the constructor and are not retained by the
+/// observation or exposed by the summary. Empty payloads remain valid. A nil
+/// broker message ID is rejected because it cannot identify an immutable raw
+/// poison delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DlqDuplicateObservation {
+    broker_message_id: Uuid,
+    payload_sha256: [u8; 32],
+}
+
+impl DlqDuplicateObservation {
+    pub fn from_payload(
+        broker_message_id: Uuid,
+        payload: &[u8],
+    ) -> Result<Self, DlqDuplicateInspectionError> {
+        if broker_message_id.is_nil() {
+            return Err(DlqDuplicateInspectionError::InvalidBrokerMessageId);
+        }
+        let mut hasher = Sha256::new();
+        hash_part(&mut hasher, DLQ_PAYLOAD_DIGEST_DOMAIN);
+        hash_part(&mut hasher, payload);
+        let digest = hasher.finalize();
+        let mut payload_sha256 = [0_u8; 32];
+        payload_sha256.copy_from_slice(&digest);
+        Ok(Self {
+            broker_message_id,
+            payload_sha256,
+        })
+    }
+}
+
+/// Count-only physical duplicate view for a bounded operator scan.
+///
+/// No broker address, stream/topic/partition/offset, message UUID, payload,
+/// payload digest, receipt identity, error code, timestamp, or credential is
+/// exposed. The summary cannot acknowledge, delete, replay, repair, or claim a
+/// delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DlqDuplicateSummary {
+    total_messages: u64,
+    unique_message_ids: u64,
+    duplicate_messages: u64,
+    duplicate_groups: u64,
+    conflicting_payload_groups: u64,
+    max_copies_per_message_id: u64,
+}
+
+impl DlqDuplicateSummary {
+    pub const fn total_messages(&self) -> u64 {
+        self.total_messages
+    }
+
+    pub const fn unique_message_ids(&self) -> u64 {
+        self.unique_message_ids
+    }
+
+    pub const fn duplicate_messages(&self) -> u64 {
+        self.duplicate_messages
+    }
+
+    pub const fn duplicate_groups(&self) -> u64 {
+        self.duplicate_groups
+    }
+
+    pub const fn conflicting_payload_groups(&self) -> u64 {
+        self.conflicting_payload_groups
+    }
+
+    pub const fn max_copies_per_message_id(&self) -> u64 {
+        self.max_copies_per_message_id
+    }
+
+    pub const fn has_physical_duplicates(&self) -> bool {
+        self.duplicate_messages > 0
+    }
+
+    pub const fn has_identity_conflicts(&self) -> bool {
+        self.conflicting_payload_groups > 0
+    }
+
+    /// Conflicting bytes for one deterministic ID are never treated as an
+    /// ordinary duplicate and always require manual investigation.
+    pub const fn requires_manual_review(&self) -> bool {
+        self.has_identity_conflicts()
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum DlqDuplicateInspectionError {
+    #[error("physical DLQ observation has a nil broker message ID")]
+    InvalidBrokerMessageId,
+    #[error("physical DLQ duplicate count overflow")]
+    CountOverflow,
+}
+
+impl DlqDuplicateInspectionError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidBrokerMessageId => "iggy.dlq_duplicate.identity_invalid",
+            Self::CountOverflow => "iggy.dlq_duplicate.count_overflow",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DuplicateGroup {
+    copies: u64,
+    payload_sha256: BTreeSet<[u8; 32]>,
+}
+
+/// Reduces physical DLQ observations to a privacy-safe duplicate summary.
+///
+/// Repeated observations with the same deterministic broker message ID and the
+/// same exact bytes are ordinary physical copies. Reuse of one ID with distinct
+/// bytes increments `conflicting_payload_groups` and must not be auto-reconciled.
+pub fn summarize_dlq_duplicates(
+    observations: impl IntoIterator<Item = DlqDuplicateObservation>,
+) -> Result<DlqDuplicateSummary, DlqDuplicateInspectionError> {
+    let mut groups = BTreeMap::<Uuid, DuplicateGroup>::new();
+    let mut total_messages = 0_u64;
+
+    for observation in observations {
+        total_messages = total_messages
+            .checked_add(1)
+            .ok_or(DlqDuplicateInspectionError::CountOverflow)?;
+        let group = groups.entry(observation.broker_message_id).or_default();
+        group.copies = group
+            .copies
+            .checked_add(1)
+            .ok_or(DlqDuplicateInspectionError::CountOverflow)?;
+        group.payload_sha256.insert(observation.payload_sha256);
+    }
+
+    let unique_message_ids =
+        u64::try_from(groups.len()).map_err(|_| DlqDuplicateInspectionError::CountOverflow)?;
+    let duplicate_messages = total_messages
+        .checked_sub(unique_message_ids)
+        .ok_or(DlqDuplicateInspectionError::CountOverflow)?;
+    let mut duplicate_groups = 0_u64;
+    let mut conflicting_payload_groups = 0_u64;
+    let mut max_copies_per_message_id = 0_u64;
+
+    for group in groups.values() {
+        max_copies_per_message_id = max_copies_per_message_id.max(group.copies);
+        if group.copies > 1 {
+            duplicate_groups = duplicate_groups
+                .checked_add(1)
+                .ok_or(DlqDuplicateInspectionError::CountOverflow)?;
+        }
+        if group.payload_sha256.len() > 1 {
+            conflicting_payload_groups = conflicting_payload_groups
+                .checked_add(1)
+                .ok_or(DlqDuplicateInspectionError::CountOverflow)?;
+        }
+    }
+
+    Ok(DlqDuplicateSummary {
+        total_messages,
+        unique_message_ids,
+        duplicate_messages,
+        duplicate_groups,
+        conflicting_payload_groups,
+        max_copies_per_message_id,
+    })
+}
+
+fn hash_part(hasher: &mut Sha256, bytes: &[u8]) {
+    let length = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    hasher.update(length.to_be_bytes());
+    hasher.update(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observation(id: u128, payload: &[u8]) -> DlqDuplicateObservation {
+        DlqDuplicateObservation::from_payload(Uuid::from_u128(id), payload).unwrap()
+    }
+
+    #[test]
+    fn repeated_id_and_exact_bytes_are_counted_as_physical_duplicates() {
+        let summary = summarize_dlq_duplicates([
+            observation(1, &[1, 2, 3]),
+            observation(1, &[1, 2, 3]),
+            observation(2, &[4]),
+        ])
+        .unwrap();
+
+        assert_eq!(summary.total_messages(), 3);
+        assert_eq!(summary.unique_message_ids(), 2);
+        assert_eq!(summary.duplicate_messages(), 1);
+        assert_eq!(summary.duplicate_groups(), 1);
+        assert_eq!(summary.conflicting_payload_groups(), 0);
+        assert_eq!(summary.max_copies_per_message_id(), 2);
+        assert!(summary.has_physical_duplicates());
+        assert!(!summary.has_identity_conflicts());
+        assert!(!summary.requires_manual_review());
+    }
+
+    #[test]
+    fn one_id_with_distinct_exact_bytes_requires_manual_review() {
+        let summary = summarize_dlq_duplicates([
+            observation(7, &[1, 2, 3]),
+            observation(7, &[1, 2, 4]),
+        ])
+        .unwrap();
+
+        assert_eq!(summary.total_messages(), 2);
+        assert_eq!(summary.unique_message_ids(), 1);
+        assert_eq!(summary.duplicate_messages(), 1);
+        assert_eq!(summary.duplicate_groups(), 1);
+        assert_eq!(summary.conflicting_payload_groups(), 1);
+        assert!(summary.has_identity_conflicts());
+        assert!(summary.requires_manual_review());
+    }
+
+    #[test]
+    fn empty_scan_and_empty_payload_are_valid() {
+        let empty = summarize_dlq_duplicates([]).unwrap();
+        assert_eq!(empty, DlqDuplicateSummary::default());
+
+        let one = summarize_dlq_duplicates([observation(9, &[])]).unwrap();
+        assert_eq!(one.total_messages(), 1);
+        assert_eq!(one.unique_message_ids(), 1);
+        assert_eq!(one.duplicate_messages(), 0);
+        assert_eq!(one.max_copies_per_message_id(), 1);
+    }
+
+    #[test]
+    fn nil_message_id_is_rejected_with_stable_code() {
+        let error = DlqDuplicateObservation::from_payload(Uuid::nil(), &[1]).unwrap_err();
+        assert_eq!(
+            error,
+            DlqDuplicateInspectionError::InvalidBrokerMessageId
+        );
+        assert_eq!(error.stable_code(), "iggy.dlq_duplicate.identity_invalid");
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -62,6 +62,7 @@ pub mod consumer;
 pub mod contract_consumer;
 pub mod contract_decode_failure;
 pub mod dlq;
+pub mod dlq_duplicate_inspection;
 #[cfg(feature = "iggy")]
 mod dlq_publisher;
 pub mod health;
@@ -85,6 +86,10 @@ pub use contract_decode_failure::{
     ConsumedContractDecodeFailure, ContractDecodeFailureKind,
 };
 pub use dlq::{DlqEntry, DlqManager};
+pub use dlq_duplicate_inspection::{
+    DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
+    summarize_dlq_duplicates,
+};
 pub use health::{HealthCheckResult, HealthStatus, health_check};
 pub use partitioning::{calculate_partition, partition_key};
 #[cfg(feature = "iggy")]

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,0 +1,112 @@
+# Profiles checkpoint: physical DLQ duplicate operations
+
+Status: **count-only classifier source-complete; external observer pending**.
+
+## Why this matters for Profiles
+
+Profiles authorization remains independent of broker and receipt state. However, downstream processing of relationship facts must not hide the difference between:
+
+- one durable neutral result with one physical DLQ copy;
+- one durable neutral result with repeated identical physical copies;
+- one deterministic DLQ ID associated with conflicting exact bytes.
+
+The new Iggy-owned classifier makes that difference visible without exposing message identities or payloads.
+
+## New owner boundary
+
+Source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+```
+
+Public API:
+
+```text
+DlqDuplicateObservation
+DlqDuplicateSummary
+DlqDuplicateInspectionError
+summarize_dlq_duplicates
+```
+
+## Count-only projection
+
+The summary exposes only:
+
+```text
+total_messages
+unique_message_ids
+duplicate_messages
+duplicate_groups
+conflicting_payload_groups
+max_copies_per_message_id
+```
+
+It excludes broker endpoints, stream coordinates, UUIDs, payloads, payload digests, receipt identities, error codes, publisher identities, timestamps, and credentials.
+
+## Duplicate classification
+
+An ordinary physical duplicate requires:
+
+```text
+same deterministic Iggy header UUID
+same exact bytes
+```
+
+The bytes are compared through an in-memory domain-separated SHA-256 digest that is never exposed by the public observation or summary.
+
+A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
+
+## Mutation boundary
+
+The classifier cannot acknowledge, delete, replay, retry, repair, claim, release, or mark anything. It cannot choose alert thresholds or operator policy.
+
+A future external-Iggy scan adapter must remain read-only and bounded. Any destructive reconciliation must be a separate explicitly authorized workflow with preview and audit evidence.
+
+## Relationship to receipt health
+
+The PostgreSQL `ConsumerPoisonReceiptInspector` remains an independent count-only summary of receipt progress. Neither side exports identifiers, so the two views cannot be joined message by message.
+
+Aggregate operational interpretation may compare trends:
+
+- expired publishing claims plus duplicate growth may indicate recovery outside the effective dedup window;
+- duplicate growth without recovery work may reflect historic or downstream duplication;
+- any conflicting-payload group requires forensic escalation.
+
+These interpretations never become Profiles authorization inputs.
+
+## Profiles authorization boundary
+
+No profile visibility, relationship, block, mute, follow, friendship, audience, or presentation decision may depend on:
+
+- physical DLQ copy count;
+- duplicate group count;
+- conflicting-payload group count;
+- receipt recovery counts;
+- deduplication configuration;
+- retained evidence metadata.
+
+Profiles presentation continues to consume authorized owner-port results. This classifier only improves operational observability of downstream neutralization.
+
+## Remaining work
+
+1. add a bounded read-only external-Iggy DLQ scan adapter;
+2. prove physical header and byte ingestion against a disposable broker;
+3. retain only count-level runtime evidence;
+4. define alert thresholds outside the classifier;
+5. define any acknowledgement/delete/replay workflow separately with explicit authorization;
+6. keep aggregate receipt and duplicate observations identifier-free.
+
+No runtime adapter or retained execution packet exists for this checkpoint. Tests and verifiers were not run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
+const transportPath = "crates/rustok-iggy/src/transport.rs";
+const receiptInspectorPath =
+  "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs";
+const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs";
+const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-inspection.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md";
+const expectedExports = [
+  "DlqDuplicateObservation",
+  "DlqDuplicateSummary",
+  "DlqDuplicateInspectionError",
+  "summarize_dlq_duplicates",
+];
+const expectedSummaryFields = [
+  "total_messages",
+  "unique_message_ids",
+  "duplicate_messages",
+  "duplicate_groups",
+  "conflicting_payload_groups",
+  "max_copies_per_message_id",
+];
+const expectedTests = [
+  "repeated_id_and_exact_bytes_are_counted_as_physical_duplicates",
+  "one_id_with_distinct_exact_bytes_requires_manual_review",
+  "empty_scan_and_empty_payload_are_valid",
+  "nil_message_id_is_rejected_with_stable_code",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
+const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
+const receiptInspector = readFileSync(resolve(repoRoot, receiptInspectorPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-inspection-source" ||
+  contract.status !== "source_complete_runtime_adapter_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.source !== sourcePath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("DLQ duplicate inspection contract identity or source status drift");
+}
+if (!sameValue(contract.public_exports, expectedExports)) {
+  fail("DLQ duplicate inspection public export allowlist drift");
+}
+if (!sameValue(contract.summary_fields, expectedSummaryFields)) {
+  fail("DLQ duplicate inspection summary field allowlist drift");
+}
+if (!sameValue(contract.required_source_tests, expectedTests)) {
+  fail("DLQ duplicate inspection source test allowlist drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("DLQ duplicate inspection verifier or documentation path drift");
+}
+
+if (
+  contract.identity?.input !== "non_nil_deterministic_iggy_message_header_uuid" ||
+  contract.identity?.payload_comparison !==
+    "domain_separated_sha256_in_memory_only" ||
+  contract.identity?.empty_payload_valid !== true ||
+  contract.identity?.nil_uuid_rejected !== true
+) {
+  fail("DLQ duplicate inspection identity boundary drift");
+}
+if (
+  contract.semantics?.duplicate_message_formula !==
+    "total_messages_minus_unique_message_ids" ||
+  contract.semantics?.ordinary_duplicate !==
+    "same_non_nil_message_id_and_same_exact_payload_digest" ||
+  contract.semantics?.identity_conflict !==
+    "same_non_nil_message_id_with_more_than_one_exact_payload_digest" ||
+  contract.semantics?.manual_review_required_for_identity_conflict !== true ||
+  contract.semantics?.empty_scan_returns_zero_summary !== true
+) {
+  fail("DLQ duplicate inspection semantic contract drift");
+}
+
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`DLQ duplicate inspection mutation became allowed: ${operation}`);
+}
+if (
+  contract.privacy_boundary?.observation_exposes_digest !== false ||
+  contract.privacy_boundary?.summary_exposes_identifiers !== false
+) {
+  fail("DLQ duplicate inspection privacy flags drift");
+}
+const requiredExcludedFields = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "error_code",
+  "publisher_identity",
+  "timestamp",
+  "credential",
+]);
+for (const field of contract.privacy_boundary?.summary_excludes ?? []) {
+  requiredExcludedFields.delete(field);
+}
+if (requiredExcludedFields.size > 0) {
+  fail(`DLQ duplicate privacy exclusions are incomplete: ${[...requiredExcludedFields].join(", ")}`);
+}
+
+for (const marker of [
+  'const DLQ_PAYLOAD_DIGEST_DOMAIN: &[u8] = b"rustok.iggy.dlq.physical_payload.v1";',
+  "pub struct DlqDuplicateObservation",
+  "broker_message_id: Uuid",
+  "payload_sha256: [u8; 32]",
+  "pub fn from_payload(",
+  "if broker_message_id.is_nil()",
+  "hash_part(&mut hasher, DLQ_PAYLOAD_DIGEST_DOMAIN);",
+  "hash_part(&mut hasher, payload);",
+  "pub struct DlqDuplicateSummary",
+  "pub const fn total_messages(&self)",
+  "pub const fn unique_message_ids(&self)",
+  "pub const fn duplicate_messages(&self)",
+  "pub const fn duplicate_groups(&self)",
+  "pub const fn conflicting_payload_groups(&self)",
+  "pub const fn max_copies_per_message_id(&self)",
+  "pub const fn has_physical_duplicates(&self)",
+  "pub const fn has_identity_conflicts(&self)",
+  "pub const fn requires_manual_review(&self)",
+  '"iggy.dlq_duplicate.identity_invalid"',
+  '"iggy.dlq_duplicate.count_overflow"',
+  "BTreeMap::<Uuid, DuplicateGroup>::new()",
+  "BTreeSet<[u8; 32]>",
+  ".checked_add(1)",
+  ".checked_sub(unique_message_ids)",
+  "group.payload_sha256.len() > 1",
+  "Ok(DlqDuplicateSummary {",
+]) {
+  requireText("DLQ duplicate inspection source", source, marker);
+}
+for (const testName of expectedTests) {
+  requireText("DLQ duplicate inspection source tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("DLQ duplicate inspection source must contain exactly four focused unit tests");
+}
+
+for (const marker of [
+  "pub broker_message_id:",
+  "pub payload_sha256:",
+  "pub fn broker_message_id(",
+  "pub fn payload_sha256(",
+  "Serialize",
+  "Deserialize",
+  ".acknowledge(",
+  ".delete(",
+  ".replay(",
+  ".retry_entry(",
+  ".reserve_and_claim(",
+  ".release_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+]) {
+  forbidText("DLQ duplicate inspection source", source, marker);
+}
+
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+for (const marker of [
+  "Failure kind, retry count, time, process identity, and random values are excluded",
+  "pub fn delivery_id(&self) -> Uuid",
+  "hash_part(&mut hasher, &self.raw_payload);",
+  ".with_broker_message_id(delivery_id)",
+]) {
+  requireText("raw poison deterministic identity", decodeFailure, marker);
+}
+for (const marker of [
+  "if entry.broker_message_id().is_some()",
+  "IggyDlqPublisher::connect",
+  ".publish(&entry)",
+]) {
+  requireText("production deterministic Iggy publisher", transport, marker);
+}
+for (const marker of [
+  "Bounded aggregate view of neutral poison-result progress",
+  "The snapshot intentionally excludes delivery identifiers",
+  "Inspection never claims, releases, publishes, acknowledges, deletes, or repairs",
+  "pub struct ConsumerPoisonReceiptSummary",
+  "pub async fn summarize(",
+]) {
+  requireText("count-only receipt inspector", receiptInspector, marker);
+}
+
+if (
+  contract.production_relationship?.raw_poison_delivery_id !==
+    "ConsumedContractDecodeFailure::delivery_id" ||
+  contract.production_relationship?.dlq_broker_message_id !==
+    "ConsumedContractDecodeFailure::to_dlq_entry" ||
+  contract.production_relationship?.physical_publisher !==
+    "IggyTransport::move_to_dlq" ||
+  contract.production_relationship?.receipt_summary !==
+    "ConsumerPoisonReceiptInspector" ||
+  contract.production_relationship
+    ?.receipt_and_physical_duplicate_summaries_are_independent !== true
+) {
+  fail("DLQ duplicate inspection production relationship drift");
+}
+
+if (failures.length > 0) {
+  console.error("Iggy DLQ duplicate inspection verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, and independent receipt-health semantics are locked; external scan adapter remains pending.",
+);


### PR DESCRIPTION
## Summary

Add an Iggy-owned, transport-neutral, read-only classifier for physical DLQ duplicates produced when deterministic message-ID deduplication is disabled, expired, capacity-evicted, or otherwise ineffective.

## Public API

- `DlqDuplicateObservation`
- `DlqDuplicateSummary`
- `DlqDuplicateInspectionError`
- `summarize_dlq_duplicates`

Each observation accepts a non-nil deterministic Iggy header UUID and exact physical bytes. The bytes are immediately reduced to a domain-separated SHA-256 value in memory. Neither exact bytes nor their digest are exposed by the observation or summary.

## Count-only summary

The result exposes only:

- total physical messages;
- unique message IDs;
- duplicate physical messages;
- duplicate groups;
- conflicting-payload groups;
- maximum copies for one message ID.

`duplicate_messages` is locked to `total_messages - unique_message_ids`.

## Duplicate semantics

An ordinary physical duplicate requires the same non-nil deterministic message ID and the same exact payload digest.

Reuse of one message ID with different exact bytes is not silently collapsed. It increments `conflicting_payload_groups`, sets `has_identity_conflicts`, and requires manual review.

Empty scans and empty payloads are valid. Nil IDs fail closed with the stable code `iggy.dlq_duplicate.identity_invalid`; count overflow uses `iggy.dlq_duplicate.count_overflow`.

## Privacy and mutation boundary

The summary excludes broker addresses, stream/topic/partition/offset, message IDs, payloads and payload digests, receipt identities, error codes, publisher identities, timestamps, and credentials.

The classifier cannot acknowledge, delete, replay, retry, repair, claim/release receipts, mark receipt state, or choose operator thresholds. A future external-Iggy adapter must remain bounded and read-only; destructive reconciliation requires a separate authorized workflow.

## Production relationship

The source contract and verifier lock:

- `ConsumedContractDecodeFailure::delivery_id` as the immutable raw-poison identity;
- `to_dlq_entry` attaching that identity as the broker message ID;
- `IggyTransport::move_to_dlq` using the deterministic publisher path;
- independence from the PostgreSQL `ConsumerPoisonReceiptInspector` count-only health summary.

Receipt health and physical duplicate health remain aggregate, identifier-free views and cannot be joined message by message.

## Evidence and documentation

- added a versioned machine source contract;
- added a static source verifier;
- added an Iggy operator/runbook document;
- added a Profiles checkpoint preserving the authorization boundary;
- added four focused unit tests for normal duplicates, conflicting bytes, empty input/payload, and nil-ID rejection.

## Remaining boundary

This slice does not add an external-Iggy scan cursor, retained runtime evidence, alert policy, acknowledgement/delete/replay workflow, or Profiles authorization input.

## Verification

Tests, Cargo commands, formatters, source verifiers, external Iggy, and retained evidence were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
cargo test -p rustok-iggy dlq_duplicate_inspection -- --nocapture
```
