### PR TITLE
feat(profiles): publish count-only DLQ alert runtime

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "module": "iggy",
   "packet": "dlq-duplicate-alert-policy-source",
-  "status": "source_complete_runtime_integration_pending",
+  "status": "source_complete_runtime_composition_pending_server_integration",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
   "summary_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
@@ -102,6 +102,16 @@
     "claim_or_mark_receipt": false,
     "change_broker_configuration": false
   },
+  "runtime_composition": {
+    "status": "source_complete_server_integration_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
+    "input": "DlqDuplicateSummary",
+    "output": "DlqDuplicateAlertRuntimeSnapshot",
+    "latest_value": true,
+    "single_writer": true,
+    "unavailable_clears_evaluation": true
+  },
   "required_source_tests": [
     "invalid_threshold_ordering_fails_closed",
     "clear_and_notice_remain_below_operator_thresholds",
@@ -110,7 +120,8 @@
     "identity_conflict_is_always_critical_and_manual"
   ],
   "remaining_work": [
-    "runtime_alert_integration",
+    "server_observer_integration",
+    "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "retained_policy_integration_evidence",
     "authorized_destructive_reconciliation_workflow",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-alert-runtime-source",
+  "status": "source_complete_server_integration_pending",
+  "owner": "rustok-iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
+  "policy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
+  "summary_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "public_exports": [
+    "DlqDuplicateAlertRuntimePublisher",
+    "DlqDuplicateAlertRuntimeSubscriber",
+    "DlqDuplicateAlertRuntimeSnapshot",
+    "DlqDuplicateAlertRuntimeError"
+  ],
+  "composition": {
+    "input": "already_observed_DlqDuplicateSummary",
+    "policy": "prevalidated_DlqDuplicateAlertPolicy",
+    "channel": "tokio_watch_latest_value",
+    "publisher_role": "single_writer",
+    "subscriber_role": "read_only",
+    "broker_scan": false,
+    "receipt_read": false
+  },
+  "snapshot": {
+    "fields": [
+      "generation",
+      "available",
+      "evaluation"
+    ],
+    "initial_generation": 0,
+    "initial_available": false,
+    "initial_evaluation": null,
+    "generation_monotonic": true,
+    "generation_overflow_fails_closed": true,
+    "available_snapshot_requires_evaluation": true,
+    "unavailable_snapshot_clears_evaluation": true,
+    "latest_value_replaces_prior_snapshot": true
+  },
+  "evaluation_projection": [
+    "level",
+    "physical_duplicates",
+    "identity_conflict",
+    "duplicate_messages_threshold_reached",
+    "duplicate_groups_threshold_reached",
+    "max_copies_threshold_reached"
+  ],
+  "subscriber": {
+    "current_snapshot": true,
+    "await_change": true,
+    "independent_subscriptions": true,
+    "publisher_closed_fails_bounded": true,
+    "write_access": false
+  },
+  "stable_errors": {
+    "generation_overflow": "iggy.dlq_duplicate.alert_runtime_generation_overflow",
+    "publisher_closed": "iggy.dlq_duplicate.alert_runtime_publisher_closed"
+  },
+  "privacy_boundary": {
+    "snapshot_excludes": [
+      "source_counts",
+      "threshold_values",
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "error_classification",
+      "publisher_identity",
+      "timestamp",
+      "credential",
+      "raw_client_error"
+    ],
+    "serialization_added": false,
+    "persistence_added": false
+  },
+  "runtime_boundary": {
+    "server_worker_startup": false,
+    "scan_scheduling": false,
+    "notification_delivery": false,
+    "delivery_channel_selection": false,
+    "suppression_or_cooldown": false,
+    "readiness_decision": false,
+    "profiles_authorization": false,
+    "telemetry_registration": false,
+    "health_registration": false
+  },
+  "mutation_boundary": {
+    "acknowledge": false,
+    "delete": false,
+    "purge": false,
+    "replay": false,
+    "retry": false,
+    "publish_broker_message": false,
+    "claim_or_mark_receipt": false,
+    "change_broker_configuration": false,
+    "change_profile_state": false
+  },
+  "required_source_tests": [
+    "initial_snapshot_is_unavailable_without_evaluation",
+    "publish_replaces_latest_identifier_free_evaluation",
+    "unavailable_transition_clears_stale_evaluation",
+    "independent_subscribers_receive_the_same_latest_snapshot",
+    "closed_publisher_has_a_stable_identifier_free_error"
+  ],
+  "remaining_work": [
+    "server_observer_integration",
+    "telemetry_and_health_projection",
+    "retained_runtime_integration_evidence",
+    "notification_delivery_and_suppression_outside_runtime",
+    "authorized_destructive_reconciliation_workflow",
+    "aggregate_receipt_and_duplicate_health_correlation"
+  ],
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md",
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -86,7 +86,7 @@
     "result": "DlqDuplicateSummary"
   },
   "alert_policy": {
-    "status": "source_complete_runtime_integration_pending",
+    "status": "source_complete_runtime_composition_pending_server_integration",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
     "input": "DlqDuplicateSummary",
@@ -96,9 +96,22 @@
     "notification_dispatch": false,
     "destructive_action": false
   },
+  "alert_runtime": {
+    "status": "source_complete_server_integration_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
+    "input": "DlqDuplicateSummary",
+    "result": "DlqDuplicateAlertRuntimeSnapshot",
+    "latest_value": true,
+    "single_writer": true,
+    "unavailable_clears_evaluation": true,
+    "notification_dispatch": false,
+    "destructive_action": false
+  },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
-    "runtime_alert_integration",
+    "server_alert_observer_integration",
+    "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",
     "correlation_with_count_only_receipt_health_without_identifier_export"

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate alert policy
 
-Status: **source complete; runtime integration and retained policy evidence pending**.
+Status: **policy and latest-value runtime composition source-complete; server integration and retained evidence pending**.
 
 ## Purpose
 
@@ -154,42 +154,61 @@ Those concerns require separate owner contracts and operational review.
 
 `IggyDlqDuplicateScanner` returns `DlqDuplicateSummary`. A caller may pass that summary to this policy, but the scanner does not own thresholds and the policy does not own the scanner.
 
-This separation keeps:
+## Latest-value runtime composition
+
+`DlqDuplicateAlertRuntimePublisher` now provides the next transport-neutral composition boundary:
 
 ```text
-observation -> count-only summary -> policy evaluation -> external delivery
+DlqDuplicateSummary
+  -> DlqDuplicateAlertPolicy::evaluate
+  -> DlqDuplicateAlertRuntimeSnapshot
+  -> read-only subscribers
 ```
 
-as four distinct boundaries.
+The runtime is defined in `dlq_duplicate_alert_runtime.rs` and documented in `dlq-duplicate-alert-runtime.md`.
+
+It is deliberately separate from the pure policy:
+
+- one single-writer publisher owns generation and the validated policy;
+- the initial snapshot is unavailable with no evaluation;
+- successful publication evaluates a summary and replaces the latest value;
+- unavailable publication clears the prior evaluation;
+- subscribers can only read or await changes;
+- no server worker, metric, health check, notification route, or persistence is selected.
+
+The watch channel is latest-value state, not an event log. Slow subscribers are not promised every intermediate generation.
 
 ## Relationship to Profiles
 
-No alert level, threshold flag, duplicate count, identity-conflict signal, scan result, or retained evidence may authorize profile visibility, follower access, block/mute behavior, or presentation.
+No alert level, threshold flag, runtime availability, generation, duplicate count, identity-conflict signal, scan result, or retained evidence may authorize profile visibility, follower access, block/mute behavior, or presentation.
 
-Profiles continues to consume authoritative owner-port results. This policy is operational observability only.
+Profiles continues to consume authoritative owner-port results. This policy and runtime composition are operational observability only.
 
 ## Source verification
 
-Machine contract:
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
 ```
 
-Static verifier:
+Static verifiers:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
 ```
 
-Focused tests define invalid configuration, clear/notice behavior, warning dimensions, critical numeric precedence, and conflict-critical manual escalation.
+Focused policy tests define invalid configuration, clear/notice behavior, warning dimensions, critical numeric precedence, and conflict-critical manual escalation. Runtime tests define initial unavailability, latest-value publication, stale-evaluation clearing, independent subscribers, and bounded publisher closure.
 
-No tests, Cargo commands, formatters, source verifiers, external Iggy connections, or retained capture were run while authoring this slice.
+No tests, Cargo commands, formatters, source verifiers, external Iggy connections, server observers, telemetry registration, alert delivery, or retained capture were run while authoring these slices.
 
 ## Remaining work
 
