### PR TITLE
Use order read port in admin routes

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -73,6 +73,26 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+    let host = {
+        let runtime = server
+            .shared_get::<rustok_commerce::graphql_runtime::CommerceOrderReadRuntime>()
+            .unwrap_or_else(|| {
+                let event_bus = server
+                    .shared_get::<rustok_outbox::TransactionalEventBus>()
+                    .expect(
+                        "TransactionalEventBus must be initialized before CommerceOrderReadRuntime",
+                    );
+                let runtime = rustok_commerce::graphql_runtime::CommerceOrderReadRuntime::in_process(
+                    server.db_clone(),
+                    event_bus,
+                );
+                server.shared_insert(runtime.clone());
+                runtime
+            });
+        host.with_shared_value(runtime)
+    };
+
     #[cfg(feature = "mod-commerce")]
     let host = {
         let runtime = server
@@ -184,6 +204,11 @@ pub fn attach_commerce_provider_registries(
 
 #[cfg(all(test, feature = "mod-payment", feature = "mod-fulfillment"))]
 mod tests {
+    #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+    use std::sync::Arc;
+
+    #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+    use rustok_outbox::{OutboxTransport, TransactionalEventBus};
     use sea_orm::Database;
 
     use super::attach_commerce_provider_registries;
@@ -196,6 +221,10 @@ mod tests {
             .await
             .expect("in-memory sqlite should connect");
         let server = ServerRuntimeContext::new(db.clone(), RustokSettings::default());
+        #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+        server.shared_insert(TransactionalEventBus::new(Arc::new(OutboxTransport::new(
+            db.clone(),
+        ))));
 
         let first = attach_commerce_provider_registries(
             rustok_api::HostRuntimeContext::new(db.clone()),
@@ -222,6 +251,20 @@ mod tests {
             first_fulfillment.descriptors(),
             second_fulfillment.descriptors()
         );
+
+        #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+        {
+            let first_order = first
+                .shared_get::<rustok_commerce::graphql_runtime::CommerceOrderReadRuntime>()
+                .expect("order read runtime should be attached");
+            let second_order = second
+                .shared_get::<rustok_commerce::graphql_runtime::CommerceOrderReadRuntime>()
+                .expect("order read runtime should be reused");
+            assert!(Arc::ptr_eq(
+                &first_order.order_read_port(),
+                &second_order.order_read_port()
+            ));
+        }
     }
 }
 

--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -196,8 +196,11 @@ These are source-contract defects, not verification-only tasks.
   Payment, and Fulfillment concrete services behind host-composed owner ports.
 - [x] Publish the order-owned `OrderReadPort` for complete detail/list projections with
   locale fallback, canonical read context/deadline policy, stable typed errors, and
-  explicit unvalidated source evidence; host composition and Commerce consumer cutover
-  remain open.
+  explicit unvalidated source evidence.
+- [x] Host-compose `CommerceOrderReadRuntime`, require it in Commerce HTTP and GraphQL
+  schema data, and cut admin REST order list/detail to the owner port while preserving
+  public envelopes and payment/fulfillment detail aggregation. GraphQL resolvers and
+  storefront order reads remain open.
 - [ ] Correct Product's declared dependency contract or extract its direct
   inventory/pricing persistence operations behind owner ports; the current manifest
   declares only Taxonomy while production code uses Inventory and Pricing persistence.
@@ -555,6 +558,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-marketplace-listing-event-contract.mjs`
 - [ ] `node scripts/verify/verify-marketplace-listing-provenance-cutover.mjs`
 - [ ] `node scripts/verify/verify-order-read-port.mjs`
+- [ ] `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - [ ] `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - [ ] `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
 - [ ] `node scripts/verify/verify-commerce-checkout-completion-cutover.mjs`
@@ -590,15 +594,20 @@ Source inspection is not execution evidence.
   staged completion paths.
 - [x] Extend the public-error guard to pricing and `PaymentCollectionPort`, including
   correlation, tenant, operation, stable code, and raw-cause bans.
-- [ ] Execute the new public-error, typed-lifecycle, and storefront-cutover static guards
-  against a repository checkout and retain their output.
+- [x] Add static source guards for host-selected order read runtime composition and
+  admin REST order list/detail cutover without changing mutation or detail-aggregation
+  ownership.
+- [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, and order-read
+  static guards against a repository checkout and retain their output.
 
 ### Compile/tests
 
 - [ ] `cargo check -p rustok-commerce --lib`
 - [ ] `cargo test -p rustok-commerce --test checkout_marketplace_economics_checkpoint`
 - [ ] `cargo check -p rustok-order --all-features`
-- [ ] Targeted `OrderReadPort` detail/list, locale fallback, context, and typed-error tests.
+- [ ] `cargo check -p rustok-server --features mod-commerce`
+- [ ] Targeted `OrderReadPort` detail/list, locale fallback, context, typed-error,
+  host-composition, and admin REST transport tests.
 - [ ] `cargo test -p rustok-order --test order_checkout_identity`
 - [ ] `cargo test -p rustok-order --test checkout_order_identity_port`
 - [ ] `cargo test -p rustok-order --test checkout_completion_port`
@@ -736,8 +745,10 @@ Source inspection is not execution evidence.
   one staged recovery runtime with explicit idempotency and host provider composition.
 - [x] Harden pricing and payment collection owner-port errors with stable public
   messages plus correlation-aware internal logging.
-- [x] Publish `OrderReadPort` for complete order detail/list projections while retaining
-  host composition and Commerce consumer cutover as explicit unvalidated follow-up work.
+- [x] Publish `OrderReadPort` for complete order detail/list projections.
+- [x] Host-compose `CommerceOrderReadRuntime` and cut admin REST order list/detail to the
+  owner port while preserving public envelopes and unchanged mutation/detail aggregation
+  ownership; GraphQL/storefront reads and execution evidence remain open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -3,11 +3,13 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::Permission;
-use rustok_api::{AuthContext, TenantContext};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
 use rustok_fulfillment::{FulfillmentError, FulfillmentService};
-use rustok_order::OrderService;
 use rustok_order::error::OrderError;
+use rustok_order::{ListOrderProjectionsRequest, OrderService, ReadOrderProjectionRequest};
 use rustok_payment::{PaymentError, PaymentService};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
@@ -54,6 +56,96 @@ impl AdminOrderErrorContext {
             operation,
         }
     }
