### PR TITLE
feat(forum): harden approved-post author counts

### DIFF
--- a/crates/rustok-forum/contracts/forum-approved-posts-index-hardening.json
+++ b/crates/rustok-forum/contracts/forum-approved-posts-index-hardening.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-26I",
+  "upstream_task": "FORUM-26H",
+  "scope": "PostgreSQL and SQLite partial author-index hardening and executable query-plan source proof for the authoritative ApprovedPosts fact",
+  "provider_file": "crates/rustok-forum/src/services/posting_policy_approved_facts.rs",
+  "migration_file": "crates/rustok-forum/src/migrations/m20260728_000005_add_forum_approved_posts_indexes.rs",
+  "migration_registry": "crates/rustok-forum/src/migrations/mod.rs",
+  "sqlite_runtime_proof": "crates/rustok-forum/tests/approved_posts_index_sqlite.rs",
+  "postgres_runtime_proof": "crates/rustok-forum/tests/approved_posts_index_postgres.rs",
+  "postgres_test_bootstrap": "crates/rustok-forum/tests/support/postgres.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-26i-approved-posts-index-hardening.md",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-approved-posts-posting-facts.json",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "indexes": {
+    "topics": {
+      "name": "idx_forum_topics_tenant_author_retained",
+      "columns": ["tenant_id", "author_id"],
+      "predicate": ["author_id IS NOT NULL", "deleted_at IS NULL"]
+    },
+    "replies": {
+      "name": "idx_forum_replies_tenant_author_approved_retained",
+      "columns": ["tenant_id", "author_id", "topic_id"],
+      "predicate": [
+        "author_id IS NOT NULL",
+        "status = 'approved'",
+        "deleted_at IS NULL"
+      ]
+    }
+  },
+  "composition": {
+    "postgresql_sqlite_parity": true,
+    "exact_provider_query_preserved": true,
+    "partial_indexes_only": true,
+    "retained_topic_filter_indexed": true,
+    "approved_retained_reply_filter_indexed": true,
+    "tenant_user_prefix_preserved": true,
+    "reply_topic_join_key_included": true,
+    "parent_topic_retention_check_preserved": true,
+    "sqlite_explain_source_proof_added": true,
+    "postgres_explain_source_proof_added": true,
+    "index_definition_source_proof_added": true,
+    "postgres_test_platform_user_fixture_repaired": true,
+    "backfill_required": false,
+    "owner_state_rewrite_required": false,
+    "provider_output_changed": false,
+    "posting_owner_enforcement_added": false,
+    "policy_configuration_changed": false,
+    "rate_limit_execution_added": false,
+    "duplicate_hashing_added": false,
+    "external_ai_scoring_call_added": false,
+    "trust_state_write_changed": false,
+    "automatic_trust_change_added": false,
+    "transport_changed": false
+  },
+  "not_delivered": [
+    "authoritative active-flag and moderation-history owner fact adapters",
+    "authoritative reputation owner fact adapter and ledger",
+    "shared topic reply and edit usage-window owner adapters",
+    "authoritative bump-age owner adapter",
+    "policy configuration persistence and administration",
+    "topic reply edit and bump owner enforcement",
+    "shared distributed rate-limit reservation commit and release execution",
+    "duplicate-content hashing and retained fingerprint",
+    "external or AI spam scoring",
+    "automatic trust promotion and demotion",
+    "GraphQL REST OpenAPI admin and storefront policy surfaces",
+    "maintainer-executed PostgreSQL and SQLite runtime output"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum --test approved_posts_index_sqlite -- --nocapture",
+      "cargo test -p rustok-forum --test approved_posts_index_postgres -- --nocapture --test-threads=1",
+      "node scripts/verify/verify-forum-approved-posts-index-hardening.mjs",
+      "node scripts/verify/verify-forum-approved-posts-posting-facts.mjs",
+      "node scripts/verify/verify-forum-approved-posts-index-debt.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/contracts/forum-approved-posts-posting-facts.json
+++ b/crates/rustok-forum/contracts/forum-approved-posts-posting-facts.json
@@ -21,6 +21,8 @@
   "owner_note": "crates/rustok-forum/docs/forum-26h-approved-posts-posting-facts.md",
   "source_proof": "crates/rustok-forum/src/services/posting_policy_approved_facts.rs#tests",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "downstream_index_hardening_task": "FORUM-26I",
+  "downstream_index_hardening_contract": "crates/rustok-forum/contracts/forum-approved-posts-index-hardening.json",
   "composition": {
     "forum_topics_and_replies_are_authority": true,
     "current_retained_snapshot": true,

--- a/crates/rustok-forum/docs/forum-26i-approved-posts-index-hardening.md
+++ b/crates/rustok-forum/docs/forum-26i-approved-posts-index-hardening.md
@@ -1,0 +1,118 @@
+# FORUM-26I approved-post index hardening
+
+Status: source-ready / unvalidated
+
+## Delivered boundary
+
+This slice closes the pre-enforcement performance debt recorded by FORUM-26H
+for the authoritative `ApprovedPosts` posting-policy fact.
+
+The owner query and its semantics remain unchanged. The migration adds bounded
+partial author indexes for the exact predicates already used by
+`ForumApprovedPostsFactPort`, and dedicated PostgreSQL and SQLite source proofs
+bind those index shapes to the aggregate query.
+
+## Index contract
+
+`forum_topics` receives
+`idx_forum_topics_tenant_author_retained (tenant_id, author_id)` with the
+partial predicate:
+
+```sql
+author_id IS NOT NULL AND deleted_at IS NULL
+```
+
+This index serves the exact tenant/user count of retained topics. Topic
+lifecycle status remains intentionally absent because `open`, `closed`, and
+`archived` are lifecycle states, not moderation approval states.
+
+`forum_replies` receives
+`idx_forum_replies_tenant_author_approved_retained
+(tenant_id, author_id, topic_id)` with the partial predicate:
+
+```sql
+author_id IS NOT NULL AND status = 'approved' AND deleted_at IS NULL
+```
+
+The trailing `topic_id` supports the required tenant-scoped parent-topic join.
+The parent topic lookup and `topic.deleted_at IS NULL` predicate remain part of
+the owner query because a retained reply beneath a soft-deleted topic must not
+contribute.
+
+Both indexes are partial rather than full-table compatibility indexes. Pending,
+rejected, hidden, flagged, deleted-status, soft-deleted, and anonymous-author
+rows do not occupy the synchronous approved-post lookup indexes.
+
+## Runtime proof contract
+
+`tests/approved_posts_index_sqlite.rs` applies the module migrations, executes
+`EXPLAIN QUERY PLAN` over the exact SQLite aggregate shape, and requires both
+partial indexes to appear. It also inspects `sqlite_master` to retain the exact
+column and predicate contract.
+
+`tests/approved_posts_index_postgres.rs` applies the module migrations in an
+isolated schema, disables sequential scans for capability proof, executes
+`EXPLAIN (FORMAT JSON)` over the exact PostgreSQL aggregate shape, and requires
+both index names in the plan. It also inspects `pg_indexes` for the retained
+column and predicate contract.
+
+The PostgreSQL module-test bootstrap now creates the minimal platform-owned
+`users (id, tenant_id)` identity fixture before Forum migrations. FORUM-26A
+introduced a tenant-composite user reference for trust state, so the previous
+Forum-only bootstrap could no longer apply the complete migration chain in an
+isolated schema. The fixture exposes only the identity columns consumed by
+Forum and does not copy platform authentication or profile state.
+
+These are source-ready executable proofs. No runtime output is claimed until a
+maintainer runs the commands below.
+
+## Migration and compatibility
+
+PostgreSQL and SQLite use the same index names, ordered columns, and logical
+partial predicates. The migration is additive and requires no backfill or
+owner-state rewrite. Existing rows become index entries automatically when
+they satisfy the predicates.
+
+Rollback drops only the two new indexes. It does not modify topics, replies,
+trust state, policy facts, or transport contracts. Removing the indexes returns
+the owner query to its FORUM-26H performance profile without changing its
+result.
+
+## Explicit exclusions
+
+This slice adds no:
+
+- posting-policy evaluation or precedence change;
+- topic, reply, edit, or bump owner enforcement;
+- policy configuration persistence or administration;
+- new owner fact or fact-value semantics;
+- distributed rate-limit reservation, commit, release, or counters;
+- duplicate-content hashing or retained fingerprint;
+- external or AI spam-scoring call;
+- trust-state write or automatic promotion/demotion;
+- event, worker, GraphQL, REST, OpenAPI, admin, or storefront surface.
+
+## Remaining FORUM-26 scope
+
+The authoritative active-flag and moderation-history adapters remain the next
+fact-owner boundary. Reputation, usage windows, bump age, policy persistence,
+owner enforcement, shared rate-limit execution, duplicate fingerprints,
+optional scoring, administration, transports, UI, and maintainer runtime
+evidence also remain open.
+
+Missing capabilities must continue to produce explicit unavailable facts. No
+owner may infer moderation, reputation, or rate-limit state from
+`forum_user_stats`, reply-status totals, local counters, or policy heuristics.
+
+## Validation status
+
+The following commands were not run by the implementation agent:
+
+```text
+cargo test -p rustok-forum --test approved_posts_index_sqlite -- --nocapture
+cargo test -p rustok-forum --test approved_posts_index_postgres -- --nocapture --test-threads=1
+node scripts/verify/verify-forum-approved-posts-index-hardening.mjs
+node scripts/verify/verify-forum-approved-posts-posting-facts.mjs
+node scripts/verify/verify-forum-approved-posts-index-debt.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -146,7 +146,7 @@ rustok-media
   -> upload, storage, descriptors, quarantine and asset lifecycle
 
 rustok-forum
-  -> category tree, topics, replies, revisions, subscriptions, read state,
+  -> category tree, topics/replies, revisions, subscriptions, read state,
      drafts, bookmarks, reports, moderation, restrictions, forum trust,
      forum reactions/reputation, attachment relations and semantic events
 
@@ -222,7 +222,7 @@ at the end of this file remain authoritative.
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
 | `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |
 | `FORUM-25` | `planned` | Full content/UI multilingual contract and RTL support. |
-| `FORUM-26` | `planned` | Anti-spam, bounded posting policy and trust levels. |
+| `FORUM-26` | `in_progress` | FORUM-26A-I provide authoritative Forum trust state/facts, posting-policy contracts, evaluation/composition, account-age, topics-read and approved-post facts, plus pre-enforcement author-index and query-plan hardening. Active flags/moderation history, reputation, usage windows, bump age, policy persistence, owner enforcement, shared rate-limit execution, duplicate hashing, optional scoring, transports, UI and maintainer runtime evidence remain. |
 | `FORUM-27` | `planned` | Member directory, forum profile, badges and activity views. |
 | `FORUM-28` | `planned` | Editor, safe renderer and renderer-version rebuilds. |
 | `FORUM-29` | `planned` | Realtime acceleration with cursor/revision reconciliation. |
@@ -1588,7 +1588,7 @@ nested quotes. Notification locale is selected from the recipient, not actor.
 
 ## `FORUM-26` — anti-spam, limits and trust levels
 
-**Status:** `planned`  
+**Status:** `in_progress`  
 **Priority:** P0  
 **Dependencies:** FORUM-19, shared rate-limit capability
 
@@ -1602,6 +1602,81 @@ scoring.
 
 External/AI scoring is optional and cannot be a synchronous correctness
 dependency. Forum owns policy; shared rate limiting owns distributed execution.
+
+### Delivered in `FORUM-26A` through `FORUM-26I`
+
+- Forum-owned tenant/user trust state, typed trust levels, managed writes and an
+  authoritative exact-user trust facts adapter replace activity-counter or role
+  inference;
+- bounded posting-action, candidate-metric, rule, outcome, evidence and decision
+  contracts define explainable local policy evaluation without executing owner
+  writes or distributed reservations;
+- the facts composer keeps missing owner capabilities explicit and preserves
+  exact tenant/user actor identity, deadlines, typed retryability and one unique
+  provider per fact kind;
+- authoritative server/users account age, Forum topic-reading activity and
+  current retained approved-post facts are published without copying owner data
+  into policy configuration;
+- `FORUM-26I` adds PostgreSQL/SQLite partial author indexes aligned to the exact
+  approved-post query, source-ready `EXPLAIN` proofs, index-definition guards and
+  the minimal platform-user fixture required by the isolated PostgreSQL Forum
+  migration bootstrap;
+- none of these slices invokes the composer from topic/reply/edit/bump commands,
+  reserves shared rate-limit capacity, hashes duplicate content, calls external
+  scoring or automatically changes trust state.
+
+### Compatibility and degraded mode
+
+Trust rows and approved-post indexes are additive. Existing users without a
+trust row retain the documented compatibility level; existing topic/reply rows
+are indexed automatically with no backfill or owner-state rewrite. The approved-
+post query and fact value remain unchanged by the index migration. Missing fact
+owners continue to return explicit unavailable results, and optional external or
+AI scoring can never become a synchronous correctness dependency. Rolling back
+`FORUM-26I` drops only the two indexes and returns the query to its prior
+performance profile without changing results.
+
+### Remaining scope
+
+- publish authoritative active-flag and moderation-history facts from the
+  moderation/report owner without inferring them from reply-status totals;
+- publish authoritative reputation, topic/reply/edit usage-window and bump-age
+  facts from their named owners;
+- persist and administer bounded policy configuration with versioned audit;
+- enforce the composed decision in topic, reply, edit and bump owner commands;
+- reserve, commit and release distributed rate-limit capacity through the shared
+  capability without making it Forum persistence;
+- add retained duplicate-content fingerprints and optional external/AI scoring;
+- add automatic trust promotion/demotion only through explicit explainable owner
+  commands and immutable evidence;
+- expose bounded admin/storefront/transport surfaces and capture maintainer-
+  executed PostgreSQL, SQLite and cross-consumer runtime evidence.
+
+### Definition of done
+
+All posting owner paths evaluate one versioned bounded policy before mutation,
+missing required facts fail closed with typed retryability, distributed limits
+cannot be bypassed through another transport, duplicate/replay behavior is
+idempotent, optional scoring failure does not break correctness, and every trust
+change and posting denial is explainable and auditable.
+
+### Verification
+
+```bash
+cargo test -p rustok-forum posting_policy
+cargo test -p rustok-forum posting_policy_approved_facts -- --nocapture
+cargo test -p rustok-forum --test approved_posts_index_sqlite -- --nocapture
+cargo test -p rustok-forum --test approved_posts_index_postgres -- --nocapture --test-threads=1
+node scripts/verify/verify-forum-posting-policy-facts.mjs
+node scripts/verify/verify-forum-topic-reading-posting-facts.mjs
+node scripts/verify/verify-forum-approved-posts-posting-facts.mjs
+node scripts/verify/verify-forum-approved-posts-index-debt.mjs
+node scripts/verify/verify-forum-approved-posts-index-hardening.mjs
+cargo xtask module validate forum
+```
+
+The FORUM-26I source and contract records do not claim successful runtime
+verification until the maintainer runs the commands above.
 
 ## `FORUM-27` — member directory and forum profile
 
@@ -2183,6 +2258,8 @@ cargo test -p rustok-forum --test read_state_transport_contract -- --nocapture
 cargo test -p rustok-forum --test storefront_read_state_contract -- --nocapture
 cargo test -p rustok-forum --test storefront_read_state_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_read_state_postgres -- --nocapture --test-threads=1
+cargo test -p rustok-forum --test approved_posts_index_sqlite -- --nocapture
+cargo test -p rustok-forum --test approved_posts_index_postgres -- --nocapture --test-threads=1
 cargo test -p rustok-forum --test topic_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_visibility_policy_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_authenticated_visibility_sqlite -- --nocapture
@@ -2209,6 +2286,7 @@ node scripts/verify/verify-forum-mention-events.mjs
 node scripts/verify/verify-forum-quote-commands.mjs
 node scripts/verify/verify-forum-mention-runtime-proof.mjs
 node scripts/verify/verify-forum-read-state-runtime-proof.mjs
+node scripts/verify/verify-forum-approved-posts-index-hardening.mjs
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
@@ -2268,10 +2346,12 @@ Recommended next slices:
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
 12. continue `FORUM-20` with reply-create command-time enforcement and optional
-    topic-local narrowing, then add moderation audiences; implement Forum trust
-    owner state under `FORUM-26` before publishing the trust facts adapter;
-13. `FORUM-23`: index projections;
-14. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
+    topic-local narrowing, then add moderation audiences; consume the delivered
+    authoritative Forum trust facts only through the exact bounded facts port;
+13. continue `FORUM-26` with authoritative active-flag and moderation-history
+    fact adapters, keeping every missing owner capability explicitly unavailable;
+14. `FORUM-23`: index projections;
+15. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.
 
 # Decisions that must not be reopened without an ADR

--- a/crates/rustok-forum/src/migrations/m20260728_000005_add_forum_approved_posts_indexes.rs
+++ b/crates/rustok-forum/src/migrations/m20260728_000005_add_forum_approved_posts_indexes.rs
@@ -1,0 +1,72 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_UP).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_UP).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum approved-post author index migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_DOWN).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_DOWN).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum approved-post author index migration does not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn execute(manager: &SchemaManager<'_>, sql: &str) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(sql)
+        .await
+        .map(|_| ())
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_forum_topics_tenant_author_retained
+    ON forum_topics (tenant_id, author_id)
+    WHERE author_id IS NOT NULL
+      AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_forum_replies_tenant_author_approved_retained
+    ON forum_replies (tenant_id, author_id, topic_id)
+    WHERE author_id IS NOT NULL
+      AND status = 'approved'
+      AND deleted_at IS NULL;
+"#;
+
+const SQLITE_UP: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_forum_topics_tenant_author_retained
+    ON forum_topics (tenant_id, author_id)
+    WHERE author_id IS NOT NULL
+      AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_forum_replies_tenant_author_approved_retained
+    ON forum_replies (tenant_id, author_id, topic_id)
+    WHERE author_id IS NOT NULL
+      AND status = 'approved'
+      AND deleted_at IS NULL;
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP INDEX IF EXISTS idx_forum_replies_tenant_author_approved_retained;
+DROP INDEX IF EXISTS idx_forum_topics_tenant_author_retained;
+"#;
+
+const SQLITE_DOWN: &str = r#"
+DROP INDEX IF EXISTS idx_forum_replies_tenant_author_approved_retained;
+DROP INDEX IF EXISTS idx_forum_topics_tenant_author_retained;
+"#;

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -36,6 +36,7 @@ mod m20260728_000001_add_forum_category_reply_create_audience;
 mod m20260728_000002_add_forum_topic_reply_create_audience;
 mod m20260728_000003_add_forum_category_moderation_audience;
 mod m20260728_000004_add_forum_user_trust_state;
+mod m20260728_000005_add_forum_approved_posts_indexes;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -80,6 +81,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260728_000002_add_forum_topic_reply_create_audience::Migration),
         Box::new(m20260728_000003_add_forum_category_moderation_audience::Migration),
         Box::new(m20260728_000004_add_forum_user_trust_state::Migration),