-1. integrate the pure policy into an explicitly owned runtime observer;
-2. define alert delivery, cooldown, and suppression outside this module;
-3. retain privacy-safe runtime policy evidence;
-4. define destructive reconciliation as a separate authorized workflow;
-5. compare aggregate receipt and duplicate trends without exporting identifiers.
+1. integrate an explicitly owned server observer;
+2. project the runtime snapshot into reviewed telemetry and health contracts;
+3. define alert delivery, cooldown, and suppression outside the policy/runtime;
+4. retain privacy-safe policy/runtime integration evidence;
+5. define destructive reconciliation as a separate authorized workflow;
+6. compare aggregate receipt and duplicate trends without exporting identifiers.

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md
@@ -1,0 +1,188 @@
+# Count-only DLQ duplicate alert runtime
+
+Status: **latest-value runtime composition source-complete; server observer integration pending**.
+
+## Purpose
+
+`DlqDuplicateAlertRuntimePublisher` composes two already separated owner inputs:
+
+```text
+DlqDuplicateSummary
+DlqDuplicateAlertPolicy
+```
+
+It evaluates an already-observed count-only summary and publishes one identifier-free latest-value snapshot for telemetry or health consumers.
+
+The runtime does not scan Iggy, read poison receipts, choose thresholds, dispatch notifications, or perform reconciliation.
+
+## Public API
+
+```text
+DlqDuplicateAlertRuntimePublisher
+DlqDuplicateAlertRuntimeSubscriber
+DlqDuplicateAlertRuntimeSnapshot
+DlqDuplicateAlertRuntimeError
+```
+
+The API is not feature-gated on the Iggy SDK. It depends only on the transport-neutral duplicate summary, the validated alert policy, and Tokio's in-memory watch channel.
+
+## Single-writer publisher
+
+The publisher owns:
+
+```text
+validated alert policy
+current generation
+tokio watch sender
+```
+
+Mutation methods require `&mut self`. This makes the publisher a deliberate single-writer component and prevents concurrent calls from publishing a lower generation after a higher generation.
+
+A runtime host may create any number of read-only subscribers through `subscribe()`.
+
+## Initial snapshot
+
+A newly created channel contains:
+
+```text
+generation = 0
+available = false
+evaluation = None
+```
+
+Initial unavailability is explicit. No severity is invented before the first successful observation.
+
+## Successful publication
+
+`publish(&DlqDuplicateSummary)`:
+
+1. advances generation with checked arithmetic;
+2. evaluates the summary through the prevalidated policy;
+3. creates `available = true` with `evaluation = Some(...)`;
+4. replaces the watch channel's latest value;
+5. returns the exact published snapshot.
+
+Only the latest snapshot is retained in memory. The runtime is not an event log and does not guarantee that a slow subscriber observes every intermediate generation.
+
+## Unavailable transition
+
+`mark_unavailable()`:
+
+1. advances generation;
+2. publishes `available = false`;
+3. sets `evaluation = None`;
+4. replaces the previous latest value.
+
+Clearing evaluation is required. A stale `Warning` or `Critical` result must not continue to appear current after the observer reports that its source snapshot is unavailable.
+
+## Subscriber boundary
+
+A subscriber can:
+
+```text
+current()
+changed().await
+```
+
+`current()` returns the latest copied snapshot. `changed()` waits for a newer watch value and then returns it.
+
+Subscribers cannot publish, alter generation, change policy, scan the broker, mutate offsets, or modify receipt/Profile state.
+
+When every publisher is dropped, a waiting subscriber fails with:
+
+```text
+iggy.dlq_duplicate.alert_runtime_publisher_closed
+```
+
+## Snapshot projection
+
+The snapshot contains only:
+
+```text
+generation
+available
+evaluation
+```
+
+The optional evaluation remains the identifier-free policy result:
+
+```text
+level
+physical_duplicates
+identity_conflict
+duplicate_messages_threshold_reached
+duplicate_groups_threshold_reached
+max_copies_threshold_reached
+```
+
+The snapshot does not expose source counts or threshold values. It also excludes broker endpoints, stream/topic/partition/offset, UUIDs, payloads or digests, receipt identities, error classifications, credentials, timestamps, publisher identity, and raw client errors.
+
+No serialization or persistence is added. A future telemetry or health adapter must preserve this projection.
+
+## Stable errors
+
+```text
+iggy.dlq_duplicate.alert_runtime_generation_overflow
+iggy.dlq_duplicate.alert_runtime_publisher_closed
+```
+
+Generation overflow fails before replacing the current snapshot. Publisher closure is bounded and contains no runtime identifiers.
+
+## Runtime boundaries
+
+This module does not:
+
+- start a server worker;
+- choose scan cadence or partitions;
+- connect to Iggy;
+- read poison receipts;
+- register metrics or health checks;
+- choose notification destinations;
+- page, suppress, cool down, or deduplicate alerts;
+- affect readiness;
+- authorize Profiles presentation;
+- acknowledge, delete, purge, replay, retry, or publish broker messages;
+- claim or mark poison receipts;
+- change broker configuration or profile state.
+
+Observation, policy evaluation, latest-value publication, telemetry projection, notification delivery, and destructive workflows remain separate owner boundaries.
+
+## Suggested server composition
+
+A future server-owned observer should:
+
+```text
+1. obtain a bounded DlqDuplicateSummary from an approved observer;
+2. call publisher.publish(summary) after successful observation;
+3. call publisher.mark_unavailable() after observation failure or shutdown;
+4. expose a subscriber only to count-free telemetry/health adapters;
+5. keep projection/readiness and Profiles authorization independent;
+6. leave paging, cooldown, suppression, and destructive actions outside this runtime.
+```
+
+The server integration must decide configuration ownership and lifecycle separately. This source slice intentionally provides no production defaults or environment variables.
+
+## Source contract
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+```
+
+Static guard:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+```
+
+Focused source tests cover initial unavailability, successful publication, stale-evaluation clearing, independent subscribers, and bounded publisher closure.
+
+No tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, or alert dispatch were run while defining this source slice.
+
+## Remaining work
+
+1. integrate one explicit server-owned observer lifecycle;
+2. project the identifier-free snapshot into reviewed telemetry and health contracts;
+3. retain runtime integration evidence;
+4. define notification delivery, cooldown, and suppression outside this module;
+5. define destructive reconciliation as a separately authorized workflow;
+6. correlate receipt and duplicate aggregate health without exporting identifiers.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier, bounded external-Iggy adapter, runtime harness, retained tooling, and alert policy source-complete; runtime execution and integration pending**.
+Status: **classifier, bounded external-Iggy adapter, runtime harness, retained tooling, alert policy, and latest-value alert runtime source-complete; runtime execution and server integration pending**.
 
 ## Purpose
 
@@ -13,7 +13,7 @@ Physical copies can exceed one when:
 - capacity pressure evicted the ID;
 - a failover or unsupported broker path did not preserve the expected dedup state.
 
-`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for a bounded set of physical observations. `dlq_duplicate_external_scan.rs` provides the bounded external-Iggy polling adapter. `dlq_duplicate_alert_policy.rs` separately evaluates the count-only summary against explicit operator thresholds.
+`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for bounded physical observations. `dlq_duplicate_external_scan.rs` provides the bounded external-Iggy adapter. `dlq_duplicate_alert_policy.rs` evaluates the count-only summary against explicit thresholds. `dlq_duplicate_alert_runtime.rs` publishes the latest identifier-free evaluation state for read-only consumers.
 
 ## Input boundary
 
@@ -105,9 +105,9 @@ The classifier and external scanner cannot:
 - mark a receipt published or acknowledged;
 - choose alert thresholds or operator policy.
 
-The separate alert policy accepts explicit caller thresholds, but it cannot scan, send notifications, choose routing/cooldown, persist policy, or perform any mutation.
+The separate alert policy accepts explicit caller thresholds but cannot scan, send notifications, choose routing/cooldown, persist policy, or mutate state. The alert runtime only replaces one in-memory latest-value snapshot and cannot start a worker, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
 
-This separation is deliberate. Observation and evaluation must not accidentally become destructive reconciliation.
+This separation is deliberate. Observation, evaluation, runtime publication, delivery, and reconciliation must remain distinct.
 
 ## Relationship to deterministic raw poison identity
 
@@ -129,13 +129,7 @@ published
 acknowledged
 ```
 
-Neither summary contains identifiers, so they cannot be joined message-by-message. An operator may compare aggregate trends, for example:
-
-- rising `expired_publishing` with rising physical duplicates suggests lease recovery outside the effective dedup window;
-- zero receipt recovery work with growing duplicates suggests historic or downstream DLQ duplication;
-- `conflicting_payload_groups > 0` always requires direct forensic escalation.
-
-These are operator interpretations, not storage-layer decisions.
+Neither summary contains identifiers, so they cannot be joined message by message. Operators may compare aggregate trends, but those interpretations are not storage or Profiles authorization decisions.
 
 ## Bounded external-Iggy adapter
 
@@ -151,7 +145,7 @@ auto_commit = false
 
 One request permits at most 128 partitions, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
 
-The adapter does not own credentials or connection lifecycle, query topology metadata, join a consumer group, persist progress, or call shutdown. See `dlq-duplicate-external-scan.md` for the complete contract.
+The adapter does not own credentials or connection lifecycle, query topology metadata, join a consumer group, persist progress, or call shutdown.
 
 ## Count-only alert policy
 
@@ -167,19 +161,42 @@ physical duplicate below warning -> Notice
 no duplicate -> Clear
 ```
 
