### PR TITLE
test(profiles): retain external DLQ duplicate scan evidence

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-external-scan-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json",
+  "runner": "scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs",
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs",
+  "evidence_path": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json",
+  "evidence_status": "runtime_execution_pending",
+  "command": {
+    "program": "cargo",
+    "args": [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--features",
+      "iggy",
+      "--test",
+      "dlq_duplicate_external_scan",
+      "--",
+      "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
+  "case": "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
+  "required_environment": {
+    "address": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS",
+    "config_path": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_CONFIG_PATH",
+    "server_artifact": "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_SERVER_ARTIFACT"
+  },
+  "optional_environment": [
+    "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME",
+    "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD"
+  ],
+  "reviewed_configuration": {
+    "section": "system.message_deduplication",
+    "required_enabled": false,
+    "retain_only": [
+      "section",
+      "enabled",
+      "canonical_sha256"
+    ],
+    "config_path_outside_repository": true,
+    "full_content_retained": false,
+    "full_file_sha256_retained": false
+  },
+  "required_summary": {
+    "total_messages": 4,
+    "unique_message_ids": 2,
+    "duplicate_messages": 2,
+    "duplicate_groups": 2,
+    "conflicting_payload_groups": 1,
+    "max_copies_per_message_id": 2,
+    "has_physical_duplicates": true,
+    "has_identity_conflicts": true,
+    "requires_manual_review": true
+  },
+  "required_offset_observations": {
+    "before_fixture_publication_stored_offset_present": false,
+    "after_first_scan_stored_offset_present": false,
+    "after_second_scan_stored_offset_present": false
+  },
+  "runner_requirements": {
+    "clean_working_tree_before": true,
+    "clean_working_tree_after": true,
+    "full_git_commit": true,
+    "commit_unchanged": true,
+    "source_hashes_unchanged": true,
+    "exact_case_only": true,
+    "running_one_test_required": true,
+    "skip_rejected": true,
+    "atomic_write_after_pass": true
+  },
+  "retained_packet": {
+    "reviewed_artifact_labels": true,
+    "canonical_dedup_configuration": true,
+    "git_toolchain_timestamps": true,
+    "exact_command": true,
+    "current_source_sha256": true,
+    "test_output_sha256_and_bytes": true,
+    "aggregate_summary_assertions": true,
+    "aggregate_absent_offset_assertions": true,
+    "case_result": "pass"
+  },
+  "privacy_exclusions": [
+    "database_url",
+    "broker_address",
+    "config_path",
+    "config_full_content",
+    "config_full_file_sha256",
+    "username",
+    "password",
+    "connection_string",
+    "raw_test_output",
+    "stream_name",
+    "partition_id",
+    "offset",
+    "broker_message_id",
+    "delivery_uuid",
+    "payload",
+    "payload_sha256",
+    "ack_token",
+    "raw_iggy_error"
+  ],
+  "source_files": [
+    "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+    "crates/rustok-iggy/src/dlq.rs",
+    "crates/rustok-iggy/src/transport.rs",
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json",
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json",
+    "scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs",
+    "scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs"
+  ],
+  "non_claims": [
+    "active_server_configuration_readback",
+    "production_history_complete",
+    "production_dedup_window_sufficiency",
+    "bundled_iggy",
+    "tls_auth_failover",
+    "multi_partition_runtime",
+    "destructive_reconciliation",
+    "profiles_authorization"
+  ]
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
@@ -124,6 +124,14 @@
       "payload"
     ]
   },