+        Box::new(m20260728_000005_add_forum_approved_posts_indexes::Migration),
     ]
 }
 

--- a/crates/rustok-forum/tests/approved_posts_index_postgres.rs
+++ b/crates/rustok-forum/tests/approved_posts_index_postgres.rs
@@ -1,0 +1,152 @@
+mod support;
+
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use serde_json::Value;
+use uuid::Uuid;
+
+use support::postgres::{PostgresForumTestDb, execute};
+use support::{TestResult, test_error};
+
+const TOPIC_INDEX: &str = "idx_forum_topics_tenant_author_retained";
+const REPLY_INDEX: &str = "idx_forum_replies_tenant_author_approved_retained";
+
+#[tokio::test]
+async fn approved_posts_aggregate_uses_partial_author_indexes_on_postgres() -> TestResult<()> {
+    let Some(context) = PostgresForumTestDb::setup("approved_posts_index").await? else {
+        return Ok(());
+    };
+
+    let outcome = async {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let sql = approved_posts_proof_sql(tenant_id, user_id);
+
+        execute(&context.db, "SET enable_seqscan = off").await?;
+        let plan_result = explain_json(&context.db, &sql).await;
+        let reset_result = execute(&context.db, "RESET enable_seqscan").await;
+        let plan = plan_result?;
+        reset_result?;
+
+        let root = plan
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("Plan"))
+            .ok_or_else(|| test_error("approved-post EXPLAIN JSON is missing the root Plan"))?;
+        let mut nodes = Vec::new();
+        collect_plan_nodes(root, &mut nodes);
+        let index_names = nodes
+            .iter()
+            .filter_map(|node| node.get("Index Name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        for index_name in [TOPIC_INDEX, REPLY_INDEX] {
+            if !index_names.iter().any(|observed| observed == &index_name) {
+                return Err(test_error(format!(
+                    "approved-post plan must use {index_name}; observed indexes: {index_names:?}"
+                )));
+            }
+        }
+
+        assert_index_definition(
+            &context.db,
+            TOPIC_INDEX,
+            &["tenant_id", "author_id", "author_id IS NOT NULL", "deleted_at IS NULL"],
+        )
+        .await?;
+        assert_index_definition(
+            &context.db,
+            REPLY_INDEX,
+            &[
+                "tenant_id",
+                "author_id",
+                "topic_id",
+                "author_id IS NOT NULL",
+                "approved",
+                "deleted_at IS NULL",
+            ],
+        )
+        .await?;
+
+        Ok(())
+    }
+    .await;
+
+    context.cleanup().await?;
+    outcome
+}
+
+/// Proof-only mirror of the owner aggregate in
+/// `services/posting_policy_approved_facts.rs`.
+fn approved_posts_proof_sql(tenant_id: Uuid, user_id: Uuid) -> String {
+    format!(
+        r#"
+SELECT
+    (
+        SELECT COUNT(*)::bigint
+        FROM forum_topics topic
+        WHERE topic.tenant_id = '{tenant_id}'
+          AND topic.author_id = '{user_id}'
+          AND topic.deleted_at IS NULL
+    ) AS approved_topics,
+    (
+        SELECT COUNT(*)::bigint
+        FROM forum_replies reply
+        JOIN forum_topics topic
+          ON topic.tenant_id = reply.tenant_id
+         AND topic.id = reply.topic_id
+        WHERE reply.tenant_id = '{tenant_id}'
+          AND reply.author_id = '{user_id}'
+          AND reply.status = 'approved'
+          AND reply.deleted_at IS NULL
+          AND topic.deleted_at IS NULL
+    ) AS approved_replies
+"#
+    )
+}
+
+async fn explain_json(
+    db: &sea_orm::DatabaseConnection,
+    sql: &str,
+) -> TestResult<Value> {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!("EXPLAIN (COSTS OFF, FORMAT JSON) {sql}"),
+        ))
+        .await?
+        .ok_or_else(|| test_error("approved-post EXPLAIN JSON returned no row"))?;
+    Ok(row.try_get("", "QUERY PLAN")?)
+}
+
+async fn assert_index_definition(
+    db: &sea_orm::DatabaseConnection,
+    index_name: &str,
+    required_fragments: &[&str],
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() AND indexname = $1",
+            vec![index_name.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error(format!("PostgreSQL migration should create {index_name}")))?;
+    let definition = row.try_get::<String>("", "indexdef")?;
+    for fragment in required_fragments {
+        if !definition.contains(fragment) {
+            return Err(test_error(format!(
+                "{index_name} is missing `{fragment}`: {definition}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn collect_plan_nodes<'a>(node: &'a Value, nodes: &mut Vec<&'a Value>) {
+    nodes.push(node);
+    if let Some(children) = node.get("Plans").and_then(Value::as_array) {
+        for child in children {
+            collect_plan_nodes(child, nodes);
+        }
+    }
+}

--- a/crates/rustok-forum/tests/approved_posts_index_sqlite.rs
+++ b/crates/rustok-forum/tests/approved_posts_index_sqlite.rs
@@ -21,6 +21,21 @@ async fn setup() -> sea_orm::DatabaseConnection {
     let db = Database::connect(options)
         .await
         .expect("approved-post index SQLite database should connect");
+
+    // Forum trust-state migrations reference the platform-owned users table.
+    // Keep this isolated module proof self-contained with only the exact
+    // identity columns consumed by the migration chain.
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE users (
+            id TEXT NOT NULL PRIMARY KEY,
+            tenant_id TEXT NOT NULL
+        )
+        "#,
+    )
+    .await
+    .expect("SQLite platform user fixture should be created");
+
     let schema = SchemaManager::new(&db);
     for migration in TaxonomyModule.migrations() {
         migration
@@ -92,39 +107,50 @@ async fn approved_posts_aggregate_uses_partial_author_indexes_on_sqlite() {
         "approved-reply subquery must use {REPLY_INDEX}; observed plan:\n{plan}"
     );
 
-    for (index_name, required_fragments) in [
-        (
-            TOPIC_INDEX,
-            ["tenant_id, author_id", "author_id IS NOT NULL", "deleted_at IS NULL"].as_slice(),
-        ),
-        (
-            REPLY_INDEX,
-            [
-                "tenant_id, author_id, topic_id",
-                "author_id IS NOT NULL",
-                "status = 'approved'",
-                "deleted_at IS NULL",
-            ]
-            .as_slice(),
-        ),
-    ] {
-        let row = db
-            .query_one(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
-                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
-                vec![index_name.into()],
-            ))
-            .await
-            .expect("SQLite index definition lookup should succeed")
-            .unwrap_or_else(|| panic!("SQLite migration should create {index_name}"));
-        let definition = row
-            .try_get::<String>("", "sql")
-            .expect("SQLite index definition should be text");
-        for fragment in required_fragments {
-            assert!(
-                definition.contains(fragment),
-                "{index_name} is missing `{fragment}`: {definition}"
-            );
-        }
+    assert_index_definition(
+        &db,
+        TOPIC_INDEX,
+        &[
+            "tenant_id, author_id",
+            "author_id IS NOT NULL",
+            "deleted_at IS NULL",
+        ],
+    )
+    .await;
+    assert_index_definition(
+        &db,
+        REPLY_INDEX,
+        &[
+            "tenant_id, author_id, topic_id",
+            "author_id IS NOT NULL",
+            "status = 'approved'",
+            "deleted_at IS NULL",
+        ],
+    )
+    .await;
+}
+
+async fn assert_index_definition(
+    db: &sea_orm::DatabaseConnection,
+    index_name: &str,
+    required_fragments: &[&str],
+) {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+            vec![index_name.into()],
+        ))
+        .await
+        .expect("SQLite index definition lookup should succeed")
+        .unwrap_or_else(|| panic!("SQLite migration should create {index_name}"));
+    let definition = row
+        .try_get::<String>("", "sql")
+        .expect("SQLite index definition should be text");
+    for fragment in required_fragments {
+        assert!(
+            definition.contains(fragment),
+            "{index_name} is missing `{fragment}`: {definition}"
+        );
     }
 }

--- a/crates/rustok-forum/tests/approved_posts_index_sqlite.rs
+++ b/crates/rustok-forum/tests/approved_posts_index_sqlite.rs
@@ -1,0 +1,130 @@
+use rustok_core::MigrationSource;
+use rustok_forum::ForumModule;
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+const TOPIC_INDEX: &str = "idx_forum_topics_tenant_author_retained";
+const REPLY_INDEX: &str = "idx_forum_replies_tenant_author_approved_retained";
+
+async fn setup() -> sea_orm::DatabaseConnection {
+    let database_url = format!(
+        "sqlite:file:forum_approved_posts_index_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(database_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("approved-post index SQLite database should connect");
+    let schema = SchemaManager::new(&db);
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&schema)
+            .await
+            .expect("forum migration should apply");
+    }
+    db
+}
+
+#[tokio::test]
+async fn approved_posts_aggregate_uses_partial_author_indexes_on_sqlite() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            r#"
+            EXPLAIN QUERY PLAN
+            SELECT
+                (
+                    SELECT COUNT(*)
+                    FROM forum_topics topic
+                    WHERE topic.tenant_id = ?1
+                      AND topic.author_id = ?2
+                      AND topic.deleted_at IS NULL
+                ) AS approved_topics,
+                (
+                    SELECT COUNT(*)
+                    FROM forum_replies reply
+                    JOIN forum_topics topic
+                      ON topic.tenant_id = reply.tenant_id
+                     AND topic.id = reply.topic_id
+                    WHERE reply.tenant_id = ?1
+                      AND reply.author_id = ?2
+                      AND reply.status = 'approved'
+                      AND reply.deleted_at IS NULL
+                      AND topic.deleted_at IS NULL
+                ) AS approved_replies
+            "#,
+            vec![tenant_id.into(), user_id.into()],
+        ))
+        .await
+        .expect("approved-post EXPLAIN QUERY PLAN should succeed");
+
+    let details = rows
+        .into_iter()
+        .map(|row| {
+            row.try_get::<String>("", "detail")
+                .expect("SQLite query plan row should expose detail")
+        })
+        .collect::<Vec<_>>();
+    let plan = details.join("\n");
+
+    assert!(
+        plan.contains(TOPIC_INDEX),
+        "approved-topic subquery must use {TOPIC_INDEX}; observed plan:\n{plan}"
+    );
+    assert!(
+        plan.contains(REPLY_INDEX),
+        "approved-reply subquery must use {REPLY_INDEX}; observed plan:\n{plan}"
+    );
+
+    for (index_name, required_fragments) in [
+        (
+            TOPIC_INDEX,
+            ["tenant_id, author_id", "author_id IS NOT NULL", "deleted_at IS NULL"].as_slice(),
+        ),
+        (
+            REPLY_INDEX,
+            [
+                "tenant_id, author_id, topic_id",
+                "author_id IS NOT NULL",
+                "status = 'approved'",
+                "deleted_at IS NULL",
+            ]
+            .as_slice(),
+        ),
+    ] {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                vec![index_name.into()],
+            ))
+            .await
+            .expect("SQLite index definition lookup should succeed")
+            .unwrap_or_else(|| panic!("SQLite migration should create {index_name}"));
+        let definition = row
+            .try_get::<String>("", "sql")
+            .expect("SQLite index definition should be text");
+        for fragment in required_fragments {
+            assert!(
+                definition.contains(fragment),
+                "{index_name} is missing `{fragment}`: {definition}"
+            );
+        }
+    }
+}

