### PR TITLE
feat(profiles): assess Iggy dedup recovery windows

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dedup-recovery-window-policy-source",
+  "status": "source_complete_runtime_calibration_pending",
+  "owner": "rustok-iggy",
+  "source": "crates/rustok-iggy/src/dedup_recovery_window_policy.rs",
+  "verifier": "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs",
+  "documentation": "crates/rustok-iggy/docs/dedup-recovery-window-policy.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md",
+  "public_exports": [
+    "IggyDeduplicationConfiguration",
+    "IggyDedupRecoveryWindowPolicy",
+    "IggyDedupRecoveryWindowAssessment",
+    "IggyDedupRecoveryWindowStatus",
+    "IggyDedupRecoveryWindowPolicyError"
+  ],
+  "required_recovery_horizon_inputs": [
+    "publication_lease",
+    "process_restart",
+    "transport_reconnect",
+    "operator_recovery"
+  ],
+  "required_capacity_input": "maximum_distinct_deterministic_message_ids_per_partition_during_recovery_horizon",
+  "expiry_rule": "checked_sum_of_all_recovery_horizon_inputs",
+  "capacity_rule": "configured_max_entries_not_below_required_per_partition_distinct_ids",
+  "configuration_modes": [
+    "disabled",
+    "enabled_with_positive_max_entries_and_expiry"
+  ],
+  "assessment_statuses": [
+    "disabled",
+    "insufficient_expiry",
+    "insufficient_capacity",
+    "insufficient_expiry_and_capacity",
+    "sufficient"
+  ],
+  "stable_codes": {
+    "disabled": "iggy.dedup_recovery.disabled",
+    "insufficient_expiry": "iggy.dedup_recovery.insufficient_expiry",
+    "insufficient_capacity": "iggy.dedup_recovery.insufficient_capacity",
+    "insufficient_expiry_and_capacity": "iggy.dedup_recovery.insufficient_expiry_and_capacity",
+    "sufficient": "iggy.dedup_recovery.sufficient",
+    "invalid_policy": "iggy.dedup_recovery.policy_invalid",
+    "invalid_configuration": "iggy.dedup_recovery.configuration_invalid",
+    "horizon_overflow": "iggy.dedup_recovery.horizon_overflow"
+  },
+  "required_source_tests": [
+    "invalid_policy_and_configuration_fail_closed",
+    "recovery_horizon_overflow_fails_closed",
+    "disabled_configuration_never_claims_sufficiency",
+    "expiry_and_capacity_deficits_are_distinguished",
+    "exact_boundary_is_sufficient_without_stronger_guarantees"
+  ],
+  "policy_boundary": {
+    "reads_active_iggy_configuration": false,
+    "connects_to_broker": false,
+    "publishes_or_consumes_messages": false,
+    "mutates_receipts_or_offsets": false,
+    "defines_production_defaults": false,
+    "authorizes_profiles_or_social_graph": false,
+    "claims_database_broker_transaction": false,
+    "claims_physical_exactly_once": false
+  },
+  "privacy_boundary": {
+    "identifier_free": true,
+    "payload_free": true,
+    "broker_coordinate_free": true,
+    "credential_free": true,
+    "configuration_path_free": true
+  },
+  "interpretation": {
+    "sufficient_means": "reviewed_expiry_and_capacity_cover_the_supplied_bounded_model",
+    "sufficient_does_not_mean": [
+      "active_configuration_verified",
+      "workload_bound_proven",
+      "failover_proven",
+      "multi_replica_proven",
+      "universal_duplicate_suppression",
+      "exactly_once"
+    ]
+  },
+  "remaining_work": [
+    "supply_reviewed_production_horizon_bounds",
+    "derive_per_partition_distinct_id_capacity_bound",
+    "bind_assessment_to_reviewed_iggy_configuration_digest",
+    "retain_runtime_calibration_packet",
+    "repeat_for_bundled_tls_auth_failover_and_multi_replica_operation"
+  ],
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/docs/dedup-recovery-window-policy.md
+++ b/crates/rustok-iggy/docs/dedup-recovery-window-policy.md
@@ -1,0 +1,77 @@
+# Iggy deduplication recovery-window policy
+
+Status: **source complete; runtime calibration remains pending**.
+
+## Purpose
+
+The short external-Iggy behavior cases prove that message-ID deduplication can be disabled, can suppress an immediate repeated ID, and can lose suppression through capacity eviction or expiry. They do not establish that one reviewed production configuration covers the complete interval between a successful DLQ publish and the latest supported recovery attempt.
+
+`IggyDedupRecoveryWindowPolicy` provides a transport-neutral, identifier-free comparison for that missing decision. It does not connect to Iggy, read active server state, mutate receipts, publish messages, commit offsets, or authorize Profiles.
+
+## Required model
+
+The caller supplies bounded upper limits for:
+
+```text
+publication lease
+process restart
+transport reconnect
+operator recovery
+```
+
+The required expiry is the checked sum of those four intervals. Overflow fails closed.
+
+The caller also supplies the maximum number of distinct deterministic message IDs that may be routed to one physical DLQ partition during the same interval. The configured `max_entries` must not be below that per physical partition bound.
+
+No production default is embedded in the crate. The lease, restart, reconnect, operator-response, and per-partition workload limits must come from reviewed deployment and operating policy.
+
+## Reviewed configuration input
+
+The policy accepts only one of these explicit states:
+
+```text
+disabled
+enabled(max_entries > 0, expiry > 0)
+```
+
+A disabled configuration never reports sufficient. Invalid enabled values fail closed before assessment.
+
+## Assessment statuses
+
+The identifier-free result distinguishes:
+
+```text
+disabled
+insufficient_expiry
+insufficient_capacity
+insufficient_expiry_and_capacity
+sufficient
+```
+
+`Sufficient` means only that the reviewed `expiry` and `max_entries` cover the supplied bounded model. It does not prove exactly-once, a PostgreSQL/Iggy transaction, active configuration readback, workload-bound correctness, failover behavior, or multi-replica behavior.
+
+## Source contract
+
+```text
+crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
+```
+
+Static verifier:
+
+```bash
+node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+```
+
+Focused source tests cover invalid policy/configuration, duration overflow, disabled mode, independent expiry/capacity deficits, and exact-boundary sufficiency.
+
+## Remaining evidence
+
+Before a stronger duplicate-suppression statement is made, operators still need to:
+
+1. publish reviewed maximum lease, restart, reconnect, and intervention bounds;
+2. derive a defensible maximum distinct-ID arrival bound per physical partition;
+3. bind the assessment to a reviewed Iggy configuration projection and digest;
+4. retain the assessment from one clean commit;
+5. repeat evidence for bundled mode, TLS/auth/failover, capacity pressure, and multi-replica recovery.
+
+The policy remains operational evidence only. Profiles privacy and visibility continue to resolve exclusively through authoritative owner ports.

