### PR TITLE
feat(product): wire storefront catalog title search

### DIFF
--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -26,9 +26,12 @@ The category-bound admin transport keeps native server functions as the
 internal path and parallel GraphQL operations for the public/headless path.
 The DB-level tenant consistency audit, `VARCHAR(32)` locale storage, catalog
 search-option discovery, detached-value marker contract, and no-compile schema
-guardrail are source-locked. Storefront/admin catalog filter and sort execution
-remains open until typed query state, both transports, server-side semantics,
-and owner UI controls are connected end to end.
+guardrail are source-locked. Storefront title search now uses typed
+`CatalogListInput`, a Product-owned `StorefrontProductListQuery`, server-side
+translation-title filtering, the native owner endpoint, the existing GraphQL
+search filter, and a snake_case `search` UI control. The broader
+storefront/admin catalog filter and sort result remains open until category,
+sort, attribute-filter, and admin parity are connected end to end.
 Product write GraphQL derives tenant and actor exclusively from authenticated
 contexts. Product-owned `map_product_public_error` is shared by GraphQL and
 native admin/storefront transports; it keeps internal errors in structured logs
@@ -117,18 +120,19 @@ rustok-pricing` dependency cycle.
    shared [Richtext plan](../../../docs/modules/rich-text-implementation-plan.md),
    assign an owner profile, migrate both transports, and keep short/meta
    descriptions plain text.
-3. Connect product-owned storefront/admin catalog controls only after the typed
-   snake_case query contract (`search`, `category_id`, `sort_by`,
-   `sort_direction`, `attribute_filters`) is carried through core request
-   models, native and GraphQL adapters, server-side filters/sorts, and both UI
-   surfaces. Recheck on 2026-07-28 found that current `main` exposes catalog
-   search-option metadata, but storefront `RouteInput`/`FetchRequest` and the
-   admin list transport do not carry the complete contract. The previous
-   completed marker was therefore reverted and is guarded against source drift.
+3. Complete the product-owned catalog controls contract. The first 2026-07-28
+   execution slice closes storefront title search through typed UI state, both
+   selected transports, and Product-owned server-side filtering. The task stays
+   open for storefront category/sort/attribute filters and matching admin
+   controls. The completed marker must not return until the full snake_case
+   query contract (`search`, `category_id`, `sort_by`, `sort_direction`,
+   `attribute_filters`) is carried through core request models, native and
+   GraphQL adapters, server-side semantics, and both UI surfaces.
 
 ## Verification
 
 - [ ] Connect storefront/admin UI controls to optional catalog filters/sorts.
+- [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - `node scripts/verify/verify-product-catalog-controls-plan-sync.mjs`
 - `node scripts/verify/verify-product-catalog-controls-plan-sync.test.mjs`
 - `npm run verify:product:runtime-fallback-smoke`

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -28,6 +28,7 @@ pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};
 pub use services::{
     CatalogService, ProductCatalogSchemaService, StorefrontProductList, StorefrontProductListItem,
+    StorefrontProductListQuery,
 };
 
 pub struct ProductModule;

--- a/crates/rustok-product/src/services/catalog.rs
+++ b/crates/rustok-product/src/services/catalog.rs
@@ -5,7 +5,10 @@ mod queries;
 mod tags;
 pub mod types;
 
-pub use types::{ProductTagState, StorefrontProductList, StorefrontProductListItem};
+pub use types::{
+    ProductTagState, StorefrontProductList, StorefrontProductListItem,
+    StorefrontProductListQuery,
+};
 
 use chrono::Utc;
 use sea_orm::{

--- a/crates/rustok-product/src/services/catalog/queries.rs
+++ b/crates/rustok-product/src/services/catalog/queries.rs
@@ -11,6 +11,29 @@ impl CatalogService {
         page: u64,
         per_page: u64,
     ) -> CommerceResult<StorefrontProductList> {
+        self.list_published_products_with_query(
+            tenant_id,
+            locale,
+            fallback_locale,
+            public_channel_slug,
+            StorefrontProductListQuery::default(),
+            page,
+            per_page,
+        )
+        .await
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_published_products_with_query(
+        &self,
+        tenant_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        public_channel_slug: Option<&str>,
+        list_query: StorefrontProductListQuery,
+        page: u64,
+        per_page: u64,
+    ) -> CommerceResult<StorefrontProductList> {
         let fallback_locale = fallback_locale.unwrap_or(PLATFORM_FALLBACK_LOCALE);
         if page == 0 || per_page == 0 || per_page > 48 {
             return Err(CommerceError::Validation(
@@ -19,7 +42,7 @@ impl CatalogService {
         }
         let offset = (page.saturating_sub(1)) * per_page;
 
-        let query = entities::product::Entity::find()
+        let mut query = entities::product::Entity::find()
             .filter(entities::product::Column::TenantId.eq(tenant_id))
             .filter(entities::product::Column::Status.eq(entities::product::ProductStatus::Active))
             .filter(entities::product::Column::PublishedAt.is_not_null())
@@ -27,6 +50,17 @@ impl CatalogService {
                 self.db.get_database_backend(),
                 public_channel_slug,
             ));
+        if let Some(search) = list_query
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            query = query.filter(product_title_search_condition(
+                self.db.get_database_backend(),
+                search,
+            ));
+        }
         let total = query.clone().count(&self.db).await?;
         let products = query
             .order_by_desc(entities::product::Column::PublishedAt)
@@ -147,4 +181,31 @@ impl CatalogService {
             fallback_locale,
         )))
     }
+}
+
+fn product_title_search_condition(backend: sea_orm::DbBackend, search: &str) -> sea_orm::Condition {
+    let pattern = format!("%{search}%");
+    let exists_sql = match backend {
+        sea_orm::DbBackend::Sqlite => {
+            "EXISTS (
+                SELECT 1
+                FROM product_translations pt
+                WHERE pt.product_id = products.id
+                  AND pt.title LIKE ?
+            )"
+        }
+        _ => {
+            "EXISTS (
+                SELECT 1
+                FROM product_translations pt
+                WHERE pt.product_id = products.id
+                  AND pt.title LIKE $1
+            )"
+        }
+    };
+
+    sea_orm::Condition::all().add(sea_orm::sea_query::Expr::cust_with_values(
+        exists_sql,
+        vec![sea_orm::Value::from(pattern)],
+    ))
 }

--- a/crates/rustok-product/src/services/catalog/types.rs
+++ b/crates/rustok-product/src/services/catalog/types.rs
@@ -2,6 +2,11 @@ use crate::entities;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StorefrontProductListQuery {
+    pub search: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorefrontProductList {
     pub items: Vec<StorefrontProductListItem>,

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -3,6 +3,9 @@ pub mod catalog_schema;
 pub mod catalog_schema_service;
 mod write_transaction;
 
-pub use catalog::{CatalogService, StorefrontProductList, StorefrontProductListItem};
+pub use catalog::{
+    CatalogService, StorefrontProductList, StorefrontProductListItem,
+    StorefrontProductListQuery,
+};
 pub use catalog_schema::*;
 pub use catalog_schema_service::*;

--- a/crates/rustok-product/storefront/src/catalog_controls.rs
+++ b/crates/rustok-product/storefront/src/catalog_controls.rs
@@ -1,0 +1,47 @@
+use rustok_ui_core::normalize_optional_ui_text;
+
+use crate::i18n::t;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CatalogListInput {
+    pub search: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatalogSearchLabels {
+    pub label: String,
+    pub placeholder: String,
+    pub submit: String,
+}
+
+pub fn build_catalog_list_input(search: Option<String>) -> CatalogListInput {
+    CatalogListInput {
+        search: normalize_optional_ui_text(search),
+    }
+}
+
+pub fn build_catalog_search_labels(locale: Option<&str>) -> CatalogSearchLabels {
+    CatalogSearchLabels {
+        label: t(locale, "product.list.searchLabel", "Search catalog"),
+        placeholder: t(
+            locale,
+            "product.list.searchPlaceholder",
+            "Search published products",
+        ),
+        submit: t(locale, "product.list.searchSubmit", "Search"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_search_trims_and_drops_blank_values() {
+        assert_eq!(
+            build_catalog_list_input(Some("  camera  ".to_string())).search,
+            Some("camera".to_string())
+        );
+        assert_eq!(build_catalog_list_input(Some("   ".to_string())).search, None);
+    }
+}

--- a/crates/rustok-product/storefront/src/lib.rs
+++ b/crates/rustok-product/storefront/src/lib.rs
@@ -1,3 +1,4 @@
+mod catalog_controls;
 mod core;
 mod i18n;
 mod model;

--- a/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
+++ b/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
@@ -1,0 +1,149 @@
+use leptos::prelude::*;
+
+use crate::catalog_controls::CatalogListInput;
+use crate::core::FetchRequest;
+use crate::model::{ProductList, ProductListItem, StorefrontProductsData};
+
+use super::native_server_adapter::{self, ApiError};
+
+pub async fn fetch_products(
+    mut request: FetchRequest,
+    controls: CatalogListInput,
+) -> Result<StorefrontProductsData, ApiError> {
+    let products = storefront_catalog_list_native(request.locale.clone(), controls.search)
+        .await
+        .map_err(ApiError::from)?;
+    let resolved_handle = request
+        .selected_handle
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            products
+                .items
+                .first()
+                .map(|item| item.handle.clone())
+                .filter(|value| !value.is_empty())
+        });
+    request.selected_handle = resolved_handle.clone();
+
+    let mut data = native_server_adapter::fetch_products(request).await?;
+    data.products = products;
+    data.selected_handle = resolved_handle.clone();
+    if resolved_handle.is_none() {
+        data.selected_product = None;
+        data.selected_pricing = None;
+        data.resolution_context = None;
+    }
+    Ok(data)
+}
+
+#[cfg(feature = "ssr")]
+fn map_product_service_error(
+    error: rustok_product::CommerceError,
+    operation: &'static str,
+) -> ServerFnError {
+    ServerFnError::new(
+        rustok_product::map_product_public_error(
+            &error,
+            operation,
+            "product_storefront_catalog_list_native",
+        )
+        .to_string(),
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn map_product_list(value: rustok_product::StorefrontProductList) -> ProductList {
+    ProductList {
+        items: value
+            .items
+            .into_iter()
+            .map(|item| ProductListItem {
+                id: item.id.to_string(),
+                status: item.status.to_string(),
+                title: item.title,
+                handle: item.handle,
+                seller_id: item.seller_id,
+                vendor: item.vendor,
+                product_type: item.product_type,
+                tags: item.tags,
+                created_at: item.created_at.to_rfc3339(),
+                published_at: item.published_at.map(|value| value.to_rfc3339()),
+            })
+            .collect(),
+        total: value.total,
+        page: value.page,
+        per_page: value.per_page,
+        has_next: value.has_next,
+    }
+}
+
+fn normalize_public_channel_slug(channel_slug: Option<&str>) -> Option<String> {
+    channel_slug
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase())
+}
+
+#[server(
+    prefix = "/api/fn",
+    endpoint = "product/storefront/catalog-list"
+)]
+async fn storefront_catalog_list_native(
+    locale: Option<String>,
+    search: Option<String>,
+) -> Result<ProductList, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        use leptos::prelude::expect_context;
+        use rustok_api::HostRuntimeContext;
+        use rustok_outbox::TransactionalEventBus;
+        use rustok_product::{CatalogService, StorefrontProductListQuery};
+
+        let runtime_ctx = expect_context::<HostRuntimeContext>();
+        let event_bus = runtime_ctx
+            .shared_get::<TransactionalEventBus>()
+            .ok_or_else(|| {
+                ServerFnError::new(
+                    "product/storefront catalog list requires TransactionalEventBus in host runtime context",
+                )
+            })?;
+        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
+            .await
+            .ok();
+        let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let requested_locale = crate::core::resolve_requested_locale(
+            locale,
+            request_context.as_ref().map(|context| context.locale.as_str()),
+            tenant.default_locale.as_str(),
+        );
+        let public_channel_slug = request_context
+            .as_ref()
+            .and_then(|context| normalize_public_channel_slug(context.channel_slug.as_deref()));
+        let products = CatalogService::new(runtime_ctx.db_clone(), event_bus)
+            .list_published_products_with_query(
+                tenant.id,
+                requested_locale.as_str(),
+                Some(tenant.default_locale.as_str()),
+                public_channel_slug.as_deref(),
+                StorefrontProductListQuery { search },
+                1,
+                12,
+            )
+            .await
+            .map_err(|error| map_product_service_error(error, "storefront_catalog_list"))?;
+
+        Ok(map_product_list(products))
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = (locale, search);
+        Err(ServerFnError::new(
+            "product/storefront/catalog-list requires the `ssr` feature",
+        ))
+    }
+}

--- a/crates/rustok-product/storefront/src/transport/graphql_adapter.rs
+++ b/crates/rustok-product/storefront/src/transport/graphql_adapter.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use super::native_server_adapter::ApiError;
+use crate::catalog_controls::CatalogListInput;
 use crate::core::{FetchRequest, build_pricing_context};
 use crate::model::{
     ProductCatalogSearchOptions, ProductDetail, ProductList, ProductPricingDetail,
@@ -144,7 +145,10 @@ where
     .map_err(ApiError::from)
 }
 
-pub async fn fetch_products(request: FetchRequest) -> Result<StorefrontProductsData, ApiError> {
+pub async fn fetch_products(
+    request: FetchRequest,
+    controls: CatalogListInput,
+) -> Result<StorefrontProductsData, ApiError> {
     fetch_storefront_products(
         request.selected_handle,
         request.locale,
@@ -154,6 +158,7 @@ pub async fn fetch_products(request: FetchRequest) -> Result<StorefrontProductsD
         request.channel_id,
         request.channel_slug,
         request.quantity,
+        controls,
     )
     .await
 }
@@ -178,6 +183,7 @@ async fn fetch_storefront_products(
     channel_id: Option<String>,
     channel_slug: Option<String>,
     quantity: Option<i32>,
+    controls: CatalogListInput,
 ) -> Result<StorefrontProductsData, ApiError> {
     let products_response: StorefrontProductsResponse = request(
         STOREFRONT_PRODUCTS_QUERY,
@@ -186,7 +192,7 @@ async fn fetch_storefront_products(
             filter: StorefrontProductsFilter {
                 vendor: None,
                 product_type: None,
-                search: None,
+                search: controls.search,
                 page: Some(1),
                 per_page: Some(12),
             },

--- a/crates/rustok-product/storefront/src/transport/mod.rs
+++ b/crates/rustok-product/storefront/src/transport/mod.rs
@@ -1,6 +1,8 @@
+mod catalog_list_native;
 mod graphql_adapter;
 mod native_server_adapter;
 
+use crate::catalog_controls::CatalogListInput;
 use crate::core::FetchRequest;
 use crate::model::{ProductCatalogSearchOptions, StorefrontProductsData};
 use rustok_ui_transport::{
@@ -21,13 +23,17 @@ fn selected_transport_path() -> UiTransportPath {
     }
 }
 
-pub async fn fetch_products(request: FetchRequest) -> TransportResult<StorefrontProductsData> {
+pub async fn fetch_products(
+    request: FetchRequest,
+    controls: CatalogListInput,
+) -> TransportResult<StorefrontProductsData> {
     let native_request = request.clone();
+    let native_controls = controls.clone();
     execute_selected_transport(
         "product",
         selected_transport_path(),
-        move || native_server_adapter::fetch_products(native_request),
-        move || graphql_adapter::fetch_products(request),
+        move || catalog_list_native::fetch_products(native_request, native_controls),
+        move || graphql_adapter::fetch_products(request, controls),
     )
     .await
 }

--- a/crates/rustok-product/storefront/src/ui/leptos.rs
+++ b/crates/rustok-product/storefront/src/ui/leptos.rs
@@ -1,3 +1,4 @@
+use crate::catalog_controls::{build_catalog_list_input, build_catalog_search_labels};
 use crate::core::{
     build_catalog_rail_view_model, build_fetch_request, build_product_catalog_rail_labels,
     build_route_input, build_selected_product_empty_view_model, build_selected_product_view_model,
@@ -25,12 +26,23 @@ pub fn ProductView() -> impl IntoView {
         read_route_query_value(&route_context, "channel_slug"),
         read_route_query_value(&route_context, "quantity"),
     );
+    let catalog_input = build_catalog_list_input(read_route_query_value(&route_context, "search"));
+    let search_labels = build_catalog_search_labels(route_input.locale.as_deref());
+    let current_search = catalog_input.search.clone().unwrap_or_default();
+    let currency = route_input.currency_code.clone();
+    let region_id = route_input.region_id.clone();
+    let price_list_id = route_input.price_list_id.clone();
+    let channel_id = route_input.channel_id.clone();
+    let channel_slug = route_input.channel_slug.clone();
+    let quantity = route_input.quantity.map(|value| value.to_string());
     let shell = build_shell_view_model(route_input.locale.as_deref());
     let fetch_request = build_fetch_request(&route_input);
 
     let resource = Resource::new_blocking(
-        move || fetch_request.clone(),
-        move |request| async move { transport::fetch_products(request).await },
+        move || (fetch_request.clone(), catalog_input.clone()),
+        move |(request, controls)| async move {
+            transport::fetch_products(request, controls).await
+        },
     );
 
     view! {
@@ -40,6 +52,33 @@ pub fn ProductView() -> impl IntoView {
                 <h2 class="text-3xl font-semibold text-card-foreground">{shell.title}</h2>
                 <p class="text-sm text-muted-foreground">{shell.subtitle}</p>
             </div>
+            <form method="get" class="mt-6 flex flex-col gap-3 rounded-2xl border border-border bg-background p-4 sm:flex-row sm:items-end">
+                <div class="min-w-0 flex-1 space-y-2">
+                    <label for="product-catalog-search" class="text-sm font-medium text-foreground">
+                        {search_labels.label}
+                    </label>
+                    <input
+                        id="product-catalog-search"
+                        name="search"
+                        type="search"
+                        value=current_search
+                        placeholder=search_labels.placeholder
+                        class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
+                    />
+                </div>
+                {currency.map(|value| view! { <input type="hidden" name="currency" value=value /> })}
+                {region_id.map(|value| view! { <input type="hidden" name="region_id" value=value /> })}
+                {price_list_id.map(|value| view! { <input type="hidden" name="price_list_id" value=value /> })}
+                {channel_id.map(|value| view! { <input type="hidden" name="channel_id" value=value /> })}
+                {channel_slug.map(|value| view! { <input type="hidden" name="channel_slug" value=value /> })}
+                {quantity.map(|value| view! { <input type="hidden" name="quantity" value=value /> })}
+                <button
+                    type="submit"
+                    class="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+                >
+                    {search_labels.submit}
+                </button>
+            </form>
             <div class="mt-8">
                 <Suspense fallback=|| view! { <div class="space-y-4"><div class="h-48 animate-pulse rounded-3xl bg-muted"></div><div class="grid gap-3 md:grid-cols-3"><div class="h-28 animate-pulse rounded-2xl bg-muted"></div><div class="h-28 animate-pulse rounded-2xl bg-muted"></div><div class="h-28 animate-pulse rounded-2xl bg-muted"></div></div></div> }>
                     {move || {

--- a/scripts/verify/verify-product-storefront-boundary.mjs
+++ b/scripts/verify/verify-product-storefront-boundary.mjs
@@ -39,12 +39,15 @@ function assertNotContains(text, pattern, description) {
 }
 
 const libPath = "crates/rustok-product/storefront/src/lib.rs";
+const catalogControlsPath = "crates/rustok-product/storefront/src/catalog_controls.rs";
 const corePath = "crates/rustok-product/storefront/src/core.rs";
 const uiPath = "crates/rustok-product/storefront/src/ui/leptos.rs";
 const transportPath = "crates/rustok-product/storefront/src/transport/mod.rs";
+const catalogListNativePath = "crates/rustok-product/storefront/src/transport/catalog_list_native.rs";
 const legacyApiPath = "crates/rustok-product/storefront/src/api.rs";
 const graphqlAdapterPath = "crates/rustok-product/storefront/src/transport/graphql_adapter.rs";
 const nativeServerAdapterPath = "crates/rustok-product/storefront/src/transport/native_server_adapter.rs";
+const catalogQueriesPath = "crates/rustok-product/src/services/catalog/queries.rs";
 const cargoPath = "crates/rustok-product/storefront/Cargo.toml";
 const implementationPlanPath = "crates/rustok-product/docs/implementation-plan.md";
 const registryPath = "docs/modules/registry.md";
@@ -52,11 +55,14 @@ const packagePath = "package.json";
 
 for (const filePath of [
   libPath,
+  catalogControlsPath,
   corePath,
   uiPath,
   transportPath,
+  catalogListNativePath,
   graphqlAdapterPath,
   nativeServerAdapterPath,
+  catalogQueriesPath,
   cargoPath,
   implementationPlanPath,
   registryPath,
@@ -69,21 +75,30 @@ if (existsSync(repoPath(legacyApiPath))) {
 }
 
 const lib = readRepo(libPath);
+const catalogControls = readRepo(catalogControlsPath);
 const core = readRepo(corePath);
 const ui = readRepo(uiPath);
 const transport = readRepo(transportPath);
+const catalogListNative = readRepo(catalogListNativePath);
 const graphqlAdapter = readRepo(graphqlAdapterPath);
 const nativeServerAdapter = readRepo(nativeServerAdapterPath);
+const catalogQueries = readRepo(catalogQueriesPath);
 const cargo = readRepo(cargoPath);
 const implementationPlan = readRepo(implementationPlanPath);
 const registry = readRepo(registryPath);
 const packageJson = readRepo(packagePath);
 
+assertContains(lib, "mod catalog_controls;", `${libPath}: crate root must wire typed catalog controls`);
 assertContains(lib, "mod core;", `${libPath}: crate root must wire core`);
 assertContains(lib, "mod transport;", `${libPath}: crate root must wire transport facade`);
 assertContains(lib, "mod ui;", `${libPath}: crate root must wire UI adapters`);
 assertContains(lib, "pub use ui::leptos::ProductView;", `${libPath}: crate root must re-export ProductView`);
 assertNotContains(lib, "mod api;", `${libPath}: crate root must not wire legacy api adapter`);
+
+assertContains(catalogControls, "pub struct CatalogListInput", `${catalogControlsPath}: storefront controls must use a typed catalog input`);
+assertContains(catalogControls, "pub search: Option<String>", `${catalogControlsPath}: typed catalog input must carry optional search`);
+assertContains(catalogControls, "normalize_optional_ui_text", `${catalogControlsPath}: catalog search must normalize optional UI text`);
+assertContains(catalogControls, "build_catalog_search_labels", `${catalogControlsPath}: catalog search copy must stay outside the Leptos adapter`);
 
 for (const marker of ["leptos::", "leptos_", "#[component]", "#[server", "Resource<", "web_sys::"]) {
   assertNotContains(core, marker, `${corePath}: core must stay Leptos/server-function free (${marker})`);
@@ -108,6 +123,10 @@ assertContains(ui, "use crate::core::{", `${uiPath}: Leptos adapter must import 
 assertContains(ui, "use crate::transport;", `${uiPath}: Leptos adapter must call the module-owned transport facade`);
 assertContains(ui, "build_product_catalog_rail_labels", `${uiPath}: UI must consume core-owned catalog rail labels`);
 assertContains(ui, "build_catalog_rail_view_model", `${uiPath}: UI must consume core-owned catalog rail view-model`);
