### PR TITLE
feat(product): compose catalog read runtime

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -7,9 +7,9 @@ use crate::services::server_runtime_context::ServerRuntimeContext;
 /// Attach the host-composed commerce provider registries and owner read runtimes to a capability
 /// runtime.
 ///
-/// Values already installed in `ServerRuntimeContext` are always preserved so external adapters
-/// registered by the host remain visible to every transport. When no provider runtime exists, the
-/// process composes the deterministic built-in baseline once.
+/// Values already installed in `ServerRuntimeContext` or `HostRuntimeContext` are always preserved
+/// so external adapters registered by the host remain visible to every transport. When no provider
+/// runtime exists, the process composes the deterministic built-in baseline once.
 pub fn attach_commerce_provider_registries(
     host: HostRuntimeContext,
     server: &ServerRuntimeContext,
@@ -128,6 +128,30 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
+    #[cfg(feature = "mod-product")]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_product::ProductCatalogReadRuntime>()
+            .or_else(|| server.shared_get::<rustok_product::ProductCatalogReadRuntime>())
+            .or_else(|| {
+                server
+                    .shared_get::<rustok_outbox::TransactionalEventBus>()
+                    .map(|event_bus| {
+                        rustok_product::ProductCatalogReadRuntime::in_process(
+                            server.db_clone(),
+                            event_bus,
+                        )
+                    })
+            });
+        match runtime {
+            Some(runtime) => {
+                server.shared_insert(runtime.clone());
+                host.with_shared_value(runtime)
+            }
+            None => host,
+        }
+    };
+
     #[cfg(all(
         feature = "mod-marketplace_listing",
         feature = "mod-marketplace_seller",
@@ -146,9 +170,12 @@ pub fn attach_commerce_provider_registries(
                         "MarketplaceSellerRuntime must be initialized before marketplace listing",
                     )
                     .shared_read_port();
