### PR TITLE
feat(profiles): add fair per-partition DLQ scan windows

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
@@ -9,6 +9,7 @@
   "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
   "public_exports": [
     "IggyDlqDuplicateScanRequest",
+    "IggyDlqDuplicateScanWindowPolicy",
     "IggyDlqDuplicateScanner",
     "IggyDlqDuplicateScanError"
   ],
@@ -23,8 +24,10 @@
     "topic_metadata_read": false,
     "connection_lifecycle_owned_by_caller": true
   },
-  "request_boundary": {
+  "global_request_boundary": {
     "same_start_offset_for_each_partition": true,
+    "one_global_message_budget": true,
+    "later_partition_starvation_possible": true,
     "maximum_partitions": 128,
     "maximum_messages": 10000,
     "maximum_batch_messages": 1000,
@@ -33,6 +36,24 @@
     "zero_partition_rejected": true,
     "duplicate_partition_rejected": true,
     "zero_message_or_batch_limit_rejected": true
+  },
+  "fair_window_policy": {
+    "type": "IggyDlqDuplicateScanWindowPolicy",
+    "method": "IggyDlqDuplicateScanner::summarize_window",
+    "same_explicit_start_offset_for_every_partition": true,
+    "equal_per_partition_message_budget": true,
+    "every_partition_attempted_on_successful_scan": true,
+    "total_message_budget_checked": true,
+    "maximum_total_messages": 10000,
+    "maximum_partitions": 128,
+    "maximum_batch_messages": 1000,
+    "all_partition_observations_combined_before_classification": true,
+    "cross_partition_identity_conflict_preserved": true,
+    "moving_cursor": false,
+    "offset_persistence": false,
+    "cross_cycle_duplicate_accumulation": false,
+    "current_tail_coverage_claimed": false,
+    "complete_history_claimed": false
   },
   "response_validation": {
     "partition_must_match_request": true,
@@ -95,16 +116,19 @@
   "required_source_tests": [
     "bounded_request_requires_unique_positive_partitions",
     "bounded_request_rejects_unbounded_counts",
+    "fair_window_policy_bounds_each_partition_and_total",
+    "fair_window_policy_rejects_unbounded_total",
     "stable_errors_do_not_expose_broker_coordinates"
   ],
   "runtime_harness": {
-    "status": "source_complete_execution_pending",
+    "status": "global_request_source_complete_execution_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json",
     "test": "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs",
     "case": "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset",
     "reviewed_dedup_disabled_broker_required": true,
     "two_identical_scans": true,
-    "three_absent_offset_checks": true
+    "three_absent_offset_checks": true,
+    "fair_window_execution_evidence": false
   },
   "source_files": [
     "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
@@ -112,8 +136,11 @@
     "crates/rustok-iggy/src/lib.rs"
   ],
   "remaining_work": [
+    "fair_window_server_observer_integration",
+    "fair_window_external_iggy_execution_evidence",
+    "moving_window_or_per_partition_cursor_policy",
+    "cross_cycle_duplicate_accumulation_policy",
     "retained_external_iggy_duplicate_scan_evidence",
-    "operator_alert_threshold_policy",
     "authorized_destructive_reconciliation_workflow",
     "aggregate_receipt_and_duplicate_health_correlation"
   ],

--- a/crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
@@ -21,8 +21,9 @@ const MAX_STREAM_NAME_BYTES: usize = 255;
 /// Bounded explicit-offset request for a read-only physical Iggy DLQ scan.
 ///
 /// The request contains no broker address, credentials, payload, message ID, or
-/// mutation policy. Every partition starts at the same explicit offset. A caller
-/// that needs partition-specific windows must issue separate requests.
+/// mutation policy. Every partition starts at the same explicit offset. The one
+/// global message budget is consumed in partition order and can stop before a
+/// later partition is polled.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IggyDlqDuplicateScanRequest {
     partitions: Vec<u32>,
@@ -39,15 +40,7 @@ impl IggyDlqDuplicateScanRequest {
         batch_size: u32,
     ) -> Result<Self, IggyDlqDuplicateScanError> {
         validate_partitions(&partitions)?;
-        if max_messages == 0 || max_messages > MAX_SCAN_MESSAGES {
-            return Err(IggyDlqDuplicateScanError::InvalidRequest);
-        }
-        if batch_size == 0
-            || batch_size > MAX_BATCH_MESSAGES
-            || batch_size > max_messages
-        {
-            return Err(IggyDlqDuplicateScanError::InvalidRequest);
-        }
+        validate_message_bounds(max_messages, batch_size)?;
         Ok(Self {
             partitions,
             start_offset,
@@ -70,6 +63,67 @@ impl IggyDlqDuplicateScanRequest {
 
     pub const fn batch_size(&self) -> u32 {
         self.batch_size
+    }
+}
+
+/// Equal per-partition budget for one bounded read-only snapshot window.
+///
+/// Every configured partition starts at the same explicit offset and receives
+/// the same maximum message budget. The total across all partitions is capped
+/// at 10,000. This policy does not own a moving cursor, persisted progress,
+/// current-tail coverage, or complete-history semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IggyDlqDuplicateScanWindowPolicy {
+    partitions: Vec<u32>,
+    start_offset: u64,
+    per_partition_messages: u32,
+    batch_size: u32,
+    total_message_budget: u32,
+}
+
+impl IggyDlqDuplicateScanWindowPolicy {
+    pub fn new(
+        partitions: Vec<u32>,
+        start_offset: u64,
+        per_partition_messages: u32,
+        batch_size: u32,
+    ) -> Result<Self, IggyDlqDuplicateScanError> {
+        validate_partitions(&partitions)?;
+        validate_message_bounds(per_partition_messages, batch_size)?;
+        let partition_count =
+            u32::try_from(partitions.len()).map_err(|_| IggyDlqDuplicateScanError::InvalidRequest)?;
+        let total_message_budget = per_partition_messages
+            .checked_mul(partition_count)
+            .filter(|total| *total <= MAX_SCAN_MESSAGES)
+            .ok_or(IggyDlqDuplicateScanError::InvalidRequest)?;
+
+        Ok(Self {
+            partitions,
+            start_offset,
+            per_partition_messages,
+            batch_size,
+            total_message_budget,
+        })
+    }
+
+    pub fn partitions(&self) -> &[u32] {
+        &self.partitions
+    }
+
+    pub const fn start_offset(&self) -> u64 {
+        self.start_offset
+    }
+
+    pub const fn per_partition_messages(&self) -> u32 {
+        self.per_partition_messages
+    }
+
+    pub const fn batch_size(&self) -> u32 {
+        self.batch_size
+    }
+
+    pub const fn total_message_budget(&self) -> u32 {
+        self.total_message_budget
     }
 }
 
@@ -117,10 +171,43 @@ impl<'a> IggyDlqDuplicateScanner<'a> {
         })
     }
 
+    /// Scans one ordered partition allowlist under a single global message cap.
     pub async fn summarize(
         &self,
         request: &IggyDlqDuplicateScanRequest,
     ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateScanError> {
+        let observations = self.collect_observations(request).await?;
+        summarize_dlq_duplicates(observations).map_err(Into::into)
+    }
+
+    /// Scans every partition under an equal per-partition budget.
+    ///
+    /// Observations from every partition are combined before classification so
+    /// an invalid repeated deterministic ID in distinct partitions is not hidden.
+    /// Cursor movement and persistence remain caller-owned and are not added here.
+    pub async fn summarize_window(
+        &self,
+        policy: &IggyDlqDuplicateScanWindowPolicy,
+    ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateScanError> {
+        let mut observations = Vec::with_capacity(policy.total_message_budget as usize);
+
+        for &partition_id in &policy.partitions {
+            let request = IggyDlqDuplicateScanRequest {
+                partitions: vec![partition_id],
+                start_offset: policy.start_offset,
+                max_messages: policy.per_partition_messages,
+                batch_size: policy.batch_size,
+            };
+            observations.extend(self.collect_observations(&request).await?);
+        }
+
+        summarize_dlq_duplicates(observations).map_err(Into::into)
+    }
+
+    async fn collect_observations(
+        &self,
+        request: &IggyDlqDuplicateScanRequest,
+    ) -> Result<Vec<DlqDuplicateObservation>, IggyDlqDuplicateScanError> {
         let mut remaining = request.max_messages;
         let mut observations = Vec::with_capacity(request.max_messages as usize);
 
@@ -187,7 +274,7 @@ impl<'a> IggyDlqDuplicateScanner<'a> {
             }
         }
 
-        summarize_dlq_duplicates(observations).map_err(Into::into)
+        Ok(observations)
     }
 }
 
@@ -226,6 +313,21 @@ fn validate_partitions(partitions: &[u32]) -> Result<(), IggyDlqDuplicateScanErr
         if partition == 0 || !unique.insert(partition) {
             return Err(IggyDlqDuplicateScanError::InvalidRequest);
         }
+    }
+    Ok(())
+}
+
+fn validate_message_bounds(
+    max_messages: u32,
+    batch_size: u32,
+) -> Result<(), IggyDlqDuplicateScanError> {
+    if max_messages == 0
+        || max_messages > MAX_SCAN_MESSAGES
+        || batch_size == 0
+        || batch_size > MAX_BATCH_MESSAGES
+        || batch_size > max_messages
+    {
+        return Err(IggyDlqDuplicateScanError::InvalidRequest);
     }
     Ok(())
 }