+  "retained_execution": {
+    "status": "source_complete_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json",
+    "runner": "scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs",
+    "verifier": "scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs",
+    "evidence_path": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json",
+    "canonical_packet_present": false
+  },
   "source_files": [
     "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
     "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",

--- a/crates/rustok-iggy/docs/dlq-duplicate-external-scan-retained-evidence.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-external-scan-retained-evidence.md
@@ -1,0 +1,199 @@
+# Retained external-Iggy DLQ duplicate scan evidence
+
+Status: **execution contract, runner, and verifier source-complete; canonical runtime packet absent**.
+
+## Purpose
+
+This retained path executes the exact source-complete runtime case for the bounded physical DLQ duplicate scanner and stores only privacy-safe aggregate evidence.
+
+It binds one clean Git commit to:
+
+- a reviewed dedup-disabled external Iggy configuration;
+- one exact Cargo test case;
+- the required duplicate/conflict count summary;
+- three required absent-offset observations;
+- current source SHA-256 values;
+- bounded service/toolchain metadata;
+- a test-output digest and byte count.
+
+It does not retain the broker endpoint, credentials, config path/content, message identifiers, payloads, offsets, or raw logs.
+
+## Files
+
+Execution contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json
+```
+
+Capture runner:
+
+```text
+scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
+```
+
+Strict verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+```
+
+Canonical packet, absent until successful execution:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json
+```
+
+## Required environment
+
+External endpoint:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS
+```
+
+Absolute reviewed server-config path outside the repository:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_CONFIG_PATH
+```
+
+Bounded operator-reviewed Iggy version, image digest, or artifact label:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_SERVER_ARTIFACT
+```
+
+Optional paired credentials:
+
+```text
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME
+RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD
+```
+
+The endpoint is validated as `host:port` and is never retained. Credentials must be both set or both empty and are never retained. Artifact metadata must not look like an endpoint.
+
+## Reviewed configuration
+
+The config file must be absolute, existing, and outside the repository. The runner reads only:
+
+```toml
+[system.message_deduplication]
+enabled = false
+```
+
+The retained canonical configuration is only:
+
+```json
+{
+  "section": "system.message_deduplication",
+  "enabled": false,
+  "canonical_sha256": "..."
+}
+```
+
+The path, full content, unrelated settings, and full-file SHA-256 are excluded.
+
+## Exact execution
+
+The runner executes only:
+
+```bash
+cargo test -p rustok-iggy --features iggy \
+  --test dlq_duplicate_external_scan -- \
+  bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset \
+  --exact --nocapture --test-threads=1
+```
+
+It requires:
+
+- process exit status zero;
+- `running 1 test`;
+- exact `<case> ... ok` output;
+- no source-harness skip marker.
+
+A missing environment variable, invalid reviewed config, failed test, skip, changed commit, changed source hash, or dirty working tree produces no canonical packet.
+
+## Clean-commit boundary
+
+Before execution the runner requires:
+
+- a clean tracked and untracked working tree;
+- a full lowercase 40-character Git commit;
+- all bound source files present.
+
+After execution it requires:
+
+- the same Git commit;
+- the same SHA-256 for every bound source file, including runner, verifier, and execution contract;
+- a still-clean working tree.
+
+Only then is the packet written through a temporary file and atomic rename.
+
+## Retained assertions
+
+The packet retains the exact aggregate expectations enforced by the runtime case:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+has_physical_duplicates = true
+has_identity_conflicts = true
+requires_manual_review = true
+```
+
+It also retains only these aggregate offset assertions:
+
+```text
+before_fixture_publication_stored_offset_present = false
+after_first_scan_stored_offset_present = false
+after_second_scan_stored_offset_present = false
+```
+
+These are contract assertions attached to one all-pass case. No partition, offset value, consumer identifier, message UUID, or payload is stored.
+
+## Packet privacy
+
+The packet permits only:
+
+- environment-variable names;
+- reviewed Iggy artifact label;
+- canonical dedup-disabled values and digest;
+- Git commit and timestamps;
+- Cargo and Rust compiler version lines;
+- exact command provenance;
+- current source hashes;
+- aggregate required summary and absent-offset booleans;
+- `pass` result;
+- test-output SHA-256 and byte count.
+
+The strict verifier rejects forbidden delivery-level or endpoint/config fields.
+
+## Maintainer flow
+
+Before execution, verify source contracts:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+```
+
+From a clean commit with required environment supplied:
+
+```bash
+node scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+```
+
+Review the generated packet before committing it. Re-execute whenever any bound source hash changes.
+
+## Non-claims
+
+This retained path does not establish active server configuration readback, complete production history, production dedup-window sufficiency, bundled mode, TLS/auth/failover, multi-partition runtime, destructive reconciliation, or Profiles authorization.
+
+No test, Cargo command, formatter, verifier, external-Iggy connection, or retained capture was executed while defining this tooling.

--- a/crates/rustok-profiles/docs/poison-duplicate-external-retained-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-external-retained-checkpoint.md
@@ -1,0 +1,109 @@
+# Profiles checkpoint: retained external DLQ duplicate scan evidence
+
+Status: **retained tooling source-complete; canonical runtime packet absent**.
+
+## New evidence boundary
+
+The external-Iggy physical duplicate scan now has a clean-commit retained path:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json
+scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
+scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+```
+
+The canonical execution packet is intentionally absent:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json
+```
+
+No Profiles runtime, API, storage, presentation, or authorization code changed.
+
+## Reviewed external service
+
+A maintainer must provide:
+
+- one external Iggy `host:port` through an environment variable;
+- an absolute reviewed config path outside the repository;
+- a bounded reviewed Iggy artifact/version label;
+- optional paired credentials.
+
+The runner reads only `system.message_deduplication.enabled` and requires `false`. It does not perform active server configuration readback.
+
+The endpoint, credentials, config path, full config, unrelated settings, and full-file hash are not retained.
+
+## Retained count-only assertions
+
+The exact all-pass runtime case binds:
+
+```text
+total_messages = 4
+unique_message_ids = 2
+duplicate_messages = 2
+duplicate_groups = 2
+conflicting_payload_groups = 1
+max_copies_per_message_id = 2
+```
+
+It also binds three aggregate absent-offset assertions:
+
+```text
+before fixture publication = absent
+after first scan = absent
+after second scan = absent
+```
+
+No actual partition, offset, message UUID, payload, or payload digest is included.
+
+## Clean-commit and freshness boundary
+
+The runner requires a clean working tree and a full Git commit before execution. It hashes current production, scanner, classifier, runtime harness, contracts, runner, and verifier sources.
+
+After the exact test passes, it requires:
+
+- unchanged `HEAD`;
+- unchanged source SHA-256 values;
+- a still-clean working tree;
+- atomic packet creation.
+
+The strict verifier rejects a packet generated from another commit or stale source hashes.
+
+## Profiles authorization remains unchanged
+
+No profile visibility, ownership, audience, relationship, block, mute, follow, friendship, or presentation decision may depend on:
+
+- the reviewed broker artifact or config digest;
+- whether the retained runner executed;
+- duplicate or conflicting-payload counts;
+- absent-offset assertions;
+- source/output hashes;
+- execution timestamps or toolchain metadata.
+
+Profiles continues to authorize through owner ports. This packet is operational evidence about downstream neutralization only.
+
+## Privacy boundary
+
+A retained packet may contain only:
+
+- environment-variable names;
+- bounded reviewed artifact label;
+- canonical `enabled=false` configuration and digest;
+- Git/toolchain/timestamps;
+- exact command provenance;
+- current source SHA-256 values;
+- aggregate summary and absent-offset assertions;
+- one `pass` result and output digest/size.
+
+It excludes endpoints, credentials, config paths/content, raw logs, stream names, partitions, offsets, UUIDs, payloads, acknowledgement tokens, and raw Iggy errors.
+
+## Remaining work
+
+1. execute the exact case against a reviewed dedup-disabled disposable broker;
+2. review and commit the canonical packet only after success;
+3. re-execute whenever a bound source hash changes;
+4. define alert thresholds outside Profiles;
+5. keep acknowledgement/delete/replay reconciliation separate and explicitly authorized;
+6. preserve identifier-free aggregate comparison with poison receipt health.
+
+Tests, Cargo commands, formatters, source verifiers, external-Iggy scans, and retained capture were not run by the implementation agent.

--- a/scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
+++ b/scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
@@ -1,0 +1,436 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json";
+const expectedSourceContract =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json";
+const expectedRunner = "scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs";
+const expectedEvidence =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json";
+const expectedCase =
+  "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset";
+const expectedCommand = {
+  program: "cargo",
+  args: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "dlq_duplicate_external_scan",
+    "--",
+    expectedCase,
+    "--exact",
+    "--nocapture",
+    "--test-threads=1",
+  ],
+};
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) fail(`${program} could not start: ${result.error.message}`);
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function strictOneLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is missing, padded, multiline, or outside the retained boundary`);
+  }
+  return value;
+}
+
+function commandOutputLine(value, field, maximumLength = 256) {
+  if (typeof value !== "string") fail(`${field} is missing`);
+  const normalized = value.replace(/\r?\n$/u, "");
+  if (
+    normalized.length === 0 ||
+    normalized.length > maximumLength ||
+    normalized.trim() !== normalized ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(normalized)
+  ) {
+    fail(`${field} is multiline or outside the retained boundary`);
+  }
+  return normalized;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`source file is missing: ${relativePath}`);
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function validateContract() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "iggy" ||
+    contract.packet !== "dlq-duplicate-external-scan-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked" ||
+    contract.source_contract !== expectedSourceContract ||
+    contract.runner !== expectedRunner ||
+    contract.verifier !== expectedVerifier ||
+    contract.evidence_path !== expectedEvidence ||
+    contract.evidence_status !== "runtime_execution_pending" ||
+    contract.case !== expectedCase
+  ) {
+    fail("external duplicate scan execution contract identity or path drift");
+  }
+  if (!sameValue(contract.command, expectedCommand)) {
+    fail("external duplicate scan exact Cargo command allowlist drift");
+  }
+  if (
+    contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+    contract.reviewed_configuration?.required_enabled !== false ||
+    contract.reviewed_configuration?.config_path_outside_repository !== true ||
+    contract.reviewed_configuration?.full_content_retained !== false ||
+    contract.reviewed_configuration?.full_file_sha256_retained !== false
+  ) {
+    fail("external duplicate scan reviewed configuration boundary drift");
+  }
+}
+
+function validateAddress(value, field) {
+  const address = strictOneLine(value, field, 255);
+  if (
+    address.includes("://") ||
+    address.includes("@") ||
+    address.includes("?") ||
+    address.includes("#")
+  ) {
+    fail(`${field} must be host:port without URL or credential delimiters`);
+  }
+  if (!/^\[[0-9a-fA-F:]+\]:\d+$|^[A-Za-z0-9._-]+:\d+$/u.test(address)) {
+    fail(`${field} must be a bounded host:port address`);
+  }
+  const port = Number(address.slice(address.lastIndexOf(":") + 1));
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    fail(`${field} port must be between 1 and 65535`);
+  }
+  return address;
+}
+
+function validateCredentialsPair() {
+  const [usernameEnvironment, passwordEnvironment] = contract.optional_environment;
+  const username = process.env[usernameEnvironment] ?? "";
+  const password = process.env[passwordEnvironment] ?? "";
+  if ((username.length === 0) !== (password.length === 0)) {
+    fail("external duplicate scan username and password must both be set or both be empty");
+  }
+  for (const [value, field] of [
+    [username, usernameEnvironment],
+    [password, passwordEnvironment],
+  ]) {
+    if (value.length === 0) continue;
+    strictOneLine(value, field, 191);
+    if (value.includes(":") || value.includes("@")) {
+      fail(`${field} contains an unsupported connection delimiter`);
+    }
+  }
+}
+
+function reviewedArtifact(value, field) {
+  const artifact = strictOneLine(value, field, 256);
+  if (
+    artifact.includes("://") ||
+    artifact.includes("@") ||
+    /^\[[0-9a-fA-F:]+\]:\d+$/u.test(artifact) ||
+    /^[A-Za-z0-9._-]+:\d+$/u.test(artifact)
+  ) {
+    fail(`${field} must be an operator-reviewed version or digest label, not an endpoint`);
+  }
+  return artifact;
+}
+
+function externalConfigPath(value, field) {
+  const supplied = strictOneLine(value, field, 4096);
+  if (!isAbsolute(supplied)) fail(`${field} must be an absolute path outside the repository`);
+  const absolutePath = resolve(supplied);
+  const root = resolve(repoRoot);
+  const prefix = `${root}${sep}`;
+  if (absolutePath === root || absolutePath.startsWith(prefix)) {
+    fail(`${field} must point outside the repository`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${field} must point to an existing external configuration file`);
+  }
+  return absolutePath;
+}
+
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote !== null && character === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && (character === '"' || character === "'")) {
+      quote = character;
+      continue;
+    }
+    if (quote === null && character === "#") return line.slice(0, index);
+  }
+  return line;
+}
+
+function parseDedupConfiguration(absolutePath, field) {
+  const lines = readFileSync(absolutePath, "utf8").split(/\r?\n/u);
+  let inSection = false;
+  let sectionFound = false;
+  let enabledRaw = null;
+
+  for (const rawLine of lines) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      if (inSection) break;
+      inSection = section[1].trim() === "system.message_deduplication";
+      sectionFound ||= inSection;
+      continue;
+    }
+    if (!inSection) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) fail(`${field} contains an invalid message_deduplication assignment`);
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key !== "enabled") continue;
+    if (enabledRaw !== null) fail(`${field} contains duplicate message_deduplication.enabled`);
+    enabledRaw = value;
+  }
+
+  if (!sectionFound) fail(`${field} is missing [system.message_deduplication]`);
+  if (enabledRaw !== "false") {
+    fail(`${field} must set message_deduplication.enabled = false`);
+  }
+  const canonical = {
+    section: "system.message_deduplication",
+    enabled: false,
+  };
+  return {
+    ...canonical,
+    canonical_sha256: sha256(JSON.stringify(canonical)),
+  };
+}
+
+function requirePassedCase(output) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail("external duplicate scan retained execution did not run exactly one test");
+  }
+  const marker = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(expectedCase)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!marker.test(output)) {
+    fail("external duplicate scan exact case did not report success");
+  }
+  if (/skipping external Iggy DLQ duplicate scan evidence/iu.test(output)) {
+    fail("external duplicate scan exact case reported a skip");
+  }
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree must be clean before external duplicate scan retained execution");
+  }
+  const commit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "git_commit",
+    40,
+  );
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("git commit must be a full lowercase SHA-1");
+  }
+  return commit;
+}
+
+function ensureOutputInsideRepository() {
+  const root = `${resolve(repoRoot)}${sep}`;
+  if (!outputPath.startsWith(root)) {
+    fail("retained external duplicate scan output must stay inside the repository");
+  }
+}
+
+function writeAtomically(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+try {
+  ensureOutputInsideRepository();
+  validateContract();
+
+  const addressEnvironment = contract.required_environment.address;
+  const configPathEnvironment = contract.required_environment.config_path;
+  const serverArtifactEnvironment = contract.required_environment.server_artifact;
+  validateAddress(process.env[addressEnvironment] ?? "", addressEnvironment);
+  validateCredentialsPair();
+  const configPath = externalConfigPath(
+    process.env[configPathEnvironment] ?? "",
+    configPathEnvironment,
+  );
+  const reviewedConfiguration = parseDedupConfiguration(
+    configPath,
+    configPathEnvironment,
+  );
+  const serverArtifact = reviewedArtifact(
+    process.env[serverArtifactEnvironment] ?? "",
+    serverArtifactEnvironment,
+  );
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = commandOutputLine(
+    runChecked("cargo", ["--version"]).stdout,
+    "cargo_version",
+  );
+  const rustcVersion = commandOutputLine(
+    runChecked("rustc", ["--version"]).stdout,
+    "rustc_version",
+  );
+  const startedAt = new Date().toISOString();
+  const result = runChecked(contract.command.program, contract.command.args);
+  const output = `${result.stdout}\n${result.stderr}`;
+  requirePassedCase(output);
+
+  const finalCommit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+    40,
+  );
+  if (finalCommit !== gitCommit) fail("git commit changed during retained execution");
+  const finalSourceSha256 = sourceHashes();
+  if (!sameValue(finalSourceSha256, initialSourceSha256)) {
+    fail("external duplicate scan source files changed during retained execution");
+  }
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during external duplicate scan retained execution");
+  }
+  const completedAt = new Date().toISOString();
+
+  writeAtomically({
+    schema_version: 1,
+    module: contract.module,
+    packet: "dlq-duplicate-external-scan-runtime-evidence",
+    status: "external_iggy_duplicate_scan_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    environment_sources: {
+      address_environment: addressEnvironment,
+      configuration_path_environment: configPathEnvironment,
+      server_artifact_environment: serverArtifactEnvironment,
+      username_environment: contract.optional_environment[0],
+      password_environment: contract.optional_environment[1],
+    },
+    reviewed_artifacts: {
+      iggy_server: serverArtifact,
+    },
+    reviewed_configuration: reviewedConfiguration,
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    source_sha256: finalSourceSha256,
+    executed_case: {
+      name: contract.case,
+      result: "pass",
+      command: contract.command,
+      required_summary: contract.required_summary,
+      required_offset_observations: contract.required_offset_observations,
+      test_output_sha256: sha256(output),
+      test_output_bytes: Buffer.byteLength(output),
+    },
+  });
+  console.log(`Retained external duplicate scan evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`External duplicate scan retained capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution-contract.json";
+const sourceContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json";
+const runnerPath = "scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-execution.json";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs";
+const expectedCase =
+  "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset";
+const expectedCommand = {
+  program: "cargo",
+  args: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "dlq_duplicate_external_scan",
+    "--",
+    expectedCase,
+    "--exact",
+    "--nocapture",
+    "--test-threads=1",
+  ],
+};
+const expectedSummary = {
+  total_messages: 4,
+  unique_message_ids: 2,
+  duplicate_messages: 2,
+  duplicate_groups: 2,
+  conflicting_payload_groups: 1,
+  max_copies_per_message_id: 2,
+  has_physical_duplicates: true,
+  has_identity_conflicts: true,
+  requires_manual_review: true,
+};
+const expectedOffsets = {
+  before_fixture_publication_stored_offset_present: false,
+  after_first_scan_stored_offset_present: false,
+  after_second_scan_stored_offset_present: false,
+};
+const expectedTopLevelKeys = [
+  "schema_version",
+  "module",
+  "packet",
+  "status",
+  "generated_from",
+  "runner",
+  "verifier",
+  "git_commit",
+  "working_tree_clean_before_run",
+  "started_at",
+  "completed_at",
+  "environment_sources",
+  "reviewed_artifacts",
+  "reviewed_configuration",
+  "toolchain",
+  "source_sha256",
+  "executed_case",
+].sort();
+const expectedCaseKeys = [
+  "name",
+  "result",
+  "command",
+  "required_summary",
+  "required_offset_observations",
+  "test_output_sha256",
+  "test_output_bytes",
+].sort();
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const sourceContract = JSON.parse(
+  readFileSync(resolve(repoRoot, sourceContractPath), "utf8"),
+);
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    fail(`source file is missing: ${relativePath}`);
+    return null;
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function currentSourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fail("could not read current git commit");
+    return null;
+  }
+  const commit = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("current git commit is not a full lowercase SHA-1");
+    return null;
+  }
+  return commit;
+}
+
+function validSha256(value, field) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${field} is not a lowercase SHA-256`);
+  }
+}
+
+function validTimestamp(value, field) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${field} is not a valid timestamp`);
+  }
+}
+
+function boundedLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is not a bounded one-line value`);
+  }
+}
+
+function boundedArtifact(value, field) {
+  boundedLine(value, field, 256);
+  if (
+    typeof value === "string" &&
+    (value.includes("://") ||
+      value.includes("@") ||
+      /^\[[0-9a-fA-F:]+\]:\d+$/u.test(value) ||
+      /^[A-Za-z0-9._-]+:\d+$/u.test(value))
+  ) {
+    fail(`${field} is endpoint-shaped rather than an artifact label`);
+  }
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectKeys(entry, keys);
+    return keys;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(entry, keys);
+    }
+  }
+  return keys;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-external-scan-execution-contract" ||
+  contract.status !== "runtime_execution_contract_locked" ||
+  contract.source_contract !== sourceContractPath ||
+  contract.runner !== runnerPath ||
+  contract.verifier !== expectedVerifier ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== "runtime_execution_pending" ||
+  contract.case !== expectedCase
+) {
+  fail("external duplicate scan execution contract identity or path drift");
+}
+if (!sameValue(contract.command, expectedCommand)) {
+  fail("external duplicate scan retained exact command drift");
+}
+if (!sameValue(contract.required_summary, expectedSummary)) {
+  fail("external duplicate scan retained summary assertions drift");
+}
+if (!sameValue(contract.required_offset_observations, expectedOffsets)) {
+  fail("external duplicate scan retained absent-offset assertions drift");
+}
+if (
+  sourceContract.status !== "source_complete_runtime_pending" ||
+  sourceContract.execution_status !== "not_run" ||
+  sourceContract.test !== "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs" ||
+  sourceContract.case !== expectedCase ||
+  sourceContract.verifier !==
+    "scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs"
+) {
+  fail("external duplicate scan runtime source contract must remain source-complete and unexecuted");
+}
+if (
+  contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+  contract.reviewed_configuration?.required_enabled !== false ||
+  !sameValue(contract.reviewed_configuration?.retain_only, [
+    "section",
+    "enabled",
+    "canonical_sha256",
+  ]) ||
+  contract.reviewed_configuration?.config_path_outside_repository !== true ||
+  contract.reviewed_configuration?.full_content_retained !== false ||
+  contract.reviewed_configuration?.full_file_sha256_retained !== false
+) {
+  fail("external duplicate scan retained reviewed configuration boundary drift");
+}
+
+for (const marker of [
+  "function strictOneLine(value, field, maximumLength = 256)",
+  "function commandOutputLine(value, field, maximumLength = 256)",
+  "validateAddress(process.env[addressEnvironment]",
+  "validateCredentialsPair();",
+  "externalConfigPath(",
+  "must point outside the repository",
+  "reviewedArtifact(",
+  "system.message_deduplication",
+  'enabledRaw !== "false"',
+  "canonical_sha256: sha256(JSON.stringify(canonical))",
+  "ensureCleanCommit()",
+  "sourceHashes()",
+  'runChecked("cargo", ["--version"])',
+  'runChecked("rustc", ["--version"])',
+  "running 1 test",
+  "exact case reported a skip",
+  "finalCommit !== gitCommit",
+  "workingTreeStatus().trim()",
+  "writeAtomically({",
+  "environment_sources",
+  "reviewed_artifacts",
+  "reviewed_configuration",
+  "source_sha256",
+  "required_summary: contract.required_summary",
+  "required_offset_observations: contract.required_offset_observations",
+  "test_output_sha256: sha256(output)",
+]) {
+  requireText("external duplicate scan retained runner", runner, marker);
+}
+
+if (failures.length === 0 && !existsSync(resolve(repoRoot, evidencePath))) {
+  console.log(
+    "Iggy external DLQ duplicate scan retained evidence verified: execution contract, reviewed dedup-disabled config extraction, strict metadata/address/credential gates, clean-commit exact-case runner, current source hashing, aggregate summary and absent-offset assertions, privacy projection, and runtime-pending status are locked; canonical execution JSON is absent.",
+  );
+  process.exit(0);
+}
+
+if (existsSync(resolve(repoRoot, evidencePath))) {
+  let evidence;
+  try {
+    evidence = JSON.parse(readFileSync(resolve(repoRoot, evidencePath), "utf8"));
+  } catch {
+    fail("external duplicate scan execution packet is not valid JSON");
+  }
+
+  if (evidence) {
+    if (!sameValue(Object.keys(evidence).sort(), expectedTopLevelKeys)) {
+      fail("external duplicate scan execution packet top-level keys drifted");
+    }
+    if (
+      evidence.schema_version !== 1 ||
+      evidence.module !== "iggy" ||
+      evidence.packet !== "dlq-duplicate-external-scan-runtime-evidence" ||
+      evidence.status !== "external_iggy_duplicate_scan_runtime_executed" ||
+      evidence.generated_from !== contractPath ||
+      evidence.runner !== runnerPath ||
+      evidence.verifier !== expectedVerifier ||
+      evidence.working_tree_clean_before_run !== true
+    ) {
+      fail("external duplicate scan execution packet identity or provenance drift");
+    }
+
+    const commit = currentCommit();
+    if (commit && evidence.git_commit !== commit) {
+      fail("external duplicate scan execution packet was generated from another commit");
+    }
+    validTimestamp(evidence.started_at, "started_at");
+    validTimestamp(evidence.completed_at, "completed_at");
+    if (
+      typeof evidence.started_at === "string" &&
+      typeof evidence.completed_at === "string" &&
+      Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)
+    ) {
+      fail("external duplicate scan completion precedes start");
+    }
+
+    if (
+      !sameValue(evidence.environment_sources, {
+        address_environment: "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_ADDRESS",
+        configuration_path_environment:
+          "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_CONFIG_PATH",
+        server_artifact_environment:
+          "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_SERVER_ARTIFACT",
+        username_environment: "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_USERNAME",
+        password_environment: "RUSTOK_IGGY_DUPLICATE_SCAN_TEST_PASSWORD",
+      })
+    ) {
+      fail("external duplicate scan environment source metadata drift");
+    }
+    if (!sameValue(Object.keys(evidence.reviewed_artifacts ?? {}), ["iggy_server"])) {
+      fail("external duplicate scan reviewed artifact keys drift");
+    }
+    boundedArtifact(evidence.reviewed_artifacts?.iggy_server, "reviewed Iggy artifact");
+    boundedLine(evidence.toolchain?.cargo, "cargo toolchain");
+    boundedLine(evidence.toolchain?.rustc, "rustc toolchain");
+
+    if (
+      !sameValue(Object.keys(evidence.reviewed_configuration ?? {}).sort(), [
+        "canonical_sha256",
+        "enabled",
+        "section",
+      ]) ||
+      evidence.reviewed_configuration?.section !== "system.message_deduplication" ||
+      evidence.reviewed_configuration?.enabled !== false
+    ) {
+      fail("external duplicate scan reviewed configuration shape or disabled mode drift");
+    } else {
+      const canonical = {
+        section: evidence.reviewed_configuration.section,
+        enabled: evidence.reviewed_configuration.enabled,
+      };
+      validSha256(
+        evidence.reviewed_configuration.canonical_sha256,
+        "reviewed configuration canonical hash",
+      );
+      if (
+        evidence.reviewed_configuration.canonical_sha256 !==
+        sha256(JSON.stringify(canonical))
+      ) {
+        fail("external duplicate scan canonical configuration digest mismatch");
+      }
+    }
+
+    const hashes = currentSourceHashes();
+    if (!sameValue(evidence.source_sha256, hashes)) {
+      fail("external duplicate scan execution source hashes are stale");
+    }
+    for (const [path, digest] of Object.entries(evidence.source_sha256 ?? {})) {
+      validSha256(digest, `source hash ${path}`);
+    }
+
+    if (!sameValue(Object.keys(evidence.executed_case ?? {}).sort(), expectedCaseKeys)) {
+      fail("external duplicate scan executed case keys drifted");
+    }
+    if (
+      evidence.executed_case?.name !== expectedCase ||
+      evidence.executed_case?.result !== "pass" ||
+      !sameValue(evidence.executed_case?.command, expectedCommand) ||
+      !sameValue(evidence.executed_case?.required_summary, expectedSummary) ||
+      !sameValue(
+        evidence.executed_case?.required_offset_observations,
+        expectedOffsets,
+      )
+    ) {
+      fail("external duplicate scan executed case assertions or result drift");
+    }
+    validSha256(
+      evidence.executed_case?.test_output_sha256,
+      "external duplicate scan test output hash",
+    );
+    if (
+      !Number.isSafeInteger(evidence.executed_case?.test_output_bytes) ||
+      evidence.executed_case.test_output_bytes <= 0
+    ) {
+      fail("external duplicate scan test output byte count is invalid");
+    }
+
+    const forbiddenKeys = new Set([
+      "database_url",
+      "broker_address",
+      "config_path",
+      "config_full_content",
+      "config_full_file_sha256",
+      "username",
+      "password",
+      "connection_string",
+      "raw_test_output",
+      "stream_name",
+      "partition_id",
+      "offset",
+      "broker_message_id",
+      "delivery_uuid",
+      "payload",
+      "payload_sha256",
+      "ack_token",
+      "raw_iggy_error",
+    ]);
+    for (const key of collectKeys(evidence)) {
+      if (forbiddenKeys.has(key)) {
+        fail(`external duplicate scan execution packet contains forbidden key: ${key}`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Iggy external DLQ duplicate scan retained verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy external DLQ duplicate scan retained evidence verified: current commit/source hashes, reviewed dedup-disabled configuration digest, bounded Iggy/toolchain metadata, exact all-pass case, count-only duplicate/conflict assertions, three absent-offset assertions, output digest, and identifier-free packet projection are locked.",
+);


### PR DESCRIPTION
## Summary

Add a fail-closed retained-execution path for the external-Iggy physical DLQ duplicate scan runtime harness merged in #2388.

## Execution contract

The versioned contract locks:

- the exact single Cargo case and command;
- required aggregate duplicate/conflict summary;
- three required absent-offset assertions;
- one external address, reviewed config path, and reviewed Iggy artifact environment;
- paired optional credentials;
- clean-commit, current-source, exact-case, skip-rejection, and atomic-write requirements;
- the canonical packet path and privacy boundary.

## Reviewed dedup-disabled configuration

The config path must be absolute, existing, and outside the repository. The runner extracts only:

```toml
[system.message_deduplication]
enabled = false
```

The packet retains only:

```json
{
  "section": "system.message_deduplication",
  "enabled": false,
  "canonical_sha256": "..."
}
```

It omits the path, full content, unrelated settings, and full-file hash.

## Capture runner

The runner:

- rejects padded, multiline, control-character, or endpoint-shaped retained metadata;
- validates the `host:port` address without retaining it;
- validates paired credentials without retaining them;
- requires a bounded reviewed Iggy artifact/version label;
- requires a clean working tree and full commit SHA;
- captures Cargo/Rust version lines and SHA-256 for production, scanner, classifier, runtime test, contracts, runner, and verifier sources;
- executes the exact case through `--exact`;
- requires `running 1 test`, exact `<case> ... ok`, and no skip marker;
- rechecks commit, source hashes, and working-tree cleanliness;
- writes the canonical packet atomically only after success.

## Retained verifier

Pending mode validates the execution/source contracts, runner gates, reviewed config extraction, strict metadata boundaries, exact command, aggregate assertions, self-inclusive source hashing, atomic output, privacy projection, and absence of the canonical packet.

Executed mode additionally requires:

- packet commit equal to current `HEAD`;
- exact top-level and case key sets;
- current source SHA-256 values;
- canonical `enabled=false` digest;
- bounded Iggy artifact and toolchain lines;
- exact all-pass case, command, summary, and absent-offset booleans;
- valid test-output digest and positive byte count;
- no endpoint, config, credential, raw-log, stream, partition, offset, UUID, payload, token, or raw-error fields.

## Privacy

The packet may retain only environment-variable names, bounded artifact metadata, canonical dedup values/digest, Git/toolchain/timestamps, exact command provenance, current source hashes, aggregate assertions, one `pass` result, and output digest/size.

It excludes broker addresses, credentials, config path/content, raw logs, stream names, partitions, offsets, message/delivery UUIDs, payloads/digests, acknowledgement tokens, and raw Iggy errors.

`dlq-duplicate-external-scan-execution.json` is intentionally absent until a maintainer performs a successful clean-commit run.

## Documentation

- added the retained operator guide;
- added a Profiles retained checkpoint;
- linked the runtime source contract to the new execution tooling while preserving execution status `not_run`.

## Non-claims

This tooling does not claim active server configuration readback, complete production history, production dedup-window sufficiency, bundled mode, TLS/auth/failover, multi-partition runtime, destructive reconciliation, or Profiles authorization.

## Verification

Tests, Cargo commands, formatters, source verifiers, retained verifiers, external-Iggy scans, and capture were not run, per maintainer instruction.

Suggested maintainer flow:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs

node scripts/evidence/capture-iggy-dlq-duplicate-external-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
```
