### PR TITLE
feat(product): cut native checkout to catalog runtime

### DIFF
--- a/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
+++ b/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
@@ -75,10 +75,7 @@ impl StorefrontStagedCheckoutRuntimeError {
     }
 }
 
-/// Backward-compatible native storefront command wrapper.
-///
-/// New transports should call `complete_storefront_checkout_input` so every
-/// checkout field is preserved while using the same staged owner-port runtime.
+/// Backward-compatible storefront command wrapper using the embedded Product provider.
 pub async fn complete_storefront_checkout(
     runtime: &StorefrontCheckoutRuntime,
     payment_provider_registry: PaymentProviderRegistry,
@@ -109,12 +106,74 @@ pub async fn complete_storefront_checkout(
     .await
 }
 
-/// Completes one storefront checkout through the durable staged owner-port
-/// pipeline. REST, GraphQL, and native transports must converge here rather
-/// than constructing the legacy `CheckoutService` facade.
+/// Host-composed storefront command wrapper.
+///
+/// Native and future remote-selected transports use this entrypoint so Product execution is chosen
+/// by `ProductCatalogReadRuntime` rather than reconstructed inside Commerce.
+pub async fn complete_storefront_checkout_with_product_port(
+    runtime: &StorefrontCheckoutRuntime,
+    payment_provider_registry: PaymentProviderRegistry,
+    product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort>,
+    tenant: &TenantContext,
+    request_context: &RequestContext,
+    auth: OptionalAuthContext,
+    idempotency_key: impl Into<String>,
+    command: StorefrontCheckoutCompletionCommand,
+) -> Result<crate::dto::CompleteCheckoutResponse, StorefrontStagedCheckoutRuntimeError> {
+    complete_storefront_checkout_input_with_product_port(
+        runtime,
+        payment_provider_registry,
+        product_catalog_read_port,
+        tenant.id,
+        request_context,
+        auth.0,
+        idempotency_key,
+        crate::dto::CompleteCheckoutInput {
+            cart_id: command.cart_id,
+            shipping_option_id: None,
+            shipping_selections: None,
+            region_id: None,
+            country_code: None,
+            locale: Some(request_context.locale.clone()),
+            create_fulfillment: command.create_fulfillment,
+            metadata: command.metadata,
+        },
+    )
+    .await
+}
+
+/// Backward-compatible input wrapper using the embedded Product provider.
 pub async fn complete_storefront_checkout_input(
     runtime: &StorefrontCheckoutRuntime,
     payment_provider_registry: PaymentProviderRegistry,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<AuthContext>,
+    idempotency_key: impl Into<String>,
+    checkout_input: crate::dto::CompleteCheckoutInput,
+) -> Result<crate::dto::CompleteCheckoutResponse, StorefrontStagedCheckoutRuntimeError> {
+    let product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort> = Arc::new(
+        rustok_product::CatalogService::new(runtime.db_clone(), runtime.event_bus()),
+    );
+    complete_storefront_checkout_input_with_product_port(
+        runtime,
+        payment_provider_registry,
+        product_catalog_read_port,
+        tenant_id,
+        request_context,
+        auth,
+        idempotency_key,
+        checkout_input,
+    )
+    .await
+}
+
+/// Completes one storefront checkout through the durable staged owner-port pipeline using the
+/// Product port selected by host composition.
+pub async fn complete_storefront_checkout_input_with_product_port(
+    runtime: &StorefrontCheckoutRuntime,
+    payment_provider_registry: PaymentProviderRegistry,
+    product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort>,
     tenant_id: Uuid,
     request_context: &RequestContext,
     auth: Option<AuthContext>,
@@ -218,10 +277,7 @@ pub async fn complete_storefront_checkout_input(
         runtime.db_clone(),
         Arc::new(rustok_region::RegionService::new(runtime.db_clone())),
         inventory_availability,
-        Arc::new(rustok_product::CatalogService::new(
-            runtime.db_clone(),
-            event_bus.clone(),
-        )),
+        product_catalog_read_port,
     );
     let marketplace_allocation_service = Arc::new(
         rustok_marketplace_allocation::MarketplaceAllocationService::new(runtime.db_clone()),

--- a/crates/rustok-order/storefront/Cargo.toml
+++ b/crates/rustok-order/storefront/Cargo.toml
@@ -14,6 +14,7 @@ ssr = [
     "dep:rustok-commerce",
     "dep:rustok-outbox",
     "dep:rustok-payment",
+    "dep:rustok-product",
     "rustok-api/server",
 ]
 
@@ -28,6 +29,7 @@ rustok-api.workspace = true
 rustok-commerce = { workspace = true, optional = true }
 rustok-outbox = { workspace = true, optional = true }
 rustok-payment = { workspace = true, optional = true }
+rustok-product = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -39,6 +39,7 @@ async fn storefront_order_complete_checkout_native(
         };
         use rustok_outbox::TransactionalEventBus;
         use rustok_payment::providers::PaymentProviderRegistry;
+        use rustok_product::ProductCatalogReadRuntime;
 
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let event_bus = runtime_ctx
@@ -54,6 +55,17 @@ async fn storefront_order_complete_checkout_native(
         let payment_provider_registry = runtime_ctx
             .shared_get::<PaymentProviderRegistry>()
             .unwrap_or_else(PaymentProviderRegistry::with_manual_provider);
+        let product_catalog_read_port = runtime_ctx
+            .shared_get::<ProductCatalogReadRuntime>()
+            .ok_or_else(|| {
+                tracing::error!(
+                    operation = "complete_storefront_checkout",
+                    dependency = "ProductCatalogReadRuntime",
+                    "native checkout runtime dependency is missing"
+                );
+                ServerFnError::new("Checkout service is temporarily unavailable")
+            })?
+            .read_port();
         let runtime = StorefrontCheckoutRuntime::new(runtime_ctx.db_clone(), event_bus);
         let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
             .await
@@ -72,9 +84,10 @@ async fn storefront_order_complete_checkout_native(
         }
         let metadata = request.metadata;
 
-        let completion = storefront_staged_checkout_runtime::complete_storefront_checkout(
+        let completion = storefront_staged_checkout_runtime::complete_storefront_checkout_with_product_port(
             &runtime,
             payment_provider_registry,
+            product_catalog_read_port,
             &tenant,
             &request_context,
             auth,

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -54,6 +54,7 @@
     "central_board": "docs/modules/registry.md",
     "verifier": "scripts/verify/verify-ecommerce-fba-registries.mjs",
     "runtime_composition_verifier": "scripts/verify/verify-product-catalog-read-runtime-composition.mjs",
+    "native_checkout_runtime_verifier": "scripts/verify/verify-product-native-checkout-catalog-runtime.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
@@ -69,12 +70,12 @@
     ],
     "source_complete_consumers": [
       "ai-product",
-      "marketplace-listing"
+      "marketplace-listing",
+      "order-storefront-native"
     ],
     "pending_consumers": [
       "commerce-checkout-http",
-      "commerce-checkout-graphql",
-      "order-storefront-native"
+      "commerce-checkout-graphql"
     ],
     "status": "source_complete_consumer_cutover_partial"
   },

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -11,16 +11,19 @@ framework-specific outbox adapter dependency.
 
 `ProductCatalogReadPort` / `product.catalog_read.v1` is implemented by
 `CatalogService`. Its in-process profile has live PostgreSQL execution evidence.
-The Product-owned `ProductCatalogReadRuntime` now gives host composition one
-typed profile selector for `embedded_native` or `external` execution. The server
+The Product-owned `ProductCatalogReadRuntime` gives host composition one typed
+profile selector for `embedded_native` or `external` execution. The server
 preserves a runtime already installed in `HostRuntimeContext` or
 `ServerRuntimeContext`, otherwise composes the embedded provider once. AI and
 Marketplace Listing consume the same selected port rather than constructing
-parallel `CatalogService` instances. The checkout transport cutover remains open:
-the staged Commerce checkout pipeline still creates the embedded Product service
-inside the consumer path. A concrete external transport adapter has not yet been
-executed, so the provider remains `boundary_ready` rather than
-`transport_verified`.
+parallel `CatalogService` instances. The Order storefront native checkout now
+reads the selected runtime from `HostRuntimeContext` and enters Commerce through
+`complete_storefront_checkout_with_product_port`; that composed function passes
+the selected port directly to `CheckoutPlanBuilder`. Backward-compatible HTTP and
+GraphQL wrappers still construct the embedded Product provider, so checkout
+transport cutover remains open for those two surfaces. A concrete external
+transport adapter has not yet been executed, so the provider remains
+`boundary_ready` rather than `transport_verified`.
 
 The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -113,15 +116,16 @@ rustok-pricing` dependency cycle.
 - FFA status: `in_progress` — both owner UI surfaces exist and must preserve
   the core/transport/UI split and native/GraphQL parity.
 - FBA status: `boundary_ready` — the read port, in-process persistence profile,
-  Product-owned runtime selector, and AI/Marketplace host composition are
-  source-complete. External transport execution and checkout consumer cutover
-  remain open.
+  Product-owned runtime selector, AI/Marketplace host composition, and native
+  checkout source cutover are complete. External transport execution plus HTTP
+  and GraphQL checkout cutover remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json`,
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
   `scripts/verify/verify-product-catalog-read-runtime-composition.mjs`,
+  `scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -137,11 +141,10 @@ rustok-pricing` dependency cycle.
    serialized `PortContext`, deadlines, typed `PortError`, tenant/locale/channel
    semantics, variant-to-product resolution, count, and pagination. Do not promote
    above `boundary_ready` from source markers alone.
-2. Complete the Commerce checkout transport cutover. HTTP, GraphQL, and native
-   checkout composition must receive `ProductCatalogReadRuntime::read_port()` and
-   the staged pipeline must stop constructing `CatalogService`. Execute
-   unavailable/deadline behavior as an explicit hard-dependency failure; do not
-   invent a degraded cart-snapshot fallback.
+2. Complete Commerce HTTP and GraphQL checkout cutover. Both compositions must
+   receive `ProductCatalogReadRuntime::read_port()` and call the composed staged
+   entrypoint. Execute unavailable/deadline behavior as an explicit
+   hard-dependency failure; do not invent a degraded cart-snapshot fallback.
 3. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
@@ -153,8 +156,9 @@ rustok-pricing` dependency cycle.
 ## Verification
 
 - [x] Compose one host-selected `ProductCatalogReadRuntime` and reuse it for AI and Marketplace Listing.
+- [x] Cut Order storefront native checkout over to the composed Product runtime.
+- [ ] Cut Commerce HTTP and GraphQL checkout over to the composed Product runtime.
 - [ ] Execute a concrete external Product catalog read adapter.
-- [ ] Cut Commerce HTTP/GraphQL/native checkout over to the composed Product runtime.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
@@ -162,6 +166,8 @@ rustok-pricing` dependency cycle.
 - [x] Connect typed attribute_filters through storefront/admin UI state, native/GraphQL transports, filterable-definition validation, and Product-owned typed EAV execution.
 - `node scripts/verify/verify-product-catalog-read-runtime-composition.mjs`
 - `node scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs`
+- `node scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`
+- `node scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
 - `node scripts/verify/verify-product-admin-category-sort.mjs`
@@ -182,9 +188,10 @@ rustok-pricing` dependency cycle.
   `ProductCatalogReadRuntime` profile selection.
 - The host selects and shares one Product read runtime; consumers receive the
   public port and must not construct parallel owner services.
-- Commerce checkout, Marketplace Listing, and AI consume Product's public read
-  contract. Pricing uses Product's public embedded service contract and does not
-  claim a read-port fallback profile. None regain Product DTO, entity, or storage
-  ownership.
+- Order native checkout, Marketplace Listing, and AI consume Product's public
+  read contract through host composition. Commerce HTTP/GraphQL checkout remain
+  explicit embedded compatibility paths until their cutover PR. Pricing uses
+  Product's public embedded service contract and does not claim a read-port
+  fallback profile. None regain Product DTO, entity, or storage ownership.
 - Hosts compose product UI packages and pass the effective locale and runtime
   context without adding a package-local locale or transport fallback.

--- a/scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
+++ b/scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
@@ -42,10 +42,12 @@ function findFunctionBody(source, functionName) {
 
 const stagedPath = "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs";
 const nativePath = "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs";
+const cargoPath = "crates/rustok-order/storefront/Cargo.toml";
 const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
 const planPath = "crates/rustok-product/docs/implementation-plan.md";
 const staged = read(stagedPath);
 const native = read(nativePath);
+const cargo = read(cargoPath);
 const registrySource = read(registryPath);
 const plan = read(planPath);
 
@@ -83,6 +85,16 @@ for (const marker of [
 }
 if (native.includes("CatalogService::new")) {
   failures.push("Order native checkout must not construct CatalogService");
+}
+for (const marker of [
+  '"dep:rustok-product"',
+  "rustok-product = { workspace = true, optional = true }",
+]) {
+  requireText(cargo, marker, "Order storefront SSR dependency");
+}
+const hydrateFeature = cargo.match(/hydrate\s*=\s*\[([^\]]*)\]/)?.[1] ?? "";
+if (hydrateFeature.includes("rustok-product")) {
+  failures.push("Order storefront hydrate feature must not include rustok-product backend dependency");
 }
 
 let registry;

--- a/scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
+++ b/scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required native checkout runtime file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireText(source, marker, description) {
+  if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+}
+
+function findFunctionBody(source, functionName) {
+  const signature = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`, "g");
+  const match = signature.exec(source);
+  if (!match) return null;
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace === -1) return null;
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace + 1, index);
+    }
+  }
+  return null;
+}
+
+const stagedPath = "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs";
+const nativePath = "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs";
+const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
+const planPath = "crates/rustok-product/docs/implementation-plan.md";
+const staged = read(stagedPath);
+const native = read(nativePath);
+const registrySource = read(registryPath);
+const plan = read(planPath);
+
+for (const marker of [
+  "complete_storefront_checkout_with_product_port",
+  "complete_storefront_checkout_input_with_product_port",
+  "product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort>",
+]) {
+  requireText(staged, marker, "Commerce staged checkout");
+}
+const composedBody = findFunctionBody(
+  staged,
+  "complete_storefront_checkout_input_with_product_port",
+);
+if (!composedBody) {
+  failures.push("Commerce staged checkout: composed input function body is missing");
+} else {
+  requireText(composedBody, "product_catalog_read_port", "Commerce composed checkout body");
+  requireText(composedBody, "CheckoutPlanBuilder::new", "Commerce composed checkout body");
+  if (composedBody.includes("CatalogService::new")) {
+    failures.push("Commerce composed checkout body must not construct CatalogService");
+  }
+}
+const compatibilityBody = findFunctionBody(staged, "complete_storefront_checkout_input");
+if (!compatibilityBody?.includes("CatalogService::new")) {
+  failures.push("Commerce compatibility wrapper must remain explicit until HTTP/GraphQL cutover");
+}
+for (const marker of [
+  "shared_get::<ProductCatalogReadRuntime>()",
+  ".read_port()",
+  "complete_storefront_checkout_with_product_port",
+  'dependency = "ProductCatalogReadRuntime"',
+]) {
+  requireText(native, marker, "Order native checkout");
+}
+if (native.includes("CatalogService::new")) {
+  failures.push("Order native checkout must not construct CatalogService");
+}
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  const composition = registry.runtime_composition ?? {};
+  const complete = composition.source_complete_consumers ?? [];
+  const pending = composition.pending_consumers ?? [];
+  if (!complete.includes("order-storefront-native")) {
+    failures.push("Product FBA registry must mark order-storefront-native source-complete");
+  }
+  if (pending.includes("order-storefront-native")) {
+    failures.push("Product FBA registry must remove order-storefront-native from pending consumers");
+  }
+  for (const consumer of ["commerce-checkout-http", "commerce-checkout-graphql"]) {
+    if (!pending.includes(consumer)) {
+      failures.push(`Product FBA registry must keep ${consumer} pending`);
+    }
+  }
+}
+for (const marker of [
+  "Order storefront native checkout",
+  "complete_storefront_checkout_with_product_port",
+  "Commerce HTTP and GraphQL checkout",
+  "verify-product-native-checkout-catalog-runtime.mjs",
+]) {
+  requireText(plan, marker, "Product implementation plan");
+}
+
+if (failures.length > 0) {
+  console.error("product native checkout catalog runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log("product native checkout catalog runtime verification passed");

--- a/scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs
+++ b/scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs
@@ -36,6 +36,13 @@ function fixture(options = {}) {
       ? "CatalogService::new"
       : `shared_get::<ProductCatalogReadRuntime>() .read_port() complete_storefront_checkout_with_product_port dependency = "ProductCatalogReadRuntime"`,
   );
+  write(
+    root,
+    "crates/rustok-order/storefront/Cargo.toml",
+    options.omitProductDependency
+      ? `[features]\nhydrate = ["leptos/hydrate"]\nssr = ["leptos/ssr"]\n[dependencies]`
+      : `[features]\nhydrate = ["leptos/hydrate"]\nssr = ["leptos/ssr", "dep:rustok-product"]\n[dependencies]\nrustok-product = { workspace = true, optional = true }`,
+  );
   const complete = options.registryPending
     ? ["ai-product", "marketplace-listing"]
     : ["ai-product", "marketplace-listing", "order-storefront-native"];
@@ -97,6 +104,10 @@ test("native checkout guard rejects Product construction in composed body", () =
 
 test("native checkout guard rejects direct native Product construction", () => {
   reject({ nativeDirect: true }, /Order native checkout/);
+});
+
+test("native checkout guard rejects missing Product SSR dependency", () => {
+  reject({ omitProductDependency: true }, /Order storefront SSR dependency/);
 });
 
 test("native checkout guard rejects stale registry pending state", () => {

--- a/scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs
+++ b/scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-native-checkout-catalog-runtime.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-native-checkout-"));
+  const composedCatalog = options.composedCatalog ? "CatalogService::new" : "";
+  write(
+    root,
+    "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs",
+    `
+    pub async fn complete_storefront_checkout_with_product_port(product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort>) { complete_storefront_checkout_input_with_product_port(); }
+    pub async fn complete_storefront_checkout_input() { CatalogService::new; }
+    pub async fn complete_storefront_checkout_input_with_product_port(product_catalog_read_port: Arc<dyn rustok_product::ProductCatalogReadPort>) { CheckoutPlanBuilder::new; product_catalog_read_port; ${composedCatalog} }
+    `,
+  );
+  write(
+    root,
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+    options.nativeDirect
+      ? "CatalogService::new"
+      : `shared_get::<ProductCatalogReadRuntime>() .read_port() complete_storefront_checkout_with_product_port dependency = "ProductCatalogReadRuntime"`,
+  );
+  const complete = options.registryPending
+    ? ["ai-product", "marketplace-listing"]
+    : ["ai-product", "marketplace-listing", "order-storefront-native"];
+  const pending = options.registryPending
+    ? ["commerce-checkout-http", "commerce-checkout-graphql", "order-storefront-native"]
+    : ["commerce-checkout-http", "commerce-checkout-graphql"];
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      runtime_composition: {
+        source_complete_consumers: complete,
+        pending_consumers: pending,
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.omitPlan
+      ? "Product plan"
+      : "Order storefront native checkout complete_storefront_checkout_with_product_port Commerce HTTP and GraphQL checkout verify-product-native-checkout-catalog-runtime.mjs",
+  );
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected native checkout mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("native checkout runtime guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("native checkout guard rejects Product construction in composed body", () => {
+  reject({ composedCatalog: true }, /must not construct CatalogService/);
+});
+
+test("native checkout guard rejects direct native Product construction", () => {
+  reject({ nativeDirect: true }, /Order native checkout/);
+});
+
+test("native checkout guard rejects stale registry pending state", () => {
+  reject({ registryPending: true }, /order-storefront-native/);
+});
+
+test("native checkout guard rejects missing plan handoff", () => {
+  reject({ omitPlan: true }, /Product implementation plan/);
+});


### PR DESCRIPTION
## Summary

- add backward-compatible Commerce staged-checkout entrypoints that accept a host-selected `Arc<dyn ProductCatalogReadPort>`;
- keep the existing HTTP/GraphQL wrappers explicit and embedded until their own bounded cutover;
- pass the composed Product port directly into `CheckoutPlanBuilder` without constructing `CatalogService` in the selected path;
- make Order storefront native checkout require `ProductCatalogReadRuntime` from `HostRuntimeContext` and return a safe temporary-unavailable error when the capability is missing;
- add the Product dependency only to the Order storefront `ssr` feature, keeping the hydrate/browser bundle free of the backend dependency;
- update the Product FBA registry and implementation plan so native checkout is source-complete while HTTP and GraphQL remain pending;
- add a focused source/mutation guard for composed-vs-compatibility semantics, native host composition, SSR dependency shape, registry state, and plan handoff.

## Boundary

This PR does not claim external adapter execution and does not promote Product above `boundary_ready`. Commerce HTTP and GraphQL checkout remain explicit embedded compatibility paths and are the next consumer-cutover slice.

## Testing

Not run by the implementation agent, following the maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
node scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs
node scripts/verify/verify-product-catalog-read-runtime-composition.mjs
npm run verify:ecommerce:fba
```
