### PR TITLE
docs(forum): synchronize audience roadmap through FORUM-20BA

### DIFF
--- a/crates/rustok-forum/contracts/forum-audience-plan-sync.json
+++ b/crates/rustok-forum/contracts/forum-audience-plan-sync.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BA",
+  "upstream_task": "FORUM-20AZ",
+  "scope": "Conflict-safe synchronization of the canonical Forum roadmap and FORUM-20AV through FORUM-20AZ owner notes after reply-create, topic-local narrowing, moderation policy, and existing moderation transport composition were delivered",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "crate_api": "crates/rustok-forum/CRATE_API.md",
+  "owner_note": "crates/rustok-forum/docs/forum-20ba-audience-plan-sync.md",
+  "source_verifier": "scripts/verify/verify-forum-audience-plan-sync.mjs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-moderation-audience-transport-composition.json",
+  "required_ledger_through": "FORUM-20BA",
+  "delivered_task_notes": [
+    "crates/rustok-forum/docs/forum-20av-reply-create-audience-enforcement.md",
+    "crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md",
+    "crates/rustok-forum/docs/forum-20ax-topic-reply-create-audience.md",
+    "crates/rustok-forum/docs/forum-20ay-moderation-audience-policy.md",
+    "crates/rustok-forum/docs/forum-20az-moderation-audience-transport-composition.md"
+  ],
+  "delivered_task_contracts": [
+    "crates/rustok-forum/contracts/forum-reply-create-audience-enforcement.json",
+    "crates/rustok-forum/contracts/forum-reply-create-audience-transport-composition.json",
+    "crates/rustok-forum/contracts/forum-topic-reply-create-audience-policy.json",
+    "crates/rustok-forum/contracts/forum-moderation-audience-policy.json",
+    "crates/rustok-forum/contracts/forum-moderation-audience-transport-composition.json"
+  ],
+  "synchronization": {
+    "canonical_ledger_advanced_through_forum_20az": true,
+    "documentation_sync_recorded_as_forum_20ba": true,
+    "reply_create_enforcement_removed_from_remaining_scope": true,
+    "reply_create_transport_composition_removed_from_remaining_scope": true,
+    "topic_local_reply_narrowing_removed_from_remaining_scope": true,
+    "category_moderation_audience_removed_from_remaining_scope": true,
+    "existing_solution_transport_composition_removed_from_remaining_scope": true,
+    "authoritative_forum_trust_status_corrected": true,
+    "owner_note_plan_debt_marked_resolved": true,
+    "latest_handoff_updated": true,
+    "runtime_behavior_changed": false,
+    "migration_changed": false,
+    "dependency_changed": false,
+    "public_contract_changed": false
+  },
+  "preserved_residuals": [
+    "remaining Forum read authorization migration",
+    "search index SEO and deep-link policy migration",
+    "visibility-scoped category and all-read commands",
+    "future moderation transports must reuse context-aware owner methods",
+    "tenant-wide scheduled reconciliation and payload redaction",
+    "channel delivery enqueue and transports",
+    "delivery-time target authorization",
+    "PostgreSQL concurrency lease contention inheritance and cross-consumer runtime evidence"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "node scripts/verify/verify-forum-audience-plan-sync.mjs",
+      "node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs",
+      "node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs",
+      "node scripts/verify/verify-forum-topic-reply-create-audience-policy.mjs",
+      "node scripts/verify/verify-forum-moderation-audience-policy.mjs",
+      "node scripts/verify/verify-forum-moderation-audience-transport-composition.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/contracts/forum-moderation-audience-transport-composition.json
+++ b/crates/rustok-forum/contracts/forum-moderation-audience-transport-composition.json
@@ -11,6 +11,8 @@
   "owner_service": "crates/rustok-forum/src/services/moderation.rs",
   "crate_root": "crates/rustok-forum/src/lib.rs",
   "owner_note": "crates/rustok-forum/docs/forum-20az-moderation-audience-transport-composition.md",
+  "downstream_plan_sync_task": "FORUM-20BA",
+  "downstream_plan_sync_contract": "crates/rustok-forum/contracts/forum-audience-plan-sync.json",
   "composition": {
     "existing_graphql_mark_solution_composed": true,
     "existing_graphql_clear_solution_composed": true,

--- a/crates/rustok-forum/docs/forum-20av-reply-create-audience-enforcement.md
+++ b/crates/rustok-forum/docs/forum-20av-reply-create-audience-enforcement.md
@@ -28,22 +28,23 @@ replace or duplicate its backlog.
 ## Compatibility
 
 Categories without a configured reply-create layer retain historical behavior.
-No migration, DTO, GraphQL, REST, OpenAPI, or dependency change is introduced in
-this slice. GraphQL and REST still call the context-free methods; policies that
-need trust, Channel, or Groups facts remain fail closed until the separate
-transport-composition slice supplies exact authenticated context.
+No migration, DTO, GraphQL, REST, OpenAPI, or dependency change was introduced
+in this owner slice. At the original FORUM-20AV boundary GraphQL and REST still
+called context-free methods; `FORUM-20AW` subsequently composed exact
+authenticated transport context without changing DTOs.
 
-Forum trust remains unavailable. `forum_user_stats` activity counters are not
-an authoritative trust model and are not used by this boundary.
+Authoritative Forum trust is now published by the Forum owner and host-composed
+through `ForumUserTrustAudienceFactsPort`. This slice did not create that trust
+state and never derives trust from `forum_user_stats` activity counters.
+
+## Canonical plan synchronization
+
+Resolved by `FORUM-20BA`. The canonical ledger records this owner enforcement,
+its `FORUM-20AW` transport composition, topic-local narrowing, moderation policy,
+and existing moderation transport composition through `FORUM-20AZ`.
 
 ## Verification status
 
 The implementation agent did not run tests, Cargo commands, formatting,
 verifiers, workflow checks, or CI. Maintainer commands are recorded in
 `forum-reply-create-audience-enforcement.json`.
-
-The canonical plan was not rewritten in this slice because the available GitHub
-connector supports only complete-file replacement and the plan exceeds two
-thousand lines; risking unrelated roadmap loss was rejected. A later safe
-repository-local edit should advance the ledger from `FORUM-20AU` to
-`FORUM-20AV` and record transport composition as the next bounded slice.

--- a/crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md
+++ b/crates/rustok-forum/docs/forum-20aw-reply-create-audience-transport-composition.md
@@ -17,13 +17,19 @@ Status: source-ready / unvalidated.
 - No reply-create, quote, GraphQL, REST, or OpenAPI DTO fields changed.
 - No migrations or dependencies changed.
 - No Forum-to-Groups crate dependency was added.
-- No trust facts adapter or Forum trust owner state was added.
-- No topic-local reply audience narrowing or moderation audience policy was added.
+- No trust facts adapter or Forum trust owner state was added by this slice.
+  Authoritative Forum trust is now supplied separately through
+  `ForumUserTrustAudienceFactsPort`.
+- No topic-local reply audience narrowing or moderation audience policy was added
+  by this slice; those boundaries were subsequently delivered in `FORUM-20AX`
+  and `FORUM-20AY`.
 - The host publication path is reused without a second provider registry or transport-owned facts query.
 
-## Canonical plan debt
+## Canonical plan synchronization
 
-The canonical `crates/rustok-forum/docs/implementation-plan.md` is intentionally not rewritten in this slice. The available GitHub contents API requires complete-file replacement, while that roadmap exceeds two thousand lines; risking unrelated roadmap loss is not acceptable. A later safe repository-local edit must advance the FORUM-20 ledger through `FORUM-20AW`, place this delivered section after `FORUM-20AV`, and retain reply topic-local narrowing plus moderation audience work as remaining scope.
+Resolved by `FORUM-20BA`. The canonical plan records reply-create owner
+enforcement and exact GraphQL/REST composition before the later topic-local and
+moderation audience slices.
 
 ## Validation status
 

--- a/crates/rustok-forum/docs/forum-20ax-topic-reply-create-audience.md
+++ b/crates/rustok-forum/docs/forum-20ax-topic-reply-create-audience.md
@@ -16,12 +16,17 @@ Status: source-ready / unvalidated.
 - Topic reply-create policy does not read or mutate `forum_topic_audience_*` visibility rows.
 - No GraphQL, REST, OpenAPI, quote, or owner DTO fields changed.
 - No dependency or host/server composition changed.
-- No Forum trust state or trust facts adapter was added; activity counters remain unrelated to trust.
-- Moderation audience policy remains a separate next slice.
+- No Forum trust state or trust facts adapter was added by this slice.
+  Authoritative Forum trust is now supplied by the Forum owner through
+  `ForumUserTrustAudienceFactsPort`; activity counters remain unrelated to trust.
+- Moderation audience policy was a separate next slice and was subsequently
+  delivered in `FORUM-20AY`.
 
-## Canonical plan debt
+## Canonical plan synchronization
 
-The canonical `crates/rustok-forum/docs/implementation-plan.md` is intentionally not rewritten in this slice. The available GitHub contents API requires complete-file replacement, while the roadmap exceeds two thousand lines; risking unrelated roadmap loss is not acceptable. A later safe repository-local edit must advance the FORUM-20 ledger through `FORUM-20AX`, remove topic-local reply narrowing from remaining scope, keep moderation audiences and Forum trust work open, and fix the previously recorded historical grammar typo.
+Resolved by `FORUM-20BA`. The canonical ledger now removes topic-local reply
+narrowing from remaining scope and records the later moderation audience chain
+through `FORUM-20AZ`.
 
 ## Validation status
 

--- a/crates/rustok-forum/docs/forum-20ay-moderation-audience-policy.md
+++ b/crates/rustok-forum/docs/forum-20ay-moderation-audience-policy.md
@@ -10,7 +10,7 @@ Status: source-ready / unvalidated.
 - Empty constraints clear only the target category layer and restore inherited root-to-category moderation policy.
 - Every public topic and reply moderation command resolves the exact tenant-scoped target category and evaluates every inherited layer before opening its write transaction.
 - Existing context-free commands preserve compatibility for unrestricted, role-only, and explicit-user decisions. Unresolved trust, Channel, or Groups selectors require an exact `PortContext` and an injected `SharedForumAudienceFactsPort`.
-- `ModerationService::with_audience_facts` and context-aware command variants publish the owner seam needed for a later GraphQL/REST composition slice.
+- `ModerationService::with_audience_facts` and context-aware command variants publish the owner seam needed for transport composition.
 - Moderator use of `mark_solution` and `clear_solution` is audience-gated. The exact tenant-scoped topic author remains independently authorized to select or clear a solution without receiving moderator privileges.
 - Denied or unresolved decisions occur before topic/reply status, pin, lock, counter, user-stat, solution, journal, and outbox writes.
 - PostgreSQL and SQLite enforce tenant/category ownership, typed values, immutable rows, and bounded direct channel/group/allow/deny inserts.
@@ -19,14 +19,19 @@ Status: source-ready / unvalidated.
 ## Boundary
 
 - GraphQL, REST, OpenAPI, quote, and moderation DTOs are unchanged.
-- Existing transports still call context-free moderation methods; exact transport context composition remains `FORUM-20AZ`.
-- No Forum trust owner state or trust facts adapter is added. Trust remains blocked on `FORUM-26` and is never derived from `forum_user_stats`.
+- Existing solution transports were composed in `FORUM-20AZ`; moderation owner
+  methods without an existing public route remain transport-neutral.
+- No Forum trust owner state or trust facts adapter was added by this slice.
+  Authoritative Forum trust is now host-composed through
+  `ForumUserTrustAudienceFactsPort` and is never derived from `forum_user_stats`.
 - No topic-local moderation layer, report queue, restriction, audit, or anti-spam policy is added.
 - No dependency or host/server source changes are included.
 
-## Canonical plan debt
+## Canonical plan synchronization
 
-The canonical `crates/rustok-forum/docs/implementation-plan.md` is intentionally not rewritten in this slice. The available GitHub contents API requires complete-file replacement while that roadmap exceeds two thousand lines; risking unrelated roadmap loss is not acceptable. A later safe repository-local edit must advance the FORUM-20 ledger through `FORUM-20AY`, retain moderation transport composition as remaining scope, and fix the previously recorded historical grammar typo.
+Resolved by `FORUM-20BA`. The canonical ledger records category moderation
+audience persistence/enforcement and the existing solution transport composition
+through `FORUM-20AZ`.
 
 ## Validation status
 

--- a/crates/rustok-forum/docs/forum-20az-moderation-audience-transport-composition.md
+++ b/crates/rustok-forum/docs/forum-20az-moderation-audience-transport-composition.md
@@ -18,11 +18,15 @@ Status: source-ready / unvalidated.
 - No new GraphQL field, REST route, OpenAPI shape, public request/response DTO, migration, dependency, host/server source, or Forum trust state is added.
 - No approve/reject/hide reply transport or pin/lock/status topic transport is introduced because those owner methods have no existing public Forum route in the current runtime.
 - Existing context-free `ModerationService` methods remain available for direct owner consumers and locally decidable compatibility; transport call sites use only context-aware methods.
-- Trust remains blocked on `FORUM-26` and is never derived from `forum_user_stats` activity counters.
+- Authoritative Forum trust is host-composed through
+  `ForumUserTrustAudienceFactsPort`; this slice did not create that owner state
+  and never derives trust from `forum_user_stats` activity counters.
 
-## Canonical plan debt
+## Canonical plan synchronization
 
-The canonical `crates/rustok-forum/docs/implementation-plan.md` is intentionally not rewritten in this slice. The available GitHub contents API requires complete-file replacement while the roadmap exceeds two thousand lines; risking unrelated roadmap loss is not acceptable. A later safe repository-local edit must advance the FORUM-20 ledger through `FORUM-20AZ`, retain Forum trust ownership and remaining exact-read migrations as open scope, and fix the previously recorded historical grammar typo.
+Resolved by `FORUM-20BA`. The canonical ledger records existing solution-route
+composition through `FORUM-20AZ`, while future moderation routes remain required
+to reuse the context-aware owner boundary.
 
 ## Validation status
 

--- a/crates/rustok-forum/docs/forum-20ba-audience-plan-sync.md
+++ b/crates/rustok-forum/docs/forum-20ba-audience-plan-sync.md
@@ -1,0 +1,60 @@
+# FORUM-20BA audience-plan synchronization
+
+Status: source-ready / unvalidated documentation synchronization.
+
+This slice repairs the canonical roadmap and owner-note drift accumulated after
+`FORUM-20AU`. It changes no runtime behavior, persistence, transport contract,
+dependency, or public request/response shape.
+
+## Synchronized delivered chain
+
+- `FORUM-20AV` enforces inherited category reply-create audience policy in every
+  public reply owner path before preparation or writes.
+- `FORUM-20AW` composes exact authenticated GraphQL and REST request context and
+  the host-published audience-facts capability into both reply-create transports.
+- `FORUM-20AX` adds optional normalized topic-local reply-create narrowing that
+  composes after category layers and cannot broaden them.
+- `FORUM-20AY` adds inherited category moderation audience persistence and owner
+  enforcement before topic/reply moderation transactions while preserving the
+  exact topic-author solution path.
+- `FORUM-20AZ` composes the existing GraphQL and REST solution mutations through
+  exact authenticated moderation context and the same host-published facts port.
+
+The canonical Forum ledger now records the implementation chain through
+`FORUM-20AZ`; this documentation synchronization is `FORUM-20BA`.
+
+## Trust correction
+
+The historical `FORUM-20AV`, `FORUM-20AX`, `FORUM-20AY`, and `FORUM-20AZ`
+notes described authoritative Forum trust as unavailable or blocked. That was
+true at their original source bases but is no longer current. `FORUM-26A/B/G`
+now provide Forum-owned trust state and facts, and the server publishes them
+through `ForumUserTrustAudienceFactsPort` as part of the shared exact audience
+facts composition.
+
+The updated notes preserve the historical boundary that those individual
+slices did not create trust state, while no longer presenting delivered trust
+composition as open work.
+
+## Preserved remaining scope
+
+- migrate remaining Forum reads and search/index/SEO/deep-link consumers to the
+  same exact richer audience decision;
+- add visibility-scoped category/all-read commands over an exact bounded owner
+  scope;
+- route any future public moderation transports through the delivered
+  context-aware owner methods instead of adding transport-local policy;
+- add scheduled reconciliation, payload redaction, channel delivery and
+  delivery-time authorization;
+- capture PostgreSQL concurrency, inheritance, lease/contention and
+  cross-consumer runtime evidence.
+
+No new moderation route is claimed. `FORUM-20AZ` covers the existing solution
+routes; approve/reject/hide and pin/lock/status remain owner methods without a
+current public Forum transport.
+
+## Verification status
+
+Tests, Cargo commands, formatting, verifiers, workflows, and CI were not run by
+the implementation agent. The source-ready commands are recorded in
+`forum-audience-plan-sync.json` and the canonical plan.

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -216,7 +216,7 @@ at the end of this file remain authoritative.
 | `FORUM-17` | `planned` | Drafts, autosave, bookmarks and optional reminders. |
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
-| `FORUM-20` | `in_progress` | FORUM-20A-AU provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation. FORUM-20AM synchronizes the ledgers; FORUM-20AN adds GraphQL group-state commands; FORUM-20AO adds auth-reactive grouped bootstrap refresh; FORUM-20AP materializes initially non-public topic-created descriptors; FORUM-20AQ adds normalized inherited category topic-create audience persistence; FORUM-20AR enforces that policy in every topic-create owner path; FORUM-20AS composes exact GraphQL/REST caller context and the host-published Groups facts provider into both create transports; FORUM-20AT publishes an exact active current-Channel fact ahead of optional Groups fallback; FORUM-20AU adds normalized inherited category reply-create audience persistence without changing reply creation. Reply-create enforcement and topic-local narrowing, moderation audiences, remaining read/search/index/SEO/deep-link migration, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
+| `FORUM-20` | `in_progress` | FORUM-20A-AZ provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation, exact topic/reply create authorization, topic-local reply narrowing, inherited moderation audiences, and existing solution-route transport composition. FORUM-20BA synchronizes the canonical ledger and owner notes after FORUM-20AV-AZ. Remaining read/search/index/SEO/deep-link migration, visibility-scoped bulk read commands, future moderation transport reuse, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `planned` | Visibility-aware index/search projections. |
@@ -1248,7 +1248,7 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - `FORUM-20P` filters topic-subscription audience pages by current recipient visibility
   while preserving sparse advancing cursors;
 - `FORUM-20Q` publishes the Groups-owned exact-membership facts adapter. Trust and
-  channel-membership adapters remain open.
+  channel-membership adapters were delivered later through FORUM-26 and FORUM-20AT.
 
 ### Delivered in `FORUM-20R` through `FORUM-20AF`
 
@@ -1363,9 +1363,9 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - accept a Channel match only from the exact normalized requested `PortContext.channel`, then
   confirm that slug through `ChannelReadPort` as active and tenant-matching;
 - never list or probe unrequested channels, and let an exact current-Channel match decide the
-  positive-selector union before optional Groups or unavailable trust facts are consulted;
+  positive-selector union before optional Groups facts are consulted;
 - keep Channel-only topic-create policy operational when Groups is not compiled, while requested
-  Groups or trust facts remain typed retryable unavailable when no delivered selector decides;
+  Groups facts remain typed retryable unavailable when no delivered selector decides;
 - add inline host tests, a machine-readable contract and a static verifier without migrations,
   public DTO changes, or a new Forum-to-Channel dependency.
 
@@ -1382,46 +1382,108 @@ visibility policy. Do not place ACL policy in arbitrary JSON.
 - leave `ReplyService::create`, REST, GraphQL and transport DTOs unchanged; command-time
   authorization remains a separate follow-up slice.
 
+### Delivered in `FORUM-20AV`
+
+- require `forum_replies:create`, resolve the exact tenant-scoped topic category, and evaluate
+  every inherited category reply-create layer before reply-body preparation or owner writes;
+- preserve explicit-deny precedence and locally decidable role/explicit-user decisions without
+  optional facts calls;
+- require exact tenant/user context and the host audience-facts capability only for unresolved
+  trust, Channel, or Groups selectors;
+- route both public reply create facades through the owner gate before reply, relation, counter,
+  user-stat, journal, or event writes without changing DTOs.
+
+### Delivered in `FORUM-20AW`
+
+- compose both legacy and inline-quote GraphQL reply-create mutations through exact authenticated
+  read-only `PortContext` values;
+- compose both REST reply-create handlers from tenant, auth and middleware request context;
+- forward claims, locale, resolved route channel, five-second deadline and bounded correlation
+  identity without accepting owner identity from request DTOs;
+- reuse the same optional host-published `SharedForumAudienceFactsPort` already used by topic
+  creation, preserving fail-closed unresolved external selectors.
+
+### Delivered in `FORUM-20AX`
+
+- persist an optional normalized topic-local reply-create audience layer independently from topic
+  visibility and inherited category reply-create storage;
+- expose managed get/replace commands under `forum_topics:manage`, with empty constraints clearing
+  only the topic layer;
+- evaluate every category layer followed by the optional topic layer so topics may narrow but
+  never broaden inherited eligibility;
+- preserve existing owner and transport paths while PostgreSQL/SQLite enforce tenant ownership,
+  typed values, immutable rows and bounded direct relations.
+
+### Delivered in `FORUM-20AY`
+
+- persist normalized inherited category moderation audience layers independently from visibility,
+  topic-create and reply-create policy;
+- expose managed get/replace commands and evaluate every inherited layer before topic/reply
+  moderation transactions;
+- preserve the exact topic-author solution path while requiring non-author moderators to hold
+  scope and satisfy the moderation audience;
+- publish context-aware moderation owner methods and PostgreSQL/SQLite ownership, immutability,
+  bounds and advisory-lock guards.
+
+### Delivered in `FORUM-20AZ`
+
+- compose existing GraphQL and REST mark/clear-solution routes through one exact authenticated
+  moderation context and the same host-published audience-facts port;
+- derive tenant and actor only from authenticated transport context and forward claims, locale,
+  route channel, five-second deadline and bounded correlation identity;
+- preserve owner-side topic-author versus moderator authorization and keep the gate before
+  solution, counter, user-stat, journal and outbox writes;
+- add no new moderation endpoint; owner methods without an existing public route remain
+  transport-neutral and future routes must reuse the context-aware boundary.
+
+### Delivered in `FORUM-20BA`
+
+- synchronize this canonical ledger through `FORUM-20AZ` and remove reply-create enforcement,
+  topic-local narrowing, category moderation audience, and existing solution-route composition
+  from remaining scope;
+- correct historical owner-note text that still described delivered Forum trust facts as
+  unavailable or blocked while preserving that AV-AZ did not create trust state themselves;
+- add `forum-audience-plan-sync.json`, `forum-20ba-audience-plan-sync.md`, and
+  `verify-forum-audience-plan-sync.mjs` to lock the ledger, five owner notes, five contracts,
+  CRATE_API boundary and latest AZ handoff together;
+- change no runtime behavior, migration, dependency or public contract.
+
 ### Compatibility and degraded mode
 
-The nullable public/authenticated category floor and the normalized category/topic
-layers require no destructive backfill. Existing content without richer layers keeps
-its previous audience. Locally decidable role and explicit-user decisions do not
-require optional facts providers. FORUM-20AT requires no migration or public DTO change:
-the host already owns the Channel runtime, and exact current-Channel facts are available
-in every Forum build. A missing or unrequested route channel is an authoritative Channel
-miss, not a discovery trigger. When Groups is not compiled, requested Groups facts remain
-typed retryable unavailable unless an exact Channel match already decides the union.
-FORUM-20AU adds only empty-by-default reply-create policy tables and managed owner
-commands; categories without a configured layer preserve existing reply behavior, and
-no optional facts capability is consulted until the separate enforcement slice.
+The nullable public/authenticated category floor and normalized category/topic layers require no
+destructive backfill. Existing content and categories/topics without richer create or moderation
+layers retain their previous behavior. Locally decidable role and explicit-user decisions do not
+require optional facts providers. Exact trust, Channel, or Groups selectors use the shared
+host-published facts capability and fail closed only when a still-required owner fact is absent.
 Forum trust is authoritative and host-composed through `ForumUserTrustAudienceFactsPort`;
-missing Channel or Groups membership capabilities remain typed and retryable only when
-the exact audience decision still requires them.
+`forum_user_stats` activity counters are never treated as trust.
 
-Forum producer commands remain independent from Notifications availability. The
-Notifications module stays default-off, derives storefront tenant and recipient identity
-from authenticated context, and exposes explicit unavailable/degraded states rather than
-shadow inbox data. Native and GraphQL storefront reads and writes select exactly one
-compile-profile transport path with no cross-path fallback. Both group-state paths delegate
-to the same owner port; the GraphQL path cannot select another tenant or recipient and must
-supply write deadline and idempotency semantics.
+FORUM-20AV-AZ add no create/moderation DTO identity fields. GraphQL and REST derive tenant and
+actor from authenticated context, and topic/reply/moderation owners validate exact context before
+target lookup or mutation. Categories without reply-create layers and topics without local
+narrowing preserve historical reply behavior. Existing solution routes are context-composed;
+no new approve/reject/hide or pin/lock/status transport is claimed. Context-free owner methods
+remain available for direct locally decidable consumers, while future public moderation routes
+must use context-aware methods. FORUM-20BA is documentation-only.
+
+Forum producer commands remain independent from Notifications availability. The Notifications
+module stays default-off, derives storefront tenant and recipient identity from authenticated
+context, and exposes explicit unavailable/degraded states rather than shadow inbox data. Native
+and GraphQL storefront reads and writes select exactly one compile-profile transport path with no
+cross-path fallback. Both group-state paths delegate to the same owner port; the GraphQL path
+cannot select another tenant or recipient and must supply write deadline and idempotency semantics.
 
 ### Remaining scope
 
-- enforce the inherited category reply-create audience before every public reply owner write,
-  compose exact request context, and add topic-local reply narrowing only as a separate bounded
-  owner policy that cannot broaden category layers;
-- add moderation audience policy persistence and enforcement plus owner write commands;
-- continue consuming the delivered Forum trust fact through the exact bounded audience
-  composition while keeping Channel and Groups adapters exact, bounded and tenant-scoped;
-- migrate remaining Forum reads plus search/index, SEO, and deep-link authorization to the
-  same exact richer audience decision;
+- migrate remaining Forum reads plus search/index, SEO, and deep-link authorization to the same
+  exact richer audience decision;
 - add visibility-scoped category/all-read commands over an exact bounded policy scope;
-- add tenant-wide scheduled reconciliation, payload redaction, channel enqueue/transports,
-  and delivery-time target authorization;
-- add PostgreSQL concurrency, lease/contention, inheritance, and cross-consumer runtime
-  evidence before promoting `FORUM-20` to `done`.
+- require any future public moderation transports to reuse the delivered context-aware owner
+  methods instead of implementing transport-local policy;
+- add tenant-wide scheduled reconciliation, payload redaction, channel enqueue/transports, and
+  delivery-time target authorization;
+- add PostgreSQL concurrency, lease/contention, inheritance, and cross-consumer runtime evidence
+  before promoting `FORUM-20` to `done`.
 
 ### Definition of done
 
@@ -1439,6 +1501,12 @@ cargo test -p rustok-forum --test topic_reply_owner_visibility_sqlite -- --nocap
 cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture
 cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
 cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test category_reply_create_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_reply_create_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test moderation_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum reply_create_transport -- --nocapture
+cargo test -p rustok-forum graphql::runtime_data -- --nocapture
+cargo test -p rustok-forum moderation_transport -- --nocapture
 node scripts/verify/verify-forum-topic-visibility-scope.mjs
 node scripts/verify/verify-forum-category-visibility-policy.mjs
 node scripts/verify/verify-forum-owner-read-visibility.mjs
@@ -1470,19 +1538,23 @@ node scripts/verify/verify-forum-category-topic-create-audience-policy.mjs
 cargo test -p rustok-forum --test topic_create_audience_enforcement_sqlite -- --nocapture
 node scripts/verify/verify-forum-topic-create-audience-enforcement.mjs
 cargo test -p rustok-forum topic_create_transport -- --nocapture
-cargo test -p rustok-forum graphql::runtime_data -- --nocapture
 node scripts/verify/verify-forum-topic-create-audience-transport-composition.mjs
-cargo test -p rustok-forum --test category_reply_create_audience_policy_sqlite -- --nocapture
 node scripts/verify/verify-forum-category-reply-create-audience-policy.mjs
+node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs
+node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
+node scripts/verify/verify-forum-topic-reply-create-audience-policy.mjs
+node scripts/verify/verify-forum-moderation-audience-policy.mjs
+node scripts/verify/verify-forum-moderation-audience-transport-composition.mjs
 node scripts/verify/verify-forum-notification-plan-sync.mjs
+node scripts/verify/verify-forum-audience-plan-sync.mjs
 cargo xtask module validate forum
 npm run verify:forum:storefront-boundary
 ```
 
 Tests, Cargo, verifiers and CI were not run while publishing the source-ready
-FORUM-20C-AU read-composition, capability-contract, persistence, transport, and
-host-facts slices. `FORUM-20` remains `in_progress` until the remaining owner and
-cross-consumer paths are delivered with maintainer runtime evidence.
+FORUM-20C-AZ implementation slices or the FORUM-20BA documentation synchronization.
+`FORUM-20` remains `in_progress` until the remaining owner and cross-consumer paths are
+delivered with maintainer runtime evidence.
 
 ## `FORUM-21` — move, merge, split and fork topics
 
@@ -2284,6 +2356,11 @@ cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocaptur
 cargo test -p rustok-forum --test audience_capability_contract -- --nocapture
 cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture
 cargo test -p rustok-forum --test category_reply_create_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_reply_create_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum --test moderation_audience_policy_sqlite -- --nocapture
+cargo test -p rustok-forum reply_create_transport -- --nocapture
+cargo test -p rustok-forum graphql::runtime_data -- --nocapture
+cargo test -p rustok-forum moderation_transport -- --nocapture
 
 cargo xtask module validate forum
 cargo xtask module test forum
@@ -2311,6 +2388,12 @@ node scripts/verify/verify-forum-category-owner-read-visibility.mjs
 node scripts/verify/verify-forum-audience-capability-ports.mjs
 node scripts/verify/verify-forum-category-audience-policy.mjs
 node scripts/verify/verify-forum-category-reply-create-audience-policy.mjs
+node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs
+node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
+node scripts/verify/verify-forum-topic-reply-create-audience-policy.mjs
+node scripts/verify/verify-forum-moderation-audience-policy.mjs
+node scripts/verify/verify-forum-moderation-audience-transport-composition.mjs
+node scripts/verify/verify-forum-audience-plan-sync.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -2362,9 +2445,9 @@ Recommended next slices:
     storefront bulk composition after the complete `FORUM-20` policy can page an
     exact category or tenant scope;
 11. `FORUM-19`: reports/moderation/restrictions;
-12. continue `FORUM-20` with reply-create command-time enforcement and optional
-    topic-local narrowing, then add moderation audiences; consume the delivered
-    authoritative Forum trust facts only through the exact bounded facts port;
+12. continue `FORUM-20` with remaining exact Forum read authorization, then
+    search/index, SEO and deep-link consumers; route any future moderation
+    transports through the delivered context-aware owner boundary;
 13. continue `FORUM-26` with authoritative active-flag and moderation-history
     fact adapters, keeping every missing owner capability explicitly unavailable;
 14. `FORUM-23`: index projections;

--- a/scripts/verify/verify-forum-audience-plan-sync.mjs
+++ b/scripts/verify/verify-forum-audience-plan-sync.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath ?? "");
+  if (!relativePath || !existsSync(absolute)) {
+    failures.push(`${relativePath || "<missing path>"}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-audience-plan-sync.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const plan = read(contract.canonical_plan);
+const crateApi = read(contract.crate_api);
+const ownerNote = read(contract.owner_note);
+const upstream = read(contract.upstream_contract);
+const taskNotes = (contract.delivered_task_notes ?? []).map((file) => ({
+  file,
+  source: read(file),
+}));
+const taskContracts = (contract.delivered_task_contracts ?? []).map((file) => ({
+  file,
+  source: read(file),
+}));
+
+if (
+  contract.schema_version !== 1 ||
+  contract.task !== "FORUM-20BA" ||
+  contract.upstream_task !== "FORUM-20AZ" ||
+  contract.required_ledger_through !== "FORUM-20BA"
+) {
+  failures.push("FORUM-20BA synchronization contract identity is invalid");
+}
+
+if (taskNotes.length !== 5 || taskContracts.length !== 5) {
+  failures.push("FORUM-20BA must bind exactly five delivered task notes and contracts");
+}
+
+for (const marker of [
+  "FORUM-20A-AZ",
+  "### Delivered in `FORUM-20AV`",
+  "### Delivered in `FORUM-20AW`",
+  "### Delivered in `FORUM-20AX`",
+  "### Delivered in `FORUM-20AY`",
+  "### Delivered in `FORUM-20AZ`",
+  "### Delivered in `FORUM-20BA`",
+  "verify-forum-audience-plan-sync.mjs",
+  "verify-forum-reply-create-audience-enforcement.mjs",
+  "verify-forum-reply-create-audience-transport-composition.mjs",
+  "verify-forum-topic-reply-create-audience-policy.mjs",
+  "verify-forum-moderation-audience-policy.mjs",
+  "verify-forum-moderation-audience-transport-composition.mjs",
+]) {
+  requireText(plan, marker, `canonical Forum plan is missing ${marker}`);
+}
+
+for (const stale of [
+  "reply-create command-time enforcement and optional\n    topic-local narrowing, then add moderation audiences",
+  "enforce the inherited category reply-create audience before every public reply owner write",
+  "add moderation audience policy persistence and enforcement plus owner write commands",
+  "FORUM-20C-AU read-composition",
+]) {
+  rejectText(plan, stale, `canonical Forum plan retains stale scope: ${stale}`);
+}
+
+for (const marker of [
+  "ForumCategoryReplyCreateAudiencePolicyService",
+  "ForumTopicReplyCreateAudiencePolicyService",
+  "ForumCategoryModerationAudiencePolicyService",
+  "FORUM-20AZ",
+]) {
+  requireText(crateApi, marker, `CRATE_API is missing delivered audience marker ${marker}`);
+}
+
+for (const marker of [
+  "FORUM-20AV",
+  "FORUM-20AW",
+  "FORUM-20AX",
+  "FORUM-20AY",
+  "FORUM-20AZ",
+  "ForumUserTrustAudienceFactsPort",
+  "No new moderation route is claimed",
+  "not run by\nthe implementation agent",
+]) {
+  requireText(ownerNote, marker, `FORUM-20BA owner note is missing ${marker}`);
+}
+
+for (const { file, source } of taskNotes) {
+  requireText(
+    source,
+    "Resolved by `FORUM-20BA`",
+    `${file}: canonical plan debt is not marked resolved by FORUM-20BA`,
+  );
+  rejectText(source, "Forum trust remains unavailable", `${file}: stale unavailable trust claim`);
+  rejectText(source, "Trust remains blocked on `FORUM-26`", `${file}: stale blocked trust claim`);
+  rejectText(
+    source,
+    "A later safe repository-local edit must advance",
+    `${file}: stale future plan-sync instruction`,
+  );
+}
+
+for (const { file, source } of taskContracts) {
+  requireText(source, '"task": "FORUM-20', `${file}: task identity is missing`);
+}
+
+for (const marker of [
+  '"downstream_plan_sync_task": "FORUM-20BA"',
+  '"downstream_plan_sync_contract": "crates/rustok-forum/contracts/forum-audience-plan-sync.json"',
+]) {
+  requireText(upstream, marker, `FORUM-20AZ handoff is missing ${marker}`);
+}
+
+for (const [key, expected] of [
+  ["canonical_ledger_advanced_through_forum_20az", true],
+  ["documentation_sync_recorded_as_forum_20ba", true],
+  ["reply_create_enforcement_removed_from_remaining_scope", true],
+  ["topic_local_reply_narrowing_removed_from_remaining_scope", true],
+  ["category_moderation_audience_removed_from_remaining_scope", true],
+  ["authoritative_forum_trust_status_corrected", true],
+  ["owner_note_plan_debt_marked_resolved", true],
+  ["latest_handoff_updated", true],
+  ["runtime_behavior_changed", false],
+  ["migration_changed", false],
+  ["dependency_changed", false],
+  ["public_contract_changed", false],
+]) {
+  if (contract.synchronization?.[key] !== expected) {
+    failures.push(`FORUM-20BA synchronization.${key} must be ${expected}`);
+  }
+}
+
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("FORUM-20BA must not claim maintainer runtime execution");
+}
+
+if (failures.length > 0) {
+  console.error("Forum audience plan synchronization verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum audience plan synchronization is source-ready.");


### PR DESCRIPTION
## Summary

- advance the canonical Forum ledger from `FORUM-20AU` through the already-delivered `FORUM-20AV`–`FORUM-20AZ` chain
- record reply-create owner enforcement, exact GraphQL/REST composition, topic-local reply narrowing, inherited moderation audience policy, and existing solution-route transport composition
- add `FORUM-20BA` as the documentation synchronization slice with a machine-readable contract and source guard
- repair five historical owner notes that still described delivered Forum trust facts as unavailable or blocked
- update the latest `FORUM-20AZ` handoff to point at the synchronization contract
- retain remaining exact-read/search/index/SEO/deep-link migration, visibility-scoped bulk reads, future moderation transport reuse, reconciliation/delivery work, and runtime evidence as open scope

## Boundary

This PR changes documentation, machine contracts, and a static verifier only. It adds no runtime behavior, migration, dependency, endpoint, request/response shape, or authorization path.

`FORUM-20AZ` covers only the existing GraphQL and REST mark/clear-solution routes. No approve/reject/hide, pin/lock/status, or other new moderation endpoint is claimed; future public moderation transports must reuse the delivered context-aware owner boundary.

## Trust correction

The AV–AZ slices did not themselves add Forum trust ownership. However, the current repository now publishes authoritative Forum trust through `ForumUserTrustAudienceFactsPort`, so the historical owner notes no longer present trust as unresolved or derive it from `forum_user_stats`.

## Validation

Tests, Cargo commands, formatting, verifiers, workflows, and CI were not run by the implementation agent, per maintainer request.

Suggested maintainer commands:

```text
node scripts/verify/verify-forum-audience-plan-sync.mjs
node scripts/verify/verify-forum-reply-create-audience-enforcement.mjs
node scripts/verify/verify-forum-reply-create-audience-transport-composition.mjs
node scripts/verify/verify-forum-topic-reply-create-audience-policy.mjs
node scripts/verify/verify-forum-moderation-audience-policy.mjs
node scripts/verify/verify-forum-moderation-audience-transport-composition.mjs
cargo xtask module validate forum
```