### PR TITLE
feat(profiles): observe DLQ duplicate alerts across delivery modes

### DIFF
--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -90,7 +90,7 @@ pub async fn start_event_dlq_duplicate_alert_observer(
     let runtime = ctx
         .shared_get::<Arc<EventRuntime>>()
         .ok_or_else(|| Error::Message("EventRuntime is unavailable".to_string()))?;
-    let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref());
+    let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref())?;
     if matches!(
         mode,
         EventDlqDuplicateAlertObserverMode::NotApplicableMemory
@@ -258,16 +258,20 @@ impl EventDlqDuplicateAlertObserverConfig {
 fn observer_mode(
     profile: EventDeliveryProfile,
     iggy_mode: Option<&IggyMode>,
-) -> EventDlqDuplicateAlertObserverMode {
+) -> Result<EventDlqDuplicateAlertObserverMode> {
     match profile {
-        EventDeliveryProfile::Memory => EventDlqDuplicateAlertObserverMode::NotApplicableMemory,
+        EventDeliveryProfile::Memory => {
+            Ok(EventDlqDuplicateAlertObserverMode::NotApplicableMemory)
+        }
         EventDeliveryProfile::OutboxLocal => {
-            EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal
+            Ok(EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal)
         }
         EventDeliveryProfile::OutboxIggy => match iggy_mode {
-            Some(IggyMode::Bundled) => EventDlqDuplicateAlertObserverMode::IggyBundled,
-            Some(IggyMode::External) => EventDlqDuplicateAlertObserverMode::IggyExternal,
-            None => EventDlqDuplicateAlertObserverMode::IggyExternal,
+            Some(IggyMode::Bundled) => Ok(EventDlqDuplicateAlertObserverMode::IggyBundled),
+            Some(IggyMode::External) => Ok(EventDlqDuplicateAlertObserverMode::IggyExternal),
+            None => Err(Error::Message(
+                "outbox_iggy runtime is missing its active Iggy mode".to_string(),
+            )),
         },
     }
 }
@@ -332,21 +336,22 @@ mod tests {
     #[test]
     fn every_event_delivery_profile_has_an_explicit_observer_mode() {
         assert_eq!(
-            observer_mode(EventDeliveryProfile::Memory, None),
+            observer_mode(EventDeliveryProfile::Memory, None).unwrap(),
             EventDlqDuplicateAlertObserverMode::NotApplicableMemory
         );
         assert_eq!(
-            observer_mode(EventDeliveryProfile::OutboxLocal, None),
+            observer_mode(EventDeliveryProfile::OutboxLocal, None).unwrap(),
             EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal
         );
         assert_eq!(
-            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::Bundled)),
+            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::Bundled)).unwrap(),
             EventDlqDuplicateAlertObserverMode::IggyBundled
         );
         assert_eq!(
-            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::External)),
+            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::External)).unwrap(),
             EventDlqDuplicateAlertObserverMode::IggyExternal
         );
+        assert!(observer_mode(EventDeliveryProfile::OutboxIggy, None).is_err());
     }
 
     #[test]

--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -73,20 +73,18 @@ struct EventDlqDuplicateAlertObserverConfig {
     policy: DlqDuplicateAlertPolicy,
 }
 
-pub async fn start_event_dlq_duplicate_alert_observer(
-    ctx: &ServerRuntimeContext,
-) -> Result<()> {
+pub async fn start_event_dlq_duplicate_alert_observer(ctx: &ServerRuntimeContext) {
     if !ctx.settings().runtime.runs_background_workers()
         || ctx.shared_contains::<EventDlqDuplicateAlertObserverHandle>()
     {
-        return Ok(());
+        return;
     }
 
     let enabled = match optional_bool_env(ENABLE_ENV, false) {
         Ok(enabled) => enabled,
         Err(_) => {
             record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
-            return Ok(());
+            return;
         }
     };
     if !enabled {
@@ -95,18 +93,18 @@ pub async fn start_event_dlq_duplicate_alert_observer(
             subscriber: None,
             handle: None,
         });
-        return Ok(());
+        return;
     }
 
     let Some(runtime) = ctx.shared_get::<Arc<EventRuntime>>() else {
         record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);
-        return Ok(());
+        return;
     };
     let mode = match observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref()) {
         Ok(mode) => mode,
         Err(_) => {
             record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
-            return Ok(());
+            return;
         }
     };
     if matches!(
@@ -123,19 +121,19 @@ pub async fn start_event_dlq_duplicate_alert_observer(
             subscriber: None,
             handle: None,
         });
-        return Ok(());
+        return;
     }
 
     let Some(transport) = ctx.shared_get::<Arc<IggyTransport>>() else {
         record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);
-        return Ok(());
+        return;
     };
     let iggy_config = transport.config().clone();
     let config = match EventDlqDuplicateAlertObserverConfig::from_env() {
         Ok(config) => config,
         Err(_) => {
             record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
-            return Ok(());
+            return;
         }
     };
 
@@ -164,7 +162,6 @@ pub async fn start_event_dlq_duplicate_alert_observer(
         mode = ?mode,
         "Starting mode-aware physical DLQ duplicate alert observer"
     );
-    Ok(())
 }
 
 fn record_startup_unavailable(ctx: &ServerRuntimeContext, error_code: &'static str) {

--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -177,25 +177,27 @@ async fn observer_loop(
             }
         }
 
