### PR TITLE
feat(index): add no-clobber archive outputs

### DIFF
--- a/crates/rustok-index/docs/partition-full-capture.md
+++ b/crates/rustok-index/docs/partition-full-capture.md
@@ -67,26 +67,29 @@ The report command writes no files, opens no PostgreSQL connection, and starts n
 
 ## Machine-readable admitted archive manifest
 
-After the report is reviewed and the retained outcome is `admitted`, print a deterministic machine-readable archive manifest. Save the derived manifest outside the immutable bundle:
+After the report is reviewed and the retained outcome is `admitted`, create a deterministic machine-readable archive manifest outside the immutable bundle:
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-archive-manifest \
   --root evidence/index-partition/retained-run \
-  > evidence/index-partition/retained-run.archive-manifest.json
+  --output evidence/index-partition/retained-run.archive-manifest.json
 ```
 
-`partition-archive-manifest` runs the same retained-bundle inspection as `partition-report`, refuses any outcome other than `admitted`, and prints JSON containing the evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, byte counts, and total retained bytes. Its `manifest_digest` is the SHA-256 digest of canonical JSON for the manifest payload before the `manifest_digest` field is added, under `canonical_json_without_manifest_digest_v1`.
+`partition-archive-manifest` runs the same retained-bundle inspection as `partition-report`, refuses any outcome other than `admitted`, and renders JSON containing the evidence identity, packet digest, provenance, PostgreSQL identity, all nine relative paths, exact-byte SHA-256 digests, byte counts, and total retained bytes. Its `manifest_digest` is the SHA-256 digest of canonical JSON for the manifest payload before the `manifest_digest` field is added, under `canonical_json_without_manifest_digest_v1`.
 
-The archive-manifest command writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. Shell redirection may save this derived index outside the immutable bundle. The manifest does not replace or modify the nine authoritative retained files, does not expose the internal filesystem snapshot, does not change admission, and does not authorize production lifecycle work.
+With `--output`, the command writes and `fsync`s a private temporary file in the external destination directory, then publishes the completed bytes through a no-clobber hard link. It refuses to overwrite any existing target, rejects lexical or canonical destinations inside the retained bundle, and removes its temporary file on failure. Without `--output`, stdout mode remains available and writes no files; avoid shell redirection for retained archive metadata because the shell can truncate an existing target before Node validates the bundle.
+
+The manifest does not replace or modify the nine authoritative retained files, does not expose the internal filesystem snapshot, does not change admission, and does not authorize production lifecycle work.
 
 ## Verify a saved archive manifest
 
-Before moving or accepting an archived packet, verify the saved manifest against the current immutable bundle:
+Before moving or accepting an archived packet, verify the saved manifest against the current immutable bundle and save the receipt outside that bundle:
 
 ```bash
 node scripts/verify/index-storage-tooling.mjs partition-archive-verify \
   --root evidence/index-partition/retained-run \
