### PR TITLE
feat(profiles): add count-only DLQ duplicate alert policy

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-alert-policy-source",
+  "status": "source_complete_runtime_integration_pending",
+  "owner": "rustok-iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
+  "summary_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "public_exports": [
+    "DlqDuplicateAlertPolicy",
+    "DlqDuplicateAlertLevel",
+    "DlqDuplicateAlertEvaluation",
+    "DlqDuplicateAlertPolicyError"
+  ],
+  "thresholds": {
+    "caller_must_supply_all": true,
+    "production_defaults": false,
+    "warning_duplicate_messages_minimum": 1,
+    "critical_duplicate_messages_not_below_warning": true,
+    "warning_duplicate_groups_minimum": 1,
+    "critical_duplicate_groups_not_below_warning": true,
+    "warning_max_copies_per_message_id_minimum": 2,
+    "critical_max_copies_not_below_warning": true,
+    "invalid_thresholds_fail_closed": true
+  },
+  "levels": [
+    "clear",
+    "notice",
+    "warning",
+    "critical"
+  ],
+  "precedence": [
+    "identity_conflict_is_always_critical",
+    "critical_numeric_threshold",
+    "warning_numeric_threshold",
+    "physical_duplicate_below_threshold_is_notice",
+    "no_physical_duplicate_is_clear"
+  ],
+  "evaluated_dimensions": [
+    "duplicate_messages",
+    "duplicate_groups",
+    "max_copies_per_message_id",
+    "identity_conflict"
+  ],
+  "evaluation_projection": [
+    "level",
+    "physical_duplicates",
+    "identity_conflict",
+    "duplicate_messages_threshold_reached",
+    "duplicate_groups_threshold_reached",
+    "max_copies_threshold_reached"
+  ],
+  "stable_codes": {
+    "clear": "iggy.dlq_duplicate.alert.clear",
+    "notice": "iggy.dlq_duplicate.alert.notice",
+    "warning": "iggy.dlq_duplicate.alert.warning",
+    "critical": "iggy.dlq_duplicate.alert.critical",
+    "invalid_policy": "iggy.dlq_duplicate.alert_policy_invalid"
+  },
+  "manual_review": {
+    "identity_conflict": true,
+    "numeric_critical_without_identity_conflict": false,
+    "destructive_action": false
+  },
+  "privacy_boundary": {
+    "input_is_count_only_summary": true,
+    "evaluation_excludes": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "error_code",
+      "publisher_identity",
+      "timestamp",
+      "credential",
+      "raw_threshold_values"
+    ],
+    "serialization_added": false
+  },
+  "policy_boundary": {
+    "delivery_channel_selection": false,
+    "paging_or_notification_dispatch": false,
+    "suppression_or_cooldown": false,
+    "scan_scheduling": false,
+    "threshold_persistence": false,
+    "broker_access": false,
+    "receipt_access": false,
+    "profiles_authorization": false
+  },
+  "mutation_boundary": {
+    "acknowledge": false,
+    "delete": false,
+    "purge": false,
+    "replay": false,
+    "retry": false,
+    "publish": false,
+    "claim_or_mark_receipt": false,
+    "change_broker_configuration": false
+  },
+  "required_source_tests": [
+    "invalid_threshold_ordering_fails_closed",
+    "clear_and_notice_remain_below_operator_thresholds",
+    "warning_reports_only_reached_warning_dimensions",
+    "critical_numeric_threshold_takes_precedence",
+    "identity_conflict_is_always_critical_and_manual"
+  ],
+  "remaining_work": [
+    "runtime_alert_integration",
+    "alert_delivery_and_suppression_outside_policy",
+    "retained_policy_integration_evidence",
+    "authorized_destructive_reconciliation_workflow",
+    "aggregate_receipt_and_duplicate_health_correlation"
+  ],
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md",
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -85,9 +85,21 @@
     "auto_commit": false,
     "result": "DlqDuplicateSummary"
   },