--- a/crates/rustok-iggy/src/dedup_recovery_window_policy.rs
+++ b/crates/rustok-iggy/src/dedup_recovery_window_policy.rs
@@ -1,0 +1,353 @@
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Reviewed Iggy message-ID deduplication settings used for an offline recovery-window
+/// assessment.
+///
+/// The configuration is supplied by an operator or retained evidence. This type does not
+/// connect to Iggy or read active server configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDeduplicationConfiguration {
+    Disabled,
+    Enabled { max_entries: u64, expiry: Duration },
+}
+
+impl IggyDeduplicationConfiguration {
+    pub const fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    pub fn enabled(
+        max_entries: u64,
+        expiry: Duration,
+    ) -> Result<Self, IggyDedupRecoveryWindowPolicyError> {
+        if max_entries == 0 || expiry.is_zero() {
+            return Err(IggyDedupRecoveryWindowPolicyError::InvalidConfiguration);
+        }
+
+        Ok(Self::Enabled {
+            max_entries,
+            expiry,
+        })
+    }
+}
+
+/// Caller-supplied upper bounds for the complete publish-to-recovery interval.
+///
+/// The required expiry is the checked sum of the publication lease, process restart,
+/// transport reconnect, and operator recovery bounds. The required capacity is the maximum
+/// number of distinct deterministic message IDs that may share one physical partition during
+/// that interval. No production default is provided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IggyDedupRecoveryWindowPolicy {
+    publication_lease: Duration,
+    process_restart: Duration,
+    transport_reconnect: Duration,
+    operator_recovery: Duration,
+    required_max_entries_per_partition: u64,
+    required_expiry: Duration,
+}
+
+impl IggyDedupRecoveryWindowPolicy {
+    pub fn new(
+        publication_lease: Duration,
+        process_restart: Duration,
+        transport_reconnect: Duration,
+        operator_recovery: Duration,
+        required_max_entries_per_partition: u64,
+    ) -> Result<Self, IggyDedupRecoveryWindowPolicyError> {
+        if publication_lease.is_zero() || required_max_entries_per_partition == 0 {
+            return Err(IggyDedupRecoveryWindowPolicyError::InvalidPolicy);
+        }
+
+        let required_expiry = publication_lease
+            .checked_add(process_restart)
+            .and_then(|value| value.checked_add(transport_reconnect))
+            .and_then(|value| value.checked_add(operator_recovery))
+            .ok_or(IggyDedupRecoveryWindowPolicyError::RecoveryHorizonOverflow)?;
+
+        Ok(Self {
+            publication_lease,
+            process_restart,
+            transport_reconnect,
+            operator_recovery,
+            required_max_entries_per_partition,
+            required_expiry,
+        })
+    }
+
+    pub const fn publication_lease(&self) -> Duration {
+        self.publication_lease
+    }
+
+    pub const fn process_restart(&self) -> Duration {
+        self.process_restart
+    }
+
+    pub const fn transport_reconnect(&self) -> Duration {
+        self.transport_reconnect
+    }
+
+    pub const fn operator_recovery(&self) -> Duration {
+        self.operator_recovery
+    }
+
+    pub const fn required_max_entries_per_partition(&self) -> u64 {
+        self.required_max_entries_per_partition
+    }
+
+    pub const fn required_expiry(&self) -> Duration {
+        self.required_expiry
+    }
+
+    pub fn assess(
+        &self,
+        configuration: IggyDeduplicationConfiguration,
+    ) -> IggyDedupRecoveryWindowAssessment {
+        let IggyDeduplicationConfiguration::Enabled {
+            max_entries,
+            expiry,
+        } = configuration
+        else {
+            return IggyDedupRecoveryWindowAssessment {
+                status: IggyDedupRecoveryWindowStatus::Disabled,
+                required_expiry: self.required_expiry,
+                configured_expiry: None,
+                required_max_entries_per_partition: self.required_max_entries_per_partition,
+                configured_max_entries: None,
+            };
+        };
+
+        let expiry_sufficient = expiry >= self.required_expiry;
+        let capacity_sufficient = max_entries >= self.required_max_entries_per_partition;
+        let status = match (expiry_sufficient, capacity_sufficient) {
+            (true, true) => IggyDedupRecoveryWindowStatus::Sufficient,
+            (false, true) => IggyDedupRecoveryWindowStatus::InsufficientExpiry,
+            (true, false) => IggyDedupRecoveryWindowStatus::InsufficientCapacity,
+            (false, false) => IggyDedupRecoveryWindowStatus::InsufficientExpiryAndCapacity,
+        };
+
+        IggyDedupRecoveryWindowAssessment {
+            status,
+            required_expiry: self.required_expiry,
+            configured_expiry: Some(expiry),
+            required_max_entries_per_partition: self.required_max_entries_per_partition,
+            configured_max_entries: Some(max_entries),
+        }
+    }
+}
+
+/// Identifier-free result of comparing one reviewed deduplication configuration with one
+/// caller-supplied recovery horizon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IggyDedupRecoveryWindowAssessment {
+    status: IggyDedupRecoveryWindowStatus,
+    required_expiry: Duration,
+    configured_expiry: Option<Duration>,
+    required_max_entries_per_partition: u64,
+    configured_max_entries: Option<u64>,
+}
+
+impl IggyDedupRecoveryWindowAssessment {
+    pub const fn status(&self) -> IggyDedupRecoveryWindowStatus {
+        self.status
+    }
+
+    pub const fn required_expiry(&self) -> Duration {
+        self.required_expiry
+    }
+
+    pub const fn configured_expiry(&self) -> Option<Duration> {
+        self.configured_expiry
+    }
+
+    pub const fn required_max_entries_per_partition(&self) -> u64 {
+        self.required_max_entries_per_partition
+    }
+
+    pub const fn configured_max_entries(&self) -> Option<u64> {
+        self.configured_max_entries
+    }
+
+    pub const fn is_sufficient(&self) -> bool {
+        matches!(self.status, IggyDedupRecoveryWindowStatus::Sufficient)
+    }
+
+    pub const fn requires_operator_action(&self) -> bool {
+        !self.is_sufficient()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDedupRecoveryWindowStatus {
+    Disabled,
+    InsufficientExpiry,
+    InsufficientCapacity,
+    InsufficientExpiryAndCapacity,
+    Sufficient,
+}
+
+impl IggyDedupRecoveryWindowStatus {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::Disabled => "iggy.dedup_recovery.disabled",
+            Self::InsufficientExpiry => "iggy.dedup_recovery.insufficient_expiry",
+            Self::InsufficientCapacity => "iggy.dedup_recovery.insufficient_capacity",
+            Self::InsufficientExpiryAndCapacity => {
+                "iggy.dedup_recovery.insufficient_expiry_and_capacity"
+            }
+            Self::Sufficient => "iggy.dedup_recovery.sufficient",
+        }
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDedupRecoveryWindowPolicyError {
+    #[error("Iggy deduplication recovery-window policy is invalid")]
+    InvalidPolicy,
+    #[error("reviewed Iggy deduplication configuration is invalid")]
+    InvalidConfiguration,
+    #[error("Iggy deduplication recovery horizon overflows Duration")]
+    RecoveryHorizonOverflow,
+}
+
+impl IggyDedupRecoveryWindowPolicyError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidPolicy => "iggy.dedup_recovery.policy_invalid",
+            Self::InvalidConfiguration => "iggy.dedup_recovery.configuration_invalid",
+            Self::RecoveryHorizonOverflow => "iggy.dedup_recovery.horizon_overflow",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> IggyDedupRecoveryWindowPolicy {
+        IggyDedupRecoveryWindowPolicy::new(
+            Duration::from_secs(30),
+            Duration::from_secs(20),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+            500,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn invalid_policy_and_configuration_fail_closed() {
+        assert_eq!(
+            IggyDedupRecoveryWindowPolicy::new(
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                1,
+            )
+            .unwrap_err(),
+            IggyDedupRecoveryWindowPolicyError::InvalidPolicy
+        );
+        assert_eq!(
+            IggyDedupRecoveryWindowPolicy::new(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::ZERO,
+                0,
+            )
+            .unwrap_err(),
+            IggyDedupRecoveryWindowPolicyError::InvalidPolicy
+        );
+        assert_eq!(
+            IggyDeduplicationConfiguration::enabled(0, Duration::from_secs(1)).unwrap_err(),
+            IggyDedupRecoveryWindowPolicyError::InvalidConfiguration
+        );
+        assert_eq!(
+            IggyDeduplicationConfiguration::enabled(1, Duration::ZERO).unwrap_err(),
+            IggyDedupRecoveryWindowPolicyError::InvalidConfiguration
+        );
+    }
+
+    #[test]
+    fn recovery_horizon_overflow_fails_closed() {
+        let error = IggyDedupRecoveryWindowPolicy::new(
+            Duration::MAX,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::ZERO,
+            1,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            IggyDedupRecoveryWindowPolicyError::RecoveryHorizonOverflow
+        );
+        assert_eq!(error.stable_code(), "iggy.dedup_recovery.horizon_overflow");
+    }
+
+    #[test]
+    fn disabled_configuration_never_claims_sufficiency() {
+        let assessment = policy().assess(IggyDeduplicationConfiguration::disabled());
+
+        assert_eq!(assessment.status(), IggyDedupRecoveryWindowStatus::Disabled);
+        assert!(!assessment.is_sufficient());
+        assert!(assessment.requires_operator_action());
+        assert_eq!(assessment.required_expiry(), Duration::from_secs(120));
+        assert_eq!(assessment.configured_expiry(), None);
+        assert_eq!(assessment.configured_max_entries(), None);
+    }
+
+    #[test]
+    fn expiry_and_capacity_deficits_are_distinguished() {
+        let policy = policy();
+        let expiry = policy.assess(
+            IggyDeduplicationConfiguration::enabled(500, Duration::from_secs(119)).unwrap(),
+        );
+        let capacity = policy.assess(
+            IggyDeduplicationConfiguration::enabled(499, Duration::from_secs(120)).unwrap(),
+        );
+        let both = policy.assess(
+            IggyDeduplicationConfiguration::enabled(499, Duration::from_secs(119)).unwrap(),
+        );
+
+        assert_eq!(
+            expiry.status(),
+            IggyDedupRecoveryWindowStatus::InsufficientExpiry
+        );
+        assert_eq!(
+            capacity.status(),
+            IggyDedupRecoveryWindowStatus::InsufficientCapacity
+        );
+        assert_eq!(
+            both.status(),
+            IggyDedupRecoveryWindowStatus::InsufficientExpiryAndCapacity
+        );
+        assert_eq!(
+            both.status().stable_code(),
+            "iggy.dedup_recovery.insufficient_expiry_and_capacity"
+        );
+    }
+
+    #[test]
+    fn exact_boundary_is_sufficient_without_stronger_guarantees() {
+        let policy = policy();
+        let assessment = policy.assess(
+            IggyDeduplicationConfiguration::enabled(500, Duration::from_secs(120)).unwrap(),
+        );
+
+        assert_eq!(assessment.status(), IggyDedupRecoveryWindowStatus::Sufficient);
+        assert!(assessment.is_sufficient());
+        assert!(!assessment.requires_operator_action());
+        assert_eq!(assessment.required_max_entries_per_partition(), 500);
+        assert_eq!(assessment.configured_max_entries(), Some(500));
+        assert_eq!(assessment.configured_expiry(), Some(Duration::from_secs(120)));
+        assert_eq!(
+            assessment.status().stable_code(),
+            "iggy.dedup_recovery.sufficient"
+        );
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -61,6 +61,7 @@ pub mod config;
 pub mod consumer;
 pub mod contract_consumer;
 pub mod contract_decode_failure;
+pub mod dedup_recovery_window_policy;
 pub mod dlq;
 #[cfg(feature = "iggy")]
 pub mod dlq_duplicate_alert_observer;
@@ -90,6 +91,11 @@ pub use contract_consumer::{
 };
 pub use contract_decode_failure::{
     ConsumedContractDecodeFailure, ContractDecodeFailureKind,
+};
+pub use dedup_recovery_window_policy::{
+    IggyDedupRecoveryWindowAssessment, IggyDedupRecoveryWindowPolicy,
+    IggyDedupRecoveryWindowPolicyError, IggyDedupRecoveryWindowStatus,
+    IggyDeduplicationConfiguration,
 };
 pub use dlq::{DlqEntry, DlqManager};
 #[cfg(feature = "iggy")]

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -82,6 +82,11 @@ mutation retry.
   execution, reviewed dedup-disabled configuration projection, current source
   hashes, aggregate two-partition absent-offset assertions, and no-clobber packet
   publication are locked.
+- A pure Iggy dedup recovery-window policy is source-complete. It checked-sums
+  caller-reviewed publication-lease, restart, reconnect, and operator-recovery
+  bounds; requires an explicit maximum distinct-ID count per physical partition;
+  distinguishes disabled, expiry, capacity, combined, and sufficient states; and
+  contains no production default or exactly-once claim.
 - Canonical retained packets remain pending and must omit credentials and
   delivery-level facts, bind reviewed source/configuration digests, and become
   stale when bound sources change.
@@ -171,9 +176,11 @@ Detailed checkpoints:
 - `crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-fair-window-external-runtime-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
+- `crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
+- `crates/rustok-iggy/docs/dedup-recovery-window-policy.md`
 
 ## Results and next work
 
@@ -213,10 +220,13 @@ Detailed checkpoints:
    best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
    multi-replica ownership on PostgreSQL plus real Iggy.
 
-9. **Prove confirmation-window sufficiency.**
-   Compare dedup `max_entries`/`expiry` against maximum lease, restart,
-   reconnect, and operator recovery horizons before making a stronger duplicate
-   guarantee.
+9. **Calibrate confirmation-window sufficiency.**
+   The source policy now compares reviewed dedup `expiry` with the checked sum of
+   lease, restart, reconnect, and operator-recovery bounds, and compares
+   `max_entries` with an explicit per-partition distinct-ID bound. Supply and
+   review those production inputs, bind them to configuration digests, execute
+   the focused tests/verifier, and retain a clean-commit assessment before making
+   a stronger duplicate-suppression statement.
 
 10. **Design moving duplicate windows or keep fixed snapshots.**
     A moving per-partition cursor must retain bounded prior identity/digest state
@@ -231,22 +241,22 @@ Detailed checkpoints:
 ## Recheck checkpoint — 2026-07-29
 
 - Rechecked the canonical plan and current `main` after the two-partition
-  fair-window harness.
+  fair-window harness and retained-capture tooling.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
 - Reconfirmed deterministic same-ID colocation and the production-reachable
   fair/global comparison.
-- Added a locked fair-window execution contract, clean-commit runner, and strict
-  retained verifier.
-- Required exact one-case success, skip rejection, unchanged commit/source
-  hashes, reviewed dedup-disabled configuration projection, and four aggregate
-  absent-offset checkpoints across two partitions.
-- Added no-clobber canonical packet publication through exclusive temporary-file
-  creation and a hard link.
-- Kept runtime execution, canonical retained packets, moving-window state,
-  production recovery-window sufficiency, bundled/TLS/auth, and multi-replica
-  claims open.
+- Rechecked the existing external-Iggy dedup cases and confirmed that immediate,
+  capacity, and expiry sequences do not establish a production recovery window.
+- Added a pure fail-closed recovery-window policy with caller-reviewed additive
+  time bounds and explicit per-partition capacity; disabled or insufficient
+  configuration cannot report sufficient.
+- Locked stable statuses/codes, focused source tests, an owner guide, a Profiles
+  checkpoint, and a static source verifier.
+- Kept active configuration readback, reviewed production calibration, runtime
+  execution, canonical retained packets, moving-window state, bundled/TLS/auth,
+  failover, and multi-replica claims open.
 - Tests, Cargo commands, repository source verifiers, external/bundled Iggy,
   retained capture, and multi-replica scenarios were not run per maintainer
   instruction.
@@ -259,6 +269,7 @@ cargo xtask module test profiles
 cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
+cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
 cargo test -p rustok-iggy dlq_duplicate_external_scan -- --nocapture
 RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS='host:8090' \
 cargo test -p rustok-iggy --features iggy \
@@ -267,6 +278,7 @@ cargo test -p rustok-iggy --features iggy \
   --exact --nocapture --test-threads=1
 cargo test -p rustok-iggy dlq_duplicate_alert_observer -- --nocapture
 cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
+node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
@@ -296,10 +308,14 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
     imply exactly-once without retained broker evidence.
 12. Operational telemetry excludes identities, payloads, broker coordinates,
     claims, credentials, and provider details.
-13. Short dedup or scan sequences do not prove production-window sufficiency.
+13. Short dedup sequences do not prove production-window sufficiency; use a
+    checked additive recovery horizon and an explicit per-partition capacity
+    bound.
 14. Production deterministic broker IDs remain colocated by the publisher's
     one-based modulo partition rule.
 15. Retained evidence is no-clobber, commit-bound, and stale after any bound
     source change.
 16. Moving duplicate windows require bounded cross-cycle identity state.
-17. Update Profiles and affected owner docs with every boundary change.
+17. A sufficient recovery-window assessment covers only the supplied reviewed
+    model and never authorizes Profiles or proves exactly-once.
+18. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md
@@ -1,0 +1,67 @@
+# Profiles checkpoint: Iggy deduplication recovery window
+
+Status: **source-complete; runtime calibration and retained evidence pending**.
+
+## Why this belongs in the Profiles improvement trail
+
+Profiles privacy is owner-port policy, but Social Graph relationship events feed downstream Index behavior used by profile discovery. Raw poison handling therefore needs an explicit reliability boundary without turning broker state into profile authorization.
+
+The existing external-Iggy cases show immediate suppression, disabled deduplication, capacity eviction, and expiry. Those short sequences do not prove that production `max_entries` and `expiry` cover the complete broker-success-to-recovery interval.
+
+## Delivered source policy
+
+`rustok-iggy` now publishes:
+
+```text
+IggyDeduplicationConfiguration
+IggyDedupRecoveryWindowPolicy
+IggyDedupRecoveryWindowAssessment
+IggyDedupRecoveryWindowStatus
+IggyDedupRecoveryWindowPolicyError
+```
+
+The policy requires caller-reviewed bounds for publication lease, process restart, transport reconnect, and operator recovery. It uses their checked sum as the required expiry. It also requires an explicit maximum number of distinct deterministic message IDs that may share one physical partition during that horizon.
+
+The assessment distinguishes disabled, insufficient expiry, insufficient capacity, both insufficient, and sufficient states. Invalid values and duration overflow fail closed. There are no production defaults.
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
+```
+
+Static verifier:
+
+```bash
+node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+```
+
+Owner guide:
+
+```text
+crates/rustok-iggy/docs/dedup-recovery-window-policy.md
+```
+
+## Profiles boundary
+
+Profiles never authorizes visibility, `followers_only`, follow controls, search inclusion, or presentation from:
+
+- deduplication enabled/disabled state;
+- `max_entries` or `expiry`;
+- recovery-window assessment status;
+- receipt state, broker counts, offsets, lag, or evidence packets.
+
+Privacy remains evaluated before localized and Media-backed presentation. Restricted or unavailable public rows remain absent.
+
+A `sufficient` assessment means only that one reviewed configuration covers the supplied bounded model. It does not prove active server configuration, a database/broker transaction, exactly-once delivery, failover, workload bounds, or multi-replica recovery.
+
+## Remaining evidence
+
+1. provide reviewed maximum lease, restart, reconnect, and operator-response bounds;
+2. derive the maximum distinct deterministic IDs per physical partition during that interval;
+3. bind those inputs to reviewed external and bundled Iggy configuration digests;
+4. execute the source verifier and focused Rust tests;
+5. retain a clean-commit calibration packet;
+6. separately prove TLS/auth/failover, capacity pressure, and multi-replica claim ownership.
+
+Tests, Cargo commands, source verifiers, broker connections, retained capture, and multi-replica scenarios were not run per maintainer instruction.

--- a/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+++ b/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json";
+const sourcePath = "crates/rustok-iggy/src/dedup_recovery_window_policy.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const documentationPath = "crates/rustok-iggy/docs/dedup-recovery-window-policy.md";
+const profilesCheckpointPath =
+  "crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md";
+const verifierPath = "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs";
+
+const expectedExports = [
+  "IggyDeduplicationConfiguration",
+  "IggyDedupRecoveryWindowPolicy",
+  "IggyDedupRecoveryWindowAssessment",
+  "IggyDedupRecoveryWindowStatus",
+  "IggyDedupRecoveryWindowPolicyError",
+];
+const expectedHorizonInputs = [
+  "publication_lease",
+  "process_restart",
+  "transport_reconnect",
+  "operator_recovery",
+];
+const expectedStatuses = [
+  "disabled",
+  "insufficient_expiry",
+  "insufficient_capacity",
+  "insufficient_expiry_and_capacity",
+  "sufficient",
+];
+const expectedTests = [
+  "invalid_policy_and_configuration_fail_closed",
+  "recovery_horizon_overflow_fails_closed",
+  "disabled_configuration_never_claims_sufficiency",
+  "expiry_and_capacity_deficits_are_distinguished",
+  "exact_boundary_is_sufficient_without_stronger_guarantees",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
+const profilesCheckpoint = readFileSync(
+  resolve(repoRoot, profilesCheckpointPath),
+  "utf8",
+);
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dedup-recovery-window-policy-source" ||
+  contract.status !== "source_complete_runtime_calibration_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.source !== sourcePath ||
+  contract.verifier !== verifierPath ||
+  contract.documentation !== documentationPath ||
+  contract.profiles_checkpoint !== profilesCheckpointPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("dedup recovery-window contract identity or source status drift");
+}
+
+if (!sameValue(contract.public_exports, expectedExports)) {
+  fail("dedup recovery-window public export allowlist drift");
+}
+if (!sameValue(contract.required_recovery_horizon_inputs, expectedHorizonInputs)) {
+  fail("dedup recovery-window horizon input allowlist drift");
+}
+if (!sameValue(contract.assessment_statuses, expectedStatuses)) {
+  fail("dedup recovery-window status allowlist drift");
+}
+if (!sameValue(contract.required_source_tests, expectedTests)) {
+  fail("dedup recovery-window focused unit-test allowlist drift");
+}
+if (
+  contract.required_capacity_input !==
+    "maximum_distinct_deterministic_message_ids_per_partition_during_recovery_horizon" ||
+  contract.expiry_rule !== "checked_sum_of_all_recovery_horizon_inputs" ||
+  contract.capacity_rule !==
+    "configured_max_entries_not_below_required_per_partition_distinct_ids"
+) {
+  fail("dedup recovery-window comparison rules drift");
+}
+
+if (
+  !sameValue(contract.stable_codes, {
+    disabled: "iggy.dedup_recovery.disabled",
+    insufficient_expiry: "iggy.dedup_recovery.insufficient_expiry",
+    insufficient_capacity: "iggy.dedup_recovery.insufficient_capacity",
+    insufficient_expiry_and_capacity:
+      "iggy.dedup_recovery.insufficient_expiry_and_capacity",
+    sufficient: "iggy.dedup_recovery.sufficient",
+    invalid_policy: "iggy.dedup_recovery.policy_invalid",
+    invalid_configuration: "iggy.dedup_recovery.configuration_invalid",
+    horizon_overflow: "iggy.dedup_recovery.horizon_overflow",
+  })
+) {
+  fail("dedup recovery-window stable code contract drift");
+}
+
+for (const [operation, allowed] of Object.entries(contract.policy_boundary ?? {})) {
+  if (allowed !== false) fail(`dedup recovery-window boundary became allowed: ${operation}`);
+}
+for (const [field, required] of Object.entries(contract.privacy_boundary ?? {})) {
+  if (required !== true) fail(`dedup recovery-window privacy boundary weakened: ${field}`);
+}
+
+for (const marker of [
+  "pub enum IggyDeduplicationConfiguration",
+  "Disabled,",
+  "Enabled { max_entries: u64, expiry: Duration },",
+  "max_entries == 0 || expiry.is_zero()",
+  "pub struct IggyDedupRecoveryWindowPolicy",
+  "publication_lease: Duration",
+  "process_restart: Duration",
+  "transport_reconnect: Duration",
+  "operator_recovery: Duration",
+  "required_max_entries_per_partition: u64",
+  ".checked_add(process_restart)",
+  ".and_then(|value| value.checked_add(transport_reconnect))",
+  ".and_then(|value| value.checked_add(operator_recovery))",
+  "pub fn assess(",
+  "let expiry_sufficient = expiry >= self.required_expiry;",
+  "let capacity_sufficient = max_entries >= self.required_max_entries_per_partition;",
+  "pub struct IggyDedupRecoveryWindowAssessment",
+  "pub enum IggyDedupRecoveryWindowStatus",
+  "InsufficientExpiryAndCapacity",
+  "pub const fn is_sufficient(&self) -> bool",
+  "pub const fn requires_operator_action(&self) -> bool",
+  'Self::Sufficient => "iggy.dedup_recovery.sufficient"',
+  "pub enum IggyDedupRecoveryWindowPolicyError",
+  'Self::InvalidPolicy => "iggy.dedup_recovery.policy_invalid"',
+  'Self::InvalidConfiguration => "iggy.dedup_recovery.configuration_invalid"',
+  'Self::RecoveryHorizonOverflow => "iggy.dedup_recovery.horizon_overflow"',
+]) {
+  requireText("dedup recovery-window policy source", source, marker);
+}
+
+for (const testName of expectedTests) {
+  requireText("dedup recovery-window policy tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("dedup recovery-window policy source must contain exactly five focused unit tests");
+}
+
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceipt",
+  "Serialize",
+  "Deserialize",
+  ".connect(",
+  ".poll_messages(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".delete(",
+  ".purge(",
+  ".replay(",
+]) {
+  forbidText("dedup recovery-window policy source", source, marker);
+}
+
+requireText(
+  "rustok-iggy module list",
+  lib,
+  "pub mod dedup_recovery_window_policy;",
+);
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+for (const marker of [
+  "checked sum",
+  "per physical partition",
+  "No production default",
+  "does not prove exactly-once",
+  "runtime calibration remains pending",
+]) {
+  requireText("dedup recovery-window documentation", documentation, marker);
+}
+for (const marker of [
+  "Profiles never authorizes",
+  "source-complete",
+  "runtime calibration",
+  "multi-replica",
+]) {
+  requireText("Profiles dedup recovery-window checkpoint", profilesCheckpoint, marker);
+}
+
+const requiredRemainingWork = new Set([
+  "supply_reviewed_production_horizon_bounds",
+  "derive_per_partition_distinct_id_capacity_bound",
+  "bind_assessment_to_reviewed_iggy_configuration_digest",
+  "retain_runtime_calibration_packet",
+  "repeat_for_bundled_tls_auth_failover_and_multi_replica_operation",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemainingWork.delete(item);
+if (requiredRemainingWork.size > 0) {
+  fail(`dedup recovery-window remaining work drift: ${[
+    ...requiredRemainingWork,
+  ].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy dedup recovery-window policy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy dedup recovery-window policy source verified: reviewed disabled/enabled configuration, checked additive recovery horizon, explicit per-partition capacity bound, fail-closed expiry/capacity assessments, stable codes, identifier-free projection, no broker or receipt access, no production defaults, and no exactly-once claim are locked; runtime calibration and retained evidence remain pending.",
+);


### PR DESCRIPTION
## Summary

- add a transport-neutral `IggyDedupRecoveryWindowPolicy`
- compare reviewed dedup `expiry` with the checked sum of publication lease, process restart, transport reconnect, and operator recovery bounds
- compare reviewed `max_entries` with an explicit maximum distinct-ID count per physical partition during that horizon
- distinguish disabled, insufficient-expiry, insufficient-capacity, combined-deficit, and sufficient results with stable codes
- fail closed on invalid configuration, invalid policy, and `Duration` overflow
- publish the policy through `rustok-iggy`
- add a source contract, focused static verifier, owner guide, Profiles checkpoint, and actualized canonical Profiles plan

## Recheck findings

The existing external-Iggy scenarios correctly cover disabled deduplication, immediate suppression, capacity eviction, and expiry. They do not prove that a reviewed production configuration covers the complete broker-success-to-recovery interval.

This PR continues the plan with a bounded calibration model rather than inferring production sufficiency from those short sequences.

## Boundaries and non-claims

- no active Iggy configuration readback
- no broker connection, publication, consumption, offset commit, or receipt mutation
- no production defaults for recovery time or per-partition capacity
- no Profiles or Social Graph authorization from the assessment
- `sufficient` covers only the caller-supplied reviewed model
- no PostgreSQL/Iggy transaction or exactly-once claim
- failover, workload calibration, retained runtime evidence, bundled/TLS/auth, and multi-replica proof remain open

## Verification

Per maintainer instruction, tests, Cargo commands, formatters, repository source verifiers, broker connections, and retained capture were not run.

Performed only on locally composed new artifacts:

```text
node --check scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
python -m json.tool crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
```

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
cargo xtask module validate profiles
cargo xtask module test profiles
```