-  --manifest evidence/index-partition/retained-run.archive-manifest.json
+  --manifest evidence/index-partition/retained-run.archive-manifest.json \
+  --output evidence/index-partition/retained-run.archive-verification.json
 ```
 
 `partition-archive-verify` requires the saved manifest to be a non-empty regular non-symlink file outside the immutable bundle. It rejects lexical or canonical paths inside the bundle and rejects a hard-link alias to any of the nine retained files. It reads the saved manifest through a stable file descriptor, verifies the saved `manifest_digest`, reruns the full retained-bundle inspection, rebuilds the admitted archive manifest, and canonical-compares the complete saved manifest to the recalculated result.
@@ -95,7 +98,7 @@ Before publishing success, the verifier confirms that the retained bundle root s
 
 The verifier fails closed on a pre-existing unexpected bundle entry, nested directory inventory drift after inspection, same-byte filesystem identity replacement, same-inode metadata drift, retained bundle root metadata drift, retained bundle root replacement, saved-manifest replacement or rewrite, post-inspection exact-byte drift, current retained-file aliasing, or identity/content drift while a file or directory is being read. The internal directory and filesystem snapshot fields remain outside `index_partition_retained_archive_manifest_v1` and `index_partition_retained_archive_verification_v1`.
 
-A successful verification prints a deterministic `index_partition_retained_archive_verification_v1` receipt with `retained_files_rechecked: true`, the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. The verifier writes no files, opens no PostgreSQL connection, and starts no Cargo or evidence stage. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
+A successful verification produces a deterministic `index_partition_retained_archive_verification_v1` receipt with `retained_files_rechecked: true`, the evidence ID, packet and manifest digests, exact-byte SHA-256 of the saved manifest file, retained file count, total retained bytes, and `production_lifecycle_authorized: false`. With `--output`, receipt publication uses the same external no-clobber temporary-file plus hard-link boundary as the archive manifest. Without `--output`, the verifier prints the receipt to stdout and writes no files. The receipt is derived metadata, not a tenth authoritative evidence input and not production authorization.
 
 A failed attempt may leave evidence schemas or raw artifacts for inspection. Do not edit or reuse them. Prepare a fresh manifest run key and a new empty directory.
 

--- a/scripts/verify/index-partition-derived-output-core.mjs
+++ b/scripts/verify/index-partition-derived-output-core.mjs
@@ -1,0 +1,139 @@
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  openSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+const identityOf = (stat) => `${stat.dev}:${stat.ino}`;
+
+const requireNonEmptyString = (value, label) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+const ensureOutsideRoot = (root, filename, label) => {
+  const relative = path.relative(root, filename);
+  const inside = relative === ''
+    || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+  if (inside) throw new Error(`${label} must stay outside the retained bundle root`);
+};
+
+const removePublishedIdentity = (filename, expectedIdentity) => {
+  try {
+    const current = lstatSync(filename, { bigint: true });
+    if (!current.isSymbolicLink() && current.isFile() && identityOf(current) === expectedIdentity) {
+      unlinkSync(filename);
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+};
+
+const removeTemporaryFile = (filename) => {
+  try {
+    unlinkSync(filename);
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+};
+
+export const renderDerivedJson = (value) => {
+  const rendered = JSON.stringify(value, null, 2);
+  if (typeof rendered !== 'string') throw new Error('derived output must be JSON serializable');
+  return `${rendered}\n`;
+};
+
+export const publishDerivedJsonOutsideRetainedBundle = ({
+  root,
+  outputPath,
+  value,
+  label = 'derived output',
+}) => {
+  const resolvedRoot = path.resolve(requireNonEmptyString(root, 'root'));
+  const rootStat = lstatSync(resolvedRoot, { bigint: true });
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error('retained bundle root must be a regular non-symlink directory');
+  }
+  const canonicalRoot = realpathSync.native(resolvedRoot);
+
+  const resolvedOutputPath = path.resolve(requireNonEmptyString(outputPath, 'outputPath'));
+  ensureOutsideRoot(resolvedRoot, resolvedOutputPath, label);
+
+  const parentPath = path.dirname(resolvedOutputPath);
+  const parentStat = lstatSync(parentPath, { bigint: true });
+  if (parentStat.isSymbolicLink() || !parentStat.isDirectory()) {
+    throw new Error(`${label} parent must be a regular non-symlink directory`);
+  }
+  const canonicalParent = realpathSync.native(parentPath);
+  ensureOutsideRoot(canonicalRoot, canonicalParent, `${label} parent`);
+
+  const bytes = Buffer.from(renderDerivedJson(value), 'utf8');
+  const temporaryPath = path.join(
+    parentPath,
+    `.${path.basename(resolvedOutputPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  let descriptor = null;
+  let temporaryIdentity = null;
+  let published = false;
+  try {
+    descriptor = openSync(temporaryPath, 'wx', 0o600);
+    writeFileSync(descriptor, bytes);
+    fsyncSync(descriptor);
+    const temporaryStat = fstatSync(descriptor, { bigint: true });
+    if (!temporaryStat.isFile()) throw new Error(`${label} temporary output must be a regular file`);
+    temporaryIdentity = identityOf(temporaryStat);
+    closeSync(descriptor);
+    descriptor = null;
+
+    try {
+      linkSync(temporaryPath, resolvedOutputPath);
+    } catch (error) {
+      if (error.code === 'EEXIST') {
+        throw new Error(`${label} already exists; refusing to overwrite`);
+      }
+      throw error;
+    }
+    published = true;
+
+    const outputStat = lstatSync(resolvedOutputPath, { bigint: true });
+    if (outputStat.isSymbolicLink()
+        || !outputStat.isFile()
+        || identityOf(outputStat) !== temporaryIdentity) {
+      throw new Error(`${label} changed while it was being published`);
+    }
+    const canonicalOutput = realpathSync.native(resolvedOutputPath);
+    ensureOutsideRoot(canonicalRoot, canonicalOutput, label);
+
+    const currentParentStat = lstatSync(parentPath, { bigint: true });
+    if (currentParentStat.isSymbolicLink()
+        || !currentParentStat.isDirectory()
+        || identityOf(currentParentStat) !== identityOf(parentStat)
+        || realpathSync.native(parentPath) !== canonicalParent) {
+      throw new Error(`${label} parent changed while it was being published`);
+    }
+
+    removeTemporaryFile(temporaryPath);
+    return {
+      path: resolvedOutputPath,
+      bytes: bytes.length,
+    };
+  } catch (error) {
+    if (descriptor !== null) closeSync(descriptor);
+    if (published && temporaryIdentity !== null) {
+      removePublishedIdentity(resolvedOutputPath, temporaryIdentity);
+    }
+    removeTemporaryFile(temporaryPath);
+    throw error;
+  }
+};

--- a/scripts/verify/index-partition-derived-output.test.mjs
+++ b/scripts/verify/index-partition-derived-output.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  publishDerivedJsonOutsideRetainedBundle,
+  renderDerivedJson,
+} from './index-partition-derived-output-core.mjs';
+
+const buildPaths = () => {
+  const parent = mkdtempSync(path.join(os.tmpdir(), 'index-partition-derived-output-'));
+  const root = path.join(parent, 'retained-run');
+  const output = path.join(parent, 'retained-run.archive-manifest.json');
+  return { parent, root, output };
+};
+
+const cleanup = (parent) => rmSync(parent, { recursive: true, force: true });
+
+test('atomically publishes deterministic derived JSON outside the retained bundle', () => {
+  const paths = buildPaths();
+  try {
+    rmSync(paths.root, { recursive: true, force: true });
+    const rootParent = path.dirname(paths.root);
+    const rootName = path.basename(paths.root);
+    mkdirSync(path.join(rootParent, rootName));
+    const value = { contract: 'derived_fixture_v1', verified: true };
+    const result = publishDerivedJsonOutsideRetainedBundle({
+      root: paths.root,
+      outputPath: paths.output,
+      value,
+      label: 'fixture output',
+    });
+    assert.equal(result.path, path.resolve(paths.output));
+    assert.equal(result.bytes, Buffer.byteLength(renderDerivedJson(value)));
+    assert.equal(readFileSync(paths.output, 'utf8'), renderDerivedJson(value));
+    assert.deepEqual(
+      readdirSync(paths.parent).sort(),
+      ['retained-run', 'retained-run.archive-manifest.json'],
+    );
+  } finally {
+    cleanup(paths.parent);
+  }
+});
+
+test('refuses to overwrite an existing derived output', () => {
+  const paths = buildPaths();
+  try {
+    mkdirSync(paths.root);
+    writeFileSync(paths.output, 'sentinel');
+    assert.throws(
+      () => publishDerivedJsonOutsideRetainedBundle({
+        root: paths.root,
+        outputPath: paths.output,
+        value: { verified: true },
+        label: 'fixture output',
+      }),
+      /already exists; refusing to overwrite/u,
+    );
+    assert.equal(readFileSync(paths.output, 'utf8'), 'sentinel');
+    assert.deepEqual(
+      readdirSync(paths.parent).sort(),
+      ['retained-run', 'retained-run.archive-manifest.json'],
+    );
+  } finally {
+    cleanup(paths.parent);
+  }
+});
+
+test('rejects derived output inside the retained bundle without creating a file', () => {
+  const paths = buildPaths();
+  try {
+    mkdirSync(paths.root);
+    const output = path.join(paths.root, 'verification-receipt.json');
+    assert.throws(
+      () => publishDerivedJsonOutsideRetainedBundle({
+        root: paths.root,
+        outputPath: output,
+        value: { verified: true },
+        label: 'fixture output',
+      }),
+      /must stay outside the retained bundle root/u,
+    );
+    assert.equal(existsSync(output), false);
+  } finally {
+    cleanup(paths.parent);
+  }
+});
+
+test('rejects an external symlink parent that resolves into the retained bundle', () => {
+  const paths = buildPaths();
+  try {
+    mkdirSync(paths.root);
+    const linkedParent = path.join(paths.parent, 'linked-root');
+    symlinkSync(paths.root, linkedParent, 'dir');
+    const output = path.join(linkedParent, 'verification-receipt.json');
+    assert.throws(
+      () => publishDerivedJsonOutsideRetainedBundle({
+        root: paths.root,
+        outputPath: output,
+        value: { verified: true },
+        label: 'fixture output',
+      }),
+      /parent must be a regular non-symlink directory/u,
+    );
+    assert.equal(existsSync(path.join(paths.root, 'verification-receipt.json')), false);
+  } finally {
+    cleanup(paths.parent);
+  }
+});

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -79,6 +79,7 @@ const runContract = (args) => {
     'verify-index-partition-maintenance-evidence.mjs',
     'verify-index-partition-cutover-evidence.mjs',
     'verify-index-partition-full-capture.mjs',
+    'verify-index-partition-derived-output.mjs',
     'verify-index-partition-post-inspection-drift.mjs',
     'verify-index-storage-source-oracle.mjs',
     'verify-index-storage-read-ordering-contract.mjs',

--- a/scripts/verify/index-storage-tooling.mjs
+++ b/scripts/verify/index-storage-tooling.mjs
@@ -23,8 +23,8 @@ const usage = () => {
   node scripts/verify/index-storage-tooling.mjs partition-assemble --manifest <manifest.json> --capture <capture.json> --output <packet.json>
   node scripts/verify/index-storage-tooling.mjs partition-validate --input <packet.json> --output <admission.json>
   node scripts/verify/index-storage-tooling.mjs partition-report --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
-  node scripts/verify/index-storage-tooling.mjs partition-archive-manifest --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>]
-  node scripts/verify/index-storage-tooling.mjs partition-archive-verify --root <bundle-directory> --manifest <archive-manifest.json> [--packet <packet.json>] [--admission <admission.json>]
+  node scripts/verify/index-storage-tooling.mjs partition-archive-manifest --root <bundle-directory> [--packet <packet.json>] [--admission <admission.json>] [--output <archive-manifest.json>]
+  node scripts/verify/index-storage-tooling.mjs partition-archive-verify --root <bundle-directory> --manifest <archive-manifest.json> [--packet <packet.json>] [--admission <admission.json>] [--output <verification-receipt.json>]
   node scripts/verify/index-storage-tooling.mjs hash <comparison.json>
   node scripts/verify/index-storage-tooling.mjs prepare --comparison <comparison.json> --selected <prototype> --owner <owner> --date <YYYY-MM-DD> --output <decision.json> [--force]
   node scripts/verify/index-storage-tooling.mjs render --comparison <comparison.json> --decision <decision.json> --output <adr.md>
@@ -40,8 +40,8 @@ Commands:
   partition-assemble          Build one packet from six retained raw JSON artifacts and exact-byte hashes.
   partition-validate          Validate a measured partition packet and publish calculated admission output.
   partition-report            Recalculate and render a read-only review of all nine retained bundle files.
-  partition-archive-manifest  Print a deterministic JSON archive manifest for one admitted retained bundle.
-  partition-archive-verify    Verify a saved archive manifest against the current admitted retained bundle.
+  partition-archive-manifest  Print or no-clobber save a deterministic JSON archive manifest for one admitted retained bundle.
+  partition-archive-verify    Verify a saved archive manifest and print or no-clobber save its receipt.
   hash                        Print the SHA-256 digest of the exact comparison.json bytes.
   prepare                     Create a non-overwriting manual decision draft bound to exact comparison bytes.
   render                      Finalize the manual storage ADR with comparison and decision SHA-256 bindings.
@@ -121,6 +121,7 @@ const runFixtures = (args) => {
     scriptPath('index-partition-evidence-assembly.test.mjs'),
     scriptPath('index-partition-full-capture-plan.test.mjs'),
     scriptPath('index-partition-review.test.mjs'),
+    scriptPath('index-partition-derived-output.test.mjs'),
     scriptPath('index-partition-post-inspection-drift.test.mjs'),
   ], 'Index storage fixture suites');
 };

