### PR TITLE
docs(index): synchronize retained evidence status

### DIFF
--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -50,14 +50,21 @@ a rewrite goal.
 - M3 schema-application leases: complete
 - M3 secondary-index lifecycle: complete
 - M3 partition admission and shadow planning: complete
+- M3 partition evidence capture and packet assembly: complete
+- M3 retained packet owner orchestration: complete
+- M3 retained bundle review and archive verification: complete
+- Real retained PostgreSQL packet execution: open
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
 configuration, scheduler, errors, and server composition have been deleted. M3
 registers the canonical production schema, publishes an Index-owned transactional
 mutation adapter, owns durable schema-application leases, manages deterministic
-schema-derived secondary indexes, and now rejects partition rollout until measured
-shadow evidence passes an explicit policy. Query execution and partition cutover
-remain absent.
+schema-derived secondary indexes, and rejects partition rollout until measured
+shadow evidence passes an explicit policy. Owner-operated tooling now captures and
+validates the nine-file retained bundle, renders a read-only review, emits an
+admitted-only archive manifest outside the bundle, and verifies the saved manifest
+against an exact recursive filesystem snapshot. Query execution and production
+partition cutover remain absent.
 
 The module-owned migration source creates:
 
@@ -114,6 +121,15 @@ constraint/index attachment, dual-write/replay, cutover, rollback, and durable
 global operation ownership remain later work and require retained PostgreSQL
 evidence.
 
+The retained evidence boundary is owner-operated and read-only after capture. Review
+recalculates packet assembly and admission from exactly nine authoritative files.
+Archive verification rereads files and the saved external manifest through stable
+descriptors, checks filesystem identity and metadata fingerprints, verifies the
+exact recursive directory inventory, and fails closed on aliases, replacement,
+metadata drift, inventory drift, or byte drift. Public manifest and receipt schemas
+remain stable, and every successful receipt keeps
+`production_lifecycle_authorized: false`.
+
 ## Current entry points
 
 - `IndexModule`
@@ -154,7 +170,10 @@ evidence.
   tagged-payload expressions, concurrent lifecycle, owner verification, catalog
   readiness checks, and operation fencing;
 - fail-closed partition admission, exact evidence identity, explicit regression
-  limits, deterministic tenant-hash shadow names, and no destructive cutover SQL.
+  limits, deterministic tenant-hash shadow names, and no destructive cutover SQL;
+- exact-byte retained review and admitted archive verification bound to stable file
+  and directory identities, metadata fingerprints, and recursive inventory without
+  production lifecycle authorization.
 
 ## M2 benchmark
 
@@ -175,6 +194,7 @@ DDL remains benchmark-only and must not be copied into production migrations.
 - [Live implementation plan](./docs/implementation-plan.md)
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)
 - [M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)
