### PR TITLE
Publish order projection read port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # RusToK ecommerce implementation plan
 
-Last reviewed: 2026-07-27
+Last reviewed: 2026-07-28
 
 ## Source of truth
 
@@ -194,6 +194,10 @@ These are source-contract defects, not verification-only tasks.
   compiled/migration evidence only when the validation policy allows it.
 - [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,
   Payment, and Fulfillment concrete services behind host-composed owner ports.
+- [x] Publish the order-owned `OrderReadPort` for complete detail/list projections with
+  locale fallback, canonical read context/deadline policy, stable typed errors, and
+  explicit unvalidated source evidence; host composition and Commerce consumer cutover
+  remain open.
 - [ ] Correct Product's declared dependency contract or extract its direct
   inventory/pricing persistence operations behind owner ports; the current manifest
   declares only Taxonomy while production code uses Inventory and Pricing persistence.
@@ -550,6 +554,7 @@ Source inspection is not execution evidence.
 - [x] `node scripts/verify/verify-marketplace-seller-events.mjs`
 - [ ] `node scripts/verify/verify-marketplace-listing-event-contract.mjs`
 - [ ] `node scripts/verify/verify-marketplace-listing-provenance-cutover.mjs`
+- [ ] `node scripts/verify/verify-order-read-port.mjs`
 - [ ] `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - [ ] `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
 - [ ] `node scripts/verify/verify-commerce-checkout-completion-cutover.mjs`
@@ -593,6 +598,7 @@ Source inspection is not execution evidence.
 - [ ] `cargo check -p rustok-commerce --lib`
 - [ ] `cargo test -p rustok-commerce --test checkout_marketplace_economics_checkpoint`
 - [ ] `cargo check -p rustok-order --all-features`
+- [ ] Targeted `OrderReadPort` detail/list, locale fallback, context, and typed-error tests.
 - [ ] `cargo test -p rustok-order --test order_checkout_identity`
 - [ ] `cargo test -p rustok-order --test checkout_order_identity_port`
 - [ ] `cargo test -p rustok-order --test checkout_completion_port`
@@ -730,6 +736,8 @@ Source inspection is not execution evidence.
   one staged recovery runtime with explicit idempotency and host provider composition.
 - [x] Harden pricing and payment collection owner-port errors with stable public
   messages plus correlation-aware internal logging.
+- [x] Publish `OrderReadPort` for complete order detail/list projections while retaining
+  host composition and Commerce consumer cutover as explicit unvalidated follow-up work.
 
 ## Change rules
 
@@ -750,6 +758,7 @@ Source inspection is not execution evidence.
 - [Checkout compensation owner cutover](./checkout-compensation-owner-cutover.md)
 - [Checkout owner stage cutover](./checkout-owner-stage-cutover.md)
 - [Public ecommerce port error safety](./public-port-error-safety.md)
+- [Order read port](../../rustok-order/docs/order-read-port.md)
 - [Order checkout compensation contract](../../rustok-order/contracts/order-checkout-compensation-v1.json)
 - [Order checkout payment settlement contract](../../rustok-order/contracts/order-checkout-payment-settlement-v1.json)
 - [Payment FBA registry](../../rustok-payment/contracts/payment-fba-registry.json)

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-28",
+  "status": "owner_port_published_unvalidated",
+  "source_base_revision": "b573adbf9a8397f5676dd617464060b878ce88a1",
+  "scope": "order detail and filtered list projections for mounted Commerce query consumers",
+  "owner": {
+    "crate": "rustok-order",
+    "port": "OrderReadPort",
+    "adapter": "InProcessOrderReadPort",
+    "factory": "in_process_order_read_port",
+    "concrete_service_owner": "OrderService"
+  },
+  "operations": [
+    {
+      "name": "read_order_projection",
+      "request": "ReadOrderProjectionRequest",
+      "result": "OrderResponse",
+      "optional_not_found": false,
+      "locale_source": "PortContext.locale",
+      "tenant_default_locale_fallback": true
+    },
+    {
+      "name": "list_order_projections",
+      "request": "ListOrderProjectionsRequest",
+      "result": "OrderProjectionPage",
+      "filters": [
+        "page",
+        "per_page",
+        "status",
+        "customer_id"
+      ],
+      "ordering": "created_at_desc",
+      "locale_source": "PortContext.locale",
+      "tenant_default_locale_fallback": true
+    }
+  ],
+  "context": {
+    "read_policy_required": true,
+    "tenant_parsed_from_port_context": true,
+    "actor_retained": true,
+    "channel_retained": true,
+    "locale_retained": true,
+    "correlation_retained": true,
+    "deadline_required": true
+  },
+  "errors": {
+    "type": "PortError",
+    "owner_message_control_flow": false,
+    "all_current_order_error_variants_mapped": true,
+    "validation_kind": "Validation",
+    "not_found_kind": "NotFound",
+    "transition_kind": "Conflict",
+    "database_kind": "Unavailable",
+    "core_kind": "InvariantViolation",
+    "database_retryable": true,
+    "core_retryable": false
+  },
+  "consumer_inventory": {
+    "commerce_admin_rest_list_detail": "concrete_order_service",
+    "commerce_storefront_detail_and_ownership": "concrete_order_service",
+    "commerce_graphql_order_list_detail": "concrete_order_service",
+    "runtime_composition_published": false,
+    "consumer_cutover_completed": false,
+    "cutover_required": true
+  },
+  "decision": {
+    "next_slice": "publish and host-compose CommerceOrderReadRuntime, then cut mounted admin REST order list/detail to OrderReadPort before GraphQL and storefront consumers",
+    "mutation_scope": "unchanged",
+    "status_promotion": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_parity_proven": false
+  }
+}

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Implementation plan for `rustok-order`
 
