### PR TITLE
test(profiles): define external DLQ duplicate scan runtime

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
@@ -8,6 +8,23 @@
   "test_target": "dlq_duplicate_external_scan",
   "test": "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
   "case": "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+  "command": {
+    "program": "cargo",
+    "args": [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--features",
+      "iggy",
+      "--test",
+      "dlq_duplicate_external_scan",
+      "--",
+      "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
   "environment": {
     "address": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS",
     "optional_username": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-external-scan-runtime-source",
+  "status": "source_complete_runtime_pending",
+  "owner": "rustok-iggy",
+  "feature": "iggy",
+  "test_target": "dlq_duplicate_external_scan",
+  "test": "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
+  "case": "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+  "environment": {
+    "address": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS",
+    "optional_username": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME",
+    "optional_password": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD",
+    "default_address": false,
+    "default_credentials": false
+  },
+  "reviewed_broker_requirement": {
+    "mode": "external_disposable_or_operator_cleaned",
+    "message_deduplication_enabled": false,
+    "configuration_readback_by_test": false,
+    "reason": "the test requires repeated deterministic header UUIDs to remain as separate physical messages"
+  },
+  "topology": {
+    "unique_stream_per_run": true,
+    "topic": "dlq",
+    "domain_partitions": 1,
+    "replication_factor": 1,
+    "stream_deletion_by_test": false
+  },
+  "fixture_publication": {
+    "api": "IggyTransport::move_to_dlq",
+    "direct_sdk_producer": false,
+    "physical_messages": 4,
+    "ordinary_duplicate": {
+      "copies": 2,
+      "same_header_uuid": true,
+      "same_exact_bytes": true
+    },
+    "identity_conflict": {
+      "copies": 2,
+      "same_header_uuid": true,
+      "different_exact_bytes": true
+    }
+  },
+  "scan_request": {
+    "partitions": [1],
+    "start_offset": 0,
+    "max_messages": 4,
+    "batch_size": 4,
+    "runs": 2,
+    "same_request_reused": true
+  },
+  "required_summary": {
+    "total_messages": 4,
+    "unique_message_ids": 2,
+    "duplicate_messages": 2,
+    "duplicate_groups": 2,
+    "conflicting_payload_groups": 1,
+    "max_copies_per_message_id": 2,
+    "has_physical_duplicates": true,
+    "has_identity_conflicts": true,
+    "requires_manual_review": true
+  },
+  "offset_non_mutation": {
+    "consumer_kind": "standalone_consumer",
+    "consumer_name": "rustok-dlq-duplicate-readonly-v1",
+    "partition": 1,
+    "checks": [
+      "before_fixture_publication",
+      "after_first_scan",
+      "after_second_scan"
+    ],
+    "required_stored_offset": null,
+    "second_scan_summary_equals_first": true,
+    "auto_commit": false
+  },
+  "sdk_observer_boundary": {
+    "allowed": [
+      "connect",
+      "IggyDlqDuplicateScanner_explicit_offset_poll",
+      "get_consumer_offset",
+      "shutdown"
+    ],
+    "forbidden": [
+      "send_messages",
+      "store_consumer_offset",
+      "delete_consumer_offset",
+      "consumer_group_cursor",
+      "acknowledge",
+      "store_offset",
+      "delete_stream",
+      "delete_topic",
+      "purge_topic",
+      "configuration_mutation"
+    ]
+  },
+  "privacy_boundary": {
+    "source_assertions_may_compare_exact_bytes": false,
+    "summary_only": true,
+    "no_logs_of": [
+      "address",
+      "credential",
+      "stream_name",
+      "partition_offset",
+      "header_uuid",
+      "payload"
+    ]
+  },
+  "source_files": [
+    "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+    "crates/rustok-iggy/src/dlq.rs",
+    "crates/rustok-iggy/src/transport.rs"
+  ],
+  "non_claims": [
+    "active_server_configuration_readback",
+    "production_history_complete",
+    "production_dedup_window_sufficiency",
+    "stored_offset_non_mutation_runtime_executed",
+    "retained_runtime_evidence",
+    "bundled_iggy",
+    "tls_auth_failover",
+    "multi_partition_runtime",
+    "destructive_reconciliation",
+    "profiles_authorization"
+  ],
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-external-scan-runtime-evidence.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-external-runtime-checkpoint.md",
+  "execution_status": "not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
@@ -97,13 +97,21 @@
     "bounded_request_rejects_unbounded_counts",
     "stable_errors_do_not_expose_broker_coordinates"
   ],