+  "alert_policy": {
+    "status": "source_complete_runtime_integration_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
+    "input": "DlqDuplicateSummary",
+    "result": "DlqDuplicateAlertEvaluation",
+    "identity_conflict_always_critical": true,
+    "production_defaults": false,
+    "notification_dispatch": false,
+    "destructive_action": false
+  },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
-    "operator_alert_threshold_policy",
+    "runtime_alert_integration",
+    "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",
     "correlation_with_count_only_receipt_health_without_identifier_export"
   ],

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
@@ -1,0 +1,195 @@
+# Count-only physical DLQ duplicate alert policy
+
+Status: **source complete; runtime integration and retained policy evidence pending**.
+
+## Purpose
+
+`DlqDuplicateAlertPolicy` converts one identifier-free `DlqDuplicateSummary` into a deterministic count-only alert evaluation.
+
+The policy does not scan Iggy, read PostgreSQL receipts, choose notification channels, send alerts, persist thresholds, or perform reconciliation. It only answers:
+
+```text
+Given these explicit operator thresholds and this count-only summary,
+which alert level applies and which aggregate dimension reached it?
+```
+
+## Public API
+
+```text
+DlqDuplicateAlertPolicy
+DlqDuplicateAlertLevel
+DlqDuplicateAlertEvaluation
+DlqDuplicateAlertPolicyError
+```
+
+The policy is transport-neutral and is not feature-gated on the Iggy SDK.
+
+## Explicit thresholds
+
+The caller must provide six values:
+
+```text
+warning_duplicate_messages
+critical_duplicate_messages
+warning_duplicate_groups
+critical_duplicate_groups
+warning_max_copies_per_message_id
+critical_max_copies_per_message_id
+```
+
+No production default is provided. This prevents the library from silently deciding an operator's traffic, retention, or incident-response tolerance.
+
+Validation fails closed unless:
+
+- duplicate-message warning is at least `1`;
+- duplicate-message critical is not below warning;
+- duplicate-group warning is at least `1`;
+- duplicate-group critical is not below warning;
+- max-copies warning is at least `2`;
+- max-copies critical is not below warning.
+
+Invalid configuration returns:
+
+```text
+iggy.dlq_duplicate.alert_policy_invalid
+```
+
+Equal warning and critical thresholds are valid. Critical evaluation has precedence, so equality intentionally produces `Critical` when that boundary is reached.
+
+## Alert levels
+
+The ordered levels are:
+
+```text
+Clear
+Notice
+Warning
+Critical
+```
+
+Stable codes:
+
+```text
+iggy.dlq_duplicate.alert.clear
+iggy.dlq_duplicate.alert.notice
+iggy.dlq_duplicate.alert.warning
+iggy.dlq_duplicate.alert.critical
+```
+
+### Clear
+
+No physical duplicate exists.
+
+### Notice
+
+Physical duplicates exist, but no warning threshold is reached.
+
+`Notice` preserves visibility for a non-zero duplicate condition without allowing the library to decide that the condition must page or notify anyone.
+
+### Warning
+
+At least one warning threshold is reached and no critical condition is present.
+
+### Critical
+
+At least one critical numeric threshold is reached, or the summary contains an identity conflict.
+
+Identity conflict always has precedence because one deterministic header UUID was observed with different exact payload bytes. It remains `Critical` even when every numeric threshold is much higher than the current counts.
+
+## Evaluation projection
+
+`DlqDuplicateAlertEvaluation` exposes only:
+
+```text
+level
+physical_duplicates
+identity_conflict
+duplicate_messages_threshold_reached
+duplicate_groups_threshold_reached
+max_copies_threshold_reached
+```
+
+The threshold booleans refer to the threshold band that selected the final level:
+
+- for `Critical`, they show critical numeric dimensions reached;
+- for `Warning`, they show warning numeric dimensions reached;
+- for `Notice` and `Clear`, all threshold flags are false.
+
+`requires_manual_review()` is true only for identity conflict. A numeric `Critical` result alone does not authorize destructive handling.
+
+## Privacy boundary
+
+Input is already the count-only `DlqDuplicateSummary`. The evaluation does not expose:
+
+- broker address;
+- stream, topic, partition, or offset;
+- message UUID;
+- payload or payload digest;
+- receipt identity or state;
+- producer identity;
+- credentials;
+- timestamps;
+- raw threshold values.
+
+The policy adds no serialization implementation. A caller that serializes or exports the evaluation must preserve the same identifier-free boundary.
+
+## Policy boundary
+
+This module does not choose or implement:
+
+- notification destination;
+- paging versus ticketing;
+- suppression, deduplication, or cooldown of alerts;
+- scan cadence;
+- threshold storage or tenant overrides;
+- readiness or liveness behavior;
+- Profiles authorization;
+- acknowledgement, delete, purge, replay, or retry;
+- broker configuration changes;
+- poison receipt claim or state transitions.
+
+Those concerns require separate owner contracts and operational review.
+
+## Relationship to the scanner
+
+`IggyDlqDuplicateScanner` returns `DlqDuplicateSummary`. A caller may pass that summary to this policy, but the scanner does not own thresholds and the policy does not own the scanner.
+
+This separation keeps:
+
+```text
+observation -> count-only summary -> policy evaluation -> external delivery
+```
+
+as four distinct boundaries.
+
+## Relationship to Profiles
+
+No alert level, threshold flag, duplicate count, identity-conflict signal, scan result, or retained evidence may authorize profile visibility, follower access, block/mute behavior, or presentation.
+
+Profiles continues to consume authoritative owner-port results. This policy is operational observability only.
+
+## Source verification
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+```
+
+Static verifier:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+```
+
+Focused tests define invalid configuration, clear/notice behavior, warning dimensions, critical numeric precedence, and conflict-critical manual escalation.
+
+No tests, Cargo commands, formatters, source verifiers, external Iggy connections, or retained capture were run while authoring this slice.
+
+## Remaining work
+
+1. integrate the pure policy into an explicitly owned runtime observer;
+2. define alert delivery, cooldown, and suppression outside this module;
+3. retain privacy-safe runtime policy evidence;
+4. define destructive reconciliation as a separate authorized workflow;
+5. compare aggregate receipt and duplicate trends without exporting identifiers.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier and bounded external-Iggy adapter source-complete; runtime evidence pending**.
+Status: **classifier, bounded external-Iggy adapter, runtime harness, retained tooling, and alert policy source-complete; runtime execution and integration pending**.
 
 ## Purpose
 
@@ -13,7 +13,7 @@ Physical copies can exceed one when:
 - capacity pressure evicted the ID;
 - a failover or unsupported broker path did not preserve the expected dedup state.
 
-`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations. `dlq_duplicate_external_scan.rs` now provides the bounded external-Iggy polling adapter described in `dlq-duplicate-external-scan.md`.
+`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations. `dlq_duplicate_external_scan.rs` provides the bounded external-Iggy polling adapter. `dlq_duplicate_alert_policy.rs` separately evaluates the count-only summary against explicit operator thresholds.
 
 ## Input boundary
 
@@ -71,7 +71,7 @@ same non-nil message header UUID
 different exact payload digests
 ```
 
-This must not be silently collapsed into an ordinary duplicate. It indicates header corruption, an invalid producer, an unsupported reuse of the deterministic ID, or an extraordinary hash/identity failure.
+This must not be silently collapsed into an ordinary duplicate. It indicates header corruption, an invalid producer, unsupported reuse of the deterministic ID, or an extraordinary hash/identity failure.
 
 The summary increments `conflicting_payload_groups` and `requires_manual_review()` returns `true`.
 
@@ -105,7 +105,9 @@ The classifier and external scanner cannot:
 - mark a receipt published or acknowledged;
 - choose alert thresholds or operator policy.
 
-This separation is deliberate. Observation must not accidentally become destructive reconciliation.
+The separate alert policy accepts explicit caller thresholds, but it cannot scan, send notifications, choose routing/cooldown, persist policy, or perform any mutation.
+
+This separation is deliberate. Observation and evaluation must not accidentally become destructive reconciliation.
 
 ## Relationship to deterministic raw poison identity
 
@@ -151,43 +153,61 @@ One request permits at most 128 partitions, 10,000 messages globally, and batche
 
 The adapter does not own credentials or connection lifecycle, query topology metadata, join a consumer group, persist progress, or call shutdown. See `dlq-duplicate-external-scan.md` for the complete contract.
 
+## Count-only alert policy
+
+`DlqDuplicateAlertPolicy` requires explicit warning and critical thresholds for duplicate messages, duplicate groups, and maximum copies for one message ID. It defines no production defaults.
+
+Evaluation order is:
+
+```text
+identity conflict -> Critical
+critical numeric threshold -> Critical
+warning numeric threshold -> Warning
+physical duplicate below warning -> Notice
+no duplicate -> Clear
+```
+
+The evaluation exposes only level and boolean reason flags. It does not expose source counts, raw threshold values, identifiers, or broker coordinates. See `dlq-duplicate-alert-policy.md`.
+
 ## Safe operational sequence
 
 1. select an external service, stream, explicit partition allowlist, offset, and message cap;
 2. connect and authenticate an `IggyClient` outside the scanner;
 3. call the bounded scanner using explicit-offset polling with `auto_commit=false`;
-4. publish only the count-only summary;
-5. close the client through the caller-owned lifecycle;
-6. treat the result as a bounded window, not automatically as complete history.
+4. pass the count-only summary to an explicitly configured alert policy when evaluation is required;
+5. publish only the identifier-free summary/evaluation through a separately owned delivery layer;
+6. close the client through the caller-owned lifecycle;
+7. treat the result as a bounded window, not automatically as complete history.
 
 Any destructive action must be a separate, explicitly authorized workflow with its own preview, selection, audit, and retained evidence.
 
+## Runtime and retained evidence status
+
+The opt-in external harness is source-complete. It uses production `move_to_dlq` to create ordinary duplicate and identity-conflict fixtures, scans the same explicit offset twice, and requires the scanner's standalone consumer offset to remain absent before and after both scans.
+
+The clean-commit retained contract, runner, verifier, reviewed dedup-disabled configuration boundary, source hashes, exact-case execution, and privacy-safe packet projection are also source-complete.
+
+The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
+
 ## Source tests and guards
-
-The focused classifier cases define:
-
-- same ID and exact bytes counted as ordinary physical duplicates;
-- same ID and different bytes escalated as an identity conflict;
-- empty scan and empty payload behavior;
-- nil ID rejection and stable error code.
-
-The external scanner cases define request bounds and identifier-free stable errors.
 
 Suggested maintainer commands:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 cargo test -p rustok-iggy dlq_duplicate -- --nocapture
 ```
 