+assertContains(ui, "build_catalog_list_input", `${uiPath}: UI must build typed catalog control state`);
+assertContains(ui, 'read_route_query_value(&route_context, "search")', `${uiPath}: UI must read the snake_case search query key`);
+assertContains(ui, 'name="search"', `${uiPath}: UI must expose the search query control`);
+assertContains(ui, "transport::fetch_products(request, controls)", `${uiPath}: UI must pass typed controls to the transport facade`);
 for (const marker of [
   "crate::i18n::t",
   "ProductCatalogRailLabels {",
@@ -132,10 +151,20 @@ for (const marker of ["crate::api", /(^|[^A-Za-z0-9_])api::/, "#[server", "Produ
 }
 
 assertContains(transport, "fetch_products", `${transportPath}: transport facade must expose fetch_products`);
+assertContains(transport, "CatalogListInput", `${transportPath}: transport facade must accept typed catalog controls`);
+assertContains(transport, "mod catalog_list_native;", `${transportPath}: transport facade must wire the owner-native catalog list path`);
+assertContains(transport, "catalog_list_native::fetch_products", `${transportPath}: selected native path must execute the owner-native catalog list`);
 assertContains(transport, "mod graphql_adapter;", `${transportPath}: transport facade must wire GraphQL adapter`);
 assertContains(transport, "mod native_server_adapter;", `${transportPath}: transport facade must wire native server adapter`);
 assertNotContains(transport, "crate::api", `${transportPath}: transport facade must not import legacy api module`);
 assertContains(graphqlAdapter, "GraphqlRequest", `${graphqlAdapterPath}: GraphQL adapter must expose GraphQL request path`);
+assertContains(graphqlAdapter, "search: controls.search", `${graphqlAdapterPath}: GraphQL storefront list must carry typed search state`);
+assertContains(catalogListNative, 'endpoint = "product/storefront/catalog-list"', `${catalogListNativePath}: native catalog list must use an owner endpoint`);
+assertContains(catalogListNative, "StorefrontProductListQuery { search }", `${catalogListNativePath}: native catalog list must map typed search into the owner query`);
+assertContains(catalogListNative, ".list_published_products_with_query(", `${catalogListNativePath}: native catalog list must execute the owner service query`);
+assertNotContains(catalogListNative, "GraphqlRequest", `${catalogListNativePath}: native catalog list must not execute GraphQL`);
+assertContains(catalogQueries, "pub async fn list_published_products_with_query", `${catalogQueriesPath}: Product owner service must expose the typed list query`);
+assertContains(catalogQueries, "product_title_search_condition", `${catalogQueriesPath}: Product owner service must execute title search server-side`);
 assertContains(nativeServerAdapter, "#[server", `${nativeServerAdapterPath}: native server adapter must keep native server-function endpoint`);
 assertNotContains(nativeServerAdapter, "GraphqlRequest", `${nativeServerAdapterPath}: native adapter must not execute the parallel GraphQL contract`);
 assertContains(nativeServerAdapter, "expect_context::<HostRuntimeContext>()", `${nativeServerAdapterPath}: native server adapter must use host runtime context`);

--- a/scripts/verify/verify-product-storefront-boundary.test.mjs
+++ b/scripts/verify/verify-product-storefront-boundary.test.mjs
@@ -17,11 +17,20 @@ function writeFixtureFile(root, relativePath, content) {
 
 function libSource() {
   return `
+mod catalog_controls;
 mod core;
 mod transport;
 mod ui;
 
 pub use ui::leptos::ProductView;
+`;
+}
+
+function catalogControlsSource() {
+  return `
+use rustok_ui_core::normalize_optional_ui_text;
+pub struct CatalogListInput { pub search: Option<String> }
+pub fn build_catalog_search_labels() {}
 `;
 }
 
@@ -48,13 +57,17 @@ function uiSource({
   metadataSeparator = false,
   routeSegmentFallback = false,
   catalogEmptyBranch = false,
+  omitSearchControl = false,
 } = {}) {
   return `
+use crate::catalog_controls::build_catalog_list_input;
 use crate::core::{build_product_catalog_rail_labels, build_catalog_rail_view_model, resolve_route_segment};
 use crate::transport;
 
 pub fn ProductView() {
-    let _transport = transport::fetch_products;
+    ${omitSearchControl ? "" : 'let controls = build_catalog_list_input(read_route_query_value(&route_context, "search"));'}
+    ${omitSearchControl ? "" : 'let _search = view! { <input name="search" /> };'}
+    ${omitSearchControl ? "" : "let _transport = transport::fetch_products(request, controls);"}
     let _labels = build_product_catalog_rail_labels;
     let _rail = build_catalog_rail_view_model;
     let _route_segment = resolve_route_segment;
@@ -69,16 +82,34 @@ pub fn ProductView() {
 
 function transportSource() {
   return `
+mod catalog_list_native;
 mod graphql_adapter;
 mod native_server_adapter;
-pub async fn fetch_products() {}
+use crate::catalog_controls::CatalogListInput;
+pub async fn fetch_products(request: FetchRequest, controls: CatalogListInput) {
+    catalog_list_native::fetch_products(request, controls);
+}
 `;
 }
 
-function graphqlAdapterSource() {
+function catalogListNativeSource({ omitNativeSearch = false } = {}) {
+  return `
+#[server(prefix = "/api/fn", endpoint = "product/storefront/catalog-list")]
+async fn storefront_catalog_list_native(search: Option<String>) {
+  ${omitNativeSearch ? "" : "let query = StorefrontProductListQuery { search };"}
+  ${omitNativeSearch ? "" : "service.list_published_products_with_query(query);"}
+}
+`;
+}
+
+function graphqlAdapterSource({ omitGraphqlSearch = false } = {}) {
   return `
 use rustok_graphql::GraphqlRequest;
-pub async fn fetch_storefront_products() {}
+pub async fn fetch_storefront_products(controls: CatalogListInput) {
+  let filter = StorefrontProductsFilter {
+    ${omitGraphqlSearch ? "search: None," : "search: controls.search,"}
+  };
+}
 `;
 }
 
@@ -95,14 +126,26 @@ async fn storefront_products_native() {
 `;
 }
 
+function catalogQueriesSource() {
+  return `
+pub async fn list_published_products_with_query() {
+  let condition = product_title_search_condition(backend, search);
+}
+fn product_title_search_condition() {}
+`;
+}
+
 function withFixture(options = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "rustok-product-storefront-boundary-"));
   writeFixtureFile(root, "crates/rustok-product/storefront/src/lib.rs", libSource());
+  writeFixtureFile(root, "crates/rustok-product/storefront/src/catalog_controls.rs", catalogControlsSource());
   writeFixtureFile(root, "crates/rustok-product/storefront/src/core.rs", coreSource(options));
   writeFixtureFile(root, "crates/rustok-product/storefront/src/ui/leptos.rs", uiSource(options));
   writeFixtureFile(root, "crates/rustok-product/storefront/src/transport/mod.rs", transportSource());
-  writeFixtureFile(root, "crates/rustok-product/storefront/src/transport/graphql_adapter.rs", graphqlAdapterSource());
+  writeFixtureFile(root, "crates/rustok-product/storefront/src/transport/catalog_list_native.rs", catalogListNativeSource(options));
+  writeFixtureFile(root, "crates/rustok-product/storefront/src/transport/graphql_adapter.rs", graphqlAdapterSource(options));
   writeFixtureFile(root, "crates/rustok-product/storefront/src/transport/native_server_adapter.rs", nativeServerAdapterSource());
+  writeFixtureFile(root, "crates/rustok-product/src/services/catalog/queries.rs", catalogQueriesSource());
   writeFixtureFile(root, "crates/rustok-product/storefront/Cargo.toml", "[package]\nname = \"rustok-product-storefront\"\n");
   if (options.legacyApi) writeFixtureFile(root, "crates/rustok-product/storefront/src/api.rs", nativeServerAdapterSource());
   writeFixtureFile(root, "crates/rustok-product/docs/implementation-plan.md", "verify-product-storefront-boundary.mjs");
@@ -125,6 +168,17 @@ function runVerifier(root) {
   });
 }
 
+function assertFixtureFails(options, pattern, message) {
+  const root = withFixture(options);
+  try {
+    const result = runVerifier(root);
+    assert.notEqual(result.status, 0, message);
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 test("product storefront boundary verifier passes canonical fixture", () => {
   const root = withFixture();
   try {
@@ -136,90 +190,90 @@ test("product storefront boundary verifier passes canonical fixture", () => {
   }
 });
 
+test("product storefront boundary verifier rejects missing search control", () => {
+  assertFixtureFails(
+    { omitSearchControl: true },
+    /snake_case search query key|search query control|typed controls/,
+    "Expected missing storefront search control fixture to fail",
+  );
+});
+
+test("product storefront boundary verifier rejects missing GraphQL search mapping", () => {
+  assertFixtureFails(
+    { omitGraphqlSearch: true },
+    /GraphQL storefront list must carry typed search state/,
+    "Expected missing GraphQL search mapping fixture to fail",
+  );
+});
+
+test("product storefront boundary verifier rejects missing native owner search", () => {
+  assertFixtureFails(
+    { omitNativeSearch: true },
+    /native catalog list must map typed search|execute the owner service query/,
+    "Expected missing native owner search fixture to fail",
+  );
+});
+
 test("product storefront boundary verifier rejects Leptos-specific core", () => {
-  const root = withFixture({ includeLeptos: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected Leptos core fixture to fail");
-    assert.match(result.stderr, /core must stay Leptos\/server-function free/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { includeLeptos: true },
+    /core must stay Leptos\/server-function free/,
+    "Expected Leptos core fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects missing catalog labels helper", () => {
-  const root = withFixture({ omitCatalogLabels: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected missing catalog labels fixture to fail");
-    assert.match(result.stderr, /build_product_catalog_rail_labels/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { omitCatalogLabels: true },
+    /build_product_catalog_rail_labels/,
+    "Expected missing catalog labels fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects catalog copy in UI", () => {
-  const root = withFixture({ directCatalogLabels: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected direct catalog copy fixture to fail");
-    assert.match(result.stderr, /catalog rail copy\/label policy must stay in core/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { directCatalogLabels: true },
+    /catalog rail copy\/label policy must stay in core/,
+    "Expected direct catalog copy fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects selected metadata separators in UI", () => {
-  const root = withFixture({ metadataSeparator: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected direct metadata separator fixture to fail");
-    assert.match(result.stderr, /selected-product metadata display policy must stay in core/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { metadataSeparator: true },
+    /selected-product metadata display policy must stay in core/,
+    "Expected direct metadata separator fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects route segment fallback in UI", () => {
-  const root = withFixture({ routeSegmentFallback: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected route segment fallback fixture to fail");
-    assert.match(result.stderr, /route segment fallback policy must stay in core/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { routeSegmentFallback: true },
+    /route segment fallback policy must stay in core/,
+    "Expected route segment fallback fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects catalog empty-state policy in UI", () => {
-  const root = withFixture({ catalogEmptyBranch: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected catalog empty-state fixture to fail");
-    assert.match(result.stderr, /catalog rail empty-state policy must stay in core/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { catalogEmptyBranch: true },
+    /catalog rail empty-state policy must stay in core/,
+    "Expected catalog empty-state fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects raw api calls from UI", () => {
-  const root = withFixture({ rawApiCall: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected raw UI api fixture to fail");
-    assert.match(result.stderr, /UI adapter must not call raw transport or services/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { rawApiCall: true },
+    /UI adapter must not call raw transport or services/,
+    "Expected raw UI api fixture to fail",
+  );
 });
 
 test("product storefront boundary verifier rejects legacy api module", () => {
-  const root = withFixture({ legacyApi: true });
-  try {
-    const result = runVerifier(root);
-    assert.notEqual(result.status, 0, "Expected legacy api fixture to fail");
-    assert.match(result.stderr, /legacy api\.rs/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assertFixtureFails(
+    { legacyApi: true },
+    /legacy api\.rs/,
+    "Expected legacy api fixture to fail",
+  );
 });


### PR DESCRIPTION
## Summary

- add typed storefront catalog search state with the snake_case `search` query key;
- execute title search inside the Product owner service;
- carry the same search through the owner-native server endpoint and GraphQL selected path;
- add a storefront GET control while preserving pricing/channel context;
- extend the Product storefront boundary guard and mutation fixtures;
- record the completed search slice while keeping the broader category/sort/attribute/admin task open.

## Scope

This is the first bounded implementation slice after restoring plan integrity in #2405. It intentionally closes storefront title search only. Category filters, attribute filters, sorting, and admin parity remain open in the Product plan.

## Testing

Not run by the implementation agent, per maintainer request.

Suggested maintainer commands:

```bash
npm run verify:product:storefront-boundary
npm run test:verify:product:storefront-boundary
node scripts/verify/verify-product-catalog-controls-plan-sync.mjs
```