--- a/scripts/verify/render-index-partition-archive-manifest.mjs
+++ b/scripts/verify/render-index-partition-archive-manifest.mjs
@@ -3,6 +3,10 @@
 import path from 'node:path';
 
 import { buildRetainedPartitionArchiveManifest } from './index-partition-archive-manifest-core.mjs';
+import {
+  publishDerivedJsonOutsideRetainedBundle,
+  renderDerivedJson,
+} from './index-partition-derived-output-core.mjs';
 import { inspectRetainedPartitionBundle } from './index-partition-review-core.mjs';
 
 const prefix = '[render-index-partition-archive-manifest]';
@@ -12,9 +16,10 @@ const usage = () => {
   node scripts/verify/render-index-partition-archive-manifest.mjs \
     --root <retained-bundle-directory> \
     [--packet <partition-packet.json>] \
-    [--admission <admission.json>]
+    [--admission <admission.json>] \
+    [--output <archive-manifest.json>]
 
-The command validates one admitted retained bundle and prints a deterministic archive manifest to stdout. It writes no files.`);
+The command validates one admitted retained bundle and prints a deterministic archive manifest to stdout by default. Stdout mode: It writes no files. With --output, it atomically creates one new regular file outside the retained bundle and refuses overwrite.`);
 };
 
 const parseArgs = (args) => {
@@ -23,8 +28,9 @@ const parseArgs = (args) => {
   for (let index = 0; index < args.length; index += 2) {
     const flag = args[index];
     const value = args[index + 1];
-    if (!['--root', '--packet', '--admission'].includes(flag) || !value || value.startsWith('--')) {
-      throw new Error('expected --root and optional --packet/--admission pairs');
+    if (!['--root', '--packet', '--admission', '--output'].includes(flag)
+        || !value || value.startsWith('--')) {
+      throw new Error('expected --root and optional --packet/--admission/--output pairs');
     }
     if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
     values.set(flag, value);
@@ -34,6 +40,7 @@ const parseArgs = (args) => {
     root: path.resolve(values.get('--root')),
     packetPath: values.has('--packet') ? path.resolve(values.get('--packet')) : undefined,
     admissionPath: values.has('--admission') ? path.resolve(values.get('--admission')) : undefined,
+    outputPath: values.has('--output') ? path.resolve(values.get('--output')) : undefined,
   };
 };
 
@@ -44,7 +51,16 @@ try {
   } else {
     const inspection = inspectRetainedPartitionBundle(options);
     const manifest = buildRetainedPartitionArchiveManifest(inspection);
-    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+    if (options.outputPath === undefined) {
+      process.stdout.write(renderDerivedJson(manifest));
+    } else {
+      publishDerivedJsonOutsideRetainedBundle({
+        root: options.root,
+        outputPath: options.outputPath,
+        value: manifest,
+        label: 'archive manifest output',
+      });
+    }
   }
 } catch (error) {
   console.error(`${prefix} ${error.message}`);

--- a/scripts/verify/verify-index-partition-archive-manifest.mjs
+++ b/scripts/verify/verify-index-partition-archive-manifest.mjs
@@ -2,8 +2,12 @@
 
 import path from 'node:path';
 
-import { inspectRetainedPartitionBundle } from './index-partition-review-core.mjs';
 import { verifySavedRetainedPartitionArchiveManifest } from './index-partition-archive-manifest-core.mjs';
+import {
+  publishDerivedJsonOutsideRetainedBundle,
+  renderDerivedJson,
+} from './index-partition-derived-output-core.mjs';
+import { inspectRetainedPartitionBundle } from './index-partition-review-core.mjs';
 
 const prefix = '[verify-index-partition-archive-manifest]';
 
@@ -13,9 +17,10 @@ const usage = () => {
     --root <retained-bundle-directory> \
     --manifest <saved-archive-manifest.json> \
     [--packet <partition-packet.json>] \
-    [--admission <admission.json>]
+    [--admission <admission.json>] \
+    [--output <verification-receipt.json>]
 
-The saved manifest must be a regular non-symlink file outside the retained bundle. The command writes no files.`);
+The saved manifest must be a regular non-symlink file outside the retained bundle. Stdout mode: The command writes no files. With --output, it atomically creates one new regular receipt outside the retained bundle and refuses overwrite.`);
 };
 
 const parseArgs = (args) => {
@@ -24,9 +29,9 @@ const parseArgs = (args) => {
   for (let index = 0; index < args.length; index += 2) {
     const flag = args[index];
     const value = args[index + 1];
-    if (!['--root', '--manifest', '--packet', '--admission'].includes(flag)
+    if (!['--root', '--manifest', '--packet', '--admission', '--output'].includes(flag)
         || !value || value.startsWith('--')) {
-      throw new Error('expected --root/--manifest and optional --packet/--admission pairs');
+      throw new Error('expected --root/--manifest and optional --packet/--admission/--output pairs');
     }
     if (values.has(flag)) throw new Error(`${flag} was provided more than once`);
     values.set(flag, value);
@@ -38,6 +43,7 @@ const parseArgs = (args) => {
     manifestPath: path.resolve(values.get('--manifest')),
     packetPath: values.has('--packet') ? path.resolve(values.get('--packet')) : undefined,
     admissionPath: values.has('--admission') ? path.resolve(values.get('--admission')) : undefined,
+    outputPath: values.has('--output') ? path.resolve(values.get('--output')) : undefined,
   };
 };
 
@@ -52,7 +58,16 @@ try {
       root: options.root,
       manifestPath: options.manifestPath,
     });
-    process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+    if (options.outputPath === undefined) {
+      process.stdout.write(renderDerivedJson(receipt));
+    } else {
+      publishDerivedJsonOutsideRetainedBundle({
+        root: options.root,
+        outputPath: options.outputPath,
+        value: receipt,
+        label: 'archive verification receipt output',
+      });
+    }
   }
 } catch (error) {
   console.error(`${prefix} ${error.message}`);

--- a/scripts/verify/verify-index-partition-derived-output.mjs
+++ b/scripts/verify/verify-index-partition-derived-output.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const prefix = '[verify-index-partition-derived-output]';
+const read = (filename) => readFileSync(filename, 'utf8');
+const requireMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (!source.includes(marker)) throw new Error(`${label} is missing ${marker}`);
+  }
+};
+
+try {
+  const core = read('scripts/verify/index-partition-derived-output-core.mjs');
+  const manifestCli = read('scripts/verify/render-index-partition-archive-manifest.mjs');
+  const verifyCli = read('scripts/verify/verify-index-partition-archive-manifest.mjs');
+  const fixture = read('scripts/verify/index-partition-derived-output.test.mjs');
+  const tooling = read('scripts/verify/index-storage-tooling.mjs');
+  const runbook = read('crates/rustok-index/docs/partition-full-capture.md');
+
+  requireMarkers(core, [
+    'randomUUID',
+    "openSync(temporaryPath, 'wx', 0o600)",
+    'writeFileSync(descriptor, bytes)',
+    'fsyncSync(descriptor)',
+    'linkSync(temporaryPath, resolvedOutputPath)',
+    'already exists; refusing to overwrite',
+    'ensureOutsideRoot(canonicalRoot, canonicalOutput, label)',
+    'removePublishedIdentity',
+    'removeTemporaryFile(temporaryPath)',
+  ], 'derived output core');
+  requireMarkers(manifestCli, [
+    "'--output'",
+    'outputPath:',
+    'publishDerivedJsonOutsideRetainedBundle',
+    'renderDerivedJson',
+    'options.outputPath === undefined',
+    "label: 'archive manifest output'",
+    'process.stdout.write',
+    'refuses overwrite',
+  ], 'archive manifest CLI');
+  requireMarkers(verifyCli, [
+    "'--output'",
+    'outputPath:',
+    'publishDerivedJsonOutsideRetainedBundle',
+    'renderDerivedJson',
+    'options.outputPath === undefined',
+    "label: 'archive verification receipt output'",
+    'process.stdout.write',
+    'refuses overwrite',
+  ], 'archive verification CLI');
+  requireMarkers(fixture, [
+    'atomically publishes deterministic derived JSON outside the retained bundle',
+    'refuses to overwrite an existing derived output',
+    'rejects derived output inside the retained bundle without creating a file',
+    'rejects an external symlink parent that resolves into the retained bundle',
+    'already exists; refusing to overwrite',
+    'must stay outside the retained bundle root',
+  ], 'derived output fixture');
+  requireMarkers(tooling, [
+    'verify-index-partition-derived-output.mjs',
+    'index-partition-derived-output.test.mjs',
+    'partition-archive-manifest',
+    'partition-archive-verify',
+    '[--output <archive-manifest.json>]',
+    '[--output <verification-receipt.json>]',
+  ], 'Index storage tooling router');
+  requireMarkers(runbook, [
+    '--output evidence/index-partition/retained-run.archive-manifest.json',
+    '--output evidence/index-partition/retained-run.archive-verification.json',
+    'no-clobber hard link',
+    'refuses to overwrite',
+    'shell can truncate an existing target',
+    'Without `--output`, stdout mode remains available',
+    'production_lifecycle_authorized: false',
+  ], 'full partition capture runbook');
+
+  console.log(`${prefix} contract satisfied`);
+} catch (error) {
+  console.error(`${prefix} ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- add an optional `--output` mode to retained archive-manifest and verification-receipt commands while preserving their existing deterministic stdout behavior;
- publish derived JSON through a private `wx` temporary file, `fsync`, and a no-clobber hard link so an existing target cannot be truncated or replaced;
- require output and its canonical parent to remain outside the immutable retained bundle and reject symlink parents;
- register focused static and fixture coverage and update the owner runbook to avoid unsafe shell redirection for retained archive metadata.

## Compatibility and safety boundary

- `index_partition_retained_archive_manifest_v1` is unchanged;
- `canonical_json_without_manifest_digest_v1` is unchanged;
- `index_partition_retained_archive_verification_v1` is unchanged;
- omitting `--output` prints the same pretty JSON plus trailing newline and writes no files;
- the nine retained authoritative files remain unchanged;
- admission thresholds, PostgreSQL access, capture stages, query execution, and production partition lifecycle are unchanged;
- successful receipts continue to contain `production_lifecycle_authorized: false`.

## Validation

Performed:

```bash
node --check scripts/verify/index-partition-derived-output-core.mjs
node --check scripts/verify/index-partition-derived-output.test.mjs
node --check scripts/verify/render-index-partition-archive-manifest.mjs
node --check scripts/verify/verify-index-partition-archive-manifest.mjs
node --check scripts/verify/index-storage-tooling.mjs
node --check scripts/verify/verify-index-partition-derived-output.mjs
node scripts/verify/verify-index-partition-derived-output.mjs
```

The focused static guard reported:

```text
[verify-index-partition-derived-output] contract satisfied
```

All seven published branch blobs match the locally prepared Git blob SHAs. The four replaced files were also reverse-checked against their exact original `main` blobs before publication. The two newer `main` commits modify only GitHub workflow files and do not overlap this slice.

Per owner instruction, test suites, fixture suites, aggregate contract execution, Rust/Cargo commands, builds, database connections, and PostgreSQL evidence were not run.

Suggested owner checks:

```bash
node --test scripts/verify/index-partition-derived-output.test.mjs
node scripts/verify/index-storage-tooling.mjs contract
node scripts/verify/index-storage-tooling.mjs fixtures
```