--- a/crates/rustok-forum/tests/support/postgres.rs
+++ b/crates/rustok-forum/tests/support/postgres.rs
@@ -41,6 +41,18 @@ impl PostgresForumTestDb {
 
         let manager = SchemaManager::new(&db);
         let migration_result = async {
+            // Forum trust-state migrations reference the platform-owned users table.
+            // Keep the shared module regression bootstrap self-contained while
+            // preserving only the exact platform identity columns Forum consumes.
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE users (
+                    id UUID NOT NULL PRIMARY KEY,
+                    tenant_id UUID NOT NULL
+                )
+                "#,
+            )
+            .await?;
             for migration in OutboxModule.migrations() {
                 migration.up(&manager).await?;
             }

--- a/scripts/verify/verify-forum-approved-posts-index-hardening.mjs
+++ b/scripts/verify/verify-forum-approved-posts-index-hardening.mjs
@@ -84,6 +84,10 @@ for (const marker of [
 for (const marker of [
   "EXPLAIN QUERY PLAN",
   "sqlite_master",
+  "CREATE TABLE users",
+  "id TEXT NOT NULL PRIMARY KEY",
+  "tenant_id TEXT NOT NULL",
+  "Forum trust-state migrations reference the platform-owned users table",
   "approved_posts_aggregate_uses_partial_author_indexes_on_sqlite",
 ]) {
   requireText(sqliteProof, marker, `SQLite proof is missing ${marker}`);
@@ -112,7 +116,7 @@ for (const marker of [
   "partial author indexes",
   "owner query and its semantics remain unchanged",
   "posting-policy evaluation or precedence change",
-  "posting owner enforcement",
+  "topic, reply, edit, or bump owner enforcement",
   "not run by the implementation agent",
 ]) {
   requireText(note, marker, `FORUM-26I owner note is missing ${marker}`);

--- a/scripts/verify/verify-forum-approved-posts-index-hardening.mjs
+++ b/scripts/verify/verify-forum-approved-posts-index-hardening.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath ?? "");
+  if (!relativePath || !existsSync(absolute)) {
+    failures.push(`${relativePath || "<missing path>"}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-approved-posts-index-hardening.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const migration = read(contract.migration_file);
+const migrationRegistry = read(contract.migration_registry);
+const provider = read(contract.provider_file);
+const sqliteProof = read(contract.sqlite_runtime_proof);
+const postgresProof = read(contract.postgres_runtime_proof);
+const postgresBootstrap = read(contract.postgres_test_bootstrap);
+const note = read(contract.owner_note);
+const upstream = read(contract.upstream_contract);
+const plan = read(contract.canonical_plan);
+
+if (
+  contract.schema_version !== 1 ||
+  contract.task !== "FORUM-26I" ||
+  contract.upstream_task !== "FORUM-26H"
+) {
+  failures.push("approved-post index hardening contract identity is invalid");
+}
+
+for (const index of [contract.indexes?.topics, contract.indexes?.replies]) {
+  if (!index?.name || !Array.isArray(index.columns) || !Array.isArray(index.predicate)) {
+    failures.push("approved-post index contract is missing a bounded index definition");
+    continue;
+  }
+  requireText(migration, index.name, `migration is missing index ${index.name}`);
+  for (const marker of [...index.columns, ...index.predicate]) {
+    requireText(
+      migration,
+      marker,
+      `migration index ${index.name} is missing contract marker ${marker}`,
+    );
+  }
+  requireText(sqliteProof, index.name, `SQLite proof is missing index ${index.name}`);
+  requireText(postgresProof, index.name, `PostgreSQL proof is missing index ${index.name}`);
+}
+
+for (const marker of [
+  "mod m20260728_000005_add_forum_approved_posts_indexes;",
+  "Box::new(m20260728_000005_add_forum_approved_posts_indexes::Migration)",
+]) {
+  requireText(migrationRegistry, marker, `migration registry is missing ${marker}`);
+}
+
+for (const marker of [
+  "topic.tenant_id = $1",
+  "topic.author_id = $2",
+  "topic.deleted_at IS NULL",
+  "reply.tenant_id = $1",
+  "reply.author_id = $2",
+  "reply.status = 'approved'",
+  "reply.deleted_at IS NULL",
+  "topic.id = reply.topic_id",
+]) {
+  requireText(provider, marker, `ApprovedPosts provider drifted from index proof marker ${marker}`);
+}
+
+for (const marker of [
+  "EXPLAIN QUERY PLAN",
+  "sqlite_master",
+  "approved_posts_aggregate_uses_partial_author_indexes_on_sqlite",
+]) {
+  requireText(sqliteProof, marker, `SQLite proof is missing ${marker}`);
+}
+for (const marker of [
+  "EXPLAIN (COSTS OFF, FORMAT JSON)",
+  "SET enable_seqscan = off",
+  "RESET enable_seqscan",
+  "pg_indexes",
+  "approved_posts_aggregate_uses_partial_author_indexes_on_postgres",
+]) {
+  requireText(postgresProof, marker, `PostgreSQL proof is missing ${marker}`);
+}
+
+for (const marker of [
+  "CREATE TABLE users",
+  "id UUID NOT NULL PRIMARY KEY",
+  "tenant_id UUID NOT NULL",
+  "Forum trust-state migrations reference the platform-owned users table",
+]) {
+  requireText(postgresBootstrap, marker, `PostgreSQL Forum bootstrap repair is missing ${marker}`);
+}
+
+for (const marker of [
+  "FORUM-26I",
+  "partial author indexes",
+  "owner query and its semantics remain unchanged",
+  "posting-policy evaluation or precedence change",
+  "posting owner enforcement",
+  "not run by the implementation agent",
+]) {
+  requireText(note, marker, `FORUM-26I owner note is missing ${marker}`);
+}
+
+for (const marker of [
+  '"downstream_index_hardening_task": "FORUM-26I"',
+  '"downstream_index_hardening_contract": "crates/rustok-forum/contracts/forum-approved-posts-index-hardening.json"',
+]) {
+  requireText(upstream, marker, `FORUM-26H contract is missing downstream marker ${marker}`);
+}
+
+for (const marker of [
+  "| `FORUM-26` | `in_progress` |",
+  "### Delivered in `FORUM-26A` through `FORUM-26I`",
+  "approved-post author indexes",
+  "approved_posts_index_sqlite",
+  "approved_posts_index_postgres",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing FORUM-26I marker ${marker}`);
+}
+
+for (const [key, expected] of [
+  ["postgresql_sqlite_parity", true],
+  ["exact_provider_query_preserved", true],
+  ["partial_indexes_only", true],
+  ["sqlite_explain_source_proof_added", true],
+  ["postgres_explain_source_proof_added", true],
+  ["backfill_required", false],
+  ["provider_output_changed", false],
+  ["posting_owner_enforcement_added", false],
+  ["rate_limit_execution_added", false],
+  ["transport_changed", false],
+]) {
+  if (contract.composition?.[key] !== expected) {
+    failures.push(`FORUM-26I composition.${key} must be ${expected}`);
+  }
+}
+
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("FORUM-26I must not claim maintainer runtime execution");
+}
+
+if (failures.length > 0) {
+  console.error("Forum approved-post index hardening verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum approved-post index hardening contract is source-ready.");


### PR DESCRIPTION
## Summary

- add PostgreSQL and SQLite partial author indexes for the authoritative `ApprovedPosts` posting-policy fact
- add source-ready `EXPLAIN` proofs and index-definition guards for both database backends
- repair the isolated PostgreSQL Forum migration fixture and the new SQLite proof fixture for the platform-owned `users` identity dependency introduced by FORUM-26A
- synchronize the canonical Forum plan, record `FORUM-26A` through `FORUM-26I`, and link the FORUM-26H handoff contract

## Scope

This is the bounded `FORUM-26I` pre-enforcement performance-hardening slice. It does not add posting-policy enforcement, distributed rate-limit execution, duplicate hashing, external scoring, automatic trust changes, transports, or UI.

## Compatibility

The migration is additive and requires no backfill. Rolling it back drops only the two new partial indexes and does not change the authoritative fact result.

## Validation

Tests, Cargo commands, verifiers, workflows, and CI were not run by the implementation agent, per maintainer request.

Suggested maintainer commands:

```text
cargo test -p rustok-forum --test approved_posts_index_sqlite -- --nocapture
cargo test -p rustok-forum --test approved_posts_index_postgres -- --nocapture --test-threads=1
node scripts/verify/verify-forum-approved-posts-index-hardening.mjs
node scripts/verify/verify-forum-approved-posts-posting-facts.mjs
node scripts/verify/verify-forum-approved-posts-index-debt.mjs
cargo xtask module validate forum
```