### PR TITLE
feat(profiles): scan physical DLQ duplicates read-only

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-external-scan-source",
+  "status": "source_complete_runtime_pending",
+  "owner": "rustok-iggy",
+  "feature": "iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+  "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "public_exports": [
+    "IggyDlqDuplicateScanRequest",
+    "IggyDlqDuplicateScanner",
+    "IggyDlqDuplicateScanError"
+  ],
+  "iggy_poll_boundary": {
+    "client": "already_connected_IggyClient_borrow",
+    "topic": "dlq",
+    "consumer_kind": "standalone_consumer",
+    "consumer_name": "rustok-dlq-duplicate-readonly-v1",
+    "partition_selection": "explicit_positive_unique_partition_ids",
+    "polling_strategy": "explicit_offset",
+    "auto_commit": false,
+    "topic_metadata_read": false,
+    "connection_lifecycle_owned_by_caller": true
+  },
+  "request_boundary": {
+    "same_start_offset_for_each_partition": true,
+    "maximum_partitions": 128,
+    "maximum_messages": 10000,
+    "maximum_batch_messages": 1000,
+    "batch_not_greater_than_scan_limit": true,
+    "empty_partition_list_rejected": true,
+    "zero_partition_rejected": true,
+    "duplicate_partition_rejected": true,
+    "zero_message_or_batch_limit_rejected": true
+  },
+  "response_validation": {
+    "partition_must_match_request": true,
+    "reported_count_must_match_messages": true,
+    "reported_count_must_not_exceed_batch": true,
+    "offsets_must_be_monotonic": true,
+    "offsets_must_not_precede_requested_offset": true,
+    "offset_overflow_rejected": true,
+    "nil_physical_header_uuid_rejected_by_classifier": true
+  },
+  "result": {
+    "type": "DlqDuplicateSummary",
+    "identifier_free": true,
+    "payload_free": true,
+    "broker_coordinate_free": true,
+    "raw_client_error_free": true
+  },
+  "privacy_boundary": {
+    "error_messages_exclude": [
+      "broker_address",
+      "stream_name",
+      "partition_id",
+      "offset",
+      "message_id",
+      "payload",
+      "credential",
+      "raw_iggy_error"
+    ],
+    "result_excludes": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "credential"
+    ]
+  },
+  "mutation_boundary": {
+    "auto_commit": false,
+    "store_consumer_offset": false,
+    "acknowledge": false,
+    "delete": false,
+    "purge": false,
+    "publish": false,
+    "replay": false,
+    "retry": false,
+    "receipt_mutation": false,
+    "connection_shutdown": false
+  },
+  "stable_errors": {
+    "invalid_request": "iggy.dlq_duplicate.scan_invalid",
+    "poll_failed": "iggy.dlq_duplicate.scan_failed",
+    "invalid_broker_response": "iggy.dlq_duplicate.scan_response_invalid",
+    "offset_overflow": "iggy.dlq_duplicate.scan_offset_overflow",
+    "classifier_errors_preserved": true
+  },
+  "required_source_tests": [
+    "bounded_request_requires_unique_positive_partitions",
+    "bounded_request_rejects_unbounded_counts",
+    "stable_errors_do_not_expose_broker_coordinates"
+  ],
+  "source_files": [
+    "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+    "crates/rustok-iggy/src/lib.rs"
+  ],
+  "remaining_work": [
+    "disposable_external_iggy_runtime_scan_harness",
+    "retained_external_iggy_duplicate_scan_evidence",
+    "operator_alert_threshold_policy",
+    "authorized_destructive_reconciliation_workflow",
+    "aggregate_receipt_and_duplicate_health_correlation"
+  ],
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-external-scan.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md",
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "module": "iggy",
   "packet": "dlq-duplicate-inspection-source",
-  "status": "source_complete_runtime_adapter_pending",
+  "status": "source_complete_runtime_evidence_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
   "public_exports": [
@@ -78,8 +78,14 @@
     "receipt_summary": "ConsumerPoisonReceiptInspector",
     "receipt_and_physical_duplicate_summaries_are_independent": true
   },