-The evaluation exposes only level and boolean reason flags. It does not expose source counts, raw threshold values, identifiers, or broker coordinates. See `dlq-duplicate-alert-policy.md`.
+The evaluation exposes only level and boolean reason flags. It does not expose source counts, raw threshold values, identifiers, or broker coordinates.
+
+## Latest-value alert runtime
+
+`DlqDuplicateAlertRuntimePublisher` accepts an already-observed `DlqDuplicateSummary` and a prevalidated policy.
+
+```text
+summary -> policy evaluate -> latest runtime snapshot -> read-only subscribers
+```
+
+The publisher is single-writer. The initial snapshot is unavailable at generation `0` with no evaluation. Every successful or unavailable transition increments generation through checked arithmetic.
+
+`mark_unavailable()` clears the previous evaluation, preventing a stale `Warning` or `Critical` value from appearing current after observer failure or shutdown.
+
+The snapshot exposes only:
+
+```text
+generation
+available
+evaluation
+```
+
+The runtime is a latest-value channel, not an event log. It does not promise delivery of every intermediate generation and adds no serialization or persistence.
 
 ## Safe operational sequence
 
 1. select an external service, stream, explicit partition allowlist, offset, and message cap;
 2. connect and authenticate an `IggyClient` outside the scanner;
-3. call the bounded scanner using explicit-offset polling with `auto_commit=false`;
-4. pass the count-only summary to an explicitly configured alert policy when evaluation is required;
-5. publish only the identifier-free summary/evaluation through a separately owned delivery layer;
-6. close the client through the caller-owned lifecycle;
-7. treat the result as a bounded window, not automatically as complete history.
+3. call the bounded scanner with explicit-offset polling and `auto_commit=false`;
+4. pass the count-only summary to an explicitly configured alert policy;
+5. publish the evaluation through the single-writer runtime;
+6. expose only read-only runtime subscribers to separately reviewed telemetry/health adapters;
+7. close the client through the caller-owned lifecycle;
+8. treat the result as a bounded window, not automatically as complete history.
 
-Any destructive action must be a separate, explicitly authorized workflow with its own preview, selection, audit, and retained evidence.
+Notification delivery, cooldown/suppression, and destructive actions require separate owner contracts.
 
 ## Runtime and retained evidence status
 
@@ -187,7 +204,7 @@ The opt-in external harness is source-complete. It uses production `move_to_dlq`
 
 The clean-commit retained contract, runner, verifier, reviewed dedup-disabled configuration boundary, source hashes, exact-case execution, and privacy-safe packet projection are also source-complete.
 
-The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
+The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully. Server observer and telemetry/health integration for the alert runtime remain pending.
 
 ## Source tests and guards
 