+- [M3 retained partition capture runbook](./docs/partition-full-capture.md)
 - [Index Engine rewrite ADR](../../DECISIONS/2026-07-23-index-engine-rewrite.md)
 - [Accepted storage ADR](../../DECISIONS/2026-07-24-index-storage-layout.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -46,12 +46,16 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M3 partition maintenance evidence runner: `complete`
 - M3 partition cutover rehearsal evidence runner: `complete`
 - M3 retained packet owner orchestration: `complete`
+- M3 retained bundle review/report: `complete`
+- M3 admitted archive manifest: `complete`
+- M3 retained archive verification and filesystem snapshot: `complete`
 - Real retained PostgreSQL packet execution: `open`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
-  full-capture orchestration, exact-byte packet assembly, and validation are
-  implemented; one retained admitted packet, query adapter, and production partition
-  lifecycle remain open
+  full-capture orchestration, exact-byte packet assembly, retained bundle review,
+  admitted archive manifest generation, saved-manifest verification, and recursive
+  filesystem integrity checks are implemented; one retained admitted packet, query
+  adapter, and production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -182,6 +186,10 @@ unpartitioned until separate shadow evidence is retained and admitted.
 - [x] Add owner-operated PostgreSQL baseline/shadow ordinary-VACUUM maintenance evidence capture.
 - [x] Add owner-operated PostgreSQL cutover/rollback rehearsal evidence capture.
 - [x] Add owner-operated full retained packet orchestration and capture finalization.
+- [x] Add read-only retained bundle review with recalculated assembly and admission.
+- [x] Add admitted archive manifest and saved-manifest verification receipt.
+- [x] Bind retained verification to stable descriptors, filesystem identity and
+      fingerprints, and an exact recursive directory inventory.
 - [ ] Execute one fresh full PostgreSQL capture and retain all six raw artifacts,
       `capture.json`, `partition-packet.json`, and `admission.json`.
 - [ ] Review and archive one complete admitted real packet before production lifecycle
@@ -204,6 +212,10 @@ slices and still-open owner evidence to these exact architectural boundaries:
       owner-operated runbook.
 - [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
       no-clobber packet publication.
+- [x] Add read-only retained bundle review, admitted archive manifest, and
+      saved-manifest verification receipt.
+- [x] Bind retained verification to an exact recursive filesystem snapshot and refuse
+      post-inspection drift.
 - [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
 - [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
 - [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.
@@ -256,6 +268,17 @@ relations.
     runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
     and run provenance, assembles exact retained bytes into `partition-packet.json`,
     validates `admission.json`, and refuses partial-output reuse or resume.
+14. The retained bundle review inspects exactly nine authoritative files, recalculates
+    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
+    deterministic read-only owner report without editing the bundle.
+15. The archive tooling emits a deterministic admitted-only manifest outside the
+    immutable bundle and verifies a saved manifest into a read-only receipt with
+    `production_lifecycle_authorized: false`.
+16. Retained verification binds every authoritative file and required directory to
+    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
+    paths, and an exact recursive inventory. It rereads the saved manifest and fails
+    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
+    while keeping public manifest and receipt schemas unchanged.
 
 ### M4 - Query engine v1
 
@@ -369,6 +392,7 @@ node scripts/verify/verify-index-partition-mutation-evidence.mjs
 node scripts/verify/verify-index-partition-maintenance-evidence.mjs
 node scripts/verify/verify-index-partition-cutover-evidence.mjs
 node scripts/verify/verify-index-partition-full-capture.mjs
+node scripts/verify/verify-index-partition-post-inspection-drift.mjs
 ```
 
 ## Progress log
@@ -381,7 +405,10 @@ node scripts/verify/verify-index-partition-full-capture.mjs
   tooling, exact-byte assembly, baseline/shadow snapshot capture, query evidence
   capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
   maintenance evidence capture.
-- 2026-07-28: completed rollback-only cutover rehearsal evidence and full retained
-  packet owner orchestration with PostgreSQL identity-bound capture finalization.
-- Repository tests, verifiers, and one real full PostgreSQL partition packet remain for
-  the owner to execute and admit before production partition lifecycle work begins.
+- 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
+  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
+  retained bundle review, admitted archive manifest generation, saved-manifest
+  verification receipts, and exact recursive filesystem snapshot enforcement.
+- Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
+  packet remain for the owner to execute and admit before production partition
+  lifecycle work begins.

--- a/scripts/verify/verify-index-partition-full-capture.mjs
+++ b/scripts/verify/verify-index-partition-full-capture.mjs
@@ -37,6 +37,7 @@ try {
   const tooling = read('scripts/verify/index-storage-tooling.mjs');
   const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
   const plan = read('crates/rustok-index/docs/implementation-plan.md');
+  const readme = read('crates/rustok-index/README.md');
   const m3Start = plan.indexOf('### M3 - PostgreSQL storage engine');
   const retainedStart = plan.indexOf('#### Retained repository contract wording');
   if (m3Start < 0 || retainedStart <= m3Start) {
@@ -276,15 +277,33 @@ try {
     'writes no files',
     'forbidden before one retained admitted packet',
   ], 'full partition capture runbook');
+  requireMarkers(readme, [
+    'M3 partition evidence capture and packet assembly: complete',
+    'M3 retained packet owner orchestration: complete',
+    'M3 retained bundle review and archive verification: complete',
+    'Real retained PostgreSQL packet execution: open',
+    'exact recursive filesystem snapshot',
+    '`production_lifecycle_authorized: false`',
+    '[M3 retained partition capture runbook](./docs/partition-full-capture.md)',
+  ], 'Index README');
   requireMarkers(plan, [
     'M3 partition cutover rehearsal evidence runner: `complete`',
     'M3 retained packet owner orchestration: `complete`',
+    'M3 retained bundle review/report: `complete`',
+    'M3 admitted archive manifest: `complete`',
+    'M3 retained archive verification and filesystem snapshot: `complete`',
     'Real retained PostgreSQL packet execution: `open`',
     '- [x] Add owner-operated PostgreSQL cutover/rollback rehearsal evidence capture.',
     '- [x] Add owner-operated full retained packet orchestration and capture finalization.',
+    '- [x] Add read-only retained bundle review with recalculated assembly and admission.',
+    '- [x] Add admitted archive manifest and saved-manifest verification receipt.',
     '12. The cutover rehearsal runner validates production and retained shadow identities,',
     '13. The full-capture orchestrator requires one explicit owner opt-in, one immutable',
-    'one retained admitted packet, query adapter, and production partition',
+    '14. The retained bundle review inspects exactly nine authoritative files,',
+    '15. The archive tooling emits a deterministic admitted-only manifest outside the',
+    '16. Retained verification binds every authoritative file and required directory',
+    'node scripts/verify/verify-index-partition-post-inspection-drift.mjs',
+    'one retained admitted packet, query',
   ], 'Index implementation plan');
   requireExactlyOnce(
     primaryM3Checklist,


### PR DESCRIPTION
## Summary

- synchronize the canonical Index implementation plan with completed retained-bundle review, admitted archive manifest, saved-manifest verification, and recursive filesystem snapshot enforcement;
- refresh the crate README with the same completed M3 boundary and the still-open real PostgreSQL packet execution gate;
- bind both owner-facing documents into the aggregate full-capture static guard so the status cannot silently regress;
- preserve the two exact owner gates before production partition lifecycle design proceeds.

## Safety boundary

This changes documentation and a static repository marker guard only. It does not change evidence capture, packet assembly, admission thresholds, manifest or receipt schemas, PostgreSQL access, query execution, or production partition lifecycle behavior.

## Validation

Performed:

```bash
node --check scripts/verify/verify-index-partition-full-capture.mjs
```

Also performed exact Git blob checks:

- all three published branch blobs match the locally prepared files;
- reversing only the intended edits reproduces the exact three original `main` blob SHAs;
- both primary owner evidence gates remain present exactly once.

Per owner instruction, test suites, fixture suites, aggregate contract execution, Rust/Cargo commands, builds, database connections, and PostgreSQL evidence were not run.

Suggested owner checks:

```bash
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```