### PR TITLE
feat(product): wire storefront category and sort controls

### DIFF
--- a/crates/rustok-commerce/src/graphql/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mod.rs
@@ -1,5 +1,6 @@
 mod marketplace_financial;
 mod mutations;
+mod product_catalog;
 #[path = "safe_query.rs"]
 mod query;
 mod types;
@@ -23,6 +24,7 @@ pub use types::*;
 #[derive(MergedObject, Default)]
 pub struct CommerceQueryRoot(
     query::CommerceQuery,
+    product_catalog::ProductCatalogQuery,
     marketplace_financial::MarketplaceFinancialQuery,
 );
 
@@ -31,6 +33,7 @@ pub type CommerceQuery = CommerceQueryRoot;
 #[allow(non_upper_case_globals)]
 pub const CommerceQuery: CommerceQueryRoot = CommerceQueryRoot(
     query::CommerceQuery,
+    product_catalog::ProductCatalogQuery,
     marketplace_financial::MarketplaceFinancialQuery,
 );
 

--- a/crates/rustok-commerce/src/graphql/product_catalog.rs
+++ b/crates/rustok-commerce/src/graphql/product_catalog.rs
@@ -1,0 +1,98 @@
+use async_graphql::{Context, InputObject, Object, Result};
+use rustok_api::{RequestContext, TenantContext, graphql::require_module_enabled};
+use rustok_outbox::TransactionalEventBus;
+use rustok_product::{CatalogService, StorefrontProductListQuery};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use super::{
+    GqlProductList, GqlProductListItem, PRODUCT_MODULE_SLUG, map_product_service_error,
+    require_storefront_channel_enabled,
+};
+
+#[derive(InputObject, Default)]
+pub struct StorefrontProductCatalogFilter {
+    pub search: Option<String>,
+    pub category_id: Option<Uuid>,
+    pub sort_by: Option<String>,
+    pub sort_direction: Option<String>,
+    pub page: Option<u64>,
+    pub per_page: Option<u64>,
+}
+
+#[derive(Default)]
+pub struct ProductCatalogQuery;
+
+#[Object]
+impl ProductCatalogQuery {
+    async fn storefront_product_catalog(
+        &self,
+        ctx: &Context<'_>,
+        locale: Option<String>,
+        filter: Option<StorefrontProductCatalogFilter>,
+    ) -> Result<GqlProductList> {
+        require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
+        require_storefront_channel_enabled(ctx).await?;
+
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let request_context = ctx.data_opt::<RequestContext>();
+        let requested_locale = locale
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .or_else(|| request_context.map(|context| context.locale.clone()))
+            .unwrap_or_else(|| tenant.default_locale.clone());
+        let public_channel_slug = request_context
+            .and_then(|context| context.channel_slug.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_ascii_lowercase());
+        let filter = filter.unwrap_or_default();
+        let page = filter.page.unwrap_or(1);
+        let per_page = filter.per_page.unwrap_or(12);
+        let list_query = StorefrontProductListQuery::try_new(
+            filter.search,
+            filter.category_id,
+            filter.sort_by,
+            filter.sort_direction,
+        )
+        .map_err(|error| map_product_service_error(error, "storefront_product_catalog_input"))?;
+        let products = CatalogService::new(db.clone(), event_bus.clone())
+            .list_published_products_with_query(
+                tenant.id,
+                requested_locale.as_str(),
+                Some(tenant.default_locale.as_str()),
+                public_channel_slug.as_deref(),
+                list_query,
+                page,
+                per_page,
+            )
+            .await
+            .map_err(|error| map_product_service_error(error, "storefront_product_catalog"))?;
+
+        Ok(GqlProductList {
+            total: products.total,
+            page: products.page,
+            per_page: products.per_page,
+            has_next: products.has_next,
+            items: products
+                .items
+                .into_iter()
+                .map(|item| GqlProductListItem {
+                    id: item.id,
+                    status: item.status.into(),
+                    title: item.title,
+                    handle: item.handle,
+                    seller_id: item.seller_id,
+                    vendor: item.vendor,
+                    product_type: item.product_type,
+                    shipping_profile_slug: None,
+                    tags: item.tags,
+                    created_at: item.created_at.to_rfc3339(),
+                    published_at: item.published_at.map(|value| value.to_rfc3339()),
+                })
+                .collect(),
+        })
+    }
+}

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -26,12 +26,13 @@ The category-bound admin transport keeps native server functions as the
 internal path and parallel GraphQL operations for the public/headless path.
 The DB-level tenant consistency audit, `VARCHAR(32)` locale storage, catalog
 search-option discovery, detached-value marker contract, and no-compile schema
-guardrail are source-locked. Storefront title search now uses typed
-`CatalogListInput`, a Product-owned `StorefrontProductListQuery`, server-side
-translation-title filtering, the native owner endpoint, the existing GraphQL
-search filter, and a snake_case `search` UI control. The broader
-storefront/admin catalog filter and sort result remains open until category,
-sort, attribute-filter, and admin parity are connected end to end.
+guardrail are source-locked. Storefront title search, exact primary-category
+filtering, and deterministic publication/creation-date sorting use typed
+`CatalogListInput`, a Product-owned `StorefrontProductListQuery`, owner-side
+validation and SQL, the native owner endpoint, a merged GraphQL resolver backed
+by the same service, and snake_case UI controls. The broader storefront/admin
+catalog result remains open until typed attribute filters and matching admin
+controls are connected end to end.
 Product write GraphQL derives tenant and actor exclusively from authenticated
 contexts. Product-owned `map_product_public_error` is shared by GraphQL and
 native admin/storefront transports; it keeps internal errors in structured logs