+  "runtime_adapter": {
+    "status": "source_complete_runtime_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+    "auto_commit": false,
+    "result": "DlqDuplicateSummary"
+  },
   "remaining_work": [
-    "bounded_read_only_iggy_dlq_scan_adapter",
     "retained_external_iggy_duplicate_scan_evidence",
     "operator_alert_threshold_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",

--- a/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
@@ -1,0 +1,163 @@
+# Bounded external-Iggy DLQ duplicate scan
+
+Status: **source complete; disposable-broker runtime evidence pending**.
+
+## Purpose
+
+`IggyDlqDuplicateScanner` adapts the transport-neutral physical duplicate classifier to an already connected external `IggyClient`.
+
+It answers one bounded operational question:
+
+```text
+Within these explicit DLQ partitions, starting at this explicit offset,
+what is the count-only physical duplicate summary for at most N messages?
+```
+
+It does not discover the broker, own credentials, create topology, persist a cursor, or perform reconciliation.
+
+## Public API
+
+```text
+IggyDlqDuplicateScanRequest
+IggyDlqDuplicateScanner
+IggyDlqDuplicateScanError
+```
+
+The result is the existing identifier-free:
+
+```text
+DlqDuplicateSummary
+```
+
+Connection and authentication lifecycle remain owned by the caller. The scanner borrows an already connected `IggyClient` and never calls shutdown.
+
+## Polling boundary
+
+The adapter is deliberately lower level than an `IggyConsumer` stream:
+
+```text
+consumer kind: standalone Consumer
+consumer name: rustok-dlq-duplicate-readonly-v1
+topic: dlq
+partition: explicit positive ID
+strategy: PollingStrategy::offset(explicit_offset)
+auto_commit: false
+```
+
+A regular consumer requires the partition to be supplied explicitly. The scanner does not use a consumer group and does not use `PollingStrategy::next`, because `next` depends on stored consumer offsets.
+
+The scanner also avoids `get_topic` and `get_topics`. Operators must supply the intended partition allowlist, so the account needs message-poll permission rather than topic-management or topic-discovery behavior from this adapter.
+
+## Request bounds
+
+One request requires:
+
+- 1 to 128 unique positive partition IDs;
+- one explicit start offset applied independently to every selected partition;
+- `max_messages` between 1 and 10,000;
+- `batch_size` between 1 and 1,000;
+- `batch_size <= max_messages`.
+
+The message budget is global across all partitions. Partitions are scanned in caller-provided order until the global budget is exhausted.
+
+A caller that needs different offsets per partition must submit separate requests. This avoids silently inventing or retaining a partition cursor map.
+
+## Response validation
+
+Each physical poll response must satisfy all of the following:
+
+- returned partition equals the requested partition;
+- reported count equals the number of returned messages;
+- reported count does not exceed the requested batch;
+- every message offset is at or after the explicit requested offset;
+- offsets in one batch are strictly increasing;
+- advancing `last_offset + 1` does not overflow;
+- every physical header ID is a non-nil UUID accepted by the classifier.
+
+Any mismatch fails closed. Raw client errors and broker coordinates are not copied into the public error.
+
+## Privacy boundary
+
+The scanner temporarily passes only these values to the in-memory classifier:
+
+```text
+physical Iggy header UUID
+exact physical payload bytes
+```
+
+The classifier immediately reduces payload bytes to a domain-separated SHA-256 value. The returned summary contains only counts and exposes no:
+
+- broker address;
+- stream or topic name;
+- partition or offset;
+- message UUID;
+- payload or payload digest;
+- credentials;
+- raw Iggy error.
+
+The scanner error codes are bounded and identifier-free:
+
+```text
+iggy.dlq_duplicate.scan_invalid
+iggy.dlq_duplicate.scan_failed
+iggy.dlq_duplicate.scan_response_invalid
+iggy.dlq_duplicate.scan_offset_overflow
+```
+
+Classifier identity/count errors retain their existing stable codes.
+
+## Mutation boundary
+
+The adapter contains no call to:
+
+- automatic offset commit;
+- consumer offset storage;
+- acknowledgement or high-level cursor offset storage;
+- stream/topic deletion or purge;
+- message publication;
+- DLQ replay or retry;
+- poison receipt claim, release, publish, or acknowledgement transitions;
+- client shutdown.
+
+Polling uses `auto_commit = false`. The fixed consumer identifier is therefore only the request identity supplied to Iggy; the adapter does not persist progress for later `next` polling.
+
+## Suggested caller flow
+
+```text
+1. Operator selects one external service and an explicit DLQ stream.
+2. Operator supplies an explicit partition allowlist and bounded offset/count window.
+3. A separately configured component connects and authenticates IggyClient.
+4. IggyDlqDuplicateScanner borrows the connected client.
+5. Scanner polls explicit offsets with auto_commit=false.
+6. Scanner returns DlqDuplicateSummary only.
+7. Caller closes the client through its own lifecycle.
+```
+
+Do not present this scanner as a complete historical inventory unless the selected partitions, offsets, retention window, and message cap cover the intended history.
+
+## Source verification
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+```
+
+Static source guard:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+```
+
+Focused source tests are embedded in `dlq_duplicate_external_scan.rs` for request bounds and stable error projection.
+
+No test, Cargo command, formatter, verifier, external Iggy connection, or runtime scan was executed while defining this slice.
+
+## Remaining work
+
+1. add a disposable external-Iggy harness that writes controlled duplicate and conflicting fixtures;
+2. prove explicit-offset polling reads the physical header UUID and exact bytes without storing offsets;
+3. prove count-only projection for ordinary duplicates and identity conflicts;
+4. retain a privacy-safe runtime packet without addresses, credentials, identifiers, payloads, offsets, or raw logs;
+5. define alert thresholds outside the scanner;
+6. keep acknowledgement/delete/replay reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **transport-neutral source complete; bounded external-Iggy scan adapter pending**.
+Status: **classifier and bounded external-Iggy adapter source-complete; runtime evidence pending**.
 
 ## Purpose
 
@@ -13,7 +13,7 @@ Physical copies can exceed one when:
 - capacity pressure evicted the ID;
 - a failover or unsupported broker path did not preserve the expected dedup state.
 
-`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations.
+`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations. `dlq_duplicate_external_scan.rs` now provides the bounded external-Iggy polling adapter described in `dlq-duplicate-external-scan.md`.
 
 ## Input boundary
 
@@ -89,15 +89,17 @@ The summary does not expose:
 - timestamps;
 - credentials.
 
-The classifier does not implement serialization. A future operator endpoint must preserve the same count-only projection unless a separately authorized forensic workflow is explicitly designed.
+The classifier does not implement serialization. Any operator endpoint must preserve the same count-only projection unless a separately authorized forensic workflow is explicitly designed.
 
 ## Mutation boundary
 
-The classifier cannot:
+The classifier and external scanner cannot:
 
 - acknowledge a DLQ cursor;
-- delete a physical message;
+- store or auto-commit a consumer offset;
+- delete or purge physical messages;
 - replay or retry a message;
+- publish a message;
 - repair broker state;
 - claim or release a poison receipt;
 - mark a receipt published or acknowledged;
@@ -133,42 +135,59 @@ Neither summary contains identifiers, so they cannot be joined message-by-messag
 
 These are operator interpretations, not storage-layer decisions.
 
+## Bounded external-Iggy adapter
+
+`IggyDlqDuplicateScanner` borrows an already connected `IggyClient` and polls only:
+
+```text
+topic = dlq
+standalone consumer
+explicit positive partition
+PollingStrategy::offset(explicit_offset)
+auto_commit = false
+```
+
+One request permits at most 128 partitions, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
+
+The adapter does not own credentials or connection lifecycle, query topology metadata, join a consumer group, persist progress, or call shutdown. See `dlq-duplicate-external-scan.md` for the complete contract.
+
 ## Safe operational sequence
 
-A future bounded external-Iggy adapter should:
-
-1. open a read-only scan cursor or metadata reader over an explicitly selected DLQ scope;
-2. enforce a maximum message count and bounded time window;
-3. extract only the physical header UUID and exact bytes into in-memory observations;
-4. call `summarize_dlq_duplicates`;
-5. publish only the count-only summary;
-6. close the observer without acknowledging, deleting, replaying, or moving messages.
+1. select an external service, stream, explicit partition allowlist, offset, and message cap;
+2. connect and authenticate an `IggyClient` outside the scanner;
+3. call the bounded scanner using explicit-offset polling with `auto_commit=false`;
+4. publish only the count-only summary;
+5. close the client through the caller-owned lifecycle;
+6. treat the result as a bounded window, not automatically as complete history.
 
 Any destructive action must be a separate, explicitly authorized workflow with its own preview, selection, audit, and retained evidence.
 
-## Source tests
+## Source tests and guards
 
-The focused unit cases define:
+The focused classifier cases define:
 
 - same ID and exact bytes counted as ordinary physical duplicates;
 - same ID and different bytes escalated as an identity conflict;
 - empty scan and empty payload behavior;
 - nil ID rejection and stable error code.
 
+The external scanner cases define request bounds and identifier-free stable errors.
+
 Suggested maintainer commands:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
-cargo test -p rustok-iggy dlq_duplicate_inspection -- --nocapture
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+cargo test -p rustok-iggy dlq_duplicate -- --nocapture
 ```
 
-No tests, Cargo commands, formatters, verifiers, or external-Iggy scans were run while defining this source slice.
+No tests, Cargo commands, formatters, verifiers, or external-Iggy scans were run while defining these source slices.
 
 ## Remaining work
 
-1. add a bounded read-only external-Iggy scan adapter;
-2. prove physical header extraction and count-only projection against a disposable broker;
-3. retain runtime evidence without identifiers, payloads, addresses, credentials, or raw logs;
+1. prove physical header and exact-byte ingestion against a disposable external broker;
+2. prove explicit-offset polling does not store consumer progress;
+3. retain runtime evidence without identifiers, payloads, addresses, credentials, offsets, or raw logs;
 4. define alert thresholds outside the inspector;
 5. design any acknowledgement/delete/replay workflow as a separate authorized operation;
 6. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
@@ -1,0 +1,299 @@
+use std::collections::BTreeSet;
+
+use iggy::prelude::{
+    Consumer, ConsumerKind, Identifier, IggyClient, MessageClient, PollingStrategy,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::dlq_duplicate_inspection::{
+    DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
+    summarize_dlq_duplicates,
+};
+
+const DLQ_TOPIC: &str = "dlq";
+const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-readonly-v1";
+const MAX_SCAN_MESSAGES: u32 = 10_000;
+const MAX_BATCH_MESSAGES: u32 = 1_000;
+const MAX_SCAN_PARTITIONS: usize = 128;
+const MAX_STREAM_NAME_BYTES: usize = 255;
+
+/// Bounded explicit-offset request for a read-only physical Iggy DLQ scan.
+///
+/// The request contains no broker address, credentials, payload, message ID, or
+/// mutation policy. Every partition starts at the same explicit offset. A caller
+/// that needs partition-specific windows must issue separate requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IggyDlqDuplicateScanRequest {
+    partitions: Vec<u32>,
+    start_offset: u64,
+    max_messages: u32,
+    batch_size: u32,
+}
+
+impl IggyDlqDuplicateScanRequest {
+    pub fn new(
+        partitions: Vec<u32>,
+        start_offset: u64,
+        max_messages: u32,
+        batch_size: u32,
+    ) -> Result<Self, IggyDlqDuplicateScanError> {
+        validate_partitions(&partitions)?;
+        if max_messages == 0 || max_messages > MAX_SCAN_MESSAGES {
+            return Err(IggyDlqDuplicateScanError::InvalidRequest);
+        }
+        if batch_size == 0
+            || batch_size > MAX_BATCH_MESSAGES
+            || batch_size > max_messages
+        {
+            return Err(IggyDlqDuplicateScanError::InvalidRequest);
+        }
+        Ok(Self {
+            partitions,
+            start_offset,
+            max_messages,
+            batch_size,
+        })
+    }
+
+    pub fn partitions(&self) -> &[u32] {
+        &self.partitions
+    }
+
+    pub const fn start_offset(&self) -> u64 {
+        self.start_offset
+    }
+
+    pub const fn max_messages(&self) -> u32 {
+        self.max_messages
+    }
+
+    pub const fn batch_size(&self) -> u32 {
+        self.batch_size
+    }
+}
+
+/// External-Iggy adapter that polls immutable physical DLQ messages without
+/// storing a consumer offset.
+///
+/// The scanner uses a standalone consumer, explicit `PollingStrategy::offset`
+/// requests, an explicit partition ID, and `auto_commit = false`. It cannot
+/// acknowledge, delete, purge, replay, publish, retry, or mutate poison receipts.
+/// It returns only the identifier-free [`DlqDuplicateSummary`]. Connection and
+/// authentication lifecycle remain owned by the caller.
+pub struct IggyDlqDuplicateScanner<'a> {
+    client: &'a IggyClient,
+    stream_id: Identifier,
+    topic_id: Identifier,
+    consumer: Consumer,
+}
+
+impl<'a> IggyDlqDuplicateScanner<'a> {
+    pub fn new(
+        client: &'a IggyClient,
+        stream_name: &str,
+    ) -> Result<Self, IggyDlqDuplicateScanError> {
+        validate_stream_name(stream_name)?;
+        let stream_id: Identifier = stream_name
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateScanError::InvalidRequest)?;
+        let topic_id: Identifier = DLQ_TOPIC
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateScanError::InvalidRequest)?;
+        let consumer_id: Identifier = READ_ONLY_CONSUMER
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateScanError::InvalidRequest)?;
+        Ok(Self {
+            client,
+            stream_id,
+            topic_id,
+            consumer: Consumer {
+                kind: ConsumerKind::Consumer,
+                id: consumer_id,
+            },
+        })
+    }
+
+    pub async fn summarize(
+        &self,
+        request: &IggyDlqDuplicateScanRequest,
+    ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateScanError> {
+        let mut remaining = request.max_messages;
+        let mut observations = Vec::with_capacity(request.max_messages as usize);
+
+        for &partition_id in &request.partitions {
+            if remaining == 0 {
+                break;
+            }
+            let mut next_offset = request.start_offset;
+
+            loop {
+                let requested_count = request.batch_size.min(remaining);
+                let polled = self
+                    .client
+                    .poll_messages(
+                        &self.stream_id,
+                        &self.topic_id,
+                        Some(partition_id),
+                        &self.consumer,
+                        &PollingStrategy::offset(next_offset),
+                        requested_count,
+                        false,
+                    )
+                    .await
+                    .map_err(|_| IggyDlqDuplicateScanError::PollFailed)?;
+
+                if polled.partition_id != partition_id
+                    || polled.count as usize != polled.messages.len()
+                    || polled.count > requested_count
+                {
+                    return Err(IggyDlqDuplicateScanError::InvalidBrokerResponse);
+                }
+                if polled.messages.is_empty() {
+                    break;
+                }
+
+                let received_count = polled.count;
+                let mut previous_offset = None;
+                for message in polled.messages {
+                    let offset = message.header.offset;
+                    if offset < next_offset
+                        || previous_offset.is_some_and(|previous| offset <= previous)
+                    {
+                        return Err(IggyDlqDuplicateScanError::InvalidBrokerResponse);
+                    }
+                    observations.push(DlqDuplicateObservation::from_payload(
+                        Uuid::from_u128(message.header.id),
+                        message.payload.as_ref(),
+                    )?);
+                    remaining = remaining
+                        .checked_sub(1)
+                        .ok_or(IggyDlqDuplicateScanError::InvalidBrokerResponse)?;
+                    previous_offset = Some(offset);
+                }
+
+                let last_offset = previous_offset
+                    .ok_or(IggyDlqDuplicateScanError::InvalidBrokerResponse)?;
+                next_offset = last_offset
+                    .checked_add(1)
+                    .ok_or(IggyDlqDuplicateScanError::OffsetOverflow)?;
+
+                if remaining == 0 || received_count < requested_count {
+                    break;
+                }
+            }
+        }
+
+        summarize_dlq_duplicates(observations).map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDlqDuplicateScanError {
+    #[error("external Iggy DLQ duplicate scan request is invalid")]
+    InvalidRequest,
+    #[error("external Iggy DLQ duplicate polling failed")]
+    PollFailed,
+    #[error("external Iggy DLQ duplicate poll response is invalid")]
+    InvalidBrokerResponse,
+    #[error("external Iggy DLQ duplicate offset overflow")]
+    OffsetOverflow,
+    #[error(transparent)]
+    Inspection(#[from] DlqDuplicateInspectionError),
+}
+
+impl IggyDlqDuplicateScanError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "iggy.dlq_duplicate.scan_invalid",
+            Self::PollFailed => "iggy.dlq_duplicate.scan_failed",
+            Self::InvalidBrokerResponse => "iggy.dlq_duplicate.scan_response_invalid",
+            Self::OffsetOverflow => "iggy.dlq_duplicate.scan_offset_overflow",
+            Self::Inspection(error) => error.stable_code(),
+        }
+    }
+}
+
+fn validate_partitions(partitions: &[u32]) -> Result<(), IggyDlqDuplicateScanError> {
+    if partitions.is_empty() || partitions.len() > MAX_SCAN_PARTITIONS {
+        return Err(IggyDlqDuplicateScanError::InvalidRequest);
+    }
+    let mut unique = BTreeSet::new();
+    for &partition in partitions {
+        if partition == 0 || !unique.insert(partition) {
+            return Err(IggyDlqDuplicateScanError::InvalidRequest);
+        }
+    }
+    Ok(())
+}
+
+fn validate_stream_name(stream_name: &str) -> Result<(), IggyDlqDuplicateScanError> {
+    if stream_name.is_empty()
+        || stream_name.trim() != stream_name
+        || stream_name.len() > MAX_STREAM_NAME_BYTES
+        || stream_name.chars().any(char::is_control)
+    {
+        return Err(IggyDlqDuplicateScanError::InvalidRequest);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_request_requires_unique_positive_partitions() {
+        let valid = IggyDlqDuplicateScanRequest::new(vec![1, 3], 42, 100, 25).unwrap();
+        assert_eq!(valid.partitions(), &[1, 3]);
+        assert_eq!(valid.start_offset(), 42);
+        assert_eq!(valid.max_messages(), 100);
+        assert_eq!(valid.batch_size(), 25);
+
+        for partitions in [vec![], vec![0], vec![1, 1]] {
+            assert!(matches!(
+                IggyDlqDuplicateScanRequest::new(partitions, 0, 1, 1),
+                Err(IggyDlqDuplicateScanError::InvalidRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn bounded_request_rejects_unbounded_counts() {
+        for (max_messages, batch_size) in [
+            (0, 1),
+            (MAX_SCAN_MESSAGES + 1, 1),
+            (1, 0),
+            (1, 2),
+            (MAX_SCAN_MESSAGES, MAX_BATCH_MESSAGES + 1),
+        ] {
+            assert!(matches!(
+                IggyDlqDuplicateScanRequest::new(vec![1], 0, max_messages, batch_size),
+                Err(IggyDlqDuplicateScanError::InvalidRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn stable_errors_do_not_expose_broker_coordinates() {
+        assert_eq!(
+            IggyDlqDuplicateScanError::InvalidRequest.stable_code(),
+            "iggy.dlq_duplicate.scan_invalid"
+        );
+        assert_eq!(
+            IggyDlqDuplicateScanError::PollFailed.stable_code(),
+            "iggy.dlq_duplicate.scan_failed"
+        );
+        assert_eq!(
+            IggyDlqDuplicateScanError::InvalidBrokerResponse.stable_code(),
+            "iggy.dlq_duplicate.scan_response_invalid"
+        );
+        assert_eq!(
+            IggyDlqDuplicateScanError::OffsetOverflow.stable_code(),
+            "iggy.dlq_duplicate.scan_offset_overflow"
+        );
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -62,6 +62,8 @@ pub mod consumer;
 pub mod contract_consumer;
 pub mod contract_decode_failure;
 pub mod dlq;
+#[cfg(feature = "iggy")]
+pub mod dlq_duplicate_external_scan;
 pub mod dlq_duplicate_inspection;
 #[cfg(feature = "iggy")]
 mod dlq_publisher;
@@ -86,6 +88,10 @@ pub use contract_decode_failure::{
     ConsumedContractDecodeFailure, ContractDecodeFailureKind,
 };
 pub use dlq::{DlqEntry, DlqManager};
+#[cfg(feature = "iggy")]
+pub use dlq_duplicate_external_scan::{
+    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest, IggyDlqDuplicateScanner,
+};
 pub use dlq_duplicate_inspection::{
     DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
     summarize_dlq_duplicates,

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **count-only classifier source-complete; external observer pending**.
+Status: **count-only classifier and bounded external observer source-complete; runtime evidence pending**.
 
 ## Why this matters for Profiles
 
@@ -10,26 +10,34 @@ Profiles authorization remains independent of broker and receipt state. However,
 - one durable neutral result with repeated identical physical copies;
 - one deterministic DLQ ID associated with conflicting exact bytes.
 
-The new Iggy-owned classifier makes that difference visible without exposing message identities or payloads.
+The Iggy-owned classifier makes that difference visible without exposing message identities or payloads. The bounded external scanner now supplies physical observations through explicit-offset polling without storing progress.
 
-## New owner boundary
+## Owner boundaries
 
-Source:
+Classifier source:
 
 ```text
 crates/rustok-iggy/src/dlq_duplicate_inspection.rs
 ```
 
-Machine contract:
+External scanner source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+```
+
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 ```
 
-Verifier:
+Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 ```
 
 Public API:
@@ -39,6 +47,9 @@ DlqDuplicateObservation
 DlqDuplicateSummary
 DlqDuplicateInspectionError
 summarize_dlq_duplicates
+IggyDlqDuplicateScanRequest
+IggyDlqDuplicateScanner
+IggyDlqDuplicateScanError
 ```
 
 ## Count-only projection
@@ -69,11 +80,21 @@ The bytes are compared through an in-memory domain-separated SHA-256 digest that
 
 A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
 
-## Mutation boundary
+## External scan boundary
 
-The classifier cannot acknowledge, delete, replay, retry, repair, claim, release, or mark anything. It cannot choose alert thresholds or operator policy.
+The scanner borrows an already connected `IggyClient` and uses:
 
-A future external-Iggy scan adapter must remain read-only and bounded. Any destructive reconciliation must be a separate explicitly authorized workflow with preview and audit evidence.
+```text
+topic = dlq
+standalone consumer
+explicit partition
+explicit offset
+auto_commit = false
+```
+
+It accepts no more than 128 unique positive partitions, 10,000 physical messages globally, and batches of 1,000. It validates returned partition/count and monotonic offsets before returning only `DlqDuplicateSummary`.
+
+The scanner does not use a consumer group, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
 
 ## Relationship to receipt health
 
@@ -94,19 +115,20 @@ No profile visibility, relationship, block, mute, follow, friendship, audience, 
 - physical DLQ copy count;
 - duplicate group count;
 - conflicting-payload group count;
+- scan partition or offset selection;
 - receipt recovery counts;
 - deduplication configuration;
 - retained evidence metadata.
 
-Profiles presentation continues to consume authorized owner-port results. This classifier only improves operational observability of downstream neutralization.
+Profiles presentation continues to consume authorized owner-port results. This classifier and scanner only improve operational observability of downstream neutralization.
 
 ## Remaining work
 
-1. add a bounded read-only external-Iggy DLQ scan adapter;
-2. prove physical header and byte ingestion against a disposable broker;
+1. prove physical header and exact-byte ingestion against a disposable external broker;
+2. prove `auto_commit=false` explicit-offset polling leaves no stored progress;
 3. retain only count-level runtime evidence;
-4. define alert thresholds outside the classifier;
-5. define any acknowledgement/delete/replay workflow separately with explicit authorization;
+4. define alert thresholds outside the classifier and Profiles;
+5. define acknowledgement/delete/replay separately with explicit authorization;
 6. keep aggregate receipt and duplicate observations identifier-free.
 
-No runtime adapter or retained execution packet exists for this checkpoint. Tests and verifiers were not run by the implementation agent.
+No retained execution packet exists for this checkpoint. Tests, Cargo commands, formatters, verifiers, and external-Iggy scans were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
@@ -1,0 +1,110 @@
+# Profiles checkpoint: bounded external DLQ duplicate scan
+
+Status: **external-Iggy scan adapter source-complete; runtime evidence pending**.
+
+## What changed
+
+`rustok-iggy` now owns a bounded read-only adapter that feeds physical external-Iggy `dlq` messages into the count-only duplicate classifier.
+
+Source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+```
+
+Public API:
+
+```text
+IggyDlqDuplicateScanRequest
+IggyDlqDuplicateScanner
+IggyDlqDuplicateScanError
+```
+
+The result remains `DlqDuplicateSummary`; no new Profiles API or authorization input was added.
+
+## Read-only Iggy boundary
+
+The scanner borrows an already connected `IggyClient` and fixes:
+
+```text
+topic = dlq
+consumer kind = standalone Consumer
+polling strategy = explicit offset
+partition = explicit positive ID
+auto_commit = false
+```
+
+It does not join a consumer group, use stored-offset `next` polling, store a consumer offset, acknowledge a cursor, discover topic topology, publish, delete, purge, replay, retry, or shut down the caller's client.
+
+## Bounded request
+
+A request is limited to:
+
+- at most 128 unique positive partitions;
+- at most 10,000 physical messages globally;
+- batches of at most 1,000 messages;
+- one explicit start offset applied independently to each partition.
+
+The scanner fails closed on response partition/count mismatch, non-monotonic offsets, offsets before the requested position, nil physical header UUID, or offset overflow.
+
+## Count-only privacy boundary
+
+During a scan, physical header UUIDs and exact bytes exist only long enough to create in-memory duplicate observations. Exact bytes are reduced to a domain-separated digest inside the classifier.
+
+The returned result exposes only:
+
+```text
+total_messages
+unique_message_ids
+duplicate_messages
+duplicate_groups
+conflicting_payload_groups
+max_copies_per_message_id
+```
+
+It does not expose broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, credentials, or raw Iggy errors.
+
+## Profiles authorization remains unchanged
+
+No profile visibility, relationship, block, mute, follow, friendship, audience, ownership, or presentation decision may depend on:
+
+- whether a DLQ scan was performed;
+- selected partitions or offsets;
+- physical duplicate counts;
+- conflicting-payload counts;
+- scanner errors;
+- broker deduplication configuration;
+- future retained evidence metadata.
+
+Profiles continues to consume authorized owner-port results. The scanner is operational observability for downstream neutralization only.
+
+## Operator interpretation
+
+A bounded scan is not automatically a complete historical inventory. Its meaning depends on the explicitly selected stream, partitions, offsets, retention window, and message cap.
+
+Aggregate receipt health and aggregate physical duplicate health remain independent identifier-free views. They may be compared as operational trends, but they cannot be joined message by message and must not become authorization evidence.
+
+Any `conflicting_payload_groups > 0` result requires manual forensic escalation. The scanner does not identify the affected UUID or provide a destructive action.
+
+## Remaining work
+
+1. add a disposable external-Iggy runtime harness with controlled duplicate/conflict fixtures;
+2. prove explicit-offset polling with `auto_commit=false` does not persist progress;
+3. retain only count-level runtime evidence;
+4. define alert thresholds outside Profiles and outside the scanner;
+5. design acknowledgement/delete/replay as a separate explicitly authorized workflow;
+6. preserve the identifier-free boundary when comparing receipt and physical duplicate trends.
+
+No tests, Cargo commands, formatters, source verifiers, external-Iggy scans, or retained capture were run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs";
+const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-external-scan.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md";
+const expectedExports = [
+  "IggyDlqDuplicateScanRequest",
+  "IggyDlqDuplicateScanner",
+  "IggyDlqDuplicateScanError",
+];
+const expectedTests = [
+  "bounded_request_requires_unique_positive_partitions",
+  "bounded_request_rejects_unbounded_counts",
+  "stable_errors_do_not_expose_broker_coordinates",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-external-scan-source" ||
+  contract.status !== "source_complete_runtime_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.feature !== "iggy" ||
+  contract.source !== sourcePath ||
+  contract.classifier_source !== classifierPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("external DLQ duplicate scan contract identity or runtime-pending status drift");
+}
+if (!sameValue(contract.public_exports, expectedExports)) {
+  fail("external DLQ duplicate scan public export allowlist drift");
+}
+if (!sameValue(contract.required_source_tests, expectedTests)) {
+  fail("external DLQ duplicate scan focused test allowlist drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("external DLQ duplicate scan verifier or documentation path drift");
+}
+if (
+  contract.iggy_poll_boundary?.client !== "already_connected_IggyClient_borrow" ||
+  contract.iggy_poll_boundary?.topic !== "dlq" ||
+  contract.iggy_poll_boundary?.consumer_kind !== "standalone_consumer" ||
+  contract.iggy_poll_boundary?.consumer_name !== "rustok-dlq-duplicate-readonly-v1" ||
+  contract.iggy_poll_boundary?.partition_selection !==
+    "explicit_positive_unique_partition_ids" ||
+  contract.iggy_poll_boundary?.polling_strategy !== "explicit_offset" ||
+  contract.iggy_poll_boundary?.auto_commit !== false ||
+  contract.iggy_poll_boundary?.topic_metadata_read !== false ||
+  contract.iggy_poll_boundary?.connection_lifecycle_owned_by_caller !== true
+) {
+  fail("external DLQ duplicate scan Iggy polling boundary drift");
+}
+if (
+  contract.request_boundary?.maximum_partitions !== 128 ||
+  contract.request_boundary?.maximum_messages !== 10000 ||
+  contract.request_boundary?.maximum_batch_messages !== 1000 ||
+  contract.request_boundary?.same_start_offset_for_each_partition !== true ||
+  contract.request_boundary?.batch_not_greater_than_scan_limit !== true
+) {
+  fail("external DLQ duplicate scan bounded request contract drift");
+}
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`external DLQ duplicate scan mutation became allowed: ${operation}`);
+}
+if (
+  contract.result?.type !== "DlqDuplicateSummary" ||
+  contract.result?.identifier_free !== true ||
+  contract.result?.payload_free !== true ||
+  contract.result?.broker_coordinate_free !== true ||
+  contract.result?.raw_client_error_free !== true
+) {
+  fail("external DLQ duplicate scan result projection drift");
+}
+
+const expectedSourceFiles = [sourcePath, classifierPath, libPath];
+if (!sameValue(contract.source_files, expectedSourceFiles)) {
+  fail("external DLQ duplicate scan source file allowlist drift");
+}
+
+for (const marker of [
+  'const DLQ_TOPIC: &str = "dlq";',
+  'const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-readonly-v1";',
+  "const MAX_SCAN_MESSAGES: u32 = 10_000;",
+  "const MAX_BATCH_MESSAGES: u32 = 1_000;",
+  "const MAX_SCAN_PARTITIONS: usize = 128;",
+  "pub struct IggyDlqDuplicateScanRequest",
+  "validate_partitions(&partitions)?;",
+  "batch_size > max_messages",
+  "pub struct IggyDlqDuplicateScanner<'a>",
+  "client: &'a IggyClient",
+  "kind: ConsumerKind::Consumer",
+  "pub async fn summarize(",
+  ".poll_messages(",
+  "Some(partition_id)",
+  "&PollingStrategy::offset(next_offset)",
+  "requested_count,\n                        false,",
+  "polled.partition_id != partition_id",
+  "polled.count as usize != polled.messages.len()",
+  "polled.count > requested_count",
+  "offset < next_offset",
+  "offset <= previous",
+  "Uuid::from_u128(message.header.id)",
+  "message.payload.as_ref()",
+  ".checked_add(1)",
+  "summarize_dlq_duplicates(observations)",
+  '"iggy.dlq_duplicate.scan_invalid"',
+  '"iggy.dlq_duplicate.scan_failed"',
+  '"iggy.dlq_duplicate.scan_response_invalid"',
+  '"iggy.dlq_duplicate.scan_offset_overflow"',
+]) {
+  requireText("external DLQ duplicate scan source", source, marker);
+}
+
+for (const testName of expectedTests) {
+  requireText("external DLQ duplicate scan source tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("external DLQ duplicate scan source must contain exactly three focused unit tests");
+}
+
+for (const marker of [
+  "ConsumerKind::ConsumerGroup",
+  "PollingStrategy::next(",
+  "auto_commit: true",
+  ".store_consumer_offset(",
+  "ConsumerOffsetClient",
+  ".consumer_group(",
+  ".store_offset(",
+  ".acknowledge(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".send_messages(",
+  ".move_to_dlq(",
+  ".retry_entry(",
+  ".reserve_and_claim(",
+  ".release_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".shutdown(",
+  ".get_topic(",
+  ".get_topics(",
+]) {
+  forbidText("external DLQ duplicate scan source", source, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateObservation",
+  "pub struct DlqDuplicateSummary",
+  "pub fn summarize_dlq_duplicates(",
+  "if broker_message_id.is_nil()",
+  "payload_sha256: [u8; 32]",
+]) {
+  requireText("transport-neutral duplicate classifier", classifier, marker);
+}
+
+requireText(
+  "rustok-iggy module list",
+  lib,
+  '#[cfg(feature = "iggy")]\npub mod dlq_duplicate_external_scan;',
+);
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+const requiredPrivacyExclusions = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "credential",
+]);
+for (const field of contract.privacy_boundary?.result_excludes ?? []) {
+  requiredPrivacyExclusions.delete(field);
+}
+if (requiredPrivacyExclusions.size > 0) {
+  fail(
+    `external DLQ duplicate scan privacy exclusions are incomplete: ${[
+      ...requiredPrivacyExclusions,
+    ].join(", ")}`,
+  );
+}
+
+const requiredNonClaims = new Set([
+  "disposable_external_iggy_runtime_scan_harness",
+  "retained_external_iggy_duplicate_scan_evidence",
+  "operator_alert_threshold_policy",
+  "authorized_destructive_reconciliation_workflow",
+  "aggregate_receipt_and_duplicate_health_correlation",
+]);
+for (const item of contract.remaining_work ?? []) requiredNonClaims.delete(item);
+if (requiredNonClaims.size > 0) {
+  fail(`external DLQ duplicate scan remaining work drift: ${[...requiredNonClaims].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy external DLQ duplicate scan source verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy external DLQ duplicate scan source verified: borrowed client lifecycle, standalone explicit-offset polling, auto_commit=false, bounded partitions/messages/batches, strict response progress, count-only projection, stable identifier-free errors, and no offset-store or destructive API are locked; external runtime evidence remains pending.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -8,6 +8,9 @@ const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const adapterContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
+const adapterSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
 const transportPath = "crates/rustok-iggy/src/transport.rs";
@@ -39,7 +42,11 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const adapterContract = JSON.parse(
+  readFileSync(resolve(repoRoot, adapterContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
 const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
@@ -70,7 +77,7 @@ if (
   contract.schema_version !== 1 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-inspection-source" ||
-  contract.status !== "source_complete_runtime_adapter_pending" ||
+  contract.status !== "source_complete_runtime_evidence_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.execution_status !== "source_not_run"
@@ -92,6 +99,20 @@ if (
   contract.profiles_checkpoint !== expectedProfilesCheckpoint
 ) {
   fail("DLQ duplicate inspection verifier or documentation path drift");
+}
+
+if (
+  contract.runtime_adapter?.status !== "source_complete_runtime_pending" ||
+  contract.runtime_adapter?.contract !== adapterContractPath ||
+  contract.runtime_adapter?.source !== adapterSourcePath ||
+  contract.runtime_adapter?.auto_commit !== false ||
+  contract.runtime_adapter?.result !== "DlqDuplicateSummary" ||
+  adapterContract.packet !== "dlq-duplicate-external-scan-source" ||
+  adapterContract.status !== "source_complete_runtime_pending" ||
+  adapterContract.source !== adapterSourcePath ||
+  adapterContract.classifier_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection runtime adapter relationship drift");
 }
 
 if (
@@ -203,6 +224,26 @@ for (const marker of [
   forbidText("DLQ duplicate inspection source", source, marker);
 }
 
+for (const marker of [
+  "pub struct IggyDlqDuplicateScanner<'a>",
+  ".poll_messages(",
+  "&PollingStrategy::offset(next_offset)",
+  "requested_count,\n                        false,",
+  "summarize_dlq_duplicates(observations)",
+]) {
+  requireText("bounded external duplicate scan adapter", adapterSource, marker);
+}
+for (const marker of [
+  ".store_consumer_offset(",
+  ".store_offset(",
+  ".acknowledge(",
+  ".send_messages(",
+  ".delete_topic(",
+  ".purge_topic(",
+]) {
+  forbidText("bounded external duplicate scan adapter", adapterSource, marker);
+}
+
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
@@ -248,6 +289,17 @@ if (
   fail("DLQ duplicate inspection production relationship drift");
 }
 
+const requiredRemaining = new Set([
+  "retained_external_iggy_duplicate_scan_evidence",
+  "operator_alert_threshold_policy",
+  "operator_ack_delete_replay_workflow_outside_inspector",
+  "correlation_with_count_only_receipt_health_without_identifier_export",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`DLQ duplicate inspection remaining work drift: ${[...requiredRemaining].join(", ")}`);
+}
+
 if (failures.length > 0) {
   console.error("Iggy DLQ duplicate inspection verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
@@ -255,5 +307,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, and independent receipt-health semantics are locked; external scan adapter remains pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, and the bounded auto_commit=false external scan adapter are locked; external runtime evidence remains pending.",
 );


### PR DESCRIPTION
## Summary

Add a bounded external-Iggy adapter for the count-only physical DLQ duplicate classifier merged in #2383.

## Public API

- `IggyDlqDuplicateScanRequest`
- `IggyDlqDuplicateScanner`
- `IggyDlqDuplicateScanError`

The scanner borrows an already connected `IggyClient` and returns only `DlqDuplicateSummary`. Connection, authentication, and shutdown remain caller-owned.

## Read-only polling boundary

The adapter fixes:

```text
topic = dlq
consumer kind = standalone Consumer
consumer name = rustok-dlq-duplicate-readonly-v1
partition = explicit positive ID
strategy = PollingStrategy::offset(explicit_offset)
auto_commit = false
```

It does not use a consumer group, stored-offset `next` polling, consumer-offset storage, high-level cursor acknowledgement, topic discovery, publication, delete/purge, replay/retry, poison receipt mutation, or client shutdown.

## Bounded request

One request permits:

- 1 to 128 unique positive partition IDs;
- one explicit start offset applied independently to every selected partition;
- 1 to 10,000 physical messages globally;
- batches of 1 to 1,000 messages;
- `batch_size <= max_messages`.

Partitions are scanned in caller-provided order until the global message budget is exhausted. Partition-specific start offsets require separate requests.

## Fail-closed response validation

Every response must preserve:

- the requested partition;
- reported count equal to the returned message vector length;
- count no greater than the requested batch;
- offsets at or after the requested position;
- strictly increasing offsets within a batch;
- non-overflowing `last_offset + 1` progress;
- non-nil physical header UUID accepted by the classifier.

Raw Iggy errors and broker coordinates are reduced to stable identifier-free errors.

## Count-only privacy boundary

Physical header UUIDs and exact payload bytes exist only long enough to create in-memory `DlqDuplicateObservation` values. The classifier reduces payloads to domain-separated SHA-256 values and returns only aggregate counts.

The result and stable errors expose no broker address, stream/topic/partition/offset, UUID, payload, payload digest, credential, or raw client error.

## Contracts and documentation

- added `dlq-duplicate-external-scan-source.json`;
- added a static source verifier that locks explicit-offset polling, `auto_commit=false`, request limits, response progress, stable errors, and forbidden mutation APIs;
- added an external scan operator guide;
- added a Profiles checkpoint preserving the owner-port authorization boundary;
- actualized the existing duplicate classifier contract, verifier, runbook, and Profiles operations checkpoint from `adapter pending` to `runtime evidence pending`.

## Remaining work

This source slice does not claim disposable-broker execution, stored-offset non-mutation runtime proof, complete historical coverage, retained runtime evidence, alert policy, destructive reconciliation, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, external-Iggy scans, and retained capture were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
cargo test -p rustok-iggy dlq_duplicate -- --nocapture
```
