### PR TITLE
Restore commerce test lifecycle runtime

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/tests/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/tests/mod.rs
@@ -127,6 +127,8 @@ pub(crate) fn test_app_context(
     let marketplace_financial_runtime = crate::MarketplaceFinancialRuntime::in_process(db.clone());
     let shipping_option_read_runtime =
         crate::graphql_runtime::CommerceShippingOptionReadRuntime::in_process(db.clone());
+    let fulfillment_lifecycle_read_runtime =
+        crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(db.clone());
     crate::controllers::CommerceHttpRuntime {
         db,
         event_bus: mock_transactional_event_bus(),
@@ -135,6 +137,7 @@ pub(crate) fn test_app_context(
         fulfillment_provider_registry:
             rustok_fulfillment::providers::FulfillmentProviderRegistry::with_manual_provider(),
         shipping_option_read_runtime,
+        fulfillment_lifecycle_read_runtime,
         marketplace_financial_runtime,
     }
 }

--- a/crates/rustok-commerce/src/controllers/store/tests/mod.rs
+++ b/crates/rustok-commerce/src/controllers/store/tests/mod.rs
@@ -237,6 +237,8 @@ pub(crate) fn test_app_context(
     let marketplace_financial_runtime = crate::MarketplaceFinancialRuntime::in_process(db.clone());
     let shipping_option_read_runtime =
         crate::graphql_runtime::CommerceShippingOptionReadRuntime::in_process(db.clone());
+    let fulfillment_lifecycle_read_runtime =
+        crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(db.clone());
     crate::controllers::CommerceHttpRuntime {
         db,
         event_bus: mock_transactional_event_bus(),
@@ -245,6 +247,7 @@ pub(crate) fn test_app_context(
         fulfillment_provider_registry:
             rustok_fulfillment::providers::FulfillmentProviderRegistry::with_manual_provider(),
         shipping_option_read_runtime,
+        fulfillment_lifecycle_read_runtime,
         marketplace_financial_runtime,
     }
 }


### PR DESCRIPTION
## Summary

- compose `CommerceFulfillmentLifecycleReadRuntime::in_process` in the admin controller test fixture;
- compose the same required lifecycle runtime in the storefront controller test fixture;
- pass both values into the current `CommerceHttpRuntime` struct shape.

## Root cause

`CommerceHttpRuntime` gained the required `fulfillment_lifecycle_read_runtime` field when fulfillment lifecycle list/detail reads moved behind `FulfillmentReadPort`. The production host composition was updated, but the two direct controller-test struct literals retained the previous field set. As a result, the controller unit-test build cannot construct `CommerceHttpRuntime`.

## Scope

This PR changes only the two shared controller fixture constructors. It does not change production routing, owner-port behavior, GraphQL/REST semantics, lifecycle mutations, evidence status, or the pending mounted capture.

## Recheck

- searched current source for direct `CommerceHttpRuntime` construction;
- confirmed the stale literals are the admin and storefront shared fixtures;
- confirmed both fixtures now use the same deterministic in-process lifecycle runtime constructor used by compatibility composition;
- reviewed the final diff: one commit, two files, three additions per file, no deletions;
- branch is one commit ahead and zero behind current `main` (`447520a127183ad37ddeaea760142c3b8315f7aa`).

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

## Next slice

Add a separate deterministic lifecycle read-port deadline/typed-failure execution contract and harness. Mounted projection capture, restart, and remote-adapter evidence remain separate maintainer-owned slices.