@@ -103,6 +104,7 @@ rustok-pricing` dependency cycle.
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
+  `scripts/verify/verify-product-storefront-category-sort.mjs`,
   `scripts/verify/verify-product-catalog-controls-plan-sync.mjs`, and
   `scripts/verify/verify-ai-product-fba.mjs` for the AI consumer contract.
 
@@ -120,19 +122,23 @@ rustok-pricing` dependency cycle.
    shared [Richtext plan](../../../docs/modules/rich-text-implementation-plan.md),
    assign an owner profile, migrate both transports, and keep short/meta
    descriptions plain text.
-3. Complete the product-owned catalog controls contract. The first 2026-07-28
-   execution slice closes storefront title search through typed UI state, both
-   selected transports, and Product-owned server-side filtering. The task stays
-   open for storefront category/sort/attribute filters and matching admin
-   controls. The completed marker must not return until the full snake_case
-   query contract (`search`, `category_id`, `sort_by`, `sort_direction`,
-   `attribute_filters`) is carried through core request models, native and
-   GraphQL adapters, server-side semantics, and both UI surfaces.
+3. Complete the product-owned catalog controls contract. The 2026-07-28
+   storefront slices close title search, exact primary-category filtering, and
+   deterministic `published_at` / `created_at` sorting through typed UI state,
+   both selected transports, and Product-owned server-side execution. The task
+   stays open for typed attribute filters and matching admin controls. The
+   completed marker must not return until the full snake_case query contract
+   (`search`, `category_id`, `sort_by`, `sort_direction`, `attribute_filters`)
+   is carried through core request models, native and GraphQL adapters,
+   server-side semantics, and both UI surfaces.
 
 ## Verification
 
 - [ ] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
+- [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
+- `node scripts/verify/verify-product-storefront-category-sort.mjs`
+- `node scripts/verify/verify-product-storefront-category-sort.test.mjs`
 - `node scripts/verify/verify-product-catalog-controls-plan-sync.mjs`
 - `node scripts/verify/verify-product-catalog-controls-plan-sync.test.mjs`
 - `npm run verify:product:runtime-fallback-smoke`

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -28,7 +28,7 @@ pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};
 pub use services::{
     CatalogService, ProductCatalogSchemaService, StorefrontProductList, StorefrontProductListItem,
-    StorefrontProductListQuery,
+    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 
 pub struct ProductModule;

--- a/crates/rustok-product/src/services/catalog.rs
+++ b/crates/rustok-product/src/services/catalog.rs
@@ -7,7 +7,7 @@ pub mod types;
 
 pub use types::{
     ProductTagState, StorefrontProductList, StorefrontProductListItem,
-    StorefrontProductListQuery,
+    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 
 use chrono::Utc;

--- a/crates/rustok-product/src/services/catalog/queries.rs
+++ b/crates/rustok-product/src/services/catalog/queries.rs
@@ -50,6 +50,9 @@ impl CatalogService {
                 self.db.get_database_backend(),
                 public_channel_slug,
             ));
+        if let Some(category_id) = list_query.category_id {
+            query = query.filter(entities::product::Column::PrimaryCategoryId.eq(category_id));
+        }
         if let Some(search) = list_query
             .search
             .as_deref()
@@ -62,9 +65,37 @@ impl CatalogService {
             ));
         }
         let total = query.clone().count(&self.db).await?;
+        let query = match (list_query.sort_by, list_query.sort_direction) {
+            (
+                StorefrontProductSortBy::PublishedAt,
+                StorefrontProductSortDirection::Asc,
+            ) => query
+                .order_by_asc(entities::product::Column::PublishedAt)
+                .order_by_asc(entities::product::Column::CreatedAt)
+                .order_by_asc(entities::product::Column::Id),
+            (
+                StorefrontProductSortBy::PublishedAt,
+                StorefrontProductSortDirection::Desc,
+            ) => query
+                .order_by_desc(entities::product::Column::PublishedAt)
+                .order_by_desc(entities::product::Column::CreatedAt)
+                .order_by_desc(entities::product::Column::Id),
+            (
+                StorefrontProductSortBy::CreatedAt,
+                StorefrontProductSortDirection::Asc,
+            ) => query
+                .order_by_asc(entities::product::Column::CreatedAt)
+                .order_by_asc(entities::product::Column::PublishedAt)
+                .order_by_asc(entities::product::Column::Id),
+            (
+                StorefrontProductSortBy::CreatedAt,
+                StorefrontProductSortDirection::Desc,
+            ) => query
+                .order_by_desc(entities::product::Column::CreatedAt)
+                .order_by_desc(entities::product::Column::PublishedAt)
+                .order_by_desc(entities::product::Column::Id),
+        };
         let products = query
-            .order_by_desc(entities::product::Column::PublishedAt)
-            .order_by_desc(entities::product::Column::CreatedAt)
             .offset(offset)
             .limit(per_page)
             .all(&self.db)

--- a/crates/rustok-product/src/services/catalog/types.rs
+++ b/crates/rustok-product/src/services/catalog/types.rs
@@ -1,10 +1,88 @@
 use crate::entities;