+  "runtime_harness": {
+    "status": "source_complete_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json",
+    "test": "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
+    "case": "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+    "reviewed_dedup_disabled_broker_required": true,
+    "two_identical_scans": true,
+    "three_absent_offset_checks": true
+  },
   "source_files": [
     "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
     "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
     "crates/rustok-iggy/src/lib.rs"
   ],
   "remaining_work": [
-    "disposable_external_iggy_runtime_scan_harness",
     "retained_external_iggy_duplicate_scan_evidence",
     "operator_alert_threshold_policy",
     "authorized_destructive_reconciliation_workflow",

--- a/crates/rustok-iggy/docs/dlq-duplicate-external-scan-runtime-evidence.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-external-scan-runtime-evidence.md
@@ -1,0 +1,186 @@
+# External-Iggy DLQ duplicate scan runtime evidence
+
+Status: **source complete; runtime execution pending**.
+
+## Purpose
+
+`dlq_duplicate_external_scan.rs` is an opt-in disposable-broker harness for the bounded external scanner. It proves the source shape for three related claims in one isolated one-partition stream:
+
+1. repeated deterministic header UUID plus repeated exact bytes is reported as an ordinary physical duplicate;
+2. repeated deterministic header UUID plus different exact bytes is reported as an identity conflict;
+3. two explicit-offset scans with `auto_commit=false` leave the standalone scanner consumer without a stored offset.
+
+The harness does not claim production history completeness, production dedup-window sufficiency, destructive reconciliation, or Profiles authorization.
+
+## Broker requirement
+
+Use one reviewed disposable or operator-cleaned external Iggy service with:
+
+```toml
+[system.message_deduplication]
+enabled = false
+```
+
+The harness does not read back the server configuration. This is an operator-reviewed prerequisite. If deduplication is enabled, repeated deterministic header UUIDs may be suppressed and the required four-message result will not be present.
+
+The harness creates a unique stream with:
+
+```text
+domain partitions = 1
+DLQ partitions = 1
+replication factor = 1
+```
+
+It does not delete the stream. Use a disposable service or perform separate operator cleanup.
+
+## Environment
+
+Required:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS
+```
+
+Optional paired credentials:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD
+```
+
+The address must be bounded `host:port` without a scheme, embedded credentials, query, or fragment. There is no default address or credential fallback. TLS, bundled mode, and failover are outside this harness.
+
+## Fixture publication
+
+All four physical fixtures are published through production:
+
+```text
+IggyTransport::move_to_dlq
+```
+
+The direct SDK client is not a producer.
+
+The fixture set is:
+
+```text
+A1: header UUID A, bytes A
+A2: header UUID A, bytes A
+B1: header UUID B, bytes B1
+B2: header UUID B, bytes B2
+```
+
+`A1/A2` define one ordinary duplicate group. `B1/B2` define one conflicting-payload group.
+
+The test source contains the bytes and generated UUIDs only in process memory. It does not print them or retain them.
+
+## Bounded scans
+
+The same scanner request is executed twice:
+
+```text
+partitions = [1]
+start_offset = 0
+max_messages = 4
+batch_size = 4
+```
+
+Both scans must return exactly:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+has_physical_duplicates = true
+has_identity_conflicts = true
+requires_manual_review = true
+```
+
+The second summary must equal the first summary. This shows that explicit-offset scanning is repeatable for the same retained physical window; it does not claim that the selected window covers complete history.
+
+## Stored-offset non-mutation
+
+The harness recreates the scanner's exact standalone consumer identity:
+
+```text
+consumer kind = Consumer
+consumer name = rustok-dlq-duplicate-readonly-v1
+partition = 1
+```
+
+It calls read-only `get_consumer_offset`:
+
+1. before fixture publication;
+2. after the first scan;
+3. after the second scan.
+
+Every observation must be `None`.
+
+The harness never calls:
+
+- `store_consumer_offset`;
+- `delete_consumer_offset`;
+- high-level cursor `store_offset`;
+- acknowledgement;
+- a consumer-group cursor;
+- direct SDK publication;
+- stream/topic deletion or purge.
+
+The scanner source separately locks `auto_commit = false` on low-level `poll_messages`.
+
+## Exact command
+
+```bash
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS='host:8090' \
+  cargo test -p rustok-iggy --features iggy \
+  --test dlq_duplicate_external_scan -- \
+  bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset \
+  --exact --nocapture --test-threads=1
+```
+
+When the required address is absent, the source harness reports a skip and returns successfully. A future retained runner must reject that skip and require the exact case to execute.
+
+## Source contracts and guards
+
+Runtime source contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+```
+
+Runtime source verifier:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+```
+
+The parent scanner contract and guard remain:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+```
+
+## Privacy boundary
+
+This source harness asserts only the count-level summary. It does not publish or retain:
+
+- broker address or credentials;
+- generated stream name;
+- partition offsets;
+- physical header UUIDs;
+- payload bytes or payload digests;
+- raw Iggy errors or logs.
+
+A future retained execution packet must keep the same boundary and store only reviewed service metadata, source/output hashes, exact command provenance, and aggregate pass results.
+
+## Remaining work
+
+1. execute the exact case against a reviewed dedup-disabled disposable service;
+2. add a clean-commit retained execution contract, runner, and strict verifier;
+3. retain only count-level evidence and absent-offset aggregate results;
+4. define alert thresholds outside the scanner;
+5. keep acknowledgement/delete/replay reconciliation in a separate authorized workflow.
+
+No test, Cargo command, formatter, verifier, external-Iggy connection, or scan was executed while defining this source slice.

--- a/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
@@ -1,6 +1,6 @@
 # Bounded external-Iggy DLQ duplicate scan
 
-Status: **source complete; disposable-broker runtime evidence pending**.
+Status: **scanner and disposable-broker harness source-complete; runtime execution pending**.
 
 ## Purpose
 
@@ -121,6 +121,32 @@ The adapter contains no call to:
 
 Polling uses `auto_commit = false`. The fixed consumer identifier is therefore only the request identity supplied to Iggy; the adapter does not persist progress for later `next` polling.
 
+## Source-complete runtime harness
+
+The opt-in `dlq_duplicate_external_scan` test target now defines one exact case against a reviewed disposable external broker with message-ID deduplication disabled.
+
+It publishes through production `IggyTransport::move_to_dlq`:
+
+```text
+A, A: same header UUID and same exact bytes
+B1, B2: same header UUID and different exact bytes
+```
+
+The same `[partition 1, offset 0, max 4, batch 4]` scan is executed twice. Both summaries must equal:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+```
+
+Read-only `get_consumer_offset` must return `None` before publication, after the first scan, and after the second scan. The test contains no direct SDK producer or offset mutation.
+
+See `dlq-duplicate-external-scan-runtime-evidence.md` for prerequisites and the exact command.
+
 ## Suggested caller flow
 
 ```text
@@ -137,27 +163,28 @@ Do not present this scanner as a complete historical inventory unless the select
 
 ## Source verification
 
-Machine contract:
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
 ```
 
-Static source guard:
+Static source guards:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 ```
 
-Focused source tests are embedded in `dlq_duplicate_external_scan.rs` for request bounds and stable error projection.
+Focused source tests are embedded in `dlq_duplicate_external_scan.rs` for request bounds and stable error projection. The opt-in integration target defines the physical duplicate/conflict and absent-offset case.
 
-No test, Cargo command, formatter, verifier, external Iggy connection, or runtime scan was executed while defining this slice.
+No test, Cargo command, formatter, verifier, external Iggy connection, or runtime scan was executed while defining these slices.
 
 ## Remaining work
 
-1. add a disposable external-Iggy harness that writes controlled duplicate and conflicting fixtures;
-2. prove explicit-offset polling reads the physical header UUID and exact bytes without storing offsets;
-3. prove count-only projection for ordinary duplicates and identity conflicts;
-4. retain a privacy-safe runtime packet without addresses, credentials, identifiers, payloads, offsets, or raw logs;
-5. define alert thresholds outside the scanner;
-6. keep acknowledgement/delete/replay reconciliation in a separately authorized workflow.
+1. execute the exact runtime case against a reviewed dedup-disabled disposable broker;
+2. retain a privacy-safe runtime packet without addresses, credentials, identifiers, payloads, offsets, or raw logs;
+3. define alert thresholds outside the scanner;
+4. keep acknowledgement/delete/replay reconciliation in a separately authorized workflow;
+5. preserve identifier-free aggregate correlation with poison receipt health.

--- a/crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs
+++ b/crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs
@@ -1,0 +1,305 @@
+#![cfg(feature = "iggy")]
+
+use std::env;
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+
+use iggy::prelude::{
+    Client, Consumer, ConsumerKind, ConsumerOffsetClient, Identifier, IggyClient,
+};
+use rustok_iggy::{
+    DlqEntry, ExternalConfig, IggyConfig, IggyDlqDuplicateScanRequest,
+    IggyDlqDuplicateScanner, IggyMode, IggyTransport, SerializationFormat,
+    TopologyConfig,
+};
+use uuid::Uuid;
+
+const ADDRESS_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD";
+const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-readonly-v1";
+const PARTITION_ID: u32 = 1;
+const PHYSICAL_MESSAGE_COUNT: u32 = 4;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset(
+) -> TestResult<()> {
+    let Some(config) = external_test_config()? else {
+        eprintln!(
+            "{ADDRESS_ENV} is not set; skipping external Iggy DLQ duplicate scan evidence"
+        );
+        return Ok(());
+    };
+
+    let stream = config.topology.stream_name.clone();
+    let transport = IggyTransport::new(config.clone()).await?;
+    let client = connect_sdk_observer(&config).await?;
+    let scanner = IggyDlqDuplicateScanner::new(&client, &stream)?;
+    let request = IggyDlqDuplicateScanRequest::new(
+        vec![PARTITION_ID],
+        0,
+        PHYSICAL_MESSAGE_COUNT,
+        PHYSICAL_MESSAGE_COUNT,
+    )?;
+
+    let stream_id: Identifier = stream.clone().try_into()?;
+    let topic_id: Identifier = "dlq".to_string().try_into()?;
+    let consumer_id: Identifier = READ_ONLY_CONSUMER.to_string().try_into()?;
+    let read_only_consumer = Consumer {
+        kind: ConsumerKind::Consumer,
+        id: consumer_id,
+    };
+
+    assert_no_stored_offset(
+        &client,
+        &read_only_consumer,
+        &stream_id,
+        &topic_id,
+    )
+    .await?;
+
+    let ordinary_duplicate_id = Uuid::new_v4();
+    let identity_conflict_id = Uuid::new_v4();
+    let ordinary_payload = vec![0xff, 0x00, 0x61, 0x01];
+    let conflict_payload_first = vec![0xff, 0x00, 0x62, 0x01];
+    let conflict_payload_second = vec![0xff, 0x00, 0x62, 0x02];
+
+    publish_physical(
+        &transport,
+        ordinary_duplicate_id,
+        ordinary_payload.clone(),
+        1,
+    )
+    .await?;
+    publish_physical(
+        &transport,
+        ordinary_duplicate_id,
+        ordinary_payload,
+        2,
+    )
+    .await?;
+    publish_physical(
+        &transport,
+        identity_conflict_id,
+        conflict_payload_first,
+        1,
+    )
+    .await?;
+    publish_physical(
+        &transport,
+        identity_conflict_id,
+        conflict_payload_second,
+        2,
+    )
+    .await?;
+
+    let first = scanner.summarize(&request).await?;
+    assert_summary(&first);
+    assert_no_stored_offset(
+        &client,
+        &read_only_consumer,
+        &stream_id,
+        &topic_id,
+    )
+    .await?;
+
+    let second = scanner.summarize(&request).await?;
+    assert_eq!(second, first);
+    assert_summary(&second);
+    assert_no_stored_offset(
+        &client,
+        &read_only_consumer,
+        &stream_id,
+        &topic_id,
+    )
+    .await?;
+
+    drop(scanner);
+    client.shutdown().await?;
+    transport.shutdown().await?;
+    Ok(())
+}
+
+fn assert_summary(summary: &rustok_iggy::DlqDuplicateSummary) {
+    assert_eq!(summary.total_messages(), 4);
+    assert_eq!(summary.unique_message_ids(), 2);
+    assert_eq!(summary.duplicate_messages(), 2);
+    assert_eq!(summary.duplicate_groups(), 2);
+    assert_eq!(summary.conflicting_payload_groups(), 1);
+    assert_eq!(summary.max_copies_per_message_id(), 2);
+    assert!(summary.has_physical_duplicates());
+    assert!(summary.has_identity_conflicts());
+    assert!(summary.requires_manual_review());
+}
+
+async fn publish_physical(
+    transport: &IggyTransport,
+    broker_message_id: Uuid,
+    payload: Vec<u8>,
+    retry_count: u32,
+) -> TestResult<()> {
+    let entry = DlqEntry::new(
+        broker_message_id,
+        "domain",
+        payload,
+        "iggy.contract.decode_invalid",
+        retry_count,
+    )
+    .with_broker_message_id(broker_message_id);
+    transport.move_to_dlq(entry).await?;
+    Ok(())
+}
+
+async fn assert_no_stored_offset(
+    client: &IggyClient,
+    consumer: &Consumer,
+    stream_id: &Identifier,
+    topic_id: &Identifier,
+) -> TestResult<()> {
+    let stored = client
+        .get_consumer_offset(consumer, stream_id, topic_id, Some(PARTITION_ID))
+        .await?;
+    if stored.is_some() {
+        return Err(invalid_data(
+            "read-only external duplicate scan unexpectedly stored a consumer offset",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+async fn connect_sdk_observer(config: &IggyConfig) -> TestResult<IggyClient> {
+    let client = IggyClient::from_connection_string(&connection_string(&config.external)?)?;
+    client.connect().await?;
+    Ok(client)
+}
+
+fn connection_string(config: &ExternalConfig) -> Result<String, IoError> {
+    let address = config
+        .addresses
+        .first()
+        .ok_or_else(|| invalid_data("external duplicate scan evidence address is missing"))?;
+    if config.protocol != "tcp" {
+        return Err(invalid_data("external duplicate scan evidence requires TCP"));
+    }
+    if config.tls_enabled || config.tls_domain.is_some() || config.tls_ca_file.is_some() {
+        return Err(invalid_data(
+            "external duplicate scan source harness does not claim TLS coverage",
+        ));
+    }
+    if config.username.is_empty() != config.password.is_empty() {
+        return Err(invalid_data(
+            "external duplicate scan username and password must both be set or both be empty",
+        ));
+    }
+    validate_connection_component(address, "address", &['@', '?', '#'])?;
+    validate_connection_component(&config.username, "username", &[':', '@'])?;
+    validate_connection_component(&config.password, "password", &[':', '@'])?;
+
+    if config.username.is_empty() {
+        Ok(format!("iggy://{address}"))
+    } else {
+        Ok(format!(
+            "iggy://{}:{}@{address}",
+            config.username, config.password
+        ))
+    }
+}
+
+fn external_test_config() -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(ADDRESS_ENV) {
+        Ok(value) => bounded_env(ADDRESS_ENV, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://")
+        || address.contains('@')
+        || address.contains('?')
+        || address.contains('#')
+    {
+        return Err(invalid_data(format!(
+            "{ADDRESS_ENV} must be host:port without URL or credential delimiters"
+        ))
+        .into());
+    }
+
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data(
+            "external duplicate scan username and password must both be set or both be empty",
+        )
+        .into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name("duplicate-scan"),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_connection_component(
+    value: &str,
+    field: &'static str,
+    forbidden: &[char],
+) -> Result<(), IoError> {
+    if let Some(delimiter) = value
+        .chars()
+        .find(|character| forbidden.contains(character))
+    {
+        return Err(invalid_data(format!(
+            "Iggy {field} contains unsupported connection delimiter '{delimiter}'"
+        )));
+    }
+    Ok(())
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-poison-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-profiles/docs/poison-duplicate-external-runtime-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-external-runtime-checkpoint.md
@@ -1,0 +1,116 @@
+# Profiles checkpoint: external DLQ duplicate scan runtime
+
+Status: **runtime harness source-complete; external execution and retained evidence pending**.
+
+## New source boundary
+
+The bounded external-Iggy scanner now has one opt-in runtime harness:
+
+```text
+crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+```
+
+Operator guide:
+
+```text
+crates/rustok-iggy/docs/dlq-duplicate-external-scan-runtime-evidence.md
+```
+
+No Profiles service, GraphQL field, storefront behavior, relation policy, or authorization port changed.
+
+## Controlled physical evidence
+
+The harness requires a reviewed disposable external broker with message-ID deduplication disabled. It publishes four physical DLQ messages only through production `IggyTransport::move_to_dlq`:
+
+```text
+A, A: same deterministic header UUID and same exact bytes
+B1, B2: same deterministic header UUID and different exact bytes
+```
+
+The expected count-only result is:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+```
+
+The conflict remains a manual-review signal. Neither the UUID nor the bytes are exposed by the result.
+
+## Repeatable read-only scan
+
+The same explicit request is executed twice:
+
+```text
+partition = 1
+start offset = 0
+maximum messages = 4
+batch size = 4
+```
+
+The second summary must equal the first. This establishes the expected source shape for repeatable explicit-offset observation; execution remains pending and no complete-history claim is made.
+
+## Stored-offset boundary
+
+The harness reads the exact standalone scanner consumer offset before publication, after the first scan, and after the second scan. All three results must be absent.
+
+This is read-only evidence around the scanner's existing:
+
+```text
+PollingStrategy::offset
+auto_commit = false
+```
+
+The source contains no offset-store/delete call, acknowledgement, consumer-group cursor, direct SDK producer, stream deletion, purge, replay, or retry.
+
+## Profiles authorization remains unchanged
+
+No profile visibility, audience, ownership, relationship, block, mute, follow, friendship, or presentation decision may depend on:
+
+- whether this harness ran;
+- the selected broker, stream, partition, or offset;
+- the count-only duplicate summary;
+- an absent or present consumer offset;
+- deduplication configuration;
+- future retained execution metadata.
+
+Profiles continues to authorize through owner ports. Physical duplicate observation is operational evidence only.
+
+## Privacy boundary
+
+The harness does not log or retain:
+
+- broker address or credentials;
+- generated stream name;
+- partition offsets;
+- physical header UUIDs;
+- payload bytes or payload digests;
+- raw Iggy errors.
+
+A future retained packet must preserve this boundary and contain only bounded reviewed artifact metadata, source/output hashes, exact command provenance, and aggregate pass status.
+
+## Remaining work
+
+1. execute the harness against a reviewed dedup-disabled disposable external service;
+2. prove the three absent-offset observations at runtime;
+3. add clean-commit retained capture and strict current-source verification;
+4. define alert thresholds outside Profiles;
+5. keep acknowledgement/delete/replay reconciliation separate and explicitly authorized;
+6. continue comparing receipt and physical duplicate health only as identifier-free aggregates.
+
+Tests, Cargo commands, formatters, source verifiers, external-Iggy scans, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
@@ -1,27 +1,30 @@
 # Profiles checkpoint: bounded external DLQ duplicate scan
 
-Status: **external-Iggy scan adapter source-complete; runtime evidence pending**.
+Status: **external-Iggy scanner and runtime harness source-complete; execution and retained evidence pending**.
 
 ## What changed
 
-`rustok-iggy` now owns a bounded read-only adapter that feeds physical external-Iggy `dlq` messages into the count-only duplicate classifier.
+`rustok-iggy` owns a bounded read-only adapter that feeds physical external-Iggy `dlq` messages into the count-only duplicate classifier. It now also owns one opt-in disposable-broker harness proving the expected source shape for duplicate/conflict classification and absent stored offsets.
 
-Source:
+Sources:
 
 ```text
 crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs
 ```
 
-Machine contract:
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
 ```
 
-Verifier:
+Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 ```
 
 Public API:
@@ -59,36 +62,50 @@ A request is limited to:
 
 The scanner fails closed on response partition/count mismatch, non-monotonic offsets, offsets before the requested position, nil physical header UUID, or offset overflow.
 
+## Source-complete runtime case
+
+The opt-in runtime case requires one reviewed dedup-disabled disposable external service. It publishes four physical messages through production `IggyTransport::move_to_dlq`:
+
+```text
+A, A: one ordinary duplicate group
+B1, B2: one conflicting-payload group
+```
+
+Two scans reuse the exact request `[partition 1, offset 0, max 4, batch 4]`. Both must return:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+```
+
+The scanner consumer offset must be absent before publication, after the first scan, and after the second scan. Runtime execution remains pending.
+
 ## Count-only privacy boundary
 
 During a scan, physical header UUIDs and exact bytes exist only long enough to create in-memory duplicate observations. Exact bytes are reduced to a domain-separated digest inside the classifier.
 
-The returned result exposes only:
+The returned result exposes only counts. It does not expose broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, credentials, or raw Iggy errors.
 
-```text
-total_messages
-unique_message_ids
-duplicate_messages
-duplicate_groups
-conflicting_payload_groups
-max_copies_per_message_id
-```
-
-It does not expose broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, credentials, or raw Iggy errors.
+The runtime harness also does not print or retain those values. A future retained packet must preserve the same boundary.
 
 ## Profiles authorization remains unchanged
 
 No profile visibility, relationship, block, mute, follow, friendship, audience, ownership, or presentation decision may depend on:
 
-- whether a DLQ scan was performed;
+- whether a DLQ scan or runtime harness was performed;
 - selected partitions or offsets;
 - physical duplicate counts;
 - conflicting-payload counts;
-- scanner errors;
+- scanner or harness errors;
 - broker deduplication configuration;
+- consumer offset presence;
 - future retained evidence metadata.
 
-Profiles continues to consume authorized owner-port results. The scanner is operational observability for downstream neutralization only.
+Profiles continues to consume authorized owner-port results. The scanner and harness are operational observability for downstream neutralization only.
 
 ## Operator interpretation
 
@@ -100,11 +117,10 @@ Any `conflicting_payload_groups > 0` result requires manual forensic escalation.
 
 ## Remaining work
 
-1. add a disposable external-Iggy runtime harness with controlled duplicate/conflict fixtures;
-2. prove explicit-offset polling with `auto_commit=false` does not persist progress;
-3. retain only count-level runtime evidence;
-4. define alert thresholds outside Profiles and outside the scanner;
-5. design acknowledgement/delete/replay as a separate explicitly authorized workflow;
-6. preserve the identifier-free boundary when comparing receipt and physical duplicate trends.
+1. execute the source-complete runtime case against a reviewed dedup-disabled disposable service;
+2. retain only count-level runtime and absent-offset evidence;
+3. define alert thresholds outside Profiles and outside the scanner;
+4. design acknowledgement/delete/replay as a separate explicitly authorized workflow;
+5. preserve the identifier-free boundary when comparing receipt and physical duplicate trends.
 
 No tests, Cargo commands, formatters, source verifiers, external-Iggy scans, or retained capture were run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json";
+const testPath = "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs";
+const scannerPath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const dlqPath = "crates/rustok-iggy/src/dlq.rs";
+const transportPath = "crates/rustok-iggy/src/transport.rs";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs";
+const expectedDocumentation =
+  "crates/rustok-iggy/docs/dlq-duplicate-external-scan-runtime-evidence.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-duplicate-external-runtime-checkpoint.md";
+const expectedCase =
+  "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset";
+const expectedCommand = {
+  program: "cargo",
+  args: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "dlq_duplicate_external_scan",
+    "--",
+    expectedCase,
+    "--exact",
+    "--nocapture",
+    "--test-threads=1",
+  ],
+};
+const expectedSummary = {
+  total_messages: 4,
+  unique_message_ids: 2,
+  duplicate_messages: 2,
+  duplicate_groups: 2,
+  conflicting_payload_groups: 1,
+  max_copies_per_message_id: 2,
+  has_physical_duplicates: true,
+  has_identity_conflicts: true,
+  requires_manual_review: true,
+};
+const expectedSources = [testPath, scannerPath, classifierPath, dlqPath, transportPath];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const test = readFileSync(resolve(repoRoot, testPath), "utf8");
+const scanner = readFileSync(resolve(repoRoot, scannerPath), "utf8");
+const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const dlq = readFileSync(resolve(repoRoot, dlqPath), "utf8");
+const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-external-scan-runtime-source" ||
+  contract.status !== "source_complete_runtime_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.feature !== "iggy" ||
+  contract.test_target !== "dlq_duplicate_external_scan" ||
+  contract.test !== testPath ||
+  contract.case !== expectedCase ||
+  contract.execution_status !== "not_run"
+) {
+  fail("external duplicate scan runtime contract identity or pending status drift");
+}
+if (!sameValue(contract.command, expectedCommand)) {
+  fail("external duplicate scan runtime exact Cargo command drift");
+}
+if (!sameValue(contract.required_summary, expectedSummary)) {
+  fail("external duplicate scan runtime expected count-only summary drift");
+}
+if (!sameValue(contract.source_files, expectedSources)) {
+  fail("external duplicate scan runtime source file allowlist drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("external duplicate scan runtime verifier or documentation path drift");
+}
+
+if (
+  contract.environment?.address !== "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS" ||
+  contract.environment?.optional_username !==
+    "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME" ||
+  contract.environment?.optional_password !==
+    "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD" ||
+  contract.environment?.default_address !== false ||
+  contract.environment?.default_credentials !== false
+) {
+  fail("external duplicate scan runtime environment boundary drift");
+}
+if (
+  contract.reviewed_broker_requirement?.mode !==
+    "external_disposable_or_operator_cleaned" ||
+  contract.reviewed_broker_requirement?.message_deduplication_enabled !== false ||
+  contract.reviewed_broker_requirement?.configuration_readback_by_test !== false
+) {
+  fail("external duplicate scan runtime reviewed broker requirement drift");
+}
+if (
+  contract.topology?.unique_stream_per_run !== true ||
+  contract.topology?.topic !== "dlq" ||
+  contract.topology?.domain_partitions !== 1 ||
+  contract.topology?.replication_factor !== 1 ||
+  contract.topology?.stream_deletion_by_test !== false
+) {
+  fail("external duplicate scan runtime topology boundary drift");
+}
+if (
+  contract.fixture_publication?.api !== "IggyTransport::move_to_dlq" ||
+  contract.fixture_publication?.direct_sdk_producer !== false ||
+  contract.fixture_publication?.physical_messages !== 4 ||
+  contract.fixture_publication?.ordinary_duplicate?.copies !== 2 ||
+  contract.fixture_publication?.ordinary_duplicate?.same_header_uuid !== true ||
+  contract.fixture_publication?.ordinary_duplicate?.same_exact_bytes !== true ||
+  contract.fixture_publication?.identity_conflict?.copies !== 2 ||
+  contract.fixture_publication?.identity_conflict?.same_header_uuid !== true ||
+  contract.fixture_publication?.identity_conflict?.different_exact_bytes !== true
+) {
+  fail("external duplicate scan runtime fixture semantics drift");
+}
+if (
+  !sameValue(contract.scan_request, {
+    partitions: [1],
+    start_offset: 0,
+    max_messages: 4,
+    batch_size: 4,
+    runs: 2,
+    same_request_reused: true,
+  })
+) {
+  fail("external duplicate scan runtime request drift");
+}
+if (
+  contract.offset_non_mutation?.consumer_kind !== "standalone_consumer" ||
+  contract.offset_non_mutation?.consumer_name !==
+    "rustok-dlq-duplicate-readonly-v1" ||
+  contract.offset_non_mutation?.partition !== 1 ||
+  !sameValue(contract.offset_non_mutation?.checks, [
+    "before_fixture_publication",
+    "after_first_scan",
+    "after_second_scan",
+  ]) ||
+  contract.offset_non_mutation?.required_stored_offset !== null ||
+  contract.offset_non_mutation?.second_scan_summary_equals_first !== true ||
+  contract.offset_non_mutation?.auto_commit !== false
+) {
+  fail("external duplicate scan runtime offset non-mutation contract drift");
+}
+if (
+  contract.privacy_boundary?.source_assertions_may_compare_exact_bytes !== false ||
+  contract.privacy_boundary?.summary_only !== true
+) {
+  fail("external duplicate scan runtime privacy boundary drift");
+}
+
+for (const marker of [
+  '#![cfg(feature = "iggy")]',
+  'const ADDRESS_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS";',
+  'const USERNAME_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME";',
+  'const PASSWORD_ENV: &str = "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD";',
+  'const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-readonly-v1";',
+  "const PARTITION_ID: u32 = 1;",
+  "const PHYSICAL_MESSAGE_COUNT: u32 = 4;",
+  `async fn ${expectedCase}(`,
+  "IggyTransport::new(config.clone()).await?",
+  "IggyDlqDuplicateScanner::new(&client, &stream)?",
+  "IggyDlqDuplicateScanRequest::new(",
+  "vec![PARTITION_ID]",
+  "ConsumerKind::Consumer",
+  "let ordinary_duplicate_id = Uuid::new_v4();",
+  "let identity_conflict_id = Uuid::new_v4();",
+  "ordinary_payload.clone()",
+  "ordinary_payload,",
+  "conflict_payload_first,",
+  "conflict_payload_second,",
+  "let first = scanner.summarize(&request).await?;",
+  "let second = scanner.summarize(&request).await?;",
+  "assert_eq!(second, first);",
+  "assert_eq!(summary.total_messages(), 4);",
+  "assert_eq!(summary.unique_message_ids(), 2);",
+  "assert_eq!(summary.duplicate_messages(), 2);",
+  "assert_eq!(summary.duplicate_groups(), 2);",
+  "assert_eq!(summary.conflicting_payload_groups(), 1);",
+  "assert_eq!(summary.max_copies_per_message_id(), 2);",
+  "assert!(summary.has_physical_duplicates());",
+  "assert!(summary.has_identity_conflicts());",
+  "assert!(summary.requires_manual_review());",
+  ".with_broker_message_id(broker_message_id)",
+  "transport.move_to_dlq(entry).await?;",
+  ".get_consumer_offset(consumer, stream_id, topic_id, Some(PARTITION_ID))",
+  "if stored.is_some()",
+  "client.shutdown().await?;",
+  "transport.shutdown().await?;",
+  "domain_partitions: 1",
+  "replication_factor: 1",
+]) {
+  requireText("external duplicate scan runtime harness", test, marker);
+}
+if (countText(test, "publish_physical(") !== 5) {
+  fail("external duplicate scan runtime harness must define and invoke four fixture publishes");
+}
+if (countText(test, "assert_no_stored_offset(") !== 4) {
+  fail("external duplicate scan runtime harness must define and invoke three offset checks");
+}
+if (countText(test, "scanner.summarize(&request).await?") !== 2) {
+  fail("external duplicate scan runtime harness must repeat the same explicit-offset scan twice");
+}
+if (countText(test, "#[tokio::test]") !== 1) {
+  fail("external duplicate scan runtime harness must contain exactly one focused runtime case");
+}
+
+for (const marker of [
+  "DATABASE_URL",
+  "localhost",
+  "127.0.0.1",
+  "PublishRequest",
+  "ExternalConnector",
+  ".poll_messages(",
+  ".send_messages(",
+  ".store_consumer_offset(",
+  ".delete_consumer_offset(",
+  ".consumer_group(",
+  ".acknowledge(",
+  ".store_offset(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".get_topic(",
+  ".get_topics(",
+]) {
+  forbidText("external duplicate scan runtime harness", test, marker);
+}
+
+for (const marker of [
+  "pub struct IggyDlqDuplicateScanner<'a>",
+  "ConsumerKind::Consumer",
+  "&PollingStrategy::offset(next_offset)",
+  "requested_count,\n                        false,",
+  "summarize_dlq_duplicates(observations)",
+]) {
+  requireText("bounded external duplicate scanner", scanner, marker);
+}
+for (const marker of [
+  ".store_consumer_offset(",
+  ".store_offset(",
+  ".acknowledge(",
+  ".send_messages(",
+  ".delete_topic(",
+  ".purge_topic(",
+]) {
+  forbidText("bounded external duplicate scanner", scanner, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateObservation",
+  "pub struct DlqDuplicateSummary",
+  "pub fn summarize_dlq_duplicates(",
+  "if broker_message_id.is_nil()",
+  "group.payload_sha256.len() > 1",
+]) {
+  requireText("transport-neutral duplicate classifier", classifier, marker);
+}
+for (const marker of [
+  "let publish_event_id = entry.broker_message_id.unwrap_or(entry.event_id);",
+  "publish_event_id.to_string()",
+]) {
+  requireText("DLQ deterministic physical publisher", dlq, marker);
+}
+for (const marker of [
+  "if entry.broker_message_id().is_some()",
+  "IggyDlqPublisher::connect",
+  ".publish(&entry)",
+]) {
+  requireText("production Iggy transport", transport, marker);
+}
+
+const requiredNonClaims = new Set([
+  "active_server_configuration_readback",
+  "production_history_complete",
+  "production_dedup_window_sufficiency",
+  "stored_offset_non_mutation_runtime_executed",
+  "retained_runtime_evidence",
+  "bundled_iggy",
+  "tls_auth_failover",
+  "multi_partition_runtime",
+  "destructive_reconciliation",
+  "profiles_authorization",
+]);
+for (const claim of contract.non_claims ?? []) requiredNonClaims.delete(claim);
+if (requiredNonClaims.size > 0) {
+  fail(`external duplicate scan runtime non-claims are incomplete: ${[
+    ...requiredNonClaims,
+  ].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy external DLQ duplicate scan runtime source verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy external DLQ duplicate scan runtime source verified: production publication of ordinary duplicate and conflicting-byte fixtures, two identical bounded explicit-offset scans, exact count-only classification, three absent-offset observations, auto_commit=false scanner parity, no SDK producer or offset mutation, reviewed dedup-disabled broker boundary, and bounded non-claims are locked; runtime execution remains pending.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
@@ -7,6 +7,9 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
+const runtimeContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json";
+const runtimeTestPath = "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
 const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
@@ -14,6 +17,8 @@ const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-external-scan
 const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-external-scan.md";
 const expectedProfilesCheckpoint =
   "crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md";
+const expectedRuntimeCase =
+  "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset";
 const expectedExports = [
   "IggyDlqDuplicateScanRequest",
   "IggyDlqDuplicateScanner",
@@ -26,6 +31,10 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const runtimeContract = JSON.parse(
+  readFileSync(resolve(repoRoot, runtimeContractPath), "utf8"),
+);
+const runtimeTest = readFileSync(resolve(repoRoot, runtimeTestPath), "utf8");
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
@@ -76,6 +85,22 @@ if (
   contract.profiles_checkpoint !== expectedProfilesCheckpoint
 ) {
   fail("external DLQ duplicate scan verifier or documentation path drift");
+}
+if (
+  contract.runtime_harness?.status !== "source_complete_execution_pending" ||
+  contract.runtime_harness?.contract !== runtimeContractPath ||
+  contract.runtime_harness?.test !== runtimeTestPath ||
+  contract.runtime_harness?.case !== expectedRuntimeCase ||
+  contract.runtime_harness?.reviewed_dedup_disabled_broker_required !== true ||
+  contract.runtime_harness?.two_identical_scans !== true ||
+  contract.runtime_harness?.three_absent_offset_checks !== true ||
+  runtimeContract.packet !== "dlq-duplicate-external-scan-runtime-source" ||
+  runtimeContract.status !== "source_complete_runtime_pending" ||
+  runtimeContract.test !== runtimeTestPath ||
+  runtimeContract.case !== expectedRuntimeCase ||
+  runtimeContract.execution_status !== "not_run"
+) {
+  fail("external DLQ duplicate scan runtime harness relationship drift");
 }
 if (
   contract.iggy_poll_boundary?.client !== "already_connected_IggyClient_borrow" ||
@@ -186,6 +211,34 @@ for (const marker of [
 }
 
 for (const marker of [
+  `async fn ${expectedRuntimeCase}(`,
+  "IggyTransport::new(config.clone()).await?",
+  "IggyDlqDuplicateScanner::new(&client, &stream)?",
+  "let first = scanner.summarize(&request).await?;",
+  "let second = scanner.summarize(&request).await?;",
+  "assert_eq!(second, first);",
+  ".get_consumer_offset(consumer, stream_id, topic_id, Some(PARTITION_ID))",
+  "if stored.is_some()",
+]) {
+  requireText("external DLQ duplicate scan runtime harness", runtimeTest, marker);
+}
+if (countText(runtimeTest, "assert_no_stored_offset(") !== 4) {
+  fail("external DLQ duplicate scan runtime harness must contain three offset checks");
+}
+for (const marker of [
+  ".store_consumer_offset(",
+  ".delete_consumer_offset(",
+  ".store_offset(",
+  ".acknowledge(",
+  ".send_messages(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+]) {
+  forbidText("external DLQ duplicate scan runtime harness", runtimeTest, marker);
+}
+
+for (const marker of [
   "pub struct DlqDuplicateObservation",
   "pub struct DlqDuplicateSummary",
   "pub fn summarize_dlq_duplicates(",
@@ -226,16 +279,15 @@ if (requiredPrivacyExclusions.size > 0) {
   );
 }
 
-const requiredNonClaims = new Set([
-  "disposable_external_iggy_runtime_scan_harness",
+const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
   "operator_alert_threshold_policy",
   "authorized_destructive_reconciliation_workflow",
   "aggregate_receipt_and_duplicate_health_correlation",
 ]);
-for (const item of contract.remaining_work ?? []) requiredNonClaims.delete(item);
-if (requiredNonClaims.size > 0) {
-  fail(`external DLQ duplicate scan remaining work drift: ${[...requiredNonClaims].join(", ")}`);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`external DLQ duplicate scan remaining work drift: ${[...requiredRemaining].join(", ")}`);
 }
 
 if (failures.length > 0) {
@@ -245,5 +297,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy external DLQ duplicate scan source verified: borrowed client lifecycle, standalone explicit-offset polling, auto_commit=false, bounded partitions/messages/batches, strict response progress, count-only projection, stable identifier-free errors, and no offset-store or destructive API are locked; external runtime evidence remains pending.",
+  "Iggy external DLQ duplicate scan source verified: borrowed client lifecycle, standalone explicit-offset polling, auto_commit=false, bounded partitions/messages/batches, strict response progress, count-only projection, stable identifier-free errors, no offset-store or destructive API, and the source-complete dedup-disabled external runtime harness with repeated scans and absent-offset checks are locked; runtime execution remains pending.",
 );


### PR DESCRIPTION
## Summary

Add one opt-in disposable external-Iggy runtime harness for the bounded read-only physical DLQ duplicate scanner merged in #2386.

## Controlled fixture

The harness requires a reviewed external disposable or operator-cleaned broker with message-ID deduplication disabled. It creates one unique one-partition stream and publishes four physical DLQ messages only through production `IggyTransport::move_to_dlq`:

```text
A1/A2: same deterministic header UUID and same exact bytes
B1/B2: same deterministic header UUID and different exact bytes
```

The direct SDK client is not a producer.

## Required count-only result

The same scanner request is executed twice:

```text
partitions = [1]
start_offset = 0
max_messages = 4
batch_size = 4
```

Both runs must return:

```text
total_messages = 4
unique_message_ids = 2
duplicate_messages = 2
duplicate_groups = 2
conflicting_payload_groups = 1
max_copies_per_message_id = 2
has_physical_duplicates = true
has_identity_conflicts = true
requires_manual_review = true
```

The second summary must equal the first.

## Offset non-mutation evidence

The harness recreates the scanner's exact standalone consumer identity and calls read-only `get_consumer_offset`:

1. before fixture publication;
2. after the first scan;
3. after the second scan.

All three results must be absent.

The source contains no `store_consumer_offset`, `delete_consumer_offset`, high-level cursor offset storage, acknowledgement, consumer-group cursor, direct SDK message publication, stream/topic deletion, or purge. The scanner source remains locked to explicit-offset polling with `auto_commit=false`.

## Environment and isolation

Required:

```text
RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS
```

Optional paired username/password variables are supported. There is no address or credential fallback. The harness requires TCP, creates a unique stream, uses one partition, and leaves cleanup to a disposable service or separate operator workflow.

The test does not read back server configuration. Dedup-disabled mode is an explicit reviewed prerequisite.

## Contracts and documentation

- added the runtime source contract with the exact Cargo command;
- added a static verifier binding the harness to production publication, scanner `auto_commit=false`, three absent-offset checks, two identical scans, exact aggregate counts, and forbidden SDK mutation APIs;
- added an operator/runtime evidence guide;
- added a Profiles runtime checkpoint preserving the owner-port authorization boundary;
- actualized the parent scanner contract, verifier, guide, and Profiles checkpoint from runtime-harness-pending to execution-pending.

## Privacy

The harness does not log or retain broker addresses, credentials, generated stream names, offsets, header UUIDs, payloads, payload digests, or raw Iggy errors. It asserts only the count-level summary and absent-offset state.

## Non-claims

This source slice does not claim active server configuration readback, production history completeness, production dedup-window sufficiency, executed offset non-mutation, retained runtime evidence, bundled mode, TLS/auth/failover, multi-partition runtime, destructive reconciliation, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, external-Iggy scans, and retained capture were not run, per maintainer instruction.

Suggested maintainer flow:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs

RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS='host:8090' \
  cargo test -p rustok-iggy --features iggy \
  --test dlq_duplicate_external_scan -- \
  bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset \
  --exact --nocapture --test-threads=1
```