-        if let Some(connected) = observer.as_ref() {
+        if let Some(connected) = observer.take() {
             match connected.summarize().await {
-                Ok(summary) => match publisher.publish(&summary) {
-                    Ok(snapshot) => record_snapshot(snapshot),
-                    Err(error) => {
-                        tracing::warn!(
-                            error_code = error.stable_code(),
-                            "Physical DLQ duplicate alert runtime stopped publishing"
-                        );
-                        return;
+                Ok(summary) => {
+                    match publisher.publish(&summary) {
+                        Ok(snapshot) => record_snapshot(snapshot),
+                        Err(error) => {
+                            tracing::warn!(
+                                error_code = error.stable_code(),
+                                "Physical DLQ duplicate alert runtime stopped publishing"
+                            );
+                            return;
+                        }
                     }
-                },
+                    observer = Some(connected);
+                }
                 Err(error) => {
                     let _ = publisher.mark_unavailable();
                     tracing::warn!(
                         error_code = error.stable_code(),
                         "Physical DLQ duplicate scan failed; reconnecting without affecting event delivery"
                     );
-                    observer = None;
                 }
             }
         }

--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -30,10 +30,15 @@ const DEFAULT_POLL_MS: u64 = 30_000;
 const MAX_POLL_MS: u64 = 300_000;
 const DEFAULT_MAX_MESSAGES: u32 = 1_000;
 const DEFAULT_BATCH_SIZE: u32 = 100;
+const STARTUP_CONFIGURATION_INVALID: &str =
+    "iggy.dlq_duplicate.alert_server_observer_configuration_invalid";
+const STARTUP_RUNTIME_UNAVAILABLE: &str =
+    "iggy.dlq_duplicate.alert_server_observer_runtime_unavailable";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventDlqDuplicateAlertObserverMode {
     Disabled,
+    Unavailable,
     NotApplicableMemory,
     NotApplicableOutboxLocal,
     IggyBundled,
@@ -77,7 +82,13 @@ pub async fn start_event_dlq_duplicate_alert_observer(
         return Ok(());
     }
 
-    let enabled = optional_bool_env(ENABLE_ENV, false)?;
+    let enabled = match optional_bool_env(ENABLE_ENV, false) {
+        Ok(enabled) => enabled,
+        Err(_) => {
+            record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
+            return Ok(());
+        }
+    };
     if !enabled {
         ctx.shared_insert(EventDlqDuplicateAlertObserverHandle {
             mode: EventDlqDuplicateAlertObserverMode::Disabled,
@@ -87,10 +98,17 @@ pub async fn start_event_dlq_duplicate_alert_observer(
         return Ok(());
     }
 
-    let runtime = ctx
-        .shared_get::<Arc<EventRuntime>>()
-        .ok_or_else(|| Error::Message("EventRuntime is unavailable".to_string()))?;
-    let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref())?;
+    let Some(runtime) = ctx.shared_get::<Arc<EventRuntime>>() else {
+        record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);
+        return Ok(());
+    };
+    let mode = match observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref()) {
+        Ok(mode) => mode,
+        Err(_) => {
+            record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
+            return Ok(());
+        }
+    };
     if matches!(
         mode,
         EventDlqDuplicateAlertObserverMode::NotApplicableMemory
@@ -108,13 +126,18 @@ pub async fn start_event_dlq_duplicate_alert_observer(
         return Ok(());
     }
 
-    let transport = ctx.shared_get::<Arc<IggyTransport>>().ok_or_else(|| {
-        Error::Message(
-            "outbox_iggy runtime did not publish its configured Iggy transport".to_string(),
-        )
-    })?;
+    let Some(transport) = ctx.shared_get::<Arc<IggyTransport>>() else {
+        record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);
+        return Ok(());
+    };
     let iggy_config = transport.config().clone();
-    let config = EventDlqDuplicateAlertObserverConfig::from_env()?;
+    let config = match EventDlqDuplicateAlertObserverConfig::from_env() {
+        Ok(config) => config,
+        Err(_) => {
+            record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
+            return Ok(());
+        }
+    };
 
     if !ctx.shared_contains::<StopHandle>() {
         let (stop_handle, _stop_rx) = StopHandle::new();
@@ -142,6 +165,18 @@ pub async fn start_event_dlq_duplicate_alert_observer(
         "Starting mode-aware physical DLQ duplicate alert observer"
     );
     Ok(())
+}
+
+fn record_startup_unavailable(ctx: &ServerRuntimeContext, error_code: &'static str) {
+    ctx.shared_insert(EventDlqDuplicateAlertObserverHandle {
+        mode: EventDlqDuplicateAlertObserverMode::Unavailable,
+        subscriber: None,
+        handle: None,
+    });
+    tracing::warn!(
+        error_code,
+        "Physical DLQ duplicate alert observer startup is unavailable; event delivery remains active"
+    );
 }
 
 async fn observer_loop(
@@ -354,6 +389,18 @@ mod tests {
             EventDlqDuplicateAlertObserverMode::IggyExternal
         );
         assert!(observer_mode(EventDeliveryProfile::OutboxIggy, None).is_err());
+    }
+
+    #[test]
+    fn startup_unavailable_state_has_no_task_or_snapshot() {
+        let handle = EventDlqDuplicateAlertObserverHandle {
+            mode: EventDlqDuplicateAlertObserverMode::Unavailable,
+            subscriber: None,
+            handle: None,
+        };
+        assert_eq!(handle.mode(), EventDlqDuplicateAlertObserverMode::Unavailable);
+        assert_eq!(handle.current_snapshot(), None);
+        assert!(!handle.is_finished());
     }
 
     #[test]

--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -1,0 +1,358 @@
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustok_iggy::{
+    DlqDuplicateAlertPolicy, DlqDuplicateAlertRuntimePublisher,
+    DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeSubscriber,
+    IggyDlqDuplicateAlertObserver, IggyMode, IggyTransport,
+};
+use tokio::task::JoinHandle;
+
+use crate::common::settings::EventDeliveryProfile;
+use crate::error::{Error, Result};
+use crate::services::app_lifecycle::StopHandle;
+use crate::services::event_transport_factory::EventRuntime;
+use crate::services::server_runtime_context::ServerRuntimeContext;
+
+const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";
+const POLL_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS";
+const START_OFFSET_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET";
+const MAX_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES";
+const BATCH_SIZE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE";
+const WARNING_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MESSAGES";
+const CRITICAL_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MESSAGES";
+const WARNING_GROUPS_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_GROUPS";
+const CRITICAL_GROUPS_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_GROUPS";
+const WARNING_MAX_COPIES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MAX_COPIES";
+const CRITICAL_MAX_COPIES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MAX_COPIES";
+const DEFAULT_POLL_MS: u64 = 30_000;
+const MAX_POLL_MS: u64 = 300_000;
+const DEFAULT_MAX_MESSAGES: u32 = 1_000;
+const DEFAULT_BATCH_SIZE: u32 = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventDlqDuplicateAlertObserverMode {
+    Disabled,
+    NotApplicableMemory,
+    NotApplicableOutboxLocal,
+    IggyBundled,
+    IggyExternal,
+}
+
+pub struct EventDlqDuplicateAlertObserverHandle {
+    mode: EventDlqDuplicateAlertObserverMode,
+    subscriber: Option<DlqDuplicateAlertRuntimeSubscriber>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl EventDlqDuplicateAlertObserverHandle {
+    pub const fn mode(&self) -> EventDlqDuplicateAlertObserverMode {
+        self.mode
+    }
+
+    pub fn current_snapshot(&self) -> Option<DlqDuplicateAlertRuntimeSnapshot> {
+        self.subscriber.as_ref().map(|subscriber| subscriber.current())
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.handle.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+}
+
+struct EventDlqDuplicateAlertObserverConfig {
+    poll: Duration,
+    start_offset: u64,
+    max_messages: u32,
+    batch_size: u32,
+    policy: DlqDuplicateAlertPolicy,
+}
+
+pub async fn start_event_dlq_duplicate_alert_observer(
+    ctx: &ServerRuntimeContext,
+) -> Result<()> {
+    if !ctx.settings().runtime.runs_background_workers()
+        || ctx.shared_contains::<EventDlqDuplicateAlertObserverHandle>()
+    {
+        return Ok(());
+    }
+
+    let enabled = optional_bool_env(ENABLE_ENV, false)?;
+    if !enabled {
+        ctx.shared_insert(EventDlqDuplicateAlertObserverHandle {
+            mode: EventDlqDuplicateAlertObserverMode::Disabled,
+            subscriber: None,
+            handle: None,
+        });
+        return Ok(());
+    }
+
+    let runtime = ctx
+        .shared_get::<Arc<EventRuntime>>()
+        .ok_or_else(|| Error::Message("EventRuntime is unavailable".to_string()))?;
+    let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref());
+    if matches!(
+        mode,
+        EventDlqDuplicateAlertObserverMode::NotApplicableMemory
+            | EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal
+    ) {
+        tracing::info!(
+            delivery_profile = runtime.delivery_profile.as_str(),
+            "Physical DLQ duplicate alert observer is not applicable to the active event delivery profile"
+        );
+        ctx.shared_insert(EventDlqDuplicateAlertObserverHandle {
+            mode,
+            subscriber: None,
+            handle: None,
+        });
+        return Ok(());
+    }
+
+    let transport = ctx.shared_get::<Arc<IggyTransport>>().ok_or_else(|| {
+        Error::Message(
+            "outbox_iggy runtime did not publish its configured Iggy transport".to_string(),
+        )
+    })?;
+    let iggy_config = transport.config().clone();
+    let config = EventDlqDuplicateAlertObserverConfig::from_env()?;
+
+    if !ctx.shared_contains::<StopHandle>() {
+        let (stop_handle, _stop_rx) = StopHandle::new();
+        ctx.shared_insert(stop_handle);
+    }
+    let stop_rx = ctx
+        .shared_get::<StopHandle>()
+        .expect("StopHandle must exist before DLQ duplicate observer startup")
+        .subscribe();
+
+    let (publisher, subscriber) = DlqDuplicateAlertRuntimePublisher::new(config.policy);
+    let handle = tokio::spawn(observer_loop(
+        iggy_config,
+        config,
+        publisher,
+        stop_rx,
+    ));
+    ctx.shared_insert(EventDlqDuplicateAlertObserverHandle {
+        mode,
+        subscriber: Some(subscriber),
+        handle: Some(handle),
+    });
+    tracing::info!(
+        mode = ?mode,
+        "Starting mode-aware physical DLQ duplicate alert observer"
+    );
+    Ok(())
+}
+
+async fn observer_loop(
+    iggy_config: rustok_iggy::IggyConfig,
+    config: EventDlqDuplicateAlertObserverConfig,
+    mut publisher: DlqDuplicateAlertRuntimePublisher,
+    mut stop_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    let mut observer = None;
+    loop {
+        if *stop_rx.borrow() {
+            let _ = publisher.mark_unavailable();
+            return;
+        }
+
+        if observer.is_none() {
+            match IggyDlqDuplicateAlertObserver::connect(
+                &iggy_config,
+                config.start_offset,
+                config.max_messages,
+                config.batch_size,
+            )
+            .await
+            {
+                Ok(connected) => observer = Some(connected),
+                Err(error) => {
+                    let _ = publisher.mark_unavailable();
+                    tracing::warn!(
+                        error_code = error.stable_code(),
+                        "Physical DLQ duplicate observer could not connect; event delivery remains active"
+                    );
+                }
+            }
+        }
+
+        if let Some(connected) = observer.as_ref() {
+            match connected.summarize().await {
+                Ok(summary) => match publisher.publish(&summary) {
+                    Ok(snapshot) => record_snapshot(snapshot),
+                    Err(error) => {
+                        tracing::warn!(
+                            error_code = error.stable_code(),
+                            "Physical DLQ duplicate alert runtime stopped publishing"
+                        );
+                        return;
+                    }
+                },
+                Err(error) => {
+                    let _ = publisher.mark_unavailable();
+                    tracing::warn!(
+                        error_code = error.stable_code(),
+                        "Physical DLQ duplicate scan failed; reconnecting without affecting event delivery"
+                    );
+                    observer = None;
+                }
+            }
+        }
+
+        if wait_or_stop(config.poll, &mut stop_rx).await {
+            let _ = publisher.mark_unavailable();
+            return;
+        }
+    }
+}
+
+fn record_snapshot(snapshot: DlqDuplicateAlertRuntimeSnapshot) {
+    let Some(evaluation) = snapshot.evaluation() else {
+        return;
+    };
+    tracing::debug!(
+        generation = snapshot.generation(),
+        level = evaluation.level().stable_code(),
+        physical_duplicates = evaluation.has_physical_duplicates(),
+        identity_conflict = evaluation.has_identity_conflict(),
+        duplicate_messages_threshold_reached = evaluation
+            .duplicate_messages_threshold_reached(),
+        duplicate_groups_threshold_reached = evaluation
+            .duplicate_groups_threshold_reached(),
+        max_copies_threshold_reached = evaluation.max_copies_threshold_reached(),
+        "Recorded identifier-free physical DLQ duplicate alert snapshot"
+    );
+}
+
+impl EventDlqDuplicateAlertObserverConfig {
+    fn from_env() -> Result<Self> {
+        let poll_ms = optional_u64_env(POLL_ENV, DEFAULT_POLL_MS)?;
+        if poll_ms == 0 || poll_ms > MAX_POLL_MS {
+            return Err(Error::Message(format!(
+                "{POLL_ENV} must be between 1 and {MAX_POLL_MS}"
+            )));
+        }
+        let max_messages = optional_u32_env(MAX_MESSAGES_ENV, DEFAULT_MAX_MESSAGES)?;
+        let batch_size = optional_u32_env(BATCH_SIZE_ENV, DEFAULT_BATCH_SIZE)?;
+        let policy = DlqDuplicateAlertPolicy::new(
+            required_u64_env(WARNING_MESSAGES_ENV)?,
+            required_u64_env(CRITICAL_MESSAGES_ENV)?,
+            required_u64_env(WARNING_GROUPS_ENV)?,
+            required_u64_env(CRITICAL_GROUPS_ENV)?,
+            required_u64_env(WARNING_MAX_COPIES_ENV)?,
+            required_u64_env(CRITICAL_MAX_COPIES_ENV)?,
+        )
+        .map_err(|error| Error::Message(error.stable_code().to_string()))?;
+
+        Ok(Self {
+            poll: Duration::from_millis(poll_ms),
+            start_offset: optional_u64_env(START_OFFSET_ENV, 0)?,
+            max_messages,
+            batch_size,
+            policy,
+        })
+    }
+}
+
+fn observer_mode(
+    profile: EventDeliveryProfile,
+    iggy_mode: Option<&IggyMode>,
+) -> EventDlqDuplicateAlertObserverMode {
+    match profile {
+        EventDeliveryProfile::Memory => EventDlqDuplicateAlertObserverMode::NotApplicableMemory,
+        EventDeliveryProfile::OutboxLocal => {
+            EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal
+        }
+        EventDeliveryProfile::OutboxIggy => match iggy_mode {
+            Some(IggyMode::Bundled) => EventDlqDuplicateAlertObserverMode::IggyBundled,
+            Some(IggyMode::External) => EventDlqDuplicateAlertObserverMode::IggyExternal,
+            None => EventDlqDuplicateAlertObserverMode::IggyExternal,
+        },
+    }
+}
+
+async fn wait_or_stop(
+    delay: Duration,
+    stop_rx: &mut tokio::sync::watch::Receiver<bool>,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => false,
+        changed = stop_rx.changed() => changed.is_err() || *stop_rx.borrow(),
+    }
+}
+
+fn optional_bool_env(name: &str, default: bool) -> Result<bool> {
+    match env::var(name) {
+        Ok(value) => parse_bool(name, &value).map_err(Error::Message),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Error::Message(format!("failed to read {name}: {error}"))),
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> std::result::Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!("{name} must be a boolean")),
+    }
+}
+
+fn optional_u64_env(name: &str, default: u64) -> Result<u64> {
+    match env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .map_err(|error| Error::Message(format!("{name} is invalid: {error}"))),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Error::Message(format!("failed to read {name}: {error}"))),
+    }
+}
+
+fn optional_u32_env(name: &str, default: u32) -> Result<u32> {
+    let value = optional_u64_env(name, u64::from(default))?;
+    u32::try_from(value).map_err(|_| Error::Message(format!("{name} exceeds u32")))
+}
+
+fn required_u64_env(name: &str) -> Result<u64> {
+    match env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .map_err(|error| Error::Message(format!("{name} is invalid: {error}"))),
+        Err(env::VarError::NotPresent) => {
+            Err(Error::Message(format!("{name} is required when {ENABLE_ENV}=true")))
+        }
+        Err(error) => Err(Error::Message(format!("failed to read {name}: {error}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_event_delivery_profile_has_an_explicit_observer_mode() {
+        assert_eq!(
+            observer_mode(EventDeliveryProfile::Memory, None),
+            EventDlqDuplicateAlertObserverMode::NotApplicableMemory
+        );
+        assert_eq!(
+            observer_mode(EventDeliveryProfile::OutboxLocal, None),
+            EventDlqDuplicateAlertObserverMode::NotApplicableOutboxLocal
+        );
+        assert_eq!(
+            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::Bundled)),
+            EventDlqDuplicateAlertObserverMode::IggyBundled
+        );
+        assert_eq!(
+            observer_mode(EventDeliveryProfile::OutboxIggy, Some(&IggyMode::External)),
+            EventDlqDuplicateAlertObserverMode::IggyExternal
+        );
+    }
+
+    #[test]
+    fn boolean_parser_is_bounded() {
+        assert_eq!(parse_bool("FLAG", "true"), Ok(true));
+        assert_eq!(parse_bool("FLAG", "off"), Ok(false));
+        assert!(parse_bool("FLAG", "sometimes").is_err());
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -26,6 +26,7 @@ pub mod email;
 pub mod event_bus;
 pub mod event_delivery_control_adapter;
 pub mod event_delivery_settings_service;
+pub mod event_dlq_duplicate_alert_observer;
 #[cfg(feature = "mod-forum")]
 pub mod forum_audience_facts {
     mod membership {

--- a/apps/server/src/services/server_bootstrap.rs
+++ b/apps/server/src/services/server_bootstrap.rs
@@ -131,7 +131,7 @@ pub async fn bootstrap_application_router(
     crate::services::event_dlq_duplicate_alert_observer::start_event_dlq_duplicate_alert_observer(
         &runtime_ctx,
     )
-    .await?;
+    .await;
 
     #[cfg(feature = "mod-notifications")]
     crate::services::notification_outbox_intake_worker::start_notification_outbox_intake_if_enabled(

--- a/apps/server/src/services/server_bootstrap.rs
+++ b/apps/server/src/services/server_bootstrap.rs
@@ -128,6 +128,11 @@ pub async fn bootstrap_application_router(
         bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;
     tracing::info!("RusTok app runtime bootstrap completed");
 
+    crate::services::event_dlq_duplicate_alert_observer::start_event_dlq_duplicate_alert_observer(
+        &runtime_ctx,
+    )
+    .await?;
+
     #[cfg(feature = "mod-notifications")]
     crate::services::notification_outbox_intake_worker::start_notification_outbox_intake_if_enabled(
         &runtime_ctx,

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "module": "iggy",
   "packet": "dlq-duplicate-alert-policy-source",
-  "status": "source_complete_runtime_composition_pending_server_integration",
+  "status": "source_complete_server_observer_execution_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
   "summary_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
@@ -103,7 +103,7 @@
     "change_broker_configuration": false
   },
   "runtime_composition": {
-    "status": "source_complete_server_integration_pending",
+    "status": "source_complete_server_observer_execution_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
     "input": "DlqDuplicateSummary",
@@ -120,7 +120,6 @@
     "identity_conflict_is_always_critical_and_manual"
   ],
   "remaining_work": [
-    "server_observer_integration",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "retained_policy_integration_evidence",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "module": "iggy",
   "packet": "dlq-duplicate-alert-runtime-source",
-  "status": "source_complete_server_integration_pending",
+  "status": "source_complete_server_observer_execution_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
   "policy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
@@ -100,6 +100,20 @@
     "change_broker_configuration": false,
     "change_profile_state": false
   },
+  "server_observer": {
+    "status": "source_complete_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
+    "iggy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+    "server_source": "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
+    "delivery_profiles": [
+      "memory_not_applicable",
+      "outbox_local_not_applicable",
+      "outbox_iggy_bundled",
+      "outbox_iggy_external"
+    ],
+    "readiness_dependency": false,
+    "profiles_authorization": false
+  },
   "required_source_tests": [
     "initial_snapshot_is_unavailable_without_evaluation",
     "publish_replaces_latest_identifier_free_evaluation",
@@ -108,7 +122,6 @@
     "closed_publisher_has_a_stable_identifier_free_error"
   ],
   "remaining_work": [
-    "server_observer_integration",
     "telemetry_and_health_projection",
     "retained_runtime_integration_evidence",
     "notification_delivery_and_suppression_outside_runtime",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -43,6 +43,10 @@
     "global_message_budget_may_stop_before_later_partitions": true,
     "partition_fairness_claimed": false,
     "explicit_start_offset": true,
+    "same_configured_start_offset_reused_each_poll": true,
+    "moving_cursor": false,
+    "current_tail_coverage_claimed": false,
+    "complete_history_claimed": false,
     "bounded_max_messages": true,
     "bounded_batch_size": true,
     "auto_commit": false,
@@ -127,6 +131,7 @@
   "execution_status": "source_not_run",
   "remaining_work": [
     "partition_fairness_or_per_partition_budget_policy",
+    "moving_window_or_per_partition_cursor_policy",
     "telemetry_projection_outside_observer",
     "health_projection_without_readiness_coupling",
     "notification_delivery_and_suppression",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -33,6 +33,8 @@
     "outbox_local_requires_iggy": false,
     "outbox_iggy_requires_shared_transport": true,
     "outbox_iggy_missing_active_mode_fails_closed": true,
+    "observer_startup_failure_is_non_fatal": true,
+    "startup_failure_mode": "unavailable",
     "non_iggy_profiles_are_errors": false
   },
   "scan": {
@@ -50,11 +52,16 @@
     "publisher": "DlqDuplicateAlertRuntimePublisher",
     "initial_snapshot_unavailable": true,
     "success_publishes_identifier_free_evaluation": true,
+    "startup_failure_records_unavailable_without_task": true,
     "connection_failure_marks_unavailable": true,
     "scan_failure_marks_unavailable": true,
     "shutdown_marks_unavailable": true,
     "reconnect_after_failure": true,
     "event_delivery_remains_active": true
+  },
+  "startup_stable_codes": {
+    "configuration_invalid": "iggy.dlq_duplicate.alert_server_observer_configuration_invalid",
+    "runtime_unavailable": "iggy.dlq_duplicate.alert_server_observer_runtime_unavailable"
   },
   "policy": {
     "all_six_thresholds_required_when_active": true,
@@ -86,6 +93,7 @@
     "starts_bundled_process": false,
     "stops_shared_transport": false,
     "creates_second_event_transport": false,
+    "server_bootstrap_dependency": false,
     "readiness_dependency": false,
     "liveness_dependency": false,
     "projection_dependency": false,
@@ -110,6 +118,7 @@
   ],
   "required_server_tests": [
     "every_event_delivery_profile_has_an_explicit_observer_mode",
+    "startup_unavailable_state_has_no_task_or_snapshot",
     "boolean_parser_is_bounded"
   ],
   "verifier": "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": 1,
+  "module": "event-delivery",
+  "packet": "dlq-duplicate-alert-server-observer-source",
+  "status": "source_complete_runtime_execution_pending",
+  "owners": [
+    "rustok-server",
+    "rustok-iggy"
+  ],
+  "iggy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+  "server_source": "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
+  "bootstrap_source": "apps/server/src/services/server_bootstrap.rs",
+  "service_registry_source": "apps/server/src/services/mod.rs",
+  "public_iggy_exports": [
+    "IggyDlqDuplicateAlertObserver",
+    "IggyDlqDuplicateAlertObserverError"
+  ],
+  "delivery_profiles": {
+    "memory": "not_applicable",
+    "outbox_local": "not_applicable",
+    "outbox_iggy": "iggy_observer"
+  },
+  "iggy_modes": {
+    "bundled": "connect_to_existing_loopback_broker",
+    "external": "connect_to_reviewed_external_addresses"
+  },
+  "activation": {
+    "default_enabled": false,
+    "enable_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED",
+    "background_workers_required": true,
+    "event_runtime_required": true,
+    "memory_requires_iggy": false,
+    "outbox_local_requires_iggy": false,
+    "outbox_iggy_requires_shared_transport": true,
+    "non_iggy_profiles_are_errors": false
+  },
+  "scan": {
+    "topic": "dlq",
+    "all_configured_domain_partitions": true,
+    "explicit_start_offset": true,
+    "bounded_max_messages": true,
+    "bounded_batch_size": true,
+    "auto_commit": false,
+    "stored_offset_polling": false
+  },
+  "runtime": {
+    "publisher": "DlqDuplicateAlertRuntimePublisher",
+    "initial_snapshot_unavailable": true,
+    "success_publishes_identifier_free_evaluation": true,
+    "connection_failure_marks_unavailable": true,
+    "scan_failure_marks_unavailable": true,
+    "shutdown_marks_unavailable": true,
+    "reconnect_after_failure": true,
+    "event_delivery_remains_active": true
+  },
+  "policy": {
+    "all_six_thresholds_required_when_active": true,
+    "production_threshold_defaults": false,
+    "notification_routing": false,
+    "cooldown_or_suppression": false
+  },
+  "privacy_boundary": {
+    "logs_and_snapshots_exclude": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "credential",
+      "raw_client_error",
+      "raw_threshold_values",
+      "source_counts"
+    ],
+    "stable_error_codes_only": true,
+    "serialization_added": false,
+    "persistence_added": false
+  },
+  "lifecycle_boundary": {
+    "starts_bundled_process": false,
+    "stops_shared_transport": false,
+    "creates_second_event_transport": false,
+    "readiness_dependency": false,
+    "liveness_dependency": false,
+    "projection_dependency": false,
+    "profiles_authorization": false
+  },
+  "mutation_boundary": {
+    "publish": false,
+    "acknowledge": false,
+    "store_offset": false,
+    "delete": false,
+    "purge": false,
+    "replay": false,
+    "retry": false,
+    "receipt_claim_or_mark": false,
+    "broker_configuration_change": false
+  },
+  "required_iggy_tests": [
+    "bundled_mode_requires_matching_loopback_address",
+    "all_configured_partitions_are_scanned_once",
+    "invalid_partition_count_fails_closed",
+    "stable_errors_expose_no_connection_details"
+  ],
+  "required_server_tests": [
+    "every_event_delivery_profile_has_an_explicit_observer_mode",
+    "boolean_parser_is_bounded"
+  ],
+  "verifier": "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md",
+  "execution_status": "source_not_run",
+  "remaining_work": [
+    "telemetry_projection_outside_observer",
+    "health_projection_without_readiness_coupling",
+    "notification_delivery_and_suppression",
+    "retained_server_observer_execution_evidence",
+    "authorized_destructive_reconciliation"
+  ]
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -37,7 +37,9 @@
   },
   "scan": {
     "topic": "dlq",
-    "all_configured_domain_partitions": true,
+    "configured_domain_partition_allowlist": true,
+    "global_message_budget_may_stop_before_later_partitions": true,
+    "partition_fairness_claimed": false,
     "explicit_start_offset": true,
     "bounded_max_messages": true,
     "bounded_batch_size": true,
@@ -102,7 +104,7 @@
   },
   "required_iggy_tests": [
     "bundled_mode_requires_matching_loopback_address",
-    "all_configured_partitions_are_scanned_once",
+    "all_configured_partitions_are_included_in_request",
     "invalid_partition_count_fails_closed",
     "stable_errors_expose_no_connection_details"
   ],
@@ -115,6 +117,7 @@
   "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md",
   "execution_status": "source_not_run",
   "remaining_work": [
+    "partition_fairness_or_per_partition_budget_policy",
     "telemetry_projection_outside_observer",
     "health_projection_without_readiness_coupling",
     "notification_delivery_and_suppression",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -32,6 +32,7 @@
     "memory_requires_iggy": false,
     "outbox_local_requires_iggy": false,
     "outbox_iggy_requires_shared_transport": true,
+    "outbox_iggy_missing_active_mode_fails_closed": true,
     "non_iggy_profiles_are_errors": false
   },
   "scan": {

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -119,11 +119,14 @@
       "bundled",
       "external"
     ],
+    "startup_failure_non_fatal": true,
+    "partition_fairness_claimed": false,
     "readiness_dependency": false,
     "profiles_authorization": false
   },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
+    "partition_fairness_or_per_partition_budget_policy",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -86,7 +86,7 @@
     "result": "DlqDuplicateSummary"
   },
   "alert_policy": {
-    "status": "source_complete_runtime_composition_pending_server_integration",
+    "status": "source_complete_server_observer_execution_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
     "input": "DlqDuplicateSummary",
@@ -97,7 +97,7 @@
     "destructive_action": false
   },
   "alert_runtime": {
-    "status": "source_complete_server_integration_pending",
+    "status": "source_complete_server_observer_execution_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
     "input": "DlqDuplicateSummary",
@@ -108,9 +108,22 @@
     "notification_dispatch": false,
     "destructive_action": false
   },
+  "server_observer": {
+    "status": "source_complete_runtime_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
+    "iggy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+    "server_source": "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
+    "memory": "not_applicable",
+    "outbox_local": "not_applicable",
+    "outbox_iggy_modes": [
+      "bundled",
+      "external"
+    ],
+    "readiness_dependency": false,
+    "profiles_authorization": false
+  },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
-    "server_alert_observer_integration",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-policy.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate alert policy
 
-Status: **policy and latest-value runtime composition source-complete; server integration and retained evidence pending**.
+Status: **policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution and retained evidence pending**.
 
 ## Purpose
 
@@ -37,16 +37,7 @@ warning_max_copies_per_message_id
 critical_max_copies_per_message_id
 ```
 
-No production default is provided. This prevents the library from silently deciding an operator's traffic, retention, or incident-response tolerance.
-
-Validation fails closed unless:
-
-- duplicate-message warning is at least `1`;
-- duplicate-message critical is not below warning;
-- duplicate-group warning is at least `1`;
-- duplicate-group critical is not below warning;
-- max-copies warning is at least `2`;
-- max-copies critical is not below warning.
+No production default is provided. Validation fails closed unless warning values are meaningful and each critical value is not below its warning value.
 
 Invalid configuration returns:
 
@@ -54,17 +45,16 @@ Invalid configuration returns:
 iggy.dlq_duplicate.alert_policy_invalid
 ```
 
-Equal warning and critical thresholds are valid. Critical evaluation has precedence, so equality intentionally produces `Critical` when that boundary is reached.
+Equal warning and critical thresholds are valid. Critical evaluation has precedence.
 
 ## Alert levels
 
-The ordered levels are:
-
 ```text
-Clear
-Notice
-Warning
-Critical
+Clear     no physical duplicate
+Notice    duplicates exist below warning thresholds
+Warning   at least one warning threshold reached
+Critical  at least one critical threshold reached
+          OR any identity conflict exists
 ```
 
 Stable codes:
@@ -76,25 +66,7 @@ iggy.dlq_duplicate.alert.warning
 iggy.dlq_duplicate.alert.critical
 ```
 
-### Clear
-
-No physical duplicate exists.
-
-### Notice
-
-Physical duplicates exist, but no warning threshold is reached.
-
-`Notice` preserves visibility for a non-zero duplicate condition without allowing the library to decide that the condition must page or notify anyone.
-
-### Warning
-
-At least one warning threshold is reached and no critical condition is present.
-
-### Critical
-
-At least one critical numeric threshold is reached, or the summary contains an identity conflict.
-
-Identity conflict always has precedence because one deterministic header UUID was observed with different exact payload bytes. It remains `Critical` even when every numeric threshold is much higher than the current counts.
+Identity conflict always has precedence because one deterministic header UUID was observed with different exact payload bytes.
 
 ## Evaluation projection
 
@@ -109,29 +81,9 @@ duplicate_groups_threshold_reached
 max_copies_threshold_reached
 ```
 
-The threshold booleans refer to the threshold band that selected the final level:
+The threshold booleans refer to the threshold band that selected the final level. `requires_manual_review()` is true only for identity conflict. A numeric `Critical` result alone does not authorize destructive handling.
 
-- for `Critical`, they show critical numeric dimensions reached;
-- for `Warning`, they show warning numeric dimensions reached;
-- for `Notice` and `Clear`, all threshold flags are false.
-
-`requires_manual_review()` is true only for identity conflict. A numeric `Critical` result alone does not authorize destructive handling.
-
-## Privacy boundary
-
-Input is already the count-only `DlqDuplicateSummary`. The evaluation does not expose:
-
-- broker address;
-- stream, topic, partition, or offset;
-- message UUID;
-- payload or payload digest;
-- receipt identity or state;
-- producer identity;
-- credentials;
-- timestamps;
-- raw threshold values.
-
-The policy adds no serialization implementation. A caller that serializes or exports the evaluation must preserve the same identifier-free boundary.
+The evaluation excludes broker addresses, stream coordinates, message UUIDs, payloads/digests, receipt identities, producer identity, credentials, timestamps, and raw threshold values.
 
 ## Policy boundary
 
@@ -146,17 +98,15 @@ This module does not choose or implement:
 - Profiles authorization;
 - acknowledgement, delete, purge, replay, or retry;
 - broker configuration changes;
-- poison receipt claim or state transitions.
-
-Those concerns require separate owner contracts and operational review.
+- poison receipt state transitions.
 
 ## Relationship to the scanner
 
-`IggyDlqDuplicateScanner` returns `DlqDuplicateSummary`. A caller may pass that summary to this policy, but the scanner does not own thresholds and the policy does not own the scanner.
+`IggyDlqDuplicateScanner` returns `DlqDuplicateSummary`. The scanner does not own thresholds and the policy does not own the scanner.
 
 ## Latest-value runtime composition
 
-`DlqDuplicateAlertRuntimePublisher` now provides the next transport-neutral composition boundary:
+`DlqDuplicateAlertRuntimePublisher` provides the transport-neutral composition boundary:
 
 ```text
 DlqDuplicateSummary
@@ -165,24 +115,38 @@ DlqDuplicateSummary
   -> read-only subscribers
 ```
 
-The runtime is defined in `dlq_duplicate_alert_runtime.rs` and documented in `dlq-duplicate-alert-runtime.md`.
-
 It is deliberately separate from the pure policy:
 
 - one single-writer publisher owns generation and the validated policy;
-- the initial snapshot is unavailable with no evaluation;
-- successful publication evaluates a summary and replaces the latest value;
+- initial state is unavailable with no evaluation;
+- successful publication replaces the latest value;
 - unavailable publication clears the prior evaluation;
 - subscribers can only read or await changes;
-- no server worker, metric, health check, notification route, or persistence is selected.
+- no broker, server lifecycle, metric, health check, notification route, or persistence is selected.
 
-The watch channel is latest-value state, not an event log. Slow subscribers are not promised every intermediate generation.
+## Mode-aware server observer
+
+The host now owns a separate integration that composes the scanner, policy, and runtime without assuming every event profile uses Iggy:
+
+```text
+memory        -> not applicable, no Iggy access
+outbox_local  -> not applicable, no Iggy access
+outbox_iggy   -> bundled or external read-only observer
+```
+
+For non-Iggy profiles, no broker client is opened and alert thresholds are not required. For `outbox_iggy`, all six thresholds remain explicit and the observer uses the exact active transport configuration.
+
+Bundled mode connects to the already-running loopback broker. External mode uses the reviewed address list. The observer never creates a second transport or process, and a missing active Iggy mode fails closed rather than being guessed.
+
+Connection or scan failure publishes unavailable state while event delivery and module projection remain active. Notification delivery, cooldown, suppression, telemetry, health projection, and destructive reconciliation remain separate owners.
+
+See `dlq-duplicate-alert-server-observer.md` for the complete mode and lifecycle contract.
 
 ## Relationship to Profiles
 
-No alert level, threshold flag, runtime availability, generation, duplicate count, identity-conflict signal, scan result, or retained evidence may authorize profile visibility, follower access, block/mute behavior, or presentation.
+No alert level, threshold flag, observer mode, runtime availability, generation, duplicate count, identity-conflict signal, scan result, or retained evidence may authorize profile visibility, follower access, block/mute behavior, or presentation.
 
-Profiles continues to consume authoritative owner-port results. This policy and runtime composition are operational observability only.
+Profiles continues to consume authoritative owner-port results. This path is operational observability only.
 
 ## Source verification
 
@@ -191,6 +155,7 @@ Machine contracts:
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 ```
 
 Static verifiers:
@@ -198,17 +163,15 @@ Static verifiers:
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-Focused policy tests define invalid configuration, clear/notice behavior, warning dimensions, critical numeric precedence, and conflict-critical manual escalation. Runtime tests define initial unavailability, latest-value publication, stale-evaluation clearing, independent subscribers, and bounded publisher closure.
-
-No tests, Cargo commands, formatters, source verifiers, external Iggy connections, server observers, telemetry registration, alert delivery, or retained capture were run while authoring these slices.
+No tests, Cargo commands, formatters, source verifiers, broker connections, server observers, telemetry registration, alert delivery, or retained capture were run while authoring these slices.
 
 ## Remaining work
 
-1. integrate an explicitly owned server observer;
-2. project the runtime snapshot into reviewed telemetry and health contracts;
-3. define alert delivery, cooldown, and suppression outside the policy/runtime;
-4. retain privacy-safe policy/runtime integration evidence;
-5. define destructive reconciliation as a separate authorized workflow;
-6. compare aggregate receipt and duplicate trends without exporting identifiers.
+1. project the runtime snapshot into reviewed telemetry and optional health without readiness coupling;
+2. define alert delivery, cooldown, and suppression outside the policy/runtime;
+3. retain privacy-safe policy/runtime/server execution evidence;
+4. define destructive reconciliation as a separate authorized workflow;
+5. compare aggregate receipt and duplicate trends without exporting identifiers.

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md
@@ -1,6 +1,6 @@
 # Count-only DLQ duplicate alert runtime
 
-Status: **latest-value runtime composition source-complete; server observer integration pending**.
+Status: **latest-value runtime and mode-aware server observer source-complete; runtime execution pending**.
 
 ## Purpose
 
@@ -13,7 +13,7 @@ DlqDuplicateAlertPolicy
 
 It evaluates an already-observed count-only summary and publishes one identifier-free latest-value snapshot for telemetry or health consumers.
 
-The runtime does not scan Iggy, read poison receipts, choose thresholds, dispatch notifications, or perform reconciliation.
+The reusable runtime does not scan Iggy, read poison receipts, choose thresholds, dispatch notifications, or perform reconciliation.
 
 ## Public API
 
@@ -117,7 +117,7 @@ max_copies_threshold_reached
 
 The snapshot does not expose source counts or threshold values. It also excludes broker endpoints, stream/topic/partition/offset, UUIDs, payloads or digests, receipt identities, error classifications, credentials, timestamps, publisher identity, and raw client errors.
 
-No serialization or persistence is added. A future telemetry or health adapter must preserve this projection.
+No serialization or persistence is added. A telemetry or health adapter must preserve this projection.
 
 ## Stable errors
 
@@ -130,7 +130,7 @@ Generation overflow fails before replacing the current snapshot. Publisher closu
 
 ## Runtime boundaries
 
-This module does not:
+This reusable module does not:
 
 - start a server worker;
 - choose scan cadence or partitions;
@@ -147,42 +147,63 @@ This module does not:
 
 Observation, policy evaluation, latest-value publication, telemetry projection, notification delivery, and destructive workflows remain separate owner boundaries.
 
-## Suggested server composition
+## Mode-aware server composition
 
-A future server-owned observer should:
+The server now owns a separate integration:
 
 ```text
-1. obtain a bounded DlqDuplicateSummary from an approved observer;
-2. call publisher.publish(summary) after successful observation;
-3. call publisher.mark_unavailable() after observation failure or shutdown;
-4. expose a subscriber only to count-free telemetry/health adapters;
-5. keep projection/readiness and Profiles authorization independent;
-6. leave paging, cooldown, suppression, and destructive actions outside this runtime.
+apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 ```
 
-The server integration must decide configuration ownership and lifecycle separately. This source slice intentionally provides no production defaults or environment variables.
+It handles every active delivery profile explicitly:
 
-## Source contract
+```text
+memory        -> not applicable, no Iggy access
+outbox_local  -> not applicable, no Iggy access
+outbox_iggy   -> bundled or external read-only Iggy observer
+```
+
+The observer is default-off. When active on `outbox_iggy`, it obtains bounded summaries from `IggyDlqDuplicateAlertObserver`, calls `publish` after successful scans, and calls `mark_unavailable` after connection failure, scan failure, or shutdown.
+
+For bundled Iggy it connects to the already-running loopback broker. For external Iggy it uses the reviewed configured address list. It never creates another `IggyTransport` or starts another bundled process.
+
+The server stores a read-only subscriber in `EventDlqDuplicateAlertObserverHandle`. Event delivery and module projection continue when observation is unavailable.
+
+Complete mode, environment, privacy, and lifecycle rules are documented in:
+
+```text
+crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+```
+
+## Source contracts
+
+Reusable runtime:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
 ```
 
-Static guard:
+Server observer:
+
+```text
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+```
+
+Static guards:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-Focused source tests cover initial unavailability, successful publication, stale-evaluation clearing, independent subscribers, and bounded publisher closure.
+Focused runtime tests cover initial unavailability, successful publication, stale-evaluation clearing, independent subscribers, and bounded publisher closure. Server and observer tests cover all delivery profiles, both Iggy modes, partition bounds, and identifier-free stable errors.
 
-No tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, or alert dispatch were run while defining this source slice.
+No tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, or alert dispatch were run while defining these source slices.
 
 ## Remaining work
 
-1. integrate one explicit server-owned observer lifecycle;
-2. project the identifier-free snapshot into reviewed telemetry and health contracts;
-3. retain runtime integration evidence;
-4. define notification delivery, cooldown, and suppression outside this module;
-5. define destructive reconciliation as a separately authorized workflow;
-6. correlate receipt and duplicate aggregate health without exporting identifiers.
+1. project the identifier-free snapshot into reviewed telemetry and optional operational health;
+2. retain runtime integration evidence for applicable Iggy modes;
+3. define notification delivery, cooldown, and suppression outside this module;
+4. define destructive reconciliation as a separately authorized workflow;
+5. correlate receipt and duplicate aggregate health without exporting identifiers.

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
@@ -12,6 +12,8 @@ The observer is global event-delivery infrastructure. It is not owned by Social 
 
 | Active profile | Observer mode | Iggy required |
 |---|---|---|
+| disabled | `Disabled` | no |
+| startup/config unavailable | `Unavailable` | no task |
 | `memory` | `NotApplicableMemory` | no |
 | `outbox_local` | `NotApplicableOutboxLocal` | no |
 | `outbox_iggy` + bundled | `IggyBundled` | yes |
@@ -19,9 +21,9 @@ The observer is global event-delivery infrastructure. It is not owned by Social 
 
 `Memory` and `OutboxLocal` are not failures. The server records an intentional not-applicable mode and exits before asking for `Arc<IggyTransport>`.
 
-Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`. A missing active Iggy mode is an internally inconsistent runtime and fails closed rather than defaulting to external.
+Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`. A missing active Iggy mode is internally inconsistent and fails closed rather than defaulting to external.
 
-## Activation
+## Activation and startup isolation
 
 The observer is default-off:
 
@@ -31,9 +33,18 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
 
 It also requires a runtime profile that runs background workers.
 
-When disabled, the server stores `Disabled` state and starts no task or broker client.
+When disabled, the server stores `Disabled` and starts no task or broker client. When enabled in a non-Iggy delivery profile, it stores the corresponding `NotApplicable` state and requires no thresholds.
 
-When enabled in a non-Iggy delivery profile, the server stores the corresponding `NotApplicable` state. Threshold variables are not required because no Iggy scan or policy evaluation can run.
+Observer-specific startup failures do **not** fail application bootstrap. Invalid enable/configuration values, a missing active Iggy mode, or a missing shared observer dependency produce `Unavailable` with no task or snapshot and return `Ok(())` to the bootstrap caller.
+
+Stable startup codes:
+
+```text
+iggy.dlq_duplicate.alert_server_observer_configuration_invalid
+iggy.dlq_duplicate.alert_server_observer_runtime_unavailable
+```
+
+Raw configuration values and raw dependency errors are not logged by this path. Event delivery and module projection continue.
 
 ## Iggy deployment modes
 
@@ -87,7 +98,7 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MAX_COPIES
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MAX_COPIES
 ```
 
-There are no production threshold defaults. Validation is delegated to `DlqDuplicateAlertPolicy` and fails closed.
+There are no production threshold defaults. Validation is delegated to `DlqDuplicateAlertPolicy` and fails closed into non-fatal `Unavailable` startup state.
 
 ## Runtime lifecycle
 
@@ -109,7 +120,7 @@ The observer does not:
 
 - create or stop an `IggyTransport`;
 - start or stop a bundled broker process;
-- change readiness or liveness;
+- become a server-bootstrap, readiness, or liveness dependency;
 - stop event delivery or module projection;
 - register notification routing, paging, cooldown, or suppression;
 - publish, acknowledge, commit offsets, delete, purge, replay, or retry broker messages;
@@ -130,5 +141,5 @@ Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connec
 2. project the shared snapshot into telemetry without exporting identifiers;
 3. expose optional operational health without readiness coupling;
 4. define alert routing, cooldown, and suppression separately;
-5. retain server-observer execution evidence for each applicable mode;
+5. retain server-observer execution evidence for each applicable mode and unavailable startup state;
 6. keep destructive reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
@@ -1,0 +1,151 @@
+# Mode-aware physical DLQ duplicate alert observer
+
+Status: **server and Iggy source complete; runtime execution pending**.
+
+## Purpose
+
+The server can now compose the bounded physical DLQ scanner, the explicit count-only alert policy, and the latest-value runtime without assuming every event-delivery profile uses Iggy.
+
+The observer is global event-delivery infrastructure. It is not owned by Social Graph, Profiles, or any one module because the physical `dlq` topic is transport-wide.
+
+## Delivery-profile matrix
+
+| Active profile | Observer mode | Iggy required |
+|---|---|---|
+| `memory` | `NotApplicableMemory` | no |
+| `outbox_local` | `NotApplicableOutboxLocal` | no |
+| `outbox_iggy` + bundled | `IggyBundled` | yes |
+| `outbox_iggy` + external | `IggyExternal` | yes |
+
+`Memory` and `OutboxLocal` are not failures. The server records an intentional not-applicable mode and never asks the runtime context for `Arc<IggyTransport>`.
+
+Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`.
+
+## Activation
+
+The observer is default-off:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
+```
+
+It also requires a runtime profile that runs background workers.
+
+When disabled, the server stores `Disabled` state and starts no task or broker client.
+
+When enabled in a non-Iggy delivery profile, the server stores the corresponding `NotApplicable` state. Threshold variables are not required because no Iggy scan or policy evaluation can run.
+
+## Iggy deployment modes
+
+### Bundled
+
+The observer does not start another broker process. It connects to the already-running loopback endpoint through the exact external credentials paired with the bundled connector.
+
+The configured external address must:
+
+- contain exactly one address;
+- be loopback (`127.0.0.1`, `localhost`, or `::1`);
+- use the configured bundled TCP port;
+- use plaintext TCP, matching the bundled connector contract.
+
+### External
+
+The observer tries the reviewed external addresses in configured order. Credentials and TLS options are used to construct SDK connection strings but are never retained in the alert runtime snapshot or logs.
+
+## Scan configuration
+
+Optional bounded scan controls:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS          default 30000, max 300000
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET     default 0
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES     default 1000
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE       default 100
+```
+
+The Iggy adapter scans every configured domain partition exactly once per request using:
+
+```text
+topic = dlq
+standalone consumer
+explicit start offset
+bounded global message count
+bounded batch size
+auto_commit = false
+```
+
+The scanner remains responsible for the hard limits: no more than 128 partitions, 10,000 messages, or 1,000 messages per batch.
+
+## Explicit alert thresholds
+
+When the observer is active on `OutboxIggy`, all six threshold variables are required:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MESSAGES
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MESSAGES
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_GROUPS
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_GROUPS
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MAX_COPIES
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MAX_COPIES
+```
+
+There are no production threshold defaults. Validation is delegated to `DlqDuplicateAlertPolicy` and fails closed.
+
+## Runtime lifecycle
+
+The server creates one `DlqDuplicateAlertRuntimePublisher` and exposes its read-only subscriber through `EventDlqDuplicateAlertObserverHandle`.
+
+On a successful scan:
+
+1. the count-only summary is evaluated;
+2. generation advances;
+3. an identifier-free available snapshot replaces the latest value.
+
+On connection failure, scan failure, or shutdown:
+
+1. generation advances;
+2. the snapshot becomes unavailable;
+3. the prior evaluation is cleared;
+4. event delivery and module projection continue.
+
+After a connection or scan failure, the observer retries after the configured poll interval.
+
+## Privacy boundary
+
+The shared snapshot and logs contain only:
+
+- generation;
+- availability;
+- alert level stable code;
+- aggregate boolean reasons.
+
+They exclude broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, receipt identities, credentials, raw client errors, raw threshold values, and source counts.
+
+## Lifecycle and mutation boundary
+
+The observer does not:
+
+- create or stop an `IggyTransport`;
+- start or stop a bundled broker process;
+- change readiness or liveness;
+- stop event delivery or module projection;
+- register notification routing, paging, cooldown, or suppression;
+- publish, acknowledge, commit offsets, delete, purge, replay, or retry broker messages;
+- claim or mark poison receipts;
+- alter Profiles authorization.
+
+## Source verification
+
+```bash
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+```
+
+Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connections, alert delivery, and retained capture were not run while authoring this slice.
+
+## Remaining work
+
+1. project the shared snapshot into telemetry without exporting identifiers;
+2. expose optional operational health without readiness coupling;
+3. define alert routing, cooldown, and suppression separately;
+4. retain server-observer execution evidence for each applicable mode;
+5. keep destructive reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
@@ -4,7 +4,7 @@ Status: **server and Iggy source complete; runtime execution pending**.
 
 ## Purpose
 
-The server can now compose the bounded physical DLQ scanner, the explicit count-only alert policy, and the latest-value runtime without assuming every event-delivery profile uses Iggy.
+The server composes the bounded physical DLQ scanner, explicit count-only alert policy, and latest-value runtime without assuming every event-delivery profile uses Iggy.
 
 The observer is global event-delivery infrastructure. It is not owned by Social Graph, Profiles, or any one module because the physical `dlq` topic is transport-wide.
 
@@ -17,9 +17,9 @@ The observer is global event-delivery infrastructure. It is not owned by Social 
 | `outbox_iggy` + bundled | `IggyBundled` | yes |
 | `outbox_iggy` + external | `IggyExternal` | yes |
 
-`Memory` and `OutboxLocal` are not failures. The server records an intentional not-applicable mode and never asks the runtime context for `Arc<IggyTransport>`.
+`Memory` and `OutboxLocal` are not failures. The server records an intentional not-applicable mode and exits before asking for `Arc<IggyTransport>`.
 
-Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`.
+Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`. A missing active Iggy mode is an internally inconsistent runtime and fails closed rather than defaulting to external.
 
 ## Activation
 
@@ -39,22 +39,17 @@ When enabled in a non-Iggy delivery profile, the server stores the corresponding
 
 ### Bundled
 
-The observer does not start another broker process. It connects to the already-running loopback endpoint through the exact external credentials paired with the bundled connector.
+The observer does not start another broker process. It connects to the already-running loopback endpoint through the credentials paired with the bundled connector.
 
-The configured external address must:
-
-- contain exactly one address;
-- be loopback (`127.0.0.1`, `localhost`, or `::1`);
-- use the configured bundled TCP port;
-- use plaintext TCP, matching the bundled connector contract.
+The configured address must be one loopback address using the configured bundled TCP port and plaintext TCP, matching the bundled connector contract.
 
 ### External
 
-The observer tries the reviewed external addresses in configured order. Credentials and TLS options are used to construct SDK connection strings but are never retained in the alert runtime snapshot or logs.
+The observer tries the reviewed external addresses in configured order. Credentials and TLS options are used to construct SDK connection strings but are never retained in the runtime snapshot or logs.
 
 ## Scan configuration
 
-Optional bounded scan controls:
+Optional bounded controls:
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS          default 30000, max 300000
@@ -63,18 +58,21 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES     default 1000
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE       default 100
 ```
 
-The Iggy adapter scans every configured domain partition exactly once per request using:
+The Iggy adapter builds a one-based allowlist containing every configured domain partition and passes it to the existing scanner:
 
 ```text
 topic = dlq
 standalone consumer
 explicit start offset
-bounded global message count
+configured partition allowlist
+one bounded global message count
 bounded batch size
 auto_commit = false
 ```
 
-The scanner remains responsible for the hard limits: no more than 128 partitions, 10,000 messages, or 1,000 messages per batch.
+The global message budget applies across the ordered partition allowlist. A busy earlier partition may exhaust the budget before later partitions are polled. This source slice therefore makes no partition-fairness or complete-history claim.
+
+The scanner remains responsible for the hard limits: no more than 128 partition identifiers, 10,000 messages globally, or 1,000 messages per batch.
 
 ## Explicit alert thresholds
 
@@ -95,31 +93,15 @@ There are no production threshold defaults. Validation is delegated to `DlqDupli
 
 The server creates one `DlqDuplicateAlertRuntimePublisher` and exposes its read-only subscriber through `EventDlqDuplicateAlertObserverHandle`.
 
-On a successful scan:
+A successful scan publishes an identifier-free available snapshot. Connection failure, scan failure, or shutdown advances generation, marks the snapshot unavailable, and clears the prior evaluation. Event delivery and module projection continue.
 
-1. the count-only summary is evaluated;
-2. generation advances;
-3. an identifier-free available snapshot replaces the latest value.
-
-On connection failure, scan failure, or shutdown:
-
-1. generation advances;
-2. the snapshot becomes unavailable;
-3. the prior evaluation is cleared;
-4. event delivery and module projection continue.
-
-After a connection or scan failure, the observer retries after the configured poll interval.
+After connection or scan failure, the observer retries after the configured poll interval.
 
 ## Privacy boundary
 
-The shared snapshot and logs contain only:
+The shared snapshot and logs contain only generation, availability, alert-level stable code, and aggregate boolean reasons.
 
-- generation;
-- availability;
-- alert level stable code;
-- aggregate boolean reasons.
-
-They exclude broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, receipt identities, credentials, raw client errors, raw threshold values, and source counts.
+They exclude broker addresses, stream/topic/partition/offset, UUIDs, payloads/digests, receipt identities, credentials, raw client errors, raw thresholds, and source counts.
 
 ## Lifecycle and mutation boundary
 
@@ -144,8 +126,9 @@ Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connec
 
 ## Remaining work
 
-1. project the shared snapshot into telemetry without exporting identifiers;
-2. expose optional operational health without readiness coupling;
-3. define alert routing, cooldown, and suppression separately;
-4. retain server-observer execution evidence for each applicable mode;
-5. keep destructive reconciliation in a separately authorized workflow.
+1. define partition fairness or an explicit per-partition budget policy;
+2. project the shared snapshot into telemetry without exporting identifiers;
+3. expose optional operational health without readiness coupling;
+4. define alert routing, cooldown, and suppression separately;
+5. retain server-observer execution evidence for each applicable mode;
+6. keep destructive reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -76,7 +76,9 @@ PollingStrategy::offset(explicit_offset)
 auto_commit = false
 ```
 
-One request permits at most 128 partitions, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
+One request permits at most 128 partition identifiers, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
+
+The global message budget is shared across the ordered partition allowlist. It may be exhausted before later partitions are polled, so the scanner and observer make no partition-fairness claim.
 
 ## Count-only alert policy
 
@@ -102,9 +104,11 @@ The runtime is a latest-value channel, not an event log. It adds no serializatio
 
 ## Mode-aware server observer
 
-The host now owns an explicit capability gate across all event-delivery profiles:
+The host owns an explicit capability gate across every delivery/startup mode:
 
 ```text
+disabled      -> Disabled
+startup issue -> Unavailable, no task or snapshot
 memory        -> NotApplicableMemory
 outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
@@ -121,24 +125,28 @@ For `outbox_iggy`, the observer reuses the exact active transport configuration 
 - connection/scan failure publishes unavailable state and retries later;
 - event delivery and module projection remain active.
 
-The observer supports all configured domain partitions and delegates every scan to the bounded `auto_commit=false` scanner.
+Observer-specific startup failures are non-fatal. Invalid observer configuration or a missing observer dependency records `Unavailable`, logs only a stable code, and returns success to server bootstrap.
+
+The observer includes every configured domain partition in the scanner request, but the single global budget may prevent later partitions from being polled.
+
+Each poll reuses the same configured explicit start offset. This is a repeated bounded window, not a moving cursor, current-tail monitor, or complete-history observer. Moving-window and per-partition cursor/fairness behavior remain separate design work.
 
 ## Safe operational sequence
 
 1. resolve the active event delivery profile;
 2. return not-applicable before Iggy access for `memory` or `outbox_local`;
 3. for `outbox_iggy`, use the already-active bundled or external configuration;
-4. scan bounded explicit offsets with `auto_commit=false`;
+4. scan one bounded explicit-offset window with `auto_commit=false`;
 5. evaluate through explicit thresholds;
 6. publish only the identifier-free latest snapshot;
-7. mark unavailable after failures or shutdown;
-8. keep telemetry, health, notification delivery, and destructive actions in separate owners.
+7. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
+8. keep cursor/fairness policy, telemetry, health, notification delivery, and destructive actions in separate owners.
 
 ## Runtime and retained evidence status
 
 The opt-in external harness and privacy-safe retained tooling are source-complete. The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
 
-The mode-aware server observer is source-complete. Runtime execution, identifier-free telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
+The mode-aware server observer is source-complete. Runtime execution, moving-window/fairness semantics, identifier-free telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
 
 ## Source verification
 
@@ -157,8 +165,9 @@ No tests, Cargo commands, formatters, verifiers, broker scans, server observers,
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. define identifier-free telemetry and optional operational health;
-3. retain mode-aware server observer execution evidence;
-4. define alert routing, cooldown, and suppression separately;
-5. design acknowledgement/delete/replay as a separately authorized operation;
-6. correlate aggregate receipt and duplicate health without exporting message identities.
+2. define partition fairness/per-partition budgets and a moving-window or per-partition cursor policy;
+3. define identifier-free telemetry and optional operational health;
+4. retain mode-aware server observer execution evidence;
+5. define alert routing, cooldown, and suppression separately;
+6. design acknowledgement/delete/replay as a separately authorized operation;
+7. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,30 +1,27 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier, bounded external-Iggy adapter, runtime harness, retained tooling, alert policy, and latest-value alert runtime source-complete; runtime execution and server integration pending**.
+Status: **classifier, bounded scanner, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution and telemetry/health projection pending**.
 
 ## Purpose
 
-The neutral poison receipt store answers whether a source delivery is reserved, publishing, published, or acknowledged. It does not answer how many physical copies currently exist in the Iggy `dlq` topic.
+The neutral poison receipt store answers whether a source delivery is reserved, publishing, published, or acknowledged. It does not answer how many physical copies currently exist in the physical `dlq` topic.
 
-Physical copies can exceed one when:
+Physical copies can exceed one when broker-side deterministic message-ID deduplication is disabled, expired, evicted, or not preserved by an unsupported path.
 
-- server-side message-ID deduplication is disabled;
-- the deterministic ID expired from the dedup window;
-- capacity pressure evicted the ID;
-- a failover or unsupported broker path did not preserve the expected dedup state.
-
-`dlq_duplicate_inspection.rs` provides a transport-neutral, read-only reduction for bounded physical observations. `dlq_duplicate_external_scan.rs` provides the bounded external-Iggy adapter. `dlq_duplicate_alert_policy.rs` evaluates the count-only summary against explicit thresholds. `dlq_duplicate_alert_runtime.rs` publishes the latest identifier-free evaluation state for read-only consumers.
-
-## Input boundary
-
-Each observation accepts:
+The implementation is deliberately split:
 
 ```text
-non-nil deterministic Iggy message header UUID
-exact physical payload bytes
+physical observations
+  -> DlqDuplicateSummary
+  -> explicit alert policy
+  -> latest-value runtime
+  -> mode-aware server observer
+  -> future telemetry/health or notification owners
 ```
 
-The exact bytes are immediately reduced to a domain-separated SHA-256 value in memory. The observation exposes neither the bytes nor their digest. Empty payloads are valid because empty raw poison bytes are already valid at the receipt boundary.
+## Input and identity boundary
+
+Each observation accepts a non-nil deterministic Iggy header UUID and exact physical payload bytes. Bytes are immediately reduced to a domain-separated SHA-256 value in memory and are never exposed by the observation or summary.
 
 A nil UUID fails closed with:
 
@@ -45,95 +42,31 @@ conflicting_payload_groups
 max_copies_per_message_id
 ```
 
-Where:
-
 ```text
 duplicate_messages = total_messages - unique_message_ids
 ```
 
-A duplicate group has more than one physical observation for the same deterministic message ID.
+An ordinary duplicate has the same deterministic ID and same exact bytes. Reuse of one ID with different exact bytes is an identity conflict and requires manual review.
 
-## Ordinary duplicate versus identity conflict
-
-### Ordinary physical duplicate
-
-```text
-same non-nil message header UUID
-same exact payload digest
-```
-
-This is the expected shape of a publish/mark ambiguity retry when the broker accepts the same deterministic ID more than once.
-
-### Identity conflict
-
-```text
-same non-nil message header UUID
-different exact payload digests
-```
-
-This must not be silently collapsed into an ordinary duplicate. It indicates header corruption, an invalid producer, unsupported reuse of the deterministic ID, or an extraordinary hash/identity failure.
-
-The summary increments `conflicting_payload_groups` and `requires_manual_review()` returns `true`.
-
-## Privacy boundary
-
-The summary does not expose:
-
-- broker address;
-- stream, topic, partition, or offset;
-- deterministic message UUID;
-- payload or payload digest;
-- receipt identity or state;
-- error classification;
-- publisher identity;
-- timestamps;
-- credentials.
-
-The classifier does not implement serialization. Any operator endpoint must preserve the same count-only projection unless a separately authorized forensic workflow is explicitly designed.
+The summary excludes broker coordinates, UUIDs, payloads/digests, receipt identities, error classification, publisher identity, timestamps, and credentials.
 
 ## Mutation boundary
 
-The classifier and external scanner cannot:
+The classifier and scanner cannot acknowledge, store offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
 
-- acknowledge a DLQ cursor;
-- store or auto-commit a consumer offset;
-- delete or purge physical messages;
-- replay or retry a message;
-- publish a message;
-- repair broker state;
-- claim or release a poison receipt;
-- mark a receipt published or acknowledged;
-- choose alert thresholds or operator policy.
+The alert policy cannot scan, route notifications, persist thresholds, or mutate state. The latest-value runtime cannot start workers, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
 
-The separate alert policy accepts explicit caller thresholds but cannot scan, send notifications, choose routing/cooldown, persist policy, or mutate state. The alert runtime only replaces one in-memory latest-value snapshot and cannot start a worker, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
+## Production identity relationship
 
-This separation is deliberate. Observation, evaluation, runtime publication, delivery, and reconciliation must remain distinct.
-
-## Relationship to deterministic raw poison identity
-
-`ConsumedContractDecodeFailure::delivery_id` derives one UUID from immutable source stream/topic/partition/offset and exact raw bytes. Failure kind, retry count, process identity, time, and random values are excluded.
+`ConsumedContractDecodeFailure::delivery_id` derives one UUID from immutable source coordinates and exact raw bytes. Failure kind, retry count, process identity, time, and random values are excluded.
 
 `to_dlq_entry` attaches that UUID as the Iggy broker message ID. `IggyTransport::move_to_dlq` uses the deterministic publisher path when this ID is present.
 
-The duplicate classifier therefore groups physical Iggy messages by the same identity used for server-side deduplication.
+`ConsumerPoisonReceiptInspector` remains an independent count-only PostgreSQL view. Receipt and physical duplicate summaries contain no identifiers and cannot be joined message by message.
 
-## Relationship to receipt health
+## Bounded Iggy scanner
 
-`ConsumerPoisonReceiptInspector` remains an independent count-only view of PostgreSQL receipt progress:
-
-```text
-reserved
-publishing
-expired_publishing
-published
-acknowledged
-```
-
-Neither summary contains identifiers, so they cannot be joined message by message. Operators may compare aggregate trends, but those interpretations are not storage or Profiles authorization decisions.
-
-## Bounded external-Iggy adapter
-
-`IggyDlqDuplicateScanner` borrows an already connected `IggyClient` and polls only:
+`IggyDlqDuplicateScanner` polls only:
 
 ```text
 topic = dlq
@@ -145,13 +78,9 @@ auto_commit = false
 
 One request permits at most 128 partitions, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
 
-The adapter does not own credentials or connection lifecycle, query topology metadata, join a consumer group, persist progress, or call shutdown.
-
 ## Count-only alert policy
 
 `DlqDuplicateAlertPolicy` requires explicit warning and critical thresholds for duplicate messages, duplicate groups, and maximum copies for one message ID. It defines no production defaults.
-
-Evaluation order is:
 
 ```text
 identity conflict -> Critical
@@ -161,54 +90,57 @@ physical duplicate below warning -> Notice
 no duplicate -> Clear
 ```
 
-The evaluation exposes only level and boolean reason flags. It does not expose source counts, raw threshold values, identifiers, or broker coordinates.
+The evaluation exposes only level and boolean reason flags.
 
 ## Latest-value alert runtime
 
-`DlqDuplicateAlertRuntimePublisher` accepts an already-observed `DlqDuplicateSummary` and a prevalidated policy.
+`DlqDuplicateAlertRuntimePublisher` accepts an already-observed summary and a prevalidated policy.
+
+Initial state is generation `0`, unavailable, with no evaluation. Successful and unavailable transitions advance generation through checked arithmetic. `mark_unavailable()` clears the previous evaluation so stale severity is not shown as current.
+
+The runtime is a latest-value channel, not an event log. It adds no serialization or persistence.
+
+## Mode-aware server observer
+
+The host now owns an explicit capability gate across all event-delivery profiles:
 
 ```text
-summary -> policy evaluate -> latest runtime snapshot -> read-only subscribers
+memory        -> NotApplicableMemory
+outbox_local  -> NotApplicableOutboxLocal
+outbox_iggy   -> IggyBundled or IggyExternal
 ```
 
-The publisher is single-writer. The initial snapshot is unavailable at generation `0` with no evaluation. Every successful or unavailable transition increments generation through checked arithmetic.
+For `memory` and `outbox_local`, no Iggy transport is requested, no broker connection is opened, and thresholds are not required. Not-applicable state is valid operation rather than a degraded condition.
 
-`mark_unavailable()` clears the previous evaluation, preventing a stale `Warning` or `Critical` value from appearing current after observer failure or shutdown.
+For `outbox_iggy`, the observer reuses the exact active transport configuration and opens a separate read-only SDK client:
 
-The snapshot exposes only:
+- bundled mode connects to the existing validated loopback broker;
+- external mode uses the reviewed address list;
+- missing active Iggy mode fails closed;
+- no second transport or broker process is created;
+- connection/scan failure publishes unavailable state and retries later;
+- event delivery and module projection remain active.
 
-```text
-generation
-available
-evaluation
-```
-
-The runtime is a latest-value channel, not an event log. It does not promise delivery of every intermediate generation and adds no serialization or persistence.
+The observer supports all configured domain partitions and delegates every scan to the bounded `auto_commit=false` scanner.
 
 ## Safe operational sequence
 
-1. select an external service, stream, explicit partition allowlist, offset, and message cap;
-2. connect and authenticate an `IggyClient` outside the scanner;
-3. call the bounded scanner with explicit-offset polling and `auto_commit=false`;
-4. pass the count-only summary to an explicitly configured alert policy;
-5. publish the evaluation through the single-writer runtime;
-6. expose only read-only runtime subscribers to separately reviewed telemetry/health adapters;
-7. close the client through the caller-owned lifecycle;
-8. treat the result as a bounded window, not automatically as complete history.
-
-Notification delivery, cooldown/suppression, and destructive actions require separate owner contracts.
+1. resolve the active event delivery profile;
+2. return not-applicable before Iggy access for `memory` or `outbox_local`;
+3. for `outbox_iggy`, use the already-active bundled or external configuration;
+4. scan bounded explicit offsets with `auto_commit=false`;
+5. evaluate through explicit thresholds;
+6. publish only the identifier-free latest snapshot;
+7. mark unavailable after failures or shutdown;
+8. keep telemetry, health, notification delivery, and destructive actions in separate owners.
 
 ## Runtime and retained evidence status
 
-The opt-in external harness is source-complete. It uses production `move_to_dlq` to create ordinary duplicate and identity-conflict fixtures, scans the same explicit offset twice, and requires the scanner's standalone consumer offset to remain absent before and after both scans.
+The opt-in external harness and privacy-safe retained tooling are source-complete. The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
 
-The clean-commit retained contract, runner, verifier, reviewed dedup-disabled configuration boundary, source hashes, exact-case execution, and privacy-safe packet projection are also source-complete.
+The mode-aware server observer is source-complete. Runtime execution, identifier-free telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
 
-The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully. Server observer and telemetry/health integration for the alert runtime remain pending.
-
-## Source tests and guards
-
-Suggested maintainer commands:
+## Source verification
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -217,16 +149,16 @@ node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
-cargo test -p rustok-iggy dlq_duplicate -- --nocapture
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-No tests, Cargo commands, formatters, verifiers, external-Iggy scans, server observers, telemetry registration, alert dispatch, or retained capture were run while defining these source slices.
+No tests, Cargo commands, formatters, verifiers, broker scans, server observers, telemetry registration, alert dispatch, or retained capture were run while defining these source slices.
 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. integrate an explicitly owned server alert observer;
-3. define identifier-free telemetry and health projection;
-4. define alert routing, cooldown, and suppression outside the classifier/policy/runtime;
-5. design acknowledgement/delete/replay as a separate authorized operation;
+2. define identifier-free telemetry and optional operational health;
+3. retain mode-aware server observer execution evidence;
+4. define alert routing, cooldown, and suppression separately;
+5. design acknowledgement/delete/replay as a separately authorized operation;
 6. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn all_configured_partitions_are_scanned_once() {
+    fn all_configured_partitions_are_included_in_request() {
         let mut config = IggyConfig::default();
         config.topology.domain_partitions = 3;
         assert_eq!(configured_partitions(&config).unwrap(), vec![1, 2, 3]);

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
@@ -1,0 +1,254 @@
+use iggy::prelude::{Client, IggyClient};
+use thiserror::Error;
+
+use crate::config::{ExternalConfig, IggyConfig, IggyMode};
+use crate::dlq_duplicate_external_scan::{
+    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest, IggyDlqDuplicateScanner,
+};
+use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
+
+/// Connected read-only source for bounded physical DLQ duplicate summaries.
+///
+/// This adapter connects to an already-running Iggy deployment. It never starts
+/// or stops a bundled broker, mutates offsets, publishes, acknowledges, deletes,
+/// purges, replays, or changes broker configuration.
+pub struct IggyDlqDuplicateAlertObserver {
+    client: IggyClient,
+    stream_name: String,
+    request: IggyDlqDuplicateScanRequest,
+}
+
+impl IggyDlqDuplicateAlertObserver {
+    pub async fn connect(
+        config: &IggyConfig,
+        start_offset: u64,
+        max_messages: u32,
+        batch_size: u32,
+    ) -> Result<Self, IggyDlqDuplicateAlertObserverError> {
+        let partitions = configured_partitions(config)?;
+        let request = IggyDlqDuplicateScanRequest::new(
+            partitions,
+            start_offset,
+            max_messages,
+            batch_size,
+        )
+        .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        let external = read_only_connection_config(config)?;
+        let connection_strings = connection_strings(&external)?;
+        let mut connected = None;
+
+        for connection_string in connection_strings {
+            let client = IggyClient::from_connection_string(&connection_string)
+                .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+            if client.connect().await.is_ok() {
+                connected = Some(client);
+                break;
+            }
+        }
+
+        let client = connected.ok_or(IggyDlqDuplicateAlertObserverError::ConnectionUnavailable)?;
+        let stream_name = config.topology.stream_name.clone();
+        IggyDlqDuplicateScanner::new(&client, &stream_name)
+            .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+
+        Ok(Self {
+            client,
+            stream_name,
+            request,
+        })
+    }
+
+    pub async fn summarize(
+        &self,
+    ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateAlertObserverError> {
+        IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?
+            .summarize(&self.request)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl std::fmt::Debug for IggyDlqDuplicateAlertObserver {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IggyDlqDuplicateAlertObserver")
+            .field("partition_count", &self.request.partitions().len())
+            .field("start_offset", &self.request.start_offset())
+            .field("max_messages", &self.request.max_messages())
+            .field("batch_size", &self.request.batch_size())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDlqDuplicateAlertObserverError {
+    #[error("physical DLQ duplicate observer configuration is invalid")]
+    InvalidConfiguration,
+    #[error("physical DLQ duplicate observer connection is unavailable")]
+    ConnectionUnavailable,
+    #[error(transparent)]
+    Scan(#[from] IggyDlqDuplicateScanError),
+}
+
+impl IggyDlqDuplicateAlertObserverError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidConfiguration => {
+                "iggy.dlq_duplicate.alert_observer_configuration_invalid"
+            }
+            Self::ConnectionUnavailable => {
+                "iggy.dlq_duplicate.alert_observer_connection_unavailable"
+            }
+            Self::Scan(error) => error.stable_code(),
+        }
+    }
+}
+
+fn configured_partitions(
+    config: &IggyConfig,
+) -> Result<Vec<u32>, IggyDlqDuplicateAlertObserverError> {
+    if config.topology.domain_partitions == 0 || config.topology.domain_partitions > 128 {
+        return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+    }
+    Ok((1..=config.topology.domain_partitions).collect())
+}
+
+fn read_only_connection_config(
+    config: &IggyConfig,
+) -> Result<ExternalConfig, IggyDlqDuplicateAlertObserverError> {
+    let external = config.external.clone();
+    if config.mode == IggyMode::Bundled {
+        if external.protocol != "tcp"
+            || external.tls_enabled
+            || external.addresses.len() != 1
+            || !is_bundled_loopback_address(
+                &external.addresses[0],
+                config.bundled.tcp_port,
+            )
+        {
+            return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+        }
+    }
+    Ok(external)
+}
+
+fn is_bundled_loopback_address(address: &str, expected_port: u16) -> bool {
+    let Some((host, port)) = address.rsplit_once(':') else {
+        return false;
+    };
+    let host = host.trim_matches(['[', ']']);
+    matches!(host, "127.0.0.1" | "localhost" | "::1")
+        && port.parse::<u16>().ok() == Some(expected_port)
+}
+
+fn connection_strings(
+    config: &ExternalConfig,
+) -> Result<Vec<String>, IggyDlqDuplicateAlertObserverError> {
+    if config.protocol != "tcp"
+        || config.addresses.is_empty()
+        || config.username.is_empty() != config.password.is_empty()
+    {
+        return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+    }
+    validate_component(&config.username, &[':', '@'])?;
+    validate_component(&config.password, &[':', '@'])?;
+    if let Some(domain) = config.tls_domain.as_deref() {
+        validate_component(domain, &['?', '&', '='])?;
+    }
+    if let Some(ca_file) = config.tls_ca_file.as_deref() {
+        validate_component(ca_file, &['?', '&', '='])?;
+    }
+
+    let mut options = Vec::new();
+    if config.tls_enabled {
+        options.push("tls=true".to_string());
+    }
+    if let Some(domain) = config.tls_domain.as_deref().filter(|value| !value.is_empty()) {
+        options.push(format!("tls_domain={domain}"));
+    }
+    if let Some(ca_file) = config.tls_ca_file.as_deref().filter(|value| !value.is_empty()) {
+        options.push(format!("tls_ca_file={ca_file}"));
+    }
+
+    config
+        .addresses
+        .iter()
+        .map(|address| {
+            if address.is_empty() {
+                return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+            }
+            validate_component(address, &['@', '?', '#'])?;
+            let mut value = if config.username.is_empty() {
+                format!("iggy://{address}")
+            } else {
+                format!("iggy://{}:{}@{address}", config.username, config.password)
+            };
+            if !options.is_empty() {
+                value.push('?');
+                value.push_str(&options.join("&"));
+            }
+            Ok(value)
+        })
+        .collect()
+}
+
+fn validate_component(
+    value: &str,
+    forbidden: &[char],
+) -> Result<(), IggyDlqDuplicateAlertObserverError> {
+    if value.chars().any(|character| forbidden.contains(&character)) {
+        return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_mode_requires_matching_loopback_address() {
+        let mut config = IggyConfig::default();
+        config.mode = IggyMode::Bundled;
+        config.bundled.tcp_port = 8091;
+        config.external.addresses = vec!["127.0.0.1:8091".to_string()];
+        assert!(read_only_connection_config(&config).is_ok());
+
+        config.external.addresses = vec!["127.0.0.1:8090".to_string()];
+        assert_eq!(
+            read_only_connection_config(&config).unwrap_err(),
+            IggyDlqDuplicateAlertObserverError::InvalidConfiguration
+        );
+    }
+
+    #[test]
+    fn all_configured_partitions_are_scanned_once() {
+        let mut config = IggyConfig::default();
+        config.topology.domain_partitions = 3;
+        assert_eq!(configured_partitions(&config).unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn invalid_partition_count_fails_closed() {
+        for partitions in [0, 129] {
+            let mut config = IggyConfig::default();
+            config.topology.domain_partitions = partitions;
+            assert_eq!(
+                configured_partitions(&config).unwrap_err(),
+                IggyDlqDuplicateAlertObserverError::InvalidConfiguration
+            );
+        }
+    }
+
+    #[test]
+    fn stable_errors_expose_no_connection_details() {
+        assert_eq!(
+            IggyDlqDuplicateAlertObserverError::InvalidConfiguration.stable_code(),
+            "iggy.dlq_duplicate.alert_observer_configuration_invalid"
+        );
+        assert_eq!(
+            IggyDlqDuplicateAlertObserverError::ConnectionUnavailable.stable_code(),
+            "iggy.dlq_duplicate.alert_observer_connection_unavailable"
+        );
+    }
+}

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
@@ -73,7 +73,6 @@ impl std::fmt::Debug for IggyDlqDuplicateAlertObserver {
         formatter
             .debug_struct("IggyDlqDuplicateAlertObserver")
             .field("partition_count", &self.request.partitions().len())
-            .field("start_offset", &self.request.start_offset())
             .field("max_messages", &self.request.max_messages())
             .field("batch_size", &self.request.batch_size())
             .finish_non_exhaustive()

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! - **EventTransport implementation**: Seamless integration for RusToK platform
 //! - **Multiple serialization formats**: JSON (default) and MessagePack
-//! - **Automatic topology management**: Streams and topics created automatically
+//! - **Automatic topology management**: Streams, topics, partitions
 //! - **Tenant-based partitioning**: Events from the same tenant maintain order
 //! - **Consumer groups and DLQ**: Higher-level streaming primitives
 //!
@@ -62,6 +62,8 @@ pub mod consumer;
 pub mod contract_consumer;
 pub mod contract_decode_failure;
 pub mod dlq;
+#[cfg(feature = "iggy")]
+pub mod dlq_duplicate_alert_observer;
 pub mod dlq_duplicate_alert_policy;
 pub mod dlq_duplicate_alert_runtime;
 #[cfg(feature = "iggy")]
@@ -90,6 +92,10 @@ pub use contract_decode_failure::{
     ConsumedContractDecodeFailure, ContractDecodeFailureKind,
 };
 pub use dlq::{DlqEntry, DlqManager};
+#[cfg(feature = "iggy")]
+pub use dlq_duplicate_alert_observer::{
+    IggyDlqDuplicateAlertObserver, IggyDlqDuplicateAlertObserverError,
+};
 pub use dlq_duplicate_alert_policy::{
     DlqDuplicateAlertEvaluation, DlqDuplicateAlertLevel, DlqDuplicateAlertPolicy,
     DlqDuplicateAlertPolicyError,

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-policy-checkpoint.md
@@ -1,21 +1,18 @@
 # Profiles checkpoint: physical DLQ duplicate alert policy
 
-Status: **count-only policy and latest-value runtime composition source-complete; server integration pending**.
+Status: **count-only policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution pending**.
 
 ## What changed
 
-`rustok-iggy` owns a transport-neutral policy that evaluates the existing count-only physical DLQ duplicate summary and an in-memory latest-value runtime composition for the resulting identifier-free evaluation.
+`rustok-iggy` owns a transport-neutral policy that evaluates the count-only physical DLQ duplicate summary and an in-memory latest-value runtime for the resulting identifier-free evaluation. The host owns a separate mode-aware observer lifecycle.
 
-Policy source:
-
-```text
-crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
-```
-
-Runtime source:
+Sources:
 
 ```text
-crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+policy:          crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+runtime:         crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+Iggy observer:   crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+server observer: apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 ```
 
 Machine contracts:
@@ -23,13 +20,7 @@ Machine contracts:
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
-```
-
-Verifiers:
-
-```text
-scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
-scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 ```
 
 No Profiles API, database table, GraphQL field, storefront behavior, privacy port, or authorization input changed.
@@ -46,25 +37,21 @@ max_copies_per_message_id
 
 There is no library-owned production default. Invalid zero, inverted, or impossible max-copies thresholds fail closed.
 
-This preserves ownership: Profiles does not select operational duplicate tolerance, and `rustok-iggy` does not invent a tenant or product policy.
+Profiles does not select operational duplicate tolerance, and `rustok-iggy` does not invent a tenant or product policy.
 
 ## Level semantics
 
 ```text
-Clear    no physical duplicate
-Notice   duplicates exist below warning thresholds
-Warning  one or more warning thresholds reached
-Critical one or more critical thresholds reached
-         OR any identity conflict exists
+Clear     no physical duplicate
+Notice    duplicates exist below warning thresholds
+Warning   one or more warning thresholds reached
+Critical  one or more critical thresholds reached
+          OR any identity conflict exists
 ```
 
-Identity conflict means one deterministic physical message UUID was observed with different exact bytes. It is always `Critical` and `requires_manual_review()` is true.
+Identity conflict is always `Critical` and requires manual review. A numeric `Critical` result without an identity conflict does not authorize payload inspection or destructive reconciliation.
 
-A numeric `Critical` result without an identity conflict does not by itself authorize manual payload inspection or destructive reconciliation.
-
-## Latest-value runtime composition
-
-The runtime sequence is:
+## Latest-value runtime
 
 ```text
 already observed DlqDuplicateSummary
@@ -74,9 +61,30 @@ already observed DlqDuplicateSummary
   -> read-only subscribers
 ```
 
-The initial state is unavailable with generation `0` and no evaluation. Successful observation publishes an available evaluation. Observation failure or shutdown publishes unavailable and clears the old evaluation so stale severity does not remain current.
+Initial state is unavailable with generation `0` and no evaluation. Observation failure or shutdown publishes unavailable and clears the old evaluation so stale severity does not remain current.
 
-The channel retains only the latest state. It is not an audit log and does not promise that every subscriber sees every intermediate generation.
+The channel retains only the latest state. It is not an audit log.
+
+## Delivery-profile-aware server composition
+
+The observer handles all active event delivery profiles explicitly:
+
+```text
+memory        -> NotApplicableMemory
+outbox_local  -> NotApplicableOutboxLocal
+outbox_iggy   -> IggyBundled or IggyExternal
+```
+
+For `memory` and `outbox_local`:
+
+- no Iggy transport is requested;
+- no broker client is opened;
+- no alert thresholds are required;
+- not-applicable state is not a Profiles degradation.
+
+For `outbox_iggy`, the observer reuses the exact active Iggy configuration. Bundled mode connects to the existing loopback broker; external mode uses reviewed configured addresses. It never creates another transport or broker process. Missing active Iggy mode fails closed.
+
+Connection and scan failures clear runtime availability but do not stop event delivery or module projection.
 
 ## Count-only runtime projection
 
@@ -88,18 +96,7 @@ available
 evaluation
 ```
 
-The optional evaluation exposes only:
-
-```text
-level
-physical_duplicates
-identity_conflict
-duplicate_messages_threshold_reached
-duplicate_groups_threshold_reached
-max_copies_threshold_reached
-```
-
-It does not expose counts from the source summary, raw threshold values, broker coordinates, UUIDs, payloads, payload digests, receipt identities, credentials, timestamps, or raw Iggy errors.
+The optional evaluation exposes only level and aggregate boolean reasons. It excludes source counts, raw thresholds, broker coordinates, UUIDs, payloads/digests, receipt identities, credentials, timestamps, and raw Iggy errors.
 
 No serialization or persistence is added.
 
@@ -107,13 +104,13 @@ No serialization or persistence is added.
 
 No profile visibility, ownership, follower access, block, mute, relationship, audience, storefront presentation, or author-card decision may depend on:
 
+- event delivery profile or Iggy deployment mode;
+- observer applicability or availability;
 - `DlqDuplicateAlertLevel`;
-- runtime availability or generation;
-- any threshold-reached boolean;
-- physical duplicate presence;
-- identity-conflict presence;
-- scanner availability or failure;
-- threshold configuration;
+- runtime generation;
+- threshold-reached booleans;
+- physical duplicate or identity-conflict presence;
+- scanner connection state;
 - alert delivery state;
 - retained evidence metadata.
 
@@ -121,30 +118,26 @@ Profiles continues to resolve privacy through authoritative owner ports and pres
 
 ## Operational separation
 
-The policy/runtime cannot:
+The policy/runtime/observer path cannot:
 
-- poll Iggy;
-- inspect PostgreSQL receipts;
-- start a server worker;
-- register telemetry or health policy;
+- change readiness or liveness;
+- stop event delivery or projection;
 - send or page;
-- choose a destination;
+- choose a destination, cooldown, or suppression;
 - persist thresholds or snapshots;
-- schedule scans;
-- affect readiness;
 - acknowledge, delete, purge, replay, retry, or publish;
-- claim, release, publish, or acknowledge a poison receipt;
+- store consumer offsets;
+- mutate poison receipts;
 - alter broker configuration or profile state.
 
-Server observation, telemetry projection, notification delivery, cooldown/suppression, and destructive reconciliation remain separate owner boundaries.
+Telemetry projection, optional health, notification delivery, cooldown/suppression, and destructive reconciliation remain separate owner boundaries.
 
 ## Remaining work
 
-1. integrate an explicitly owned server observer;
-2. define reviewed telemetry and health projection;
-3. define alert routing, cooldown, and suppression outside Profiles and outside the policy/runtime;
-4. retain identifier-free runtime integration evidence;
-5. keep destructive reconciliation in a separate authorized workflow;
-6. compare receipt and duplicate health only as aggregate operational trends.
+1. define reviewed telemetry and optional health without readiness coupling;
+2. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
+3. retain identifier-free runtime/server execution evidence;
+4. keep destructive reconciliation in a separate authorized workflow;
+5. compare receipt and duplicate health only as aggregate operational trends.
 
-No tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, alert delivery, or retained capture were run by the implementation agent.
+No tests, Cargo commands, formatters, verifiers, server observers, broker connections, alert delivery, or retained capture were run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-runtime-checkpoint.md
@@ -1,50 +1,64 @@
 # Profiles checkpoint: DLQ duplicate alert runtime
 
-Status: **identifier-free latest-value runtime source-complete; server integration pending**.
+Status: **identifier-free latest-value runtime and mode-aware server observer source-complete; runtime execution pending**.
 
 ## What changed
 
-`rustok-iggy` now owns an in-memory runtime composition for the count-only physical DLQ duplicate alert policy.
+`rustok-iggy` owns an in-memory runtime composition for the count-only physical DLQ duplicate alert policy, and the server now owns a separate observer lifecycle that uses it only when the active event-delivery profile has an Iggy capability.
 
-Source:
+Reusable runtime source:
 
 ```text
 crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
 ```
 
-Machine contract:
+Server observer sources:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+```
+
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 ```
 
-Verifier:
+Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
-```
-
-Public API:
-
-```text
-DlqDuplicateAlertRuntimePublisher
-DlqDuplicateAlertRuntimeSubscriber
-DlqDuplicateAlertRuntimeSnapshot
-DlqDuplicateAlertRuntimeError
+scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
 No Profiles API, storage, policy port, GraphQL field, storefront behavior, or authorization input changed.
 
+## Delivery-profile boundary
+
+The server observer handles all event-delivery profiles explicitly:
+
+```text
+memory        -> NotApplicableMemory
+outbox_local  -> NotApplicableOutboxLocal
+outbox_iggy   -> IggyBundled or IggyExternal
+```
+
+`memory` and `outbox_local` do not request an Iggy transport, do not open a broker connection, and do not require alert threshold configuration. Their not-applicable state is valid platform operation, not a Profiles degradation.
+
+Only `outbox_iggy` resolves the shared `IggyTransport` already created by the event runtime. The observer never creates a second transport or bundled broker process.
+
 ## Composition boundary
 
-The publisher accepts only:
+The reusable publisher accepts only:
 
 ```text
 already observed DlqDuplicateSummary
 prevalidated DlqDuplicateAlertPolicy
 ```
 
-It does not scan Iggy, read PostgreSQL poison receipts, choose thresholds, or start a worker.
+The server's Iggy-specific source obtains the summary through bounded explicit-offset polling with `auto_commit=false`. It supports both the existing bundled loopback deployment and reviewed external addresses.
 
 The single writer evaluates the summary and replaces one Tokio watch latest-value snapshot. Read-only subscribers may observe the current value or await a change.
 
@@ -60,7 +74,7 @@ evaluation = None
 
 Every successful publication or unavailable transition increments generation through checked arithmetic.
 
-`mark_unavailable()` always clears evaluation. This prevents a stale Warning or Critical result from appearing current after observer failure or shutdown.
+Connection failure, scan failure, and shutdown call `mark_unavailable()`, which clears evaluation. This prevents a stale Warning or Critical result from appearing current while event delivery and module projection continue.
 
 ## Identifier-free snapshot
 
@@ -91,6 +105,8 @@ The runtime adds no serialization or persistence.
 
 No profile visibility, owner access, relationship, follow, block, mute, friendship, audience, storefront, GraphQL, or presentation decision may depend on:
 
+- event delivery profile;
+- observer mode or applicability;
 - runtime availability;
 - runtime generation;
 - alert level;
@@ -104,34 +120,36 @@ Profiles continues to authorize through owner ports and its canonical privacy-be
 
 ## Runtime and mutation boundary
 
-The runtime does not:
+The runtime and server observer do not:
 
-- register readiness or health policy;
-- emit metrics directly;
-- choose notification delivery, paging, cooldown, suppression, or escalation timing;
+- change readiness or liveness;
+- stop event delivery or module projection;
+- emit notification delivery, paging, cooldown, suppression, or escalation timing;
 - acknowledge, delete, purge, replay, retry, or publish broker messages;
+- store consumer offsets;
 - claim, release, or mark poison receipts;
 - change broker configuration;
 - change profile state.
 
-A future server adapter may consume the snapshot only as operational observability. Notification and destructive workflows require separate owner contracts and authorization.
+Telemetry and optional operational health may consume the shared snapshot later, but they require separate contracts and must remain independent of readiness and Profiles authorization.
 
 ## Stable errors
 
 ```text
 iggy.dlq_duplicate.alert_runtime_generation_overflow
 iggy.dlq_duplicate.alert_runtime_publisher_closed
+iggy.dlq_duplicate.alert_observer_configuration_invalid
+iggy.dlq_duplicate.alert_observer_connection_unavailable
 ```
 
-Both are identifier-free and do not reveal broker or delivery facts.
+All are identifier-free and do not reveal broker or delivery facts.
 
 ## Remaining work
 
-1. integrate an explicit server-owned observer lifecycle;
-2. define reviewed telemetry and health projection without source counts or identifiers;
-3. retain runtime integration evidence;
-4. keep notification delivery and suppression outside the runtime;
-5. keep destructive reconciliation separately authorized;
-6. preserve the rule that operational alert state never authorizes Profiles presentation.
+1. define reviewed telemetry and optional operational health projection;
+2. retain server observer execution evidence for applicable Iggy modes;
+3. keep notification delivery and suppression outside the runtime;
+4. keep destructive reconciliation separately authorized;
+5. preserve the rule that operational alert state never authorizes Profiles presentation.
 
 Tests, Cargo commands, formatters, source verifiers, server observers, external-Iggy scans, telemetry registration, and alert dispatch were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
@@ -1,0 +1,131 @@
+# Profiles checkpoint: mode-aware physical DLQ duplicate alert observer
+
+Status: **server composition source complete; runtime execution pending**.
+
+## What changed
+
+The host now has one global event-delivery observer composition for the physical DLQ duplicate alert path.
+
+It combines:
+
+```text
+bounded physical DLQ scan
+  -> DlqDuplicateSummary
+  -> explicit DlqDuplicateAlertPolicy
+  -> DlqDuplicateAlertRuntimePublisher
+  -> identifier-free latest snapshot
+```
+
+The observer is intentionally not a Profiles service. Profiles remains a consumer of authoritative privacy and relationship owner ports only.
+
+## Delivery modes are explicit
+
+The composition does not assume that every deployment uses Iggy:
+
+```text
+memory        -> NotApplicableMemory
+outbox_local  -> NotApplicableOutboxLocal
+outbox_iggy   -> IggyBundled or IggyExternal
+```
+
+For `memory` and `outbox_local`:
+
+- no `IggyTransport` is requested;
+- no broker connection is opened;
+- no alert thresholds are required;
+- not-applicable state is not an error or degraded Profiles condition.
+
+For `outbox_iggy`, the observer uses the exact shared transport configuration already activated by the event runtime. It does not create another transport or broker.
+
+## Bundled and external Iggy
+
+Both Iggy deployment modes are handled explicitly:
+
+- bundled mode connects to the existing validated loopback broker and matching TCP port;
+- external mode connects to reviewed configured addresses and credentials.
+
+The observer never starts or owns the bundled process and never shuts down the shared event transport.
+
+## Activation and policy
+
+The observer is default-off:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
+```
+
+When active on `outbox_iggy`, all warning and critical thresholds must be supplied explicitly. The library and server do not invent production tolerance defaults.
+
+## Shared operational projection
+
+`EventDlqDuplicateAlertObserverHandle` exposes only:
+
+- the explicit observer mode;
+- whether the task has finished;
+- the latest optional `DlqDuplicateAlertRuntimeSnapshot`.
+
+The snapshot contains generation, availability, and the identifier-free alert evaluation. On connection failure, scan failure, or shutdown, availability becomes false and the prior evaluation is cleared.
+
+This state may later feed telemetry or an operational health endpoint, but it must not become readiness or authorization input.
+
+## Profiles authorization boundary
+
+No profile visibility, ownership, follower access, relationship, block, mute, audience, storefront presentation, author card, or privacy-port result may depend on:
+
+- event delivery profile;
+- observer applicability or availability;
+- Iggy bundled/external mode;
+- duplicate alert level;
+- threshold booleans;
+- scanner connection state;
+- alert generation;
+- retained observer evidence.
+
+A missing or failed Iggy observer never changes Profiles data access. Event delivery and module projection remain active.
+
+## Privacy boundary
+
+The observer does not expose:
+
+- broker addresses or credentials;
+- stream/topic/partition/offset;
+- deterministic message UUIDs;
+- payloads or payload digests;
+- poison receipt identities;
+- raw client errors;
+- raw threshold values;
+- source counts.
+
+Logs and shared state retain only stable codes, availability, generation, alert level, and aggregate boolean reasons.
+
+## Mutation boundary
+
+The observer cannot:
+
+- publish or acknowledge messages;
+- commit consumer offsets;
+- delete, purge, replay, or retry DLQ entries;
+- claim or mark poison receipts;
+- start or stop the bundled Iggy process;
+- change event delivery configuration;
+- dispatch notifications;
+- alter Profiles state.
+
+## Source ownership
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+```
+
+## Remaining work
+
+1. add identifier-free telemetry projection;
+2. add optional operational health without readiness coupling;
+3. define notification routing, cooldown, and suppression separately;
+4. retain execution evidence for applicable Iggy modes;
+5. keep any destructive reconciliation separately authorized.
+
+Tests, Cargo commands, formatters, verifiers, server startup, broker connections, alert delivery, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
@@ -16,9 +16,11 @@ bounded physical DLQ scan
 
 The observer is intentionally not a Profiles service. Profiles remains a consumer of authoritative privacy and relationship owner ports only.
 
-## Delivery modes are explicit
+## Delivery and startup modes are explicit
 
 ```text
+disabled      -> Disabled
+startup issue -> Unavailable, no task or snapshot
 memory        -> NotApplicableMemory
 outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
@@ -33,6 +35,13 @@ For `memory` and `outbox_local`:
 
 For `outbox_iggy`, the observer uses the exact shared transport configuration activated by the event runtime. It does not create another transport or broker. Missing active Iggy mode fails closed rather than being guessed.
 
+Observer-specific startup errors are non-fatal. Invalid observer configuration or a missing observer dependency records `Unavailable`, logs only a stable code, and returns success to server bootstrap. Event delivery and module projection continue.
+
+```text
+iggy.dlq_duplicate.alert_server_observer_configuration_invalid
+iggy.dlq_duplicate.alert_server_observer_runtime_unavailable
+```
+
 ## Bundled and external Iggy
 
 - bundled mode connects to the existing validated loopback broker and matching TCP port;
@@ -42,7 +51,7 @@ The observer never starts or owns the bundled process and never shuts down the s
 
 ## Bounded scan semantics
 
-The observer builds an allowlist containing every configured domain partition and delegates it to the existing explicit-offset scanner with `auto_commit=false`.
+The observer builds an allowlist containing every configured domain partition and delegates it to the explicit-offset scanner with `auto_commit=false`.
 
 The scanner uses one **global** message budget across the ordered allowlist. An earlier busy partition can exhaust that budget before later partitions are polled. This checkpoint therefore makes no partition-fairness or complete-history claim.
 
@@ -56,7 +65,7 @@ The observer is default-off:
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
 ```
 
-When active on `outbox_iggy`, all warning and critical thresholds must be supplied explicitly. The library and server do not invent production tolerance defaults.
+When active on `outbox_iggy`, all warning and critical thresholds must be supplied explicitly. Invalid values enter non-fatal `Unavailable` state; the library and server do not invent production tolerance defaults.
 
 ## Shared operational projection
 
@@ -66,44 +75,33 @@ When active on `outbox_iggy`, all warning and critical thresholds must be suppli
 - whether the task has finished;
 - the latest optional `DlqDuplicateAlertRuntimeSnapshot`.
 
-The snapshot contains generation, availability, and the identifier-free alert evaluation. On connection failure, scan failure, or shutdown, availability becomes false and the prior evaluation is cleared.
+Startup-unavailable state has no task and no snapshot. After a task starts, connection failure, scan failure, or shutdown clears runtime availability and prior evaluation.
 
-This state may later feed telemetry or an operational health endpoint, but it must not become readiness or authorization input.
+This state may later feed telemetry or an operational health endpoint, but it must not become bootstrap, readiness, or authorization input.
 
 ## Profiles authorization boundary
 
 No profile visibility, ownership, follower access, relationship, block, mute, audience, storefront presentation, author card, or privacy-port result may depend on:
 
 - event delivery profile;
-- observer applicability or availability;
+- observer startup, applicability, availability, or generation;
 - Iggy bundled/external mode;
 - partition ordering, fairness, or budget exhaustion;
-- duplicate alert level;
-- threshold booleans;
+- duplicate alert level or threshold booleans;
 - scanner connection state;
-- alert generation;
 - retained observer evidence.
 
-A missing or failed Iggy observer never changes Profiles data access. Event delivery and module projection remain active.
+A missing or failed observer never changes Profiles data access. Event delivery and module projection remain active.
 
 ## Privacy boundary
 
 The observer does not expose broker addresses/credentials, stream coordinates, UUIDs, payloads/digests, poison receipt identities, raw client errors, raw thresholds, or source counts.
 
-Logs and shared state retain only stable codes, availability, generation, alert level, and aggregate boolean reasons.
+Logs and shared state retain only stable codes, mode, availability, generation, alert level, and aggregate boolean reasons.
 
 ## Mutation boundary
 
-The observer cannot:
-
-- publish or acknowledge messages;
-- commit consumer offsets;
-- delete, purge, replay, or retry DLQ entries;
-- claim or mark poison receipts;
-- start or stop the bundled Iggy process;
-- change event delivery configuration;
-- dispatch notifications;
-- alter Profiles state.
+The observer cannot publish/acknowledge messages, commit offsets, delete/purge/replay/retry DLQ entries, mutate poison receipts, start/stop bundled Iggy, change event delivery, dispatch notifications, or alter Profiles state.
 
 ## Source ownership
 
@@ -120,7 +118,7 @@ scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 2. add identifier-free telemetry projection;
 3. add optional operational health without readiness coupling;
 4. define notification routing, cooldown, and suppression separately;
-5. retain execution evidence for applicable Iggy modes;
+5. retain execution evidence for applicable Iggy and unavailable startup modes;
 6. keep destructive reconciliation separately authorized.
 
 Tests, Cargo commands, formatters, verifiers, server startup, broker connections, alert delivery, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
@@ -4,9 +4,7 @@ Status: **server composition source complete; runtime execution pending**.
 
 ## What changed
 
-The host now has one global event-delivery observer composition for the physical DLQ duplicate alert path.
-
-It combines:
+The host now has one global event-delivery observer composition for the physical DLQ duplicate alert path:
 
 ```text
 bounded physical DLQ scan
@@ -19,8 +17,6 @@ bounded physical DLQ scan
 The observer is intentionally not a Profiles service. Profiles remains a consumer of authoritative privacy and relationship owner ports only.
 
 ## Delivery modes are explicit
-
-The composition does not assume that every deployment uses Iggy:
 
 ```text
 memory        -> NotApplicableMemory
@@ -35,16 +31,22 @@ For `memory` and `outbox_local`:
 - no alert thresholds are required;
 - not-applicable state is not an error or degraded Profiles condition.
 
-For `outbox_iggy`, the observer uses the exact shared transport configuration already activated by the event runtime. It does not create another transport or broker.
+For `outbox_iggy`, the observer uses the exact shared transport configuration activated by the event runtime. It does not create another transport or broker. Missing active Iggy mode fails closed rather than being guessed.
 
 ## Bundled and external Iggy
-
-Both Iggy deployment modes are handled explicitly:
 
 - bundled mode connects to the existing validated loopback broker and matching TCP port;
 - external mode connects to reviewed configured addresses and credentials.
 
 The observer never starts or owns the bundled process and never shuts down the shared event transport.
+
+## Bounded scan semantics
+
+The observer builds an allowlist containing every configured domain partition and delegates it to the existing explicit-offset scanner with `auto_commit=false`.
+
+The scanner uses one **global** message budget across the ordered allowlist. An earlier busy partition can exhaust that budget before later partitions are polled. This checkpoint therefore makes no partition-fairness or complete-history claim.
+
+A future per-partition budget or fairness policy must remain operational and must not become a Profiles input.
 
 ## Activation and policy
 
@@ -75,6 +77,7 @@ No profile visibility, ownership, follower access, relationship, block, mute, au
 - event delivery profile;
 - observer applicability or availability;
 - Iggy bundled/external mode;
+- partition ordering, fairness, or budget exhaustion;
 - duplicate alert level;
 - threshold booleans;
 - scanner connection state;
@@ -85,16 +88,7 @@ A missing or failed Iggy observer never changes Profiles data access. Event deli
 
 ## Privacy boundary
 
-The observer does not expose:
-
-- broker addresses or credentials;
-- stream/topic/partition/offset;
-- deterministic message UUIDs;
-- payloads or payload digests;
-- poison receipt identities;
-- raw client errors;
-- raw threshold values;
-- source counts.
+The observer does not expose broker addresses/credentials, stream coordinates, UUIDs, payloads/digests, poison receipt identities, raw client errors, raw thresholds, or source counts.
 
 Logs and shared state retain only stable codes, availability, generation, alert level, and aggregate boolean reasons.
 
@@ -122,10 +116,11 @@ scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 
 ## Remaining work
 
-1. add identifier-free telemetry projection;
-2. add optional operational health without readiness coupling;
-3. define notification routing, cooldown, and suppression separately;
-4. retain execution evidence for applicable Iggy modes;
-5. keep any destructive reconciliation separately authorized.
+1. define partition fairness or an explicit per-partition budget policy;
+2. add identifier-free telemetry projection;
+3. add optional operational health without readiness coupling;
+4. define notification routing, cooldown, and suppression separately;
+5. retain execution evidence for applicable Iggy modes;
+6. keep destructive reconciliation separately authorized.
 
 Tests, Cargo commands, formatters, verifiers, server startup, broker connections, alert delivery, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **count-only classifier, bounded external observer, runtime harness, retained tooling, alert policy, and latest-value alert runtime source-complete; runtime execution and server integration pending**.
+Status: **classifier, bounded scanner, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution and telemetry/health projection pending**.
 
 ## Why this matters for Profiles
 
@@ -10,15 +10,17 @@ Profiles authorization remains independent of broker and receipt state. Downstre
 - one durable neutral result with repeated identical physical copies;
 - one deterministic DLQ ID associated with conflicting exact bytes.
 
-The Iggy-owned classifier exposes this distinction without message identities or payloads. The bounded external scanner supplies observations through explicit-offset polling without storing progress. The alert policy evaluates only the count-only summary. The alert runtime publishes only identifier-free latest state. None becomes a Profiles authorization input.
+The Iggy-owned classifier exposes this distinction without message identities or payloads. The bounded scanner supplies observations through explicit-offset polling without storing progress. The alert policy evaluates only the count-only summary. The latest-value runtime and server observer publish only identifier-free operational state. None becomes a Profiles authorization input.
 
 ## Owner boundaries
 
 ```text
-classifier: crates/rustok-iggy/src/dlq_duplicate_inspection.rs
-scanner:    crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
-policy:     crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
-runtime:    crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+classifier:      crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+scanner:         crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+policy:          crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+runtime:         crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+Iggy observer:   crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+server observer: apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 ```
 
 Machine contracts:
@@ -28,6 +30,7 @@ crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 ```
 
 Verifiers:
@@ -37,6 +40,7 @@ scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
 ## Count-only projections
@@ -79,7 +83,7 @@ An ordinary physical duplicate requires the same deterministic Iggy header UUID 
 
 A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
 
-## External scan boundary
+## Bounded scan boundary
 
 The scanner borrows an already connected `IggyClient` and uses:
 
@@ -121,13 +125,32 @@ The publisher is single-writer. Initial state is generation `0`, unavailable, wi
 
 Unavailable publication clears the previous evaluation so stale severity does not remain current. The channel retains only the latest state and is not an audit log.
 
-The runtime does not start a server worker, register telemetry/health, select readiness, deliver notifications, persist state, or mutate broker/receipt/Profile state.
+## Mode-aware server observer
+
+The server handles every event-delivery profile explicitly:
+
+```text
+memory        -> NotApplicableMemory
+outbox_local  -> NotApplicableOutboxLocal
+outbox_iggy   -> IggyBundled or IggyExternal
+```
+
+For `memory` and `outbox_local`, absence of Iggy is expected platform behavior:
+
+- no shared `IggyTransport` is requested;
+- no broker client is opened;
+- no alert thresholds are required;
+- not-applicable state is not an error, readiness failure, or Profiles degradation.
+
+For `outbox_iggy`, the observer reuses the exact active transport configuration and opens only a separate read-only SDK client. Bundled mode connects to the existing validated loopback broker; external mode uses the reviewed address list. A missing active Iggy mode fails closed instead of being guessed.
+
+Connection failure, scan failure, and shutdown publish unavailable state while event delivery and module projection remain active. The observer does not create a second transport, start or stop a bundled process, commit offsets, or dispatch notifications.
 
 ## Runtime and retained status
 
 The external-Iggy harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
 
-The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. Server observer and telemetry/health integration for the alert runtime remain pending.
+The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. The mode-aware server observer is source-complete; telemetry, optional operational health, and retained server execution evidence remain pending.
 
 ## Relationship to receipt health
 
@@ -139,12 +162,13 @@ Aggregate operational interpretation may compare trends, but those interpretatio
 
 No profile visibility, relationship, block, mute, follow, friendship, audience, storefront, GraphQL, author-card, or presentation decision may depend on:
 
+- event delivery profile or Iggy deployment mode;
+- observer applicability, availability, or generation;
 - physical DLQ copy or duplicate-group counts;
 - identity-conflict presence;
 - alert level or threshold flags;
-- runtime availability or generation;
 - scan partition or offset selection;
-- scanner, runtime, telemetry, or alert-delivery state;
+- scanner, runtime, telemetry, health, or alert-delivery state;
 - receipt recovery counts;
 - deduplication or alert-threshold configuration;
 - retained evidence metadata.
@@ -154,8 +178,8 @@ Profiles presentation continues to consume authorized owner-port results. These 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. integrate an explicitly owned server alert observer;
-3. define identifier-free telemetry and health projection;
+2. define identifier-free telemetry and optional operational health without readiness coupling;
+3. retain mode-aware server observer execution evidence;
 4. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
 5. define acknowledgement/delete/replay separately with explicit authorization;
 6. keep aggregate receipt and duplicate observations identifier-free.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -97,6 +97,10 @@ auto_commit = false
 
 It accepts no more than 128 unique positive partitions, 10,000 physical messages globally, and batches of 1,000. It validates returned partition/count and monotonic offsets before returning only `DlqDuplicateSummary`.
 
+The server observer places every configured domain partition into the request allowlist, but the scanner has one global message budget across the ordered list. An earlier busy partition may exhaust that budget before later partitions are polled. No fairness or complete-partition claim is made.
+
+Each polling cycle reuses the same configured explicit start offset. The current observer therefore measures a repeated bounded window; it does not own a moving cursor, tail coverage, or complete-history semantics. A future per-partition budget or moving-window policy requires a separate source contract.
+
 The scanner does not use a consumer group, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
 
 ## Alert policy boundary
@@ -127,9 +131,11 @@ Unavailable publication clears the previous evaluation so stale severity does no
 
 ## Mode-aware server observer
 
-The server handles every event-delivery profile explicitly:
+The server handles every event-delivery and observer startup mode explicitly:
 
 ```text
+disabled      -> Disabled
+startup issue -> Unavailable, no task or snapshot
 memory        -> NotApplicableMemory
 outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
@@ -144,13 +150,15 @@ For `memory` and `outbox_local`, absence of Iggy is expected platform behavior:
 
 For `outbox_iggy`, the observer reuses the exact active transport configuration and opens only a separate read-only SDK client. Bundled mode connects to the existing validated loopback broker; external mode uses the reviewed address list. A missing active Iggy mode fails closed instead of being guessed.
 
-Connection failure, scan failure, and shutdown publish unavailable state while event delivery and module projection remain active. The observer does not create a second transport, start or stop a bundled process, commit offsets, or dispatch notifications.
+Observer-specific startup failures are non-fatal: invalid configuration or missing observer dependencies produce `Unavailable`, log a stable code, and return success to application bootstrap. Connection failure, scan failure, and shutdown publish unavailable state while event delivery and module projection remain active.
+
+The observer does not create a second transport, start or stop a bundled process, commit offsets, or dispatch notifications.
 
 ## Runtime and retained status
 
 The external-Iggy harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
 
-The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. The mode-aware server observer is source-complete; telemetry, optional operational health, and retained server execution evidence remain pending.
+The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. The mode-aware server observer is source-complete; telemetry, optional operational health, moving-window/fairness policy, and retained server execution evidence remain pending.
 
 ## Relationship to receipt health
 
@@ -163,11 +171,11 @@ Aggregate operational interpretation may compare trends, but those interpretatio
 No profile visibility, relationship, block, mute, follow, friendship, audience, storefront, GraphQL, author-card, or presentation decision may depend on:
 
 - event delivery profile or Iggy deployment mode;
-- observer applicability, availability, or generation;
+- observer startup, applicability, availability, or generation;
+- partition ordering, fairness, fixed-window selection, or budget exhaustion;
 - physical DLQ copy or duplicate-group counts;
 - identity-conflict presence;
 - alert level or threshold flags;
-- scan partition or offset selection;
 - scanner, runtime, telemetry, health, or alert-delivery state;
 - receipt recovery counts;
 - deduplication or alert-threshold configuration;
@@ -178,10 +186,11 @@ Profiles presentation continues to consume authorized owner-port results. These 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. define identifier-free telemetry and optional operational health without readiness coupling;
-3. retain mode-aware server observer execution evidence;
-4. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
-5. define acknowledgement/delete/replay separately with explicit authorization;
-6. keep aggregate receipt and duplicate observations identifier-free.
+2. define partition fairness/per-partition budgets and a moving-window or per-partition cursor policy;
+3. define identifier-free telemetry and optional operational health without readiness coupling;
+4. retain mode-aware server observer execution evidence;
+5. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
+6. define acknowledgement/delete/replay separately with explicit authorization;
+7. keep aggregate receipt and duplicate observations identifier-free.
 
 Tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const iggySourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const serverSourcePath =
+  "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
+const bootstrapPath = "apps/server/src/services/server_bootstrap.rs";
+const servicesPath = "apps/server/src/services/mod.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const runtimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
+const scannerSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const iggySource = readFileSync(resolve(repoRoot, iggySourcePath), "utf8");
+const serverSource = readFileSync(resolve(repoRoot, serverSourcePath), "utf8");
+const bootstrap = readFileSync(resolve(repoRoot, bootstrapPath), "utf8");
+const services = readFileSync(resolve(repoRoot, servicesPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const runtimeSource = readFileSync(resolve(repoRoot, runtimeSourcePath), "utf8");
+const scannerSource = readFileSync(resolve(repoRoot, scannerSourcePath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "event-delivery" ||
+  contract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  contract.status !== "source_complete_runtime_execution_pending" ||
+  !sameValue(contract.owners, ["rustok-server", "rustok-iggy"]) ||
+  contract.iggy_source !== iggySourcePath ||
+  contract.server_source !== serverSourcePath ||
+  contract.bootstrap_source !== bootstrapPath ||
+  contract.service_registry_source !== servicesPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("DLQ duplicate alert server observer identity or status drift");
+}
+
+if (
+  !sameValue(contract.delivery_profiles, {
+    memory: "not_applicable",
+    outbox_local: "not_applicable",
+    outbox_iggy: "iggy_observer",
+  })
+) {
+  fail("event delivery profile observer matrix drift");
+}
+if (
+  !sameValue(contract.iggy_modes, {
+    bundled: "connect_to_existing_loopback_broker",
+    external: "connect_to_reviewed_external_addresses",
+  })
+) {
+  fail("Iggy bundled/external observer matrix drift");
+}
+if (
+  contract.activation?.default_enabled !== false ||
+  contract.activation?.enable_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED" ||
+  contract.activation?.background_workers_required !== true ||
+  contract.activation?.event_runtime_required !== true ||
+  contract.activation?.memory_requires_iggy !== false ||
+  contract.activation?.outbox_local_requires_iggy !== false ||
+  contract.activation?.outbox_iggy_requires_shared_transport !== true ||
+  contract.activation?.non_iggy_profiles_are_errors !== false
+) {
+  fail("DLQ duplicate observer activation boundary drift");
+}
+if (
+  contract.scan?.topic !== "dlq" ||
+  contract.scan?.all_configured_domain_partitions !== true ||
+  contract.scan?.explicit_start_offset !== true ||
+  contract.scan?.bounded_max_messages !== true ||
+  contract.scan?.bounded_batch_size !== true ||
+  contract.scan?.auto_commit !== false ||
+  contract.scan?.stored_offset_polling !== false
+) {
+  fail("DLQ duplicate observer scan boundary drift");
+}
+if (
+  contract.runtime?.publisher !== "DlqDuplicateAlertRuntimePublisher" ||
+  contract.runtime?.initial_snapshot_unavailable !== true ||
+  contract.runtime?.success_publishes_identifier_free_evaluation !== true ||
+  contract.runtime?.connection_failure_marks_unavailable !== true ||
+  contract.runtime?.scan_failure_marks_unavailable !== true ||
+  contract.runtime?.shutdown_marks_unavailable !== true ||
+  contract.runtime?.reconnect_after_failure !== true ||
+  contract.runtime?.event_delivery_remains_active !== true
+) {
+  fail("DLQ duplicate observer runtime boundary drift");
+}
+for (const [operation, allowed] of Object.entries(contract.lifecycle_boundary ?? {})) {
+  if (allowed !== false) fail(`observer lifecycle coupling became allowed: ${operation}`);
+}
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`observer mutation became allowed: ${operation}`);
+}
+if (
+  contract.policy?.all_six_thresholds_required_when_active !== true ||
+  contract.policy?.production_threshold_defaults !== false ||
+  contract.policy?.notification_routing !== false ||
+  contract.policy?.cooldown_or_suppression !== false
+) {
+  fail("observer policy boundary drift");
+}
+
+const expectedIggyTests = [
+  "bundled_mode_requires_matching_loopback_address",
+  "all_configured_partitions_are_scanned_once",
+  "invalid_partition_count_fails_closed",
+  "stable_errors_expose_no_connection_details",
+];
+const expectedServerTests = [
+  "every_event_delivery_profile_has_an_explicit_observer_mode",
+  "boolean_parser_is_bounded",
+];
+if (!sameValue(contract.required_iggy_tests, expectedIggyTests)) {
+  fail("Iggy observer source test allowlist drift");
+}
+if (!sameValue(contract.required_server_tests, expectedServerTests)) {
+  fail("server observer source test allowlist drift");
+}
+for (const testName of expectedIggyTests) {
+  requireText("Iggy observer tests", iggySource, `fn ${testName}()`);
+}
+for (const testName of expectedServerTests) {
+  requireText("server observer tests", serverSource, `fn ${testName}()`);
+}
+if (countText(iggySource, "#[test]") !== expectedIggyTests.length) {
+  fail("Iggy observer source must contain exactly four focused tests");
+}
+if (countText(serverSource, "#[test]") !== expectedServerTests.length) {
+  fail("server observer source must contain exactly two focused tests");
+}
+
+for (const marker of [
+  "pub struct IggyDlqDuplicateAlertObserver",
+  "client: IggyClient",
+  "request: IggyDlqDuplicateScanRequest",
+  "pub async fn connect(",
+  "let partitions = configured_partitions(config)?;",
+  "IggyDlqDuplicateScanRequest::new(",
+  "let external = read_only_connection_config(config)?;",
+  "for connection_string in connection_strings",
+  "client.connect().await.is_ok()",
+  "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
+  ".summarize(&self.request)",
+  "config.mode == IggyMode::Bundled",
+  "is_bundled_loopback_address(",
+  "config.topology.domain_partitions > 128",
+  '"iggy.dlq_duplicate.alert_observer_configuration_invalid"',
+  '"iggy.dlq_duplicate.alert_observer_connection_unavailable"',
+]) {
+  requireText("Iggy DLQ duplicate alert observer", iggySource, marker);
+}
+
+for (const marker of [
+  'const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";',
+  "pub enum EventDlqDuplicateAlertObserverMode",
+  "NotApplicableMemory",
+  "NotApplicableOutboxLocal",
+  "IggyBundled",
+  "IggyExternal",
+  "pub async fn start_event_dlq_duplicate_alert_observer(",
+  "let enabled = optional_bool_env(ENABLE_ENV, false)?;",
+  "EventDeliveryProfile::Memory",
+  "EventDeliveryProfile::OutboxLocal",
+  "EventDeliveryProfile::OutboxIggy",
+  "ctx.shared_get::<Arc<IggyTransport>>()",
+  "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
+  "IggyDlqDuplicateAlertObserver::connect(",
+  "connected.summarize().await",
+  "publisher.publish(&summary)",
+  "publisher.mark_unavailable()",
+  "event delivery remains active",
+  "reconnecting without affecting event delivery",
+]) {
+  requireText("mode-aware server observer", serverSource, marker);
+}
+
+const nonApplicableIndex = serverSource.indexOf(
+  "EventDlqDuplicateAlertObserverMode::NotApplicableMemory",
+);
+const sharedTransportIndex = serverSource.indexOf("ctx.shared_get::<Arc<IggyTransport>>()");
+if (nonApplicableIndex < 0 || sharedTransportIndex < 0 || nonApplicableIndex > sharedTransportIndex) {
+  fail("non-Iggy delivery profiles must exit before shared Iggy transport access");
+}
+
+for (const marker of [
+  "IggyTransport::new(",
+  "BundledConnector::new(",
+  ".shutdown(",
+  ".store_offset(",
+  ".store_consumer_offset(",
+  ".acknowledge(",
+  ".send_messages(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".notify(",
+  ".page(",
+]) {
+  forbidText("observer sources", `${iggySource}\n${serverSource}`, marker);
+}
+
+for (const marker of [
+  "Serialize",
+  "Deserialize",
+  "broker_address",
+  "payload_sha256",
+  "raw_client_error",
+]) {
+  forbidText("runtime observer structs", `${iggySource}\n${serverSource}`, marker);
+}
+
+requireText("runtime composition", runtimeSource, "pub struct DlqDuplicateAlertRuntimePublisher");
+requireText("runtime composition", runtimeSource, "pub fn mark_unavailable(");
+requireText("bounded scanner", scannerSource, "requested_count,\n                        false,");
+requireText("Iggy module registry", lib, "pub mod dlq_duplicate_alert_observer;");
+for (const exportName of contract.public_iggy_exports ?? []) {
+  requireText("Iggy public exports", lib, exportName);
+}
+requireText(
+  "server service registry",
+  services,
+  "pub mod event_dlq_duplicate_alert_observer;",
+);
+requireText(
+  "server bootstrap",
+  bootstrap,
+  "start_event_dlq_duplicate_alert_observer(",
+);
+
+const requiredPrivacyExclusions = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "credential",
+  "raw_client_error",
+  "raw_threshold_values",
+  "source_counts",
+]);
+for (const field of contract.privacy_boundary?.logs_and_snapshots_exclude ?? []) {
+  requiredPrivacyExclusions.delete(field);
+}
+if (requiredPrivacyExclusions.size > 0) {
+  fail(`observer privacy exclusions are incomplete: ${[
+    ...requiredPrivacyExclusions,
+  ].join(", ")}`);
+}
+if (
+  contract.privacy_boundary?.stable_error_codes_only !== true ||
+  contract.privacy_boundary?.serialization_added !== false ||
+  contract.privacy_boundary?.persistence_added !== false
+) {
+  fail("observer privacy flags drift");
+}
+
+if (
+  contract.verifier !==
+    "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs" ||
+  contract.documentation !==
+    "crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md" ||
+  contract.profiles_checkpoint !==
+    "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md"
+) {
+  fail("observer verifier or documentation path drift");
+}
+
+if (failures.length > 0) {
+  console.error("Event DLQ duplicate alert server observer verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, OutboxIggy bundled/external observation, bounded auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+);

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -99,6 +99,10 @@ if (
   contract.scan?.global_message_budget_may_stop_before_later_partitions !== true ||
   contract.scan?.partition_fairness_claimed !== false ||
   contract.scan?.explicit_start_offset !== true ||
+  contract.scan?.same_configured_start_offset_reused_each_poll !== true ||
+  contract.scan?.moving_cursor !== false ||
+  contract.scan?.current_tail_coverage_claimed !== false ||
+  contract.scan?.complete_history_claimed !== false ||
   contract.scan?.bounded_max_messages !== true ||
   contract.scan?.bounded_batch_size !== true ||
   contract.scan?.auto_commit !== false ||
@@ -197,6 +201,7 @@ for (const marker of [
 
 for (const marker of [
   'const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";',
+  'const START_OFFSET_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET";',
   '"iggy.dlq_duplicate.alert_server_observer_configuration_invalid"',
   '"iggy.dlq_duplicate.alert_server_observer_runtime_unavailable"',
   "pub enum EventDlqDuplicateAlertObserverMode",
@@ -209,7 +214,6 @@ for (const marker of [
   "let enabled = match optional_bool_env(ENABLE_ENV, false)",
   "record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);",
   "record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);",
-  "return Ok(());",
   "EventDeliveryProfile::Memory",
   "EventDeliveryProfile::OutboxLocal",
   "EventDeliveryProfile::OutboxIggy",
@@ -218,8 +222,10 @@ for (const marker of [
   "ctx.shared_get::<Arc<IggyTransport>>()",
   "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
   "IggyDlqDuplicateAlertObserver::connect(",
+  "config.start_offset",
   "if let Some(connected) = observer.take()",
   "connected.summarize().await",
+  "observer = Some(connected);",
   "publisher.publish(&summary)",
   "publisher.mark_unavailable()",
   "event delivery remains active",
@@ -269,6 +275,7 @@ for (const marker of [
 requireText("runtime composition", runtimeSource, "pub struct DlqDuplicateAlertRuntimePublisher");
 requireText("runtime composition", runtimeSource, "pub fn mark_unavailable(");
 requireText("bounded scanner", scannerSource, "let mut remaining = request.max_messages;");
+requireText("bounded scanner", scannerSource, "let mut next_offset = request.start_offset;");
 requireText("bounded scanner", scannerSource, "if remaining == 0");
 requireText("bounded scanner", scannerSource, "requested_count,\n                        false,");
 requireText("Iggy module registry", lib, "pub mod dlq_duplicate_alert_observer;");
@@ -330,6 +337,7 @@ if (
 
 const requiredRemaining = new Set([
   "partition_fairness_or_per_partition_budget_policy",
+  "moving_window_or_per_partition_cursor_policy",
   "telemetry_projection_outside_observer",
   "health_projection_without_readiness_coupling",
   "notification_delivery_and_suppression",
@@ -348,5 +356,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without a fairness claim, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without fairness, moving-cursor, current-tail, or complete-history claims, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
 );

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -86,6 +86,7 @@ if (
   contract.activation?.memory_requires_iggy !== false ||
   contract.activation?.outbox_local_requires_iggy !== false ||
   contract.activation?.outbox_iggy_requires_shared_transport !== true ||
+  contract.activation?.outbox_iggy_missing_active_mode_fails_closed !== true ||
   contract.activation?.non_iggy_profiles_are_errors !== false
 ) {
   fail("DLQ duplicate observer activation boundary drift");
@@ -187,9 +188,12 @@ for (const marker of [
   "IggyExternal",
   "pub async fn start_event_dlq_duplicate_alert_observer(",
   "let enabled = optional_bool_env(ENABLE_ENV, false)?;",
+  "let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref())?;",
   "EventDeliveryProfile::Memory",
   "EventDeliveryProfile::OutboxLocal",
   "EventDeliveryProfile::OutboxIggy",
+  '"outbox_iggy runtime is missing its active Iggy mode"',
+  "observer_mode(EventDeliveryProfile::OutboxIggy, None).is_err()",
   "ctx.shared_get::<Arc<IggyTransport>>()",
   "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
   "IggyDlqDuplicateAlertObserver::connect(",
@@ -307,5 +311,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, OutboxIggy bundled/external observation, bounded auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, fail-closed OutboxIggy active-mode selection, bundled/external observation, bounded auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
 );

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -93,7 +93,9 @@ if (
 }
 if (
   contract.scan?.topic !== "dlq" ||
-  contract.scan?.all_configured_domain_partitions !== true ||
+  contract.scan?.configured_domain_partition_allowlist !== true ||
+  contract.scan?.global_message_budget_may_stop_before_later_partitions !== true ||
+  contract.scan?.partition_fairness_claimed !== false ||
   contract.scan?.explicit_start_offset !== true ||
   contract.scan?.bounded_max_messages !== true ||
   contract.scan?.bounded_batch_size !== true ||
@@ -131,7 +133,7 @@ if (
 
 const expectedIggyTests = [
   "bundled_mode_requires_matching_loopback_address",
-  "all_configured_partitions_are_scanned_once",
+  "all_configured_partitions_are_included_in_request",
   "invalid_partition_count_fails_closed",
   "stable_errors_expose_no_connection_details",
 ];
@@ -246,6 +248,8 @@ for (const marker of [
 
 requireText("runtime composition", runtimeSource, "pub struct DlqDuplicateAlertRuntimePublisher");
 requireText("runtime composition", runtimeSource, "pub fn mark_unavailable(");
+requireText("bounded scanner", scannerSource, "let mut remaining = request.max_messages;");
+requireText("bounded scanner", scannerSource, "if remaining == 0");
 requireText("bounded scanner", scannerSource, "requested_count,\n                        false,");
 requireText("Iggy module registry", lib, "pub mod dlq_duplicate_alert_observer;");
 for (const exportName of contract.public_iggy_exports ?? []) {
@@ -304,6 +308,19 @@ if (
   fail("observer verifier or documentation path drift");
 }
 
+const requiredRemaining = new Set([
+  "partition_fairness_or_per_partition_budget_policy",
+  "telemetry_projection_outside_observer",
+  "health_projection_without_readiness_coupling",
+  "notification_delivery_and_suppression",
+  "retained_server_observer_execution_evidence",
+  "authorized_destructive_reconciliation",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`observer remaining work drift: ${[...requiredRemaining].join(", ")}`);
+}
+
 if (failures.length > 0) {
   console.error("Event DLQ duplicate alert server observer verification failed:");
   for (const failure of failures) console.error(`- ${failure}`);
@@ -311,5 +328,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, fail-closed OutboxIggy active-mode selection, bundled/external observation, bounded auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, fail-closed OutboxIggy active-mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without a fairness claim, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
 );

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -87,6 +87,8 @@ if (
   contract.activation?.outbox_local_requires_iggy !== false ||
   contract.activation?.outbox_iggy_requires_shared_transport !== true ||
   contract.activation?.outbox_iggy_missing_active_mode_fails_closed !== true ||
+  contract.activation?.observer_startup_failure_is_non_fatal !== true ||
+  contract.activation?.startup_failure_mode !== "unavailable" ||
   contract.activation?.non_iggy_profiles_are_errors !== false
 ) {
   fail("DLQ duplicate observer activation boundary drift");
@@ -108,6 +110,7 @@ if (
   contract.runtime?.publisher !== "DlqDuplicateAlertRuntimePublisher" ||
   contract.runtime?.initial_snapshot_unavailable !== true ||
   contract.runtime?.success_publishes_identifier_free_evaluation !== true ||
+  contract.runtime?.startup_failure_records_unavailable_without_task !== true ||
   contract.runtime?.connection_failure_marks_unavailable !== true ||
   contract.runtime?.scan_failure_marks_unavailable !== true ||
   contract.runtime?.shutdown_marks_unavailable !== true ||
@@ -115,6 +118,16 @@ if (
   contract.runtime?.event_delivery_remains_active !== true
 ) {
   fail("DLQ duplicate observer runtime boundary drift");
+}
+if (
+  !sameValue(contract.startup_stable_codes, {
+    configuration_invalid:
+      "iggy.dlq_duplicate.alert_server_observer_configuration_invalid",
+    runtime_unavailable:
+      "iggy.dlq_duplicate.alert_server_observer_runtime_unavailable",
+  })
+) {
+  fail("DLQ duplicate observer startup stable-code drift");
 }
 for (const [operation, allowed] of Object.entries(contract.lifecycle_boundary ?? {})) {
   if (allowed !== false) fail(`observer lifecycle coupling became allowed: ${operation}`);
@@ -139,6 +152,7 @@ const expectedIggyTests = [
 ];
 const expectedServerTests = [
   "every_event_delivery_profile_has_an_explicit_observer_mode",
+  "startup_unavailable_state_has_no_task_or_snapshot",
   "boolean_parser_is_bounded",
 ];
 if (!sameValue(contract.required_iggy_tests, expectedIggyTests)) {
@@ -157,7 +171,7 @@ if (countText(iggySource, "#[test]") !== expectedIggyTests.length) {
   fail("Iggy observer source must contain exactly four focused tests");
 }
 if (countText(serverSource, "#[test]") !== expectedServerTests.length) {
-  fail("server observer source must contain exactly two focused tests");
+  fail("server observer source must contain exactly three focused tests");
 }
 
 for (const marker of [
@@ -183,14 +197,19 @@ for (const marker of [
 
 for (const marker of [
   'const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";',
+  '"iggy.dlq_duplicate.alert_server_observer_configuration_invalid"',
+  '"iggy.dlq_duplicate.alert_server_observer_runtime_unavailable"',
   "pub enum EventDlqDuplicateAlertObserverMode",
+  "Unavailable",
   "NotApplicableMemory",
   "NotApplicableOutboxLocal",
   "IggyBundled",
   "IggyExternal",
   "pub async fn start_event_dlq_duplicate_alert_observer(",
-  "let enabled = optional_bool_env(ENABLE_ENV, false)?;",
-  "let mode = observer_mode(runtime.delivery_profile, runtime.iggy_mode.as_ref())?;",
+  "let enabled = match optional_bool_env(ENABLE_ENV, false)",
+  "record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);",
+  "record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);",
+  "return Ok(());",
   "EventDeliveryProfile::Memory",
   "EventDeliveryProfile::OutboxLocal",
   "EventDeliveryProfile::OutboxIggy",
@@ -199,6 +218,7 @@ for (const marker of [
   "ctx.shared_get::<Arc<IggyTransport>>()",
   "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
   "IggyDlqDuplicateAlertObserver::connect(",
+  "if let Some(connected) = observer.take()",
   "connected.summarize().await",
   "publisher.publish(&summary)",
   "publisher.mark_unavailable()",
@@ -328,5 +348,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, fail-closed OutboxIggy active-mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without a fairness claim, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without a fairness claim, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
@@ -80,7 +80,7 @@ if (
   contract.schema_version !== 1 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-alert-policy-source" ||
-  contract.status !== "source_complete_runtime_composition_pending_server_integration" ||
+  contract.status !== "source_complete_server_observer_execution_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.summary_source !== summaryPath ||
@@ -156,7 +156,8 @@ for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? 
 }
 
 if (
-  contract.runtime_composition?.status !== "source_complete_server_integration_pending" ||
+  contract.runtime_composition?.status !==
+    "source_complete_server_observer_execution_pending" ||
   contract.runtime_composition?.contract !== runtimeContractPath ||
   contract.runtime_composition?.source !== runtimeSourcePath ||
   contract.runtime_composition?.input !== "DlqDuplicateSummary" ||
@@ -165,12 +166,13 @@ if (
   contract.runtime_composition?.single_writer !== true ||
   contract.runtime_composition?.unavailable_clears_evaluation !== true ||
   runtimeContract.packet !== "dlq-duplicate-alert-runtime-source" ||
-  runtimeContract.status !== "source_complete_server_integration_pending" ||
+  runtimeContract.status !== "source_complete_server_observer_execution_pending" ||
   runtimeContract.source !== runtimeSourcePath ||
   runtimeContract.policy_source !== sourcePath ||
-  runtimeContract.summary_source !== summaryPath
+  runtimeContract.summary_source !== summaryPath ||
+  runtimeContract.server_observer?.status !== "source_complete_execution_pending"
 ) {
-  fail("DLQ duplicate alert runtime composition relationship drift");
+  fail("DLQ duplicate alert runtime/server-observer relationship drift");
 }
 
 const requiredExcludedFields = new Set([
@@ -193,7 +195,9 @@ for (const field of contract.privacy_boundary?.evaluation_excludes ?? []) {
   requiredExcludedFields.delete(field);
 }
 if (requiredExcludedFields.size > 0) {
-  fail(`DLQ duplicate alert privacy exclusions are incomplete: ${[...requiredExcludedFields].join(", ")}`);
+  fail(`DLQ duplicate alert privacy exclusions are incomplete: ${[
+    ...requiredExcludedFields,
+  ].join(", ")}`);
 }
 
 if (
@@ -236,19 +240,11 @@ for (const marker of [
   'Self::Warning => "iggy.dlq_duplicate.alert.warning"',
   'Self::Critical => "iggy.dlq_duplicate.alert.critical"',
   "pub struct DlqDuplicateAlertEvaluation",
-  "level: DlqDuplicateAlertLevel",
-  "physical_duplicates: bool",
-  "identity_conflict: bool",
-  "duplicate_messages_threshold_reached: bool",
-  "duplicate_groups_threshold_reached: bool",
-  "max_copies_threshold_reached: bool",
   "pub const fn requires_manual_review(&self) -> bool",
-  "pub enum DlqDuplicateAlertPolicyError",
   'Self::InvalidThresholds => "iggy.dlq_duplicate.alert_policy_invalid"',
 ]) {
   requireText("DLQ duplicate alert policy source", source, marker);
 }
-
 for (const testName of expectedTests) {
   requireText("DLQ duplicate alert policy tests", source, `fn ${testName}()`);
 }
@@ -259,10 +255,6 @@ if (countText(source, "#[test]") !== expectedTests.length) {
 for (const marker of [
   "pub warning_duplicate_messages:",
   "pub critical_duplicate_messages:",
-  "pub warning_duplicate_groups:",
-  "pub critical_duplicate_groups:",
-  "pub warning_max_copies_per_message_id:",
-  "pub critical_max_copies_per_message_id:",
   "Serialize",
   "Deserialize",
   "tokio::sync::watch",
@@ -277,10 +269,8 @@ for (const marker of [
   ".replay(",
   ".retry_entry(",
   ".reserve_and_claim(",
-  ".release_claim(",
   ".mark_published(",
   ".mark_acknowledged(",
-  ".send(",
   ".notify(",
   ".page(",
 ]) {
@@ -315,7 +305,6 @@ for (const exportName of expectedExports) {
 }
 
 const requiredRemainingWork = new Set([
-  "server_observer_integration",
   "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "retained_policy_integration_evidence",
@@ -324,7 +313,9 @@ const requiredRemainingWork = new Set([
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemainingWork.delete(item);
 if (requiredRemainingWork.size > 0) {
-  fail(`DLQ duplicate alert remaining work drift: ${[...requiredRemainingWork].join(", ")}`);
+  fail(`DLQ duplicate alert remaining work drift: ${[
+    ...requiredRemainingWork,
+  ].join(", ")}`);
 }
 
 if (failures.length > 0) {
@@ -334,5 +325,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate alert policy source verified: explicit monotonic thresholds, clear/notice/warning/critical precedence, conflict-critical manual escalation, count-only boolean projection, stable codes, no production defaults, no broker/receipt access, no notification dispatch, no destructive action, and the single-writer stale-clearing latest-value runtime composition are locked; server integration remains pending.",
+  "Iggy DLQ duplicate alert policy source verified: explicit monotonic thresholds, clear/notice/warning/critical precedence, conflict-critical manual escalation, count-only boolean projection, stable codes, no production defaults, no broker/receipt access, no notification dispatch, no destructive action, and the single-writer runtime plus mode-aware server observer relationship are locked; execution and telemetry/health projection remain pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
@@ -10,6 +10,12 @@ const contractPath =
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
 const policyPath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
 const summaryPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const observerContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const observerIggySourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const observerServerSourcePath =
+  "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs";
 const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-alert-runtime.md";
@@ -30,9 +36,20 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const observerContract = JSON.parse(
+  readFileSync(resolve(repoRoot, observerContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const policy = readFileSync(resolve(repoRoot, policyPath), "utf8");
 const summary = readFileSync(resolve(repoRoot, summaryPath), "utf8");
+const observerIggySource = readFileSync(
+  resolve(repoRoot, observerIggySourcePath),
+  "utf8",
+);
+const observerServerSource = readFileSync(
+  resolve(repoRoot, observerServerSourcePath),
+  "utf8",
+);
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const failures = [];
 
@@ -60,7 +77,7 @@ if (
   contract.schema_version !== 1 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-alert-runtime-source" ||
-  contract.status !== "source_complete_server_integration_pending" ||
+  contract.status !== "source_complete_server_observer_execution_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.policy_source !== policyPath ||
@@ -122,6 +139,27 @@ for (const [operation, allowed] of Object.entries(contract.runtime_boundary ?? {
 }
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
   if (allowed !== false) fail(`DLQ duplicate alert runtime mutation became enabled: ${operation}`);
+}
+
+if (
+  contract.server_observer?.status !== "source_complete_execution_pending" ||
+  contract.server_observer?.contract !== observerContractPath ||
+  contract.server_observer?.iggy_source !== observerIggySourcePath ||
+  contract.server_observer?.server_source !== observerServerSourcePath ||
+  !sameValue(contract.server_observer?.delivery_profiles, [
+    "memory_not_applicable",
+    "outbox_local_not_applicable",
+    "outbox_iggy_bundled",
+    "outbox_iggy_external",
+  ]) ||
+  contract.server_observer?.readiness_dependency !== false ||
+  contract.server_observer?.profiles_authorization !== false ||
+  observerContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  observerContract.status !== "source_complete_runtime_execution_pending" ||
+  observerContract.iggy_source !== observerIggySourcePath ||
+  observerContract.server_source !== observerServerSourcePath
+) {
+  fail("DLQ duplicate alert server observer relationship drift");
 }
 
 for (const marker of [
@@ -211,6 +249,22 @@ for (const marker of [
 ]) {
   requireText("DLQ duplicate summary source", summary, marker);
 }
+for (const marker of [
+  "pub struct IggyDlqDuplicateAlertObserver",
+  "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
+]) {
+  requireText("Iggy observer composition", observerIggySource, marker);
+}
+for (const marker of [
+  "NotApplicableMemory",
+  "NotApplicableOutboxLocal",
+  "IggyBundled",
+  "IggyExternal",
+  "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
+  "publisher.mark_unavailable()",
+]) {
+  requireText("server observer composition", observerServerSource, marker);
+}
 
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_runtime;");
 for (const exportName of expectedExports) {
@@ -251,7 +305,6 @@ if (
 }
 
 const requiredRemaining = new Set([
-  "server_observer_integration",
   "telemetry_and_health_projection",
   "retained_runtime_integration_evidence",
   "notification_delivery_and_suppression_outside_runtime",
@@ -270,5 +323,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate alert runtime source verified: single-writer monotonic latest-value publication, initial/unavailable stale-clearing semantics, read-only independent subscribers, identifier-free stable errors, no broker/receipt/Profile mutation, and no notification/readiness implementation are locked; server integration remains pending.",
+  "Iggy DLQ duplicate alert runtime source verified: single-writer monotonic latest-value publication, initial/unavailable stale-clearing semantics, read-only independent subscribers, identifier-free stable errors, no broker/receipt/Profile mutation, and the explicit Memory/OutboxLocal/OutboxIggy server observer relationship are locked; server execution and telemetry/health projection remain pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -17,6 +17,12 @@ const alertSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
 const alertRuntimeContractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
 const alertRuntimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
+const observerContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const observerIggySourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const observerServerSourcePath =
+  "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
 const transportPath = "crates/rustok-iggy/src/transport.rs";
@@ -57,10 +63,15 @@ const alertContract = JSON.parse(
 const alertRuntimeContract = JSON.parse(
   readFileSync(resolve(repoRoot, alertRuntimeContractPath), "utf8"),
 );
+const observerContract = JSON.parse(
+  readFileSync(resolve(repoRoot, observerContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
 const alertSource = readFileSync(resolve(repoRoot, alertSourcePath), "utf8");
 const alertRuntimeSource = readFileSync(resolve(repoRoot, alertRuntimeSourcePath), "utf8");
+const observerIggySource = readFileSync(resolve(repoRoot, observerIggySourcePath), "utf8");
+const observerServerSource = readFileSync(resolve(repoRoot, observerServerSourcePath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
 const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
@@ -116,63 +127,8 @@ if (
 }
 
 if (
-  contract.runtime_adapter?.status !== "source_complete_runtime_pending" ||
-  contract.runtime_adapter?.contract !== adapterContractPath ||
-  contract.runtime_adapter?.source !== adapterSourcePath ||
-  contract.runtime_adapter?.auto_commit !== false ||
-  contract.runtime_adapter?.result !== "DlqDuplicateSummary" ||
-  adapterContract.packet !== "dlq-duplicate-external-scan-source" ||
-  adapterContract.status !== "source_complete_runtime_pending" ||
-  adapterContract.source !== adapterSourcePath ||
-  adapterContract.classifier_source !== sourcePath
-) {
-  fail("DLQ duplicate inspection runtime adapter relationship drift");
-}
-
-if (
-  contract.alert_policy?.status !==
-    "source_complete_runtime_composition_pending_server_integration" ||
-  contract.alert_policy?.contract !== alertContractPath ||
-  contract.alert_policy?.source !== alertSourcePath ||
-  contract.alert_policy?.input !== "DlqDuplicateSummary" ||
-  contract.alert_policy?.result !== "DlqDuplicateAlertEvaluation" ||
-  contract.alert_policy?.identity_conflict_always_critical !== true ||
-  contract.alert_policy?.production_defaults !== false ||
-  contract.alert_policy?.notification_dispatch !== false ||
-  contract.alert_policy?.destructive_action !== false ||
-  alertContract.packet !== "dlq-duplicate-alert-policy-source" ||
-  alertContract.status !==
-    "source_complete_runtime_composition_pending_server_integration" ||
-  alertContract.source !== alertSourcePath ||
-  alertContract.summary_source !== sourcePath
-) {
-  fail("DLQ duplicate inspection alert policy relationship drift");
-}
-
-if (
-  contract.alert_runtime?.status !== "source_complete_server_integration_pending" ||
-  contract.alert_runtime?.contract !== alertRuntimeContractPath ||
-  contract.alert_runtime?.source !== alertRuntimeSourcePath ||
-  contract.alert_runtime?.input !== "DlqDuplicateSummary" ||
-  contract.alert_runtime?.result !== "DlqDuplicateAlertRuntimeSnapshot" ||
-  contract.alert_runtime?.latest_value !== true ||
-  contract.alert_runtime?.single_writer !== true ||
-  contract.alert_runtime?.unavailable_clears_evaluation !== true ||
-  contract.alert_runtime?.notification_dispatch !== false ||
-  contract.alert_runtime?.destructive_action !== false ||
-  alertRuntimeContract.packet !== "dlq-duplicate-alert-runtime-source" ||
-  alertRuntimeContract.status !== "source_complete_server_integration_pending" ||
-  alertRuntimeContract.source !== alertRuntimeSourcePath ||
-  alertRuntimeContract.policy_source !== alertSourcePath ||
-  alertRuntimeContract.summary_source !== sourcePath
-) {
-  fail("DLQ duplicate inspection alert runtime relationship drift");
-}
-
-if (
   contract.identity?.input !== "non_nil_deterministic_iggy_message_header_uuid" ||
-  contract.identity?.payload_comparison !==
-    "domain_separated_sha256_in_memory_only" ||
+  contract.identity?.payload_comparison !== "domain_separated_sha256_in_memory_only" ||
   contract.identity?.empty_payload_valid !== true ||
   contract.identity?.nil_uuid_rejected !== true
 ) {
@@ -190,7 +146,6 @@ if (
 ) {
   fail("DLQ duplicate inspection semantic contract drift");
 }
-
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
   if (allowed !== false) fail(`DLQ duplicate inspection mutation became allowed: ${operation}`);
 }
@@ -200,6 +155,71 @@ if (
 ) {
   fail("DLQ duplicate inspection privacy flags drift");
 }
+
+if (
+  contract.runtime_adapter?.status !== "source_complete_runtime_pending" ||
+  contract.runtime_adapter?.contract !== adapterContractPath ||
+  contract.runtime_adapter?.source !== adapterSourcePath ||
+  contract.runtime_adapter?.auto_commit !== false ||
+  contract.runtime_adapter?.result !== "DlqDuplicateSummary" ||
+  adapterContract.packet !== "dlq-duplicate-external-scan-source" ||
+  adapterContract.source !== adapterSourcePath ||
+  adapterContract.classifier_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection runtime adapter relationship drift");
+}
+if (
+  contract.alert_policy?.status !== "source_complete_server_observer_execution_pending" ||
+  contract.alert_policy?.contract !== alertContractPath ||
+  contract.alert_policy?.source !== alertSourcePath ||
+  contract.alert_policy?.input !== "DlqDuplicateSummary" ||
+  contract.alert_policy?.result !== "DlqDuplicateAlertEvaluation" ||
+  contract.alert_policy?.identity_conflict_always_critical !== true ||
+  contract.alert_policy?.production_defaults !== false ||
+  contract.alert_policy?.notification_dispatch !== false ||
+  contract.alert_policy?.destructive_action !== false ||
+  alertContract.status !== "source_complete_server_observer_execution_pending" ||
+  alertContract.source !== alertSourcePath ||
+  alertContract.summary_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection alert policy relationship drift");
+}
+if (
+  contract.alert_runtime?.status !== "source_complete_server_observer_execution_pending" ||
+  contract.alert_runtime?.contract !== alertRuntimeContractPath ||
+  contract.alert_runtime?.source !== alertRuntimeSourcePath ||
+  contract.alert_runtime?.input !== "DlqDuplicateSummary" ||
+  contract.alert_runtime?.result !== "DlqDuplicateAlertRuntimeSnapshot" ||
+  contract.alert_runtime?.latest_value !== true ||
+  contract.alert_runtime?.single_writer !== true ||
+  contract.alert_runtime?.unavailable_clears_evaluation !== true ||
+  contract.alert_runtime?.notification_dispatch !== false ||
+  contract.alert_runtime?.destructive_action !== false ||
+  alertRuntimeContract.status !== "source_complete_server_observer_execution_pending" ||
+  alertRuntimeContract.source !== alertRuntimeSourcePath ||
+  alertRuntimeContract.policy_source !== alertSourcePath ||
+  alertRuntimeContract.summary_source !== sourcePath
+) {
+  fail("DLQ duplicate inspection alert runtime relationship drift");
+}
+if (
+  contract.server_observer?.status !== "source_complete_runtime_execution_pending" ||
+  contract.server_observer?.contract !== observerContractPath ||
+  contract.server_observer?.iggy_source !== observerIggySourcePath ||
+  contract.server_observer?.server_source !== observerServerSourcePath ||
+  contract.server_observer?.memory !== "not_applicable" ||
+  contract.server_observer?.outbox_local !== "not_applicable" ||
+  !sameValue(contract.server_observer?.outbox_iggy_modes, ["bundled", "external"]) ||
+  contract.server_observer?.readiness_dependency !== false ||
+  contract.server_observer?.profiles_authorization !== false ||
+  observerContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  observerContract.status !== "source_complete_runtime_execution_pending" ||
+  observerContract.iggy_source !== observerIggySourcePath ||
+  observerContract.server_source !== observerServerSourcePath
+) {
+  fail("DLQ duplicate inspection server observer relationship drift");
+}
+
 const requiredExcludedFields = new Set([
   "broker_address",
   "stream",
@@ -219,7 +239,9 @@ for (const field of contract.privacy_boundary?.summary_excludes ?? []) {
   requiredExcludedFields.delete(field);
 }
 if (requiredExcludedFields.size > 0) {
-  fail(`DLQ duplicate privacy exclusions are incomplete: ${[...requiredExcludedFields].join(", ")}`);
+  fail(`DLQ duplicate privacy exclusions are incomplete: ${[
+    ...requiredExcludedFields,
+  ].join(", ")}`);
 }
 
 for (const marker of [
@@ -258,7 +280,6 @@ for (const testName of expectedTests) {
 if (countText(source, "#[test]") !== expectedTests.length) {
   fail("DLQ duplicate inspection source must contain exactly four focused unit tests");
 }
-
 for (const marker of [
   "pub broker_message_id:",
   "pub payload_sha256:",
@@ -288,87 +309,44 @@ for (const marker of [
   requireText("bounded external duplicate scan adapter", adapterSource, marker);
 }
 for (const marker of [
-  ".store_consumer_offset(",
-  ".store_offset(",
-  ".acknowledge(",
-  ".send_messages(",
-  ".delete_topic(",
-  ".purge_topic(",
-]) {
-  forbidText("bounded external duplicate scan adapter", adapterSource, marker);
-}
-
-for (const marker of [
   "pub struct DlqDuplicateAlertPolicy",
   "pub const fn evaluate(",
-  "summary: &DlqDuplicateSummary",
   "pub enum DlqDuplicateAlertLevel",
-  "DlqDuplicateAlertLevel::Critical",
-  "DlqDuplicateAlertLevel::Warning",
-  "DlqDuplicateAlertLevel::Notice",
-  "DlqDuplicateAlertLevel::Clear",
   "pub struct DlqDuplicateAlertEvaluation",
-  "pub const fn requires_manual_review(&self) -> bool",
-  '"iggy.dlq_duplicate.alert_policy_invalid"',
 ]) {
   requireText("count-only duplicate alert policy", alertSource, marker);
 }
 for (const marker of [
-  "IggyClient",
-  "IggyTransport",
-  "ConsumerPoisonReceipt",
-  "tokio::sync::watch",
-  ".acknowledge(",
-  ".delete(",
-  ".replay(",
-  ".send(",
-  ".notify(",
-  ".page(",
-]) {
-  forbidText("count-only duplicate alert policy", alertSource, marker);
-}
-
-for (const marker of [
   "pub struct DlqDuplicateAlertRuntimePublisher",
-  "pub struct DlqDuplicateAlertRuntimeSubscriber",
   "pub struct DlqDuplicateAlertRuntimeSnapshot",
-  "watch::channel(DlqDuplicateAlertRuntimeSnapshot::unavailable(0))",
-  "pub fn publish(\n        &mut self,",
-  "self.policy.evaluate(summary)",
-  "pub fn mark_unavailable(\n        &mut self,",
+  "pub fn mark_unavailable(",
   "evaluation: None",
-  ".checked_add(1)",
-  '"iggy.dlq_duplicate.alert_runtime_publisher_closed"',
 ]) {
-  requireText("count-only duplicate alert runtime", alertRuntimeSource, marker);
+  requireText("latest-value alert runtime", alertRuntimeSource, marker);
 }
 for (const marker of [
-  "IggyClient",
-  "IggyTransport",
-  "ConsumerPoisonReceiptInspector",
-  ".poll_messages(",
-  ".get_consumer_offset(",
-  ".move_to_dlq(",
-  ".acknowledge(",
-  ".delete_topic(",
-  ".purge_topic(",
-  ".notify(",
-  ".page(",
+  "pub struct IggyDlqDuplicateAlertObserver",
+  "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
 ]) {
-  forbidText("count-only duplicate alert runtime", alertRuntimeSource, marker);
+  requireText("Iggy alert observer", observerIggySource, marker);
+}
+for (const marker of [
+  "NotApplicableMemory",
+  "NotApplicableOutboxLocal",
+  "IggyBundled",
+  "IggyExternal",
+  "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
+  "publisher.mark_unavailable()",
+]) {
+  requireText("server alert observer", observerServerSource, marker);
 }
 
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_runtime;");
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_observer;");
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
-}
-for (const exportName of alertContract.public_exports ?? []) {
-  requireText("rustok-iggy alert exports", lib, exportName);
-}
-for (const exportName of alertRuntimeContract.public_exports ?? []) {
-  requireText("rustok-iggy alert runtime exports", lib, exportName);
 }
 
 for (const marker of [
@@ -413,7 +391,6 @@ if (
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
-  "server_alert_observer_integration",
   "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "operator_ack_delete_replay_workflow_outside_inspector",
@@ -421,7 +398,9 @@ const requiredRemaining = new Set([
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
 if (requiredRemaining.size > 0) {
-  fail(`DLQ duplicate inspection remaining work drift: ${[...requiredRemaining].join(", ")}`);
+  fail(`DLQ duplicate inspection remaining work drift: ${[
+    ...requiredRemaining,
+  ].join(", ")}`);
 }
 
 if (failures.length > 0) {
@@ -431,5 +410,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, conflict escalation, stable errors, no broker/receipt mutation, focused tests, independent receipt-health semantics, bounded auto_commit=false external scan, explicit no-default count-only alert policy, and single-writer stale-clearing latest-value alert runtime are locked; retained execution and server integration remain pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, bounded auto_commit=false scanning, explicit alert policy, single-writer latest-value runtime, and mode-aware Memory/OutboxLocal/OutboxIggy server observation are locked; retained execution and telemetry/health projection remain pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -210,10 +210,17 @@ if (
   contract.server_observer?.memory !== "not_applicable" ||
   contract.server_observer?.outbox_local !== "not_applicable" ||
   !sameValue(contract.server_observer?.outbox_iggy_modes, ["bundled", "external"]) ||
+  contract.server_observer?.startup_failure_non_fatal !== true ||
+  contract.server_observer?.partition_fairness_claimed !== false ||
   contract.server_observer?.readiness_dependency !== false ||
   contract.server_observer?.profiles_authorization !== false ||
   observerContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
   observerContract.status !== "source_complete_runtime_execution_pending" ||
+  observerContract.activation?.observer_startup_failure_is_non_fatal !== true ||
+  observerContract.scan?.partition_fairness_claimed !== false ||
+  observerContract.scan?.moving_cursor !== false ||
+  observerContract.scan?.current_tail_coverage_claimed !== false ||
+  observerContract.scan?.complete_history_claimed !== false ||
   observerContract.iggy_source !== observerIggySourcePath ||
   observerContract.server_source !== observerServerSourcePath
 ) {
@@ -331,10 +338,12 @@ for (const marker of [
   requireText("Iggy alert observer", observerIggySource, marker);
 }
 for (const marker of [
+  "Unavailable",
   "NotApplicableMemory",
   "NotApplicableOutboxLocal",
   "IggyBundled",
   "IggyExternal",
+  "record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);",
   "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
   "publisher.mark_unavailable()",
 ]) {
@@ -391,6 +400,8 @@ if (
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
+  "partition_fairness_or_per_partition_budget_policy",
+  "moving_window_or_per_partition_cursor_policy",
   "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "operator_ack_delete_replay_workflow_outside_inspector",
@@ -410,5 +421,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, bounded auto_commit=false scanning, explicit alert policy, single-writer latest-value runtime, and mode-aware Memory/OutboxLocal/OutboxIggy server observation are locked; retained execution and telemetry/health projection remain pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, bounded auto_commit=false scanning, explicit alert policy, single-writer latest-value runtime, and mode-aware Memory/OutboxLocal/OutboxIggy server observation with non-fatal startup and explicit fairness/moving-window non-claims are locked; retained execution and telemetry/health projection remain pending.",
 );


### PR DESCRIPTION
## Summary

Add a mode-aware server composition for the count-only physical DLQ duplicate alert path without assuming that every event-delivery profile uses Iggy.

## Event delivery profile matrix

The observer handles every current profile explicitly:

```text
memory        -> NotApplicableMemory
outbox_local  -> NotApplicableOutboxLocal
outbox_iggy   -> IggyBundled or IggyExternal
```

For `memory` and `outbox_local`:

- no `IggyTransport` is requested;
- no broker client is opened;
- no alert thresholds are required;
- not-applicable state is valid operation, not an error or readiness degradation.

Only `outbox_iggy` resolves the shared transport already created by `build_event_runtime`.

## Iggy deployment modes

A new `IggyDlqDuplicateAlertObserver` supports both active Iggy modes:

- bundled: connects to the already-running validated loopback broker and matching TCP port;
- external: tries the reviewed configured addresses in order using the configured credentials/TLS options.

It never creates another `IggyTransport`, starts another bundled broker process, or shuts down the shared transport.

## Activation and non-fatal startup

The observer is default-off:

```text
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
```

Startup/configuration modes are explicit:

```text
disabled      -> Disabled
startup issue -> Unavailable, no task or snapshot
```

Invalid observer configuration, a missing active Iggy mode, or a missing observer dependency logs only a stable identifier-free code, records `Unavailable`, and returns normally to server bootstrap. Observer startup therefore cannot stop application bootstrap, event delivery, module projection, readiness, or Profiles authorization.

Stable startup codes:

```text
iggy.dlq_duplicate.alert_server_observer_configuration_invalid
iggy.dlq_duplicate.alert_server_observer_runtime_unavailable
```

## Bounded read-only scan

The Iggy adapter:

- includes every configured domain partition in the request allowlist;
- uses an explicit configured start offset;
- delegates to the existing bounded scanner;
- uses `auto_commit=false`;
- returns only `DlqDuplicateSummary`.

The scanner has one global message budget across the ordered partition allowlist. An earlier busy partition may exhaust it before later partitions are polled.

Each polling cycle also reuses the same configured explicit start offset. This PR therefore does **not** claim:

- partition fairness;
- a per-partition budget;
- a moving cursor;
- current-tail coverage;
- complete history.

Those are retained as explicit next design work rather than being implied by the observer.

## Runtime lifecycle

The server composes the existing single-writer `DlqDuplicateAlertRuntimePublisher`:

- successful scan -> publish identifier-free available evaluation;
- connection failure -> mark unavailable and retry;
- scan failure -> mark unavailable, drop the client, and reconnect;
- shutdown -> mark unavailable.

Unavailable transitions clear the previous evaluation so stale Warning/Critical state does not appear current.

The shared handle exposes only observer mode, task-finished state, and the optional latest identifier-free runtime snapshot.

## Privacy and mutation boundary

Logs and snapshots exclude broker addresses, stream/topic/partition/offset, UUIDs, payloads/digests, receipt identities, credentials, raw client errors, raw thresholds, and source counts.

The observer cannot publish, acknowledge, store offsets, delete, purge, replay, retry, mutate receipts, change broker configuration, dispatch notifications, or change Profiles state.

## Contracts and documentation

- added a versioned mode-aware server observer contract;
- added a static verifier;
- added Iggy observer and server mode source tests;
- added an Iggy operator guide and Profiles checkpoint;
- linked and actualized the parent duplicate inspection, alert policy, and latest-value runtime contracts/verifiers/docs;
- preserved moving-window/fairness, telemetry/health, notification delivery, retained execution evidence, and destructive reconciliation as separate remaining work.

## Verification

Tests, Cargo commands, formatters, source verifiers, server startup, broker connections, telemetry registration, alert dispatch, and retained capture were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
cargo test -p rustok-iggy dlq_duplicate_alert_observer -- --nocapture
cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
```
