### PR TITLE
Remove order read staging branch

### DIFF
--- a/.github/order-read-port-staging-cleanup.md
+++ b/.github/order-read-port-staging-cleanup.md
@@ -1,0 +1,1 @@
+Temporary branch-cleanup marker. This file is merged only into the feature branch and is removed when the feature ref is restored to its reviewed atomic commit.


### PR DESCRIPTION
Internal branch-cleanup PR. It merges a temporary marker into the feature branch solely so GitHub can delete the technical head branch. The feature ref will immediately be restored to the reviewed atomic commit, so this marker and merge do not enter the final PR or `main`.