@@ -199,15 +216,17 @@ node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
 cargo test -p rustok-iggy dlq_duplicate -- --nocapture
 ```
 
-No tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert dispatch, or retained capture were run while defining these source slices.
+No tests, Cargo commands, formatters, verifiers, external-Iggy scans, server observers, telemetry registration, alert dispatch, or retained capture were run while defining these source slices.
 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. integrate the pure alert policy into an explicitly owned runtime observer;
-3. define alert routing, cooldown, and suppression outside the classifier and policy;
-4. design acknowledgement/delete/replay as a separate authorized operation;
-5. correlate aggregate receipt and duplicate health without exporting message identities.
+2. integrate an explicitly owned server alert observer;
+3. define identifier-free telemetry and health projection;
+4. define alert routing, cooldown, and suppression outside the classifier/policy/runtime;
+5. design acknowledgement/delete/replay as a separate authorized operation;
+6. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
@@ -50,12 +50,13 @@ impl DlqDuplicateAlertRuntimeSnapshot {
     }
 }
 
-/// Publisher side of the in-memory duplicate alert runtime composition.
+/// Single-writer publisher side of the in-memory duplicate alert runtime composition.
 ///
 /// It does not scan Iggy, read poison receipts, persist state, dispatch notifications, choose
 /// cooldown or suppression, affect readiness, or mutate broker/receipt/Profile state.
 pub struct DlqDuplicateAlertRuntimePublisher {
     policy: DlqDuplicateAlertPolicy,
+    generation: u64,
     sender: watch::Sender<DlqDuplicateAlertRuntimeSnapshot>,
 }
 
@@ -68,7 +69,11 @@ impl DlqDuplicateAlertRuntimePublisher {
     ) {
         let (sender, receiver) = watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0));
         (
-            Self { policy, sender },
+            Self {
+                policy,
+                generation: 0,
+                sender,
+            },
             DlqDuplicateAlertRuntimeSubscriber { receiver },
         )
     }
@@ -81,10 +86,10 @@ impl DlqDuplicateAlertRuntimePublisher {
 
     /// Evaluates one already-observed count-only summary and replaces the latest snapshot.
     pub fn publish(
-        &self,
+        &mut self,
         summary: &DlqDuplicateSummary,
     ) -> Result<DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeError> {
-        let generation = self.next_generation()?;
+        let generation = self.advance_generation()?;
         let snapshot = DlqDuplicateAlertRuntimeSnapshot::available(
             generation,
             self.policy.evaluate(summary),
@@ -96,19 +101,19 @@ impl DlqDuplicateAlertRuntimePublisher {
     /// Marks observation unavailable and clears the prior evaluation so stale severity is not
     /// presented as current state.
     pub fn mark_unavailable(
-        &self,
+        &mut self,
     ) -> Result<DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeError> {
-        let snapshot = DlqDuplicateAlertRuntimeSnapshot::unavailable(self.next_generation()?);
+        let snapshot = DlqDuplicateAlertRuntimeSnapshot::unavailable(self.advance_generation()?);
         self.sender.send_replace(snapshot);
         Ok(snapshot)
     }
 
-    fn next_generation(&self) -> Result<u64, DlqDuplicateAlertRuntimeError> {
-        self.sender
-            .borrow()
+    fn advance_generation(&mut self) -> Result<u64, DlqDuplicateAlertRuntimeError> {
+        self.generation = self
             .generation
             .checked_add(1)
-            .ok_or(DlqDuplicateAlertRuntimeError::GenerationOverflow)
+            .ok_or(DlqDuplicateAlertRuntimeError::GenerationOverflow)?;
+        Ok(self.generation)
     }
 }
 
@@ -182,7 +187,7 @@ mod tests {
 
     #[tokio::test]
     async fn publish_replaces_latest_identifier_free_evaluation() {
-        let (publisher, mut subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let (mut publisher, mut subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
         let published = publisher
             .publish(&summary(&[(1, &[1]), (1, &[1]), (2, &[2]), (2, &[2])]))
             .unwrap();
@@ -199,7 +204,7 @@ mod tests {
 
     #[test]
     fn unavailable_transition_clears_stale_evaluation() {
-        let (publisher, subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let (mut publisher, subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
         publisher
             .publish(&summary(&[(1, &[1]), (1, &[1])]))
             .unwrap();
@@ -212,7 +217,7 @@ mod tests {
 
     #[test]
     fn independent_subscribers_receive_the_same_latest_snapshot() {
-        let (publisher, first) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let (mut publisher, first) = DlqDuplicateAlertRuntimePublisher::new(policy());
         let second = publisher.subscribe();
         let published = publisher
             .publish(&summary(&[(7, &[1]), (7, &[2])]))

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
@@ -1,0 +1,236 @@
+use thiserror::Error;
+use tokio::sync::watch;
+
+use crate::dlq_duplicate_alert_policy::{
+    DlqDuplicateAlertEvaluation, DlqDuplicateAlertPolicy,
+};
+use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
+
+/// Identifier-free latest-value snapshot for duplicate alert telemetry and health consumers.
+///
+/// The snapshot contains no source counts, thresholds, broker coordinates, message identity,
+/// payload facts, credentials, timestamps, notification routing, or destructive action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlqDuplicateAlertRuntimeSnapshot {
+    generation: u64,
+    available: bool,
+    evaluation: Option<DlqDuplicateAlertEvaluation>,
+}
+
+impl DlqDuplicateAlertRuntimeSnapshot {
+    const fn unavailable(generation: u64) -> Self {
+        Self {
+            generation,
+            available: false,
+            evaluation: None,
+        }
+    }
+
+    const fn available(
+        generation: u64,
+        evaluation: DlqDuplicateAlertEvaluation,
+    ) -> Self {
+        Self {
+            generation,
+            available: true,
+            evaluation: Some(evaluation),
+        }
+    }
+
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub const fn is_available(&self) -> bool {
+        self.available
+    }
+
+    pub const fn evaluation(&self) -> Option<DlqDuplicateAlertEvaluation> {
+        self.evaluation
+    }
+}
+
+/// Publisher side of the in-memory duplicate alert runtime composition.
+///
+/// It does not scan Iggy, read poison receipts, persist state, dispatch notifications, choose
+/// cooldown or suppression, affect readiness, or mutate broker/receipt/Profile state.
+pub struct DlqDuplicateAlertRuntimePublisher {
+    policy: DlqDuplicateAlertPolicy,
+    sender: watch::Sender<DlqDuplicateAlertRuntimeSnapshot>,
+}
+
+impl DlqDuplicateAlertRuntimePublisher {
+    pub fn new(
+        policy: DlqDuplicateAlertPolicy,
+    ) -> (
+        Self,
+        DlqDuplicateAlertRuntimeSubscriber,
+    ) {
+        let (sender, receiver) = watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0));
+        (
+            Self { policy, sender },
+            DlqDuplicateAlertRuntimeSubscriber { receiver },
+        )
+    }
+
+    pub fn subscribe(&self) -> DlqDuplicateAlertRuntimeSubscriber {
+        DlqDuplicateAlertRuntimeSubscriber {
+            receiver: self.sender.subscribe(),
+        }
+    }
+
+    /// Evaluates one already-observed count-only summary and replaces the latest snapshot.
+    pub fn publish(
+        &self,
+        summary: &DlqDuplicateSummary,
+    ) -> Result<DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeError> {
+        let generation = self.next_generation()?;
+        let snapshot = DlqDuplicateAlertRuntimeSnapshot::available(
+            generation,
+            self.policy.evaluate(summary),
+        );
+        self.sender.send_replace(snapshot);
+        Ok(snapshot)
+    }
+
+    /// Marks observation unavailable and clears the prior evaluation so stale severity is not
+    /// presented as current state.
+    pub fn mark_unavailable(
+        &self,
+    ) -> Result<DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeError> {
+        let snapshot = DlqDuplicateAlertRuntimeSnapshot::unavailable(self.next_generation()?);
+        self.sender.send_replace(snapshot);
+        Ok(snapshot)
+    }
+
+    fn next_generation(&self) -> Result<u64, DlqDuplicateAlertRuntimeError> {
+        self.sender
+            .borrow()
+            .generation
+            .checked_add(1)
+            .ok_or(DlqDuplicateAlertRuntimeError::GenerationOverflow)
+    }
+}
+
+/// Read-only subscriber for telemetry and health composition.
+pub struct DlqDuplicateAlertRuntimeSubscriber {
+    receiver: watch::Receiver<DlqDuplicateAlertRuntimeSnapshot>,
+}
+
+impl DlqDuplicateAlertRuntimeSubscriber {
+    pub fn current(&self) -> DlqDuplicateAlertRuntimeSnapshot {
+        *self.receiver.borrow()
+    }
+
+    pub async fn changed(
+        &mut self,
+    ) -> Result<DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeError> {
+        self.receiver
+            .changed()
+            .await
+            .map_err(|_| DlqDuplicateAlertRuntimeError::PublisherClosed)?;
+        Ok(self.current())
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum DlqDuplicateAlertRuntimeError {
+    #[error("physical DLQ duplicate alert runtime generation overflow")]
+    GenerationOverflow,
+    #[error("physical DLQ duplicate alert runtime publisher closed")]
+    PublisherClosed,
+}
+
+impl DlqDuplicateAlertRuntimeError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::GenerationOverflow => {
+                "iggy.dlq_duplicate.alert_runtime_generation_overflow"
+            }
+            Self::PublisherClosed => "iggy.dlq_duplicate.alert_runtime_publisher_closed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::{DlqDuplicateObservation, summarize_dlq_duplicates};
+
+    use super::*;
+
+    fn policy() -> DlqDuplicateAlertPolicy {
+        DlqDuplicateAlertPolicy::new(2, 4, 2, 3, 3, 5).unwrap()
+    }
+
+    fn summary(entries: &[(u128, &[u8])]) -> DlqDuplicateSummary {
+        summarize_dlq_duplicates(entries.iter().map(|(id, payload)| {
+            DlqDuplicateObservation::from_payload(Uuid::from_u128(*id), payload).unwrap()
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn initial_snapshot_is_unavailable_without_evaluation() {
+        let (_publisher, subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let snapshot = subscriber.current();
+        assert_eq!(snapshot.generation(), 0);
+        assert!(!snapshot.is_available());
+        assert_eq!(snapshot.evaluation(), None);
+    }
+
+    #[tokio::test]
+    async fn publish_replaces_latest_identifier_free_evaluation() {
+        let (publisher, mut subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let published = publisher
+            .publish(&summary(&[(1, &[1]), (1, &[1]), (2, &[2]), (2, &[2])]))
+            .unwrap();
+        assert_eq!(published.generation(), 1);
+        assert!(published.is_available());
+        assert_eq!(
+            published.evaluation().unwrap().level(),
+            crate::DlqDuplicateAlertLevel::Warning
+        );
+
+        let observed = subscriber.changed().await.unwrap();
+        assert_eq!(observed, published);
+    }
+
+    #[test]
+    fn unavailable_transition_clears_stale_evaluation() {
+        let (publisher, subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        publisher
+            .publish(&summary(&[(1, &[1]), (1, &[1])]))
+            .unwrap();
+        let unavailable = publisher.mark_unavailable().unwrap();
+        assert_eq!(unavailable.generation(), 2);
+        assert!(!unavailable.is_available());
+        assert_eq!(unavailable.evaluation(), None);
+        assert_eq!(subscriber.current(), unavailable);
+    }
+
+    #[test]
+    fn independent_subscribers_receive_the_same_latest_snapshot() {
+        let (publisher, first) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        let second = publisher.subscribe();
+        let published = publisher
+            .publish(&summary(&[(7, &[1]), (7, &[2])]))
+            .unwrap();
+        assert_eq!(first.current(), published);
+        assert_eq!(second.current(), published);
+        assert!(published.evaluation().unwrap().requires_manual_review());
+    }
+
+    #[tokio::test]
+    async fn closed_publisher_has_a_stable_identifier_free_error() {
+        let (publisher, mut subscriber) = DlqDuplicateAlertRuntimePublisher::new(policy());
+        drop(publisher);
+        let error = subscriber.changed().await.unwrap_err();
+        assert_eq!(error, DlqDuplicateAlertRuntimeError::PublisherClosed);
+        assert_eq!(
+            error.stable_code(),
+            "iggy.dlq_duplicate.alert_runtime_publisher_closed"
+        );
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -63,6 +63,7 @@ pub mod contract_consumer;
 pub mod contract_decode_failure;
 pub mod dlq;
 pub mod dlq_duplicate_alert_policy;
+pub mod dlq_duplicate_alert_runtime;
 #[cfg(feature = "iggy")]
 pub mod dlq_duplicate_external_scan;
 pub mod dlq_duplicate_inspection;
@@ -92,6 +93,10 @@ pub use dlq::{DlqEntry, DlqManager};
 pub use dlq_duplicate_alert_policy::{
     DlqDuplicateAlertEvaluation, DlqDuplicateAlertLevel, DlqDuplicateAlertPolicy,
     DlqDuplicateAlertPolicyError,
+};
+pub use dlq_duplicate_alert_runtime::{
+    DlqDuplicateAlertRuntimeError, DlqDuplicateAlertRuntimePublisher,
+    DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeSubscriber,
 };
 #[cfg(feature = "iggy")]
 pub use dlq_duplicate_external_scan::{

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
@@ -1,36 +1,35 @@
 # Profiles checkpoint: physical DLQ duplicate alert policy
 
-Status: **count-only policy source-complete; runtime integration pending**.
+Status: **count-only policy and latest-value runtime composition source-complete; server integration pending**.
 
 ## What changed
 
-`rustok-iggy` now owns a transport-neutral policy that evaluates the existing count-only physical DLQ duplicate summary.
+`rustok-iggy` owns a transport-neutral policy that evaluates the existing count-only physical DLQ duplicate summary and an in-memory latest-value runtime composition for the resulting identifier-free evaluation.
 
-Source:
+Policy source:
 
 ```text
 crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
 ```
 
-Machine contract:
+Runtime source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+```
+
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
 ```
 
-Verifier:
+Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
-```
-
-Public API:
-
-```text
-DlqDuplicateAlertPolicy
-DlqDuplicateAlertLevel
-DlqDuplicateAlertEvaluation
-DlqDuplicateAlertPolicyError
+scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
 ```
 
 No Profiles API, database table, GraphQL field, storefront behavior, privacy port, or authorization input changed.
@@ -63,9 +62,33 @@ Identity conflict means one deterministic physical message UUID was observed wit
 
 A numeric `Critical` result without an identity conflict does not by itself authorize manual payload inspection or destructive reconciliation.
 
-## Count-only projection
+## Latest-value runtime composition
 