-No tests, Cargo commands, formatters, verifiers, or external-Iggy scans were run while defining these source slices.
+No tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert dispatch, or retained capture were run while defining these source slices.
 
 ## Remaining work
 
-1. prove physical header and exact-byte ingestion against a disposable external broker;
-2. prove explicit-offset polling does not store consumer progress;
-3. retain runtime evidence without identifiers, payloads, addresses, credentials, offsets, or raw logs;
-4. define alert thresholds outside the inspector;
-5. design any acknowledgement/delete/replay workflow as a separate authorized operation;
-6. correlate aggregate receipt and duplicate health without exporting message identities.
+1. execute and retain the reviewed external-Iggy duplicate scan packet;
+2. integrate the pure alert policy into an explicitly owned runtime observer;
+3. define alert routing, cooldown, and suppression outside the classifier and policy;
+4. design acknowledgement/delete/replay as a separate authorized operation;
+5. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
@@ -1,0 +1,296 @@
+use thiserror::Error;
+
+use crate::DlqDuplicateSummary;
+
+/// Operator-selected count thresholds for a transport-neutral physical DLQ
+/// duplicate alert evaluation.
+///
+/// The policy contains no broker coordinates, identifiers, payload facts,
+/// credentials, delivery state, or destructive action. Callers must choose all
+/// thresholds explicitly; this module does not define a production default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlqDuplicateAlertPolicy {
+    warning_duplicate_messages: u64,
+    critical_duplicate_messages: u64,
+    warning_duplicate_groups: u64,
+    critical_duplicate_groups: u64,
+    warning_max_copies_per_message_id: u64,
+    critical_max_copies_per_message_id: u64,
+}
+
+impl DlqDuplicateAlertPolicy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        warning_duplicate_messages: u64,
+        critical_duplicate_messages: u64,
+        warning_duplicate_groups: u64,
+        critical_duplicate_groups: u64,
+        warning_max_copies_per_message_id: u64,
+        critical_max_copies_per_message_id: u64,
+    ) -> Result<Self, DlqDuplicateAlertPolicyError> {
+        if warning_duplicate_messages == 0
+            || warning_duplicate_groups == 0
+            || warning_max_copies_per_message_id < 2
+            || critical_duplicate_messages < warning_duplicate_messages
+            || critical_duplicate_groups < warning_duplicate_groups
+            || critical_max_copies_per_message_id < warning_max_copies_per_message_id
+        {
+            return Err(DlqDuplicateAlertPolicyError::InvalidThresholds);
+        }
+
+        Ok(Self {
+            warning_duplicate_messages,
+            critical_duplicate_messages,
+            warning_duplicate_groups,
+            critical_duplicate_groups,
+            warning_max_copies_per_message_id,
+            critical_max_copies_per_message_id,
+        })
+    }
+
+    pub const fn evaluate(
+        &self,
+        summary: &DlqDuplicateSummary,
+    ) -> DlqDuplicateAlertEvaluation {
+        let identity_conflict = summary.has_identity_conflicts();
+        let critical_duplicate_messages =
+            summary.duplicate_messages() >= self.critical_duplicate_messages;
+        let critical_duplicate_groups =
+            summary.duplicate_groups() >= self.critical_duplicate_groups;
+        let critical_max_copies =
+            summary.max_copies_per_message_id() >= self.critical_max_copies_per_message_id;
+
+        if identity_conflict
+            || critical_duplicate_messages
+            || critical_duplicate_groups
+            || critical_max_copies
+        {
+            return DlqDuplicateAlertEvaluation {
+                level: DlqDuplicateAlertLevel::Critical,
+                physical_duplicates: summary.has_physical_duplicates(),
+                identity_conflict,
+                duplicate_messages_threshold_reached: critical_duplicate_messages,
+                duplicate_groups_threshold_reached: critical_duplicate_groups,
+                max_copies_threshold_reached: critical_max_copies,
+            };
+        }
+
+        let warning_duplicate_messages =
+            summary.duplicate_messages() >= self.warning_duplicate_messages;
+        let warning_duplicate_groups =
+            summary.duplicate_groups() >= self.warning_duplicate_groups;
+        let warning_max_copies =
+            summary.max_copies_per_message_id() >= self.warning_max_copies_per_message_id;
+
+        if warning_duplicate_messages || warning_duplicate_groups || warning_max_copies {
+            return DlqDuplicateAlertEvaluation {
+                level: DlqDuplicateAlertLevel::Warning,
+                physical_duplicates: summary.has_physical_duplicates(),
+                identity_conflict: false,
+                duplicate_messages_threshold_reached: warning_duplicate_messages,
+                duplicate_groups_threshold_reached: warning_duplicate_groups,
+                max_copies_threshold_reached: warning_max_copies,
+            };
+        }
+
+        if summary.has_physical_duplicates() {
+            return DlqDuplicateAlertEvaluation {
+                level: DlqDuplicateAlertLevel::Notice,
+                physical_duplicates: true,
+                identity_conflict: false,
+                duplicate_messages_threshold_reached: false,
+                duplicate_groups_threshold_reached: false,
+                max_copies_threshold_reached: false,
+            };
+        }
+
+        DlqDuplicateAlertEvaluation {
+            level: DlqDuplicateAlertLevel::Clear,
+            physical_duplicates: false,
+            identity_conflict: false,
+            duplicate_messages_threshold_reached: false,
+            duplicate_groups_threshold_reached: false,
+            max_copies_threshold_reached: false,
+        }
+    }
+}
+
+/// Count-only alert level. Delivery channel, paging, suppression, and escalation
+/// timing remain caller-owned policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DlqDuplicateAlertLevel {
+    Clear,
+    Notice,
+    Warning,
+    Critical,
+}
+
+impl DlqDuplicateAlertLevel {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::Clear => "iggy.dlq_duplicate.alert.clear",
+            Self::Notice => "iggy.dlq_duplicate.alert.notice",
+            Self::Warning => "iggy.dlq_duplicate.alert.warning",
+            Self::Critical => "iggy.dlq_duplicate.alert.critical",
+        }
+    }
+}
+
+/// Identifier-free result of evaluating one count-only duplicate summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlqDuplicateAlertEvaluation {
+    level: DlqDuplicateAlertLevel,
+    physical_duplicates: bool,
+    identity_conflict: bool,
+    duplicate_messages_threshold_reached: bool,
+    duplicate_groups_threshold_reached: bool,
+    max_copies_threshold_reached: bool,
+}
+
+impl DlqDuplicateAlertEvaluation {
+    pub const fn level(&self) -> DlqDuplicateAlertLevel {
+        self.level
+    }
+
+    pub const fn has_physical_duplicates(&self) -> bool {
+        self.physical_duplicates
+    }
+
+    pub const fn has_identity_conflict(&self) -> bool {
+        self.identity_conflict
+    }
+
+    pub const fn duplicate_messages_threshold_reached(&self) -> bool {
+        self.duplicate_messages_threshold_reached
+    }
+
+    pub const fn duplicate_groups_threshold_reached(&self) -> bool {
+        self.duplicate_groups_threshold_reached
+    }
+
+    pub const fn max_copies_threshold_reached(&self) -> bool {
+        self.max_copies_threshold_reached
+    }
+
+    /// Conflicting exact bytes for one deterministic message ID always require
+    /// separate manual investigation, independent of numeric thresholds.
+    pub const fn requires_manual_review(&self) -> bool {
+        self.identity_conflict
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum DlqDuplicateAlertPolicyError {
+    #[error("physical DLQ duplicate alert thresholds are invalid")]
+    InvalidThresholds,
+}
+
+impl DlqDuplicateAlertPolicyError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidThresholds => "iggy.dlq_duplicate.alert_policy_invalid",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::{
+        DlqDuplicateObservation, summarize_dlq_duplicates,
+    };
+
+    use super::*;
+
+    fn policy() -> DlqDuplicateAlertPolicy {
+        DlqDuplicateAlertPolicy::new(2, 4, 2, 3, 3, 5).unwrap()
+    }
+
+    fn summary(entries: &[(u128, &[u8])]) -> DlqDuplicateSummary {
+        summarize_dlq_duplicates(entries.iter().map(|(id, payload)| {
+            DlqDuplicateObservation::from_payload(Uuid::from_u128(*id), payload).unwrap()
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn invalid_threshold_ordering_fails_closed() {
+        for candidate in [
+            DlqDuplicateAlertPolicy::new(0, 1, 1, 1, 2, 2),
+            DlqDuplicateAlertPolicy::new(2, 1, 1, 1, 2, 2),
+            DlqDuplicateAlertPolicy::new(1, 1, 0, 1, 2, 2),
+            DlqDuplicateAlertPolicy::new(1, 1, 2, 1, 2, 2),
+            DlqDuplicateAlertPolicy::new(1, 1, 1, 1, 1, 2),
+            DlqDuplicateAlertPolicy::new(1, 1, 1, 1, 3, 2),
+        ] {
+            let error = candidate.unwrap_err();
+            assert_eq!(error, DlqDuplicateAlertPolicyError::InvalidThresholds);
+            assert_eq!(error.stable_code(), "iggy.dlq_duplicate.alert_policy_invalid");
+        }
+    }
+
+    #[test]
+    fn clear_and_notice_remain_below_operator_thresholds() {
+        let clear = policy().evaluate(&summary(&[(1, &[1]), (2, &[2])]));
+        assert_eq!(clear.level(), DlqDuplicateAlertLevel::Clear);
+        assert!(!clear.has_physical_duplicates());
+
+        let notice = policy().evaluate(&summary(&[(1, &[1]), (1, &[1]), (2, &[2])]));
+        assert_eq!(notice.level(), DlqDuplicateAlertLevel::Notice);
+        assert!(notice.has_physical_duplicates());
+        assert!(!notice.duplicate_messages_threshold_reached());
+        assert!(!notice.requires_manual_review());
+    }
+
+    #[test]
+    fn warning_reports_only_reached_warning_dimensions() {
+        let warning = policy().evaluate(&summary(&[
+            (1, &[1]),
+            (1, &[1]),
+            (2, &[2]),
+            (2, &[2]),
+            (3, &[3]),
+        ]));
+
+        assert_eq!(warning.level(), DlqDuplicateAlertLevel::Warning);
+        assert!(warning.duplicate_messages_threshold_reached());
+        assert!(warning.duplicate_groups_threshold_reached());
+        assert!(!warning.max_copies_threshold_reached());
+        assert!(!warning.has_identity_conflict());
+    }
+
+    #[test]
+    fn critical_numeric_threshold_takes_precedence() {
+        let critical = policy().evaluate(&summary(&[
+            (1, &[1]),
+            (1, &[1]),
+            (1, &[1]),
+            (1, &[1]),
+            (1, &[1]),
+        ]));
+
+        assert_eq!(critical.level(), DlqDuplicateAlertLevel::Critical);
+        assert!(critical.duplicate_messages_threshold_reached());
+        assert!(critical.max_copies_threshold_reached());
+        assert!(!critical.duplicate_groups_threshold_reached());
+        assert!(!critical.requires_manual_review());
+    }
+
+    #[test]
+    fn identity_conflict_is_always_critical_and_manual() {
+        let critical = DlqDuplicateAlertPolicy::new(10, 20, 10, 20, 10, 20)
+            .unwrap()
+            .evaluate(&summary(&[(7, &[1]), (7, &[2])]));
+
+        assert_eq!(critical.level(), DlqDuplicateAlertLevel::Critical);
+        assert!(critical.has_physical_duplicates());
+        assert!(critical.has_identity_conflict());
+        assert!(critical.requires_manual_review());
+        assert!(!critical.duplicate_messages_threshold_reached());
+        assert_eq!(
+            critical.level().stable_code(),
+            "iggy.dlq_duplicate.alert.critical"
+        );
+    }
+}

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::DlqDuplicateSummary;
+use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
 
 /// Operator-selected count thresholds for a transport-neutral physical DLQ
 /// duplicate alert evaluation.
@@ -197,9 +197,7 @@ impl DlqDuplicateAlertPolicyError {
 mod tests {
     use uuid::Uuid;
 
-    use crate::{
-        DlqDuplicateObservation, summarize_dlq_duplicates,
-    };
+    use crate::{DlqDuplicateObservation, summarize_dlq_duplicates};
 
     use super::*;
 

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! # Features
 //!
-//! - **EventTransport implementation**: Seamless integration with RusToK event system
+//! - **EventTransport implementation**: Seamless integration for RusToK platform
 //! - **Multiple serialization formats**: JSON (default) and MessagePack
 //! - **Automatic topology management**: Streams and topics created automatically
 //! - **Tenant-based partitioning**: Events from the same tenant maintain order
@@ -62,6 +62,7 @@ pub mod consumer;
 pub mod contract_consumer;
 pub mod contract_decode_failure;
 pub mod dlq;
+pub mod dlq_duplicate_alert_policy;
 #[cfg(feature = "iggy")]
 pub mod dlq_duplicate_external_scan;
 pub mod dlq_duplicate_inspection;
@@ -88,6 +89,10 @@ pub use contract_decode_failure::{
     ConsumedContractDecodeFailure, ContractDecodeFailureKind,
 };
 pub use dlq::{DlqEntry, DlqManager};
+pub use dlq_duplicate_alert_policy::{
+    DlqDuplicateAlertEvaluation, DlqDuplicateAlertLevel, DlqDuplicateAlertPolicy,
+    DlqDuplicateAlertPolicyError,
+};
 #[cfg(feature = "iggy")]
 pub use dlq_duplicate_external_scan::{
     IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest, IggyDlqDuplicateScanner,

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
@@ -1,0 +1,128 @@
+# Profiles checkpoint: physical DLQ duplicate alert policy
+
+Status: **count-only policy source-complete; runtime integration pending**.
+
+## What changed
+
+`rustok-iggy` now owns a transport-neutral policy that evaluates the existing count-only physical DLQ duplicate summary.
+
+Source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+```
+
+Public API:
+
+```text
+DlqDuplicateAlertPolicy
+DlqDuplicateAlertLevel
+DlqDuplicateAlertEvaluation
+DlqDuplicateAlertPolicyError
+```
+
+No Profiles API, database table, GraphQL field, storefront behavior, privacy port, or authorization input changed.
+
+## Explicit operator thresholds
+
+The policy requires explicit warning and critical thresholds for:
+
+```text
+duplicate_messages
+duplicate_groups
+max_copies_per_message_id
+```
+
+There is no library-owned production default. Invalid zero, inverted, or impossible max-copies thresholds fail closed.
+
+This preserves ownership: Profiles does not select operational duplicate tolerance, and `rustok-iggy` does not invent a tenant or product policy.
+
+## Level semantics
+
+```text
+Clear    no physical duplicate
+Notice   duplicates exist below warning thresholds
+Warning  one or more warning thresholds reached
+Critical one or more critical thresholds reached
+         OR any identity conflict exists
+```
+
+Identity conflict means one deterministic physical message UUID was observed with different exact bytes. It is always `Critical` and `requires_manual_review()` is true.
+
+A numeric `Critical` result without an identity conflict does not by itself authorize manual payload inspection or destructive reconciliation.
+
+## Count-only projection
+
+The evaluation exposes only:
+
+```text
+level
+physical_duplicates
+identity_conflict
+duplicate_messages_threshold_reached
+duplicate_groups_threshold_reached
+max_copies_threshold_reached
+```
+
+It does not expose counts from the source summary, raw threshold values, broker coordinates, UUIDs, payloads, payload digests, receipt identities, credentials, timestamps, or raw Iggy errors.
+
+## Profiles authorization boundary
+
+No profile visibility, ownership, follower access, block, mute, relationship, audience, storefront presentation, or author-card decision may depend on:
+
+- `DlqDuplicateAlertLevel`;
+- any threshold-reached boolean;
+- physical duplicate presence;
+- identity-conflict presence;
+- scanner availability or failure;
+- threshold configuration;
+- alert delivery state;
+- retained evidence metadata.
+
+Profiles continues to resolve privacy through authoritative owner ports and presents only approved owner results.
+
+## Operational separation
+
+The intended sequence remains:
+
+```text
+external bounded scan
+  -> DlqDuplicateSummary
+  -> DlqDuplicateAlertPolicy::evaluate
+  -> identifier-free evaluation
+  -> separately owned notification/suppression runtime
+```
+
+The policy itself cannot:
+
+- poll Iggy;
+- inspect PostgreSQL receipts;
+- send or page;
+- choose a destination;
+- persist thresholds;
+- schedule scans;
+- acknowledge, delete, purge, replay, retry, or publish;
+- claim, release, publish, or acknowledge a poison receipt;
+- alter broker configuration.
+
+## Remaining work
+
+1. integrate the policy into an explicitly owned runtime observer;
+2. define alert routing, cooldown, and suppression outside Profiles and outside the policy;
+3. retain identifier-free runtime policy evidence;
+4. keep destructive reconciliation in a separate authorized workflow;
+5. compare receipt and duplicate health only as aggregate operational trends.
+
+No tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert delivery, or retained capture were run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **count-only classifier and bounded external observer source-complete; runtime evidence pending**.
+Status: **count-only classifier, bounded external observer, runtime harness, retained tooling, and alert policy source-complete; runtime execution and integration pending**.
 
 ## Why this matters for Profiles
 
@@ -10,7 +10,7 @@ Profiles authorization remains independent of broker and receipt state. However,
 - one durable neutral result with repeated identical physical copies;
 - one deterministic DLQ ID associated with conflicting exact bytes.
 
-The Iggy-owned classifier makes that difference visible without exposing message identities or payloads. The bounded external scanner now supplies physical observations through explicit-offset polling without storing progress.
+The Iggy-owned classifier makes that difference visible without exposing message identities or payloads. The bounded external scanner supplies physical observations through explicit-offset polling without storing progress. The separate alert policy evaluates only the count-only summary and does not become a Profiles input.
 
 ## Owner boundaries
 
@@ -26,11 +26,18 @@ External scanner source:
 crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
 ```
 
+Alert policy source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+```
+
 Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 ```
 
 Verifiers:
@@ -38,18 +45,16 @@ Verifiers:
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 ```
 
-Public API:
+Public API additionally includes:
 
 ```text
-DlqDuplicateObservation
-DlqDuplicateSummary
-DlqDuplicateInspectionError
-summarize_dlq_duplicates
-IggyDlqDuplicateScanRequest
-IggyDlqDuplicateScanner
-IggyDlqDuplicateScanError
+DlqDuplicateAlertPolicy
+DlqDuplicateAlertLevel
+DlqDuplicateAlertEvaluation
+DlqDuplicateAlertPolicyError
 ```
 
 ## Count-only projection
@@ -65,7 +70,18 @@ conflicting_payload_groups
 max_copies_per_message_id
 ```
 
-It excludes broker endpoints, stream coordinates, UUIDs, payloads, payload digests, receipt identities, error codes, publisher identities, timestamps, and credentials.
+The policy evaluation exposes only:
+
+```text
+level
+physical_duplicates
+identity_conflict
+duplicate_messages_threshold_reached
+duplicate_groups_threshold_reached
+max_copies_threshold_reached
+```
+
+Both projections exclude broker endpoints, stream coordinates, UUIDs, payloads, payload digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors. The evaluation also excludes source counts and raw threshold values.
 
 ## Duplicate classification
 
@@ -96,6 +112,28 @@ It accepts no more than 128 unique positive partitions, 10,000 physical messages
 
 The scanner does not use a consumer group, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
 
+## Alert policy boundary
+
+The caller must supply warning and critical thresholds for duplicate messages, duplicate groups, and max copies per message ID. The library provides no production defaults.
+
+Level precedence is:
+
+```text
+identity conflict -> Critical
+critical numeric threshold -> Critical
+warning numeric threshold -> Warning
+physical duplicate below warning -> Notice
+no duplicate -> Clear
+```
+
+The policy does not choose notification routing, paging, cooldown, suppression, scan cadence, threshold persistence, or any destructive action.
+
+## Runtime and retained status
+
+The external-Iggy runtime harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
+
+The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run.
+
 ## Relationship to receipt health
 
 The PostgreSQL `ConsumerPoisonReceiptInspector` remains an independent count-only summary of receipt progress. Neither side exports identifiers, so the two views cannot be joined message by message.
@@ -104,7 +142,7 @@ Aggregate operational interpretation may compare trends:
 
 - expired publishing claims plus duplicate growth may indicate recovery outside the effective dedup window;
 - duplicate growth without recovery work may reflect historic or downstream duplication;
-- any conflicting-payload group requires forensic escalation.
+- any identity conflict requires forensic escalation.
 
 These interpretations never become Profiles authorization inputs.
 
@@ -112,23 +150,23 @@ These interpretations never become Profiles authorization inputs.
 
 No profile visibility, relationship, block, mute, follow, friendship, audience, or presentation decision may depend on:
 
-- physical DLQ copy count;
-- duplicate group count;
-- conflicting-payload group count;
+- physical DLQ copy or duplicate-group counts;
+- identity-conflict presence;
+- alert level or threshold flags;
 - scan partition or offset selection;
+- scanner or alert-delivery state;
 - receipt recovery counts;
-- deduplication configuration;
+- deduplication or alert-threshold configuration;
 - retained evidence metadata.
 
-Profiles presentation continues to consume authorized owner-port results. This classifier and scanner only improve operational observability of downstream neutralization.
+Profiles presentation continues to consume authorized owner-port results. These components only improve operational observability of downstream neutralization.
 
 ## Remaining work
 
-1. prove physical header and exact-byte ingestion against a disposable external broker;
-2. prove `auto_commit=false` explicit-offset polling leaves no stored progress;
-3. retain only count-level runtime evidence;
-4. define alert thresholds outside the classifier and Profiles;
-5. define acknowledgement/delete/replay separately with explicit authorization;
-6. keep aggregate receipt and duplicate observations identifier-free.
+1. execute and retain the reviewed external-Iggy duplicate scan packet;
+2. integrate the pure alert policy into an explicitly owned runtime observer;
+3. define alert routing, cooldown, and suppression outside Profiles and the policy;
+4. define acknowledgement/delete/replay separately with explicit authorization;
+5. keep aggregate receipt and duplicate observations identifier-free.
 
-No retained execution packet exists for this checkpoint. Tests, Cargo commands, formatters, verifiers, and external-Iggy scans were not run by the implementation agent.
+Tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert dispatch, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
+const summaryPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs";
+const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md";
+const expectedExports = [
+  "DlqDuplicateAlertPolicy",
+  "DlqDuplicateAlertLevel",
+  "DlqDuplicateAlertEvaluation",
+  "DlqDuplicateAlertPolicyError",
+];
+const expectedLevels = ["clear", "notice", "warning", "critical"];
+const expectedDimensions = [
+  "duplicate_messages",
+  "duplicate_groups",
+  "max_copies_per_message_id",
+  "identity_conflict",
+];
+const expectedProjection = [
+  "level",
+  "physical_duplicates",
+  "identity_conflict",
+  "duplicate_messages_threshold_reached",
+  "duplicate_groups_threshold_reached",
+  "max_copies_threshold_reached",
+];
+const expectedTests = [
+  "invalid_threshold_ordering_fails_closed",
+  "clear_and_notice_remain_below_operator_thresholds",
+  "warning_reports_only_reached_warning_dimensions",
+  "critical_numeric_threshold_takes_precedence",
+  "identity_conflict_is_always_critical_and_manual",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const summary = readFileSync(resolve(repoRoot, summaryPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-alert-policy-source" ||
+  contract.status !== "source_complete_runtime_integration_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.source !== sourcePath ||
+  contract.summary_source !== summaryPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("DLQ duplicate alert policy contract identity or source status drift");
+}
+if (!sameValue(contract.public_exports, expectedExports)) {
+  fail("DLQ duplicate alert policy public export allowlist drift");
+}
+if (!sameValue(contract.levels, expectedLevels)) {
+  fail("DLQ duplicate alert level allowlist drift");
+}
+if (!sameValue(contract.evaluated_dimensions, expectedDimensions)) {
+  fail("DLQ duplicate alert evaluated dimension allowlist drift");
+}
+if (!sameValue(contract.evaluation_projection, expectedProjection)) {
+  fail("DLQ duplicate alert evaluation projection drift");
+}
+if (!sameValue(contract.required_source_tests, expectedTests)) {
+  fail("DLQ duplicate alert policy source test allowlist drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("DLQ duplicate alert policy verifier or documentation path drift");
+}
+
+if (
+  contract.thresholds?.caller_must_supply_all !== true ||
+  contract.thresholds?.production_defaults !== false ||
+  contract.thresholds?.warning_duplicate_messages_minimum !== 1 ||
+  contract.thresholds?.critical_duplicate_messages_not_below_warning !== true ||
+  contract.thresholds?.warning_duplicate_groups_minimum !== 1 ||
+  contract.thresholds?.critical_duplicate_groups_not_below_warning !== true ||
+  contract.thresholds?.warning_max_copies_per_message_id_minimum !== 2 ||
+  contract.thresholds?.critical_max_copies_not_below_warning !== true ||
+  contract.thresholds?.invalid_thresholds_fail_closed !== true
+) {
+  fail("DLQ duplicate alert threshold contract drift");
+}
+if (
+  !sameValue(contract.precedence, [
+    "identity_conflict_is_always_critical",
+    "critical_numeric_threshold",
+    "warning_numeric_threshold",
+    "physical_duplicate_below_threshold_is_notice",
+    "no_physical_duplicate_is_clear",
+  ])
+) {
+  fail("DLQ duplicate alert precedence drift");
+}
+if (
+  contract.manual_review?.identity_conflict !== true ||
+  contract.manual_review?.numeric_critical_without_identity_conflict !== false ||
+  contract.manual_review?.destructive_action !== false
+) {
+  fail("DLQ duplicate alert manual-review boundary drift");
+}
+if (
+  contract.privacy_boundary?.input_is_count_only_summary !== true ||
+  contract.privacy_boundary?.serialization_added !== false
+) {
+  fail("DLQ duplicate alert privacy boundary drift");
+}
+for (const [operation, allowed] of Object.entries(contract.policy_boundary ?? {})) {
+  if (allowed !== false) fail(`DLQ duplicate alert external policy became allowed: ${operation}`);
+}
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`DLQ duplicate alert mutation became allowed: ${operation}`);
+}
+
+const requiredExcludedFields = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "error_code",
+  "publisher_identity",
+  "timestamp",
+  "credential",
+  "raw_threshold_values",
+]);
+for (const field of contract.privacy_boundary?.evaluation_excludes ?? []) {
+  requiredExcludedFields.delete(field);
+}
+if (requiredExcludedFields.size > 0) {
+  fail(`DLQ duplicate alert privacy exclusions are incomplete: ${[...requiredExcludedFields].join(", ")}`);
+}
+
+if (
+  !sameValue(contract.stable_codes, {
+    clear: "iggy.dlq_duplicate.alert.clear",
+    notice: "iggy.dlq_duplicate.alert.notice",
+    warning: "iggy.dlq_duplicate.alert.warning",
+    critical: "iggy.dlq_duplicate.alert.critical",
+    invalid_policy: "iggy.dlq_duplicate.alert_policy_invalid",
+  })
+) {
+  fail("DLQ duplicate alert stable code contract drift");
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateAlertPolicy",
+  "warning_duplicate_messages: u64",
+  "critical_duplicate_messages: u64",
+  "warning_duplicate_groups: u64",
+  "critical_duplicate_groups: u64",
+  "warning_max_copies_per_message_id: u64",
+  "critical_max_copies_per_message_id: u64",
+  "pub fn new(",
+  "warning_duplicate_messages == 0",
+  "warning_duplicate_groups == 0",
+  "warning_max_copies_per_message_id < 2",
+  "critical_duplicate_messages < warning_duplicate_messages",
+  "critical_duplicate_groups < warning_duplicate_groups",
+  "critical_max_copies_per_message_id < warning_max_copies_per_message_id",
+  "pub const fn evaluate(",
+  "summary: &DlqDuplicateSummary",
+  "let identity_conflict = summary.has_identity_conflicts();",
+  "DlqDuplicateAlertLevel::Critical",
+  "DlqDuplicateAlertLevel::Warning",
+  "DlqDuplicateAlertLevel::Notice",
+  "DlqDuplicateAlertLevel::Clear",
+  "pub enum DlqDuplicateAlertLevel",
+  'Self::Clear => "iggy.dlq_duplicate.alert.clear"',
+  'Self::Notice => "iggy.dlq_duplicate.alert.notice"',
+  'Self::Warning => "iggy.dlq_duplicate.alert.warning"',
+  'Self::Critical => "iggy.dlq_duplicate.alert.critical"',
+  "pub struct DlqDuplicateAlertEvaluation",
+  "level: DlqDuplicateAlertLevel",
+  "physical_duplicates: bool",
+  "identity_conflict: bool",
+  "duplicate_messages_threshold_reached: bool",
+  "duplicate_groups_threshold_reached: bool",
+  "max_copies_threshold_reached: bool",
+  "pub const fn requires_manual_review(&self) -> bool",
+  "pub enum DlqDuplicateAlertPolicyError",
+  'Self::InvalidThresholds => "iggy.dlq_duplicate.alert_policy_invalid"',
+]) {
+  requireText("DLQ duplicate alert policy source", source, marker);
+}
+
+for (const testName of expectedTests) {
+  requireText("DLQ duplicate alert policy tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("DLQ duplicate alert policy source must contain exactly five focused unit tests");
+}
+
+for (const marker of [
+  "pub warning_duplicate_messages:",
+  "pub critical_duplicate_messages:",
+  "pub warning_duplicate_groups:",
+  "pub critical_duplicate_groups:",
+  "pub warning_max_copies_per_message_id:",
+  "pub critical_max_copies_per_message_id:",
+  "Serialize",
+  "Deserialize",
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceipt",
+  ".poll_messages(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".delete(",
+  ".purge(",
+  ".replay(",
+  ".retry_entry(",
+  ".reserve_and_claim(",
+  ".release_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".send(",
+  ".notify(",
+  ".page(",
+]) {
+  forbidText("DLQ duplicate alert policy source", source, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateSummary",
+  "pub const fn duplicate_messages(&self)",
+  "pub const fn duplicate_groups(&self)",
+  "pub const fn max_copies_per_message_id(&self)",
+  "pub const fn has_physical_duplicates(&self)",
+  "pub const fn has_identity_conflicts(&self)",
+]) {
+  requireText("count-only DLQ duplicate summary", summary, marker);
+}
+
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+const requiredRemainingWork = new Set([
+  "runtime_alert_integration",
+  "alert_delivery_and_suppression_outside_policy",
+  "retained_policy_integration_evidence",
+  "authorized_destructive_reconciliation_workflow",
+  "aggregate_receipt_and_duplicate_health_correlation",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemainingWork.delete(item);
+if (requiredRemainingWork.size > 0) {
+  fail(`DLQ duplicate alert remaining work drift: ${[...requiredRemainingWork].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy DLQ duplicate alert policy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy DLQ duplicate alert policy source verified: explicit monotonic thresholds, clear/notice/warning/critical precedence, conflict-critical manual escalation, count-only boolean projection, stable codes, no production defaults, no broker/receipt access, no notification dispatch, and no destructive action are locked; runtime integration remains pending.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -11,6 +11,9 @@ const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
 const adapterContractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
 const adapterSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+const alertContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
+const alertSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
 const transportPath = "crates/rustok-iggy/src/transport.rs";
@@ -45,8 +48,12 @@ const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"
 const adapterContract = JSON.parse(
   readFileSync(resolve(repoRoot, adapterContractPath), "utf8"),
 );
+const alertContract = JSON.parse(
+  readFileSync(resolve(repoRoot, alertContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
+const alertSource = readFileSync(resolve(repoRoot, alertSourcePath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
 const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
@@ -113,6 +120,24 @@ if (
   adapterContract.classifier_source !== sourcePath
 ) {
   fail("DLQ duplicate inspection runtime adapter relationship drift");
+}
+
+if (
+  contract.alert_policy?.status !== "source_complete_runtime_integration_pending" ||
+  contract.alert_policy?.contract !== alertContractPath ||
+  contract.alert_policy?.source !== alertSourcePath ||
+  contract.alert_policy?.input !== "DlqDuplicateSummary" ||
+  contract.alert_policy?.result !== "DlqDuplicateAlertEvaluation" ||
+  contract.alert_policy?.identity_conflict_always_critical !== true ||
+  contract.alert_policy?.production_defaults !== false ||
+  contract.alert_policy?.notification_dispatch !== false ||
+  contract.alert_policy?.destructive_action !== false ||
+  alertContract.packet !== "dlq-duplicate-alert-policy-source" ||
+  alertContract.status !== "source_complete_runtime_integration_pending" ||
+  alertContract.source !== alertSourcePath ||
+  alertContract.summary_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection alert policy relationship drift");
 }
 
 if (
@@ -244,9 +269,42 @@ for (const marker of [
   forbidText("bounded external duplicate scan adapter", adapterSource, marker);
 }
 
+for (const marker of [
+  "pub struct DlqDuplicateAlertPolicy",
+  "pub const fn evaluate(",
+  "summary: &DlqDuplicateSummary",
+  "pub enum DlqDuplicateAlertLevel",
+  "DlqDuplicateAlertLevel::Critical",
+  "DlqDuplicateAlertLevel::Warning",
+  "DlqDuplicateAlertLevel::Notice",
+  "DlqDuplicateAlertLevel::Clear",
+  "pub struct DlqDuplicateAlertEvaluation",
+  "pub const fn requires_manual_review(&self) -> bool",
+  '"iggy.dlq_duplicate.alert_policy_invalid"',
+]) {
+  requireText("count-only duplicate alert policy", alertSource, marker);
+}
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceipt",
+  ".acknowledge(",
+  ".delete(",
+  ".replay(",
+  ".send(",
+  ".notify(",
+  ".page(",
+]) {
+  forbidText("count-only duplicate alert policy", alertSource, marker);
+}
+
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
+}
+for (const exportName of alertContract.public_exports ?? []) {
+  requireText("rustok-iggy alert exports", lib, exportName);
 }
 
 for (const marker of [
@@ -291,7 +349,8 @@ if (
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
-  "operator_alert_threshold_policy",
+  "runtime_alert_integration",
+  "alert_delivery_and_suppression_outside_policy",
   "operator_ack_delete_replay_workflow_outside_inspector",
   "correlation_with_count_only_receipt_health_without_identifier_export",
 ]);
@@ -307,5 +366,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, and the bounded auto_commit=false external scan adapter are locked; external runtime evidence remains pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, bounded auto_commit=false external scan, and explicit no-default count-only alert policy are locked; retained runtime and alert integration evidence remain pending.",
 );


### PR DESCRIPTION
## Summary

Add a transport-neutral, count-only alert policy over `DlqDuplicateSummary`.

## Public API

- `DlqDuplicateAlertPolicy`
- `DlqDuplicateAlertLevel`
- `DlqDuplicateAlertEvaluation`
- `DlqDuplicateAlertPolicyError`

The policy is not feature-gated on the Iggy SDK and contains no broker, receipt, Profiles, notification, or mutation dependency.

## Explicit thresholds

Callers must provide warning and critical thresholds for:

- duplicate physical messages;
- duplicate groups;
- maximum copies for one deterministic message ID.

The library defines no production defaults. Validation fails closed for zero warning message/group thresholds, max-copies warning below 2, or any critical threshold below its warning threshold.

Equal warning and critical thresholds are allowed; critical precedence is intentional.

## Levels and precedence

```text
identity conflict -> Critical
critical numeric threshold -> Critical
warning numeric threshold -> Warning
physical duplicate below warning -> Notice
no physical duplicate -> Clear
```

Stable level codes are:

```text
iggy.dlq_duplicate.alert.clear
iggy.dlq_duplicate.alert.notice
iggy.dlq_duplicate.alert.warning
iggy.dlq_duplicate.alert.critical
```

Invalid configuration uses `iggy.dlq_duplicate.alert_policy_invalid`.

## Evaluation projection

The result exposes only:

- level;
- physical-duplicate presence;
- identity-conflict presence;
- three threshold-reached booleans.

It excludes source counts, raw threshold values, broker coordinates, UUIDs, payloads/digests, receipt identities, credentials, timestamps, and raw client errors.

Identity conflict is always critical and requires manual review. Numeric critical results alone do not authorize forensic access or destructive reconciliation.

## Policy boundary

The module does not:

- scan Iggy or read poison receipts;
- choose alert destination, paging, cooldown, suppression, or cadence;
- persist thresholds;
- affect readiness or Profiles authorization;
- acknowledge, delete, purge, replay, retry, publish, or change broker/receipt state.

Observation, evaluation, delivery, and destructive workflows remain separate owner boundaries.

## Contracts and documentation

- added a versioned source contract;
- added a static verifier;
- added five focused source tests;
- added an Iggy policy runbook;
- added a Profiles checkpoint;
- actualized the parent duplicate-inspection contract, verifier, runbook, and operations checkpoint so alert-policy source is no longer listed as pending.

## Remaining work

- runtime observer integration;
- notification routing, cooldown, and suppression outside the policy;
- retained policy integration evidence;
- separately authorized destructive reconciliation;
- aggregate receipt/duplicate trend correlation without identifiers.

## Verification

Tests, Cargo commands, formatters, source verifiers, external-Iggy scans, alert dispatch, and retained capture were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
cargo test -p rustok-iggy dlq_duplicate_alert_policy -- --nocapture
```