-Last reviewed: 2026-07-23
+Last reviewed: 2026-07-28
 
 ## Current state
 
@@ -53,6 +53,14 @@ shipping, or hash facts rather than fabricating attribution. The metadata bridge
 and old JSON indexes must be removed after all completion/result consumers use
 typed identity exclusively.
 
+Complete order detail and filtered-list projection reads are now published through
+`OrderReadPort`. `InProcessOrderReadPort` owns concrete `OrderService`
+construction, requires read policy, parses tenant identity from `PortContext`,
+preserves requested and tenant-default locale fallback, list ordering, filters,
+and pagination total, and maps every current `OrderError` to stable `PortError`
+policy without owner-message control flow. Commerce runtime composition and
+consumer cutover remain open and unvalidated.
+
 ## FFA/FBA boundary
 
 - FFA status: `in_progress`
@@ -68,18 +76,23 @@ typed identity exclusively.
 - Published provider ports: `CheckoutCompletionPort`,
   `CheckoutOrderIdentityPort`, `CheckoutOrderCompensationPort`, and
   `CheckoutOrderPaymentSettlementPort`.
+- Source-ready internal projection boundary: `OrderReadPort`; it is not a new FBA
+  provider contract.
+- Order read source evidence:
+  `crates/rustok-order/contracts/evidence/order-read-port-source.json`.
 - Static contract evidence:
   `crates/rustok-order/contracts/evidence/order-contract-test-static-matrix.json`.
 - `scripts/verify/verify-order-admin-boundary.mjs`,
   `scripts/verify/verify-order-storefront-boundary.mjs`,
+  `scripts/verify/verify-order-read-port.mjs`,
   `scripts/verify/verify-commerce-storefront-transport-handoff.mjs`,
   `scripts/verify/verify-commerce-order-identity-boundary.mjs`,
   `scripts/verify/verify-commerce-checkout-completion-cutover.mjs`,
   `scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs`,
   `scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`, and
   `scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs` lock the current
-  UI, transport, identity, staged-consumer, lifecycle, compensation, and payment
-  settlement split.
+  UI, transport, projection, identity, staged-consumer, lifecycle, compensation,
+  and payment settlement split.
 - No status promotion is allowed from source inspection. Clean/upgraded
   migrations, compile/tests, contention, restart, mounted consumers, and
   remote-profile evidence remain missing.
@@ -130,6 +143,30 @@ typed identity exclusively.
 - [ ] Remove old JSON expression indexes, generated columns, metadata identity
   writes, old creation/confirmation/compensation/pipeline source, and
   `adopt_legacy` after every production consumer is cut over.