-The evaluation exposes only:
+The runtime sequence is:
+
+```text
+already observed DlqDuplicateSummary
+  -> prevalidated DlqDuplicateAlertPolicy
+  -> single-writer runtime publisher
+  -> identifier-free latest snapshot
+  -> read-only subscribers
+```
+
+The initial state is unavailable with generation `0` and no evaluation. Successful observation publishes an available evaluation. Observation failure or shutdown publishes unavailable and clears the old evaluation so stale severity does not remain current.
+
+The channel retains only the latest state. It is not an audit log and does not promise that every subscriber sees every intermediate generation.
+
+## Count-only runtime projection
+
+The runtime snapshot exposes only:
+
+```text
+generation
+available
+evaluation
+```
+
+The optional evaluation exposes only:
 
 ```text
 level
@@ -78,11 +101,14 @@ max_copies_threshold_reached
 
 It does not expose counts from the source summary, raw threshold values, broker coordinates, UUIDs, payloads, payload digests, receipt identities, credentials, timestamps, or raw Iggy errors.
 
+No serialization or persistence is added.
+
 ## Profiles authorization boundary
 
 No profile visibility, ownership, follower access, block, mute, relationship, audience, storefront presentation, or author-card decision may depend on:
 
 - `DlqDuplicateAlertLevel`;
+- runtime availability or generation;
 - any threshold-reached boolean;
 - physical duplicate presence;
 - identity-conflict presence;
@@ -95,34 +121,30 @@ Profiles continues to resolve privacy through authoritative owner ports and pres
 
 ## Operational separation
 
-The intended sequence remains:
-
-```text
-external bounded scan
-  -> DlqDuplicateSummary
-  -> DlqDuplicateAlertPolicy::evaluate
-  -> identifier-free evaluation
-  -> separately owned notification/suppression runtime
-```
-
-The policy itself cannot:
+The policy/runtime cannot:
 
 - poll Iggy;
 - inspect PostgreSQL receipts;
+- start a server worker;
+- register telemetry or health policy;
 - send or page;
 - choose a destination;
-- persist thresholds;
+- persist thresholds or snapshots;
 - schedule scans;
+- affect readiness;
 - acknowledge, delete, purge, replay, retry, or publish;
 - claim, release, publish, or acknowledge a poison receipt;
-- alter broker configuration.
+- alter broker configuration or profile state.
+
+Server observation, telemetry projection, notification delivery, cooldown/suppression, and destructive reconciliation remain separate owner boundaries.
 
 ## Remaining work
 
-1. integrate the policy into an explicitly owned runtime observer;
-2. define alert routing, cooldown, and suppression outside Profiles and outside the policy;
-3. retain identifier-free runtime policy evidence;
-4. keep destructive reconciliation in a separate authorized workflow;
-5. compare receipt and duplicate health only as aggregate operational trends.
+1. integrate an explicitly owned server observer;
+2. define reviewed telemetry and health projection;
+3. define alert routing, cooldown, and suppression outside Profiles and outside the policy/runtime;
+4. retain identifier-free runtime integration evidence;
+5. keep destructive reconciliation in a separate authorized workflow;
+6. compare receipt and duplicate health only as aggregate operational trends.
 
-No tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert delivery, or retained capture were run by the implementation agent.
+No tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, alert delivery, or retained capture were run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md
@@ -1,0 +1,137 @@
+# Profiles checkpoint: DLQ duplicate alert runtime
+
+Status: **identifier-free latest-value runtime source-complete; server integration pending**.
+
+## What changed
+
+`rustok-iggy` now owns an in-memory runtime composition for the count-only physical DLQ duplicate alert policy.
+
+Source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+```
+
+Public API:
+
+```text
+DlqDuplicateAlertRuntimePublisher
+DlqDuplicateAlertRuntimeSubscriber
+DlqDuplicateAlertRuntimeSnapshot
+DlqDuplicateAlertRuntimeError
+```
+
+No Profiles API, storage, policy port, GraphQL field, storefront behavior, or authorization input changed.
+
+## Composition boundary
+
+The publisher accepts only:
+
+```text
+already observed DlqDuplicateSummary
+prevalidated DlqDuplicateAlertPolicy
+```
+
+It does not scan Iggy, read PostgreSQL poison receipts, choose thresholds, or start a worker.
+
+The single writer evaluates the summary and replaces one Tokio watch latest-value snapshot. Read-only subscribers may observe the current value or await a change.
+
+## Initial and unavailable state
+
+The initial snapshot is:
+
+```text
+generation = 0
+available = false
+evaluation = None
+```
+
+Every successful publication or unavailable transition increments generation through checked arithmetic.
+
+`mark_unavailable()` always clears evaluation. This prevents a stale Warning or Critical result from appearing current after observer failure or shutdown.
+
+## Identifier-free snapshot
+
+The runtime snapshot exposes only:
+
+```text
+generation
+available
+evaluation
+```
+
+The evaluation exposes only:
+
+```text
+level
+physical_duplicates
+identity_conflict
+duplicate_messages_threshold_reached
+duplicate_groups_threshold_reached
+max_copies_threshold_reached
+```
+
+It does not expose source counts, threshold values, broker endpoints, stream/topic/partition/offset, UUIDs, payloads or digests, receipt identities, error classifications, credentials, timestamps, or raw client errors.
+
+The runtime adds no serialization or persistence.
+
+## Profiles authorization remains unchanged
+
+No profile visibility, owner access, relationship, follow, block, mute, friendship, audience, storefront, GraphQL, or presentation decision may depend on:
+
+- runtime availability;
+- runtime generation;
+- alert level;
+- threshold-reached booleans;
+- identity-conflict state;
+- publisher closure;
+- future telemetry/health projection;
+- retained runtime evidence.
+
+Profiles continues to authorize through owner ports and its canonical privacy-before-presentation policy.
+
+## Runtime and mutation boundary
+
+The runtime does not:
+
+- register readiness or health policy;
+- emit metrics directly;
+- choose notification delivery, paging, cooldown, suppression, or escalation timing;
+- acknowledge, delete, purge, replay, retry, or publish broker messages;
+- claim, release, or mark poison receipts;
+- change broker configuration;
+- change profile state.
+
+A future server adapter may consume the snapshot only as operational observability. Notification and destructive workflows require separate owner contracts and authorization.
+
+## Stable errors
+
+```text
+iggy.dlq_duplicate.alert_runtime_generation_overflow
+iggy.dlq_duplicate.alert_runtime_publisher_closed
+```
+
+Both are identifier-free and do not reveal broker or delivery facts.
+
+## Remaining work
+
+1. integrate an explicit server-owned observer lifecycle;
+2. define reviewed telemetry and health projection without source counts or identifiers;
+3. retain runtime integration evidence;
+4. keep notification delivery and suppression outside the runtime;
+5. keep destructive reconciliation separately authorized;
+6. preserve the rule that operational alert state never authorizes Profiles presentation.
+
+Tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, and alert dispatch were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,35 +1,24 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **count-only classifier, bounded external observer, runtime harness, retained tooling, and alert policy source-complete; runtime execution and integration pending**.
+Status: **count-only classifier, bounded external observer, runtime harness, retained tooling, alert policy, and latest-value alert runtime source-complete; runtime execution and server integration pending**.
 
 ## Why this matters for Profiles
 
-Profiles authorization remains independent of broker and receipt state. However, downstream processing of relationship facts must not hide the difference between:
+Profiles authorization remains independent of broker and receipt state. Downstream processing must still distinguish:
 
 - one durable neutral result with one physical DLQ copy;
 - one durable neutral result with repeated identical physical copies;
 - one deterministic DLQ ID associated with conflicting exact bytes.
 
-The Iggy-owned classifier makes that difference visible without exposing message identities or payloads. The bounded external scanner supplies physical observations through explicit-offset polling without storing progress. The separate alert policy evaluates only the count-only summary and does not become a Profiles input.
+The Iggy-owned classifier exposes this distinction without message identities or payloads. The bounded external scanner supplies observations through explicit-offset polling without storing progress. The alert policy evaluates only the count-only summary. The alert runtime publishes only identifier-free latest state. None becomes a Profiles authorization input.
 
 ## Owner boundaries
 
-Classifier source:
-
 ```text
-crates/rustok-iggy/src/dlq_duplicate_inspection.rs
-```
-
-External scanner source:
-
-```text
-crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
-```
-
-Alert policy source:
-
-```text
-crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+classifier: crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+scanner:    crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+policy:     crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+runtime:    crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
 ```
 
 Machine contracts:
@@ -38,6 +27,7 @@ Machine contracts:
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
 ```
 
 Verifiers:
@@ -46,20 +36,12 @@ Verifiers:
 scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
 ```
 
-Public API additionally includes:
+## Count-only projections
 
-```text
-DlqDuplicateAlertPolicy
-DlqDuplicateAlertLevel
-DlqDuplicateAlertEvaluation
-DlqDuplicateAlertPolicyError
-```
-
-## Count-only projection
-
-The summary exposes only:
+The physical summary exposes only aggregate counts:
 
 ```text
 total_messages
@@ -81,18 +63,19 @@ duplicate_groups_threshold_reached
 max_copies_threshold_reached
 ```
 