@@ -275,6 +377,29 @@ mod tests {
                 Err(IggyDlqDuplicateScanError::InvalidRequest)
             ));
         }
+    }
+
+    #[test]
+    fn fair_window_policy_bounds_each_partition_and_total() {
+        let policy = IggyDlqDuplicateScanWindowPolicy::new(vec![1, 2, 3], 50, 100, 25)
+            .unwrap();
+        assert_eq!(policy.partitions(), &[1, 2, 3]);
+        assert_eq!(policy.start_offset(), 50);
+        assert_eq!(policy.per_partition_messages(), 100);
+        assert_eq!(policy.batch_size(), 25);
+        assert_eq!(policy.total_message_budget(), 300);
+    }
+
+    #[test]
+    fn fair_window_policy_rejects_unbounded_total() {
+        assert!(matches!(
+            IggyDlqDuplicateScanWindowPolicy::new(vec![1, 2], 0, 5_001, 100),
+            Err(IggyDlqDuplicateScanError::InvalidRequest)
+        ));
+        assert!(matches!(
+            IggyDlqDuplicateScanWindowPolicy::new(vec![1, 2], 0, 100, 101),
+            Err(IggyDlqDuplicateScanError::InvalidRequest)
+        ));
     }
 
     #[test]

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -106,7 +106,8 @@ pub use dlq_duplicate_alert_runtime::{
 };
 #[cfg(feature = "iggy")]
 pub use dlq_duplicate_external_scan::{
-    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest, IggyDlqDuplicateScanner,
+    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest,
+    IggyDlqDuplicateScanWindowPolicy, IggyDlqDuplicateScanner,
 };
 pub use dlq_duplicate_inspection::{
     DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,


### PR DESCRIPTION
## Summary

Add a bounded equal-per-partition snapshot policy for physical Iggy DLQ duplicate inspection while retaining the existing ordered global-budget request unchanged.

## Existing global-budget request

`IggyDlqDuplicateScanRequest` remains available with its existing semantics:

- one ordered partition allowlist;
- one shared explicit start offset;
- one global message cap;
- later partitions may be skipped when an earlier partition consumes the cap.

No compatibility behavior is silently changed.

## Fair snapshot policy

Add:

```text
IggyDlqDuplicateScanWindowPolicy
IggyDlqDuplicateScanner::summarize_window
```

The policy requires:

- unique positive partitions;
- one explicit start offset;
- one equal per-partition message cap;
- one bounded batch size;
- checked `partition_count * per_partition_messages <= 10000`.

A successful fair-window scan attempts every configured partition under the same cap. Physical observations from all partitions are combined before `summarize_dlq_duplicates`, preserving repeated deterministic IDs and conflicting payload groups across partitions.

## Read-only boundary

Both scan modes use:

```text
topic = dlq
standalone consumer
explicit partition
PollingStrategy::offset(explicit_offset)
auto_commit = false
```

They do not store offsets, acknowledge, publish, delete, purge, replay, retry, mutate receipts, alter broker configuration, or shut down the caller-owned client.

## Deliberate non-claims

The fair policy is one bounded snapshot window. This PR does not add or claim:

- a moving cursor;
- persisted offsets;
- cross-cycle identity/digest accumulation;
- current-tail coverage;
- complete history.

Moving each partition independently without retaining bounded prior identity state could split duplicate copies across cycles and hide the relationship. Cursor movement and cross-cycle accumulation remain a separate reviewed design.

## Event-delivery modes

This source slice does not change `Memory`, `OutboxLocal`, or the server observer lifecycle. The existing mode-aware observer still uses the original global-budget request. Fair-window server integration is retained as the next separate PR.

## Contracts and documentation

- expanded the scanner source contract to distinguish global and fair APIs;
- updated the scanner verifier and five focused source tests;
- updated Iggy and Profiles scanner documentation;
- linked the fair policy into the parent duplicate-inspection contract/verifier;
- actualized the aggregate Profiles operations plan;
- retained multi-partition external-Iggy evidence and server integration as pending.

## Verification

Tests, Cargo commands, formatters, source verifiers, broker scans, server observers, telemetry registration, and retained capture were not run, per maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
cargo test -p rustok-iggy dlq_duplicate_external_scan -- --nocapture
```
