### PR TITLE
test(profiles): add fair-window retained capture

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-fair-window-external-scan-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json",
+  "runner": "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs",
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs",
+  "evidence_path": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution.json",
+  "evidence_status": "runtime_execution_pending",
+  "command": {
+    "program": "cargo",
+    "args": [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--features",
+      "iggy",
+      "--test",
+      "dlq_duplicate_fair_window_external_scan",
+      "--",
+      "fair_window_scans_each_partition_and_differs_from_global_budget",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
+  "case": "fair_window_scans_each_partition_and_differs_from_global_budget",
+  "required_environment": {
+    "address": "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS",
+    "config_path": "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_CONFIG_PATH",
+    "server_artifact": "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_SERVER_ARTIFACT"
+  },
+  "optional_environment": [
+    "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_USERNAME",
+    "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_PASSWORD"
+  ],
+  "reviewed_configuration": {
+    "section": "system.message_deduplication",
+    "required_enabled": false,
+    "retain_only": [
+      "section",
+      "enabled",
+      "canonical_sha256"
+    ],
+    "config_path_outside_repository": true,
+    "full_content_retained": false,
+    "full_file_sha256_retained": false
+  },
+  "required_fair_summary": {
+    "total_messages": 4,
+    "unique_message_ids": 2,
+    "duplicate_messages": 2,
+    "duplicate_groups": 2,
+    "conflicting_payload_groups": 1,
+    "max_copies_per_message_id": 2,
+    "has_physical_duplicates": true,
+    "has_identity_conflicts": true,
+    "requires_manual_review": true
+  },
+  "required_global_summary": {
+    "total_messages": 4,
+    "unique_message_ids": 3,
+    "duplicate_messages": 1,
+    "duplicate_groups": 1,
+    "conflicting_payload_groups": 0,
+    "max_copies_per_message_id": 2,
+    "has_physical_duplicates": true,
+    "has_identity_conflicts": false,
+    "requires_manual_review": false
+  },
+  "required_comparison": {
+    "fair_summary_repeated_equal": true,
+    "global_summary_differs_from_fair": true
+  },
+  "required_offset_observations": {
+    "partitions_checked": 2,
+    "before_fixture_publication_stored_offset_count": 0,
+    "after_first_fair_window_stored_offset_count": 0,
+    "after_global_request_stored_offset_count": 0,
+    "after_second_fair_window_stored_offset_count": 0
+  },
+  "runner_requirements": {
+    "clean_working_tree_before": true,
+    "clean_working_tree_after_test": true,
+    "full_git_commit": true,
+    "commit_unchanged": true,
+    "source_hashes_unchanged": true,
+    "exact_case_only": true,
+    "running_one_test_required": true,
+    "skip_rejected": true,
+    "no_clobber_atomic_write_after_pass": true
+  },
+  "retained_packet": {
+    "reviewed_artifact_labels": true,
+    "canonical_dedup_configuration": true,
+    "git_toolchain_timestamps": true,
+    "exact_command": true,
+    "current_source_sha256": true,
+    "test_output_sha256_and_bytes": true,
+    "fair_and_global_summary_assertions": true,
+    "aggregate_two_partition_absent_offset_assertions": true,
+    "case_result": "pass"
+  },
+  "privacy_exclusions": [
+    "database_url",
+    "broker_address",
+    "config_path",
+    "config_full_content",
+    "config_full_file_sha256",
+    "username",
+    "password",
+    "connection_string",
+    "raw_test_output",
+    "stream_name",
+    "partition_id",
+    "partition_ids",
+    "offset",
+    "broker_message_id",
+    "delivery_uuid",
+    "payload",
+    "payload_sha256",
+    "ack_token",
+    "raw_iggy_error"
+  ],
+  "source_files": [
+    "crates/rustok-iggy/tests/dlq_duplicate_fair_window_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+    "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+    "crates/rustok-iggy/src/dlq_publisher.rs",
+    "crates/rustok-iggy/src/transport.rs",
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json",
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json",
+    "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs",
+    "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs"
+  ],
+  "non_claims": [
+    "active_server_configuration_readback",
+    "production_history_complete",
+    "production_dedup_window_sufficiency",
+    "same_broker_message_id_split_across_partitions",
+    "moving_cursor",
+    "cross_cycle_duplicate_accumulation",
+    "bundled_iggy",
+    "tls_auth_failover",
+    "destructive_reconciliation",
+    "profiles_authorization"
+  ]
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dlq-duplicate-fair-window-external-scan-runtime-source",
   "status": "source_complete_runtime_pending",
@@ -127,6 +127,15 @@
     "required_stored_offset": null,
     "second_fair_summary_equals_first": true,
     "auto_commit": false
+  },
+  "retained_execution": {
+    "status": "capture_source_complete_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json",
+    "runner": "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs",
+    "verifier": "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs",
+    "evidence_path": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution.json",
+    "canonical_packet_present": false,
+    "no_clobber_write": true
   },
   "sdk_observer_boundary": {
     "allowed": [

--- a/crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md
@@ -1,15 +1,17 @@
 # External-Iggy fair-window duplicate scan runtime evidence
 
-Status: **source complete; runtime execution and retained packet pending**.
+Status: **two-partition harness and retained-capture tooling source complete; runtime execution and canonical packet pending**.
 
 ## Purpose
 
-This harness proves the production-reachable difference between the bounded
+This evidence slice proves the production-reachable difference between the bounded
 `fair_window` policy and the compatibility `global_budget` request across two
-physical DLQ partitions.
+physical DLQ partitions. It also defines a clean-commit runner and a strict
+privacy-safe retained packet verifier.
 
-It does not prove moving cursors, complete history, or that one deterministic
-broker message ID can be split across partitions.
+It does not prove moving cursors, complete history, deduplication-window
+sufficiency, or that one deterministic broker message ID can be split across
+partitions.
 
 ## Exact case
 
@@ -23,51 +25,64 @@ Target:
 crates/rustok-iggy/tests/dlq_duplicate_fair_window_external_scan.rs
 ```
 
-Exact command:
+Exact Cargo command:
 
 ```bash
-RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS='host:8090' \
 cargo test -p rustok-iggy --features iggy \
   --test dlq_duplicate_fair_window_external_scan -- \
   fair_window_scans_each_partition_and_differs_from_global_budget \
   --exact --nocapture --test-threads=1
 ```
 
-Optional credentials:
+The source harness reads:
 
 ```text
-RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_USERNAME
-RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_PASSWORD
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_USERNAME       optional
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_PASSWORD       optional
 ```
 
-The address has no default. Missing configuration skips the source harness, so a
-future retained runner must reject skips and require exactly one passing case.
+The address has no default. Missing configuration skips the source harness, so
+the retained runner rejects skip output and requires exactly one passing test.
 
-## Reviewed broker
+## Reviewed broker and configuration
 
 The broker must be disposable or operator-cleaned and must have Iggy message-ID
 deduplication disabled. The test does not read server configuration.
 
-The harness creates one unique stream with two domain/DLQ partitions and does not
-delete it.
+The retained runner additionally requires:
+
+```text
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_CONFIG_PATH
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_SERVER_ARTIFACT
+```
+
+`CONFIG_PATH` must be an absolute regular file outside the repository. The
+runner reads only `[system.message_deduplication].enabled`, requires `false`,
+and retains only:
+
+```text
+section
+enabled
+canonical_sha256
+```
+
+The full configuration, its path, and its full-file digest are not retained.
+`SERVER_ARTIFACT` is a bounded operator-reviewed version or digest label, not an
+endpoint.
 
 ## Production partition invariant
 
-`IggyTransport::move_to_dlq` uses `IggyDlqPublisher` when a deterministic broker
-message ID is present. The publisher selects:
+`IggyTransport::move_to_dlq` uses `IggyDlqPublisher` for deterministic broker
+message IDs. The publisher selects:
 
 ```text
 partition = (broker_message_id_as_u128 mod partition_count) + 1
 ```
 
-Therefore every physical copy with the same broker message ID is colocated in the
-same partition. The harness deliberately preserves that production invariant and
-does not use a direct SDK fixture producer to force an impossible split.
-
-The scanner still combines observations from every requested partition before
-classification. This matters for one aggregate summary, but production runtime
-evidence must not claim that identical deterministic IDs were physically split
-across partitions.
+Every physical copy with the same broker message ID is therefore colocated in
+one partition. The harness preserves this production invariant and uses no
+direct SDK fixture producer.
 
 ## Fixture
 
@@ -76,16 +91,15 @@ Five messages are published only through production
 
 ```text
 partition 1:
-  A1, A2  same deterministic header UUID and same exact bytes
+  A1, A2  same deterministic UUID and same exact bytes
   C       one additional unique message beyond the fair cap
 
 partition 2:
-  B1, B2  same deterministic header UUID and different exact bytes
+  B1, B2  same deterministic UUID and different exact bytes
 ```
 
-The broker IDs are selected locally so the production modulo rule routes them to
-the intended partition. IDs, payloads, stream names, offsets, and addresses are
-never logged or retained.
+The fixed non-nil UUIDs are checked against the production modulo rule before
+publication.
 
 ## Fair-window proof
 
@@ -112,9 +126,7 @@ has_identity_conflicts = true
 requires_manual_review = true
 ```
 
-This proves that partition 1 cannot consume partition 2's budget: the third
-partition-1 message is outside the fair window while both partition-2 messages are
-included.
+This proves that partition 1 cannot consume partition 2's budget.
 
 ## Compatibility-global comparison
 
@@ -141,12 +153,12 @@ has_identity_conflicts = false
 requires_manual_review = false
 ```
 
-The result must differ from the fair summary. Partition 1 consumes three of the
-four global slots before partition 2 receives one.
+The global result must differ from the fair result.
 
 ## Offset non-mutation
 
-The standalone scanner consumer offset must be absent for partitions 1 and 2:
+The standalone scanner consumer offset must be absent for both configured
+partitions:
 
 ```text
 before fixture publication
@@ -155,30 +167,101 @@ after compatibility global scan
 after second fair scan
 ```
 
-The harness contains no offset store/delete, consumer group, acknowledgement,
-message send through the SDK observer, stream/topic deletion, or purge.
+The retained packet stores only the aggregate assertion that two partitions
+were checked and zero stored offsets were present at every checkpoint. It does
+not retain partition IDs or offset values.
 
-## Privacy and non-claims
+## Retained capture
 
-Only identifier-free aggregate summaries are asserted. The harness does not
-retain or print connection details, stream names, partitions, offsets, UUIDs,
-payloads, payload digests, credentials, or raw Iggy errors.
+Machine contract:
 
-It does not claim:
+```text
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-fair-window-external-scan-execution-contract.json
+```
 
-- runtime execution or retained evidence;
-- active server configuration readback;
-- production history completeness;
-- deduplication-window sufficiency;
-- same-ID cross-partition publication;
-- moving cursors or cross-cycle duplicate accumulation;
-- bundled Iggy, TLS/auth/failover, destructive reconciliation, or Profiles policy.
+Runner:
 
-## Source guard
+```text
+scripts/evidence/
+  capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
+```
+
+Verifier:
+
+```text
+scripts/verify/
+  verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
+```
+
+Canonical packet path:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-fair-window-external-scan-execution.json
+```
+
+The runner requires a clean worktree and a full unchanged commit, hashes every
+bound source before and after the exact test, rejects skip output, and records
+bounded Cargo/Rust/Iggy labels plus the test-output digest and byte count.
+
+Packet publication is no-clobber. A temporary file is created with exclusive
+creation and hard-linked to the canonical path. An existing canonical packet is
+never replaced.
+
+Example capture:
+
+```bash
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS='host:8090' \
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_CONFIG_PATH='/outside/repo/iggy.toml' \
+RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_SERVER_ARTIFACT='iggy-server-reviewed-build' \
+node scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
+```
+
+Source and retained guards:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
 ```
+
+Before execution, the retained verifier succeeds only when the execution
+contract and runner are locked and the canonical packet is absent. After
+execution it additionally requires the packet commit and all source hashes to
+match the current checkout.
+
+## Privacy boundary
+
+The retained packet excludes:
+
+```text
+broker address
+configuration path or full content
+username/password/connection string
+raw test output
+stream name
+partition IDs
+offsets
+broker/delivery UUIDs
+payloads and payload digests
+ack tokens
+raw Iggy errors
+```
+
+It retains only identifier-free fair/global summaries, aggregate absent-offset
+assertions, reviewed configuration projection, bounded artifact/toolchain
+labels, current source hashes, timestamps, and output digest/size.
+
+## Non-claims
+
+This source slice does not claim:
+
+- runtime execution or a canonical retained packet;
+- active server configuration readback;
+- production history completeness or deduplication-window sufficiency;
+- same-ID cross-partition publication;
+- moving cursors or cross-cycle duplicate accumulation;
+- bundled Iggy, TLS/auth/failover, destructive reconciliation, or Profiles policy.
 
 No test, verifier, Cargo command, broker connection, or retained capture was run
 by the implementation agent.

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -31,8 +31,8 @@ mutation retry.
 
 ### Social Graph and Index
 
-- Durable command receipts bind a tenant-scoped normalized idempotency key to one
-  complete command identity and share a transaction with relation mutation,
+- Durable command receipts bind one tenant-scoped normalized idempotency key to
+  one complete command identity and share a transaction with relation mutation,
   optional event append, response snapshot, and completion.
 - `social_graph.relation.state_changed` is a sealed persisted-revision fact.
   No-op and receipt replay emit nothing; event failure rolls owner state back.
@@ -78,9 +78,13 @@ mutation retry.
   partition.
 - The fair-window duplicate-scan harness is source-complete for two partitions
   and compares equal per-partition budgets with the ordered global budget.
-- Retained packets must omit credentials and delivery-level facts, bind reviewed
-  source hashes/configuration digests, and become stale when bound sources
-  change.
+- Fair-window clean-commit retained capture is source-complete: exact-case
+  execution, reviewed dedup-disabled configuration projection, current source
+  hashes, aggregate two-partition absent-offset assertions, and no-clobber packet
+  publication are locked.
+- Canonical retained packets remain pending and must omit credentials and
+  delivery-level facts, bind reviewed source/configuration digests, and become
+  stale when bound sources change.
 
 ## Physical DLQ duplicate inspection
 
@@ -116,11 +120,10 @@ partition = (broker_message_id_as_u128 mod partition_count) + 1
 ```
 
 Production copies carrying the same broker UUID are therefore colocated in one
-partition. The scanner still combines observations from every requested
-partition, but production runtime evidence must not claim that
+partition. Runtime evidence must not claim that
 `IggyTransport::move_to_dlq` split one deterministic ID across partitions.
 
-The fair-window runtime source uses a production-reachable fixture instead:
+The fair-window fixture is production-reachable:
 
 ```text
 partition 1: A/A ordinary duplicate plus one unique overflow message
@@ -129,11 +132,39 @@ partition 2: B1/B2 conflicting-payload duplicate
 
 With a cap of two messages per partition, the fair scan observes both duplicate
 groups and the conflict. The ordered global request with four total slots reads
-three messages from partition 1 and only one from partition 2, producing a
-different summary. The fair policy runs twice from offset zero, and stored
+three messages from partition 1 and one from partition 2, producing a different
+summary. The fair policy runs twice from offset zero, and stored
 standalone-consumer offsets must remain absent on both partitions.
 
-Execution and retained capture remain pending.
+### Fair-window retained capture
+
+Source-complete paths:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-fair-window-external-scan-runtime-source.json
+  dlq-duplicate-fair-window-external-scan-execution-contract.json
+scripts/evidence/
+  capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
+scripts/verify/
+  verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
+  verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
+```
+
+The runner requires a clean unchanged commit, one exact passing case, no skip,
+unchanged bound-source hashes, reviewed external Iggy and dedup-disabled
+configuration labels, and a clean worktree after the test.
+
+The packet retains fair/global summaries, four zero stored-offset counts over two
+checked partitions, bounded artifact/toolchain labels, source hashes,
+timestamps, and test-output digest/size. It excludes endpoints, paths,
+credentials, raw output, stream/partition/offset/UUID/payload facts, ack tokens,
+and raw Iggy errors.
+
+Publication is no-clobber: an exclusive temporary file is hard-linked to the
+canonical path, so existing reviewed evidence cannot be replaced.
+
+Runtime execution and the canonical packet remain pending.
 
 Detailed checkpoints:
 
@@ -172,10 +203,10 @@ Detailed checkpoints:
    on reviewed disposable brokers. Retain separate privacy-safe packets and
    reviewed configuration digests.
 
-7. **Add retained fair-window capture.**
-   Require a clean unchanged commit, the exact one-case Cargo command, no skip,
-   two absent-offset partitions, current source hashes, bounded toolchain/server
-   labels, and atomic privacy-safe packet writing.
+7. **Execute and retain the fair-window packet.**
+   Run the locked capture on one clean unchanged commit, inspect the generated
+   no-clobber packet, commit it, and rerun the retained verifier. Source changes
+   invalidate the packet.
 
 8. **Compose receipt-plus-broker recovery evidence.**
    Prove claim -> exact publish -> durable `published` -> source ack ->
@@ -197,25 +228,27 @@ Detailed checkpoints:
     retention, reconciliation, operator cleanup, and bounded replay/rescan
     repair.
 
-## Recheck checkpoint — 2026-07-28
+## Recheck checkpoint — 2026-07-29
 
-- Rechecked the canonical plan and current `main` after the fair-window server
-  integration.
+- Rechecked the canonical plan and current `main` after the two-partition
+  fair-window harness.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
-- Rechecked production deterministic DLQ partitioning and corrected the planned
-  runtime claim: production same-ID copies are colocated and are not a valid
-  cross-partition fixture.
-- Added a two-partition fair-window source harness that proves equal partition
-  budgets by comparing fair and global identifier-free summaries.
-- Locked absent standalone-consumer offsets for both partitions across repeated
-  fair scans and the compatibility global scan.
-- Kept runtime execution, retained fair-window capture, moving-window state,
+- Reconfirmed deterministic same-ID colocation and the production-reachable
+  fair/global comparison.
+- Added a locked fair-window execution contract, clean-commit runner, and strict
+  retained verifier.
+- Required exact one-case success, skip rejection, unchanged commit/source
+  hashes, reviewed dedup-disabled configuration projection, and four aggregate
+  absent-offset checkpoints across two partitions.
+- Added no-clobber canonical packet publication through exclusive temporary-file
+  creation and a hard link.
+- Kept runtime execution, canonical retained packets, moving-window state,
   production recovery-window sufficiency, bundled/TLS/auth, and multi-replica
   claims open.
-- Tests, Cargo commands, formatters, repository source verifiers, PostgreSQL,
-  external/bundled Iggy, and multi-replica scenarios were not run per maintainer
+- Tests, Cargo commands, repository source verifiers, external/bundled Iggy,
+  retained capture, and multi-replica scenarios were not run per maintainer
   instruction.
 
 ## Verification backlog
@@ -237,6 +270,7 @@ cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
 node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 node scripts/verify/verify-profiles-storefront-boundary.mjs
@@ -265,5 +299,7 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
 13. Short dedup or scan sequences do not prove production-window sufficiency.
 14. Production deterministic broker IDs remain colocated by the publisher's
     one-based modulo partition rule.
-15. Moving duplicate windows require bounded cross-cycle identity state.
-16. Update Profiles and affected owner docs with every boundary change.
+15. Retained evidence is no-clobber, commit-bound, and stale after any bound
+    source change.
+16. Moving duplicate windows require bounded cross-cycle identity state.
+17. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/poison-duplicate-fair-window-external-runtime-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-fair-window-external-runtime-checkpoint.md
@@ -1,36 +1,39 @@
-# Profiles checkpoint: external fair-window DLQ duplicate runtime source
+# Profiles checkpoint: external fair-window DLQ duplicate retained capture
 
-Status: **two-partition source harness complete; execution and retained evidence pending**.
+Status: **two-partition harness and retained-capture tooling source complete; execution and canonical evidence pending**.
 
-## What was added
+## Delivered source
 
-`rustok-iggy` now defines one opt-in production-path scenario for the explicit
-`fair_window` duplicate scanner:
+`rustok-iggy` now contains:
 
 ```text
-crates/rustok-iggy/tests/dlq_duplicate_fair_window_external_scan.rs
+crates/rustok-iggy/tests/
+  dlq_duplicate_fair_window_external_scan.rs
 crates/rustok-iggy/contracts/evidence/
   dlq-duplicate-fair-window-external-scan-runtime-source.json
+  dlq-duplicate-fair-window-external-scan-execution-contract.json
+scripts/evidence/
+  capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
 scripts/verify/
   verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
+  verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
 ```
 
-The scenario compares the fair policy with the compatibility global request over
-the same five physical DLQ messages.
+The canonical execution packet remains absent until the exact case is run on a
+reviewed broker.
 
-## Production-reachable fixture
+## Production-reachable scenario
 
-The test uses only `IggyTransport::move_to_dlq`. It does not use a direct SDK
-producer.
+The test publishes only through `IggyTransport::move_to_dlq`.
 
-Production DLQ publication chooses:
+Production routing is:
 
 ```text
 partition = (broker_message_id_as_u128 mod partition_count) + 1
 ```
 
 Copies with the same deterministic broker ID are therefore colocated. The
-runtime source does not claim that one ID is physically split across partitions.
+scenario does not claim a same-ID cross-partition fixture.
 
 Fixture shape:
 
@@ -39,27 +42,61 @@ partition 1: ordinary duplicate A/A, then one unique overflow message
 partition 2: conflicting-payload duplicate B1/B2
 ```
 
-## Fair versus global result
+The fair policy reads two messages from each partition. The ordered global
+request reads three messages from partition 1 and one from partition 2. Their
+identifier-free summaries must differ, and the same fair policy must produce the
+same summary twice from offset zero.
 
-The fair policy reads two messages from each partition and reports two duplicate
-groups, including one conflicting-payload group.
+## Read-only proof
 
-The ordered global request reads three messages from partition 1 and one from
-partition 2. Its identifier-free summary therefore has only one duplicate group
-and no observed identity conflict.
+Stored standalone-consumer offsets must remain absent for both partitions:
 
-This difference locks the equal per-partition budget without inventing a moving
-cursor or a cross-partition same-ID fixture.
+```text
+before publication
+after first fair scan
+after global scan
+after second fair scan
+```
 
-## Read-only boundary
+The packet retains only `partitions_checked = 2` and zero stored-offset counts.
+It does not retain partition IDs or offset values.
 
-Both scans use explicit offset zero and `auto_commit=false`. Stored consumer
-offsets must remain absent for both partitions before publication and after every
-scan.
+The harness cannot acknowledge, store/delete offsets, join a consumer group,
+delete or purge topology, replay, retry, mutate poison receipts, or alter broker
+configuration.
 
-The source harness cannot acknowledge, store/delete offsets, publish through the
-observer SDK client, join a consumer group, delete/purge topology, mutate poison
-receipts, or alter broker configuration.
+## Clean-commit capture
+
+The execution contract requires:
+
+- one exact Cargo case and `running 1 test`;
+- rejection of skipped execution;
+- a clean worktree before the run and after the test;
+- one full unchanged Git commit;
+- unchanged hashes for every bound source;
+- a reviewed external Iggy artifact label;
+- reviewed `message_deduplication.enabled = false`;
+- bounded Cargo/Rust toolchain labels;
+- fair and global summary assertions;
+- four aggregate absent-offset checkpoints over two partitions;
+- test-output SHA-256 and byte count.
+
+The configuration path must point outside the repository. Only the canonical
+deduplication section, disabled value, and its canonical digest are retained.
+
+Packet publication is no-clobber: the runner exclusively creates a temporary
+file and hard-links it to the canonical path. Existing evidence cannot be
+silently replaced.
+
+## Privacy boundary
+
+The packet excludes broker endpoints, configuration paths/content, credentials,
+connection strings, raw output, stream names, partition IDs, offsets, UUIDs,
+payloads/digests, acknowledgement tokens, and raw Iggy errors.
+
+It retains only bounded provenance, current source hashes, reviewed
+configuration projection, toolchain/artifact labels, timestamps, identifier-free
+summaries, aggregate absent-offset assertions, and output digest/size.
 
 ## Profiles boundary
 
@@ -77,12 +114,12 @@ Profiles remains a consumer of authoritative owner ports only.
 
 ## Remaining work
 
-1. execute the exact case on a reviewed dedup-disabled disposable broker;
-2. add a clean-commit retained runner and privacy-safe packet;
-3. execute and retain the compatibility-global case;
+1. run the exact fair-window case on a reviewed dedup-disabled disposable broker;
+2. inspect and commit the generated canonical packet;
+3. execute and retain the compatibility-global packet separately;
 4. decide whether fixed snapshots are sufficient or design bounded moving-window
    state that preserves identities across cycles;
 5. keep destructive reconciliation separately authorized.
 
-No tests, Cargo commands, source verifiers, broker scans, or retained capture were
-run by the implementation agent.
+No tests, Cargo commands, source verifiers, broker scans, or retained capture
+were run by the implementation agent.

--- a/scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
+++ b/scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json";
+const expectedSourceContract =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json";
+const expectedRunner =
+  "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs";
+const expectedEvidence =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution.json";
+const expectedCase =
+  "fair_window_scans_each_partition_and_differs_from_global_budget";
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) fail(`${program} could not start: ${result.error.message}`);
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function strictOneLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is missing, padded, multiline, or outside the retained boundary`);
+  }
+  return value;
+}
+
+function commandOutputLine(value, field, maximumLength = 256) {
+  if (typeof value !== "string") fail(`${field} is missing`);
+  return strictOneLine(value.replace(/\r?\n$/u, ""), field, maximumLength);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`source file is missing: ${relativePath}`);
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function validateContract() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "iggy" ||
+    contract.packet !==
+      "dlq-duplicate-fair-window-external-scan-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked" ||
+    contract.source_contract !== expectedSourceContract ||
+    contract.runner !== expectedRunner ||
+    contract.verifier !== expectedVerifier ||
+    contract.evidence_path !== expectedEvidence ||
+    contract.evidence_status !== "runtime_execution_pending" ||
+    contract.case !== expectedCase
+  ) {
+    fail("fair-window execution contract identity or path drift");
+  }
+  if (
+    contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+    contract.reviewed_configuration?.required_enabled !== false ||
+    contract.reviewed_configuration?.config_path_outside_repository !== true ||
+    contract.reviewed_configuration?.full_content_retained !== false ||
+    contract.reviewed_configuration?.full_file_sha256_retained !== false
+  ) {
+    fail("fair-window reviewed configuration boundary drift");
+  }
+  if (
+    contract.required_offset_observations?.partitions_checked !== 2 ||
+    Object.entries(contract.required_offset_observations)
+      .filter(([key]) => key !== "partitions_checked")
+      .some(([, value]) => value !== 0)
+  ) {
+    fail("fair-window aggregate absent-offset requirements drift");
+  }
+  if (
+    contract.required_comparison?.fair_summary_repeated_equal !== true ||
+    contract.required_comparison?.global_summary_differs_from_fair !== true
+  ) {
+    fail("fair-window summary comparison requirements drift");
+  }
+}
+
+function validateAddress(value, field) {
+  const address = strictOneLine(value, field, 255);
+  if (
+    address.includes("://") ||
+    address.includes("@") ||
+    address.includes("?") ||
+    address.includes("#")
+  ) {
+    fail(`${field} must be host:port without URL or credential delimiters`);
+  }
+  if (!/^\[[0-9a-fA-F:]+\]:\d+$|^[A-Za-z0-9._-]+:\d+$/u.test(address)) {
+    fail(`${field} must be a bounded host:port address`);
+  }
+  const port = Number(address.slice(address.lastIndexOf(":") + 1));
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    fail(`${field} port must be between 1 and 65535`);
+  }
+}
+
+function validateCredentialsPair() {
+  const [usernameEnvironment, passwordEnvironment] = contract.optional_environment;
+  const username = process.env[usernameEnvironment] ?? "";
+  const password = process.env[passwordEnvironment] ?? "";
+  if ((username.length === 0) !== (password.length === 0)) {
+    fail("fair-window username and password must both be set or both be empty");
+  }
+  for (const [value, field] of [
+    [username, usernameEnvironment],
+    [password, passwordEnvironment],
+  ]) {
+    if (value.length === 0) continue;
+    strictOneLine(value, field, 191);
+    if (value.includes(":") || value.includes("@")) {
+      fail(`${field} contains an unsupported connection delimiter`);
+    }
+  }
+}
+
+function reviewedArtifact(value, field) {
+  const artifact = strictOneLine(value, field, 256);
+  if (
+    artifact.includes("://") ||
+    artifact.includes("@") ||
+    /^\[[0-9a-fA-F:]+\]:\d+$/u.test(artifact) ||
+    /^[A-Za-z0-9._-]+:\d+$/u.test(artifact)
+  ) {
+    fail(`${field} must be an operator-reviewed version or digest label, not an endpoint`);
+  }
+  return artifact;
+}
+
+function externalConfigPath(value, field) {
+  const supplied = strictOneLine(value, field, 4096);
+  if (!isAbsolute(supplied)) fail(`${field} must be an absolute path outside the repository`);
+  const absolutePath = resolve(supplied);
+  const repository = resolve(repoRoot);
+  if (absolutePath === repository || absolutePath.startsWith(`${repository}${sep}`)) {
+    fail(`${field} must point outside the repository`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${field} must point to an existing external configuration file`);
+  }
+  return absolutePath;
+}
+
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote !== null && character === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && (character === '"' || character === "'")) {
+      quote = character;
+      continue;
+    }
+    if (quote === null && character === "#") return line.slice(0, index);
+  }
+  return line;
+}
+
+function parseDedupConfiguration(absolutePath, field) {
+  const lines = readFileSync(absolutePath, "utf8").split(/\r?\n/u);
+  let inSection = false;
+  let sectionFound = false;
+  let enabledRaw = null;
+  for (const rawLine of lines) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      if (inSection) break;
+      inSection = section[1].trim() === "system.message_deduplication";
+      sectionFound ||= inSection;
+      continue;
+    }
+    if (!inSection) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) fail(`${field} contains an invalid message_deduplication assignment`);
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key !== "enabled") continue;
+    if (enabledRaw !== null) fail(`${field} contains duplicate message_deduplication.enabled`);
+    enabledRaw = value;
+  }
+  if (!sectionFound) fail(`${field} is missing [system.message_deduplication]`);
+  if (enabledRaw !== "false") {
+    fail(`${field} must set message_deduplication.enabled = false`);
+  }
+  const canonical = { section: "system.message_deduplication", enabled: false };
+  return { ...canonical, canonical_sha256: sha256(JSON.stringify(canonical)) };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function requirePassedCase(output) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail("fair-window retained execution did not run exactly one test");
+  }
+  const marker = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(expectedCase)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!marker.test(output)) fail("fair-window exact case did not report success");
+  if (/skipping external Iggy fair-window duplicate scan evidence/iu.test(output)) {
+    fail("fair-window exact case reported a skip");
+  }
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree must be clean before fair-window retained execution");
+  }
+  const commit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "git_commit",
+    40,
+  );
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("git commit must be a full lowercase SHA-1");
+  }
+  return commit;
+}
+
+function ensureOutputInsideRepository() {
+  const repository = `${resolve(repoRoot)}${sep}`;
+  if (!outputPath.startsWith(repository)) {
+    fail("fair-window retained output must stay inside the repository");
+  }
+}
+
+function writeNoClobber(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  if (existsSync(outputPath)) {
+    fail("fair-window retained evidence already exists and will not be replaced");
+  }
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+    linkSync(temporaryPath, outputPath);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
+}
+
+try {
+  ensureOutputInsideRepository();
+  validateContract();
+
+  const addressEnvironment = contract.required_environment.address;
+  const configPathEnvironment = contract.required_environment.config_path;
+  const serverArtifactEnvironment = contract.required_environment.server_artifact;
+  validateAddress(process.env[addressEnvironment] ?? "", addressEnvironment);
+  validateCredentialsPair();
+  const configPath = externalConfigPath(
+    process.env[configPathEnvironment] ?? "",
+    configPathEnvironment,
+  );
+  const reviewedConfiguration = parseDedupConfiguration(
+    configPath,
+    configPathEnvironment,
+  );
+  const serverArtifact = reviewedArtifact(
+    process.env[serverArtifactEnvironment] ?? "",
+    serverArtifactEnvironment,
+  );
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = commandOutputLine(
+    runChecked("cargo", ["--version"]).stdout,
+    "cargo_version",
+  );
+  const rustcVersion = commandOutputLine(
+    runChecked("rustc", ["--version"]).stdout,
+    "rustc_version",
+  );
+  const startedAt = new Date().toISOString();
+  const result = runChecked(contract.command.program, contract.command.args);
+  const output = `${result.stdout}\n${result.stderr}`;
+  requirePassedCase(output);
+
+  const finalCommit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+    40,
+  );
+  if (finalCommit !== gitCommit) fail("git commit changed during fair-window execution");
+  const finalSourceSha256 = sourceHashes();
+  if (!same(finalSourceSha256, initialSourceSha256)) {
+    fail("fair-window source files changed during retained execution");
+  }
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during fair-window retained test execution");
+  }
+  const completedAt = new Date().toISOString();
+
+  writeNoClobber({
+    schema_version: 1,
+    module: contract.module,
+    packet: "dlq-duplicate-fair-window-external-scan-runtime-evidence",
+    status: "external_iggy_fair_window_duplicate_scan_runtime_executed",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    environment_sources: {
+      address_environment: addressEnvironment,
+      configuration_path_environment: configPathEnvironment,
+      server_artifact_environment: serverArtifactEnvironment,
+      username_environment: contract.optional_environment[0],
+      password_environment: contract.optional_environment[1],
+    },
+    reviewed_artifacts: { iggy_server: serverArtifact },
+    reviewed_configuration: reviewedConfiguration,
+    toolchain: { cargo: cargoVersion, rustc: rustcVersion },
+    source_sha256: finalSourceSha256,
+    executed_case: {
+      name: contract.case,
+      result: "pass",
+      command: contract.command,
+      required_fair_summary: contract.required_fair_summary,
+      required_global_summary: contract.required_global_summary,
+      required_comparison: contract.required_comparison,
+      required_offset_observations: contract.required_offset_observations,
+      test_output_sha256: sha256(output),
+      test_output_bytes: Buffer.byteLength(output),
+    },
+  });
+  console.log(`Retained fair-window scan evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`Fair-window retained capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json";
+const sourceContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-runtime-source.json";
+const runnerPath =
+  "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution.json";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs";
+const expectedCase =
+  "fair_window_scans_each_partition_and_differs_from_global_budget";
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const sourceContract = JSON.parse(
+  readFileSync(resolve(repoRoot, sourceContractPath), "utf8"),
+);
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const failures = [];
+
+const expectedCommand = {
+  program: "cargo",
+  args: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--features",
+    "iggy",
+    "--test",
+    "dlq_duplicate_fair_window_external_scan",
+    "--",
+    expectedCase,
+    "--exact",
+    "--nocapture",
+    "--test-threads=1",
+  ],
+};
+const expectedFairSummary = {
+  total_messages: 4,
+  unique_message_ids: 2,
+  duplicate_messages: 2,
+  duplicate_groups: 2,
+  conflicting_payload_groups: 1,
+  max_copies_per_message_id: 2,
+  has_physical_duplicates: true,
+  has_identity_conflicts: true,
+  requires_manual_review: true,
+};
+const expectedGlobalSummary = {
+  total_messages: 4,
+  unique_message_ids: 3,
+  duplicate_messages: 1,
+  duplicate_groups: 1,
+  conflicting_payload_groups: 0,
+  max_copies_per_message_id: 2,
+  has_physical_duplicates: true,
+  has_identity_conflicts: false,
+  requires_manual_review: false,
+};
+const expectedComparison = {
+  fair_summary_repeated_equal: true,
+  global_summary_differs_from_fair: true,
+};
+const expectedOffsets = {
+  partitions_checked: 2,
+  before_fixture_publication_stored_offset_count: 0,
+  after_first_fair_window_stored_offset_count: 0,
+  after_global_request_stored_offset_count: 0,
+  after_second_fair_window_stored_offset_count: 0,
+};
+const expectedTopLevelKeys = [
+  "schema_version",
+  "module",
+  "packet",
+  "status",
+  "generated_from",
+  "runner",
+  "verifier",
+  "git_commit",
+  "working_tree_clean_before_run",
+  "started_at",
+  "completed_at",
+  "environment_sources",
+  "reviewed_artifacts",
+  "reviewed_configuration",
+  "toolchain",
+  "source_sha256",
+  "executed_case",
+].sort();
+const expectedCaseKeys = [
+  "name",
+  "result",
+  "command",
+  "required_fair_summary",
+  "required_global_summary",
+  "required_comparison",
+  "required_offset_observations",
+  "test_output_sha256",
+  "test_output_bytes",
+].sort();
+
+function fail(message) {
+  failures.push(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    fail(`source file is missing: ${relativePath}`);
+    return null;
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function currentSourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fail("could not read current git commit");
+    return null;
+  }
+  const commit = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("current git commit is not a full lowercase SHA-1");
+    return null;
+  }
+  return commit;
+}
+
+function validSha256(value, field) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${field} is not a lowercase SHA-256`);
+  }
+}
+
+function validTimestamp(value, field) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${field} is not a valid timestamp`);
+  }
+}
+
+function boundedLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is not a bounded one-line value`);
+  }
+}
+
+function boundedArtifact(value, field) {
+  boundedLine(value, field, 256);
+  if (
+    typeof value === "string" &&
+    (value.includes("://") ||
+      value.includes("@") ||
+      /^\[[0-9a-fA-F:]+\]:\d+$/u.test(value) ||
+      /^[A-Za-z0-9._-]+:\d+$/u.test(value))
+  ) {
+    fail(`${field} is endpoint-shaped rather than an artifact label`);
+  }
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectKeys(entry, keys);
+  } else if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      keys.push(key);
+      collectKeys(entry, keys);
+    }
+  }
+  return keys;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !==
+    "dlq-duplicate-fair-window-external-scan-execution-contract" ||
+  contract.status !== "runtime_execution_contract_locked" ||
+  contract.source_contract !== sourceContractPath ||
+  contract.runner !== runnerPath ||
+  contract.verifier !== expectedVerifier ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== "runtime_execution_pending" ||
+  contract.case !== expectedCase
+) {
+  fail("fair-window retained execution contract identity or path drift");
+}
+if (!same(contract.command, expectedCommand)) {
+  fail("fair-window retained exact command drift");
+}
+if (!same(contract.required_fair_summary, expectedFairSummary)) {
+  fail("fair-window retained fair summary drift");
+}
+if (!same(contract.required_global_summary, expectedGlobalSummary)) {
+  fail("fair-window retained global summary drift");
+}
+if (!same(contract.required_comparison, expectedComparison)) {
+  fail("fair-window retained comparison drift");
+}
+if (!same(contract.required_offset_observations, expectedOffsets)) {
+  fail("fair-window retained aggregate absent-offset drift");
+}
+if (
+  sourceContract.status !== "source_complete_runtime_pending" ||
+  sourceContract.execution_status !== "not_run" ||
+  sourceContract.test !==
+    "crates/rustok-iggy/tests/dlq_duplicate_fair_window_external_scan.rs" ||
+  sourceContract.case !== expectedCase ||
+  sourceContract.retained_execution?.contract !== contractPath ||
+  sourceContract.retained_execution?.runner !== runnerPath ||
+  sourceContract.retained_execution?.verifier !== expectedVerifier ||
+  sourceContract.retained_execution?.evidence_path !== evidencePath ||
+  sourceContract.retained_execution?.canonical_packet_present !== false ||
+  sourceContract.retained_execution?.no_clobber_write !== true
+) {
+  fail("fair-window runtime source contract retained relationship drift");
+}
+if (
+  contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+  contract.reviewed_configuration?.required_enabled !== false ||
+  !same(contract.reviewed_configuration?.retain_only, [
+    "section",
+    "enabled",
+    "canonical_sha256",
+  ]) ||
+  contract.reviewed_configuration?.config_path_outside_repository !== true ||
+  contract.reviewed_configuration?.full_content_retained !== false ||
+  contract.reviewed_configuration?.full_file_sha256_retained !== false
+) {
+  fail("fair-window reviewed configuration boundary drift");
+}
+
+for (const marker of [
+  "function strictOneLine(value, field, maximumLength = 256)",
+  "function commandOutputLine(value, field, maximumLength = 256)",
+  "validateAddress(process.env[addressEnvironment]",
+  "validateCredentialsPair();",
+  "externalConfigPath(",
+  "must point outside the repository",
+  "reviewedArtifact(",
+  "system.message_deduplication",
+  'enabledRaw !== "false"',
+  "canonical_sha256: sha256(JSON.stringify(canonical))",
+  "ensureCleanCommit()",
+  "sourceHashes()",
+  'runChecked("cargo", ["--version"])',
+  'runChecked("rustc", ["--version"])',
+  "running 1 test",
+  "exact case reported a skip",
+  "finalCommit !== gitCommit",
+  "workingTreeStatus().trim()",
+  "writeNoClobber({",
+  'flag: "wx"',
+  "linkSync(temporaryPath, outputPath)",
+  "required_fair_summary: contract.required_fair_summary",
+  "required_global_summary: contract.required_global_summary",
+  "required_comparison: contract.required_comparison",
+  "required_offset_observations: contract.required_offset_observations",
+  "test_output_sha256: sha256(output)",
+]) {
+  requireText("fair-window retained runner", runner, marker);
+}
+
+if (failures.length === 0 && !existsSync(resolve(repoRoot, evidencePath))) {
+  console.log(
+    "Iggy fair-window retained evidence verified: clean-commit exact-case capture, reviewed dedup-disabled configuration projection, current source hashes, fair/global assertions, two-partition absent-offset aggregates, privacy exclusions, and no-clobber publication are locked; canonical execution JSON is absent.",
+  );
+  process.exit(0);
+}
+
+if (existsSync(resolve(repoRoot, evidencePath))) {
+  let evidence;
+  try {
+    evidence = JSON.parse(readFileSync(resolve(repoRoot, evidencePath), "utf8"));
+  } catch {
+    fail("fair-window execution packet is not valid JSON");
+  }
+
+  if (evidence) {
+    if (!same(Object.keys(evidence).sort(), expectedTopLevelKeys)) {
+      fail("fair-window execution packet top-level keys drifted");
+    }
+    if (
+      evidence.schema_version !== 1 ||
+      evidence.module !== "iggy" ||
+      evidence.packet !==
+        "dlq-duplicate-fair-window-external-scan-runtime-evidence" ||
+      evidence.status !==
+        "external_iggy_fair_window_duplicate_scan_runtime_executed" ||
+      evidence.generated_from !== contractPath ||
+      evidence.runner !== runnerPath ||
+      evidence.verifier !== expectedVerifier ||
+      evidence.working_tree_clean_before_run !== true
+    ) {
+      fail("fair-window execution packet identity or provenance drift");
+    }
+
+    const commit = currentCommit();
+    if (commit && evidence.git_commit !== commit) {
+      fail("fair-window execution packet was generated from another commit");
+    }
+    validTimestamp(evidence.started_at, "started_at");
+    validTimestamp(evidence.completed_at, "completed_at");
+    if (
+      typeof evidence.started_at === "string" &&
+      typeof evidence.completed_at === "string" &&
+      Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)
+    ) {
+      fail("fair-window completion precedes start");
+    }
+
+    if (
+      !same(evidence.environment_sources, {
+        address_environment: "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS",
+        configuration_path_environment:
+          "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_CONFIG_PATH",
+        server_artifact_environment:
+          "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_SERVER_ARTIFACT",
+        username_environment: "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_USERNAME",
+        password_environment: "RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_PASSWORD",
+      })
+    ) {
+      fail("fair-window environment source metadata drift");
+    }
+    if (!same(Object.keys(evidence.reviewed_artifacts ?? {}), ["iggy_server"])) {
+      fail("fair-window reviewed artifact keys drift");
+    }
+    boundedArtifact(evidence.reviewed_artifacts?.iggy_server, "reviewed Iggy artifact");
+    boundedLine(evidence.toolchain?.cargo, "cargo toolchain");
+    boundedLine(evidence.toolchain?.rustc, "rustc toolchain");
+
+    if (
+      !same(Object.keys(evidence.reviewed_configuration ?? {}).sort(), [
+        "canonical_sha256",
+        "enabled",
+        "section",
+      ]) ||
+      evidence.reviewed_configuration?.section !==
+        "system.message_deduplication" ||
+      evidence.reviewed_configuration?.enabled !== false
+    ) {
+      fail("fair-window reviewed configuration shape drift");
+    } else {
+      const canonical = {
+        section: evidence.reviewed_configuration.section,
+        enabled: evidence.reviewed_configuration.enabled,
+      };
+      validSha256(
+        evidence.reviewed_configuration.canonical_sha256,
+        "reviewed configuration canonical hash",
+      );
+      if (
+        evidence.reviewed_configuration.canonical_sha256 !==
+        sha256(JSON.stringify(canonical))
+      ) {
+        fail("fair-window canonical configuration digest mismatch");
+      }
+    }
+
+    const hashes = currentSourceHashes();
+    if (!same(evidence.source_sha256, hashes)) {
+      fail("fair-window execution source hashes are stale");
+    }
+    for (const [path, digest] of Object.entries(evidence.source_sha256 ?? {})) {
+      validSha256(digest, `source hash ${path}`);
+    }
+
+    if (!same(Object.keys(evidence.executed_case ?? {}).sort(), expectedCaseKeys)) {
+      fail("fair-window executed case keys drifted");
+    }
+    if (
+      evidence.executed_case?.name !== expectedCase ||
+      evidence.executed_case?.result !== "pass" ||
+      !same(evidence.executed_case?.command, expectedCommand) ||
+      !same(evidence.executed_case?.required_fair_summary, expectedFairSummary) ||
+      !same(evidence.executed_case?.required_global_summary, expectedGlobalSummary) ||
+      !same(evidence.executed_case?.required_comparison, expectedComparison) ||
+      !same(evidence.executed_case?.required_offset_observations, expectedOffsets)
+    ) {
+      fail("fair-window executed case assertions or result drift");
+    }
+    validSha256(
+      evidence.executed_case?.test_output_sha256,
+      "fair-window test output hash",
+    );
+    if (
+      !Number.isSafeInteger(evidence.executed_case?.test_output_bytes) ||
+      evidence.executed_case.test_output_bytes <= 0
+    ) {
+      fail("fair-window test output byte count is invalid");
+    }
+
+    const forbiddenKeys = new Set(contract.privacy_exclusions ?? []);
+    for (const key of collectKeys(evidence)) {
+      if (forbiddenKeys.has(key)) {
+        fail(`fair-window execution packet contains forbidden key: ${key}`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Iggy fair-window retained verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy fair-window retained evidence verified: current commit/source hashes, reviewed dedup-disabled configuration digest, bounded Iggy/toolchain labels, exact all-pass case, fair/global summary assertions, four aggregate absent-offset checkpoints over two partitions, output digest, no-clobber provenance, and identifier-free packet projection are locked.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
@@ -12,14 +12,27 @@ const testPath =
 const scannerPath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
 const publisherPath = "crates/rustok-iggy/src/dlq_publisher.rs";
 const transportPath = "crates/rustok-iggy/src/transport.rs";
+const executionContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution-contract.json";
+const runnerPath =
+  "scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs";
+const retainedVerifierPath =
+  "scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-fair-window-external-scan-execution.json";
 const expectedCase =
   "fair_window_scans_each_partition_and_differs_from_global_budget";
 
 const contract = JSON.parse(readFileSync(resolve(root, contractPath), "utf8"));
+const executionContract = JSON.parse(
+  readFileSync(resolve(root, executionContractPath), "utf8"),
+);
 const test = readFileSync(resolve(root, testPath), "utf8");
 const scanner = readFileSync(resolve(root, scannerPath), "utf8");
 const publisher = readFileSync(resolve(root, publisherPath), "utf8");
 const transport = readFileSync(resolve(root, transportPath), "utf8");
+const runner = readFileSync(resolve(root, runnerPath), "utf8");
+const retainedVerifier = readFileSync(resolve(root, retainedVerifierPath), "utf8");
 const failures = [];
 
 const same = (actual, expected) =>
@@ -32,20 +45,6 @@ const forbidText = (name, text, marker) => {
   if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
 };
 const count = (text, marker) => text.split(marker).length - 1;
-
-if (
-  contract.schema_version !== 1 ||
-  contract.module !== "iggy" ||
-  contract.packet !==
-    "dlq-duplicate-fair-window-external-scan-runtime-source" ||
-  contract.status !== "source_complete_runtime_pending" ||
-  contract.test_target !== "dlq_duplicate_fair_window_external_scan" ||
-  contract.test !== testPath ||
-  contract.case !== expectedCase ||
-  contract.execution_status !== "not_run"
-) {
-  fail("fair-window runtime contract identity or status drift");
-}
 
 const expectedCommand = {
   program: "cargo",
@@ -64,32 +63,6 @@ const expectedCommand = {
     "--test-threads=1",
   ],
 };
-if (!same(contract.command, expectedCommand)) {
-  fail("fair-window exact Cargo command drift");
-}
-
-if (
-  contract.topology?.domain_partitions !== 2 ||
-  contract.topology?.replication_factor !== 1 ||
-  contract.reviewed_broker_requirement?.message_deduplication_enabled !== false ||
-  contract.fixture_publication?.api !== "IggyTransport::move_to_dlq" ||
-  contract.fixture_publication?.direct_sdk_producer !== false ||
-  contract.fixture_publication?.physical_messages !== 5
-) {
-  fail("fair-window broker, topology, or fixture boundary drift");
-}
-
-if (
-  contract.production_partitioning?.publisher !== "IggyDlqPublisher" ||
-  contract.production_partitioning?.formula !==
-    "(broker_message_id_as_u128 mod partition_count) + 1" ||
-  contract.production_partitioning?.same_broker_message_id_colocated !== true ||
-  contract.production_partitioning
-    ?.same_broker_message_id_split_across_partitions_claimed !== false
-) {
-  fail("production partition invariant drift");
-}
-
 const fairSummary = {
   total_messages: 4,
   unique_message_ids: 2,
@@ -112,6 +85,43 @@ const globalSummary = {
   has_identity_conflicts: false,
   requires_manual_review: false,
 };
+
+if (
+  contract.schema_version !== 2 ||
+  contract.module !== "iggy" ||
+  contract.packet !==
+    "dlq-duplicate-fair-window-external-scan-runtime-source" ||
+  contract.status !== "source_complete_runtime_pending" ||
+  contract.test_target !== "dlq_duplicate_fair_window_external_scan" ||
+  contract.test !== testPath ||
+  contract.case !== expectedCase ||
+  contract.execution_status !== "not_run"
+) {
+  fail("fair-window runtime contract identity or status drift");
+}
+if (!same(contract.command, expectedCommand)) {
+  fail("fair-window exact Cargo command drift");
+}
+if (
+  contract.topology?.domain_partitions !== 2 ||
+  contract.topology?.replication_factor !== 1 ||
+  contract.reviewed_broker_requirement?.message_deduplication_enabled !== false ||
+  contract.fixture_publication?.api !== "IggyTransport::move_to_dlq" ||
+  contract.fixture_publication?.direct_sdk_producer !== false ||
+  contract.fixture_publication?.physical_messages !== 5
+) {
+  fail("fair-window broker, topology, or fixture boundary drift");
+}
+if (
+  contract.production_partitioning?.publisher !== "IggyDlqPublisher" ||
+  contract.production_partitioning?.formula !==
+    "(broker_message_id_as_u128 mod partition_count) + 1" ||
+  contract.production_partitioning?.same_broker_message_id_colocated !== true ||
+  contract.production_partitioning
+    ?.same_broker_message_id_split_across_partitions_claimed !== false
+) {
+  fail("production partition invariant drift");
+}
 if (
   !same(contract.fair_window, {
     partitions: [1, 2],
@@ -152,6 +162,29 @@ if (
   fail("fair-window absent-offset contract drift");
 }
 
+if (
+  contract.retained_execution?.status !==
+    "capture_source_complete_execution_pending" ||
+  contract.retained_execution?.contract !== executionContractPath ||
+  contract.retained_execution?.runner !== runnerPath ||
+  contract.retained_execution?.verifier !== retainedVerifierPath ||
+  contract.retained_execution?.evidence_path !== evidencePath ||
+  contract.retained_execution?.canonical_packet_present !== false ||
+  contract.retained_execution?.no_clobber_write !== true ||
+  executionContract.packet !==
+    "dlq-duplicate-fair-window-external-scan-execution-contract" ||
+  executionContract.status !== "runtime_execution_contract_locked" ||
+  executionContract.source_contract !== contractPath ||
+  executionContract.runner !== runnerPath ||
+  executionContract.verifier !== retainedVerifierPath ||
+  executionContract.evidence_path !== evidencePath ||
+  executionContract.evidence_status !== "runtime_execution_pending" ||
+  executionContract.case !== expectedCase ||
+  !same(executionContract.command, expectedCommand)
+) {
+  fail("fair-window retained execution relationship drift");
+}
+
 for (const marker of [
   '#![cfg(feature = "iggy")]',
   `async fn ${expectedCase}(`,
@@ -173,7 +206,6 @@ for (const marker of [
 ]) {
   requireText("fair-window runtime harness", test, marker);
 }
-
 if (count(test, "#[tokio::test]") !== 1) {
   fail("fair-window harness must contain exactly one runtime case");
 }
@@ -189,7 +221,6 @@ if (count(test, "summarize_window(&fair_policy)") !== 2) {
 if (count(test, "summarize(&global_request)") !== 1) {
   fail("compatibility global request must run once");
 }
-
 for (const marker of [
   "PublishRequest",
   "ExternalConnector",
@@ -230,6 +261,28 @@ for (const marker of [
 ]) {
   requireText("production transport", transport, marker);
 }
+for (const marker of [
+  "ensureCleanCommit()",
+  "sourceHashes()",
+  "requirePassedCase(output)",
+  "writeNoClobber({",
+  'flag: "wx"',
+  "linkSync(temporaryPath, outputPath)",
+  "required_fair_summary: contract.required_fair_summary",
+  "required_global_summary: contract.required_global_summary",
+  "required_offset_observations: contract.required_offset_observations",
+]) {
+  requireText("fair-window retained runner", runner, marker);
+}
+for (const marker of [
+  "currentSourceHashes()",
+  "currentCommit()",
+  "canonical execution JSON is absent",
+  "const forbiddenKeys = new Set(contract.privacy_exclusions ?? [])",
+  "fair-window execution source hashes are stale",
+]) {
+  requireText("fair-window retained verifier", retainedVerifier, marker);
+}
 
 const requiredNonClaims = new Set([
   "runtime_executed",
@@ -268,5 +321,5 @@ if (failures.length) {
 }
 
 console.log(
-  "Iggy fair-window external runtime source verified: two production-routed partitions, equal per-partition caps, fair/global summary divergence, repeated fixed-window equality, absent offsets on both partitions, deterministic same-ID colocation, no direct SDK producer, and no moving-cursor or Profiles claim are locked; runtime execution remains pending.",
+  "Iggy fair-window external runtime source verified: production-routed two-partition fair/global comparison, repeated fixed-window equality, absent offsets, deterministic same-ID colocation, clean-commit no-clobber retained capture, privacy-safe retained verification, and no moving-cursor or Profiles claim are locked; runtime execution remains pending.",
 );


### PR DESCRIPTION
## Summary

- lock a separate execution contract for the two-partition external-Iggy `fair_window` case
- add a clean-commit exact-case capture runner with reviewed dedup-disabled configuration projection
- retain both fair and compatibility-global identifier-free summaries
- retain four aggregate zero-offset checkpoints across two checked partitions without partition IDs or offset values
- bind the packet to one unchanged Git commit and current hashes for every reviewed source
- publish the canonical packet with exclusive temporary-file creation and a no-clobber hard link
- add a strict retained verifier that supports both the pending-packet and current-packet states
- actualize the fair-window source contract, Iggy guide, Profiles checkpoint, and canonical Profiles plan

## Privacy boundary

The retained packet excludes broker endpoints, configuration paths/content, credentials, connection strings, raw test output, stream names, partition IDs, offsets, UUIDs, payloads/digests, acknowledgement tokens, and raw Iggy errors.

It retains only bounded provenance, reviewed configuration projection, artifact/toolchain labels, current source hashes, timestamps, fair/global aggregate summaries, aggregate absent-offset assertions, and test-output digest/size.

## Safety and non-claims

- an existing canonical packet is never replaced
- the runner requires a clean worktree before execution and after the test
- skipped or non-exact execution is rejected
- no runtime execution or canonical evidence packet is claimed in this PR
- no moving cursor, cross-cycle state, current-tail, complete-history, TLS/auth/failover, reconciliation, or Profiles authorization claim

## Verification

Tests, Cargo commands, repository source verifiers, broker connections, and retained capture were not run per maintainer instruction.

Performed only on the locally composed files:

```text
node --check scripts/evidence/capture-iggy-dlq-duplicate-fair-window-external-scan.mjs
node --check scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
node --check scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-retained.mjs
python -m json.tool <both changed JSON contracts>
```

All eight published branch blobs match the locally composed Git blob SHAs.