+}
+
+fn admin_order_read_port_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    order_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = order_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-order:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_admin_order_port_error(
+    context: AdminOrderErrorContext,
+    port_context: &PortContext,
+    owner_operation: &'static str,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_ORDER_OWNER,
+        owner_operation,
+        correlation_id = %port_context.correlation_id,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        order_id = ?context.order_id,
+        customer_id = ?context.customer_id,
+        operation = %context.operation,
+        actor = ?port_context.actor,
+        channel = ?port_context.channel,
+        locale = %port_context.locale,
+        deadline_ms = ?port_context.deadline_ms,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_BOUNDARY,
+        "commerce admin order owner read failed"
+    );
+    HttpError::new(status, code, message)
 }
 
 fn admin_order_error_policy(error: &OrderError) -> AdminOrderHttpPolicy {
@@ -130,7 +222,7 @@ pub async fn list_orders(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Query(params): Query<ListOrdersParams>,
 ) -> HttpResult<Json<PaginatedResponse<OrderResponse>>> {
     ensure_permissions(
@@ -141,21 +233,23 @@ pub async fn list_orders(
 
     let pagination = params.pagination.unwrap_or_default();
     let customer_id = params.customer_id;
-    let (orders, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .list_orders_with_locale_fallback(
-            tenant.id,
-            rustok_order::dto::ListOrdersInput {
+    let read_context =
+        admin_order_read_port_context(tenant.id, &auth, &request_context, None, "list_orders");
+    let page = runtime
+        .order_read_port()
+        .list_order_projections(
+            read_context.clone(),
+            ListOrderProjectionsRequest {
                 page: pagination.page,
                 per_page: pagination.limit(),
                 status: params.status,
                 customer_id,
+                tenant_default_locale: Some(tenant.default_locale.clone()),
             },
-            request_context.locale.as_str(),
-            Some(tenant.default_locale.as_str()),
         )
         .await
         .map_err(|error| {
-            map_admin_order_error(
+            map_admin_order_port_error(
                 AdminOrderErrorContext::new(
                     tenant.id,
                     auth.user_id,
@@ -163,13 +257,19 @@ pub async fn list_orders(
                     customer_id,
                     "list_orders",
                 ),
+                &read_context,
+                "list_order_projections",
                 error,
             )
         })?;
 
     Ok(Json(PaginatedResponse {
-        data: orders,
-        meta: super::super::common::PaginationMeta::new(pagination.page, pagination.limit(), total),
+        data: page.items,
+        meta: super::super::common::PaginationMeta::new(
+            pagination.page,
+            pagination.limit(),
+            page.total,
+        ),
     }))
 }
 
@@ -188,7 +288,7 @@ pub async fn show_order(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<AdminOrderDetailResponse>> {
     ensure_permissions(
@@ -197,17 +297,23 @@ pub async fn show_order(
         "Permission denied: orders:read required",
     )?;
 
-    let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .get_order_with_locale_fallback(
-            tenant.id,
-            id,
-            request_context.locale.as_str(),
-            Some(tenant.default_locale.as_str()),
+    let read_context =
+        admin_order_read_port_context(tenant.id, &auth, &request_context, Some(id), "get_order");
+    let order = runtime
+        .order_read_port()
+        .read_order_projection(
+            read_context.clone(),
+            ReadOrderProjectionRequest {
+                order_id: id,
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
         )
         .await
         .map_err(|error| {
-            map_admin_order_error(
+            map_admin_order_port_error(
                 AdminOrderErrorContext::new(tenant.id, auth.user_id, Some(id), None, "get_order"),
+                &read_context,
+                "read_order_projection",
                 error,
             )
         })?;

--- a/crates/rustok-commerce/src/controllers/admin/tests/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/tests/mod.rs
@@ -124,20 +124,26 @@ impl Deref for PaymentService {
 pub(crate) fn test_app_context(
     db: sea_orm::DatabaseConnection,
 ) -> crate::controllers::CommerceHttpRuntime {
+    let event_bus = mock_transactional_event_bus();
     let marketplace_financial_runtime = crate::MarketplaceFinancialRuntime::in_process(db.clone());
     let shipping_option_read_runtime =
         crate::graphql_runtime::CommerceShippingOptionReadRuntime::in_process(db.clone());
     let fulfillment_lifecycle_read_runtime =
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(db.clone());
+    let order_read_runtime = crate::graphql_runtime::CommerceOrderReadRuntime::in_process(
+        db.clone(),
+        event_bus.clone(),
+    );
     crate::controllers::CommerceHttpRuntime {
         db,
-        event_bus: mock_transactional_event_bus(),
+        event_bus,
         payment_provider_registry:
             rustok_payment::providers::PaymentProviderRegistry::with_manual_provider(),
         fulfillment_provider_registry:
             rustok_fulfillment::providers::FulfillmentProviderRegistry::with_manual_provider(),
         shipping_option_read_runtime,
         fulfillment_lifecycle_read_runtime,
+        order_read_runtime,
         marketplace_financial_runtime,
     }
 }

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -24,6 +24,7 @@ pub struct CommerceHttpRuntime {
     shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
+    order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
 
@@ -68,6 +69,10 @@ impl CommerceHttpRuntime {
             .fulfillment_read_port()
     }
 
+    fn order_read_port(&self) -> std::sync::Arc<dyn rustok_order::OrderReadPort> {
+        self.order_read_runtime.order_read_port()
+    }
+
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
             .operator_service(self.db_clone(), self.event_bus())
@@ -102,6 +107,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceFulfillmentLifecycleReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let order_read_runtime = runtime
+            .shared_get::<crate::graphql_runtime::CommerceOrderReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require CommerceOrderReadRuntime in HostRuntimeContext"
+                )
+            })?;
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
@@ -120,6 +132,7 @@ impl CommerceHttpRuntime {
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
             shipping_option_read_runtime,
             fulfillment_lifecycle_read_runtime,
+            order_read_runtime,
             marketplace_financial_runtime,
         })
     }

--- a/crates/rustok-commerce/src/controllers/store/tests/mod.rs
+++ b/crates/rustok-commerce/src/controllers/store/tests/mod.rs
@@ -234,20 +234,26 @@ pub(crate) fn storefront_product_input() -> CreateProductInput {
 pub(crate) fn test_app_context(
     db: sea_orm::DatabaseConnection,
 ) -> crate::controllers::CommerceHttpRuntime {
+    let event_bus = mock_transactional_event_bus();
     let marketplace_financial_runtime = crate::MarketplaceFinancialRuntime::in_process(db.clone());
     let shipping_option_read_runtime =
         crate::graphql_runtime::CommerceShippingOptionReadRuntime::in_process(db.clone());
     let fulfillment_lifecycle_read_runtime =
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime::in_process(db.clone());
+    let order_read_runtime = crate::graphql_runtime::CommerceOrderReadRuntime::in_process(
+        db.clone(),
+        event_bus.clone(),
+    );
     crate::controllers::CommerceHttpRuntime {
         db,
-        event_bus: mock_transactional_event_bus(),
+        event_bus,
         payment_provider_registry:
             rustok_payment::providers::PaymentProviderRegistry::with_manual_provider(),
         fulfillment_provider_registry:
             rustok_fulfillment::providers::FulfillmentProviderRegistry::with_manual_provider(),
         shipping_option_read_runtime,
         fulfillment_lifecycle_read_runtime,
+        order_read_runtime,
         marketplace_financial_runtime,
     }
 }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -10,6 +10,7 @@ use rustok_fulfillment::{
     in_process_fulfillment_read_port, in_process_shipping_option_admin_read_port,
     in_process_shipping_option_read_port,
 };
+use rustok_order::{OrderReadPort, in_process_order_read_port};
 use rustok_payment::providers::PaymentProviderRegistry;
 use sea_orm::DatabaseConnection;
 
@@ -72,6 +73,33 @@ impl CommerceFulfillmentLifecycleReadRuntime {
 
     pub fn fulfillment_read_port(&self) -> Arc<dyn FulfillmentReadPort> {
         self.fulfillment_reads.clone()
+    }
+}
+
+/// Host-selected complete order projection read port.
+///
+/// HTTP admin routes consume this runtime in the current source wave. GraphQL schema data carries
+/// the same host-selected value so later resolver cutover cannot silently construct a different
+/// owner adapter.
+#[derive(Clone)]
+pub struct CommerceOrderReadRuntime {
+    order_reads: Arc<dyn OrderReadPort>,
+}
+
+impl CommerceOrderReadRuntime {
+    pub fn new(order_reads: Arc<dyn OrderReadPort>) -> Self {
+        Self { order_reads }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        event_bus: rustok_outbox::TransactionalEventBus,
+    ) -> Self {
+        Self::new(in_process_order_read_port(db, event_bus))
+    }
+
+    pub fn order_read_port(&self) -> Arc<dyn OrderReadPort> {
+        self.order_reads.clone()
     }
 }
 
@@ -138,8 +166,9 @@ pub(crate) fn fulfillment_lifecycle_read_runtime_for_current_graphql_scope(
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual
 /// provider registries remain deterministic fallbacks. Mounted shipping-option and fulfillment
-/// lifecycle reads consume host-selected runtime data; directly embedded compatibility schemas
-/// retain explicit in-process read fallbacks.
+/// lifecycle reads consume host-selected runtime data; order reads are now also required in schema
+/// composition ahead of resolver cutover. Directly embedded compatibility schemas retain explicit
+/// in-process fulfillment and shipping-option read fallbacks only.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
@@ -147,6 +176,7 @@ pub struct CommerceGraphqlRuntimeData {
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
+    order_read_runtime: CommerceOrderReadRuntime,
 }
 
 impl CommerceGraphqlRuntimeData {
@@ -168,6 +198,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn fulfillment_lifecycle_read_runtime(&self) -> CommerceFulfillmentLifecycleReadRuntime {
         self.fulfillment_lifecycle_read_runtime.clone()
+    }
+
+    pub fn order_read_runtime(&self) -> CommerceOrderReadRuntime {
+        self.order_read_runtime.clone()
     }
 }
 
@@ -199,6 +233,11 @@ pub fn attach_schema_data(
             .unwrap_or_else(|| {
                 CommerceFulfillmentLifecycleReadRuntime::in_process(inputs.db_clone())
             }),
+        order_read_runtime: inputs
+            .shared_get::<CommerceOrderReadRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires CommerceOrderReadRuntime in host composition".to_string()
+            })?,
     })
 }
 

--- a/crates/rustok-commerce/tests/fulfillment_read_port_failure_contract.rs
+++ b/crates/rustok-commerce/tests/fulfillment_read_port_failure_contract.rs
@@ -15,8 +15,8 @@ use rustok_api::{
 };
 use rustok_commerce::graphql::{CommerceMutation, CommerceQuery};
 use rustok_commerce::graphql_runtime::{
-    CommerceFulfillmentLifecycleReadRuntime, CommerceShippingOptionReadRuntime,
-    CommerceShippingOptionReadScope,
+    CommerceFulfillmentLifecycleReadRuntime, CommerceOrderReadRuntime,
+    CommerceShippingOptionReadRuntime, CommerceShippingOptionReadScope,
 };
 use rustok_commerce::{MarketplaceFinancialRuntime, dto::CreateOrderInput};
 use rustok_fulfillment::{
@@ -200,12 +200,17 @@ fn host_runtime(
     db: &DatabaseConnection,
     fulfillment_port: Arc<dyn FulfillmentReadPort>,
 ) -> HostRuntimeContext {
+    let event_bus = mock_transactional_event_bus();
     HostRuntimeContext::new(db.clone())
-        .with_shared_value(mock_transactional_event_bus())
+        .with_shared_value(event_bus.clone())
         .with_shared_value(MarketplaceFinancialRuntime::in_process(db.clone()))
         .with_shared_value(CommerceShippingOptionReadRuntime::in_process(db.clone()))
         .with_shared_value(CommerceFulfillmentLifecycleReadRuntime::new(
             fulfillment_port,
+        ))
+        .with_shared_value(CommerceOrderReadRuntime::in_process(
+            db.clone(),
+            event_bus,
         ))
 }
 

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-28",
-  "status": "owner_port_published_unvalidated",
-  "source_base_revision": "b573adbf9a8397f5676dd617464060b878ce88a1",
+  "status": "admin_rest_cutover_unvalidated",
+  "source_base_revision": "4ec8abcff51f30d3c949cf49705f8e0d402dff9f",
   "scope": "order detail and filtered list projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
@@ -42,7 +42,17 @@
     "channel_retained": true,
     "locale_retained": true,
     "correlation_retained": true,
-    "deadline_required": true
+    "deadline_required": true,
+    "admin_deadline_seconds": 2
+  },
+  "runtime_composition": {
+    "type": "CommerceOrderReadRuntime",
+    "server_runtime_reuse": true,
+    "in_process_default_composed_once": true,
+    "host_runtime_attachment": true,
+    "commerce_http_required": true,
+    "commerce_graphql_schema_data_required": true,
+    "graphql_resolver_scope_published": false
   },
   "errors": {
     "type": "PortError",
@@ -54,18 +64,25 @@
     "database_kind": "Unavailable",
     "core_kind": "InvariantViolation",
     "database_retryable": true,
-    "core_retryable": false
+    "core_retryable": false,
+    "admin_public_envelopes_preserved": true
   },
   "consumer_inventory": {
-    "commerce_admin_rest_list_detail": "concrete_order_service",
+    "commerce_admin_rest_list_detail": "order_read_port",
+    "commerce_admin_rest_cutover_completed": true,
     "commerce_storefront_detail_and_ownership": "concrete_order_service",
     "commerce_graphql_order_list_detail": "concrete_order_service",
-    "runtime_composition_published": false,
-    "consumer_cutover_completed": false,
+    "runtime_composition_published": true,
+    "all_consumer_cutover_completed": false,
     "cutover_required": true
   },
+  "unchanged_scope": {
+    "admin_order_mutations": "concrete_order_service",
+    "admin_detail_payment_lookup": "concrete_payment_service",
+    "admin_detail_fulfillment_lookup": "concrete_fulfillment_service"
+  },
   "decision": {
-    "next_slice": "publish and host-compose CommerceOrderReadRuntime, then cut mounted admin REST order list/detail to OrderReadPort before GraphQL and storefront consumers",
+    "next_slice": "cut mounted GraphQL order list/detail to the host-selected CommerceOrderReadRuntime, then cut storefront detail and ownership reads separately",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -53,13 +53,13 @@ shipping, or hash facts rather than fabricating attribution. The metadata bridge
 and old JSON indexes must be removed after all completion/result consumers use
 typed identity exclusively.
 
-Complete order detail and filtered-list projection reads are now published through
-`OrderReadPort`. `InProcessOrderReadPort` owns concrete `OrderService`
-construction, requires read policy, parses tenant identity from `PortContext`,
-preserves requested and tenant-default locale fallback, list ordering, filters,
-and pagination total, and maps every current `OrderError` to stable `PortError`
-policy without owner-message control flow. Commerce runtime composition and
-consumer cutover remain open and unvalidated.
+Complete order detail and filtered-list projection reads are published through
+`OrderReadPort`. `CommerceOrderReadRuntime` now carries one host-selected owner
+port through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
+GraphQL schema data. Mounted admin REST list/detail reads use the port with locale,
+channel, deadline, filters, ordering, pagination total, public error envelopes,
+and payment/fulfillment detail aggregation preserved. GraphQL resolvers and
+storefront order reads remain open and unvalidated.
 
 ## FFA/FBA boundary
 
@@ -85,6 +85,7 @@ consumer cutover remain open and unvalidated.
 - `scripts/verify/verify-order-admin-boundary.mjs`,
   `scripts/verify/verify-order-storefront-boundary.mjs`,
   `scripts/verify/verify-order-read-port.mjs`,
+  `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`,
   `scripts/verify/verify-commerce-storefront-transport-handoff.mjs`,
   `scripts/verify/verify-commerce-order-identity-boundary.mjs`,
   `scripts/verify/verify-commerce-checkout-completion-cutover.mjs`,
@@ -94,8 +95,8 @@ consumer cutover remain open and unvalidated.
   UI, transport, projection, identity, staged-consumer, lifecycle, compensation,
   and payment settlement split.
 - No status promotion is allowed from source inspection. Clean/upgraded
-  migrations, compile/tests, contention, restart, mounted consumers, and
-  remote-profile evidence remain missing.
+  migrations, compile/tests, contention, restart, remaining mounted consumers,
+  and remote-profile evidence remain missing.
 
 ## Checkout identity, completion, compensation, and settlement workstream
 
@@ -157,14 +158,16 @@ consumer cutover remain open and unvalidated.
 - [x] Map every current `OrderError` variant to stable `PortError` policy without
   owner-message control flow.
 - [x] Export the canonical `in_process_order_read_port` factory.
-- [x] Retain source evidence and a focused guard without claiming Commerce
-  consumer cutover or runtime parity.
-- [ ] Publish and host-compose `CommerceOrderReadRuntime`.
-- [ ] Require the host-selected runtime in Commerce HTTP and GraphQL composition.
-- [ ] Cut admin REST order list/detail over to the owner port while preserving
-  locale, filters, pagination total, detail aggregation, and public envelopes.
-- [ ] Cut GraphQL order list/detail and storefront order detail/ownership reads
-  over in separate atomic changes.
+- [x] Retain source evidence and a focused guard without claiming runtime parity.
+- [x] Publish and host-compose `CommerceOrderReadRuntime` while preserving an
+  externally installed runtime.
+- [x] Require the host-selected runtime in Commerce HTTP and GraphQL schema-data
+  composition.
+- [x] Cut admin REST order list/detail over to the owner port while preserving
+  locale, channel, deadline, filters, pagination total, detail aggregation, and
+  public envelopes.
+- [ ] Cut GraphQL order list/detail over to the host-selected runtime.
+- [ ] Cut storefront order detail/ownership reads over in a separate atomic change.
 - [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence before status promotion.
 
@@ -219,15 +222,15 @@ consumer cutover remain open and unvalidated.
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Cut mounted order projection reads to the owner port.** Compose one
-   host-selected `CommerceOrderReadRuntime`, cut admin REST first, then GraphQL and
-   storefront reads without changing order mutations or payment/fulfillment detail
+7. **Finish mounted order projection read cutover.** Admin REST list/detail now use
+   the host-selected `CommerceOrderReadRuntime`; cut GraphQL next and storefront
+   reads separately without changing order mutations or payment/fulfillment detail
    ownership.
-   **Depends on:** the published `OrderReadPort` and current public transport
-   envelope inventory.
-   **Done when:** mounted detail/list/ownership projection reads no longer construct
-   `OrderService`, retain locale/filter/pagination/authorization behavior, and have
-   bounded parity evidence.
+   **Depends on:** the published runtime and current public transport envelope
+   inventory.
+   **Done when:** every mounted detail/list/ownership projection read no longer
+   constructs `OrderService`, retains locale/filter/pagination/authorization
+   behavior, and has bounded parity evidence.
 
 8. **Keep order and commerce documentation synchronized.** Update local docs,
    manifests, registries, central status, and the umbrella commerce plan whenever
@@ -239,6 +242,7 @@ consumer cutover remain open and unvalidated.
 
 - `npm run verify:ecommerce:fba`
 - `node scripts/verify/verify-order-read-port.mjs`
+- `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
 - `node scripts/verify/verify-commerce-checkout-completion-cutover.mjs`
@@ -253,11 +257,12 @@ consumer cutover remain open and unvalidated.
 - `cargo xtask module test order`
 - `cargo check -p rustok-order --all-features`
 - `cargo check -p rustok-commerce --lib`
+- `cargo check -p rustok-server --features mod-commerce`
 - `cargo test -p rustok-order --test order_checkout_identity`
 - `cargo test -p rustok-order --test checkout_order_identity_port`
 - `cargo test -p rustok-order --test checkout_completion_port`
-- Targeted order read-port detail/list, locale fallback, context, and error-policy
-  tests.
+- Targeted order read-port detail/list, locale fallback, context, error-policy,
+  host-composition, and admin transport tests.
 - Targeted staged checkout completion/adoption/replay, unknown lifecycle,
   compensation, and payment settlement tests.
 - Clean/upgraded/down/reapply identity migrations on SQLite/PostgreSQL/MySQL.

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,6 +1,6 @@
 # Order read port
 
-Status: owner port published, unvalidated; Commerce consumer cutover remains open.
+Status: owner port and host runtime published; admin REST list/detail cut over, unvalidated.
 
 ## Scope
 
@@ -14,8 +14,9 @@ needed by mounted Commerce REST and GraphQL query consumers. It is separate from
 - order lifecycle, return, and order-change mutations, which remain on existing
   order-owner commands and services.
 
-This source wave publishes the owner boundary only. It does not claim that
-Commerce consumers have already stopped constructing `OrderService`.
+The owner boundary and host-selected runtime are now published. Mounted admin REST
+order list/detail reads use the port. GraphQL and storefront order reads remain
+explicit later cutovers.
 
 ## Operations
 
@@ -52,6 +53,79 @@ maps to `Validation`; missing order/return/change maps to `NotFound`; invalid
 transitions map to `Conflict`; database failures map to retryable `Unavailable`;
 and owner-core failures fail closed as non-retryable `InvariantViolation`.
 
+## Commerce runtime composition
+
+`CommerceOrderReadRuntime` contains one host-selected `Arc<dyn OrderReadPort>` and
+exposes:
+
+- `new` for an externally selected adapter;
+- `in_process` for the deterministic local adapter;
+- `order_read_port` for consumer injection.
+
+The default application host:
+
+1. reuses an existing `CommerceOrderReadRuntime` from `ServerRuntimeContext`;
+2. otherwise obtains the shared `TransactionalEventBus` and builds the in-process
+   runtime once;
+3. caches the runtime in `ServerRuntimeContext`;
+4. attaches the same value to `HostRuntimeContext`.
+
+`CommerceHttpRuntime` now requires this value. Commerce GraphQL schema-data
+composition also requires it, preventing a later resolver cutover from silently
+constructing a different adapter. This wave does not add a GraphQL resolver scope
+or change any GraphQL order resolver.
+
+## Admin REST cutover
+
+`GET /admin/orders` now calls `list_order_projections` and preserves:
+
+- `orders:list` authorization;
+- page and per-page values;
+- status and customer filters;
+- requested locale and tenant-default fallback;
+- descending owner ordering and owner pagination total;
+- the existing `PaginatedResponse<OrderResponse>` envelope.
+
+`GET /admin/orders/{id}` now calls `read_order_projection` and preserves:
+
+- `orders:read` authorization;
+- requested locale and tenant-default fallback;
+- the complete `OrderResponse` projection;
+- the existing `AdminOrderDetailResponse` envelope;
+- the existing payment-collection and fulfillment aggregation lookups.
+
+Both handlers create a two-second read `PortContext` with tenant identity,
+authenticated user actor, request locale, optional request channel, and a
+resource-scoped correlation id.
+
+`PortErrorKind` is mapped back to the established admin HTTP policy:
+
+- validation -> `400 commerce_admin_order_invalid`;
+- not found -> `404 commerce_admin_not_found`;
+- conflict -> `409 commerce_admin_order_state_conflict`;
+- forbidden -> `401 commerce_permission_denied`;
+- unavailable/timeout -> `503 commerce_admin_order_storage_unavailable`;
+- invariant violation -> `500 commerce_admin_order_failed`.
+
+The mapper logs stable internal code, retryability, owner operation, correlation,
+actor/channel/locale/deadline context, and route identities without copying owner
+messages into public envelopes.
+
+## Unchanged behavior
+
+This source wave deliberately leaves these paths unchanged:
+
+- admin order mark-paid, ship, deliver, and cancel mutations still construct
+  `OrderService`;
+- admin order detail payment lookup still constructs `PaymentService`;
+- admin order detail fulfillment lookup still constructs `FulfillmentService`;
+- storefront order detail and ownership checks still construct `OrderService`;
+- GraphQL order detail and list still construct their current concrete service;
+- return and order-change paths still require wider owner contracts.
+
+Keeping payment/fulfillment aggregation and mutations out of this cutover avoids
+claiming ownership changes beyond the two order projection reads.
+
 ## Context and diagnostics
 
 The owner boundary retains operation, correlation id, tenant, actor, channel
@@ -61,26 +135,14 @@ Only database and core failures retain the typed internal cause in technical
 logs. Public `PortError.message` values are stable and do not contain raw storage
 or owner-invariant details.
 
-## Current consumer inventory
+## Remaining source work
 
-The following mounted Commerce reads still construct `OrderService` and are not
-changed in this wave:
-
-- admin REST order list and detail;
-- storefront order detail and ownership checks;
-- GraphQL order detail and list;
-- return/order-change mutation and query paths that require a wider owner contract.
-
-Admin order detail also aggregates payment and fulfillment projections. Its
-order-source cutover should remain separate from payment/fulfillment aggregation
-cutover so public envelope compatibility can be reviewed independently.
-
-## Next source slice
-
-Publish `CommerceOrderReadRuntime`, allow a host-selected `Arc<dyn OrderReadPort>`,
-compose/cache it in the default application host, require it in
-`CommerceHttpRuntime`, and cut admin REST order list/detail over first. GraphQL and
-storefront reads should follow in separate atomic changes.
+1. cut mounted GraphQL order detail/list reads to the host-selected runtime;
+2. cut storefront order detail and ownership checks in a separate atomic change;
+3. publish wider owner contracts before moving return/order-change reads or order
+   mutations;
+4. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
+   evidence before any status promotion.
 
 ## Evidence
 
@@ -88,15 +150,19 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `owner_port_published_unvalidated`. Runtime composition, Commerce
-consumer cutover, compile evidence, mounted parity, deadline/failure execution,
-restart, and remote-adapter evidence remain false or open.
+Its status is `admin_rest_cutover_unvalidated`. Host composition and admin REST
+source cutover are recorded as complete. GraphQL/storefront consumer cutover,
+compile evidence, mounted parity, deadline/failure execution, restart, and
+remote-adapter evidence remain false or open.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-order-read-port.mjs
+node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
 cargo check -p rustok-order --lib
+cargo check -p rustok-commerce --lib
+cargo check -p rustok-server --features mod-commerce
 ```
 
 Tests, Cargo commands, formatting, verifiers, workflow checks, and CI were not run

--- a/scripts/verify/verify-commerce-admin-order-route-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-route-error-context.mjs
@@ -30,11 +30,17 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const mapper = between(
+const readMapper = between(
+  orders,
+  'fn admin_order_read_port_context(',
+  'fn admin_order_error_policy(',
+  'admin order read mapper',
+);
+const mutationMapper = between(
   orders,
   'fn admin_order_error_policy(',
   '/// Show admin ecommerce order',
-  'admin order route mapper',
+  'admin order mutation mapper',
 );
 const listRoute = between(
   orders,
@@ -71,11 +77,13 @@ const cancelRoute = cancelStart < 0 ? '' : orders.slice(cancelStart);
 if (cancelStart < 0) failures.push('cancel order route: unable to isolate source block');
 
 for (const [value, label] of [
-  ['use rustok_order::error::OrderError;', 'typed order error import'],
+  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed read context imports'],
+  ['use rustok_order::error::OrderError;', 'typed mutation error import'],
+  ['ListOrderProjectionsRequest, OrderService, ReadOrderProjectionRequest', 'read request and mutation service imports'],
   ['use rustok_web::{HttpError, HttpResult};', 'typed HTTP error import'],
   ['const ADMIN_ORDER_OWNER: &str = "rustok_order.admin_orders";', 'owner constant'],
   ['const ADMIN_ORDER_BOUNDARY: &str = "commerce_admin_order_http";', 'HTTP boundary constant'],
-  ['type AdminOrderHttpPolicy = (', 'static HTTP policy type'],
+  ['type AdminOrderHttpPolicy = (', 'static mutation HTTP policy type'],
   ['struct AdminOrderErrorContext {', 'order error context'],
   ['tenant_id: Uuid,', 'tenant field'],
   ['actor_id: Uuid,', 'actor field'],
@@ -85,6 +93,33 @@ for (const [value, label] of [
 ]) requireText(orders, value, label);
 
 for (const [value, label] of [
+  ['PortContext::new(', 'PortContext construction'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
+  ['request_context.locale.as_str()', 'requested locale'],
+  ['format!("commerce-admin-order:{operation}:{resource_id}")', 'resource correlation'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded deadline'],
+  ['request_context.channel_slug.as_deref()', 'optional channel'],
+  ['fn map_admin_order_port_error(', 'typed port mapper'],
+  ['PortErrorKind::Validation', 'validation kind'],
+  ['PortErrorKind::NotFound', 'not-found kind'],
+  ['PortErrorKind::Conflict', 'conflict kind'],
+  ['PortErrorKind::Forbidden', 'forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable/timeout kinds'],
+  ['PortErrorKind::InvariantViolation', 'invariant kind'],
+  ['"commerce_admin_order_invalid"', 'validation code'],
+  ['"commerce_admin_not_found"', 'not-found code'],
+  ['"commerce_admin_order_state_conflict"', 'conflict code'],
+  ['"commerce_permission_denied"', 'permission code'],
+  ['"commerce_admin_order_storage_unavailable"', 'storage code'],
+  ['"commerce_admin_order_failed"', 'fail-closed code'],
+  ['owner_operation,', 'owner operation log'],
+  ['correlation_id = %port_context.correlation_id', 'correlation log'],
+  ['internal_code = %error.code', 'stable internal code log'],
+  ['retryable = error.retryable', 'retryability log'],
+  ['HttpError::new(status, code, message)', 'static read envelope'],
+]) requireText(readMapper, value, label);
+
+for (const [value, label] of [
   ['OrderError::Validation(_)', 'validation variant'],
   ['OrderError::OrderNotFound(_)', 'order not-found variant'],
   ['OrderError::OrderReturnNotFound(_)', 'return not-found variant'],
@@ -92,52 +127,42 @@ for (const [value, label] of [
   ['OrderError::InvalidTransition { .. }', 'transition variant'],
   ['OrderError::Database(_)', 'database variant'],
   ['OrderError::Core(_)', 'core variant'],
-  ['StatusCode::BAD_REQUEST', 'bad-request status'],
-  ['StatusCode::NOT_FOUND', 'not-found status'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
-  ['"commerce_admin_order_invalid"', 'validation code'],
-  ['"commerce_admin_not_found"', 'not-found code'],
-  ['"commerce_admin_order_state_conflict"', 'conflict code'],
-  ['"commerce_admin_order_storage_unavailable"', 'storage code'],
-  ['"commerce_admin_order_failed"', 'fail-closed code'],
-  ['"Order request is invalid"', 'static validation message'],
-  ['"Commerce resource not found"', 'static not-found message'],
-  ['"Order operation conflicts with the current state"', 'static conflict message'],
-  ['"Order storage is temporarily unavailable"', 'static storage message'],
-  ['"Order operation could not be completed safely"', 'static fail-closed message'],
   ['if let OrderError::OrderNotFound(id) = &error', 'typed order identity adoption'],
   ['context.order_id = Some(*id);', 'adopted order identity'],
   ['error = ?error', 'typed cause log'],
   ['owner = ADMIN_ORDER_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['actor_id = %context.actor_id', 'actor log'],
-  ['order_id = ?context.order_id', 'order identity log'],
-  ['customer_id = ?context.customer_id', 'customer identity log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public-code log'],
-  ['status = %status', 'status log'],
-  ['boundary = ADMIN_ORDER_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'static envelope constructor'],
-]) requireText(mapper, value, label);
+  ['HttpError::new(status, code, message)', 'static mutation envelope'],
+]) requireText(mutationMapper, value, label);
 
-for (const [block, operation, identity, serviceCall, label] of [
+for (const [block, operation, ownerCall, requestMarker, label] of [
   [
     listRoute,
     '"list_orders"',
-    'tenant.id,\n                    auth.user_id,\n                    None,\n                    customer_id,',
-    '.list_orders_with_locale_fallback(',
+    '.list_order_projections(',
+    'ListOrderProjectionsRequest {',
     'list route',
   ],
   [
     showRoute,
     '"get_order"',
-    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
-    '.get_order_with_locale_fallback(',
+    '.read_order_projection(',
+    'ReadOrderProjectionRequest {',
     'show route',
   ],
+]) {
+  requireText(block, 'admin_order_read_port_context(', `${label} PortContext`);
+  requireText(block, '.order_read_port()', `${label} injected port`);
+  requireText(block, ownerCall, `${label} owner call`);
+  requireText(block, requestMarker, `${label} typed request`);
+  requireText(block, 'map_admin_order_port_error(', `${label} port mapper`);
+  requireText(block, 'AdminOrderErrorContext::new(', `${label} route identity`);
+  requireText(block, operation, `${label} operation`);
+  requireText(block, 'tenant_default_locale: Some(tenant.default_locale.clone())', `${label} locale fallback`);
+  forbidText(block, 'OrderService::new', `${label} concrete order service`);
+  forbidText(block, 'map_admin_order_error(', `${label} mutation mapper`);
+}
+
+for (const [block, operation, identity, serviceCall, label] of [
   [
     markPaidRoute,
     '"mark_order_paid"',
@@ -148,7 +173,7 @@ for (const [block, operation, identity, serviceCall, label] of [
   [
     shipRoute,
     '"ship_order"',
-    'tenant.id,\n                    auth.user_id,\n                    Some(id),\n                    None,',
+    'tenant.id, auth.user_id, Some(id), None, "ship_order"',
     '.ship_order(',
     'ship route',
   ],
@@ -167,12 +192,14 @@ for (const [block, operation, identity, serviceCall, label] of [
     'cancel route',
   ],
 ]) {
+  requireText(block, 'OrderService::new(runtime.db_clone(), runtime.event_bus())', `${label} concrete mutation owner`);
   requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
-  requireText(block, 'map_admin_order_error(', `${label} mapper handoff`);
+  requireText(block, 'map_admin_order_error(', `${label} mutation mapper`);
   requireText(block, 'AdminOrderErrorContext::new(', `${label} context construction`);
   requireText(block, operation, `${label} operation`);
   requireText(block, identity, `${label} truthful route identity`);
   requireText(block, serviceCall, `${label} service contract`);
+  forbidText(block, 'map_admin_order_port_error(', `${label} read mapper`);
 }
 
 for (const [value, label] of [
@@ -184,8 +211,8 @@ for (const [value, label] of [
   ['customer_id,', 'customer filter forwarding'],
   ['page: pagination.page', 'pagination page forwarding'],
   ['per_page: pagination.limit()', 'pagination size forwarding'],
-  ['request_context.locale.as_str()', 'requested locale forwarding'],
-  ['Some(tenant.default_locale.as_str())', 'tenant fallback locale forwarding'],
+  ['data: page.items,', 'owner list items'],
+  ['page.total,', 'owner pagination total'],
   ['input.payment_id', 'payment identity forwarding'],
   ['input.payment_method', 'payment method forwarding'],
   ['input.tracking_number', 'tracking forwarding'],
@@ -201,10 +228,15 @@ for (const [value, label] of [
   ['map_order_detail_fulfillment_error(tenant.id, id, error)', 'fulfillment detail mapper call'],
 ]) requireText(showRoute + orders, value, label);
 
-const mapperUses =
+const mutationMapperUses =
   orders.match(/map_admin_order_error\(\s+AdminOrderErrorContext::new\(/g) ?? [];
-if (mapperUses.length !== 6) {
-  failures.push(`expected six context-aware admin order mapper callsites, found ${mapperUses.length}`);
+if (mutationMapperUses.length !== 4) {
+  failures.push(`expected four context-aware admin order mutation mapper callsites, found ${mutationMapperUses.length}`);
+}
+const readMapperUses =
+  orders.match(/map_admin_order_port_error\(\s+AdminOrderErrorContext::new\(/g) ?? [];
+if (readMapperUses.length !== 2) {
+  failures.push(`expected two context-aware admin order read mapper callsites, found ${readMapperUses.length}`);
 }
 
 for (const [value, label] of [
@@ -233,5 +265,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin order routes retain typed causes, route identities, and static public envelopes',
+  '✔ Commerce admin order reads use typed owner ports while mutations retain typed concrete-owner errors and all public envelopes remain static',
 );

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -12,6 +12,15 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 
 const owner = read('crates/rustok-order/src/order_read.rs');
 const exports = read('crates/rustok-order/src/lib.rs');
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const adminOrders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
+const adminFixtures = read('crates/rustok-commerce/src/controllers/admin/tests/mod.rs');
+const storefrontFixtures = read('crates/rustok-commerce/src/controllers/store/tests/mod.rs');
+const fulfillmentFailureContract = read(
+  'crates/rustok-commerce/tests/fulfillment_read_port_failure_contract.rs',
+);
 const evidence = JSON.parse(
   read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
 );
@@ -25,6 +34,15 @@ const requireText = (source, value, label) => {
 };
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
 };
 
 for (const [source, value, label] of [
@@ -56,9 +74,40 @@ for (const [source, value, label] of [
   [exports, 'OrderReadPort,', 'root trait export'],
   [exports, 'InProcessOrderReadPort,', 'root adapter export'],
   [exports, 'in_process_order_read_port,', 'root factory export'],
-  [note, 'Status: owner port published, unvalidated', 'owner note status'],
-  [orderPlan, 'OrderReadPort', 'order plan checkpoint'],
-  [commercePlan, 'OrderReadPort', 'commerce plan checkpoint'],
+  [graphqlRuntime, 'pub struct CommerceOrderReadRuntime {', 'Commerce order runtime'],
+  [graphqlRuntime, 'order_reads: Arc<dyn OrderReadPort>', 'runtime owner port'],
+  [graphqlRuntime, 'in_process_order_read_port(db, event_bus)', 'runtime in-process factory'],
+  [graphqlRuntime, 'pub fn order_read_port(&self)', 'runtime port getter'],
+  [graphqlRuntime, 'order_read_runtime: CommerceOrderReadRuntime,', 'GraphQL runtime data field'],
+  [graphqlRuntime, '.shared_get::<CommerceOrderReadRuntime>()', 'GraphQL host runtime requirement'],
+  [graphqlRuntime, 'commerce GraphQL requires CommerceOrderReadRuntime in host composition', 'GraphQL fail-closed message'],
+  [httpRuntime, 'order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,', 'HTTP runtime field'],
+  [httpRuntime, 'fn order_read_port(&self)', 'HTTP port getter'],
+  [httpRuntime, '.shared_get::<crate::graphql_runtime::CommerceOrderReadRuntime>()', 'HTTP host requirement'],
+  [httpRuntime, 'Commerce HTTP routes require CommerceOrderReadRuntime in HostRuntimeContext', 'HTTP fail-closed message'],
+  [serverRuntime, '.shared_get::<rustok_commerce::graphql_runtime::CommerceOrderReadRuntime>()', 'server runtime reuse'],
+  [serverRuntime, 'CommerceOrderReadRuntime::in_process(', 'server in-process composition'],
+  [serverRuntime, 'server.shared_insert(runtime.clone());', 'server runtime cache'],
+  [serverRuntime, 'host.with_shared_value(runtime)', 'host runtime attachment'],
+  [adminOrders, 'fn admin_order_read_port_context(', 'admin PortContext builder'],
+  [adminOrders, 'PortActor::user(auth.user_id.to_string())', 'admin actor propagation'],
+  [adminOrders, '.with_deadline(std::time::Duration::from_secs(2))', 'admin deadline'],
+  [adminOrders, 'request_context.channel_slug.as_deref()', 'admin channel propagation'],
+  [adminOrders, 'fn map_admin_order_port_error(', 'admin PortError mapper'],
+  [adminOrders, '.list_order_projections(', 'admin list port call'],
+  [adminOrders, '.read_order_projection(', 'admin detail port call'],
+  [adminOrders, 'tenant_default_locale: Some(tenant.default_locale.clone())', 'admin locale fallback'],
+  [adminOrders, 'data: page.items,', 'admin list envelope'],
+  [adminOrders, 'page.total,', 'admin owner total'],
+  [adminOrders, 'find_latest_collection_by_order(tenant.id, id)', 'unchanged payment aggregation'],
+  [adminOrders, 'find_by_order(tenant.id, id)', 'unchanged fulfillment aggregation'],
+  [adminFixtures, 'CommerceOrderReadRuntime::in_process(', 'admin fixture runtime'],
+  [storefrontFixtures, 'CommerceOrderReadRuntime::in_process(', 'storefront fixture runtime'],
+  [fulfillmentFailureContract, 'CommerceOrderReadRuntime::in_process(', 'manual host fixture runtime'],
+  [fulfillmentFailureContract, '.with_shared_value(event_bus.clone())', 'manual host fixture shared event bus'],
+  [note, 'Status: owner port and host runtime published; admin REST list/detail cut over, unvalidated.', 'owner note status'],
+  [orderPlan, 'CommerceOrderReadRuntime', 'order plan runtime checkpoint'],
+  [commercePlan, 'CommerceOrderReadRuntime', 'commerce plan runtime checkpoint'],
 ]) requireText(source, value, label);
 
 for (const [value, label] of [
@@ -68,7 +117,36 @@ for (const [value, label] of [
   ['PortError::new(kind, code, error', 'raw owner error publication'],
 ]) forbidText(owner, value, label);
 
-if (evidence.status !== 'owner_port_published_unvalidated') {
+const listRoute = between(
+  adminOrders,
+  'pub async fn list_orders(',
+  '#[utoipa::path(\n    get,\n    path = "/admin/orders/{id}"',
+  'admin list route',
+);
+const showRoute = between(
+  adminOrders,
+  'pub async fn show_order(',
+  'fn map_order_detail_payment_error(',
+  'admin detail route',
+);
+for (const [route, label] of [
+  [listRoute, 'admin list route'],
+  [showRoute, 'admin detail route'],
+]) {
+  forbidText(route, 'OrderService::new', `${label} concrete owner construction`);
+  forbidText(route, '.list_orders_with_locale_fallback(', `${label} concrete list call`);
+  forbidText(route, '.get_order_with_locale_fallback(', `${label} concrete detail call`);
+  requireText(route, 'runtime\n        .order_read_port()', `${label} injected owner port`);
+}
+
+for (const [value, label] of [
+  ['.mark_paid(', 'mark-paid mutation remains owner service'],
+  ['.ship_order(', 'ship mutation remains owner service'],
+  ['.deliver_order(', 'deliver mutation remains owner service'],
+  ['.cancel_order(', 'cancel mutation remains owner service'],
+]) requireText(adminOrders, value, label);
+
+if (evidence.status !== 'admin_rest_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.owner?.port !== 'OrderReadPort') {
@@ -81,23 +159,46 @@ if (evidence.operations?.map((operation) => operation.name).join(',') !==
     'read_order_projection,list_order_projections') {
   failures.push('evidence operation inventory mismatch');
 }
+if (evidence.runtime_composition?.type !== 'CommerceOrderReadRuntime') {
+  failures.push('evidence runtime type must be CommerceOrderReadRuntime');
+}
+for (const key of [
+  'server_runtime_reuse',
+  'in_process_default_composed_once',
+  'host_runtime_attachment',
+  'commerce_http_required',
+  'commerce_graphql_schema_data_required',
+]) {
+  if (evidence.runtime_composition?.[key] !== true) {
+    failures.push(`evidence runtime_composition.${key} must be true`);
+  }
+}
+if (evidence.runtime_composition?.graphql_resolver_scope_published !== false) {
+  failures.push('GraphQL resolver scope must remain unpublished in this wave');
+}
 if (evidence.errors?.owner_message_control_flow !== false) {
   failures.push('evidence must forbid owner-message control flow');
 }
 if (evidence.errors?.all_current_order_error_variants_mapped !== true) {
   failures.push('evidence must record complete current OrderError mapping');
 }
-if (evidence.consumer_inventory?.runtime_composition_published !== false) {
-  failures.push('runtime composition must remain unpublished in this wave');
+if (evidence.consumer_inventory?.commerce_admin_rest_list_detail !== 'order_read_port') {
+  failures.push('admin REST list/detail must be recorded on order_read_port');
 }
-if (evidence.consumer_inventory?.consumer_cutover_completed !== false) {
-  failures.push('Commerce consumer cutover must remain incomplete in this wave');
+if (evidence.consumer_inventory?.commerce_admin_rest_cutover_completed !== true) {
+  failures.push('admin REST source cutover must be complete');
+}
+if (evidence.consumer_inventory?.runtime_composition_published !== true) {
+  failures.push('runtime composition must be published');
+}
+if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
+  failures.push('all-consumer cutover must remain incomplete');
 }
 if (evidence.consumer_inventory?.cutover_required !== true) {
-  failures.push('evidence must retain the pending Commerce cutover');
+  failures.push('evidence must retain pending GraphQL/storefront cutover');
 }
 if (evidence.decision?.status_promotion !== false) {
-  failures.push('source publication must not promote status');
+  failures.push('source cutover must not promote status');
 }
 for (const key of [
   'tests_run',
@@ -120,5 +221,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Order detail/list projections are published through a typed owner read port while Commerce runtime composition and consumer cutover remain explicitly pending',
+  '✔ Order read runtime is host-composed and admin REST list/detail use the typed owner port while GraphQL/storefront cutover and runtime evidence remain pending',
 );


### PR DESCRIPTION
## Summary

- publish host-selectable `CommerceOrderReadRuntime` over `OrderReadPort`;
- reuse/cache it in `ServerRuntimeContext` and attach the same value to `HostRuntimeContext`;
- require it in Commerce HTTP and Commerce GraphQL schema-data composition;
- cut mounted admin REST order list/detail reads to the owner port;
- preserve locale fallback, optional channel, two-second deadline, filters, ordering, owner total, authorization, and public HTTP envelopes;
- retain order mutations plus payment/fulfillment detail aggregation on their existing concrete services;
- keep GraphQL resolvers and storefront order reads as explicit follow-up work.

## Admin REST cutover

`GET /admin/orders` now calls `list_order_projections` and preserves the existing `PaginatedResponse<OrderResponse>` contract.

`GET /admin/orders/{id}` now calls `read_order_projection` while preserving `AdminOrderDetailResponse`, including unchanged payment-collection and fulfillment lookups.

Typed `PortErrorKind` values map back to the established public order policies without copying owner messages.

## Composition

The default server reuses an externally installed `CommerceOrderReadRuntime`; otherwise it composes the in-process adapter once from the shared database and `TransactionalEventBus`, caches it, and attaches it to the host. Commerce HTTP and GraphQL schema data fail closed when the runtime is absent.

No GraphQL resolver task-local scope is published in this change, so GraphQL order queries are not claimed as cut over.

## Evidence and plans

- evidence status: `admin_rest_cutover_unvalidated`;
- source base: `4ec8abcff51f30d3c949cf49705f8e0d402dff9f`;
- broad Product/Order/Payment/Fulfillment concrete-service P0 remains open;
- GraphQL/storefront consumer cutover remains open;
- compile/runtime/parity flags remain false.

## Recheck

- intervening changes affected only workflows, Index, and Forum files;
- no overlap with this PR's 13-file scope;
- final branch is one atomic commit ahead and zero behind;
- full patch review restored an accidentally truncated fulfillment fixture before the atomic rebuild;
- no test or fixture content is removed by the final diff.

## Validation

Tests, Cargo commands, formatting commands, verifiers, workflow checks, and CI were not run, per maintainer instruction.