+use crate::error::{CommerceError, CommerceResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StorefrontProductSortBy {
+    #[default]
+    PublishedAt,
+    CreatedAt,
+}
+
+impl StorefrontProductSortBy {
+    fn parse(value: Option<String>) -> CommerceResult<Self> {
+        match value.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("published_at") => Ok(Self::PublishedAt),
+            Some("created_at") => Ok(Self::CreatedAt),
+            Some(_) => Err(CommerceError::Validation(
+                "sort_by must be `published_at` or `created_at`".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StorefrontProductSortDirection {
+    Asc,
+    #[default]
+    Desc,
+}
+
+impl StorefrontProductSortDirection {
+    fn parse(value: Option<String>) -> CommerceResult<Self> {
+        match value.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("desc") => Ok(Self::Desc),
+            Some("asc") => Ok(Self::Asc),
+            Some(_) => Err(CommerceError::Validation(
+                "sort_direction must be `asc` or `desc`".to_string(),
+            )),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StorefrontProductListQuery {
     pub search: Option<String>,
+    pub category_id: Option<Uuid>,
+    pub sort_by: StorefrontProductSortBy,
+    pub sort_direction: StorefrontProductSortDirection,
+}
+
+impl StorefrontProductListQuery {
+    pub fn try_new(
+        search: Option<String>,
+        category_id: Option<Uuid>,
+        sort_by: Option<String>,
+        sort_direction: Option<String>,
+    ) -> CommerceResult<Self> {
+        Ok(Self {
+            search: search
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            category_id,
+            sort_by: StorefrontProductSortBy::parse(sort_by)?,
+            sort_direction: StorefrontProductSortDirection::parse(sort_direction)?,
+        })
+    }
+
+    pub fn try_from_transport(
+        search: Option<String>,
+        category_id: Option<String>,
+        sort_by: Option<String>,
+        sort_direction: Option<String>,
+    ) -> CommerceResult<Self> {
+        let category_id = category_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .map(|value| {
+                Uuid::parse_str(value.as_str()).map_err(|_| {
+                    CommerceError::Validation("category_id must be a UUID".to_string())
+                })
+            })
+            .transpose()?;
+        Self::try_new(search, category_id, sort_by, sort_direction)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,4 +111,40 @@ pub struct StorefrontProductListItem {
 #[derive(Debug, Clone)]
 pub struct ProductTagState {
     pub tags: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storefront_list_query_rejects_invalid_transport_values() {
+        assert!(
+            StorefrontProductListQuery::try_from_transport(
+                None,
+                Some("invalid".to_string()),
+                None,
+                None,
+            )
+            .is_err()
+        );
+        assert!(
+            StorefrontProductListQuery::try_new(
+                None,
+                None,
+                Some("title".to_string()),
+                None,
+            )
+            .is_err()
+        );
+        assert!(
+            StorefrontProductListQuery::try_new(
+                None,
+                None,
+                None,
+                Some("sideways".to_string()),
+            )
+            .is_err()
+        );
+    }
 }

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -5,7 +5,7 @@ mod write_transaction;
 
 pub use catalog::{
     CatalogService, StorefrontProductList, StorefrontProductListItem,
-    StorefrontProductListQuery,
+    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 pub use catalog_schema::*;
 pub use catalog_schema_service::*;

--- a/crates/rustok-product/storefront/src/catalog_controls.rs
+++ b/crates/rustok-product/storefront/src/catalog_controls.rs
@@ -2,34 +2,93 @@ use rustok_ui_core::normalize_optional_ui_text;
 
 use crate::i18n::t;
 
+const SORT_BY_PUBLISHED_AT: &str = "published_at";
+const SORT_BY_CREATED_AT: &str = "created_at";
+const SORT_DIRECTION_ASC: &str = "asc";
+const SORT_DIRECTION_DESC: &str = "desc";
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CatalogListInput {
     pub search: Option<String>,
+    pub category_id: Option<String>,
+    pub sort_by: Option<String>,
+    pub sort_direction: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CatalogSearchLabels {
-    pub label: String,
-    pub placeholder: String,
+    pub search_label: String,
+    pub search_placeholder: String,
+    pub category_label: String,
+    pub all_categories: String,
+    pub sort_by_label: String,
+    pub sort_by_published_at: String,
+    pub sort_by_created_at: String,
+    pub sort_direction_label: String,
+    pub sort_direction_desc: String,
+    pub sort_direction_asc: String,
     pub submit: String,
 }
 
-pub fn build_catalog_list_input(search: Option<String>) -> CatalogListInput {
+pub fn build_catalog_list_input(
+    search: Option<String>,
+    category_id: Option<String>,
+    sort_by: Option<String>,
+    sort_direction: Option<String>,
+) -> CatalogListInput {
     CatalogListInput {
         search: normalize_optional_ui_text(search),
+        category_id: normalize_category_id(category_id),
+        sort_by: normalize_sort_by(sort_by),
+        sort_direction: normalize_sort_direction(sort_direction),
     }
 }
 
 pub fn build_catalog_search_labels(locale: Option<&str>) -> CatalogSearchLabels {
     CatalogSearchLabels {
-        label: t(locale, "product.list.searchLabel", "Search catalog"),
-        placeholder: t(
+        search_label: t(locale, "product.list.searchLabel", "Search catalog"),
+        search_placeholder: t(
             locale,
             "product.list.searchPlaceholder",
             "Search published products",
         ),
-        submit: t(locale, "product.list.searchSubmit", "Search"),
+        category_label: t(locale, "product.list.categoryLabel", "Category"),
+        all_categories: t(locale, "product.list.allCategories", "All categories"),
+        sort_by_label: t(locale, "product.list.sortByLabel", "Sort by"),
+        sort_by_published_at: t(
+            locale,
+            "product.list.sortPublishedAt",
+            "Publication date",
+        ),
+        sort_by_created_at: t(locale, "product.list.sortCreatedAt", "Creation date"),
+        sort_direction_label: t(
+            locale,
+            "product.list.sortDirectionLabel",
+            "Direction",
+        ),
+        sort_direction_desc: t(locale, "product.list.sortDescending", "Newest first"),
+        sort_direction_asc: t(locale, "product.list.sortAscending", "Oldest first"),
+        submit: t(locale, "product.list.searchSubmit", "Apply"),
     }
+}
+
+fn normalize_category_id(value: Option<String>) -> Option<String> {
+    normalize_optional_ui_text(value)
+        .filter(|value| uuid::Uuid::parse_str(value.as_str()).is_ok())
+}
+
+fn normalize_sort_by(value: Option<String>) -> Option<String> {
+    normalize_optional_ui_text(value).and_then(|value| match value.as_str() {
+        SORT_BY_PUBLISHED_AT | SORT_BY_CREATED_AT => Some(value),
+        _ => None,
+    })
+}
+
+fn normalize_sort_direction(value: Option<String>) -> Option<String> {
+    normalize_optional_ui_text(value).and_then(|value| match value.as_str() {
+        SORT_DIRECTION_ASC | SORT_DIRECTION_DESC => Some(value),
+        _ => None,
+    })
 }
 
 #[cfg(test)]
@@ -37,11 +96,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn catalog_search_trims_and_drops_blank_values() {
-        assert_eq!(
-            build_catalog_list_input(Some("  camera  ".to_string())).search,
-            Some("camera".to_string())
+    fn catalog_controls_trim_and_drop_invalid_values() {
+        let category_id = uuid::Uuid::new_v4().to_string();
+        let controls = build_catalog_list_input(
+            Some("  camera  ".to_string()),
+            Some(format!("  {category_id}  ")),
+            Some("created_at".to_string()),
+            Some("asc".to_string()),
         );
-        assert_eq!(build_catalog_list_input(Some("   ".to_string())).search, None);
+
+        assert_eq!(controls.search, Some("camera".to_string()));
+        assert_eq!(controls.category_id, Some(category_id));
+        assert_eq!(controls.sort_by, Some("created_at".to_string()));
+        assert_eq!(controls.sort_direction, Some("asc".to_string()));
+
+        let invalid = build_catalog_list_input(
+            Some("   ".to_string()),
+            Some("not-a-uuid".to_string()),
+            Some("title".to_string()),
+            Some("sideways".to_string()),
+        );
+        assert_eq!(invalid, CatalogListInput::default());
     }
 }

--- a/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
+++ b/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
@@ -10,9 +10,15 @@ pub async fn fetch_products(
     mut request: FetchRequest,
     controls: CatalogListInput,
 ) -> Result<StorefrontProductsData, ApiError> {
-    let products = storefront_catalog_list_native(request.locale.clone(), controls.search)
-        .await
-        .map_err(ApiError::from)?;
+    let products = storefront_catalog_list_native(
+        request.locale.clone(),
+        controls.search,
+        controls.category_id,
+        controls.sort_by,
+        controls.sort_direction,
+    )
+    .await
+    .map_err(ApiError::from)?;
     let resolved_handle = request
         .selected_handle
         .as_deref()
@@ -94,6 +100,9 @@ fn normalize_public_channel_slug(channel_slug: Option<&str>) -> Option<String> {
 async fn storefront_catalog_list_native(
     locale: Option<String>,
     search: Option<String>,
+    category_id: Option<String>,
+    sort_by: Option<String>,
+    sort_direction: Option<String>,
 ) -> Result<ProductList, ServerFnError> {
     #[cfg(feature = "ssr")]
     {
@@ -124,13 +133,20 @@ async fn storefront_catalog_list_native(
         let public_channel_slug = request_context
             .as_ref()
             .and_then(|context| normalize_public_channel_slug(context.channel_slug.as_deref()));
+        let list_query = StorefrontProductListQuery::try_from_transport(
+            search,
+            category_id,
+            sort_by,
+            sort_direction,
+        )
+        .map_err(|error| map_product_service_error(error, "storefront_catalog_list_input"))?;
         let products = CatalogService::new(runtime_ctx.db_clone(), event_bus)
             .list_published_products_with_query(
                 tenant.id,
                 requested_locale.as_str(),
                 Some(tenant.default_locale.as_str()),
                 public_channel_slug.as_deref(),
-                StorefrontProductListQuery { search },
+                list_query,
                 1,
                 12,
             )
@@ -141,7 +157,7 @@ async fn storefront_catalog_list_native(
     }
     #[cfg(not(feature = "ssr"))]
     {
-        let _ = (locale, search);
+        let _ = (locale, search, category_id, sort_by, sort_direction);
         Err(ServerFnError::new(
             "product/storefront/catalog-list requires the `ssr` feature",
         ))

--- a/crates/rustok-product/storefront/src/transport/graphql_adapter.rs
+++ b/crates/rustok-product/storefront/src/transport/graphql_adapter.rs
@@ -10,7 +10,7 @@ use crate::model::{
 use rustok_graphql::{GraphqlRequest, execute as execute_graphql};
 use serde::{Deserialize, Serialize};
 
-const STOREFRONT_PRODUCTS_QUERY: &str = "query StorefrontCommerceProducts($locale: String, $filter: StorefrontProductsFilter) { storefrontProducts(locale: $locale, filter: $filter) { total page perPage hasNext items { id status title handle sellerId vendor productType tags createdAt publishedAt } } }";
+const STOREFRONT_PRODUCTS_QUERY: &str = "query StorefrontProductCatalog($locale: String, $filter: StorefrontProductCatalogFilter) { storefrontProductCatalog(locale: $locale, filter: $filter) { total page perPage hasNext items { id status title handle sellerId vendor productType tags createdAt publishedAt } } }";
 const STOREFRONT_PRODUCT_QUERY: &str = "query StorefrontCommerceProduct($locale: String, $handle: String!) { storefrontProduct(locale: $locale, handle: $handle) { id status sellerId vendor productType tags publishedAt translations { locale title handle description } variants { id title sku inventoryQuantity inStock prices { currencyCode amount compareAtAmount onSale } } } }";
 const STOREFRONT_PRICING_PRODUCT_QUERY: &str = "query StorefrontProductPricing($locale: String, $handle: String!, $currencyCode: String, $regionId: UUID, $priceListId: UUID, $channelId: UUID, $channelSlug: String, $quantity: Int) { storefrontPricingProduct(locale: $locale, handle: $handle, currencyCode: $currencyCode, regionId: $regionId, priceListId: $priceListId, channelId: $channelId, channelSlug: $channelSlug, quantity: $quantity) { variants { id title sku prices { currencyCode amount compareAtAmount discountPercent onSale } effectivePrice { currencyCode amount compareAtAmount discountPercent onSale priceListId channelId channelSlug } } } }";
 const STOREFRONT_CATALOG_SEARCH_OPTIONS_QUERY: &str = "query StorefrontCatalogSearchOptions($locale: String!) { storefrontCatalogSearchOptions(locale: $locale) { categoryOptions { value label } attributeOptions { value label } } }";
@@ -23,8 +23,8 @@ impl From<rustok_graphql::GraphqlHttpError> for ApiError {
 
 #[derive(Debug, Deserialize)]
 struct StorefrontProductsResponse {
-    #[serde(rename = "storefrontProducts")]
-    storefront_products: ProductList,
+    #[serde(rename = "storefrontProductCatalog")]
+    storefront_product_catalog: ProductList,
 }
 
 #[derive(Debug, Deserialize)]
@@ -70,10 +70,13 @@ struct StorefrontPricingProductVariables {
 
 #[derive(Debug, Serialize)]
 struct StorefrontProductsFilter {
-    vendor: Option<String>,
-    #[serde(rename = "productType")]
-    product_type: Option<String>,
     search: Option<String>,
+    #[serde(rename = "categoryId")]
+    category_id: Option<String>,
+    #[serde(rename = "sortBy")]
+    sort_by: Option<String>,
+    #[serde(rename = "sortDirection")]
+    sort_direction: Option<String>,
     page: Option<u64>,
     #[serde(rename = "perPage")]
     per_page: Option<u64>,
@@ -190,9 +193,10 @@ async fn fetch_storefront_products(
         StorefrontProductsVariables {
             locale: locale.clone(),
             filter: StorefrontProductsFilter {
-                vendor: None,
-                product_type: None,
                 search: controls.search,
+                category_id: controls.category_id,
+                sort_by: controls.sort_by,
+                sort_direction: controls.sort_direction,
                 page: Some(1),
                 per_page: Some(12),
             },
@@ -202,7 +206,7 @@ async fn fetch_storefront_products(
 
     let resolved_handle = selected_handle.or_else(|| {
         products_response
-            .storefront_products
+            .storefront_product_catalog
             .items
             .first()
             .map(|item| item.handle.clone())
@@ -263,7 +267,7 @@ async fn fetch_storefront_products(
     };
 
     Ok(StorefrontProductsData {
-        products: products_response.storefront_products,
+        products: products_response.storefront_product_catalog,
         selected_product,
         selected_pricing,
         selected_handle: resolved_handle,

--- a/crates/rustok-product/storefront/src/ui/leptos.rs
+++ b/crates/rustok-product/storefront/src/ui/leptos.rs
@@ -5,8 +5,8 @@ use crate::core::{
     build_shell_view_model, build_transport_error_dom_evidence, resolve_route_segment,
 };
 use crate::model::{
-    ProductDetail, ProductListItem, ProductPricingContext, ProductPricingDetail,
-    StorefrontProductsData,
+    ProductCatalogSearchOptions, ProductDetail, ProductListItem, ProductPricingContext,
+    ProductPricingDetail, StorefrontProductsData,
 };
 use crate::transport;
 use leptos::prelude::*;
@@ -26,9 +26,47 @@ pub fn ProductView() -> impl IntoView {
         read_route_query_value(&route_context, "channel_slug"),
         read_route_query_value(&route_context, "quantity"),
     );
-    let catalog_input = build_catalog_list_input(read_route_query_value(&route_context, "search"));
-    let search_labels = build_catalog_search_labels(route_input.locale.as_deref());
+    let catalog_input = build_catalog_list_input(
+        read_route_query_value(&route_context, "search"),
+        read_route_query_value(&route_context, "category_id"),
+        read_route_query_value(&route_context, "sort_by"),
+        read_route_query_value(&route_context, "sort_direction"),
+    );
+    let control_labels = build_catalog_search_labels(route_input.locale.as_deref());
     let current_search = catalog_input.search.clone().unwrap_or_default();
+    let current_category_id = catalog_input.category_id.clone().unwrap_or_default();
+    let current_sort_by = catalog_input
+        .sort_by
+        .clone()
+        .unwrap_or_else(|| "published_at".to_string());
+    let current_sort_direction = catalog_input
+        .sort_direction
+        .clone()
+        .unwrap_or_else(|| "desc".to_string());
+    let options_locale = route_input.locale.clone().unwrap_or_default();
+    let options_resource = Resource::new_blocking(
+        move || options_locale.clone(),
+        move |locale| async move {
+            transport::fetch_catalog_search_options(locale)
+                .await
+                .unwrap_or_else(|_| ProductCatalogSearchOptions::default())
+        },
+    );
+    let search_label = control_labels.search_label;
+    let search_placeholder = control_labels.search_placeholder;
+    let category_label = control_labels.category_label;
+    let all_categories = control_labels.all_categories;
+    let sort_by_label = control_labels.sort_by_label;
+    let sort_by_published_at = control_labels.sort_by_published_at;
+    let sort_by_created_at = control_labels.sort_by_created_at;
+    let sort_direction_label = control_labels.sort_direction_label;
+    let sort_direction_desc = control_labels.sort_direction_desc;
+    let sort_direction_asc = control_labels.sort_direction_asc;
+    let submit_label = control_labels.submit;
+    let category_fallback_value = current_category_id.clone();
+    let category_fallback_label = all_categories.clone();
+    let category_options_selected = current_category_id.clone();
+    let category_options_all_label = all_categories.clone();
     let currency = route_input.currency_code.clone();
     let region_id = route_input.region_id.clone();
     let price_list_id = route_input.price_list_id.clone();
@@ -52,19 +90,83 @@ pub fn ProductView() -> impl IntoView {
                 <h2 class="text-3xl font-semibold text-card-foreground">{shell.title}</h2>
                 <p class="text-sm text-muted-foreground">{shell.subtitle}</p>
             </div>
-            <form method="get" class="mt-6 flex flex-col gap-3 rounded-2xl border border-border bg-background p-4 sm:flex-row sm:items-end">
-                <div class="min-w-0 flex-1 space-y-2">
+            <form method="get" class="mt-6 grid gap-3 rounded-2xl border border-border bg-background p-4 md:grid-cols-2 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_auto] xl:items-end">
+                <div class="min-w-0 space-y-2">
                     <label for="product-catalog-search" class="text-sm font-medium text-foreground">
-                        {search_labels.label}
+                        {search_label}
                     </label>
                     <input
                         id="product-catalog-search"
                         name="search"
                         type="search"
                         value=current_search
-                        placeholder=search_labels.placeholder
+                        placeholder=search_placeholder
                         class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
                     />
+                </div>
+                <div class="min-w-0 space-y-2">
+                    <label for="product-catalog-category" class="text-sm font-medium text-foreground">
+                        {category_label}
+                    </label>
+                    <Suspense fallback=move || view! {
+                        <select
+                            id="product-catalog-category"
+                            name="category_id"
+                            class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground"
+                        >
+                            <option value=category_fallback_value.clone()>{category_fallback_label.clone()}</option>
+                        </select>
+                    }>
+                        {move || {
+                            let options_resource = options_resource;
+                            let selected_category_id = category_options_selected.clone();
+                            let all_categories = category_options_all_label.clone();
+                            Suspend::new(async move {
+                                let options = options_resource.await;
+                                view! {
+                                    <select
+                                        id="product-catalog-category"
+                                        name="category_id"
+                                        class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
+                                    >
+                                        <option value="" selected=selected_category_id.is_empty()>{all_categories}</option>
+                                        {options.category_options.into_iter().map(|option| {
+                                            let selected = option.value == selected_category_id;
+                                            view! {
+                                                <option value=option.value selected=selected>{option.label}</option>
+                                            }
+                                        }).collect_view()}
+                                    </select>
+                                }
+                            })
+                        }}
+                    </Suspense>
+                </div>
+                <div class="min-w-0 space-y-2">
+                    <label for="product-catalog-sort-by" class="text-sm font-medium text-foreground">
+                        {sort_by_label}
+                    </label>
+                    <select
+                        id="product-catalog-sort-by"
+                        name="sort_by"
+                        class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
+                    >
+                        <option value="published_at" selected=current_sort_by == "published_at">{sort_by_published_at}</option>
+                        <option value="created_at" selected=current_sort_by == "created_at">{sort_by_created_at}</option>
+                    </select>
+                </div>
+                <div class="min-w-0 space-y-2">
+                    <label for="product-catalog-sort-direction" class="text-sm font-medium text-foreground">
+                        {sort_direction_label}
+                    </label>
+                    <select
+                        id="product-catalog-sort-direction"
+                        name="sort_direction"
+                        class="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
+                    >
+                        <option value="desc" selected=current_sort_direction == "desc">{sort_direction_desc}</option>
+                        <option value="asc" selected=current_sort_direction == "asc">{sort_direction_asc}</option>
+                    </select>
                 </div>
                 {currency.map(|value| view! { <input type="hidden" name="currency" value=value /> })}
                 {region_id.map(|value| view! { <input type="hidden" name="region_id" value=value /> })}
@@ -76,7 +178,7 @@ pub fn ProductView() -> impl IntoView {
                     type="submit"
                     class="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
                 >
-                    {search_labels.submit}
+                    {submit_label}
                 </button>
             </form>
             <div class="mt-8">

--- a/scripts/verify/verify-product-storefront-boundary.mjs
+++ b/scripts/verify/verify-product-storefront-boundary.mjs
@@ -160,7 +160,7 @@ assertNotContains(transport, "crate::api", `${transportPath}: transport facade m
 assertContains(graphqlAdapter, "GraphqlRequest", `${graphqlAdapterPath}: GraphQL adapter must expose GraphQL request path`);
 assertContains(graphqlAdapter, "search: controls.search", `${graphqlAdapterPath}: GraphQL storefront list must carry typed search state`);
 assertContains(catalogListNative, 'endpoint = "product/storefront/catalog-list"', `${catalogListNativePath}: native catalog list must use an owner endpoint`);
-assertContains(catalogListNative, "StorefrontProductListQuery { search }", `${catalogListNativePath}: native catalog list must map typed search into the owner query`);
+assertContains(catalogListNative, "StorefrontProductListQuery::try_from_transport", `${catalogListNativePath}: native catalog list must validate typed controls through the Product owner query`);
 assertContains(catalogListNative, ".list_published_products_with_query(", `${catalogListNativePath}: native catalog list must execute the owner service query`);
 assertNotContains(catalogListNative, "GraphqlRequest", `${catalogListNativePath}: native catalog list must not execute GraphQL`);
 assertContains(catalogQueries, "pub async fn list_published_products_with_query", `${catalogQueriesPath}: Product owner service must expose the typed list query`);

--- a/scripts/verify/verify-product-storefront-boundary.test.mjs
+++ b/scripts/verify/verify-product-storefront-boundary.test.mjs
@@ -96,7 +96,7 @@ function catalogListNativeSource({ omitNativeSearch = false } = {}) {
   return `
 #[server(prefix = "/api/fn", endpoint = "product/storefront/catalog-list")]
 async fn storefront_catalog_list_native(search: Option<String>) {
-  ${omitNativeSearch ? "" : "let query = StorefrontProductListQuery { search };"}
+  ${omitNativeSearch ? "" : "let query = StorefrontProductListQuery::try_from_transport(search, category_id, sort_by, sort_direction);"}
   ${omitNativeSearch ? "" : "service.list_published_products_with_query(query);"}
 }
 `;
@@ -209,7 +209,7 @@ test("product storefront boundary verifier rejects missing GraphQL search mappin
 test("product storefront boundary verifier rejects missing native owner search", () => {
   assertFixtureFails(
     { omitNativeSearch: true },
-    /native catalog list must map typed search|execute the owner service query/,
+    /native catalog list must validate typed controls|execute the owner service query/,
     "Expected missing native owner search fixture to fail",
   );
 });

--- a/scripts/verify/verify-product-storefront-category-sort.mjs
+++ b/scripts/verify/verify-product-storefront-category-sort.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+const controlsPath = "crates/rustok-product/storefront/src/catalog_controls.rs";
+const ownerTypesPath = "crates/rustok-product/src/services/catalog/types.rs";
+const ownerQueriesPath = "crates/rustok-product/src/services/catalog/queries.rs";
+const nativePath = "crates/rustok-product/storefront/src/transport/catalog_list_native.rs";
+const graphqlAdapterPath = "crates/rustok-product/storefront/src/transport/graphql_adapter.rs";
+const graphqlResolverPath = "crates/rustok-commerce/src/graphql/product_catalog.rs";
+const graphqlRootPath = "crates/rustok-commerce/src/graphql/mod.rs";
+const uiPath = "crates/rustok-product/storefront/src/ui/leptos.rs";
+const planPath = "crates/rustok-product/docs/implementation-plan.md";
+
+const controls = read(controlsPath);
+const ownerTypes = read(ownerTypesPath);
+const ownerQueries = read(ownerQueriesPath);
+const native = read(nativePath);
+const graphqlAdapter = read(graphqlAdapterPath);
+const graphqlResolver = read(graphqlResolverPath);
+const graphqlRoot = read(graphqlRootPath);
+const ui = read(uiPath);
+const plan = read(planPath);
+
+for (const marker of [
+  "pub category_id: Option<String>",
+  "pub sort_by: Option<String>",
+  "pub sort_direction: Option<String>",
+  "normalize_category_id",
+  "normalize_sort_by",
+  "normalize_sort_direction",
+]) {
+  requireText(controls, marker, `${controlsPath}: missing typed control marker ${marker}`);
+}
+
+for (const marker of [
+  "pub category_id: Option<Uuid>",
+  "StorefrontProductSortBy",
+  "StorefrontProductSortDirection",
+  "try_from_transport",
+]) {
+  requireText(ownerTypes, marker, `${ownerTypesPath}: missing owner query marker ${marker}`);
+}
+
+for (const marker of [
+  "PrimaryCategoryId.eq(category_id)",
+  "StorefrontProductSortBy::PublishedAt",
+  "StorefrontProductSortBy::CreatedAt",
+  "StorefrontProductSortDirection::Asc",
+  "StorefrontProductSortDirection::Desc",
+]) {
+  requireText(ownerQueries, marker, `${ownerQueriesPath}: missing owner execution marker ${marker}`);
+}
+
+for (const marker of [
+  "controls.category_id",
+  "controls.sort_by",
+  "controls.sort_direction",
+  "StorefrontProductListQuery::try_from_transport",
+]) {
+  requireText(native, marker, `${nativePath}: missing native transport marker ${marker}`);
+}
+
+for (const marker of [
+  "storefrontProductCatalog",
+  "category_id: controls.category_id",
+  "sort_by: controls.sort_by",
+  "sort_direction: controls.sort_direction",
+]) {
+  requireText(graphqlAdapter, marker, `${graphqlAdapterPath}: missing GraphQL adapter marker ${marker}`);
+}
+
+for (const marker of [
+  "pub struct StorefrontProductCatalogFilter",
+  "pub category_id: Option<Uuid>",
+  "StorefrontProductListQuery::try_new",
+  ".list_published_products_with_query(",
+]) {
+  requireText(graphqlResolver, marker, `${graphqlResolverPath}: missing GraphQL resolver marker ${marker}`);
+}
+requireText(
+  graphqlRoot,
+  "product_catalog::ProductCatalogQuery",
+  `${graphqlRootPath}: Product catalog resolver must be merged into the Commerce query root`,
+);
+
+for (const marker of [
+  'read_route_query_value(&route_context, "category_id")',
+  'read_route_query_value(&route_context, "sort_by")',
+  'read_route_query_value(&route_context, "sort_direction")',
+  'name="category_id"',
+  'name="sort_by"',
+  'name="sort_direction"',
+  "fetch_catalog_search_options",
+]) {
+  requireText(ui, marker, `${uiPath}: missing storefront UI marker ${marker}`);
+}
+
+requireText(
+  plan,
+  "Connect storefront category and deterministic date sorting",
+  `${planPath}: completed category/sort slice must be recorded`,
+);
+requireText(
+  plan,
+  "verify-product-storefront-category-sort.mjs",
+  `${planPath}: category/sort verifier must be listed`,
+);
+
+if (failures.length > 0) {
+  console.error("product storefront category/sort verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("product storefront category/sort verification passed");

--- a/scripts/verify/verify-product-storefront-category-sort.test.mjs
+++ b/scripts/verify/verify-product-storefront-category-sort.test.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-storefront-category-sort.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function run(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-category-sort-"));
+  try {
+    write(
+      root,
+      "crates/rustok-product/storefront/src/catalog_controls.rs",
+      `
+pub struct CatalogListInput {
+  pub category_id: Option<String>,
+  pub sort_by: Option<String>,
+  pub sort_direction: Option<String>,
+}
+fn normalize_category_id() {}
+fn normalize_sort_by() {}
+fn normalize_sort_direction() {}
+`,
+    );
+    write(
+      root,
+      "crates/rustok-product/src/services/catalog/types.rs",
+      `
+pub category_id: Option<Uuid>
+pub enum StorefrontProductSortBy {}
+pub enum StorefrontProductSortDirection {}
+pub fn try_from_transport() {}
+`,
+    );
+    write(
+      root,
+      "crates/rustok-product/src/services/catalog/queries.rs",
+      options.omitOwnerCategory
+        ? `StorefrontProductSortBy::PublishedAt StorefrontProductSortBy::CreatedAt StorefrontProductSortDirection::Asc StorefrontProductSortDirection::Desc`
+        : `PrimaryCategoryId.eq(category_id) StorefrontProductSortBy::PublishedAt StorefrontProductSortBy::CreatedAt StorefrontProductSortDirection::Asc StorefrontProductSortDirection::Desc`,
+    );
+    write(
+      root,
+      "crates/rustok-product/storefront/src/transport/catalog_list_native.rs",
+      `
+controls.category_id
+controls.sort_by
+controls.sort_direction
+StorefrontProductListQuery::try_from_transport
+`,
+    );
+    write(
+      root,
+      "crates/rustok-product/storefront/src/transport/graphql_adapter.rs",
+      options.omitGraphqlSort
+        ? `storefrontProductCatalog category_id: controls.category_id`
+        : `storefrontProductCatalog category_id: controls.category_id sort_by: controls.sort_by sort_direction: controls.sort_direction`,
+    );
+    write(
+      root,
+      "crates/rustok-commerce/src/graphql/product_catalog.rs",
+      `
+pub struct StorefrontProductCatalogFilter
+pub category_id: Option<Uuid>
+StorefrontProductListQuery::try_new
+.list_published_products_with_query(
+`,
+    );
+    write(
+      root,
+      "crates/rustok-commerce/src/graphql/mod.rs",
+      `product_catalog::ProductCatalogQuery`,
+    );
+    write(
+      root,
+      "crates/rustok-product/storefront/src/ui/leptos.rs",
+      options.omitUiControls
+        ? `fetch_catalog_search_options`
+        : `
+read_route_query_value(&route_context, "category_id")
+read_route_query_value(&route_context, "sort_by")
+read_route_query_value(&route_context, "sort_direction")
+name="category_id"
+name="sort_by"
+name="sort_direction"
+fetch_catalog_search_options
+`,
+    );
+    write(
+      root,
+      "crates/rustok-product/docs/implementation-plan.md",
+      options.omitPlanMarker
+        ? `verify-product-storefront-category-sort.mjs`
+        : `Connect storefront category and deterministic date sorting
+verify-product-storefront-category-sort.mjs`,
+    );
+
+    return spawnSync("node", [scriptPath], {
+      cwd: path.resolve("."),
+      env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("accepts the canonical storefront category and sort contract", () => {
+  const result = run();
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /verification passed/);
+});
+
+test("rejects a missing owner category predicate", () => {
+  const result = run({ omitOwnerCategory: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /PrimaryCategoryId/);
+});
+
+test("rejects missing GraphQL sort propagation", () => {
+  const result = run({ omitGraphqlSort: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /sort_by|sort_direction/);
+});
+
+test("rejects missing storefront query controls", () => {
+  const result = run({ omitUiControls: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /category_id|sort_by|sort_direction/);
+});
+
+test("rejects missing plan completion marker", () => {
+  const result = run({ omitPlanMarker: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /completed category\/sort slice/);
+});


### PR DESCRIPTION
## Summary

- add typed storefront `category_id`, `sort_by`, and `sort_direction` control state;
- validate UUID categories and whitelist deterministic `published_at` / `created_at` ordering in Product;
- execute exact primary-category filtering and stable date sorting in `CatalogService`;
- carry the same contract through the native owner endpoint and a merged GraphQL resolver backed by the Product service;
- populate the storefront category control from Product-owned catalog options;
- update the existing storefront boundary guard and add dedicated category/sort mutation fixtures;
- mark this bounded storefront slice complete while keeping attribute filters and admin parity open.

## Scope

The category filter is exact against `primary_category_id`. Sorting supports `published_at` and `created_at`, each with `asc` or `desc`, plus deterministic timestamp and product-id tie-breakers.

This PR does not implement typed EAV attribute filters or matching admin controls; the umbrella plan item remains open.

## Testing

Not run by the implementation agent, following the established maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-storefront-category-sort.mjs
node scripts/verify/verify-product-storefront-category-sort.test.mjs
npm run verify:product:storefront-boundary
npm run test:verify:product:storefront-boundary
node scripts/verify/verify-product-catalog-controls-plan-sync.mjs
```