+
+## Order projection read source checklist
+
+- [x] Publish one owner `OrderReadPort` for complete detail and filtered list
+  projections.
+- [x] Preserve `OrderResponse`, descending creation ordering, status/customer
+  filters, page/per-page handling, and owner pagination total.
+- [x] Use `PortContext.locale` as requested locale and retain an explicit optional
+  tenant-default fallback locale in typed requests.
+- [x] Require `PortCallPolicy::read()` and parse tenant identity from
+  `PortContext`.
+- [x] Map every current `OrderError` variant to stable `PortError` policy without
+  owner-message control flow.
+- [x] Export the canonical `in_process_order_read_port` factory.
+- [x] Retain source evidence and a focused guard without claiming Commerce
+  consumer cutover or runtime parity.
+- [ ] Publish and host-compose `CommerceOrderReadRuntime`.
+- [ ] Require the host-selected runtime in Commerce HTTP and GraphQL composition.
+- [ ] Cut admin REST order list/detail over to the owner port while preserving
+  locale, filters, pagination total, detail aggregation, and public envelopes.
+- [ ] Cut GraphQL order list/detail and storefront order detail/ownership reads
+  over in separate atomic changes.
+- [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
+  evidence before status promotion.
 
 ## Open results
 
@@ -182,14 +219,26 @@ typed identity exclusively.
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Keep order and commerce documentation synchronized.** Update local docs,
+7. **Cut mounted order projection reads to the owner port.** Compose one
+   host-selected `CommerceOrderReadRuntime`, cut admin REST first, then GraphQL and
+   storefront reads without changing order mutations or payment/fulfillment detail
+   ownership.
+   **Depends on:** the published `OrderReadPort` and current public transport
+   envelope inventory.
+   **Done when:** mounted detail/list/ownership projection reads no longer construct
+   `OrderService`, retain locale/filter/pagination/authorization behavior, and have
+   bounded parity evidence.
+
+8. **Keep order and commerce documentation synchronized.** Update local docs,
    manifests, registries, central status, and the umbrella commerce plan whenever
-   order lifecycle, checkout snapshots, or identity ownership changes.
+   order lifecycle, checkout snapshots, identity ownership, or projection read
+   ownership changes.
    **Done when:** no stale cross-module responsibility or evidence claim remains.
 
 ## Verification
 
 - `npm run verify:ecommerce:fba`
+- `node scripts/verify/verify-order-read-port.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
 - `node scripts/verify/verify-commerce-checkout-completion-cutover.mjs`
@@ -207,6 +256,8 @@ typed identity exclusively.
 - `cargo test -p rustok-order --test order_checkout_identity`
 - `cargo test -p rustok-order --test checkout_order_identity_port`
 - `cargo test -p rustok-order --test checkout_completion_port`
+- Targeted order read-port detail/list, locale fallback, context, and error-policy
+  tests.
 - Targeted staged checkout completion/adoption/replay, unknown lifecycle,
   compensation, and payment settlement tests.
 - Clean/upgraded/down/reapply identity migrations on SQLite/PostgreSQL/MySQL.

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,0 +1,103 @@
+# Order read port
+
+Status: owner port published, unvalidated; Commerce consumer cutover remains open.
+
+## Scope
+
+`OrderReadPort` is the order-owned boundary for complete order projection reads
+needed by mounted Commerce REST and GraphQL query consumers. It is separate from:
+
+- `CheckoutCompletionPort`, which owns checkout create/place/replay;
+- `CheckoutOrderIdentityPort`, which owns checkout/order identity;
+- `CheckoutOrderCompensationPort`, which owns checkout cancellation recovery;
+- `CheckoutOrderPaymentSettlementPort`, which owns captured-payment settlement;
+- order lifecycle, return, and order-change mutations, which remain on existing
+  order-owner commands and services.
+
+This source wave publishes the owner boundary only. It does not claim that
+Commerce consumers have already stopped constructing `OrderService`.
+
+## Operations
+
+The owner publishes two read-only operations:
+
+- `read_order_projection` returns one complete `OrderResponse` by order id;
+- `list_order_projections` preserves page, per-page, status, customer filtering,
+  descending creation ordering, and the owner pagination total through
+  `OrderProjectionPage`.
+
+Both operations use `PortContext.locale` as the requested locale and accept an
+optional tenant-default fallback locale in the typed request. The existing owner
+DTO is returned unchanged; Commerce does not define a partial order projection.
+
+## In-process adapter
+
+`InProcessOrderReadPort` owns concrete `OrderService` construction. The root
+factory is:
+
+```rust
+in_process_order_read_port(db, event_bus)
+```
+
+Every operation:
+
+1. requires `PortCallPolicy::read()`;
+2. parses tenant identity from `PortContext`;
+3. delegates to the existing locale-aware owner service operation;
+4. maps every current `OrderError` variant to stable `PortError` policy;
+5. preserves complete owner projections and list totals.
+
+The adapter does not inspect owner error messages for control flow. Validation
+maps to `Validation`; missing order/return/change maps to `NotFound`; invalid
+transitions map to `Conflict`; database failures map to retryable `Unavailable`;
+and owner-core failures fail closed as non-retryable `InvariantViolation`.
+
+## Context and diagnostics
+
+The owner boundary retains operation, correlation id, tenant, actor, channel
+length, requested/fallback locale lengths, causation/trace presence, deadline,
+order/customer/filter facts, stable owner code, error kind, and retryability.
+Only database and core failures retain the typed internal cause in technical
+logs. Public `PortError.message` values are stable and do not contain raw storage
+or owner-invariant details.
+
+## Current consumer inventory
+
+The following mounted Commerce reads still construct `OrderService` and are not
+changed in this wave:
+
+- admin REST order list and detail;
+- storefront order detail and ownership checks;
+- GraphQL order detail and list;
+- return/order-change mutation and query paths that require a wider owner contract.
+
+Admin order detail also aggregates payment and fulfillment projections. Its
+order-source cutover should remain separate from payment/fulfillment aggregation
+cutover so public envelope compatibility can be reviewed independently.
+
+## Next source slice
+
+Publish `CommerceOrderReadRuntime`, allow a host-selected `Arc<dyn OrderReadPort>`,
+compose/cache it in the default application host, require it in
+`CommerceHttpRuntime`, and cut admin REST order list/detail over first. GraphQL and
+storefront reads should follow in separate atomic changes.
+
+## Evidence
+
+Source evidence is retained at:
+
+`crates/rustok-order/contracts/evidence/order-read-port-source.json`
+
+Its status is `owner_port_published_unvalidated`. Runtime composition, Commerce
+consumer cutover, compile evidence, mounted parity, deadline/failure execution,
+restart, and remote-adapter evidence remain false or open.
+
+## Intended checks
+
+```bash
+node scripts/verify/verify-order-read-port.mjs
+cargo check -p rustok-order --lib
+```
+
+Tests, Cargo commands, formatting, verifiers, workflow checks, and CI were not run
+by the implementation agent.

--- a/crates/rustok-order/src/lib.rs
+++ b/crates/rustok-order/src/lib.rs
@@ -24,6 +24,7 @@ pub mod dto;
 pub mod entities;
 pub mod error;
 pub mod migrations;
+mod order_read;
 pub mod ports;
 pub mod services;
 pub mod status;
@@ -56,6 +57,10 @@ pub use checkout_payment_settlement::{
 };
 pub use dto::*;
 pub use entities::*;
+pub use order_read::{
+    InProcessOrderReadPort, ListOrderProjectionsRequest, OrderProjectionPage, OrderReadPort,
+    ReadOrderProjectionRequest, in_process_order_read_port,
+};
 pub use ports::*;
 pub use status::*;
 

--- a/crates/rustok-order/src/order_read.rs
+++ b/crates/rustok-order/src/order_read.rs
@@ -1,0 +1,284 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use rustok_outbox::TransactionalEventBus;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{ListOrdersInput, OrderError, OrderResponse, OrderService};
+
+/// Transport-neutral order-owner boundary for complete order projection reads.
+#[async_trait]
+pub trait OrderReadPort: Send + Sync {
+    async fn read_order_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderProjectionRequest,
+    ) -> Result<OrderResponse, PortError>;
+
+    async fn list_order_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderProjectionsRequest,
+    ) -> Result<OrderProjectionPage, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadOrderProjectionRequest {
+    pub order_id: Uuid,
+    pub tenant_default_locale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListOrderProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub status: Option<String>,
+    pub customer_id: Option<Uuid>,
+    pub tenant_default_locale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderProjectionPage {
+    pub items: Vec<OrderResponse>,
+    pub total: u64,
+}
+
+pub struct InProcessOrderReadPort {
+    inner: OrderService,
+}
+
+impl InProcessOrderReadPort {
+    pub fn new(
+        db: sea_orm::DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> Self {
+        Self {
+            inner: OrderService::new(db, event_bus),
+        }
+    }
+
+    pub fn from_service(inner: OrderService) -> Self {
+        Self { inner }
+    }
+}
+
+pub fn in_process_order_read_port(
+    db: sea_orm::DatabaseConnection,
+    event_bus: TransactionalEventBus,
+) -> Arc<dyn OrderReadPort> {
+    Arc::new(InProcessOrderReadPort::new(db, event_bus))
+}
+
+#[async_trait]
+impl OrderReadPort for InProcessOrderReadPort {
+    async fn read_order_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderProjectionRequest,
+    ) -> Result<OrderResponse, PortError> {
+        const OPERATION: &str = "read_order_projection";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        let fallback_locale_length = request.tenant_default_locale.as_deref().map(str::len);
+
+        self.inner
+            .get_order_with_locale_fallback(
+                tenant_id,
+                request.order_id,
+                context.locale.as_str(),
+                request.tenant_default_locale.as_deref(),
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    Some(request.order_id),
+                    None,
+                    None,
+                    fallback_locale_length,
+                    error,
+                )
+            })
+    }
+
+    async fn list_order_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderProjectionsRequest,
+    ) -> Result<OrderProjectionPage, PortError> {
+        const OPERATION: &str = "list_order_projections";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        let status_length = request.status.as_deref().map(str::len);
+        let customer_id = request.customer_id;
+        let fallback_locale_length = request.tenant_default_locale.as_deref().map(str::len);
+
+        let (items, total) = self
+            .inner
+            .list_orders_with_locale_fallback(
+                tenant_id,
+                ListOrdersInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    status: request.status,
+                    customer_id,
+                },
+                context.locale.as_str(),
+                request.tenant_default_locale.as_deref(),
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    None,
+                    customer_id,
+                    status_length,
+                    fallback_locale_length,
+                    error,
+                )
+            })?;
+
+        Ok(OrderProjectionPage { items, total })
+    }
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+        tracing::warn!(
+            error = ?error,
+            owner = "rustok_order",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            code = "order.context_invalid",
+            boundary = "order_read_port",
+            "order read context is invalid"
+        );
+        PortError::validation(
+            "order.context_invalid",
+            "order request context is invalid",
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_owner_error(
+    context: &PortContext,
+    operation: &'static str,
+    order_id: Option<Uuid>,
+    customer_id: Option<Uuid>,
+    status_length: Option<usize>,
+    fallback_locale_length: Option<usize>,
+    error: OrderError,
+) -> PortError {
+    let (kind, code, message, retryable, error_kind) = match &error {
+        OrderError::Validation(_) => (
+            PortErrorKind::Validation,
+            "order.validation",
+            "order request is invalid",
+            false,
+            "validation",
+        ),
+        OrderError::OrderNotFound(_) => (
+            PortErrorKind::NotFound,
+            "order.order_not_found",
+            "order was not found",
+            false,
+            "order_not_found",
+        ),
+        OrderError::OrderReturnNotFound(_) => (
+            PortErrorKind::NotFound,
+            "order.return_not_found",
+            "order return was not found",
+            false,
+            "return_not_found",
+        ),
+        OrderError::OrderChangeNotFound(_) => (
+            PortErrorKind::NotFound,
+            "order.change_not_found",
+            "order change was not found",
+            false,
+            "change_not_found",
+        ),
+        OrderError::InvalidTransition { .. } => (
+            PortErrorKind::Conflict,
+            "order.invalid_transition",
+            "order lifecycle transition conflicts with the current state",
+            false,
+            "invalid_transition",
+        ),
+        OrderError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "order.database_unavailable",
+            "order storage is temporarily unavailable",
+            true,
+            "database",
+        ),
+        OrderError::Core(_) => (
+            PortErrorKind::InvariantViolation,
+            "order.operation_failed",
+            "order operation could not be completed safely",
+            false,
+            "core",
+        ),
+    };
+
+    if matches!(&error, OrderError::Database(_) | OrderError::Core(_)) {
+        tracing::error!(
+            error = ?error,
+            owner = "rustok_order",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            fallback_locale_length = ?fallback_locale_length,
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            order_id = ?order_id,
+            customer_id = ?customer_id,
+            status_length = ?status_length,
+            error_kind,
+            code,
+            retryable,
+            boundary = "order_read_port",
+            "order projection read failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = "rustok_order",
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel_length = context.channel.as_deref().map(str::len),
+            locale_length = context.locale.len(),
+            fallback_locale_length = ?fallback_locale_length,
+            causation_id_present = context.causation_id.is_some(),
+            traceparent_present = context.traceparent.is_some(),
+            deadline_ms = ?context.deadline_ms,
+            order_id = ?order_id,
+            customer_id = ?customer_id,
+            status_length = ?status_length,
+            error_kind,
+            code,
+            retryable,
+            boundary = "order_read_port",
+            "order projection read was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const owner = read('crates/rustok-order/src/order_read.rs');
+const exports = read('crates/rustok-order/src/lib.rs');
+const evidence = JSON.parse(
+  read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
+);
+const note = read('crates/rustok-order/docs/order-read-port.md');
+const orderPlan = read('crates/rustok-order/docs/implementation-plan.md');
+const commercePlan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [owner, 'pub trait OrderReadPort: Send + Sync {', 'owner read trait'],
+  [owner, 'async fn read_order_projection(', 'detail operation'],
+  [owner, 'async fn list_order_projections(', 'list operation'],
+  [owner, 'pub struct ReadOrderProjectionRequest {', 'detail request'],
+  [owner, 'pub struct ListOrderProjectionsRequest {', 'list request'],
+  [owner, 'pub struct OrderProjectionPage {', 'page projection'],
+  [owner, 'pub struct InProcessOrderReadPort {', 'in-process adapter'],
+  [owner, 'pub fn in_process_order_read_port(', 'root factory'],
+  [owner, 'context.require_policy(PortCallPolicy::read())?', 'read policy'],
+  [owner, 'Uuid::parse_str(&context.tenant_id)', 'tenant parsing'],
+  [owner, '.get_order_with_locale_fallback(', 'owner detail delegation'],
+  [owner, '.list_orders_with_locale_fallback(', 'owner list delegation'],
+  [owner, 'context.locale.as_str()', 'requested locale propagation'],
+  [owner, 'request.tenant_default_locale.as_deref()', 'fallback locale propagation'],
+  [owner, 'OrderError::Validation(_)', 'validation mapping'],
+  [owner, 'OrderError::OrderNotFound(_)', 'order not-found mapping'],
+  [owner, 'OrderError::OrderReturnNotFound(_)', 'return not-found mapping'],
+  [owner, 'OrderError::OrderChangeNotFound(_)', 'change not-found mapping'],
+  [owner, 'OrderError::InvalidTransition { .. }', 'transition mapping'],
+  [owner, 'OrderError::Database(_)', 'database mapping'],
+  [owner, 'OrderError::Core(_)', 'core mapping'],
+  [owner, 'PortErrorKind::InvariantViolation', 'core fail-closed kind'],
+  [owner, 'PortError::new(kind, code, message, retryable)', 'stable port error'],
+  [owner, 'boundary = "order_read_port"', 'owner diagnostic boundary'],
+  [exports, 'mod order_read;', 'private owner module'],
+  [exports, 'OrderReadPort,', 'root trait export'],
+  [exports, 'InProcessOrderReadPort,', 'root adapter export'],
+  [exports, 'in_process_order_read_port,', 'root factory export'],
+  [note, 'Status: owner port published, unvalidated', 'owner note status'],
+  [orderPlan, 'OrderReadPort', 'order plan checkpoint'],
+  [commercePlan, 'OrderReadPort', 'commerce plan checkpoint'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['error.message', 'owner message control flow'],
+  ['error.to_string()', 'owner error string control flow'],
+  ['format!("{error}")', 'formatted owner error control flow'],
+  ['PortError::new(kind, code, error', 'raw owner error publication'],
+]) forbidText(owner, value, label);
+
+if (evidence.status !== 'owner_port_published_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (evidence.owner?.port !== 'OrderReadPort') {
+  failures.push('evidence owner port must be OrderReadPort');
+}
+if (evidence.owner?.adapter !== 'InProcessOrderReadPort') {
+  failures.push('evidence adapter must be InProcessOrderReadPort');
+}
+if (evidence.operations?.map((operation) => operation.name).join(',') !==
+    'read_order_projection,list_order_projections') {
+  failures.push('evidence operation inventory mismatch');
+}
+if (evidence.errors?.owner_message_control_flow !== false) {
+  failures.push('evidence must forbid owner-message control flow');
+}
+if (evidence.errors?.all_current_order_error_variants_mapped !== true) {
+  failures.push('evidence must record complete current OrderError mapping');
+}
+if (evidence.consumer_inventory?.runtime_composition_published !== false) {
+  failures.push('runtime composition must remain unpublished in this wave');
+}
+if (evidence.consumer_inventory?.consumer_cutover_completed !== false) {
+  failures.push('Commerce consumer cutover must remain incomplete in this wave');
+}
+if (evidence.consumer_inventory?.cutover_required !== true) {
+  failures.push('evidence must retain the pending Commerce cutover');
+}
+if (evidence.decision?.status_promotion !== false) {
+  failures.push('source publication must not promote status');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Order read port source verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Order detail/list projections are published through a typed owner read port while Commerce runtime composition and consumer cutover remain explicitly pending',
+);


### PR DESCRIPTION
## Summary

- publish the order-owned `OrderReadPort` for complete order detail and filtered list projections;
- add typed detail/list requests, an owner pagination envelope, and a canonical in-process factory;
- preserve requested locale through `PortContext.locale` with an explicit tenant-default fallback;
- require read deadline policy and parse tenant identity from the port context;
- map every current `OrderError` variant to stable `PortError` kinds/codes without owner-message control flow;
- retain Commerce runtime composition and mounted consumer cutover as explicit follow-up work.

## Owner boundary

`OrderReadPort` publishes:

- `read_order_projection` → `OrderResponse`;
- `list_order_projections` → `OrderProjectionPage`.

The list request retains page, per-page, status, customer, locale fallback, current descending creation ordering, and the owner pagination total. The in-process adapter is the only new source that constructs `OrderService`.

## Error policy

- validation → `Validation` / `order.validation`;
- missing order → `NotFound` / `order.order_not_found`;
- missing return/change compatibility variants → stable `NotFound` codes;
- invalid transition → `Conflict` / `order.invalid_transition`;
- database failure → retryable `Unavailable` / `order.database_unavailable`;
- owner core failure → non-retryable `InvariantViolation` / `order.operation_failed`.

Technical database/core causes remain in internal structured logs. Public messages are stable and do not copy owner or storage error text.

## Source evidence

- add `order-read-port-source.json` with status `owner_port_published_unvalidated`;
- add the owner runbook and focused static source verifier;
- checkpoint both the order plan and the canonical Commerce P0 plan;
- keep the broad mounted concrete-service cutover item open;
- retain all compile/runtime/parity flags as false.

## Follow-up

The next atomic source slice is to publish and host-compose `CommerceOrderReadRuntime`, require it in Commerce HTTP/GraphQL composition, and cut admin REST order list/detail first. GraphQL and storefront reads remain separate later changes. Order mutations and payment/fulfillment detail aggregation are unchanged.

## Recheck

- original source base: `d3c235f58ffbea04978208790d3d37a1dde44988`;
- reconciled current `main`: `b573adbf9a8397f5676dd617464060b878ce88a1`;
- intervening changes were limited to Iggy, Profiles, Index, and Forum files with no overlap;
- rebuilt one atomic commit over current `main`;
- final branch is one commit ahead and zero behind;
- final scope is seven files;
- temporary staging ref was removed through #2396 and its marker is absent from this PR.

## Validation

Tests, Cargo commands, formatting commands, verifier execution, workflow checks, and CI were not run, per maintainer instruction.

Maintainer-owned commands are recorded in the plans, including:

`node scripts/verify/verify-order-read-port.mjs`

`cargo check -p rustok-order --all-features`