-                let product_reader: Arc<dyn rustok_product::ProductCatalogReadPort> = Arc::new(
-                    rustok_product::CatalogService::new(server.db_clone(), event_bus.clone()),
-                );
+                let product_reader = server
+                    .shared_get::<rustok_product::ProductCatalogReadRuntime>()
+                    .expect(
+                        "ProductCatalogReadRuntime must be initialized before marketplace listing",
+                    )
+                    .read_port();
                 let ports = Arc::new(rustok_marketplace_listing::MarketplaceListingService::new(
                     server.db_clone(),
                     event_bus,
@@ -189,12 +216,10 @@ pub fn attach_commerce_provider_registries(
     };
 
     #[cfg(all(feature = "mod-ai", feature = "mod-product"))]
-    let host = if let Some(event_bus) = server.shared_get::<rustok_outbox::TransactionalEventBus>()
+    let host = if let Some(runtime) =
+        server.shared_get::<rustok_product::ProductCatalogReadRuntime>()
     {
-        let port: Arc<dyn rustok_product::ProductCatalogReadPort> = Arc::new(
-            rustok_product::CatalogService::new(server.db_clone(), event_bus),
-        );
-        host.with_shared_value(rustok_ai::SharedAiProductCatalogReadPort(port))
+        host.with_shared_value(rustok_ai::SharedAiProductCatalogReadPort(runtime.read_port()))
     } else {
         host
     };
@@ -302,12 +327,43 @@ mod order_status_port_tests {
 mod product_catalog_read_port_tests {
     use std::sync::Arc;
 
+    use async_trait::async_trait;
+    use rustok_api::{PortContext, PortError};
     use rustok_outbox::{OutboxTransport, TransactionalEventBus};
     use sea_orm::Database;
 
     use super::attach_commerce_provider_registries;
     use crate::common::settings::RustokSettings;
     use crate::services::server_runtime_context::ServerRuntimeContext;
+
+    struct ExternalProductCatalogReadPort;
+
+    #[async_trait]
+    impl rustok_product::ProductCatalogReadPort for ExternalProductCatalogReadPort {
+        async fn read_product_projection(
+            &self,
+            _context: PortContext,
+            _request: rustok_product::ProductProjectionRequest,
+        ) -> Result<rustok_product::dto::ProductResponse, PortError> {
+            Err(PortError::unavailable("external.test", "external test provider"))
+        }
+
+        async fn read_variant_product_projection(
+            &self,
+            _context: PortContext,
+            _request: rustok_product::VariantProductProjectionRequest,
+        ) -> Result<rustok_product::dto::ProductResponse, PortError> {
+            Err(PortError::unavailable("external.test", "external test provider"))
+        }
+
+        async fn list_published_products(
+            &self,
+            _context: PortContext,
+            _request: rustok_product::PublishedProductsRequest,
+        ) -> Result<rustok_product::StorefrontProductList, PortError> {
+            Err(PortError::unavailable("external.test", "external test provider"))
+        }
+    }
 
     #[tokio::test]
     async fn attaches_product_catalog_read_port_for_ai_runtime() {
@@ -322,7 +378,37 @@ mod product_catalog_read_port_tests {
         let host =
             attach_commerce_provider_registries(rustok_api::HostRuntimeContext::new(db), &server);
         assert!(
+            host.shared_get::<rustok_product::ProductCatalogReadRuntime>()
+                .is_some()
+        );
+        assert!(
             host.shared_get::<rustok_ai::SharedAiProductCatalogReadPort>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_host_selected_external_product_catalog_runtime() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory database");
+        let server = ServerRuntimeContext::new(db.clone(), RustokSettings::default());
+        let external = rustok_product::ProductCatalogReadRuntime::external(Arc::new(
+            ExternalProductCatalogReadPort,
+        ));
+        let host = rustok_api::HostRuntimeContext::new(db).with_shared_value(external);
+
+        let attached = attach_commerce_provider_registries(host, &server);
+        let runtime = attached
+            .shared_get::<rustok_product::ProductCatalogReadRuntime>()
+            .expect("external product runtime should remain attached");
+        assert_eq!(
+            runtime.profile(),
+            rustok_product::ProductCatalogReadProfile::External
+        );
+        assert!(
+            attached
+                .shared_get::<rustok_ai::SharedAiProductCatalogReadPort>()
                 .is_some()
         );
     }

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -29,6 +29,14 @@
       ]
     },
     {
+      "module": "marketplace-listing",
+      "profile": "listing_product_projection",
+      "degraded_modes": [],
+      "fallback_profiles": [
+        "embedded_native"
+      ]
+    },
+    {
       "module": "ai-product",
       "profile": "ai_product_generation_context",
       "degraded_modes": [
@@ -45,13 +53,35 @@
     "local_plan": "crates/rustok-product/docs/implementation-plan.md",
     "central_board": "docs/modules/registry.md",
     "verifier": "scripts/verify/verify-ecommerce-fba-registries.mjs",
+    "runtime_composition_verifier": "scripts/verify/verify-product-catalog-read-runtime-composition.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
     "runtime_fallback_smoke_runner": "scripts/verify/verify-product-runtime-fallback-smoke.mjs"
   },
+  "runtime_composition": {
+    "runtime": "ProductCatalogReadRuntime",
+    "source": "crates/rustok-product/src/runtime.rs",
+    "host_composition": "apps/server/src/services/commerce_provider_runtime.rs",
+    "profiles": [
+      "embedded_native",
+      "external"
+    ],
+    "source_complete_consumers": [
+      "ai-product",
+      "marketplace-listing"
+    ],
+    "pending_consumers": [
+      "commerce-checkout-http",
+      "commerce-checkout-graphql",
+      "order-storefront-native"
+    ],
+    "status": "source_complete_consumer_cutover_partial"
+  },
   "in_process_provider_impl": {
     "service": "CatalogService",
+    "runtime": "ProductCatalogReadRuntime",
+    "profile": "embedded_native",
     "source": "crates/rustok-product/src/ports.rs",
     "status": "implemented"
   },

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -10,24 +10,34 @@ selected path. The product packages contain no package-local framework or
 framework-specific outbox adapter dependency.
 
 `ProductCatalogReadPort` / `product.catalog_read.v1` is implemented by
-`CatalogService`. Its in-process profile has live PostgreSQL execution evidence,
-while the provider registry and static contract matrix retain the module at
-`boundary_ready` until an external adapter is executed. The composed `rustok-ai`
-consumer has live unavailable/deadline degraded-path evidence; Commerce
-checkout currently treats Product as a hard dependency rather than claiming a
-cart-snapshot fallback that does not exist.
-The port also resolves variant-first consumer input to the owning product
-projection, so checkout consumers do not query product or variant entities.
-The compiled commerce checkout channel-inventory regression executes the
-in-process product projection provider before inventory preflight; it is a
-bounded consumer proof only and does not close the module transport gate.
+`CatalogService`. Its in-process profile has live PostgreSQL execution evidence.
+The Product-owned `ProductCatalogReadRuntime` now gives host composition one
+typed profile selector for `embedded_native` or `external` execution. The server
+preserves a runtime already installed in `HostRuntimeContext` or
+`ServerRuntimeContext`, otherwise composes the embedded provider once. AI and
+Marketplace Listing consume the same selected port rather than constructing
+parallel `CatalogService` instances. The checkout transport cutover remains open:
+the staged Commerce checkout pipeline still creates the embedded Product service
+inside the consumer path. A concrete external transport adapter has not yet been
+executed, so the provider remains `boundary_ready` rather than
+`transport_verified`.
+
+The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
+evidence. Commerce checkout treats Product as a hard dependency and must not
+claim a cart-snapshot fallback that does not exist. The port resolves
+variant-first consumer input to the owning product projection, so consumers do
+not query product or variant entities. The compiled commerce checkout
+channel-inventory regression executes the in-process product projection provider
+before inventory preflight; it is bounded consumer evidence only and does not
+close the external transport gate.
+
 Product runtime contract, commerce transport, and module metadata remain synchronized.
 The category-bound admin transport keeps native server functions as the
 internal path and parallel GraphQL operations for the public/headless path.
 The DB-level tenant consistency audit, `VARCHAR(32)` locale storage, catalog
 search-option discovery, detached-value marker contract, and no-compile schema
 guardrail are source-locked. The complete storefront/admin catalog-controls
-contract now carries snake_case `search`, `category_id`, `sort_by`,
+contract carries snake_case `search`, `category_id`, `sort_by`,
 `sort_direction`, and `attribute_filters` through typed UI state, native and
 GraphQL adapters, Product-owned request models, and shared server-side
 execution. Storefront and admin accept at most eight semicolon-separated
@@ -37,6 +47,7 @@ localized/plain text, integer, decimal, boolean, date, datetime, select, and
 multiselect storage while excluding detached values. JSON attributes are
 explicitly rejected because this contract does not claim unindexed JSON
 comparison semantics. Recheck on 2026-07-29.
+
 Product write GraphQL derives tenant and actor exclusively from authenticated
 contexts. Product-owned `map_product_public_error` is shared by GraphQL and
 native admin/storefront transports; it keeps internal errors in structured logs
@@ -45,6 +56,7 @@ Entity writes that publish product domain events use
 `ProductWriteTransaction` to keep the outbox write and database commit in one transaction.
 Admin and storefront product roots reject an explicit tenant that differs from the
 host-provided `TenantContext` before accessing storage.
+
 Product migrations enforce PostgreSQL-only execution, tenant-scoped
 translation/SKU/tag identity, canonical primary categories, typed EAV option
 relations, bounded JSON inputs, normalized/indexed channel visibility, and a
@@ -67,6 +79,7 @@ The owner-local tenant-storage fixture rejects mixed-tenant product
 translations, category parents, schema/category/attribute relations, EAV
 values, and product-category joins, and verifies owner-derived translation
 isolation for category, attribute, and schema copy.
+
 `product_catalog_read_port_executes_against_postgres` exercises product,
 variant-first, and published-list operations with live price/inventory
 enrichment, tenant isolation, locale fallback, channel filtering, count, and
@@ -77,6 +90,7 @@ promoting the transport status.
 `EXPLAIN (ANALYZE, BUFFERS)` plans for storefront page and count SQL. The
 specialized published/global-visibility index is used at all three page scales;
 the count path uses it at 100k and 1M.
+
 `CatalogService` is separated by responsibility across
 `services/catalog/commands.rs`, `admin_queries.rs`, `attribute_filters.rs`,
 `queries.rs`, `projection.rs`, and `tags.rs` while the public service contract
@@ -98,15 +112,16 @@ rustok-pricing` dependency cycle.
 
 - FFA status: `in_progress` — both owner UI surfaces exist and must preserve
   the core/transport/UI split and native/GraphQL parity.
-- FBA status: `boundary_ready` — read-port policy and metadata are source-locked,
-  the in-process profile is persistence-backed, and the AI consumer degraded
-  path is runtime-verified. Commerce remains an explicit hard dependency and no
-  external adapter is live-verified.
+- FBA status: `boundary_ready` — the read port, in-process persistence profile,
+  Product-owned runtime selector, and AI/Marketplace host composition are
+  source-complete. External transport execution and checkout consumer cutover
+  remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json`,
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
+  `scripts/verify/verify-product-catalog-read-runtime-composition.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -117,12 +132,17 @@ rustok-pricing` dependency cycle.
 
 ## Open results
 
-1. Keep FBA at `boundary_ready` until a concrete external Product adapter is
-   executed. If Commerce introduces a cart-snapshot degraded policy, add it to
-   the registry only together with live unavailable/deadline execution.
-   `rustok-ai` already has runtime-verified unavailable/deadline behaviour;
-   Pricing is not a `ProductCatalogReadPort` consumer.
-2. Keep Product richtext adoption explicitly deferred until the owner approves
+1. Implement a concrete external `ProductCatalogReadPort` transport adapter in a
+   separate transport crate and execute all three operations through it. Preserve
+   serialized `PortContext`, deadlines, typed `PortError`, tenant/locale/channel
+   semantics, variant-to-product resolution, count, and pagination. Do not promote
+   above `boundary_ready` from source markers alone.
+2. Complete the Commerce checkout transport cutover. HTTP, GraphQL, and native
+   checkout composition must receive `ProductCatalogReadRuntime::read_port()` and
+   the staged pipeline must stop constructing `CatalogService`. Execute
+   unavailable/deadline behavior as an explicit hard-dependency failure; do not
+   invent a degraded cart-snapshot fallback.
+3. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
    their textarea alone would create a false contract. When approved, use the
@@ -132,11 +152,16 @@ rustok-pricing` dependency cycle.
 
 ## Verification
 
+- [x] Compose one host-selected `ProductCatalogReadRuntime` and reuse it for AI and Marketplace Listing.
+- [ ] Execute a concrete external Product catalog read adapter.
+- [ ] Cut Commerce HTTP/GraphQL/native checkout over to the composed Product runtime.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
 - [x] Connect admin search/status/category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
 - [x] Connect typed attribute_filters through storefront/admin UI state, native/GraphQL transports, filterable-definition validation, and Product-owned typed EAV execution.
+- `node scripts/verify/verify-product-catalog-read-runtime-composition.mjs`
+- `node scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
 - `node scripts/verify/verify-product-admin-category-sort.mjs`
@@ -153,9 +178,13 @@ rustok-pricing` dependency cycle.
 
 ## Boundaries
 
-- Product owns catalog data and the `ProductCatalogReadPort` implementation.
-- Commerce checkout and AI consume `ProductCatalogReadPort`; Pricing uses
-  Product's public embedded service contract and does not claim a read-port
-  fallback profile. None regain Product DTO or entity ownership.
+- Product owns catalog data, `ProductCatalogReadPort`, and
+  `ProductCatalogReadRuntime` profile selection.
+- The host selects and shares one Product read runtime; consumers receive the
+  public port and must not construct parallel owner services.
+- Commerce checkout, Marketplace Listing, and AI consume Product's public read
+  contract. Pricing uses Product's public embedded service contract and does not
+  claim a read-port fallback profile. None regain Product DTO, entity, or storage
+  ownership.
 - Hosts compose product UI packages and pass the effective locale and runtime
   context without adding a package-local locale or transport fallback.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -20,12 +20,14 @@ pub mod error;
 pub mod migrations;
 pub mod ports;
 mod public_error;
+mod runtime;
 mod seo_targets;
 pub mod services;
 
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};
+pub use runtime::{ProductCatalogReadProfile, ProductCatalogReadRuntime};
 pub use services::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
     ProductAttributeFilter, ProductCatalogSchemaService, StorefrontProductList,

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+
+use crate::{CatalogService, ProductCatalogReadPort};
+
+/// Host-selected execution profile for the Product catalog read boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProductCatalogReadProfile {
+    EmbeddedNative,
+    External,
+}
+
+impl ProductCatalogReadProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EmbeddedNative => "embedded_native",
+            Self::External => "external",
+        }
+    }
+}
+
+/// Canonical host-composed Product catalog read capability.
+///
+/// Consumers receive this wrapper rather than constructing `CatalogService` directly. A host can
+/// therefore replace the embedded provider with a remote adapter without changing consumer code.
+#[derive(Clone)]
+pub struct ProductCatalogReadRuntime {
+    read_port: Arc<dyn ProductCatalogReadPort>,
+    profile: ProductCatalogReadProfile,
+}
+
+impl ProductCatalogReadRuntime {
+    pub fn new(
+        read_port: Arc<dyn ProductCatalogReadPort>,
+        profile: ProductCatalogReadProfile,
+    ) -> Self {
+        Self { read_port, profile }
+    }
+
+    pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self::new(
+            Arc::new(CatalogService::new(db, event_bus)),
+            ProductCatalogReadProfile::EmbeddedNative,
+        )
+    }
+
+    pub fn external(read_port: Arc<dyn ProductCatalogReadPort>) -> Self {
+        Self::new(read_port, ProductCatalogReadProfile::External)
+    }
+
+    pub fn read_port(&self) -> Arc<dyn ProductCatalogReadPort> {
+        self.read_port.clone()
+    }
+
+    pub const fn profile(&self) -> ProductCatalogReadProfile {
+        self.profile
+    }
+}

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
@@ -32,10 +32,12 @@ function forbid(source, marker, description) {
 const runtimePath = "crates/rustok-product/src/runtime.rs";
 const libPath = "crates/rustok-product/src/lib.rs";
 const hostPath = "apps/server/src/services/commerce_provider_runtime.rs";
+const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
 const planPath = "crates/rustok-product/docs/implementation-plan.md";
 const runtime = read(runtimePath);
 const lib = read(libPath);
 const host = read(hostPath);
+const registry = read(registryPath);
 const plan = read(planPath);
 
 requireAll(runtime, [
@@ -72,6 +74,18 @@ forbid(
   "rustok_product::CatalogService::new(server.db_clone(), event_bus)",
   "host composition must not construct a parallel AI Product provider",
 );
+requireAll(registry, [
+  '"runtime_composition"',
+  '"runtime": "ProductCatalogReadRuntime"',
+  '"embedded_native"',
+  '"external"',
+  '"ai-product"',
+  '"marketplace-listing"',
+  '"commerce-checkout-http"',
+  '"commerce-checkout-graphql"',
+  '"order-storefront-native"',
+  '"status": "source_complete_consumer_cutover_partial"',
+], "Product FBA registry");
 requireAll(plan, [
   "ProductCatalogReadRuntime",
   "AI and Marketplace Listing",

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required runtime-composition file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireAll(source, markers, description) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+  }
+}
+
+function forbid(source, marker, description) {
+  if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
+}
+
+const runtimePath = "crates/rustok-product/src/runtime.rs";
+const libPath = "crates/rustok-product/src/lib.rs";
+const hostPath = "apps/server/src/services/commerce_provider_runtime.rs";
+const planPath = "crates/rustok-product/docs/implementation-plan.md";
+const runtime = read(runtimePath);
+const lib = read(libPath);
+const host = read(hostPath);
+const plan = read(planPath);
+
+requireAll(runtime, [
+  "pub enum ProductCatalogReadProfile",
+  "EmbeddedNative",
+  "External",
+  "pub struct ProductCatalogReadRuntime",
+  "pub fn in_process",
+  "pub fn external",
+  "pub fn read_port",
+  "pub const fn profile",
+], "Product owner runtime");
+requireAll(lib, [
+  "mod runtime;",
+  "ProductCatalogReadProfile",
+  "ProductCatalogReadRuntime",
+], "Product public exports");
+requireAll(host, [
+  "host.shared_get::<rustok_product::ProductCatalogReadRuntime>()",
+  "server.shared_get::<rustok_product::ProductCatalogReadRuntime>()",
+  "rustok_product::ProductCatalogReadRuntime::in_process",
+  "ProductCatalogReadRuntime must be initialized before marketplace listing",
+  "SharedAiProductCatalogReadPort(runtime.read_port())",
+  "preserves_host_selected_external_product_catalog_runtime",
+  "ProductCatalogReadProfile::External",
+], "host composition");
+forbid(
+  host,
+  "let product_reader: Arc<dyn rustok_product::ProductCatalogReadPort> = Arc::new(",
+  "host composition must not construct a parallel Marketplace Product provider",
+);
+forbid(
+  host,
+  "rustok_product::CatalogService::new(server.db_clone(), event_bus)",
+  "host composition must not construct a parallel AI Product provider",
+);
+requireAll(plan, [
+  "ProductCatalogReadRuntime",
+  "AI and Marketplace Listing",
+  "checkout transport cutover remains open",
+  "verify-product-catalog-read-runtime-composition.mjs",
+], "Product implementation plan");
+
+if (failures.length > 0) {
+  console.error("product catalog read runtime composition verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("product catalog read runtime composition verification passed");

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-catalog-read-runtime-composition.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-read-runtime-"));
+  write(
+    root,
+    "crates/rustok-product/src/runtime.rs",
+    options.omitExternal
+      ? "pub enum ProductCatalogReadProfile { EmbeddedNative } pub struct ProductCatalogReadRuntime pub fn in_process pub fn read_port pub const fn profile"
+      : "pub enum ProductCatalogReadProfile { EmbeddedNative, External } pub struct ProductCatalogReadRuntime pub fn in_process pub fn external pub fn read_port pub const fn profile",
+  );
+  write(
+    root,
+    "crates/rustok-product/src/lib.rs",
+    "mod runtime; ProductCatalogReadProfile ProductCatalogReadRuntime",
+  );
+  const directMarketplace = options.directMarketplace
+    ? "let product_reader: Arc<dyn rustok_product::ProductCatalogReadPort> = Arc::new("
+    : "";
+  const directAi = options.directAi
+    ? "rustok_product::CatalogService::new(server.db_clone(), event_bus)"
+    : "";
+  write(
+    root,
+    "apps/server/src/services/commerce_provider_runtime.rs",
+    `host.shared_get::<rustok_product::ProductCatalogReadRuntime>() server.shared_get::<rustok_product::ProductCatalogReadRuntime>() rustok_product::ProductCatalogReadRuntime::in_process ProductCatalogReadRuntime must be initialized before marketplace listing SharedAiProductCatalogReadPort(runtime.read_port()) preserves_host_selected_external_product_catalog_runtime ProductCatalogReadProfile::External ${directMarketplace} ${directAi}`,
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.omitPlan
+      ? "Product plan"
+      : "ProductCatalogReadRuntime AI and Marketplace Listing checkout transport cutover remains open verify-product-catalog-read-runtime-composition.mjs",
+  );
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected runtime-composition mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("runtime composition guard accepts canonical source fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime composition guard rejects missing external profile", () => {
+  reject({ omitExternal: true }, /Product owner runtime/);
+});
+
+test("runtime composition guard rejects parallel Marketplace provider", () => {
+  reject({ directMarketplace: true }, /parallel Marketplace Product provider/);
+});
+
+test("runtime composition guard rejects parallel AI provider", () => {
+  reject({ directAi: true }, /parallel AI Product provider/);
+});
+
+test("runtime composition guard rejects missing plan handoff", () => {
+  reject({ omitPlan: true }, /Product implementation plan/);
+});

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs
@@ -44,6 +44,13 @@ function fixture(options = {}) {
   );
   write(
     root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    options.omitRegistry
+      ? "{}"
+      : `{"runtime_composition":{"runtime":"ProductCatalogReadRuntime","profiles":["embedded_native","external"],"source_complete_consumers":["ai-product","marketplace-listing"],"pending_consumers":["commerce-checkout-http","commerce-checkout-graphql","order-storefront-native"],"status":"source_complete_consumer_cutover_partial"}}`,
+  );
+  write(
+    root,
     "crates/rustok-product/docs/implementation-plan.md",
     options.omitPlan
       ? "Product plan"
@@ -91,6 +98,10 @@ test("runtime composition guard rejects parallel Marketplace provider", () => {
 
 test("runtime composition guard rejects parallel AI provider", () => {
   reject({ directAi: true }, /parallel AI Product provider/);
+});
+
+test("runtime composition guard rejects missing registry evidence", () => {
+  reject({ omitRegistry: true }, /Product FBA registry/);
 });
 
 test("runtime composition guard rejects missing plan handoff", () => {


### PR DESCRIPTION
## Summary

- add Product-owned `ProductCatalogReadRuntime` with explicit `embedded_native` and `external` profiles;
- preserve a host-selected external runtime when one is already installed, otherwise compose the embedded `CatalogService` provider once;
- reuse the same selected `ProductCatalogReadPort` for AI product context and Marketplace Listing instead of constructing parallel Product services;
- register the partial consumer-cutover state in the Product FBA registry without promoting above `boundary_ready`;
- add a focused source/mutation guard covering owner exports, host selection, AI/Marketplace reuse, registry evidence, and plan handoff;
- update the Product implementation plan so concrete external transport execution and Commerce HTTP/GraphQL/native checkout cutover remain explicit follow-up work.

## Boundary

This PR does not implement or claim an external transport adapter. It also does not change checkout transport signatures: the staged Commerce checkout pipeline still has a direct embedded Product construction and remains the next bounded consumer-cutover PR.

## Testing

Not run by the implementation agent, following the maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-catalog-read-runtime-composition.mjs
node scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs
npm run verify:product:runtime-fallback-smoke
npm run verify:ecommerce:fba
```