-Both projections exclude broker endpoints, stream coordinates, UUIDs, payloads, payload digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors. The evaluation also excludes source counts and raw threshold values.
+The runtime snapshot exposes only:
+
+```text
+generation
+available
+evaluation
+```
+
+These projections exclude broker endpoints, stream coordinates, UUIDs, payloads/digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors. Policy/runtime projections also exclude source counts and raw threshold values.
 
 ## Duplicate classification
 
-An ordinary physical duplicate requires:
-
-```text
-same deterministic Iggy header UUID
-same exact bytes
-```
-
-The bytes are compared through an in-memory domain-separated SHA-256 digest that is never exposed by the public observation or summary.
+An ordinary physical duplicate requires the same deterministic Iggy header UUID and the same exact bytes. Bytes are compared through an in-memory domain-separated SHA-256 digest that is never exposed.
 
 A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
 
@@ -114,9 +97,7 @@ The scanner does not use a consumer group, stored-offset `next` polling, offset 
 
 ## Alert policy boundary
 
-The caller must supply warning and critical thresholds for duplicate messages, duplicate groups, and max copies per message ID. The library provides no production defaults.
-
-Level precedence is:
+The caller supplies warning and critical thresholds for duplicate messages, duplicate groups, and max copies per message ID. The library provides no production defaults.
 
 ```text
 identity conflict -> Critical
@@ -126,35 +107,44 @@ physical duplicate below warning -> Notice
 no duplicate -> Clear
 ```
 
-The policy does not choose notification routing, paging, cooldown, suppression, scan cadence, threshold persistence, or any destructive action.
+The policy does not choose notification routing, paging, cooldown, suppression, scan cadence, threshold persistence, or destructive action.
+
+## Latest-value alert runtime
+
+The runtime accepts an already observed summary and a prevalidated policy:
+
+```text
+summary -> policy evaluation -> latest snapshot -> read-only subscribers
+```
+
+The publisher is single-writer. Initial state is generation `0`, unavailable, with no evaluation. Every successful or unavailable transition increments generation through checked arithmetic.
+
+Unavailable publication clears the previous evaluation so stale severity does not remain current. The channel retains only the latest state and is not an audit log.
+
+The runtime does not start a server worker, register telemetry/health, select readiness, deliver notifications, persist state, or mutate broker/receipt/Profile state.
 
 ## Runtime and retained status
 
-The external-Iggy runtime harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
+The external-Iggy harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
 
-The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run.
+The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. Server observer and telemetry/health integration for the alert runtime remain pending.
 
 ## Relationship to receipt health
 
-The PostgreSQL `ConsumerPoisonReceiptInspector` remains an independent count-only summary of receipt progress. Neither side exports identifiers, so the two views cannot be joined message by message.
+The PostgreSQL `ConsumerPoisonReceiptInspector` remains an independent count-only summary of receipt progress. Neither side exports identifiers, so the views cannot be joined message by message.
 
-Aggregate operational interpretation may compare trends:
-
-- expired publishing claims plus duplicate growth may indicate recovery outside the effective dedup window;
-- duplicate growth without recovery work may reflect historic or downstream duplication;
-- any identity conflict requires forensic escalation.
-
-These interpretations never become Profiles authorization inputs.
+Aggregate operational interpretation may compare trends, but those interpretations never become Profiles authorization inputs.
 
 ## Profiles authorization boundary
 
-No profile visibility, relationship, block, mute, follow, friendship, audience, or presentation decision may depend on:
+No profile visibility, relationship, block, mute, follow, friendship, audience, storefront, GraphQL, author-card, or presentation decision may depend on:
 
 - physical DLQ copy or duplicate-group counts;
 - identity-conflict presence;
 - alert level or threshold flags;
+- runtime availability or generation;
 - scan partition or offset selection;
-- scanner or alert-delivery state;
+- scanner, runtime, telemetry, or alert-delivery state;
 - receipt recovery counts;
 - deduplication or alert-threshold configuration;
 - retained evidence metadata.
@@ -164,9 +154,10 @@ Profiles presentation continues to consume authorized owner-port results. These 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. integrate the pure alert policy into an explicitly owned runtime observer;
-3. define alert routing, cooldown, and suppression outside Profiles and the policy;
-4. define acknowledgement/delete/replay separately with explicit authorization;
-5. keep aggregate receipt and duplicate observations identifier-free.
+2. integrate an explicitly owned server alert observer;
+3. define identifier-free telemetry and health projection;
+4. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
+5. define acknowledgement/delete/replay separately with explicit authorization;
+6. keep aggregate receipt and duplicate observations identifier-free.
 
-Tests, Cargo commands, formatters, verifiers, external-Iggy scans, alert dispatch, and retained capture were not run by the implementation agent.
+Tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
@@ -7,7 +7,10 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
+const runtimeContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
+const runtimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
 const summaryPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs";
