### PR TITLE
feat(profiles): integrate fair DLQ scan windows

### DIFF
--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -17,8 +17,11 @@ use crate::services::server_runtime_context::ServerRuntimeContext;
 
 const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";
 const POLL_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS";
+const SCAN_MODE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE";
 const START_OFFSET_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET";
 const MAX_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES";
+const PER_PARTITION_MESSAGES_ENV: &str =
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES";
 const BATCH_SIZE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE";
 const WARNING_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MESSAGES";
 const CRITICAL_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MESSAGES";
@@ -45,6 +48,18 @@ pub enum EventDlqDuplicateAlertObserverMode {
     IggyExternal,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventDlqDuplicateAlertScanConfig {
+    GlobalBudget {
+        max_messages: u32,
+        batch_size: u32,
+    },
+    FairWindow {
+        per_partition_messages: u32,
+        batch_size: u32,
+    },
+}
+
 pub struct EventDlqDuplicateAlertObserverHandle {
     mode: EventDlqDuplicateAlertObserverMode,
     subscriber: Option<DlqDuplicateAlertRuntimeSubscriber>,
@@ -68,8 +83,7 @@ impl EventDlqDuplicateAlertObserverHandle {
 struct EventDlqDuplicateAlertObserverConfig {
     poll: Duration,
     start_offset: u64,
-    max_messages: u32,
-    batch_size: u32,
+    scan: EventDlqDuplicateAlertScanConfig,
     policy: DlqDuplicateAlertPolicy,
 }
 
@@ -190,14 +204,33 @@ async fn observer_loop(
         }
 
         if observer.is_none() {
-            match IggyDlqDuplicateAlertObserver::connect(
-                &iggy_config,
-                config.start_offset,
-                config.max_messages,
-                config.batch_size,
-            )
-            .await
-            {
+            let connection = match config.scan {
+                EventDlqDuplicateAlertScanConfig::GlobalBudget {
+                    max_messages,
+                    batch_size,
+                } => {
+                    IggyDlqDuplicateAlertObserver::connect(
+                        &iggy_config,
+                        config.start_offset,
+                        max_messages,
+                        batch_size,
+                    )
+                    .await
+                }
+                EventDlqDuplicateAlertScanConfig::FairWindow {
+                    per_partition_messages,
+                    batch_size,
+                } => {
+                    IggyDlqDuplicateAlertObserver::connect_fair_window(
+                        &iggy_config,
+                        config.start_offset,
+                        per_partition_messages,
+                        batch_size,
+                    )
+                    .await
+                }
+            };
+            match connection {
                 Ok(connected) => observer = Some(connected),
                 Err(error) => {
                     let _ = publisher.mark_unavailable();
@@ -267,8 +300,24 @@ impl EventDlqDuplicateAlertObserverConfig {
                 "{POLL_ENV} must be between 1 and {MAX_POLL_MS}"
             )));
         }
-        let max_messages = optional_u32_env(MAX_MESSAGES_ENV, DEFAULT_MAX_MESSAGES)?;
-        let batch_size = optional_u32_env(BATCH_SIZE_ENV, DEFAULT_BATCH_SIZE)?;
+        let scan = match optional_scan_mode_env()? {
+            EventDlqDuplicateAlertScanMode::GlobalBudget => {
+                EventDlqDuplicateAlertScanConfig::GlobalBudget {
+                    max_messages: optional_u32_env(MAX_MESSAGES_ENV, DEFAULT_MAX_MESSAGES)?,
+                    batch_size: optional_u32_env(BATCH_SIZE_ENV, DEFAULT_BATCH_SIZE)?,
+                }
+            }
+            EventDlqDuplicateAlertScanMode::FairWindow => {
+                let per_partition_messages = required_u32_env(PER_PARTITION_MESSAGES_ENV)?;
+                EventDlqDuplicateAlertScanConfig::FairWindow {
+                    per_partition_messages,
+                    batch_size: optional_u32_env(
+                        BATCH_SIZE_ENV,
+                        DEFAULT_BATCH_SIZE.min(per_partition_messages),
+                    )?,
+                }
+            }
+        };
         let policy = DlqDuplicateAlertPolicy::new(
             required_u64_env(WARNING_MESSAGES_ENV)?,
             required_u64_env(CRITICAL_MESSAGES_ENV)?,
@@ -282,10 +331,37 @@ impl EventDlqDuplicateAlertObserverConfig {
         Ok(Self {
             poll: Duration::from_millis(poll_ms),
             start_offset: optional_u64_env(START_OFFSET_ENV, 0)?,
-            max_messages,
-            batch_size,
+            scan,
             policy,
         })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventDlqDuplicateAlertScanMode {
+    GlobalBudget,
+    FairWindow,
+}
+
+fn optional_scan_mode_env() -> Result<EventDlqDuplicateAlertScanMode> {
+    match env::var(SCAN_MODE_ENV) {
+        Ok(value) => parse_scan_mode(&value).map_err(Error::Message),
+        Err(env::VarError::NotPresent) => Ok(EventDlqDuplicateAlertScanMode::GlobalBudget),
+        Err(error) => Err(Error::Message(format!(
+            "failed to read {SCAN_MODE_ENV}: {error}"
+        ))),
+    }
+}
+
+fn parse_scan_mode(
+    value: &str,
+) -> std::result::Result<EventDlqDuplicateAlertScanMode, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "global" | "global_budget" => Ok(EventDlqDuplicateAlertScanMode::GlobalBudget),
+        "fair" | "fair_window" => Ok(EventDlqDuplicateAlertScanMode::FairWindow),
+        _ => Err(format!(
+            "{SCAN_MODE_ENV} must be global_budget or fair_window"
+        )),
     }
 }
 
@@ -351,6 +427,11 @@ fn optional_u32_env(name: &str, default: u32) -> Result<u32> {
     u32::try_from(value).map_err(|_| Error::Message(format!("{name} exceeds u32")))
 }
 
+fn required_u32_env(name: &str) -> Result<u32> {
+    let value = required_u64_env(name)?;
+    u32::try_from(value).map_err(|_| Error::Message(format!("{name} exceeds u32")))
+}
+
 fn required_u64_env(name: &str) -> Result<u64> {
     match env::var(name) {
         Ok(value) => value
@@ -398,6 +479,19 @@ mod tests {
         assert_eq!(handle.mode(), EventDlqDuplicateAlertObserverMode::Unavailable);
         assert_eq!(handle.current_snapshot(), None);
         assert!(!handle.is_finished());
+    }
+
+    #[test]
+    fn scan_mode_parser_preserves_global_default_and_explicit_fair_window() {
+        assert_eq!(
+            parse_scan_mode("global_budget").unwrap(),
+            EventDlqDuplicateAlertScanMode::GlobalBudget
+        );
+        assert_eq!(
+            parse_scan_mode("fair_window").unwrap(),
+            EventDlqDuplicateAlertScanMode::FairWindow
+        );
+        assert!(parse_scan_mode("moving_cursor").is_err());
     }
 
     #[test]

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "event-delivery",
   "packet": "dlq-duplicate-alert-server-observer-source",
   "status": "source_complete_runtime_execution_pending",
@@ -13,7 +13,8 @@
   "service_registry_source": "apps/server/src/services/mod.rs",
   "public_iggy_exports": [
     "IggyDlqDuplicateAlertObserver",
-    "IggyDlqDuplicateAlertObserverError"
+    "IggyDlqDuplicateAlertObserverError",
+    "IggyDlqDuplicateAlertScanMode"
   ],
   "delivery_profiles": {
     "memory": "not_applicable",
@@ -40,15 +41,39 @@
   "scan": {
     "topic": "dlq",
     "configured_domain_partition_allowlist": true,
-    "global_message_budget_may_stop_before_later_partitions": true,
-    "partition_fairness_claimed": false,
+    "scan_mode_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE",
+    "default_scan_mode": "global_budget",
+    "global_budget_mode": {
+      "accepted_values": [
+        "global",
+        "global_budget"
+      ],
+      "max_messages_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES",
+      "default_max_messages": 1000,
+      "one_global_message_budget": true,
+      "later_partition_starvation_possible": true
+    },
+    "fair_window_mode": {
+      "accepted_values": [
+        "fair",
+        "fair_window"
+      ],
+      "per_partition_messages_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES",
+      "per_partition_messages_required": true,
+      "equal_per_partition_message_budget": true,
+      "every_partition_attempted_on_successful_scan": true,
+      "total_message_budget_checked_by_scanner": true,
+      "maximum_total_messages": 10000,
+      "all_partition_observations_combined_before_classification": true
+    },
+    "batch_size_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE",
+    "default_batch_size": 100,
     "explicit_start_offset": true,
     "same_configured_start_offset_reused_each_poll": true,
     "moving_cursor": false,
+    "cross_cycle_duplicate_accumulation": false,
     "current_tail_coverage_claimed": false,
     "complete_history_claimed": false,
-    "bounded_max_messages": true,
-    "bounded_batch_size": true,
     "auto_commit": false,
     "stored_offset_polling": false
   },
@@ -117,12 +142,14 @@
   "required_iggy_tests": [
     "bundled_mode_requires_matching_loopback_address",
     "all_configured_partitions_are_included_in_request",
+    "global_and_fair_scan_modes_remain_explicit",
     "invalid_partition_count_fails_closed",
     "stable_errors_expose_no_connection_details"
   ],
   "required_server_tests": [
     "every_event_delivery_profile_has_an_explicit_observer_mode",
     "startup_unavailable_state_has_no_task_or_snapshot",
+    "scan_mode_parser_preserves_global_default_and_explicit_fair_window",
     "boolean_parser_is_bounded"
   ],
   "verifier": "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs",
@@ -130,8 +157,9 @@
   "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md",
   "execution_status": "source_not_run",
   "remaining_work": [
-    "partition_fairness_or_per_partition_budget_policy",
+    "fair_window_external_iggy_execution_evidence",
     "moving_window_or_per_partition_cursor_policy",
+    "cross_cycle_duplicate_accumulation_policy",
     "telemetry_projection_outside_observer",
     "health_projection_without_readiness_coupling",
     "notification_delivery_and_suppression",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dlq-duplicate-external-scan-source",
   "status": "source_complete_runtime_pending",
@@ -54,6 +54,14 @@
     "cross_cycle_duplicate_accumulation": false,
     "current_tail_coverage_claimed": false,
     "complete_history_claimed": false
+  },
+  "server_integration": {
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
+    "default_mode": "global_budget",
+    "fair_window_mode": "explicit_opt_in",
+    "per_partition_limit_required": true,
+    "profiles_authorization": false,
+    "runtime_execution_pending": true
   },
   "response_validation": {
     "partition_must_match_request": true,
@@ -136,7 +144,6 @@
     "crates/rustok-iggy/src/lib.rs"
   ],
   "remaining_work": [
-    "fair_window_server_observer_integration",
     "fair_window_external_iggy_execution_evidence",
     "moving_window_or_per_partition_cursor_policy",
     "cross_cycle_duplicate_accumulation_policy",

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
@@ -35,7 +35,7 @@ It also requires a runtime profile that runs background workers.
 
 When disabled, the server stores `Disabled` and starts no task or broker client. When enabled in a non-Iggy delivery profile, it stores the corresponding `NotApplicable` state and requires no thresholds.
 
-Observer-specific startup failures do **not** fail application bootstrap. Invalid enable/configuration values, a missing active Iggy mode, or a missing shared observer dependency produce `Unavailable` with no task or snapshot and return `Ok(())` to the bootstrap caller.
+Observer-specific startup failures do **not** fail application bootstrap. Invalid enable/configuration values, a missing active Iggy mode, or a missing shared observer dependency produce `Unavailable` with no task or snapshot and return normally to the bootstrap caller.
 
 Stable startup codes:
 
@@ -58,32 +58,69 @@ The configured address must be one loopback address using the configured bundled
 
 The observer tries the reviewed external addresses in configured order. Credentials and TLS options are used to construct SDK connection strings but are never retained in the runtime snapshot or logs.
 
-## Scan configuration
+## Scan modes
 
-Optional bounded controls:
+The scan mode is explicit:
 
 ```text
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS          default 30000, max 300000
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET     default 0
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES     default 1000
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE       default 100
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
 ```
 
-The Iggy adapter builds a one-based allowlist containing every configured domain partition and passes it to the existing scanner:
+`global` and `fair` are accepted aliases. The default remains `global_budget`, preserving the previously published server behavior.
+
+Common controls:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS       default 30000, max 300000
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET  default 0
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE    default 100
+```
+
+Both modes use:
 
 ```text
 topic = dlq
 standalone consumer
 explicit start offset
-configured partition allowlist
-one bounded global message count
-bounded batch size
+configured one-based partition allowlist
 auto_commit = false
 ```
 
-The global message budget applies across the ordered partition allowlist. A busy earlier partition may exhaust the budget before later partitions are polled. This source slice therefore makes no partition-fairness or complete-history claim.
+### Compatibility global budget
 
-The scanner remains responsible for the hard limits: no more than 128 partition identifiers, 10,000 messages globally, or 1,000 messages per batch.
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES  default 1000
+```
+
+One bounded budget is consumed across the ordered partition allowlist. A busy earlier partition may exhaust it before later partitions are polled.
+
+### Fair snapshot window
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES  required
+```
+
+Every configured partition receives the same message cap and is attempted on a successful scan. The scanner validates:
+
+```text
+partition_count * per_partition_messages <= 10000
+batch_size <= per_partition_messages
+partition_count <= 128
+batch_size <= 1000
+```
+
+Observations from all partitions are combined before classification, so a repeated deterministic header UUID or conflicting payload group spanning partitions remains visible in the aggregate summary.
+
+Fairness is limited to one fixed snapshot window. Every poll still reuses the same configured start offset. Neither mode adds:
+
+- a moving cursor;
+- persisted offsets;
+- cross-cycle identity or digest accumulation;
+- current-tail coverage;
+- complete-history proof.
+
+Moving a partition window without retaining bounded prior identity state could split copies across cycles and hide their relationship. That remains a separate reviewed design.
 
 ## Explicit alert thresholds
 
@@ -137,9 +174,10 @@ Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connec
 
 ## Remaining work
 
-1. define partition fairness or an explicit per-partition budget policy;
-2. project the shared snapshot into telemetry without exporting identifiers;
-3. expose optional operational health without readiness coupling;
-4. define alert routing, cooldown, and suppression separately;
-5. retain server-observer execution evidence for each applicable mode and unavailable startup state;
-6. keep destructive reconciliation in a separately authorized workflow.
+1. execute fair-window scans against reviewed external Iggy partitions and retain evidence;
+2. design moving per-partition windows with bounded cross-cycle duplicate state, or explicitly reject them;
+3. project the shared snapshot into telemetry without exporting identifiers;
+4. expose optional operational health without readiness coupling;
+5. define alert routing, cooldown, and suppression separately;
+6. retain server-observer execution evidence for each applicable mode and unavailable startup state;
+7. keep destructive reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-external-scan.md
@@ -1,16 +1,21 @@
 # Bounded external-Iggy DLQ duplicate scan
 
-Status: **scanner and disposable-broker harness source-complete; runtime execution pending**.
+Status: **global scanner harness and fair-window source complete; runtime execution pending**.
 
 ## Purpose
 
 `IggyDlqDuplicateScanner` adapts the transport-neutral physical duplicate classifier to an already connected external `IggyClient`.
 
-It answers one bounded operational question:
+It supports two explicit bounded questions:
 
 ```text
-Within these explicit DLQ partitions, starting at this explicit offset,
-what is the count-only physical duplicate summary for at most N messages?
+global request:
+  within these ordered DLQ partitions, starting at one explicit offset,
+  what is the count-only summary for at most N messages total?
+
+fair snapshot window:
+  within every selected DLQ partition, starting at one explicit offset,
+  what is the count-only summary for at most N messages per partition?
 ```
 
 It does not discover the broker, own credentials, create topology, persist a cursor, or perform reconciliation.
@@ -19,6 +24,7 @@ It does not discover the broker, own credentials, create topology, persist a cur
 
 ```text
 IggyDlqDuplicateScanRequest
+IggyDlqDuplicateScanWindowPolicy
 IggyDlqDuplicateScanner
 IggyDlqDuplicateScanError
 ```
@@ -48,9 +54,9 @@ A regular consumer requires the partition to be supplied explicitly. The scanner
 
 The scanner also avoids `get_topic` and `get_topics`. Operators must supply the intended partition allowlist, so the account needs message-poll permission rather than topic-management or topic-discovery behavior from this adapter.
 
-## Request bounds
+## Global request bounds
 
-One request requires:
+`IggyDlqDuplicateScanRequest` requires:
 
 - 1 to 128 unique positive partition IDs;
 - one explicit start offset applied independently to every selected partition;
@@ -58,9 +64,24 @@ One request requires:
 - `batch_size` between 1 and 1,000;
 - `batch_size <= max_messages`.
 
-The message budget is global across all partitions. Partitions are scanned in caller-provided order until the global budget is exhausted.
+The message budget is global across all partitions. Partitions are scanned in caller-provided order until the global budget is exhausted. A busy earlier partition may prevent later partitions from being polled.
 
-A caller that needs different offsets per partition must submit separate requests. This avoids silently inventing or retaining a partition cursor map.
+## Fair snapshot-window bounds
+
+`IggyDlqDuplicateScanWindowPolicy` requires:
+
+- 1 to 128 unique positive partition IDs;
+- one explicit start offset applied independently to every selected partition;
+- one positive `per_partition_messages`;
+- `batch_size` between 1 and 1,000;
+- `batch_size <= per_partition_messages`;
+- checked `partition_count * per_partition_messages <= 10,000`.
+
+On a successful fair-window scan, every configured partition is attempted under the same cap. All observations are combined before `summarize_dlq_duplicates`, preserving repeated deterministic IDs and conflicting payload groups that span partitions.
+
+This is one fixed snapshot window. It does not add a moving cursor, per-partition stored progress, cross-cycle identity/digest accumulation, current-tail coverage, or complete-history proof.
+
+A caller that needs different offsets per partition must submit separate reviewed requests. Moving independent windows without retaining bounded prior identity state can split duplicate copies across cycles and hide the relationship.
 
 ## Response validation
 
@@ -76,6 +97,23 @@ Each physical poll response must satisfy all of the following:
 
 Any mismatch fails closed. Raw client errors and broker coordinates are not copied into the public error.
 
+## Server integration
+
+The mode-aware event-delivery observer now supports both scanner policies:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
+```
+
+`global_budget` remains the default for compatibility. `fair_window` is explicit opt-in and requires:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES
+```
+
+The server integration does not change `memory` or `outbox_local`, does not create another `IggyTransport`, and cannot become a Profiles authorization input.
+
 ## Privacy boundary
 
 The scanner temporarily passes only these values to the in-memory classifier:
@@ -85,15 +123,7 @@ physical Iggy header UUID
 exact physical payload bytes
 ```
 
-The classifier immediately reduces payload bytes to a domain-separated SHA-256 value. The returned summary contains only counts and exposes no:
-
-- broker address;
-- stream or topic name;
-- partition or offset;
-- message UUID;
-- payload or payload digest;
-- credentials;
-- raw Iggy error.
+The classifier immediately reduces payload bytes to a domain-separated SHA-256 value. The returned summary contains only counts and exposes no broker address, stream/topic/partition/offset, message UUID, payload/digest, credentials, or raw Iggy error.
 
 The scanner error codes are bounded and identifier-free:
 
@@ -123,7 +153,7 @@ Polling uses `auto_commit = false`. The fixed consumer identifier is therefore o
 
 ## Source-complete runtime harness
 
-The opt-in `dlq_duplicate_external_scan` test target now defines one exact case against a reviewed disposable external broker with message-ID deduplication disabled.
+The opt-in `dlq_duplicate_external_scan` target defines one exact compatibility-global case against a reviewed disposable external broker with message-ID deduplication disabled.
 
 It publishes through production `IggyTransport::move_to_dlq`:
 
@@ -145,21 +175,7 @@ max_copies_per_message_id = 2
 
 Read-only `get_consumer_offset` must return `None` before publication, after the first scan, and after the second scan. The test contains no direct SDK producer or offset mutation.
 
-See `dlq-duplicate-external-scan-runtime-evidence.md` for prerequisites and the exact command.
-
-## Suggested caller flow
-
-```text
-1. Operator selects one external service and an explicit DLQ stream.
-2. Operator supplies an explicit partition allowlist and bounded offset/count window.
-3. A separately configured component connects and authenticates IggyClient.
-4. IggyDlqDuplicateScanner borrows the connected client.
-5. Scanner polls explicit offsets with auto_commit=false.
-6. Scanner returns DlqDuplicateSummary only.
-7. Caller closes the client through its own lifecycle.
-```
-
-Do not present this scanner as a complete historical inventory unless the selected partitions, offsets, retention window, and message cap cover the intended history.
+Fair-window external-Iggy execution evidence remains separate and pending.
 
 ## Source verification
 
@@ -168,6 +184,7 @@ Machine contracts:
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 ```
 
 Static source guards:
@@ -175,16 +192,16 @@ Static source guards:
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
-
-Focused source tests are embedded in `dlq_duplicate_external_scan.rs` for request bounds and stable error projection. The opt-in integration target defines the physical duplicate/conflict and absent-offset case.
 
 No test, Cargo command, formatter, verifier, external Iggy connection, or runtime scan was executed while defining these slices.
 
 ## Remaining work
 
-1. execute the exact runtime case against a reviewed dedup-disabled disposable broker;
-2. retain a privacy-safe runtime packet without addresses, credentials, identifiers, payloads, offsets, or raw logs;
-3. define alert thresholds outside the scanner;
-4. keep acknowledgement/delete/replay reconciliation in a separately authorized workflow;
-5. preserve identifier-free aggregate correlation with poison receipt health.
+1. execute the compatibility-global runtime case against a reviewed dedup-disabled disposable broker;
+2. add and execute a multi-partition fair-window case, including a cross-partition duplicate/conflict group;
+3. retain privacy-safe packets without addresses, credentials, identifiers, payloads, offsets, or raw logs;
+4. design moving windows plus bounded cross-cycle duplicate state, or keep fixed windows;
+5. keep acknowledgement/delete/replay reconciliation in a separately authorized workflow;
+6. preserve identifier-free aggregate correlation with poison receipt health.

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
@@ -3,9 +3,31 @@ use thiserror::Error;
 
 use crate::config::{ExternalConfig, IggyConfig, IggyMode};
 use crate::dlq_duplicate_external_scan::{
-    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest, IggyDlqDuplicateScanner,
+    IggyDlqDuplicateScanError, IggyDlqDuplicateScanRequest,
+    IggyDlqDuplicateScanWindowPolicy, IggyDlqDuplicateScanner,
 };
 use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
+
+/// Active bounded physical DLQ scan policy for the connected observer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDlqDuplicateAlertScanMode {
+    GlobalBudget,
+    FairWindow,
+}
+
+enum IggyDlqDuplicateAlertScan {
+    Global(IggyDlqDuplicateScanRequest),
+    FairWindow(IggyDlqDuplicateScanWindowPolicy),
+}
+
+impl IggyDlqDuplicateAlertScan {
+    const fn mode(&self) -> IggyDlqDuplicateAlertScanMode {
+        match self {
+            Self::Global(_) => IggyDlqDuplicateAlertScanMode::GlobalBudget,
+            Self::FairWindow(_) => IggyDlqDuplicateAlertScanMode::FairWindow,
+        }
+    }
+}
 
 /// Connected read-only source for bounded physical DLQ duplicate summaries.
 ///
@@ -15,10 +37,11 @@ use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
 pub struct IggyDlqDuplicateAlertObserver {
     client: IggyClient,
     stream_name: String,
-    request: IggyDlqDuplicateScanRequest,
+    scan: IggyDlqDuplicateAlertScan,
 }
 
 impl IggyDlqDuplicateAlertObserver {
+    /// Connect with the compatibility global-budget scan.
     pub async fn connect(
         config: &IggyConfig,
         start_offset: u64,
@@ -33,6 +56,31 @@ impl IggyDlqDuplicateAlertObserver {
             batch_size,
         )
         .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        Self::connect_with_scan(config, IggyDlqDuplicateAlertScan::Global(request)).await
+    }
+
+    /// Connect with one equal per-partition snapshot budget.
+    pub async fn connect_fair_window(
+        config: &IggyConfig,
+        start_offset: u64,
+        per_partition_messages: u32,
+        batch_size: u32,
+    ) -> Result<Self, IggyDlqDuplicateAlertObserverError> {
+        let partitions = configured_partitions(config)?;
+        let policy = IggyDlqDuplicateScanWindowPolicy::new(
+            partitions,
+            start_offset,
+            per_partition_messages,
+            batch_size,
+        )
+        .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        Self::connect_with_scan(config, IggyDlqDuplicateAlertScan::FairWindow(policy)).await
+    }
+
+    async fn connect_with_scan(
+        config: &IggyConfig,
+        scan: IggyDlqDuplicateAlertScan,
+    ) -> Result<Self, IggyDlqDuplicateAlertObserverError> {
         let external = read_only_connection_config(config)?;
         let connection_strings = connection_strings(&external)?;
         let mut connected = None;
@@ -54,28 +102,53 @@ impl IggyDlqDuplicateAlertObserver {
         Ok(Self {
             client,
             stream_name,
-            request,
+            scan,
         })
+    }
+
+    pub const fn scan_mode(&self) -> IggyDlqDuplicateAlertScanMode {
+        self.scan.mode()
     }
 
     pub async fn summarize(
         &self,
     ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateAlertObserverError> {
-        IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?
-            .summarize(&self.request)
-            .await
-            .map_err(Into::into)
+        let scanner = IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?;
+        match &self.scan {
+            IggyDlqDuplicateAlertScan::Global(request) => {
+                scanner.summarize(request).await.map_err(Into::into)
+            }
+            IggyDlqDuplicateAlertScan::FairWindow(policy) => scanner
+                .summarize_window(policy)
+                .await
+                .map_err(Into::into),
+        }
     }
 }
 
 impl std::fmt::Debug for IggyDlqDuplicateAlertObserver {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("IggyDlqDuplicateAlertObserver")
-            .field("partition_count", &self.request.partitions().len())
-            .field("max_messages", &self.request.max_messages())
-            .field("batch_size", &self.request.batch_size())
-            .finish_non_exhaustive()
+        let mut debug = formatter.debug_struct("IggyDlqDuplicateAlertObserver");
+        debug.field("scan_mode", &self.scan.mode());
+        match &self.scan {
+            IggyDlqDuplicateAlertScan::Global(request) => {
+                debug
+                    .field("partition_count", &request.partitions().len())
+                    .field("max_messages", &request.max_messages())
+                    .field("batch_size", &request.batch_size());
+            }
+            IggyDlqDuplicateAlertScan::FairWindow(policy) => {
+                debug
+                    .field("partition_count", &policy.partitions().len())
+                    .field(
+                        "per_partition_messages",
+                        &policy.per_partition_messages(),
+                    )
+                    .field("total_message_budget", &policy.total_message_budget())
+                    .field("batch_size", &policy.batch_size());
+            }
+        }
+        debug.finish_non_exhaustive()
     }
 }
 
@@ -225,6 +298,18 @@ mod tests {
         let mut config = IggyConfig::default();
         config.topology.domain_partitions = 3;
         assert_eq!(configured_partitions(&config).unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn global_and_fair_scan_modes_remain_explicit() {
+        let global = IggyDlqDuplicateAlertScan::Global(
+            IggyDlqDuplicateScanRequest::new(vec![1, 2], 0, 100, 25).unwrap(),
+        );
+        let fair = IggyDlqDuplicateAlertScan::FairWindow(
+            IggyDlqDuplicateScanWindowPolicy::new(vec![1, 2], 0, 50, 25).unwrap(),
+        );
+        assert_eq!(global.mode(), IggyDlqDuplicateAlertScanMode::GlobalBudget);
+        assert_eq!(fair.mode(), IggyDlqDuplicateAlertScanMode::FairWindow);
     }
 
     #[test]

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -95,6 +95,7 @@ pub use dlq::{DlqEntry, DlqManager};
 #[cfg(feature = "iggy")]
 pub use dlq_duplicate_alert_observer::{
     IggyDlqDuplicateAlertObserver, IggyDlqDuplicateAlertObserverError,
+    IggyDlqDuplicateAlertScanMode,
 };
 pub use dlq_duplicate_alert_policy::{
     DlqDuplicateAlertEvaluation, DlqDuplicateAlertLevel, DlqDuplicateAlertPolicy,

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -2,341 +2,203 @@
 
 ## Current state
 
-`rustok-profiles` owns public profile storage and translations, tags, handles,
-visibility policy, owner reads, audience-bound presentation, summary batching,
-GraphQL self-service, `profile.updated`, owner-local backfill, Media-backed image
-presentation, and the module-owned profile storefront.
+`rustok-profiles` owns profile storage, translations, tags, handles, visibility policy,
+owner reads, audience-bound presentation, summary batching, self-service GraphQL,
+`profile.updated`, owner-local backfill, Media-backed image presentation, and the
+module-owned storefront.
 
-Profiles is not an auth, customer, seller, staff, Social Graph, Index, search, or
-broker aggregate. Public GraphQL, Customer Admin enrichment, Blog/Forum author cards,
-and storefront reads share privacy-before-presentation ordering and hide restricted
-or unavailable rows as absent.
+Profiles is not an auth, customer, seller, staff, Social Graph, Index, search, broker,
+receipt, or telemetry aggregate. Public GraphQL, Customer Admin enrichment,
+Blog/Forum author cards, and storefront reads must evaluate privacy before localized
+presentation and must hide restricted or unavailable rows as absent.
 
-`followers_only` resolves through authoritative Social Graph owner ports. Profiles
-never reads relation tables and never authorizes from an event, Index projection,
-decoded/raw DLQ receipt, neutral receipt aggregate, broker identifier, consumer
-offset, lag metric, poison health signal, PostgreSQL evidence packet, physical Iggy
-header observation, deduplication count observation, or any real-Iggy evidence harness.
+`followers_only` resolves through authoritative bounded Social Graph owner ports.
+Profiles never reads relation tables and never authorizes from events, Index state,
+DLQ receipts, broker identifiers, offsets, lag, poison health, PostgreSQL/Iggy evidence,
+deduplication observations, or duplicate-scan modes.
 
 Media descriptors remain Media-owned. Profiles validates tenant, uploader, and MIME
-constraints and exposes only Media-selected descriptors. It does not know storage
-keys, provider endpoints, or ingress construction.
+constraints and exposes only Media-selected descriptors; storage keys, provider
+endpoints, and ingress construction remain outside Profiles.
 
 The storefront mounts `/modules/profiles?handle=<handle>`, supports SSR-first native
-and explicit GraphQL transports, renders approved avatar/banner descriptors, and
-exposes authenticated follow/unfollow with unique idempotency keys, optimistic
-revisions, and one read-only conflict refresh without automatic mutation retry.
+and explicit GraphQL transports, package i18n, approved avatar/banner descriptors,
+and authenticated follow/unfollow with unique idempotency keys, optimistic revisions,
+and one read-only conflict refresh without automatic mutation retry.
 
-## Delivered Social Graph and Index boundary
+## Delivered boundaries
 
-- Durable Social Graph command receipts bind a tenant-scoped normalized idempotency
-  key to one complete command identity and share a transaction with relation mutation,
-  optional event append, response snapshot, and completion.
+### Social Graph and Index
+
+- Durable command receipts bind a tenant-scoped normalized idempotency key to one
+  complete command identity and share a transaction with relation mutation, optional
+  event append, response snapshot, and completion.
 - `social_graph.relation.state_changed` is a sealed persisted-revision fact. No-op and
   receipt replay emit nothing; event failure rolls owner state back.
-- Bounded relation-event replay is service/system-only, tenant-scoped, page-atomic,
-  and driven by an exclusive UUID cursor. Social Graph persistence remains the
-  authoritative drift-repair source.
-- The generic Index adapter maps active revisions to non-localized upserts, inactive
-  revisions to tombstones, relation id to entity id, and relation revision to
-  monotonic revision/source-version semantics.
-- `SocialGraphIndexProjector` registers the tenant schema through Index-owned
-  persistence before durable inbox apply.
-- `Applied`, `Duplicate`, and `StaleIgnored` are terminal durable results.
-- Runtime execution is default-off through
-  `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED`; explicit enablement requires a worker
-  host and `outbox_iggy`.
-- Relay, worker, and observers reuse the single `Arc<IggyTransport>` owned by
-  `EventRuntime`; no worker starts another bundled broker.
-- Decoded-event and raw-delivery receipt state is recognized before projection or a
-  new terminal-policy choice. Existing durable work remains recoverable when creation
-  of new DLQ decisions is later disabled.
-- The explicit append-only platform tail contains both
-  `m20260727_000004_create_index_dlq_receipts` and
-  `m20260728_000001_create_consumer_poison_receipts` without rewriting its published
-  prefix.
+- Bounded replay is service/system-only, tenant-scoped, page-atomic, and driven by an
+  exclusive UUID cursor. Social Graph persistence remains the repair source.
+- Index registration and projection use Index-owned contracts and persistence;
+  `Applied`, `Duplicate`, and `StaleIgnored` are terminal durable results.
+- Runtime consumers are default-off, require a worker host plus `outbox_iggy`, and
+  reuse the single `Arc<IggyTransport>` owned by `EventRuntime`.
+- Index/search projections can improve discovery but never authorize profile visibility.
 
-## Delivered raw contract decode-failure boundary
+### Raw decode failures and poison receipts
 
-`PersistentContractConsumerGroup::receive_delivery` returns either a validated event
-or `ConsumedContractDecodeFailure` without committing the cursor.
+- `PersistentContractConsumerGroup::receive_delivery` returns either a validated event
+  or exact-byte `ConsumedContractDecodeFailure` without committing the source cursor.
+- Stable failure classes are bounded; deterministic RFC 9562 UUIDv8 identity derives
+  only from source coordinates and exact payload. No tenant/domain identity is invented.
+- Neutral durable receipts recognize or reserve work before publication, fence claims,
+  retain first diagnostics, and separate `published` from post-source-commit
+  `acknowledged` bookkeeping.
+- The approved order remains receipt recognition/claim, exact-byte DLQ publication,
+  durable `published`, exact source acknowledgement, then best-effort `acknowledged`.
+- Existing terminal receipts remain recoverable after later policy disablement.
+- Count-only receipt inspection, stale clearing, metrics, and degraded observer-task
+  health remain operational signals only and never become readiness or authorization.
 
-- stream/topic metadata is validated before deserialization;
-- malformed or schema-invalid deliveries retain exact bytes, partition, offset, and
-  opaque acknowledgement token;
-- stable classifications are limited to `iggy.contract.decode_invalid` and
-  `iggy.contract.schema_invalid`;
-- a versioned RFC 9562 UUIDv8 derives only from stream, topic, partition, offset, and
-  exact payload;
-- retry count, classification, time, process identity, credentials, connector message
-  identity, acknowledgement token, and randomness cannot drift the delivery identity;
-- no tenant, actor, relation, or domain event identity is invented;
-- compatibility `receive()` returns a bounded error and performs no implicit ack.
+### Evidence tooling
 
-`rustok-iggy-connector` owns the neutral durable result:
+- Isolated PostgreSQL concurrency, reclaim fencing, collision rollback, diagnostic
+  retention, aggregate consistency, clean-commit capture, source hashing, and strict
+  retained-packet verification are source-complete; canonical execution is pending.
+- External Iggy reconnect/redelivery, exact-byte DLQ, physical UUID/u128 header,
+  one-based partition, and four dedup behavior scenarios are source-complete and
+  runtime-pending.
+- Retained packets must omit credentials and delivery-level facts, bind reviewed source
+  hashes/configuration digests, and become stale when bound sources change.
 
-- source coordinates and deterministic delivery UUID bind exact payload, including an
-  empty payload;
-- UUID/source/payload reuse with different facts fails closed;
-- first error code and observed attempt are retained as one diagnostic pair;
-- states are `reserved`, leased `publishing`, terminal `published`, and
-  post-source-commit `acknowledged`;
-- the store performs no broker publication, source commit, authorization, reclaim
-  policy, retention, repair, or deletion choice;
-- read-only inspection exposes fixed consumer-group counts only.
+## Physical DLQ duplicate inspection
 
-The Social Graph Index worker composes the approved order:
+Two bounded policies are source-complete:
 
-1. recognize or reserve the neutral receipt;
-2. claim publication ownership;
-3. publish `failure.to_dlq_entry(1)` with exact bytes;
-4. persist `published`;
-5. acknowledge the exact source cursor;
-6. record `acknowledged` as best-effort bookkeeping.
+- `global_budget`: one ordered partition allowlist and one shared cap. A busy early
+  partition may prevent later partitions from being polled.
+- `fair_window`: one equal cap for every selected partition, checked total
+  `partition_count * per_partition_messages <= 10000`, and all observations combined
+  before duplicate classification.
 
-A terminal receipt enters acknowledgement-only recovery. The raw path never invokes
-Index projection and never affects Profiles privacy.
+The event-delivery server observer keeps `global_budget` as the compatibility default
+and accepts explicit `fair_window` only for `outbox_iggy`:
 
-## Operational and evidence checkpoint
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES=<positive cap>
+```
 
-Source-complete operational visibility includes:
+`memory` and `outbox_local` remain intentional not-applicable modes and do not resolve
+Iggy. Both policies use explicit offsets and `auto_commit=false`. Every observer cycle
+reuses the configured start offset; neither policy owns moving cursors, stored progress,
+cross-cycle duplicate state, current-tail coverage, or complete-history semantics.
 
-- bounded delivery/retry/failure/DLQ/lifecycle metrics;
-- complete-partition consumer lag only when every broker checkpoint is coherent;
-- count-only poison receipt gauges for `total`, `reserved`, `publishing`,
-  `expired_publishing`, `published`, and `acknowledged`;
-- stale count clearing and snapshot availability/timestamp;
-- degraded health when the read-only observer task is missing or stopped, without
-  making receipt counts a readiness or authorization decision.
+A successful fair-window scan attempts every configured partition under the same cap
+and preserves cross-partition duplicate/conflicting-payload groups in the aggregate.
+External multi-partition execution, retained server evidence, and moving-window design
+remain pending. No duplicate observation or scan state may become a Profiles input.
 
-PostgreSQL evidence tooling is source-complete:
+Detailed checkpoints:
 
-- unique schema per scenario and independent one-connection pools;
-- concurrent claim ownership and `Busy` loser;
-- lease reclaim with old-publisher `ClaimLost` fencing;
-- collision rollback and unchanged original row;
-- atomic first-diagnostic retention;
-- terminal aggregate consistency;
-- clean-commit runner, bounded PostgreSQL/toolchain metadata, source/output SHA-256,
-  atomic packet writing, and strict current-source verification.
-
-The canonical PostgreSQL execution JSON remains absent until a maintainer executes the
-runner successfully.
-
-External real-Iggy cursor evidence is source-complete and runtime-pending:
-
-- one unique disposable/operator-cleaned stream and one partition;
-- two non-empty malformed payloads injected only through fixture-level
-  `ExternalConnector::publish`;
-- production typed receive retains exact first bytes, offset, ack token, stable code,
-  and deterministic UUID without source ack;
-- production `IggyTransport::move_to_dlq` publishes the exact first bytes;
-- first transport shutdown without source ack followed by a new transport and the same
-  group must redeliver the same offset, bytes, and UUID;
-- explicit source ack must then expose the second malformed payload at a greater
-  offset;
-- an independent real DLQ cursor verifies both payloads byte-for-byte.
-
-External physical-header evidence is source-complete and runtime-pending:
-
-- one production `ConsumedContractDecodeFailure` creates one `DlqEntry`;
-- one production `IggyTransport::move_to_dlq` call publishes the entry;
-- a probe-only SDK consumer opened before publication reads exactly one physical DLQ
-  message;
-- physical `message.header.id` must equal the connector UUID as `u128`;
-- physical partition must equal `(uuid_as_u128 mod 3) + 1` and remain one-based;
-- physical payload must remain exact;
-- only the probe's physical header offset is committed, then both probe and transport
-  shut down explicitly.
-
-External deduplication behavior evidence is now source-complete and runtime-pending.
-Four separately configured disposable brokers are required. Every scenario uses a
-unique one-partition stream, production `move_to_dlq`, and a count-only SDK
-`get_topic` observer:
-
-- disabled `A, A`: `0 -> 1 -> 2`;
-- enabled immediate `A, A`: `0 -> 1 -> 1`;
-- `max_entries = 1`, `A, A, B, A`: `0 -> 1 -> 1 -> 2 -> 3`;
-- expiry `A, A, wait, A`: `0 -> 1 -> 1 -> 2`.
-
-The capacity scenario proves immediate suppression before `B` and observed acceptance
-of `A` afterward. The expiry scenario proves immediate suppression before one bounded
-operator-configured wait. The observer can only read partition `messages_count` and
-shut down; it cannot publish, consume payloads, store offsets, modify configuration,
-delete streams, or mutate receipts.
-
-The test does not read back server configuration. Retained execution must include
-reviewed configuration digests for `enabled`, `max_entries`, and `expiry`, require all
-four named tests to execute rather than skip, and retain broker/toolchain/source/output
-metadata without credentials. The short behavior sequences do not prove that a chosen
-window covers the maximum production lease/restart/reconnect/recovery horizon.
-
-Cursor lifecycle, physical header, dedup behavior, PostgreSQL ordering, and production
-confirmation policy are separate evidence boundaries. None authorizes Profiles and none
-alone proves physical exactly-once.
-
-## FFA/FBA boundary
-
-- FFA status: `in_progress`.
-- FBA status: `not_started`.
-- Structural shape: `core_transport_ui`.
-- The Leptos storefront has native/GraphQL transports, package i18n, fail-closed
-  transport selection, Media/Social Graph owner composition, and optimistic conflict
-  recovery.
-- FBA remains blocked on compiled/live transport, Media isolation, provider identity,
-  public ingress/storage delivery, and retained runtime evidence.
+- `crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md`
+- `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
+- `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
+- `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
 
 ## Results and next work
 
 1. **Keep owner reads separate from audience-bound presentation.**
-   **Status:** source-complete for current consumers. Privacy is evaluated before
-   localized summary/tag loading; foreign modules do not read profile tables.
+   Source-complete for current consumers; retain privacy-before-presentation ordering.
 
-2. **Finish followers-only and downstream presentation policy.**
-   **Status:** source-complete for owner privacy ports, public GraphQL, author cards,
-   storefront, Customer Admin enrichment, command receipts, transactional events,
-   cleanup, replay, schema registration, result-first Index apply/ack, durable decoded
-   and raw DLQ recovery, shared-transport lifecycle, metrics, lag, and count-only poison
-   health.
-   **Remaining:** compiled/runtime evidence for privacy, schema concurrency, replay
-   repair, storefront, Customer Admin, Blog/Forum, and Media.
+2. **Finish compiled/runtime presentation evidence.**
+   Execute storefront, Customer Admin, Blog/Forum, Media, privacy, replay, and schema
+   concurrency scenarios without introducing foreign-table reads.
 
 3. **Publish and retain storefront evidence.**
-   Execute SSR/hydrate/GraphQL route, auth, i18n, Media direct/proxy/fallback, follow
-   conflict, durable receipt, relation-event, and accessibility scenarios.
+   Cover SSR/hydration/GraphQL, auth, i18n, Media direct/proxy/fallback, follow conflict,
+   durable receipts/events, and accessibility.
 
 4. **Keep profile backfill owner-local.**
-   The CLI remains source-complete and uses owner auth/tenant/customer reads plus
-   optional Outbox publication while preserving dry-run semantics and aggregate
-   telemetry. Compiled/runtime proof remains open.
+   Preserve dry-run semantics and owner auth/tenant/customer reads; retain runtime proof.
 
 5. **Execute retained PostgreSQL poison evidence.**
-   Run the clean-commit capture runner, review the bounded packet, commit the canonical
-   JSON, and repeat whenever a bound source hash changes.
+   Run the clean-commit capture, review the bounded packet, commit canonical JSON, and
+   repeat whenever a bound source hash changes.
 
-6. **Execute external cursor, header, and dedup evidence.**
-   Run the three harnesses on reviewed disposable brokers and retain separate packets
-   for source reconnect/redelivery, physical UUID/header/partition, and the four dedup
-   count sequences plus reviewed configuration digests.
+6. **Execute external Iggy evidence.**
+   Run reconnect/redelivery, physical header/partition, dedup behavior, compatibility
+   global duplicate scan, and multi-partition fair-window harnesses on reviewed
+   disposable brokers; retain separate privacy-safe packets and config digests.
 
-7. **Compose receipt-plus-broker evidence.**
-   Prove reserve/claim -> exact publish -> durable `published` -> source ack ->
-   best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
-   multi-replica claim ownership on PostgreSQL plus real Iggy.
+7. **Compose receipt-plus-broker recovery evidence.**
+   Prove claim -> exact publish -> durable `published` -> source ack -> best-effort
+   `acknowledged`, process loss, acknowledgement-only recovery, and multi-replica
+   ownership on PostgreSQL plus real Iggy.
 
 8. **Prove confirmation-window sufficiency.**
-   Compare dedup `max_entries`/`expiry` against maximum publication lease, restart,
-   reconnect, and operator recovery horizons. Choose an enforced monitored window or a
-   stronger outbox/transaction mechanism before any stronger duplicate guarantee.
+   Compare dedup `max_entries`/`expiry` against maximum lease, restart, reconnect, and
+   operator recovery horizons before making any stronger duplicate guarantee.
 
-9. **Retain production operations.**
-   Prove bundled mode, restart, TLS/auth/failover, position reconnect, rebalance,
-   retention/reconciliation, operator cleanup, and bounded replay/rescan repair.
+9. **Design moving duplicate windows or keep fixed snapshots.**
+   A moving per-partition cursor must retain bounded prior identity/digest state so
+   copies split across cycles remain related. Fixed snapshots must not be presented as
+   current-tail or complete-history evidence.
+
+10. **Retain production operations.**
+    Prove bundled mode, restart, TLS/auth/failover, reconnect, rebalance, retention,
+    reconciliation, operator cleanup, and bounded replay/rescan repair.
 
 ## Recheck checkpoint — 2026-07-28
 
-- Rechecked the canonical plan and current `main` using short merge/new-branch cycles
-  because multiple agents change the repository in parallel.
-- Reconfirmed privacy-before-presentation, bounded follower reads, owner-scoped writes,
-  Media-owned descriptors, no automatic mutation retry, and the rule that
-  Index/broker/receipt/metric/evidence state never authorizes profile presentation.
-- Preserved command receipts, transactional sealed events, bounded replay, Index schema
-  registration, result-first consumption, decoded/raw DLQ receipts, deterministic
-  delivery identity, shared transport, readiness, metrics, and position observation.
-- Closed append-only migration-tail reconciliation.
-- Added count-only receipt inspection/metrics, stale clearing, degraded observer-task
-  health, and the operator runbook.
-- Added isolated PostgreSQL scenarios and clean-commit retained evidence tooling; the
-  execution packet remains pending.
-- Added external-Iggy cursor reconnect/redelivery and exact-byte DLQ source evidence.
-- Added one-message physical UUID/u128 header and one-based partition source evidence.
-- Added four external dedup behavior scenarios for disabled, enabled, one-entry capacity
-  eviction, and expiry, with count-only observation and reviewed-config boundaries.
-- Kept server-config readback, retained external execution, production recovery-window
-  sufficiency, database ordering, bundled/TLS/auth, and multi-replica claims open.
-- Tests, Cargo commands, formatters, source verifiers, PostgreSQL, external/bundled Iggy,
-  and multi-replica scenarios were not run, per maintainer instruction.
+- Rechecked the canonical plan and current `main` after the previous short PR cycle.
+- Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
+  fail-closed follower reads, no automatic mutation retry, and the rule that operational
+  state never authorizes profile presentation.
+- Rechecked and merged the bounded fair per-partition scanner while preserving the
+  compatibility global-budget request.
+- Added explicit server scan-mode selection: `global_budget` remains default;
+  `fair_window` requires an explicit per-partition cap and remains fixed-offset.
+- Corrected the stale external-scan source contract verifier and documentation that had
+  not been actualized with the fair-window API.
+- Kept runtime execution, retained evidence, moving-window/cross-cycle state,
+  production recovery-window sufficiency, bundled/TLS/auth, and multi-replica claims open.
+- Tests, Cargo commands, formatters, repository source verifiers, PostgreSQL,
+  external/bundled Iggy, and multi-replica scenarios were not run per maintainer instruction.
 
-## Verification
+## Verification backlog
 
-- `cargo run -p rustok-events --example event_contract_digests -- --write`
-- `cargo xtask module validate profiles`
-- `cargo xtask module test profiles`
-- `cargo check -p rustok-profiles-storefront --all-targets`
-- `cargo test -p rustok-profiles-storefront`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
-- `cargo test -p rustok-iggy contract_decode_failure --lib -- --nocapture`
-- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy -- --nocapture --test-threads=1`
-- `RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS='host:8090' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_header -- --nocapture --test-threads=1`
-- `RUSTOK_IGGY_DEDUP_DISABLED_ADDRESS='host:8090' RUSTOK_IGGY_DEDUP_ENABLED_ADDRESS='host:8091' RUSTOK_IGGY_DEDUP_CAPACITY_ADDRESS='host:8092' RUSTOK_IGGY_DEDUP_EXPIRY_ADDRESS='host:8093' RUSTOK_IGGY_DEDUP_EXPIRY_WAIT_MS='1500' cargo test -p rustok-iggy --features iggy --test contract_poison_external_iggy_dedup -- --nocapture --test-threads=1`
-- `node scripts/verify/verify-iggy-contract-decode-failure.mjs`
-- `node scripts/verify/verify-iggy-contract-poison-external-evidence.mjs`
-- `node scripts/verify/verify-iggy-contract-poison-external-header-evidence.mjs`
-- `node scripts/verify/verify-iggy-contract-poison-external-dedup-evidence.mjs`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy-connector --features iggy,migrations --all-targets`
-- `cargo test -p rustok-iggy-connector --features migrations consumer_poison_receipt -- --nocapture`
-- `cargo test -p rustok-iggy-connector --features migrations consumer_poison_inspection -- --nocapture`
-- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' cargo test -p rustok-iggy-connector --features migrations --test consumer_poison_receipt_postgres -- --nocapture`
-- `RUSTOK_IGGY_CONNECTOR_TEST_DATABASE_URL='postgresql://…' node scripts/evidence/capture-iggy-consumer-poison-postgres.mjs`
-- `node scripts/verify/verify-iggy-consumer-poison-receipts.mjs`
-- `node scripts/verify/verify-iggy-consumer-poison-inspection.mjs`
-- `node scripts/verify/verify-iggy-consumer-poison-postgres-evidence.mjs`
-- `node scripts/verify/verify-iggy-consumer-poison-retained-evidence.mjs`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-index --all-targets`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`
-- `node scripts/verify/verify-index-schema-registration.mjs`
-- `node scripts/verify/verify-iggy-consumer-position.mjs`
-- `node scripts/verify/verify-social-graph-index-consumer.mjs`
-- `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
-- `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
-- `node scripts/verify/verify-social-graph-index-dlq-receipts.mjs`
-- `node scripts/verify/verify-social-graph-index-poison-observer.mjs`
-- `node scripts/verify/verify-runtime-consumer-metrics.mjs`
-- `node scripts/verify/verify-social-graph-command-receipts.mjs`
-- `node scripts/verify/verify-social-graph-receipt-cleanup.mjs`
-- `node scripts/verify/verify-social-graph-receipt-cleanup-cli.mjs`
-- `node scripts/verify/verify-social-graph-relation-outbox.mjs`
-- `node scripts/verify/verify-social-graph-relation-event-replay.mjs`
-- `node scripts/verify/verify-profiles-storefront-boundary.mjs`
-- `rustok-cli profiles backfill --tenant-id <uuid> --dry-run`
-- `rustok-cli social_graph receipt-cleanup --tenant-id <uuid> --retention-days 30 --limit 100 --dry-run`
+```text
+cargo xtask module validate profiles
+cargo xtask module test profiles
+cargo check -p rustok-profiles-storefront --all-targets
+cargo test -p rustok-profiles-storefront
+RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
+cargo test -p rustok-iggy dlq_duplicate_external_scan -- --nocapture
+cargo test -p rustok-iggy dlq_duplicate_alert_observer -- --nocapture
+cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
+node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+node scripts/verify/verify-profiles-storefront-boundary.mjs
+```
 
 ## Change rules
 
 1. Keep profile policy and storage in Profiles.
 2. Keep privacy reads independent from localized presentation and foreign tables.
 3. Public GraphQL/storefront reads use the canonical visibility matrix.
-4. Presentation consumers use `ProfilePresentationService`; raw readers remain owner-internal.
+4. Presentation consumers use `ProfilePresentationService`; raw readers remain internal.
 5. `followers_only` resolves through bounded fail-closed Social Graph ports.
 6. Profile media resolves through Media owner ports only.
-7. Module UI stays package-owned with explicit transports and package i18n.
-8. Follow controls use owner ports, unique idempotency, optimistic revision, and no automatic retry.
-9. Operational telemetry excludes presentation copy, identities, idempotency keys,
-   cursors, payloads, broker IDs, claims, roles, credentials, and provider details.
-10. Index/search projections may use sealed owner events, generic Index contracts,
-    monotonic source versions, and bounded replay, but never authorize visibility.
-11. Durable workers persist/recognize the owner result before ack; exact-byte DLQ
-    publication and terminal receipt persistence precede source ack.
-12. Deterministic IDs bind immutable source identity and exact payload but never
-    authorize presentation or imply exactly-once without retained broker evidence.
-13. Publish lag only from a complete partition-qualified broker snapshot; partition and
-    offset are values, never metric labels.
-14. Undecodable bytes must not invent tenant or domain event identity; acknowledge only
-    after an approved terminal result exists.
-15. Existing durable poison choices remain recoverable across later policy disablement;
-    new undecodable deliveries remain uncommitted without enabled terminal policy.
-16. Count-only health and PostgreSQL/Iggy evidence never authorize, acknowledge, reclaim,
-    repair, retain, or delete production delivery state.
-17. Retained packets require a clean commit, omit credentials/delivery-level facts, and
-    become stale when a bound source SHA-256 changes.
-18. Real-Iggy fixture injection may create malformed bytes, but production receive, DLQ,
-    and acknowledgement must use reviewed transport APIs.
-19. Direct SDK probes may only observe explicitly scoped broker facts and shut down;
-    they must not publish, choose policy, modify configuration, or mutate receipts.
-20. Dedup behavior tests require separately reviewed server configs and cannot present
-    operator claims as server readback.
-21. Do not claim production-window sufficiency or exactly-once from short disabled,
-    enabled, capacity, or expiry sequences.
-22. Update Profiles and affected owner docs with every boundary change.
+7. Follow controls use owner ports, unique idempotency, optimistic revision, and no
+   automatic retry.
+8. Index/broker/receipt/metric/evidence state never authorizes visibility.
+9. Durable workers recognize/persist the owner result before source acknowledgement.
+10. Exact-byte DLQ publication and terminal receipt persistence precede source ack.
+11. Deterministic IDs bind immutable source identity and exact payload but do not imply
+    exactly-once without retained broker evidence.
+12. Operational telemetry excludes identities, payloads, broker coordinates, claims,
+    credentials, and provider details.
+13. Short dedup or scan sequences do not prove production-window sufficiency.
+14. Moving duplicate windows require bounded cross-cycle identity state.
+15. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
@@ -1,10 +1,10 @@
 # Profiles checkpoint: mode-aware physical DLQ duplicate alert observer
 
-Status: **server composition source complete; runtime execution pending**.
+Status: **global and fair-window server composition source complete; runtime execution pending**.
 
 ## What changed
 
-The host now has one global event-delivery observer composition for the physical DLQ duplicate alert path:
+The host has one global event-delivery observer composition for the physical DLQ duplicate alert path:
 
 ```text
 bounded physical DLQ scan
@@ -51,11 +51,22 @@ The observer never starts or owns the bundled process and never shuts down the s
 
 ## Bounded scan semantics
 
-The observer builds an allowlist containing every configured domain partition and delegates it to the explicit-offset scanner with `auto_commit=false`.
+The observer builds an allowlist containing every configured domain partition and uses explicit-offset, `auto_commit=false` polling.
 
-The scanner uses one **global** message budget across the ordered allowlist. An earlier busy partition can exhaust that budget before later partitions are polled. This checkpoint therefore makes no partition-fairness or complete-history claim.
+Two scan modes are available:
 
-A future per-partition budget or fairness policy must remain operational and must not become a Profiles input.
+```text
+global_budget  -> one compatibility budget across the ordered allowlist
+fair_window    -> one equal budget for every configured partition
+```
+
+`global_budget` remains the default, so existing deployments do not silently change semantics.
+
+`fair_window` requires an explicit `RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES`. The scanner checks the total budget against 10,000 messages and combines all partition observations before classification. A successful fair-window scan therefore attempts every configured partition under the same cap and preserves cross-partition duplicate or identity-conflict groups.
+
+The fair mode is one fixed snapshot only. Every poll reuses the same configured start offset. It does not provide a moving cursor, stored offsets, cross-cycle duplicate accumulation, current-tail coverage, or complete-history proof.
+
+No scan mode may become a Profiles input.
 
 ## Activation and policy
 
@@ -63,6 +74,13 @@ The observer is default-off:
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
+```
+
+The scan mode is explicit:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
 ```
 
 When active on `outbox_iggy`, all warning and critical thresholds must be supplied explicitly. Invalid values enter non-fatal `Unavailable` state; the library and server do not invent production tolerance defaults.
@@ -86,7 +104,8 @@ No profile visibility, ownership, follower access, relationship, block, mute, au
 - event delivery profile;
 - observer startup, applicability, availability, or generation;
 - Iggy bundled/external mode;
-- partition ordering, fairness, or budget exhaustion;
+- global or fair scan selection;
+- partition ordering, fairness, budget exhaustion, or fixed-window coverage;
 - duplicate alert level or threshold booleans;
 - scanner connection state;
 - retained observer evidence.
@@ -114,11 +133,12 @@ scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 
 ## Remaining work
 
-1. define partition fairness or an explicit per-partition budget policy;
-2. add identifier-free telemetry projection;
-3. add optional operational health without readiness coupling;
-4. define notification routing, cooldown, and suppression separately;
-5. retain execution evidence for applicable Iggy and unavailable startup modes;
-6. keep destructive reconciliation separately authorized.
+1. execute and retain fair-window external-Iggy evidence;
+2. design moving windows plus bounded cross-cycle duplicate state, or keep fixed windows;
+3. add identifier-free telemetry projection;
+4. add optional operational health without readiness coupling;
+5. define notification routing, cooldown, and suppression separately;
+6. retain execution evidence for applicable Iggy and unavailable startup modes;
+7. keep destructive reconciliation separately authorized.
 
 Tests, Cargo commands, formatters, verifiers, server startup, broker connections, alert delivery, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md
@@ -1,36 +1,16 @@
 # Profiles checkpoint: bounded external DLQ duplicate scan
 
-Status: **external-Iggy scanner and runtime harness source-complete; execution and retained evidence pending**.
+Status: **global scanner harness and fair-window server source complete; execution and retained evidence pending**.
 
 ## What changed
 
-`rustok-iggy` owns a bounded read-only adapter that feeds physical external-Iggy `dlq` messages into the count-only duplicate classifier. It now also owns one opt-in disposable-broker harness proving the expected source shape for duplicate/conflict classification and absent stored offsets.
-
-Sources:
-
-```text
-crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
-crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs
-```
-
-Machine contracts:
-
-```text
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json
-```
-
-Verifiers:
-
-```text
-scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
-scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
-```
+`rustok-iggy` owns a bounded read-only adapter that feeds physical external-Iggy `dlq` messages into the count-only duplicate classifier.
 
 Public API:
 
 ```text
 IggyDlqDuplicateScanRequest
+IggyDlqDuplicateScanWindowPolicy
 IggyDlqDuplicateScanner
 IggyDlqDuplicateScanError
 ```
@@ -51,20 +31,44 @@ auto_commit = false
 
 It does not join a consumer group, use stored-offset `next` polling, store a consumer offset, acknowledge a cursor, discover topic topology, publish, delete, purge, replay, retry, or shut down the caller's client.
 
-## Bounded request
+## Global request
 
-A request is limited to:
+The compatibility request is limited to:
 
 - at most 128 unique positive partitions;
 - at most 10,000 physical messages globally;
 - batches of at most 1,000 messages;
 - one explicit start offset applied independently to each partition.
 
-The scanner fails closed on response partition/count mismatch, non-monotonic offsets, offsets before the requested position, nil physical header UUID, or offset overflow.
+The ordered global budget may be consumed before later partitions are polled.
+
+## Fair snapshot window
+
+The fair policy assigns one equal positive message cap to every selected partition and checks:
+
+```text
+partition_count * per_partition_messages <= 10000
+batch_size <= per_partition_messages
+```
+
+A successful scan attempts every configured partition and combines all observations before classification. This preserves duplicate and conflicting-payload groups that span partitions.
+
+The fair policy remains one fixed window. It does not provide moving cursors, stored progress, cross-cycle duplicate accumulation, current-tail coverage, or complete-history proof.
+
+## Server integration
+
+The event-delivery observer keeps `global_budget` as the default and supports explicit:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES=<positive cap>
+```
+
+This applies only to `outbox_iggy`. `memory` and `outbox_local` remain intentional not-applicable modes and do not require Iggy.
 
 ## Source-complete runtime case
 
-The opt-in runtime case requires one reviewed dedup-disabled disposable external service. It publishes four physical messages through production `IggyTransport::move_to_dlq`:
+The existing opt-in runtime case remains global-budget evidence. It requires one reviewed dedup-disabled disposable external service and publishes four physical messages through production `IggyTransport::move_to_dlq`:
 
 ```text
 A, A: one ordinary duplicate group
@@ -84,32 +88,31 @@ max_copies_per_message_id = 2
 
 The scanner consumer offset must be absent before publication, after the first scan, and after the second scan. Runtime execution remains pending.
 
+A separate multi-partition fair-window harness and retained packet remain pending.
+
 ## Count-only privacy boundary
 
 During a scan, physical header UUIDs and exact bytes exist only long enough to create in-memory duplicate observations. Exact bytes are reduced to a domain-separated digest inside the classifier.
 
 The returned result exposes only counts. It does not expose broker addresses, stream/topic/partition/offset, UUIDs, payloads, payload digests, credentials, or raw Iggy errors.
 
-The runtime harness also does not print or retain those values. A future retained packet must preserve the same boundary.
-
 ## Profiles authorization remains unchanged
 
 No profile visibility, relationship, block, mute, follow, friendship, audience, ownership, or presentation decision may depend on:
 
-- whether a DLQ scan or runtime harness was performed;
-- selected partitions or offsets;
-- physical duplicate counts;
-- conflicting-payload counts;
-- scanner or harness errors;
+- whether a global or fair DLQ scan was performed;
+- selected partitions, offsets, or scan mode;
+- physical duplicate or conflicting-payload counts;
+- scanner, observer, or harness errors;
 - broker deduplication configuration;
 - consumer offset presence;
 - future retained evidence metadata.
 
-Profiles continues to consume authorized owner-port results. The scanner and harness are operational observability for downstream neutralization only.
+Profiles continues to consume authorized owner-port results. The scanner and observer are operational observability for downstream neutralization only.
 
 ## Operator interpretation
 
-A bounded scan is not automatically a complete historical inventory. Its meaning depends on the explicitly selected stream, partitions, offsets, retention window, and message cap.
+A bounded scan is not automatically a complete historical inventory. Its meaning depends on the explicitly selected stream, partitions, offsets, retention window, and message caps.
 
 Aggregate receipt health and aggregate physical duplicate health remain independent identifier-free views. They may be compared as operational trends, but they cannot be joined message by message and must not become authorization evidence.
 
@@ -117,9 +120,9 @@ Any `conflicting_payload_groups > 0` result requires manual forensic escalation.
 
 ## Remaining work
 
-1. execute the source-complete runtime case against a reviewed dedup-disabled disposable service;
-2. retain only count-level runtime and absent-offset evidence;
-3. define alert thresholds outside Profiles and outside the scanner;
+1. execute and retain the compatibility-global runtime case;
+2. add and execute multi-partition fair-window evidence;
+3. design moving windows plus bounded cross-cycle duplicate state, or keep fixed windows;
 4. design acknowledgement/delete/replay as a separate explicitly authorized workflow;
 5. preserve the identifier-free boundary when comparing receipt and physical duplicate trends.
 

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -47,7 +47,7 @@ function countText(text, marker) {
 }
 
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "event-delivery" ||
   contract.packet !== "dlq-duplicate-alert-server-observer-source" ||
   contract.status !== "source_complete_runtime_execution_pending" ||
@@ -66,18 +66,15 @@ if (
     memory: "not_applicable",
     outbox_local: "not_applicable",
     outbox_iggy: "iggy_observer",
-  })
-) {
-  fail("event delivery profile observer matrix drift");
-}
-if (
+  }) ||
   !sameValue(contract.iggy_modes, {
     bundled: "connect_to_existing_loopback_broker",
     external: "connect_to_reviewed_external_addresses",
   })
 ) {
-  fail("Iggy bundled/external observer matrix drift");
+  fail("event-delivery or Iggy observer matrix drift");
 }
+
 if (
   contract.activation?.default_enabled !== false ||
   contract.activation?.enable_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED" ||
@@ -93,23 +90,42 @@ if (
 ) {
   fail("DLQ duplicate observer activation boundary drift");
 }
+
+const scan = contract.scan ?? {};
 if (
-  contract.scan?.topic !== "dlq" ||
-  contract.scan?.configured_domain_partition_allowlist !== true ||
-  contract.scan?.global_message_budget_may_stop_before_later_partitions !== true ||
-  contract.scan?.partition_fairness_claimed !== false ||
-  contract.scan?.explicit_start_offset !== true ||
-  contract.scan?.same_configured_start_offset_reused_each_poll !== true ||
-  contract.scan?.moving_cursor !== false ||
-  contract.scan?.current_tail_coverage_claimed !== false ||
-  contract.scan?.complete_history_claimed !== false ||
-  contract.scan?.bounded_max_messages !== true ||
-  contract.scan?.bounded_batch_size !== true ||
-  contract.scan?.auto_commit !== false ||
-  contract.scan?.stored_offset_polling !== false
+  scan.topic !== "dlq" ||
+  scan.configured_domain_partition_allowlist !== true ||
+  scan.scan_mode_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE" ||
+  scan.default_scan_mode !== "global_budget" ||
+  !sameValue(scan.global_budget_mode?.accepted_values, ["global", "global_budget"]) ||
+  scan.global_budget_mode?.max_messages_env !==
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES" ||
+  scan.global_budget_mode?.default_max_messages !== 1000 ||
+  scan.global_budget_mode?.one_global_message_budget !== true ||
+  scan.global_budget_mode?.later_partition_starvation_possible !== true ||
+  !sameValue(scan.fair_window_mode?.accepted_values, ["fair", "fair_window"]) ||
+  scan.fair_window_mode?.per_partition_messages_env !==
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES" ||
+  scan.fair_window_mode?.per_partition_messages_required !== true ||
+  scan.fair_window_mode?.equal_per_partition_message_budget !== true ||
+  scan.fair_window_mode?.every_partition_attempted_on_successful_scan !== true ||
+  scan.fair_window_mode?.total_message_budget_checked_by_scanner !== true ||
+  scan.fair_window_mode?.maximum_total_messages !== 10000 ||
+  scan.fair_window_mode?.all_partition_observations_combined_before_classification !== true ||
+  scan.batch_size_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE" ||
+  scan.default_batch_size !== 100 ||
+  scan.explicit_start_offset !== true ||
+  scan.same_configured_start_offset_reused_each_poll !== true ||
+  scan.moving_cursor !== false ||
+  scan.cross_cycle_duplicate_accumulation !== false ||
+  scan.current_tail_coverage_claimed !== false ||
+  scan.complete_history_claimed !== false ||
+  scan.auto_commit !== false ||
+  scan.stored_offset_polling !== false
 ) {
-  fail("DLQ duplicate observer scan boundary drift");
+  fail("DLQ duplicate observer scan-mode boundary drift");
 }
+
 if (
   contract.runtime?.publisher !== "DlqDuplicateAlertRuntimePublisher" ||
   contract.runtime?.initial_snapshot_unavailable !== true ||
@@ -123,6 +139,7 @@ if (
 ) {
   fail("DLQ duplicate observer runtime boundary drift");
 }
+
 if (
   !sameValue(contract.startup_stable_codes, {
     configuration_invalid:
@@ -133,12 +150,14 @@ if (
 ) {
   fail("DLQ duplicate observer startup stable-code drift");
 }
+
 for (const [operation, allowed] of Object.entries(contract.lifecycle_boundary ?? {})) {
   if (allowed !== false) fail(`observer lifecycle coupling became allowed: ${operation}`);
 }
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
   if (allowed !== false) fail(`observer mutation became allowed: ${operation}`);
 }
+
 if (
   contract.policy?.all_six_thresholds_required_when_active !== true ||
   contract.policy?.production_threshold_defaults !== false ||
@@ -151,12 +170,14 @@ if (
 const expectedIggyTests = [
   "bundled_mode_requires_matching_loopback_address",
   "all_configured_partitions_are_included_in_request",
+  "global_and_fair_scan_modes_remain_explicit",
   "invalid_partition_count_fails_closed",
   "stable_errors_expose_no_connection_details",
 ];
 const expectedServerTests = [
   "every_event_delivery_profile_has_an_explicit_observer_mode",
   "startup_unavailable_state_has_no_task_or_snapshot",
+  "scan_mode_parser_preserves_global_default_and_explicit_fair_window",
   "boolean_parser_is_bounded",
 ];
 if (!sameValue(contract.required_iggy_tests, expectedIggyTests)) {
@@ -172,24 +193,26 @@ for (const testName of expectedServerTests) {
   requireText("server observer tests", serverSource, `fn ${testName}()`);
 }
 if (countText(iggySource, "#[test]") !== expectedIggyTests.length) {
-  fail("Iggy observer source must contain exactly four focused tests");
+  fail("Iggy observer source must contain exactly five focused tests");
 }
 if (countText(serverSource, "#[test]") !== expectedServerTests.length) {
-  fail("server observer source must contain exactly three focused tests");
+  fail("server observer source must contain exactly four focused tests");
 }
 
 for (const marker of [
+  "pub enum IggyDlqDuplicateAlertScanMode",
+  "GlobalBudget",
+  "FairWindow",
   "pub struct IggyDlqDuplicateAlertObserver",
-  "client: IggyClient",
-  "request: IggyDlqDuplicateScanRequest",
+  "scan: IggyDlqDuplicateAlertScan",
   "pub async fn connect(",
-  "let partitions = configured_partitions(config)?;",
   "IggyDlqDuplicateScanRequest::new(",
-  "let external = read_only_connection_config(config)?;",
-  "for connection_string in connection_strings",
-  "client.connect().await.is_ok()",
+  "pub async fn connect_fair_window(",
+  "IggyDlqDuplicateScanWindowPolicy::new(",
+  "Self::connect_with_scan(",
   "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
-  ".summarize(&self.request)",
+  "scanner.summarize(request)",
+  ".summarize_window(policy)",
   "config.mode == IggyMode::Bundled",
   "is_bundled_loopback_address(",
   "config.topology.domain_partitions > 128",
@@ -201,31 +224,23 @@ for (const marker of [
 
 for (const marker of [
   'const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";',
-  'const START_OFFSET_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET";',
+  'const SCAN_MODE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE";',
+  '"RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES"',
   '"iggy.dlq_duplicate.alert_server_observer_configuration_invalid"',
   '"iggy.dlq_duplicate.alert_server_observer_runtime_unavailable"',
   "pub enum EventDlqDuplicateAlertObserverMode",
-  "Unavailable",
   "NotApplicableMemory",
   "NotApplicableOutboxLocal",
   "IggyBundled",
   "IggyExternal",
-  "pub async fn start_event_dlq_duplicate_alert_observer(",
-  "let enabled = match optional_bool_env(ENABLE_ENV, false)",
-  "record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);",
-  "record_startup_unavailable(ctx, STARTUP_RUNTIME_UNAVAILABLE);",
-  "EventDeliveryProfile::Memory",
-  "EventDeliveryProfile::OutboxLocal",
-  "EventDeliveryProfile::OutboxIggy",
-  '"outbox_iggy runtime is missing its active Iggy mode"',
-  "observer_mode(EventDeliveryProfile::OutboxIggy, None).is_err()",
-  "ctx.shared_get::<Arc<IggyTransport>>()",
-  "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
+  "EventDlqDuplicateAlertScanConfig::GlobalBudget",
+  "EventDlqDuplicateAlertScanConfig::FairWindow",
   "IggyDlqDuplicateAlertObserver::connect(",
-  "config.start_offset",
-  "if let Some(connected) = observer.take()",
+  "IggyDlqDuplicateAlertObserver::connect_fair_window(",
+  '"global" | "global_budget"',
+  '"fair" | "fair_window"',
+  "required_u32_env(PER_PARTITION_MESSAGES_ENV)",
   "connected.summarize().await",
-  "observer = Some(connected);",
   "publisher.publish(&summary)",
   "publisher.mark_unavailable()",
   "event delivery remains active",
@@ -238,7 +253,11 @@ const nonApplicableIndex = serverSource.indexOf(
   "EventDlqDuplicateAlertObserverMode::NotApplicableMemory",
 );
 const sharedTransportIndex = serverSource.indexOf("ctx.shared_get::<Arc<IggyTransport>>()");
-if (nonApplicableIndex < 0 || sharedTransportIndex < 0 || nonApplicableIndex > sharedTransportIndex) {
+if (
+  nonApplicableIndex < 0 ||
+  sharedTransportIndex < 0 ||
+  nonApplicableIndex > sharedTransportIndex
+) {
   fail("non-Iggy delivery profiles must exit before shared Iggy transport access");
 }
 
@@ -272,13 +291,23 @@ for (const marker of [
   forbidText("runtime observer structs", `${iggySource}\n${serverSource}`, marker);
 }
 
-requireText("runtime composition", runtimeSource, "pub struct DlqDuplicateAlertRuntimePublisher");
+requireText(
+  "runtime composition",
+  runtimeSource,
+  "pub struct DlqDuplicateAlertRuntimePublisher",
+);
 requireText("runtime composition", runtimeSource, "pub fn mark_unavailable(");
-requireText("bounded scanner", scannerSource, "let mut remaining = request.max_messages;");
-requireText("bounded scanner", scannerSource, "let mut next_offset = request.start_offset;");
-requireText("bounded scanner", scannerSource, "if remaining == 0");
-requireText("bounded scanner", scannerSource, "requested_count,\n                        false,");
-requireText("Iggy module registry", lib, "pub mod dlq_duplicate_alert_observer;");
+requireText(
+  "bounded scanner",
+  scannerSource,
+  "pub struct IggyDlqDuplicateScanWindowPolicy",
+);
+requireText("bounded scanner", scannerSource, "pub async fn summarize_window(");
+requireText(
+  "Iggy module registry",
+  lib,
+  "pub mod dlq_duplicate_alert_observer;",
+);
 for (const exportName of contract.public_iggy_exports ?? []) {
   requireText("Iggy public exports", lib, exportName);
 }
@@ -312,9 +341,11 @@ for (const field of contract.privacy_boundary?.logs_and_snapshots_exclude ?? [])
   requiredPrivacyExclusions.delete(field);
 }
 if (requiredPrivacyExclusions.size > 0) {
-  fail(`observer privacy exclusions are incomplete: ${[
-    ...requiredPrivacyExclusions,
-  ].join(", ")}`);
+  fail(
+    `observer privacy exclusions are incomplete: ${[
+      ...requiredPrivacyExclusions,
+    ].join(", ")}`,
+  );
 }
 if (
   contract.privacy_boundary?.stable_error_codes_only !== true ||
@@ -336,8 +367,9 @@ if (
 }
 
 const requiredRemaining = new Set([
-  "partition_fairness_or_per_partition_budget_policy",
+  "fair_window_external_iggy_execution_evidence",
   "moving_window_or_per_partition_cursor_policy",
+  "cross_cycle_duplicate_accumulation_policy",
   "telemetry_projection_outside_observer",
   "health_projection_without_readiness_coupling",
   "notification_delivery_and_suppression",
@@ -356,5 +388,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, bundled/external observation, a configured partition allowlist under one bounded global message budget without fairness, moving-cursor, current-tail, or complete-history claims, auto_commit=false scans, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, compatibility global-budget scans, explicit fair-window per-partition scans, bounded total budget, auto_commit=false, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
@@ -9,6 +9,8 @@ const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
 const runtimeContractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-runtime-source.json";
+const serverContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
 const runtimeTestPath = "crates/rustok-iggy/tests/dlq_duplicate_external_scan.rs";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
 const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
@@ -21,18 +23,24 @@ const expectedRuntimeCase =
   "bounded_scan_classifies_duplicates_and_preserves_absent_consumer_offset";
 const expectedExports = [
   "IggyDlqDuplicateScanRequest",
+  "IggyDlqDuplicateScanWindowPolicy",
   "IggyDlqDuplicateScanner",
   "IggyDlqDuplicateScanError",
 ];
 const expectedTests = [
   "bounded_request_requires_unique_positive_partitions",
   "bounded_request_rejects_unbounded_counts",
+  "fair_window_policy_bounds_each_partition_and_total",
+  "fair_window_policy_rejects_unbounded_total",
   "stable_errors_do_not_expose_broker_coordinates",
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
 const runtimeContract = JSON.parse(
   readFileSync(resolve(repoRoot, runtimeContractPath), "utf8"),
+);
+const serverContract = JSON.parse(
+  readFileSync(resolve(repoRoot, serverContractPath), "utf8"),
 );
 const runtimeTest = readFileSync(resolve(repoRoot, runtimeTestPath), "utf8");
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
@@ -61,7 +69,7 @@ function countText(text, marker) {
 }
 
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-external-scan-source" ||
   contract.status !== "source_complete_runtime_pending" ||
@@ -86,14 +94,17 @@ if (
 ) {
   fail("external DLQ duplicate scan verifier or documentation path drift");
 }
+
 if (
-  contract.runtime_harness?.status !== "source_complete_execution_pending" ||
+  contract.runtime_harness?.status !==
+    "global_request_source_complete_execution_pending" ||
   contract.runtime_harness?.contract !== runtimeContractPath ||
   contract.runtime_harness?.test !== runtimeTestPath ||
   contract.runtime_harness?.case !== expectedRuntimeCase ||
   contract.runtime_harness?.reviewed_dedup_disabled_broker_required !== true ||
   contract.runtime_harness?.two_identical_scans !== true ||
   contract.runtime_harness?.three_absent_offset_checks !== true ||
+  contract.runtime_harness?.fair_window_execution_evidence !== false ||
   runtimeContract.packet !== "dlq-duplicate-external-scan-runtime-source" ||
   runtimeContract.status !== "source_complete_runtime_pending" ||
   runtimeContract.test !== runtimeTestPath ||
@@ -102,6 +113,21 @@ if (
 ) {
   fail("external DLQ duplicate scan runtime harness relationship drift");
 }
+
+if (
+  contract.server_integration?.contract !== serverContractPath ||
+  contract.server_integration?.default_mode !== "global_budget" ||
+  contract.server_integration?.fair_window_mode !== "explicit_opt_in" ||
+  contract.server_integration?.per_partition_limit_required !== true ||
+  contract.server_integration?.profiles_authorization !== false ||
+  contract.server_integration?.runtime_execution_pending !== true ||
+  serverContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  serverContract.scan?.default_scan_mode !== "global_budget" ||
+  serverContract.scan?.fair_window_mode?.equal_per_partition_message_budget !== true
+) {
+  fail("fair-window server observer integration drift");
+}
+
 if (
   contract.iggy_poll_boundary?.client !== "already_connected_IggyClient_borrow" ||
   contract.iggy_poll_boundary?.topic !== "dlq" ||
@@ -116,15 +142,46 @@ if (
 ) {
   fail("external DLQ duplicate scan Iggy polling boundary drift");
 }
+
+const globalRequest = contract.global_request_boundary ?? {};
 if (
-  contract.request_boundary?.maximum_partitions !== 128 ||
-  contract.request_boundary?.maximum_messages !== 10000 ||
-  contract.request_boundary?.maximum_batch_messages !== 1000 ||
-  contract.request_boundary?.same_start_offset_for_each_partition !== true ||
-  contract.request_boundary?.batch_not_greater_than_scan_limit !== true
+  globalRequest.maximum_partitions !== 128 ||
+  globalRequest.maximum_messages !== 10000 ||
+  globalRequest.maximum_batch_messages !== 1000 ||
+  globalRequest.same_start_offset_for_each_partition !== true ||
+  globalRequest.one_global_message_budget !== true ||
+  globalRequest.later_partition_starvation_possible !== true ||
+  globalRequest.batch_not_greater_than_scan_limit !== true ||
+  globalRequest.empty_partition_list_rejected !== true ||
+  globalRequest.zero_partition_rejected !== true ||
+  globalRequest.duplicate_partition_rejected !== true ||
+  globalRequest.zero_message_or_batch_limit_rejected !== true
 ) {
-  fail("external DLQ duplicate scan bounded request contract drift");
+  fail("external DLQ duplicate global request contract drift");
 }
+
+const fairWindow = contract.fair_window_policy ?? {};
+if (
+  fairWindow.type !== "IggyDlqDuplicateScanWindowPolicy" ||
+  fairWindow.method !== "IggyDlqDuplicateScanner::summarize_window" ||
+  fairWindow.same_explicit_start_offset_for_every_partition !== true ||
+  fairWindow.equal_per_partition_message_budget !== true ||
+  fairWindow.every_partition_attempted_on_successful_scan !== true ||
+  fairWindow.total_message_budget_checked !== true ||
+  fairWindow.maximum_total_messages !== 10000 ||
+  fairWindow.maximum_partitions !== 128 ||
+  fairWindow.maximum_batch_messages !== 1000 ||
+  fairWindow.all_partition_observations_combined_before_classification !== true ||
+  fairWindow.cross_partition_identity_conflict_preserved !== true ||
+  fairWindow.moving_cursor !== false ||
+  fairWindow.offset_persistence !== false ||
+  fairWindow.cross_cycle_duplicate_accumulation !== false ||
+  fairWindow.current_tail_coverage_claimed !== false ||
+  fairWindow.complete_history_claimed !== false
+) {
+  fail("external DLQ duplicate fair-window policy drift");
+}
+
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
   if (allowed !== false) fail(`external DLQ duplicate scan mutation became allowed: ${operation}`);
 }
@@ -138,8 +195,7 @@ if (
   fail("external DLQ duplicate scan result projection drift");
 }
 
-const expectedSourceFiles = [sourcePath, classifierPath, libPath];
-if (!sameValue(contract.source_files, expectedSourceFiles)) {
+if (!sameValue(contract.source_files, [sourcePath, classifierPath, libPath])) {
   fail("external DLQ duplicate scan source file allowlist drift");
 }
 
@@ -150,12 +206,15 @@ for (const marker of [
   "const MAX_BATCH_MESSAGES: u32 = 1_000;",
   "const MAX_SCAN_PARTITIONS: usize = 128;",
   "pub struct IggyDlqDuplicateScanRequest",
-  "validate_partitions(&partitions)?;",
-  "batch_size > max_messages",
+  "pub struct IggyDlqDuplicateScanWindowPolicy",
+  "Equal per-partition budget",
+  "checked_mul(partition_count)",
+  ".filter(|total| *total <= MAX_SCAN_MESSAGES)",
   "pub struct IggyDlqDuplicateScanner<'a>",
   "client: &'a IggyClient",
-  "kind: ConsumerKind::Consumer",
   "pub async fn summarize(",
+  "pub async fn summarize_window(",
+  "observations.extend(self.collect_observations(&request).await?);",
   ".poll_messages(",
   "Some(partition_id)",
   "&PollingStrategy::offset(next_offset)",
@@ -181,7 +240,7 @@ for (const testName of expectedTests) {
   requireText("external DLQ duplicate scan source tests", source, `fn ${testName}()`);
 }
 if (countText(source, "#[test]") !== expectedTests.length) {
-  fail("external DLQ duplicate scan source must contain exactly three focused unit tests");
+  fail("external DLQ duplicate scan source must contain exactly five focused unit tests");
 }
 
 for (const marker of [
@@ -280,8 +339,10 @@ if (requiredPrivacyExclusions.size > 0) {
 }
 
 const requiredRemaining = new Set([
+  "fair_window_external_iggy_execution_evidence",
+  "moving_window_or_per_partition_cursor_policy",
+  "cross_cycle_duplicate_accumulation_policy",
   "retained_external_iggy_duplicate_scan_evidence",
-  "operator_alert_threshold_policy",
   "authorized_destructive_reconciliation_workflow",
   "aggregate_receipt_and_duplicate_health_correlation",
 ]);
@@ -297,5 +358,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy external DLQ duplicate scan source verified: borrowed client lifecycle, standalone explicit-offset polling, auto_commit=false, bounded partitions/messages/batches, strict response progress, count-only projection, stable identifier-free errors, no offset-store or destructive API, and the source-complete dedup-disabled external runtime harness with repeated scans and absent-offset checks are locked; runtime execution remains pending.",
+  "Iggy external DLQ duplicate scan source verified: borrowed client lifecycle, standalone explicit-offset polling, auto_commit=false, compatibility global budgets, bounded fair per-partition windows, strict response progress, count-only projection, stable identifier-free errors, explicit server fair-window integration, no offset-store or destructive API, and the source-complete global runtime harness are locked; runtime execution remains pending.",
 );


### PR DESCRIPTION
## Summary

- keep the existing `global_budget` DLQ duplicate scan as the compatibility default
- add explicit opt-in `fair_window` server composition with a required per-partition cap
- preserve `memory` and `outbox_local` as not-applicable modes without resolving Iggy
- expose the observer scan mode and dispatch to the bounded fair-window scanner
- actualize the Profiles implementation plan and both poison/DLQ checkpoints
- synchronize the external-scan and server-observer source contracts, documentation, and static verifiers
- correct the stale external-scan verifier that still described the pre-fair-window API

## Boundaries

- no moving cursor, persisted offset, cross-cycle duplicate accumulation, current-tail, or complete-history guarantee
- no Profiles authorization dependency on scanner/observer state
- no publish, acknowledgement, offset commit, replay, delete, purge, receipt mutation, or second transport lifecycle
- total fair-window budget remains bounded by the scanner at 10,000 messages

## Verification

Tests, Cargo commands, formatters, repository source verifiers, server startup, and Iggy runtime scenarios were not run per maintainer instruction.