@@ -44,7 +47,11 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const runtimeContract = JSON.parse(
+  readFileSync(resolve(repoRoot, runtimeContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const runtimeSource = readFileSync(resolve(repoRoot, runtimeSourcePath), "utf8");
 const summary = readFileSync(resolve(repoRoot, summaryPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const failures = [];
@@ -73,7 +80,7 @@ if (
   contract.schema_version !== 1 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-alert-policy-source" ||
-  contract.status !== "source_complete_runtime_integration_pending" ||
+  contract.status !== "source_complete_runtime_composition_pending_server_integration" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.summary_source !== summaryPath ||
@@ -146,6 +153,24 @@ for (const [operation, allowed] of Object.entries(contract.policy_boundary ?? {}
 }
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
   if (allowed !== false) fail(`DLQ duplicate alert mutation became allowed: ${operation}`);
+}
+
+if (
+  contract.runtime_composition?.status !== "source_complete_server_integration_pending" ||
+  contract.runtime_composition?.contract !== runtimeContractPath ||
+  contract.runtime_composition?.source !== runtimeSourcePath ||
+  contract.runtime_composition?.input !== "DlqDuplicateSummary" ||
+  contract.runtime_composition?.output !== "DlqDuplicateAlertRuntimeSnapshot" ||
+  contract.runtime_composition?.latest_value !== true ||
+  contract.runtime_composition?.single_writer !== true ||
+  contract.runtime_composition?.unavailable_clears_evaluation !== true ||
+  runtimeContract.packet !== "dlq-duplicate-alert-runtime-source" ||
+  runtimeContract.status !== "source_complete_server_integration_pending" ||
+  runtimeContract.source !== runtimeSourcePath ||
+  runtimeContract.policy_source !== sourcePath ||
+  runtimeContract.summary_source !== summaryPath
+) {
+  fail("DLQ duplicate alert runtime composition relationship drift");
 }
 
 const requiredExcludedFields = new Set([
@@ -240,6 +265,7 @@ for (const marker of [
   "pub critical_max_copies_per_message_id:",
   "Serialize",
   "Deserialize",
+  "tokio::sync::watch",
   "IggyClient",
   "IggyTransport",
   "ConsumerPoisonReceipt",
@@ -271,6 +297,17 @@ for (const marker of [
 ]) {
   requireText("count-only DLQ duplicate summary", summary, marker);
 }
+for (const marker of [
+  "pub struct DlqDuplicateAlertRuntimePublisher",
+  "pub struct DlqDuplicateAlertRuntimeSnapshot",
+  "watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0))",
+  "pub fn publish(\n        &mut self,",
+  "self.policy.evaluate(summary)",
+  "pub fn mark_unavailable(\n        &mut self,",
+  "evaluation: None",
+]) {
+  requireText("DLQ duplicate alert runtime source", runtimeSource, marker);
+}
 
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
 for (const exportName of expectedExports) {
@@ -278,7 +315,8 @@ for (const exportName of expectedExports) {
 }
 
 const requiredRemainingWork = new Set([
-  "runtime_alert_integration",
+  "server_observer_integration",
+  "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "retained_policy_integration_evidence",
   "authorized_destructive_reconciliation_workflow",
@@ -296,5 +334,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate alert policy source verified: explicit monotonic thresholds, clear/notice/warning/critical precedence, conflict-critical manual escalation, count-only boolean projection, stable codes, no production defaults, no broker/receipt access, no notification dispatch, and no destructive action are locked; runtime integration remains pending.",
+  "Iggy DLQ duplicate alert policy source verified: explicit monotonic thresholds, clear/notice/warning/critical precedence, conflict-critical manual escalation, count-only boolean projection, stable codes, no production defaults, no broker/receipt access, no notification dispatch, no destructive action, and the single-writer stale-clearing latest-value runtime composition are locked; server integration remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
+const policyPath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
+const summaryPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs";
+const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md";
+const expectedProfilesCheckpoint =
+  "crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md";
+const expectedExports = [
+  "DlqDuplicateAlertRuntimePublisher",
+  "DlqDuplicateAlertRuntimeSubscriber",
+  "DlqDuplicateAlertRuntimeSnapshot",
+  "DlqDuplicateAlertRuntimeError",
+];
+const expectedTests = [
+  "initial_snapshot_is_unavailable_without_evaluation",
+  "publish_replaces_latest_identifier_free_evaluation",
+  "unavailable_transition_clears_stale_evaluation",
+  "independent_subscribers_receive_the_same_latest_snapshot",
+  "closed_publisher_has_a_stable_identifier_free_error",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const policy = readFileSync(resolve(repoRoot, policyPath), "utf8");
+const summary = readFileSync(resolve(repoRoot, summaryPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-alert-runtime-source" ||
+  contract.status !== "source_complete_server_integration_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.source !== sourcePath ||
+  contract.policy_source !== policyPath ||
+  contract.summary_source !== summaryPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("DLQ duplicate alert runtime contract identity or source status drift");
+}
+if (!sameValue(contract.public_exports, expectedExports)) {
+  fail("DLQ duplicate alert runtime public export allowlist drift");
+}
+if (!sameValue(contract.required_source_tests, expectedTests)) {
+  fail("DLQ duplicate alert runtime focused test allowlist drift");
+}
+if (
+  contract.verifier !== expectedVerifier ||
+  contract.documentation !== expectedDocumentation ||
+  contract.profiles_checkpoint !== expectedProfilesCheckpoint
+) {
+  fail("DLQ duplicate alert runtime verifier or documentation path drift");
+}
+
+if (
+  contract.composition?.input !== "already_observed_DlqDuplicateSummary" ||
+  contract.composition?.policy !== "prevalidated_DlqDuplicateAlertPolicy" ||
+  contract.composition?.channel !== "tokio_watch_latest_value" ||
+  contract.composition?.publisher_role !== "single_writer" ||
+  contract.composition?.subscriber_role !== "read_only" ||
+  contract.composition?.broker_scan !== false ||
+  contract.composition?.receipt_read !== false
+) {
+  fail("DLQ duplicate alert runtime composition boundary drift");
+}
+if (
+  !sameValue(contract.snapshot?.fields, ["generation", "available", "evaluation"]) ||
+  contract.snapshot?.initial_generation !== 0 ||
+  contract.snapshot?.initial_available !== false ||
+  contract.snapshot?.initial_evaluation !== null ||
+  contract.snapshot?.generation_monotonic !== true ||
+  contract.snapshot?.generation_overflow_fails_closed !== true ||
+  contract.snapshot?.available_snapshot_requires_evaluation !== true ||
+  contract.snapshot?.unavailable_snapshot_clears_evaluation !== true ||
+  contract.snapshot?.latest_value_replaces_prior_snapshot !== true
+) {
+  fail("DLQ duplicate alert runtime snapshot semantics drift");
+}
+if (
+  contract.subscriber?.current_snapshot !== true ||
+  contract.subscriber?.await_change !== true ||
+  contract.subscriber?.independent_subscriptions !== true ||
+  contract.subscriber?.publisher_closed_fails_bounded !== true ||
+  contract.subscriber?.write_access !== false
+) {
+  fail("DLQ duplicate alert runtime subscriber boundary drift");
+}
+
+for (const [operation, allowed] of Object.entries(contract.runtime_boundary ?? {})) {
+  if (allowed !== false) fail(`DLQ duplicate alert runtime operation became enabled: ${operation}`);
+}
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`DLQ duplicate alert runtime mutation became enabled: ${operation}`);
+}
+
+for (const marker of [
+  "use tokio::sync::watch;",
+  "pub struct DlqDuplicateAlertRuntimeSnapshot",
+  "generation: u64",
+  "available: bool",
+  "evaluation: Option<DlqDuplicateAlertEvaluation>",
+  "const fn unavailable(generation: u64)",
+  "evaluation: None",
+  "const fn available(",
+  "evaluation: Some(evaluation)",
+  "pub struct DlqDuplicateAlertRuntimePublisher",
+  "policy: DlqDuplicateAlertPolicy",
+  "generation: u64",
+  "sender: watch::Sender<DlqDuplicateAlertRuntimeSnapshot>",
+  "watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0))",
+  "pub fn subscribe(&self)",
+  "pub fn publish(\n        &mut self,",
+  "self.policy.evaluate(summary)",
+  "self.sender.send_replace(snapshot);",
+  "pub fn mark_unavailable(\n        &mut self,",
+  "DlqDuplicateAlertRuntimeSnapshot::unavailable(self.advance_generation()?)",
+  "fn advance_generation(&mut self)",
+  ".checked_add(1)",
+  "pub struct DlqDuplicateAlertRuntimeSubscriber",
+  "receiver: watch::Receiver<DlqDuplicateAlertRuntimeSnapshot>",
+  "pub fn current(&self)",
+  "pub async fn changed(",
+  ".map_err(|_| DlqDuplicateAlertRuntimeError::PublisherClosed)?;",
+  "pub enum DlqDuplicateAlertRuntimeError",
+  '"iggy.dlq_duplicate.alert_runtime_generation_overflow"',
+  '"iggy.dlq_duplicate.alert_runtime_publisher_closed"',
+]) {
+  requireText("DLQ duplicate alert runtime source", source, marker);
+}
+for (const testName of expectedTests) {
+  requireText("DLQ duplicate alert runtime source tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") + countText(source, "#[tokio::test]") !== expectedTests.length) {
+  fail("DLQ duplicate alert runtime source must contain exactly five focused tests");
+}
+
+for (const marker of [
+  "Serialize",
+  "Deserialize",
+  "tracing::",
+  "println!(",
+  "eprintln!(",
+  ".poll_messages(",
+  ".get_consumer_offset(",
+  ".summarize(",
+  ".move_to_dlq(",
+  ".send_messages(",
+  ".store_consumer_offset(",
+  ".acknowledge(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  "Profile",
+  "readiness",
+  "notification",
+  "cooldown",
+  "suppression",
+]) {
+  forbidText("DLQ duplicate alert runtime source", source, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateAlertPolicy",
+  "pub const fn evaluate(",
+  "pub struct DlqDuplicateAlertEvaluation",
+  "pub enum DlqDuplicateAlertLevel",
+]) {
+  requireText("DLQ duplicate alert policy source", policy, marker);
+}
+for (const marker of [
+  "pub struct DlqDuplicateSummary",
+  "pub const fn has_physical_duplicates(&self)",
+  "pub const fn has_identity_conflicts(&self)",
+]) {
+  requireText("DLQ duplicate summary source", summary, marker);
+}
+
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_runtime;");
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+const requiredPrivacyExclusions = new Set([
+  "source_counts",
+  "threshold_values",
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "error_classification",
+  "publisher_identity",
+  "timestamp",
+  "credential",
+  "raw_client_error",
+]);
+for (const field of contract.privacy_boundary?.snapshot_excludes ?? []) {
+  requiredPrivacyExclusions.delete(field);
+}
+if (requiredPrivacyExclusions.size > 0) {
+  fail(`DLQ duplicate alert runtime privacy exclusions are incomplete: ${[
+    ...requiredPrivacyExclusions,
+  ].join(", ")}`);
+}
+if (
+  contract.privacy_boundary?.serialization_added !== false ||
+  contract.privacy_boundary?.persistence_added !== false
+) {
+  fail("DLQ duplicate alert runtime privacy persistence boundary drift");
+}
+
+const requiredRemaining = new Set([
+  "server_observer_integration",
+  "telemetry_and_health_projection",
+  "retained_runtime_integration_evidence",
+  "notification_delivery_and_suppression_outside_runtime",
+  "authorized_destructive_reconciliation_workflow",
+  "aggregate_receipt_and_duplicate_health_correlation",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`DLQ duplicate alert runtime remaining work drift: ${[...requiredRemaining].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy DLQ duplicate alert runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy DLQ duplicate alert runtime source verified: single-writer monotonic latest-value publication, initial/unavailable stale-clearing semantics, read-only independent subscribers, identifier-free stable errors, no broker/receipt/Profile mutation, and no notification/readiness policy are locked; server integration remains pending.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
@@ -171,6 +171,12 @@ for (const marker of [
   "tracing::",
   "println!(",
   "eprintln!(",
+  "ServerRuntimeContext",
+  "consumer_poison_metrics",
+  "runtime_consumer_metrics",
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceiptInspector",
   ".poll_messages(",
   ".get_consumer_offset(",
   ".summarize(",
@@ -184,11 +190,8 @@ for (const marker of [
   ".reserve_and_claim(",
   ".mark_published(",
   ".mark_acknowledged(",
-  "Profile",
-  "readiness",
-  "notification",
-  "cooldown",
-  "suppression",
+  ".notify(",
+  ".page(",
 ]) {
   forbidText("DLQ duplicate alert runtime source", source, marker);
 }
@@ -267,5 +270,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate alert runtime source verified: single-writer monotonic latest-value publication, initial/unavailable stale-clearing semantics, read-only independent subscribers, identifier-free stable errors, no broker/receipt/Profile mutation, and no notification/readiness policy are locked; server integration remains pending.",
+  "Iggy DLQ duplicate alert runtime source verified: single-writer monotonic latest-value publication, initial/unavailable stale-clearing semantics, read-only independent subscribers, identifier-free stable errors, no broker/receipt/Profile mutation, and no notification/readiness implementation are locked; server integration remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -14,6 +14,9 @@ const adapterSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
 const alertContractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
 const alertSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
+const alertRuntimeContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
+const alertRuntimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
 const transportPath = "crates/rustok-iggy/src/transport.rs";
@@ -51,9 +54,13 @@ const adapterContract = JSON.parse(
 const alertContract = JSON.parse(
   readFileSync(resolve(repoRoot, alertContractPath), "utf8"),
 );
+const alertRuntimeContract = JSON.parse(
+  readFileSync(resolve(repoRoot, alertRuntimeContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
 const alertSource = readFileSync(resolve(repoRoot, alertSourcePath), "utf8");
+const alertRuntimeSource = readFileSync(resolve(repoRoot, alertRuntimeSourcePath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
 const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
@@ -123,7 +130,8 @@ if (
 }
 
 if (
-  contract.alert_policy?.status !== "source_complete_runtime_integration_pending" ||
+  contract.alert_policy?.status !==
+    "source_complete_runtime_composition_pending_server_integration" ||
   contract.alert_policy?.contract !== alertContractPath ||
   contract.alert_policy?.source !== alertSourcePath ||
   contract.alert_policy?.input !== "DlqDuplicateSummary" ||
@@ -133,11 +141,32 @@ if (
   contract.alert_policy?.notification_dispatch !== false ||
   contract.alert_policy?.destructive_action !== false ||
   alertContract.packet !== "dlq-duplicate-alert-policy-source" ||
-  alertContract.status !== "source_complete_runtime_integration_pending" ||
+  alertContract.status !==
+    "source_complete_runtime_composition_pending_server_integration" ||
   alertContract.source !== alertSourcePath ||
   alertContract.summary_source !== sourcePath
 ) {
   fail("DLQ duplicate inspection alert policy relationship drift");
+}
+
+if (
+  contract.alert_runtime?.status !== "source_complete_server_integration_pending" ||
+  contract.alert_runtime?.contract !== alertRuntimeContractPath ||
+  contract.alert_runtime?.source !== alertRuntimeSourcePath ||
+  contract.alert_runtime?.input !== "DlqDuplicateSummary" ||
+  contract.alert_runtime?.result !== "DlqDuplicateAlertRuntimeSnapshot" ||
+  contract.alert_runtime?.latest_value !== true ||
+  contract.alert_runtime?.single_writer !== true ||
+  contract.alert_runtime?.unavailable_clears_evaluation !== true ||
+  contract.alert_runtime?.notification_dispatch !== false ||
+  contract.alert_runtime?.destructive_action !== false ||
+  alertRuntimeContract.packet !== "dlq-duplicate-alert-runtime-source" ||
+  alertRuntimeContract.status !== "source_complete_server_integration_pending" ||
+  alertRuntimeContract.source !== alertRuntimeSourcePath ||
+  alertRuntimeContract.policy_source !== alertSourcePath ||
+  alertRuntimeContract.summary_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection alert runtime relationship drift");
 }
 
 if (
@@ -288,6 +317,7 @@ for (const marker of [
   "IggyClient",
   "IggyTransport",
   "ConsumerPoisonReceipt",
+  "tokio::sync::watch",
   ".acknowledge(",
   ".delete(",
   ".replay(",
@@ -298,13 +328,47 @@ for (const marker of [
   forbidText("count-only duplicate alert policy", alertSource, marker);
 }
 
+for (const marker of [
+  "pub struct DlqDuplicateAlertRuntimePublisher",
+  "pub struct DlqDuplicateAlertRuntimeSubscriber",
+  "pub struct DlqDuplicateAlertRuntimeSnapshot",
+  "watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0))",
+  "pub fn publish(\n        &mut self,",
+  "self.policy.evaluate(summary)",
+  "pub fn mark_unavailable(\n        &mut self,",
+  "evaluation: None",
+  ".checked_add(1)",
+  '"iggy.dlq_duplicate.alert_runtime_publisher_closed"',
+]) {
+  requireText("count-only duplicate alert runtime", alertRuntimeSource, marker);
+}
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceiptInspector",
+  ".poll_messages(",
+  ".get_consumer_offset(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".notify(",
+  ".page(",
+]) {
+  forbidText("count-only duplicate alert runtime", alertRuntimeSource, marker);
+}
+
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_runtime;");
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
 }
 for (const exportName of alertContract.public_exports ?? []) {
   requireText("rustok-iggy alert exports", lib, exportName);
+}
+for (const exportName of alertRuntimeContract.public_exports ?? []) {
+  requireText("rustok-iggy alert runtime exports", lib, exportName);
 }
 
 for (const marker of [
@@ -349,7 +413,8 @@ if (
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
-  "runtime_alert_integration",
+  "server_alert_observer_integration",
+  "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "operator_ack_delete_replay_workflow_outside_inspector",
   "correlation_with_count_only_receipt_health_without_identifier_export",
@@ -366,5 +431,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, bounded auto_commit=false external scan, and explicit no-default count-only alert policy are locked; retained runtime and alert integration evidence remain pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, bounded auto_commit=false external scan, explicit no-default count-only alert policy, and single-writer stale-clearing latest-value alert runtime are locked; retained execution and server integration remain pending.",
 );


### PR DESCRIPTION
## Summary

Add a transport-neutral latest-value runtime composition for the count-only physical DLQ duplicate alert policy merged in #2393.

## Public API

- `DlqDuplicateAlertRuntimePublisher`
- `DlqDuplicateAlertRuntimeSubscriber`
- `DlqDuplicateAlertRuntimeSnapshot`
- `DlqDuplicateAlertRuntimeError`

The module is not feature-gated on the Iggy SDK and does not own a broker connection, receipt store, server worker, telemetry registry, notification route, or Profiles policy.

## Single-writer latest-value model

`DlqDuplicateAlertRuntimePublisher` owns one prevalidated `DlqDuplicateAlertPolicy`, one monotonic generation, and one Tokio watch sender.

Mutation requires `&mut self`, making publication explicitly single-writer and preventing concurrent publication from replacing a newer generation with an older one.

Initial state is:

```text
generation = 0
available = false
evaluation = None
```

## Successful and unavailable transitions

`publish(&DlqDuplicateSummary)`:

1. advances generation using checked arithmetic;
2. evaluates the already-observed count-only summary;
3. publishes `available=true` with the identifier-free evaluation;
4. replaces the channel's latest value.

`mark_unavailable()` advances generation and publishes `available=false` with `evaluation=None`. Clearing the prior evaluation prevents stale Warning/Critical state from appearing current after observation failure or shutdown.

The watch channel is latest-value state, not an event log; slow subscribers are not promised every intermediate generation.

## Read-only subscribers

Subscribers can only:

- read `current()`;
- await `changed()`;
- receive the same latest snapshot through independent subscriptions.

Publisher closure maps to the bounded stable code:

```text
iggy.dlq_duplicate.alert_runtime_publisher_closed
```

Generation overflow maps to:

```text
iggy.dlq_duplicate.alert_runtime_generation_overflow
```

## Identifier-free projection

The runtime snapshot contains only:

```text
generation
available
evaluation
```

The optional evaluation contains only alert level and boolean aggregate reasons. It excludes source counts, raw thresholds, broker endpoints, stream/topic/partition/offset, UUIDs, payloads/digests, receipt identities, credentials, timestamps, publisher identity, and raw client errors.

No serialization or persistence is added.

## Boundaries

This source slice does not:

- scan Iggy or read poison receipts;
- start a server observer or choose scan cadence;
- register telemetry, health, readiness, or liveness policy;
- dispatch notifications or choose paging/cooldown/suppression;
- acknowledge, delete, purge, replay, retry, or publish broker messages;
- claim or mark receipts;
- change broker configuration or Profile state.

Observation, pure policy evaluation, latest-value publication, server lifecycle, telemetry/health projection, notification delivery, and destructive reconciliation remain separate owner boundaries.

## Contracts and documentation

- added `dlq-duplicate-alert-runtime-source.json`;
- added a static source verifier;
- added five focused source tests;
- added an Iggy runtime guide and Profiles checkpoint;
- linked the parent alert-policy and duplicate-inspection contracts/verifiers/docs/checkpoints to the new runtime composition;
- preserved server observer, telemetry/health projection, notification delivery, retained evidence, and destructive workflows as remaining work.

## Verification

Tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
cargo test -p rustok-iggy dlq_duplicate_alert -- --nocapture
```
