### PR TITLE
test(profiles): retain Iggy dedup recovery calibration

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json
+++ b/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dedup-recovery-window-calibration-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "source_contract": "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json",
+  "test_target": "dedup_recovery_window_calibration",
+  "case": "reviewed_configuration_covers_recovery_window",
+  "runner": "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs",
+  "verifier": "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs",
+  "source_verifier": "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs",
+  "evidence_path": "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution.json",
+  "evidence_status": "runtime_calibration_pending",
+  "command": {
+    "program": "cargo",
+    "args": [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--test",
+      "dedup_recovery_window_calibration",
+      "--",
+      "reviewed_configuration_covers_recovery_window",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ]
+  },
+  "required_environment": {
+    "bounds_path": "RUSTOK_IGGY_DEDUP_RECOVERY_BOUNDS_PATH",
+    "config_path": "RUSTOK_IGGY_DEDUP_RECOVERY_CONFIG_PATH",
+    "server_artifact": "RUSTOK_IGGY_DEDUP_RECOVERY_SERVER_ARTIFACT"
+  },
+  "bounds_contract": {
+    "schema_version": 1,
+    "required_fields": [
+      "publication_lease_milliseconds",
+      "process_restart_milliseconds",
+      "transport_reconnect_milliseconds",
+      "operator_recovery_milliseconds",
+      "required_max_entries_per_partition",
+      "capacity_basis"
+    ],
+    "path_outside_repository": true,
+    "full_content_retained": false,
+    "full_file_sha256_retained": false,
+    "canonical_projection_retained": true
+  },
+  "reviewed_configuration": {
+    "section": "system.message_deduplication",
+    "required_enabled": true,
+    "required_positive_fields": [
+      "max_entries",
+      "expiry"
+    ],
+    "config_path_outside_repository": true,
+    "full_content_retained": false,
+    "full_file_sha256_retained": false,
+    "canonical_projection_retained": true
+  },
+  "expected_assessment": {
+    "status": "iggy.dedup_recovery.sufficient",
+    "required_expiry": "checked_sum_of_reviewed_bounds",
+    "configured_expiry_not_below_required": true,
+    "configured_max_entries_not_below_required": true,
+    "stronger_guarantee": false
+  },
+  "runner_requirements": {
+    "clean_working_tree_before": true,
+    "clean_working_tree_after_test": true,
+    "full_git_commit": true,
+    "commit_unchanged": true,
+    "source_hashes_unchanged": true,
+    "exact_case_only": true,
+    "running_one_test_required": true,
+    "skip_rejected": true,
+    "no_clobber_atomic_write_after_pass": true
+  },
+  "retained_packet": {
+    "reviewed_bounds_projection_and_digest": true,
+    "reviewed_configuration_projection_and_digest": true,
+    "reviewed_server_artifact_label": true,
+    "git_toolchain_timestamps": true,
+    "exact_command": true,
+    "current_source_sha256": true,
+    "test_output_sha256_and_bytes": true,
+    "identifier_free_sufficient_assessment": true,
+    "case_result": "pass"
+  },
+  "privacy_exclusions": [
+    "bounds_path",
+    "bounds_full_content",
+    "bounds_full_file_sha256",
+    "config_path",
+    "config_full_content",
+    "config_full_file_sha256",
+    "broker_address",
+    "username",
+    "password",
+    "connection_string",
+    "raw_test_output",
+    "stream_name",
+    "partition_id",
+    "offset",
+    "broker_message_id",
+    "delivery_uuid",
+    "payload",
+    "payload_sha256",
+    "ack_token",
+    "raw_iggy_error"
+  ],
+  "source_files": [
+    "crates/rustok-iggy/src/dedup_recovery_window_policy.rs",
+    "crates/rustok-iggy/src/lib.rs",
+    "crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs",
+    "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json",
+    "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json",
+    "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs",
+    "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs",
+    "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs"
+  ],
+  "non_claims": [
+    "active_server_configuration_readback",
+    "capacity_basis_correctness_proven",
+    "production_workload_observed",
+    "failover_proven",
+    "multi_replica_proven",
+    "database_broker_transaction",
+    "physical_exactly_once",
+    "profiles_authorization"
+  ]
+}

--- a/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dedup-recovery-window-policy-source",
-  "status": "source_complete_runtime_calibration_pending",
+  "status": "source_complete_retained_calibration_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dedup_recovery_window_policy.rs",
   "verifier": "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs",
@@ -80,11 +80,24 @@
       "exactly_once"
     ]
   },
+  "retained_calibration": {
+    "status": "capture_source_complete_execution_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json",
+    "test": "crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs",
+    "runner": "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs",
+    "verifier": "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs",
+    "evidence_path": "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution.json",
+    "canonical_packet_present": false,
+    "requires_reviewed_bounds_file": true,
+    "requires_reviewed_enabled_configuration": true,
+    "requires_sufficient_assessment": true,
+    "no_clobber_write": true
+  },
   "remaining_work": [
-    "supply_reviewed_production_horizon_bounds",
-    "derive_per_partition_distinct_id_capacity_bound",
-    "bind_assessment_to_reviewed_iggy_configuration_digest",
-    "retain_runtime_calibration_packet",
+    "execute_retained_calibration_on_reviewed_production_inputs",
+    "review_capacity_basis_and_recovery_horizon_bounds",
+    "commit_no_clobber_calibration_packet",
+    "repeat_when_bound_source_configuration_or_bounds_change",
     "repeat_for_bundled_tls_auth_failover_and_multi_replica_operation"
   ],
   "execution_status": "source_not_run"

--- a/crates/rustok-iggy/docs/dedup-recovery-window-policy.md
+++ b/crates/rustok-iggy/docs/dedup-recovery-window-policy.md
@@ -1,6 +1,6 @@
 # Iggy deduplication recovery-window policy
 
-Status: **source complete; runtime calibration remains pending**.
+Status: **policy and retained-calibration tooling source complete; runtime calibration and canonical packet pending**.
 
 ## Purpose
 
@@ -64,14 +64,72 @@ node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
 
 Focused source tests cover invalid policy/configuration, duration overflow, disabled mode, independent expiry/capacity deficits, and exact-boundary sufficiency.
 
+## Retained calibration
+
+The retained path requires two operator-reviewed files outside the repository.
+
+Recovery bounds JSON:
+
+```json
+{
+  "schema_version": 1,
+  "publication_lease_milliseconds": 30000,
+  "process_restart_milliseconds": 20000,
+  "transport_reconnect_milliseconds": 10000,
+  "operator_recovery_milliseconds": 60000,
+  "required_max_entries_per_partition": 500,
+  "capacity_basis": "reviewed peak per-partition arrival bound"
+}
+```
+
+Iggy configuration:
+
+```toml
+[system.message_deduplication]
+enabled = true
+max_entries = 500
+expiry = "2m"
+```
+
+The capture reads only the versioned bounds allowlist and the Iggy deduplication section. It retains canonical projections and their SHA-256 values, not file paths, full contents, or full-file hashes.
+
+Execution contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dedup-recovery-window-calibration-execution-contract.json
+```
+
+Exact environment-driven Rust case:
+
+```text
+crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs
+reviewed_configuration_covers_recovery_window
+```
+
+Capture and retained verifier:
+
+```bash
+RUSTOK_IGGY_DEDUP_RECOVERY_BOUNDS_PATH=/outside/repository/bounds.json \
+RUSTOK_IGGY_DEDUP_RECOVERY_CONFIG_PATH=/outside/repository/iggy.toml \
+RUSTOK_IGGY_DEDUP_RECOVERY_SERVER_ARTIFACT=reviewed-iggy-build \
+node scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs
+
+node scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
+```
+
+The runner requires one clean unchanged commit, exact one-test success, no skip, current source hashes, a reviewed server artifact label, sufficient expiry and capacity, and a clean worktree after execution. Publication is no-clobber.
+
+The canonical packet remains pending until a maintainer supplies reviewed production inputs and runs the capture. Any bound source, configuration, or recovery-bounds change makes an existing packet stale.
+
 ## Remaining evidence
 
 Before a stronger duplicate-suppression statement is made, operators still need to:
 
-1. publish reviewed maximum lease, restart, reconnect, and intervention bounds;
-2. derive a defensible maximum distinct-ID arrival bound per physical partition;
-3. bind the assessment to a reviewed Iggy configuration projection and digest;
-4. retain the assessment from one clean commit;
-5. repeat evidence for bundled mode, TLS/auth/failover, capacity pressure, and multi-replica recovery.
+1. review the maximum lease, restart, reconnect, and intervention bounds;
+2. review the maximum distinct-ID arrival bound per physical partition;
+3. execute the clean-commit retained calibration and commit the no-clobber packet;
+4. repeat calibration whenever a bound source, configuration, or input changes;
+5. separately prove bundled mode, TLS/auth/failover, capacity pressure, and multi-replica recovery.
 
-The policy remains operational evidence only. Profiles privacy and visibility continue to resolve exclusively through authoritative owner ports.
+The policy and packet remain operational evidence only. Profiles privacy and visibility continue to resolve exclusively through authoritative owner ports.

--- a/crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs
+++ b/crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs
@@ -1,0 +1,116 @@
+use std::{env, time::Duration};
+
+use rustok_iggy::{
+    IggyDedupRecoveryWindowPolicy, IggyDedupRecoveryWindowStatus,
+    IggyDeduplicationConfiguration,
+};
+
+const SKIP_MESSAGE: &str =
+    "skipping Iggy dedup recovery-window retained calibration: required environment is absent";
+
+const PUBLICATION_LEASE_MS: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_PUBLICATION_LEASE_MS";
+const PROCESS_RESTART_MS: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_PROCESS_RESTART_MS";
+const TRANSPORT_RECONNECT_MS: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_TRANSPORT_RECONNECT_MS";
+const OPERATOR_RECOVERY_MS: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_OPERATOR_RECOVERY_MS";
+const REQUIRED_MAX_ENTRIES: &str =
+    "RUSTOK_IGGY_DEDUP_RECOVERY_REQUIRED_MAX_ENTRIES_PER_PARTITION";
+const CONFIGURED_MAX_ENTRIES: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_CONFIGURED_MAX_ENTRIES";
+const CONFIGURED_EXPIRY_MS: &str = "RUSTOK_IGGY_DEDUP_RECOVERY_CONFIGURED_EXPIRY_MS";
+
+fn required_environment() -> Option<Vec<(&'static str, String)>> {
+    let names = [
+        PUBLICATION_LEASE_MS,
+        PROCESS_RESTART_MS,
+        TRANSPORT_RECONNECT_MS,
+        OPERATOR_RECOVERY_MS,
+        REQUIRED_MAX_ENTRIES,
+        CONFIGURED_MAX_ENTRIES,
+        CONFIGURED_EXPIRY_MS,
+    ];
+    let values = names
+        .iter()
+        .map(|name| (*name, env::var(name).ok()))
+        .collect::<Vec<_>>();
+
+    if values.iter().all(|(_, value)| value.is_none()) {
+        return None;
+    }
+
+    Some(
+        values
+            .into_iter()
+            .map(|(name, value)| {
+                (
+                    name,
+                    value.unwrap_or_else(|| {
+                        panic!("{name} must be set when retained calibration is requested")
+                    }),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn parse_u64(values: &[(&str, String)], name: &str, allow_zero: bool) -> u64 {
+    let raw = values
+        .iter()
+        .find_map(|(candidate, value)| (*candidate == name).then_some(value.as_str()))
+        .expect("required retained calibration environment must exist");
+    assert_eq!(raw.trim(), raw, "{name} must not contain surrounding whitespace");
+    let parsed = raw
+        .parse::<u64>()
+        .unwrap_or_else(|_| panic!("{name} must be an unsigned integer"));
+    assert!(allow_zero || parsed > 0, "{name} must be positive");
+    parsed
+}
+
+#[test]
+fn reviewed_configuration_covers_recovery_window() {
+    let Some(values) = required_environment() else {
+        eprintln!("{SKIP_MESSAGE}");
+        return;
+    };
+
+    let publication_lease_ms = parse_u64(&values, PUBLICATION_LEASE_MS, false);
+    let process_restart_ms = parse_u64(&values, PROCESS_RESTART_MS, true);
+    let transport_reconnect_ms = parse_u64(&values, TRANSPORT_RECONNECT_MS, true);
+    let operator_recovery_ms = parse_u64(&values, OPERATOR_RECOVERY_MS, true);
+    let required_max_entries = parse_u64(&values, REQUIRED_MAX_ENTRIES, false);
+    let configured_max_entries = parse_u64(&values, CONFIGURED_MAX_ENTRIES, false);
+    let configured_expiry_ms = parse_u64(&values, CONFIGURED_EXPIRY_MS, false);
+
+    let policy = IggyDedupRecoveryWindowPolicy::new(
+        Duration::from_millis(publication_lease_ms),
+        Duration::from_millis(process_restart_ms),
+        Duration::from_millis(transport_reconnect_ms),
+        Duration::from_millis(operator_recovery_ms),
+        required_max_entries,
+    )
+    .expect("reviewed recovery-window bounds must be valid");
+    let configuration = IggyDeduplicationConfiguration::enabled(
+        configured_max_entries,
+        Duration::from_millis(configured_expiry_ms),
+    )
+    .expect("reviewed Iggy deduplication configuration must be valid");
+    let assessment = policy.assess(configuration);
+
+    assert_eq!(
+        assessment.status(),
+        IggyDedupRecoveryWindowStatus::Sufficient,
+        "reviewed Iggy deduplication configuration does not cover the supplied recovery model"
+    );
+
+    println!(
+        "RUSTOK_DEDUP_RECOVERY_CALIBRATION status={} required_expiry_ms={} configured_expiry_ms={} required_max_entries_per_partition={} configured_max_entries={}",
+        assessment.status().stable_code(),
+        assessment.required_expiry().as_millis(),
+        assessment
+            .configured_expiry()
+            .expect("enabled configuration retains expiry")
+            .as_millis(),
+        assessment.required_max_entries_per_partition(),
+        assessment
+            .configured_max_entries()
+            .expect("enabled configuration retains max_entries"),
+    );
+}

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -87,9 +87,14 @@ mutation retry.
   bounds; requires an explicit maximum distinct-ID count per physical partition;
   distinguishes disabled, expiry, capacity, combined, and sufficient states; and
   contains no production default or exactly-once claim.
+- Recovery-window retained calibration tooling is source-complete. A versioned
+  external bounds file and reviewed enabled Iggy configuration are reduced to
+  canonical privacy-safe projections; one exact Rust case must report a
+  sufficient assessment from a clean unchanged commit before a no-clobber packet
+  can be published.
 - Canonical retained packets remain pending and must omit credentials and
-  delivery-level facts, bind reviewed source/configuration digests, and become
-  stale when bound sources change.
+  delivery-level facts, bind reviewed source/configuration/input digests, and
+  become stale when any bound source or reviewed input changes.
 
 ## Physical DLQ duplicate inspection
 
@@ -171,6 +176,38 @@ canonical path, so existing reviewed evidence cannot be replaced.
 
 Runtime execution and the canonical packet remain pending.
 
+### Recovery-window retained calibration
+
+Source-complete paths:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dedup-recovery-window-policy-source.json
+  dedup-recovery-window-calibration-execution-contract.json
+crates/rustok-iggy/tests/
+  dedup_recovery_window_calibration.rs
+scripts/evidence/
+  capture-iggy-dedup-recovery-window-calibration.mjs
+scripts/verify/
+  verify-iggy-dedup-recovery-window-policy.mjs
+  verify-iggy-dedup-recovery-window-retained.mjs
+```
+
+The capture requires one reviewed versioned recovery-bounds JSON and one reviewed
+Iggy configuration outside the repository. The bounds projection retains the
+lease, restart, reconnect, operator-recovery, required per-partition entry count,
+capacity-basis label, checked required expiry, and canonical digest. The Iggy
+projection retains only enabled, `max_entries`, `expiry`, normalized milliseconds,
+and its canonical digest.
+
+The exact Rust case is opt-in for ordinary test runs, but retained capture rejects
+a skip and requires `running 1 test`, the exact named pass, a sufficient status,
+an unchanged commit and source hash set, and a clean worktree. It retains no
+input paths, full files, endpoints, credentials, identifiers, broker coordinates,
+payloads, or raw output. Publication is no-clobber.
+
+Runtime calibration and the canonical packet remain pending.
+
 Detailed checkpoints:
 
 - `crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md`
@@ -220,13 +257,12 @@ Detailed checkpoints:
    best-effort `acknowledged`, process loss, acknowledgement-only recovery, and
    multi-replica ownership on PostgreSQL plus real Iggy.
 
-9. **Calibrate confirmation-window sufficiency.**
-   The source policy now compares reviewed dedup `expiry` with the checked sum of
-   lease, restart, reconnect, and operator-recovery bounds, and compares
-   `max_entries` with an explicit per-partition distinct-ID bound. Supply and
-   review those production inputs, bind them to configuration digests, execute
-   the focused tests/verifier, and retain a clean-commit assessment before making
-   a stronger duplicate-suppression statement.
+9. **Execute recovery-window calibration.**
+   Review the production lease, restart, reconnect, operator-response, and
+   per-partition distinct-ID bounds; run the locked sufficient-only capture
+   against a reviewed enabled Iggy configuration; inspect and commit the
+   no-clobber packet; and repeat whenever a bound source, configuration, or input
+   changes. A packet covers only that supplied model.
 
 10. **Design moving duplicate windows or keep fixed snapshots.**
     A moving per-partition cursor must retain bounded prior identity/digest state
@@ -240,25 +276,26 @@ Detailed checkpoints:
 
 ## Recheck checkpoint — 2026-07-29
 
-- Rechecked the canonical plan and current `main` after the two-partition
-  fair-window harness and retained-capture tooling.
+- Rechecked the canonical plan and current `main` after the recovery-window
+  policy merge.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
 - Reconfirmed deterministic same-ID colocation and the production-reachable
   fair/global comparison.
-- Rechecked the existing external-Iggy dedup cases and confirmed that immediate,
+- Rechecked the external-Iggy dedup cases and confirmed that immediate,
   capacity, and expiry sequences do not establish a production recovery window.
-- Added a pure fail-closed recovery-window policy with caller-reviewed additive
-  time bounds and explicit per-partition capacity; disabled or insufficient
-  configuration cannot report sufficient.
-- Locked stable statuses/codes, focused source tests, an owner guide, a Profiles
-  checkpoint, and a static source verifier.
-- Kept active configuration readback, reviewed production calibration, runtime
-  execution, canonical retained packets, moving-window state, bundled/TLS/auth,
-  failover, and multi-replica claims open.
-- Tests, Cargo commands, repository source verifiers, external/bundled Iggy,
-  retained capture, and multi-replica scenarios were not run per maintainer
+- Reconfirmed the pure fail-closed recovery-window policy and added a locked
+  retained-calibration path around reviewed bounds and reviewed enabled Iggy
+  configuration.
+- Added one exact opt-in Rust calibration case, strict skip rejection, checked
+  reviewed-input projections and digests, current source hashes, clean-commit
+  requirements, a sufficient-only gate, and no-clobber packet publication.
+- Kept active configuration readback, correctness of the operator capacity
+  basis, runtime execution, canonical retained packets, moving-window state,
+  bundled/TLS/auth, failover, and multi-replica claims open.
+- Tests, Cargo commands, repository source verifiers, retained capture,
+  external/bundled Iggy, and multi-replica scenarios were not run per maintainer
   instruction.
 
 ## Verification backlog
@@ -270,6 +307,13 @@ cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
 cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
+cargo test -p rustok-iggy --test dedup_recovery_window_calibration
+node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+node scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
+RUSTOK_IGGY_DEDUP_RECOVERY_BOUNDS_PATH=/outside/repository/bounds.json \
+RUSTOK_IGGY_DEDUP_RECOVERY_CONFIG_PATH=/outside/repository/iggy.toml \
+RUSTOK_IGGY_DEDUP_RECOVERY_SERVER_ARTIFACT=reviewed-iggy-build \
+node scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs
 cargo test -p rustok-iggy dlq_duplicate_external_scan -- --nocapture
 RUSTOK_IGGY_FAIR_WINDOW_SCAN_TEST_ADDRESS='host:8090' \
 cargo test -p rustok-iggy --features iggy \
@@ -278,7 +322,6 @@ cargo test -p rustok-iggy --features iggy \
   --exact --nocapture --test-threads=1
 cargo test -p rustok-iggy dlq_duplicate_alert_observer -- --nocapture
 cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
-node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-fair-window-external-scan-runtime.mjs
@@ -295,7 +338,7 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
 3. Public GraphQL/storefront reads use the canonical visibility matrix.
 4. Presentation consumers use `ProfilePresentationService`; raw readers remain
    internal.
-5. `followers_only` resolves through bounded fail-closed Social Graph ports.
+5. `followers_only` resolves through bounded fail-closed Social Graph owner ports.
 6. Profile media resolves through Media owner ports only.
 7. Follow controls use owner ports, unique idempotency, optimistic revision, and
    no automatic retry.
@@ -314,7 +357,7 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
 14. Production deterministic broker IDs remain colocated by the publisher's
     one-based modulo partition rule.
 15. Retained evidence is no-clobber, commit-bound, and stale after any bound
-    source change.
+    source or reviewed input change.
 16. Moving duplicate windows require bounded cross-cycle identity state.
 17. A sufficient recovery-window assessment covers only the supplied reviewed
     model and never authorizes Profiles or proves exactly-once.

--- a/crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: Iggy deduplication recovery window
 
-Status: **source-complete; runtime calibration and retained evidence pending**.
+Status: **policy and retained-calibration tooling source-complete; runtime calibration and canonical evidence pending**.
 
 ## Why this belongs in the Profiles improvement trail
 
@@ -10,7 +10,7 @@ The existing external-Iggy cases show immediate suppression, disabled deduplicat
 
 ## Delivered source policy
 
-`rustok-iggy` now publishes:
+`rustok-iggy` publishes:
 
 ```text
 IggyDeduplicationConfiguration
@@ -36,11 +36,36 @@ Static verifier:
 node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
 ```
 
-Owner guide:
+## Delivered retained calibration boundary
+
+The retained slice adds:
 
 ```text
-crates/rustok-iggy/docs/dedup-recovery-window-policy.md
+crates/rustok-iggy/contracts/evidence/
+  dedup-recovery-window-calibration-execution-contract.json
+crates/rustok-iggy/tests/
+  dedup_recovery_window_calibration.rs
+scripts/evidence/
+  capture-iggy-dedup-recovery-window-calibration.mjs
+scripts/verify/
+  verify-iggy-dedup-recovery-window-retained.mjs
 ```
+
+The runner requires a versioned reviewed recovery-bounds JSON and a reviewed external Iggy configuration file outside the repository. It retains only:
+
+- the bounded recovery inputs and checked required expiry;
+- the reviewed per-partition capacity basis and required entry count;
+- the canonical enabled/max-entries/expiry configuration projection;
+- canonical projection digests;
+- a bounded server artifact label;
+- one exact sufficient Rust assessment;
+- commit, toolchain, timestamps, current source hashes, and test-output digest/size.
+
+It does not retain input paths, full files, full-file hashes, endpoints, credentials, payloads, UUIDs, partitions, offsets, acknowledgement tokens, or raw logs.
+
+The exact Rust case skips when no calibration environment is present so ordinary test runs remain opt-in. The retained runner rejects that skip, requires `running 1 test`, requires the named case to pass, and refuses to write a packet unless both reviewed expiry and capacity cover the supplied model.
+
+Packet publication is no-clobber and commit-bound. The canonical packet is intentionally absent until a maintainer performs the calibration.
 
 ## Profiles boundary
 
@@ -49,19 +74,20 @@ Profiles never authorizes visibility, `followers_only`, follow controls, search 
 - deduplication enabled/disabled state;
 - `max_entries` or `expiry`;
 - recovery-window assessment status;
+- reviewed bounds or configuration digests;
 - receipt state, broker counts, offsets, lag, or evidence packets.
 
 Privacy remains evaluated before localized and Media-backed presentation. Restricted or unavailable public rows remain absent.
 
-A `sufficient` assessment means only that one reviewed configuration covers the supplied bounded model. It does not prove active server configuration, a database/broker transaction, exactly-once delivery, failover, workload bounds, or multi-replica recovery.
+A `sufficient` assessment means only that one reviewed configuration covers the supplied bounded model. It does not prove active server configuration, the capacity basis itself, a database/broker transaction, exactly-once delivery, failover, or multi-replica recovery.
 
 ## Remaining evidence
 
-1. provide reviewed maximum lease, restart, reconnect, and operator-response bounds;
-2. derive the maximum distinct deterministic IDs per physical partition during that interval;
-3. bind those inputs to reviewed external and bundled Iggy configuration digests;
-4. execute the source verifier and focused Rust tests;
-5. retain a clean-commit calibration packet;
-6. separately prove TLS/auth/failover, capacity pressure, and multi-replica claim ownership.
+1. review and supply production lease, restart, reconnect, and operator-response bounds;
+2. review the maximum distinct deterministic IDs per physical partition during that interval;
+3. run the source and retained verifiers plus the exact calibration capture;
+4. inspect and commit the generated no-clobber packet;
+5. repeat whenever a bound source, configuration, or bounds input changes;
+6. separately prove bundled mode, TLS/auth/failover, capacity pressure, and multi-replica claim ownership.
 
-Tests, Cargo commands, source verifiers, broker connections, retained capture, and multi-replica scenarios were not run per maintainer instruction.
+Tests, Cargo commands, source verifiers, retained capture, broker connections, and multi-replica scenarios were not run per maintainer instruction.

--- a/scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs
+++ b/scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json";
+const expectedSourceContract =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json";
+const expectedRunner =
+  "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs";
+const expectedVerifier =
+  "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs";
+const expectedSourceVerifier =
+  "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs";
+const expectedEvidence =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution.json";
+const expectedCase = "reviewed_configuration_covers_recovery_window";
+const expectedStatus = "iggy.dedup_recovery.sufficient";
+const testEnvironment = {
+  publicationLease: "RUSTOK_IGGY_DEDUP_RECOVERY_PUBLICATION_LEASE_MS",
+  processRestart: "RUSTOK_IGGY_DEDUP_RECOVERY_PROCESS_RESTART_MS",
+  transportReconnect: "RUSTOK_IGGY_DEDUP_RECOVERY_TRANSPORT_RECONNECT_MS",
+  operatorRecovery: "RUSTOK_IGGY_DEDUP_RECOVERY_OPERATOR_RECOVERY_MS",
+  requiredMaxEntries:
+    "RUSTOK_IGGY_DEDUP_RECOVERY_REQUIRED_MAX_ENTRIES_PER_PARTITION",
+  configuredMaxEntries: "RUSTOK_IGGY_DEDUP_RECOVERY_CONFIGURED_MAX_ENTRIES",
+  configuredExpiry: "RUSTOK_IGGY_DEDUP_RECOVERY_CONFIGURED_EXPIRY_MS",
+};
+const skipMarker =
+  "skipping Iggy dedup recovery-window retained calibration: required environment is absent";
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPath = resolve(repoRoot, contract.evidence_path);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) fail(`${program} could not start: ${result.error.message}`);
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function strictOneLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is missing, padded, multiline, or outside the retained boundary`);
+  }
+  return value;
+}
+
+function commandOutputLine(value, field, maximumLength = 256) {
+  if (typeof value !== "string") fail(`${field} is missing`);
+  return strictOneLine(value.replace(/\r?\n$/u, ""), field, maximumLength);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`source file is missing: ${relativePath}`);
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function validateContract() {
+  const expectedCommand = {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-iggy",
+      "--test",
+      "dedup_recovery_window_calibration",
+      "--",
+      expectedCase,
+      "--exact",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  };
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "iggy" ||
+    contract.packet !== "dedup-recovery-window-calibration-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked" ||
+    contract.source_contract !== expectedSourceContract ||
+    contract.runner !== expectedRunner ||
+    contract.verifier !== expectedVerifier ||
+    contract.source_verifier !== expectedSourceVerifier ||
+    contract.evidence_path !== expectedEvidence ||
+    contract.evidence_status !== "runtime_calibration_pending" ||
+    contract.case !== expectedCase ||
+    !same(contract.command, expectedCommand) ||
+    contract.expected_assessment?.status !== expectedStatus
+  ) {
+    fail("dedup recovery-window calibration execution contract drift");
+  }
+  if (
+    contract.bounds_contract?.schema_version !== 1 ||
+    contract.bounds_contract?.path_outside_repository !== true ||
+    contract.bounds_contract?.full_content_retained !== false ||
+    contract.bounds_contract?.full_file_sha256_retained !== false ||
+    contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+    contract.reviewed_configuration?.required_enabled !== true ||
+    contract.reviewed_configuration?.config_path_outside_repository !== true ||
+    contract.reviewed_configuration?.full_content_retained !== false ||
+    contract.reviewed_configuration?.full_file_sha256_retained !== false ||
+    contract.runner_requirements?.no_clobber_atomic_write_after_pass !== true
+  ) {
+    fail("dedup recovery-window calibration retained boundary drift");
+  }
+}
+
+function externalFile(value, field) {
+  const supplied = strictOneLine(value, field, 4096);
+  if (!isAbsolute(supplied)) fail(`${field} must be an absolute path outside the repository`);
+  const absolutePath = resolve(supplied);
+  const repository = resolve(repoRoot);
+  if (absolutePath === repository || absolutePath.startsWith(`${repository}${sep}`)) {
+    fail(`${field} must point outside the repository`);
+  }
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`${field} must point to an existing external file`);
+  }
+  return absolutePath;
+}
+
+function reviewedArtifact(value, field) {
+  const artifact = strictOneLine(value, field, 256);
+  if (
+    artifact.includes("://") ||
+    artifact.includes("@") ||
+    /^\[[0-9a-fA-F:]+\]:\d+$/u.test(artifact) ||
+    /^[A-Za-z0-9._-]+:\d+$/u.test(artifact)
+  ) {
+    fail(`${field} must be a reviewed version or digest label, not an endpoint`);
+  }
+  return artifact;
+}
+
+function integer(value, field, allowZero) {
+  if (!Number.isSafeInteger(value) || value < 0 || (!allowZero && value === 0)) {
+    fail(`${field} must be a ${allowZero ? "non-negative" : "positive"} safe integer`);
+  }
+  return value;
+}
+
+function reviewedBounds(absolutePath) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(absolutePath, "utf8"));
+  } catch (error) {
+    fail(`reviewed bounds JSON is invalid: ${error.message}`);
+  }
+  const expectedKeys = [
+    "schema_version",
+    "publication_lease_milliseconds",
+    "process_restart_milliseconds",
+    "transport_reconnect_milliseconds",
+    "operator_recovery_milliseconds",
+    "required_max_entries_per_partition",
+    "capacity_basis",
+  ];
+  if (
+    raw === null ||
+    Array.isArray(raw) ||
+    typeof raw !== "object" ||
+    !same(Object.keys(raw).sort(), [...expectedKeys].sort()) ||
+    raw.schema_version !== 1
+  ) {
+    fail("reviewed recovery bounds must use the exact versioned field allowlist");
+  }
+  const canonical = {
+    schema_version: 1,
+    publication_lease_milliseconds: integer(
+      raw.publication_lease_milliseconds,
+      "publication_lease_milliseconds",
+      false,
+    ),
+    process_restart_milliseconds: integer(
+      raw.process_restart_milliseconds,
+      "process_restart_milliseconds",
+      true,
+    ),
+    transport_reconnect_milliseconds: integer(
+      raw.transport_reconnect_milliseconds,
+      "transport_reconnect_milliseconds",
+      true,
+    ),
+    operator_recovery_milliseconds: integer(
+      raw.operator_recovery_milliseconds,
+      "operator_recovery_milliseconds",
+      true,
+    ),
+    required_max_entries_per_partition: integer(
+      raw.required_max_entries_per_partition,
+      "required_max_entries_per_partition",
+      false,
+    ),
+    capacity_basis: reviewedArtifact(raw.capacity_basis, "capacity_basis"),
+  };
+  const requiredExpiry =
+    canonical.publication_lease_milliseconds +
+    canonical.process_restart_milliseconds +
+    canonical.transport_reconnect_milliseconds +
+    canonical.operator_recovery_milliseconds;
+  if (!Number.isSafeInteger(requiredExpiry) || requiredExpiry <= 0) {
+    fail("reviewed recovery horizon overflows the retained JavaScript boundary");
+  }
+  return {
+    ...canonical,
+    required_expiry_milliseconds: requiredExpiry,
+    canonical_sha256: sha256(JSON.stringify(canonical)),
+  };
+}
+
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (quote === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote !== null && character === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && (character === '"' || character === "'")) {
+      quote = character;
+      continue;
+    }
+    if (quote === null && character === "#") return line.slice(0, index);
+  }
+  return line;
+}
+
+function parseTomlString(value, field) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return strictOneLine(JSON.parse(value), field, 128);
+    } catch {
+      fail(`${field} contains an invalid quoted TOML string`);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return strictOneLine(value.slice(1, -1), field, 128);
+  }
+  return strictOneLine(value, field, 128);
+}
+
+function durationMilliseconds(value, field) {
+  const match = /^(\d+)(ms|s|m|h|d)$/u.exec(value);
+  if (!match) fail(`${field} must be a duration such as 500ms, 10s, 5m, 1h, or 1d`);
+  const multipliers = { ms: 1, s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+  const milliseconds = Number(match[1]) * multipliers[match[2]];
+  return integer(milliseconds, `${field} milliseconds`, false);
+}
+
+function reviewedConfiguration(absolutePath) {
+  const lines = readFileSync(absolutePath, "utf8").split(/\r?\n/u);
+  let inSection = false;
+  let sectionFound = false;
+  const values = new Map();
+  for (const rawLine of lines) {
+    const line = stripTomlComment(rawLine).trim();
+    if (!line) continue;
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      if (inSection) break;
+      inSection = section[1].trim() === "system.message_deduplication";
+      sectionFound ||= inSection;
+      continue;
+    }
+    if (!inSection) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) fail("reviewed Iggy config contains an invalid assignment");
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!["enabled", "max_entries", "expiry"].includes(key)) continue;
+    if (values.has(key)) fail(`reviewed Iggy config contains duplicate key: ${key}`);
+    values.set(key, value);
+  }
+  if (!sectionFound) fail("reviewed Iggy config is missing [system.message_deduplication]");
+  if (values.get("enabled") !== "true") {
+    fail("reviewed Iggy config must set message_deduplication.enabled = true");
+  }
+  const maxEntriesRaw = values.get("max_entries") ?? "";
+  if (!/^\d+$/u.test(maxEntriesRaw)) fail("reviewed max_entries must be an integer");
+  const maxEntries = integer(Number(maxEntriesRaw), "reviewed max_entries", false);
+  const expiry = parseTomlString(values.get("expiry") ?? "", "reviewed expiry");
+  const expiryMilliseconds = durationMilliseconds(expiry, "reviewed expiry");
+  const canonical = {
+    section: "system.message_deduplication",
+    enabled: true,
+    max_entries: maxEntries,
+    expiry,
+    expiry_milliseconds: expiryMilliseconds,
+  };
+  return { ...canonical, canonical_sha256: sha256(JSON.stringify(canonical)) };
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree must be clean before retained recovery-window calibration");
+  }
+  const commit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "git_commit",
+    40,
+  );
+  if (!/^[0-9a-f]{40}$/u.test(commit)) fail("git commit must be a full lowercase SHA-1");
+  return commit;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function parsePassedAssessment(output, bounds, configuration) {
+  if (!/(?:^|\r?\n)running 1 test(?:\r?\n|$)/u.test(output)) {
+    fail("retained recovery-window calibration did not run exactly one test");
+  }
+  const passed = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(expectedCase)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!passed.test(output)) fail("retained recovery-window calibration case did not pass");
+  if (output.includes(skipMarker)) fail("retained recovery-window calibration reported a skip");
+  const marker =
+    /RUSTOK_DEDUP_RECOVERY_CALIBRATION status=(\S+) required_expiry_ms=(\d+) configured_expiry_ms=(\d+) required_max_entries_per_partition=(\d+) configured_max_entries=(\d+)/u.exec(
+      output,
+    );
+  if (!marker) fail("retained recovery-window calibration output marker is missing");
+  const assessment = {
+    status: marker[1],
+    required_expiry_milliseconds: Number(marker[2]),
+    configured_expiry_milliseconds: Number(marker[3]),
+    required_max_entries_per_partition: Number(marker[4]),
+    configured_max_entries: Number(marker[5]),
+  };
+  if (
+    assessment.status !== expectedStatus ||
+    assessment.required_expiry_milliseconds !== bounds.required_expiry_milliseconds ||
+    assessment.configured_expiry_milliseconds !== configuration.expiry_milliseconds ||
+    assessment.required_max_entries_per_partition !==
+      bounds.required_max_entries_per_partition ||
+    assessment.configured_max_entries !== configuration.max_entries
+  ) {
+    fail("Rust recovery-window assessment does not match reviewed inputs");
+  }
+  return assessment;
+}
+
+function ensureOutputInsideRepository() {
+  const repository = `${resolve(repoRoot)}${sep}`;
+  if (!outputPath.startsWith(repository)) {
+    fail("retained recovery-window output must stay inside the repository");
+  }
+}
+
+function writeNoClobber(packet) {
+  ensureOutputInsideRepository();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  if (existsSync(outputPath)) {
+    fail("retained recovery-window evidence already exists and will not be replaced");
+  }
+  const temporaryPath = `${outputPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(packet, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+    linkSync(temporaryPath, outputPath);
+  } finally {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  }
+}
+
+try {
+  validateContract();
+  ensureOutputInsideRepository();
+
+  const boundsEnvironment = contract.required_environment.bounds_path;
+  const configEnvironment = contract.required_environment.config_path;
+  const artifactEnvironment = contract.required_environment.server_artifact;
+  const bounds = reviewedBounds(
+    externalFile(process.env[boundsEnvironment] ?? "", boundsEnvironment),
+  );
+  const configuration = reviewedConfiguration(
+    externalFile(process.env[configEnvironment] ?? "", configEnvironment),
+  );
+  const serverArtifact = reviewedArtifact(
+    process.env[artifactEnvironment] ?? "",
+    artifactEnvironment,
+  );
+
+  if (
+    configuration.expiry_milliseconds < bounds.required_expiry_milliseconds ||
+    configuration.max_entries < bounds.required_max_entries_per_partition
+  ) {
+    fail("reviewed Iggy configuration does not cover the supplied recovery-window bounds");
+  }
+
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = commandOutputLine(
+    runChecked("cargo", ["--version"]).stdout,
+    "cargo_version",
+  );
+  const rustcVersion = commandOutputLine(
+    runChecked("rustc", ["--version"]).stdout,
+    "rustc_version",
+  );
+  const startedAt = new Date().toISOString();
+
+  const testEnv = {
+    ...process.env,
+    [testEnvironment.publicationLease]: String(bounds.publication_lease_milliseconds),
+    [testEnvironment.processRestart]: String(bounds.process_restart_milliseconds),
+    [testEnvironment.transportReconnect]: String(bounds.transport_reconnect_milliseconds),
+    [testEnvironment.operatorRecovery]: String(bounds.operator_recovery_milliseconds),
+    [testEnvironment.requiredMaxEntries]: String(
+      bounds.required_max_entries_per_partition,
+    ),
+    [testEnvironment.configuredMaxEntries]: String(configuration.max_entries),
+    [testEnvironment.configuredExpiry]: String(configuration.expiry_milliseconds),
+  };
+  const result = runChecked(contract.command.program, contract.command.args, testEnv);
+  const output = `${result.stdout}\n${result.stderr}`;
+  const assessment = parsePassedAssessment(output, bounds, configuration);
+
+  const finalCommit = commandOutputLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+    40,
+  );
+  if (finalCommit !== gitCommit) fail("git commit changed during retained calibration");
+  const finalSourceSha256 = sourceHashes();
+  if (!same(finalSourceSha256, initialSourceSha256)) {
+    fail("bound recovery-window sources changed during retained calibration");
+  }
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during retained recovery-window calibration");
+  }
+
+  writeNoClobber({
+    schema_version: 1,
+    module: "iggy",
+    packet: "dedup-recovery-window-calibration-runtime-evidence",
+    status: "reviewed_recovery_window_sufficient",
+    generated_from: contractPath,
+    runner: expectedRunner,
+    verifier: expectedVerifier,
+    source_verifier: expectedSourceVerifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    working_tree_clean_after_run: true,
+    started_at: startedAt,
+    completed_at: new Date().toISOString(),
+    toolchain: { cargo: cargoVersion, rustc: rustcVersion },
+    input_environment_names: {
+      bounds_path: boundsEnvironment,
+      config_path: configEnvironment,
+      server_artifact: artifactEnvironment,
+    },
+    reviewed_bounds: bounds,
+    reviewed_configuration: configuration,
+    server_artifact: serverArtifact,
+    assessment,
+    command: contract.command,
+    case: expectedCase,
+    result: "pass",
+    source_sha256: finalSourceSha256,
+    test_output_sha256: sha256(output),
+    test_output_bytes: Buffer.byteLength(output),
+  });
+  console.log(
+    `Retained Iggy dedup recovery-window calibration written to ${contract.evidence_path}`,
+  );
+} catch (error) {
+  console.error(`Iggy dedup recovery-window calibration capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+++ b/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -304,7 +304,7 @@ for (const marker of [
   requireText("dedup recovery-window capture runner", runner, marker);
 }
 for (const marker of [
-  "canonical packet is pending",
+  "canonical runtime packet is pending",
   "canonical recovery-window source hash is stale",
   "canonical sufficient recovery-window assessment drift",
   "forbidden field",

--- a/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
+++ b/scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -7,12 +7,21 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json";
+const executionContractPath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json";
 const sourcePath = "crates/rustok-iggy/src/dedup_recovery_window_policy.rs";
+const testPath = "crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const documentationPath = "crates/rustok-iggy/docs/dedup-recovery-window-policy.md";
 const profilesCheckpointPath =
   "crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md";
 const verifierPath = "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs";
+const runnerPath =
+  "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs";
+const retainedVerifierPath =
+  "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution.json";
 
 const expectedExports = [
   "IggyDeduplicationConfiguration",
@@ -43,13 +52,19 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const executionContract = JSON.parse(
+  readFileSync(resolve(repoRoot, executionContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const test = readFileSync(resolve(repoRoot, testPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
 const profilesCheckpoint = readFileSync(
   resolve(repoRoot, profilesCheckpointPath),
   "utf8",
 );
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const retainedVerifier = readFileSync(resolve(repoRoot, retainedVerifierPath), "utf8");
 const failures = [];
 
 function fail(message) {
@@ -73,10 +88,10 @@ function countText(text, marker) {
 }
 
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "iggy" ||
   contract.packet !== "dedup-recovery-window-policy-source" ||
-  contract.status !== "source_complete_runtime_calibration_pending" ||
+  contract.status !== "source_complete_retained_calibration_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.verifier !== verifierPath ||
@@ -130,6 +145,38 @@ for (const [operation, allowed] of Object.entries(contract.policy_boundary ?? {}
 }
 for (const [field, required] of Object.entries(contract.privacy_boundary ?? {})) {
   if (required !== true) fail(`dedup recovery-window privacy boundary weakened: ${field}`);
+}
+
+const retained = contract.retained_calibration;
+if (
+  retained?.status !== "capture_source_complete_execution_pending" ||
+  retained?.contract !== executionContractPath ||
+  retained?.test !== testPath ||
+  retained?.runner !== runnerPath ||
+  retained?.verifier !== retainedVerifierPath ||
+  retained?.evidence_path !== evidencePath ||
+  retained?.canonical_packet_present !== false ||
+  retained?.requires_reviewed_bounds_file !== true ||
+  retained?.requires_reviewed_enabled_configuration !== true ||
+  retained?.requires_sufficient_assessment !== true ||
+  retained?.no_clobber_write !== true
+) {
+  fail("dedup recovery-window retained calibration relationship drift");
+}
+if (
+  executionContract.packet !==
+    "dedup-recovery-window-calibration-execution-contract" ||
+  executionContract.status !== "runtime_execution_contract_locked" ||
+  executionContract.source_contract !== contractPath ||
+  executionContract.test_target !== "dedup_recovery_window_calibration" ||
+  executionContract.case !== "reviewed_configuration_covers_recovery_window" ||
+  executionContract.runner !== runnerPath ||
+  executionContract.verifier !== retainedVerifierPath ||
+  executionContract.source_verifier !== verifierPath ||
+  executionContract.evidence_path !== evidencePath ||
+  executionContract.evidence_status !== "runtime_calibration_pending"
+) {
+  fail("dedup recovery-window execution contract relationship drift");
 }
 
 for (const marker of [
@@ -190,6 +237,32 @@ for (const marker of [
   forbidText("dedup recovery-window policy source", source, marker);
 }
 
+for (const marker of [
+  "const SKIP_MESSAGE",
+  "fn reviewed_configuration_covers_recovery_window()",
+  "IggyDedupRecoveryWindowPolicy::new(",
+  "IggyDeduplicationConfiguration::enabled(",
+  "IggyDedupRecoveryWindowStatus::Sufficient",
+  "RUSTOK_DEDUP_RECOVERY_CALIBRATION status={}",
+]) {
+  requireText("dedup recovery-window retained calibration test", test, marker);
+}
+if (countText(test, "#[test]") !== 1) {
+  fail("dedup recovery-window retained calibration must contain exactly one focused test");
+}
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  ".connect(",
+  ".poll_messages(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".delete(",
+  ".purge(",
+]) {
+  forbidText("dedup recovery-window retained calibration test", test, marker);
+}
+
 requireText(
   "rustok-iggy module list",
   lib,
@@ -204,24 +277,46 @@ for (const marker of [
   "per physical partition",
   "No production default",
   "does not prove exactly-once",
-  "runtime calibration remains pending",
+  "Retained calibration",
+  "canonical packet remains pending",
 ]) {
   requireText("dedup recovery-window documentation", documentation, marker);
 }
 for (const marker of [
   "Profiles never authorizes",
   "source-complete",
-  "runtime calibration",
+  "retained calibration",
+  "no-clobber",
   "multi-replica",
 ]) {
   requireText("Profiles dedup recovery-window checkpoint", profilesCheckpoint, marker);
 }
+for (const marker of [
+  "function reviewedBounds(",
+  "function reviewedConfiguration(",
+  "function ensureCleanCommit(",
+  "function parsePassedAssessment(",
+  "function writeNoClobber(",
+  "linkSync(temporaryPath, outputPath)",
+  "sourceHashes()",
+  "reported a skip",
+]) {
+  requireText("dedup recovery-window capture runner", runner, marker);
+}
+for (const marker of [
+  "canonical packet is pending",
+  "canonical recovery-window source hash is stale",
+  "canonical sufficient recovery-window assessment drift",
+  "forbidden field",
+]) {
+  requireText("dedup recovery-window retained verifier", retainedVerifier, marker);
+}
 
 const requiredRemainingWork = new Set([
-  "supply_reviewed_production_horizon_bounds",
-  "derive_per_partition_distinct_id_capacity_bound",
-  "bind_assessment_to_reviewed_iggy_configuration_digest",
-  "retain_runtime_calibration_packet",
+  "execute_retained_calibration_on_reviewed_production_inputs",
+  "review_capacity_basis_and_recovery_horizon_bounds",
+  "commit_no_clobber_calibration_packet",
+  "repeat_when_bound_source_configuration_or_bounds_change",
   "repeat_for_bundled_tls_auth_failover_and_multi_replica_operation",
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemainingWork.delete(item);
@@ -238,5 +333,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy dedup recovery-window policy source verified: reviewed disabled/enabled configuration, checked additive recovery horizon, explicit per-partition capacity bound, fail-closed expiry/capacity assessments, stable codes, identifier-free projection, no broker or receipt access, no production defaults, and no exactly-once claim are locked; runtime calibration and retained evidence remain pending.",
+  "Iggy dedup recovery-window policy source verified: reviewed disabled/enabled configuration, checked additive recovery horizon, explicit per-partition capacity bound, fail-closed assessments, stable codes, identifier-free projection, exact retained calibration test, reviewed bounds/config digests, clean-commit source binding, skip rejection, sufficient-only gate, no-clobber publication, no broker or receipt access, no production defaults, and no exactly-once claim are locked; runtime calibration and canonical retained evidence remain pending.",
 );

--- a/scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
+++ b/scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const sourceContractPath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json";
+const executionContractPath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json";
+const evidencePath =
+  "crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution.json";
+const runnerPath =
+  "scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs";
+const verifierPath =
+  "scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs";
+const sourceVerifierPath =
+  "scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs";
+const testPath = "crates/rustok-iggy/tests/dedup_recovery_window_calibration.rs";
+const expectedCase = "reviewed_configuration_covers_recovery_window";
+const expectedStatus = "iggy.dedup_recovery.sufficient";
+
+const sourceContract = JSON.parse(
+  readFileSync(resolve(repoRoot, sourceContractPath), "utf8"),
+);
+const contract = JSON.parse(
+  readFileSync(resolve(repoRoot, executionContractPath), "utf8"),
+);
+const runner = readFileSync(resolve(repoRoot, runnerPath), "utf8");
+const test = readFileSync(resolve(repoRoot, testPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  const absolutePath = resolve(repoRoot, relativePath);
+  if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) {
+    fail(`bound source file is missing: ${relativePath}`);
+    return null;
+  }
+  return sha256(readFileSync(absolutePath));
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function boundedLine(value, field, maximumLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value ||
+    /[\r\n\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    fail(`${field} is outside the retained one-line boundary`);
+    return false;
+  }
+  return true;
+}
+
+function safeInteger(value, field, allowZero = false) {
+  if (!Number.isSafeInteger(value) || value < 0 || (!allowZero && value === 0)) {
+    fail(`${field} must be a ${allowZero ? "non-negative" : "positive"} safe integer`);
+    return false;
+  }
+  return true;
+}
+
+const expectedCommand = {
+  program: "cargo",
+  args: [
+    "test",
+    "-p",
+    "rustok-iggy",
+    "--test",
+    "dedup_recovery_window_calibration",
+    "--",
+    expectedCase,
+    "--exact",
+    "--nocapture",
+    "--test-threads=1",
+  ],
+};
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dedup-recovery-window-calibration-execution-contract" ||
+  contract.status !== "runtime_execution_contract_locked" ||
+  contract.source_contract !== sourceContractPath ||
+  contract.test_target !== "dedup_recovery_window_calibration" ||
+  contract.case !== expectedCase ||
+  contract.runner !== runnerPath ||
+  contract.verifier !== verifierPath ||
+  contract.source_verifier !== sourceVerifierPath ||
+  contract.evidence_path !== evidencePath ||
+  contract.evidence_status !== "runtime_calibration_pending" ||
+  !same(contract.command, expectedCommand)
+) {
+  fail("dedup recovery-window retained execution contract identity drift");
+}
+
+if (
+  sourceContract.schema_version !== 2 ||
+  sourceContract.status !== "source_complete_retained_calibration_pending" ||
+  sourceContract.retained_calibration?.contract !== executionContractPath ||
+  sourceContract.retained_calibration?.test !== testPath ||
+  sourceContract.retained_calibration?.runner !== runnerPath ||
+  sourceContract.retained_calibration?.verifier !== verifierPath ||
+  sourceContract.retained_calibration?.evidence_path !== evidencePath ||
+  sourceContract.retained_calibration?.canonical_packet_present !== false ||
+  sourceContract.retained_calibration?.no_clobber_write !== true
+) {
+  fail("dedup recovery-window source/retained relationship drift");
+}
+
+if (
+  contract.expected_assessment?.status !== expectedStatus ||
+  contract.expected_assessment?.configured_expiry_not_below_required !== true ||
+  contract.expected_assessment?.configured_max_entries_not_below_required !== true ||
+  contract.expected_assessment?.stronger_guarantee !== false
+) {
+  fail("dedup recovery-window expected assessment drift");
+}
+if (
+  contract.bounds_contract?.schema_version !== 1 ||
+  contract.bounds_contract?.path_outside_repository !== true ||
+  contract.bounds_contract?.full_content_retained !== false ||
+  contract.bounds_contract?.full_file_sha256_retained !== false ||
+  contract.bounds_contract?.canonical_projection_retained !== true ||
+  contract.reviewed_configuration?.section !== "system.message_deduplication" ||
+  contract.reviewed_configuration?.required_enabled !== true ||
+  contract.reviewed_configuration?.config_path_outside_repository !== true ||
+  contract.reviewed_configuration?.full_content_retained !== false ||
+  contract.reviewed_configuration?.full_file_sha256_retained !== false ||
+  contract.reviewed_configuration?.canonical_projection_retained !== true
+) {
+  fail("dedup recovery-window reviewed input boundary drift");
+}
+for (const requirement of Object.values(contract.runner_requirements ?? {})) {
+  if (requirement !== true) fail("dedup recovery-window runner requirement weakened");
+}
+for (const retained of Object.values(contract.retained_packet ?? {})) {
+  if (retained !== true && retained !== "pass") {
+    fail("dedup recovery-window retained packet requirement weakened");
+  }
+}
+
+for (const marker of [
+  "const SKIP_MESSAGE",
+  "reviewed_configuration_covers_recovery_window",
+  "IggyDedupRecoveryWindowPolicy::new(",
+  "IggyDeduplicationConfiguration::enabled(",
+  "IggyDedupRecoveryWindowStatus::Sufficient",
+  "RUSTOK_DEDUP_RECOVERY_CALIBRATION status={}",
+  "required_expiry_ms={}",
+  "configured_expiry_ms={}",
+  "required_max_entries_per_partition={}",
+  "configured_max_entries={}",
+]) {
+  requireText("dedup recovery-window calibration test", test, marker);
+}
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  ".connect(",
+  ".poll_messages(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  ".delete(",
+  ".purge(",
+]) {
+  forbidText("dedup recovery-window calibration test", test, marker);
+}
+
+for (const marker of [
+  "function reviewedBounds(",
+  "function reviewedConfiguration(",
+  "function ensureCleanCommit(",
+  "function parsePassedAssessment(",
+  "function writeNoClobber(",
+  "linkSync(temporaryPath, outputPath)",
+  "sourceHashes()",
+  "working tree must be clean",
+  "reported a skip",
+  "reviewed Iggy configuration does not cover",
+]) {
+  requireText("dedup recovery-window capture runner", runner, marker);
+}
+for (const marker of [
+  "broker_address:",
+  "username:",
+  "password:",
+  "raw_test_output:",
+  "payload:",
+  "delivery_uuid:",
+  "ack_token:",
+]) {
+  forbidText("dedup recovery-window capture packet", runner, marker);
+}
+
+const expectedSourceFiles = [
+  "crates/rustok-iggy/src/dedup_recovery_window_policy.rs",
+  "crates/rustok-iggy/src/lib.rs",
+  testPath,
+  sourceContractPath,
+  executionContractPath,
+  runnerPath,
+  sourceVerifierPath,
+  verifierPath,
+];
+if (!same(contract.source_files, expectedSourceFiles)) {
+  fail("dedup recovery-window retained source hash allowlist drift");
+}
+
+const absoluteEvidence = resolve(repoRoot, evidencePath);
+if (!existsSync(absoluteEvidence)) {
+  if (failures.length > 0) {
+    console.error("Iggy dedup recovery-window retained verification failed:");
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exit(1);
+  }
+  console.log(
+    "Iggy dedup recovery-window retained source verified: execution contract, exact environment-driven Rust calibration, reviewed bounds/config projections, clean-commit source binding, skip rejection, sufficient-only gate, privacy exclusions, and no-clobber publication are locked; canonical runtime packet is pending.",
+  );
+  process.exit(0);
+}
+
+let packet;
+try {
+  packet = JSON.parse(readFileSync(absoluteEvidence, "utf8"));
+} catch (error) {
+  fail(`canonical recovery-window packet is invalid JSON: ${error.message}`);
+}
+
+if (packet) {
+  if (
+    packet.schema_version !== 1 ||
+    packet.module !== "iggy" ||
+    packet.packet !== "dedup-recovery-window-calibration-runtime-evidence" ||
+    packet.status !== "reviewed_recovery_window_sufficient" ||
+    packet.generated_from !== executionContractPath ||
+    packet.runner !== runnerPath ||
+    packet.verifier !== verifierPath ||
+    packet.source_verifier !== sourceVerifierPath ||
+    packet.case !== expectedCase ||
+    packet.result !== "pass" ||
+    !same(packet.command, expectedCommand)
+  ) {
+    fail("canonical recovery-window packet identity drift");
+  }
+
+  if (
+    typeof packet.git_commit !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(packet.git_commit) ||
+    packet.working_tree_clean_before_run !== true ||
+    packet.working_tree_clean_after_run !== true
+  ) {
+    fail("canonical recovery-window commit/clean-tree evidence drift");
+  }
+  if (
+    Number.isNaN(Date.parse(packet.started_at)) ||
+    Number.isNaN(Date.parse(packet.completed_at)) ||
+    Date.parse(packet.completed_at) < Date.parse(packet.started_at)
+  ) {
+    fail("canonical recovery-window timestamps are invalid");
+  }
+  boundedLine(packet.toolchain?.cargo, "toolchain.cargo");
+  boundedLine(packet.toolchain?.rustc, "toolchain.rustc");
+  boundedLine(packet.server_artifact, "server_artifact");
+
+  const bounds = packet.reviewed_bounds;
+  if (
+    bounds?.schema_version !== 1 ||
+    !safeInteger(bounds?.publication_lease_milliseconds, "publication lease") ||
+    !safeInteger(bounds?.process_restart_milliseconds, "process restart", true) ||
+    !safeInteger(bounds?.transport_reconnect_milliseconds, "transport reconnect", true) ||
+    !safeInteger(bounds?.operator_recovery_milliseconds, "operator recovery", true) ||
+    !safeInteger(
+      bounds?.required_max_entries_per_partition,
+      "required max entries per partition",
+    ) ||
+    !safeInteger(bounds?.required_expiry_milliseconds, "required expiry") ||
+    !boundedLine(bounds?.capacity_basis, "capacity_basis") ||
+    typeof bounds?.canonical_sha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(bounds.canonical_sha256)
+  ) {
+    fail("canonical reviewed recovery bounds are invalid");
+  } else {
+    const canonicalBounds = {
+      schema_version: 1,
+      publication_lease_milliseconds: bounds.publication_lease_milliseconds,
+      process_restart_milliseconds: bounds.process_restart_milliseconds,
+      transport_reconnect_milliseconds: bounds.transport_reconnect_milliseconds,
+      operator_recovery_milliseconds: bounds.operator_recovery_milliseconds,
+      required_max_entries_per_partition: bounds.required_max_entries_per_partition,
+      capacity_basis: bounds.capacity_basis,
+    };
+    const requiredExpiry =
+      bounds.publication_lease_milliseconds +
+      bounds.process_restart_milliseconds +
+      bounds.transport_reconnect_milliseconds +
+      bounds.operator_recovery_milliseconds;
+    if (
+      bounds.required_expiry_milliseconds !== requiredExpiry ||
+      bounds.canonical_sha256 !== sha256(JSON.stringify(canonicalBounds))
+    ) {
+      fail("canonical reviewed recovery bounds digest or checked sum drift");
+    }
+  }
+
+  const configuration = packet.reviewed_configuration;
+  if (
+    configuration?.section !== "system.message_deduplication" ||
+    configuration?.enabled !== true ||
+    !safeInteger(configuration?.max_entries, "configured max_entries") ||
+    !boundedLine(configuration?.expiry, "configured expiry", 128) ||
+    !safeInteger(configuration?.expiry_milliseconds, "configured expiry milliseconds") ||
+    typeof configuration?.canonical_sha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(configuration.canonical_sha256)
+  ) {
+    fail("canonical reviewed Iggy configuration is invalid");
+  } else {
+    const canonicalConfiguration = {
+      section: "system.message_deduplication",
+      enabled: true,
+      max_entries: configuration.max_entries,
+      expiry: configuration.expiry,
+      expiry_milliseconds: configuration.expiry_milliseconds,
+    };
+    if (
+      configuration.canonical_sha256 !==
+      sha256(JSON.stringify(canonicalConfiguration))
+    ) {
+      fail("canonical reviewed Iggy configuration digest drift");
+    }
+  }
+
+  if (
+    packet.assessment?.status !== expectedStatus ||
+    packet.assessment?.required_expiry_milliseconds !==
+      packet.reviewed_bounds?.required_expiry_milliseconds ||
+    packet.assessment?.configured_expiry_milliseconds !==
+      packet.reviewed_configuration?.expiry_milliseconds ||
+    packet.assessment?.required_max_entries_per_partition !==
+      packet.reviewed_bounds?.required_max_entries_per_partition ||
+    packet.assessment?.configured_max_entries !==
+      packet.reviewed_configuration?.max_entries ||
+    packet.reviewed_configuration?.expiry_milliseconds <
+      packet.reviewed_bounds?.required_expiry_milliseconds ||
+    packet.reviewed_configuration?.max_entries <
+      packet.reviewed_bounds?.required_max_entries_per_partition
+  ) {
+    fail("canonical sufficient recovery-window assessment drift");
+  }
+
+  if (
+    typeof packet.test_output_sha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(packet.test_output_sha256) ||
+    !safeInteger(packet.test_output_bytes, "test_output_bytes") ||
+    packet.input_environment_names?.bounds_path !==
+      contract.required_environment.bounds_path ||
+    packet.input_environment_names?.config_path !==
+      contract.required_environment.config_path ||
+    packet.input_environment_names?.server_artifact !==
+      contract.required_environment.server_artifact
+  ) {
+    fail("canonical recovery-window provenance drift");
+  }
+
+  if (
+    packet.source_sha256 === null ||
+    Array.isArray(packet.source_sha256) ||
+    typeof packet.source_sha256 !== "object" ||
+    !same(Object.keys(packet.source_sha256), contract.source_files)
+  ) {
+    fail("canonical recovery-window source hash map drift");
+  } else {
+    for (const relativePath of contract.source_files) {
+      const retained = packet.source_sha256[relativePath];
+      const current = fileSha256(relativePath);
+      if (
+        typeof retained !== "string" ||
+        !/^[0-9a-f]{64}$/u.test(retained) ||
+        retained !== current
+      ) {
+        fail(`canonical recovery-window source hash is stale: ${relativePath}`);
+      }
+    }
+  }
+
+  const forbiddenKeys = new Set(contract.privacy_exclusions);
+  function inspect(value) {
+    if (Array.isArray(value)) {
+      for (const item of value) inspect(item);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    for (const [key, nested] of Object.entries(value)) {
+      if (forbiddenKeys.has(key)) fail(`canonical packet contains forbidden field: ${key}`);
+      inspect(nested);
+    }
+  }
+  inspect(packet);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy dedup recovery-window retained verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy dedup recovery-window retained evidence verified: one clean commit binds reviewed recovery bounds, per-partition capacity basis, reviewed enabled Iggy configuration, exact sufficient Rust assessment, current source hashes, bounded toolchain/output digests, privacy exclusions, and no-clobber publication without claiming active readback, failover, multi-replica behavior, a database/broker transaction, exactly-once, or Profiles authorization.",
+);

--- a/scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
+++ b/scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
@@ -409,15 +409,17 @@ if (packet) {
   }
 
   const forbiddenKeys = new Set(contract.privacy_exclusions);
-  function inspect(value) {
+  function inspect(value, parentKey = "") {
     if (Array.isArray(value)) {
-      for (const item of value) inspect(item);
+      for (const item of value) inspect(item, parentKey);
       return;
     }
     if (value === null || typeof value !== "object") return;
     for (const [key, nested] of Object.entries(value)) {
-      if (forbiddenKeys.has(key)) fail(`canonical packet contains forbidden field: ${key}`);
-      inspect(nested);
+      if (forbiddenKeys.has(key) && parentKey !== "input_environment_names") {
+        fail(`canonical packet contains forbidden field: ${key}`);
+      }
+      inspect(nested, key);
     }
   }
   inspect(packet);


### PR DESCRIPTION
## Summary

- add one exact opt-in Rust calibration case for `IggyDedupRecoveryWindowPolicy`
- require reviewed publication-lease, restart, reconnect, operator-recovery, and per-partition capacity bounds
- parse one reviewed enabled Iggy message-deduplication configuration outside the repository
- require configured `expiry` and `max_entries` to cover the reviewed model before retaining evidence
- retain canonical privacy-safe bounds/configuration projections and SHA-256 values
- bind evidence to one clean unchanged Git commit and current hashes for every reviewed source
- reject skipped or non-exact execution and require one named passing test
- publish the canonical packet with no-clobber hard-link semantics
- add a strict retained verifier and actualize the Iggy guide, Profiles checkpoint, and canonical Profiles plan

## Recheck findings

The pure recovery-window policy merged in #2417 correctly distinguishes disabled, expiry-deficient, capacity-deficient, combined-deficit, and sufficient configurations. What remained open was a retained calibration path that binds a sufficient assessment to reviewed production inputs without treating short Iggy behavior sequences as production-window proof.

This PR supplies that source-complete retained path. The canonical execution packet remains intentionally absent until a maintainer reviews real bounds/configuration and runs the capture.

## Privacy boundary

The retained packet excludes input paths, full files, full-file hashes, broker addresses, credentials, connection strings, raw test output, streams, partitions, offsets, message IDs, delivery UUIDs, payloads/digests, acknowledgement tokens, and raw Iggy errors.

It retains only bounded reviewed projections and digests, a reviewed server artifact label, exact command/case/result, current source hashes, clean-tree facts, timestamps, toolchain labels, and test-output digest/size.

## Safety and non-claims

- an existing canonical packet is never replaced
- insufficient expiry or capacity cannot publish evidence
- skipped or non-exact execution is rejected
- a sufficient result covers only the supplied reviewed model
- no active server configuration readback
- no proof that the operator capacity basis is correct
- no broker connection, receipt mutation, offset commit, or Profiles authorization
- no PostgreSQL/Iggy transaction, failover, multi-replica, or exactly-once claim

## Verification

Per maintainer instruction, tests, Cargo commands, formatters, repository source verifiers, retained capture, and broker connections were not run.

Performed only on locally composed artifacts:

```text
node --check scripts/evidence/capture-iggy-dedup-recovery-window-calibration.mjs
node --check scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
node --check scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
python -m json.tool crates/rustok-iggy/contracts/evidence/dedup-recovery-window-policy-source.json
python -m json.tool crates/rustok-iggy/contracts/evidence/dedup-recovery-window-calibration-execution-contract.json
```

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
cargo test -p rustok-iggy --test dedup_recovery_window_calibration
node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
node scripts/verify/verify-iggy-dedup-recovery-window-retained.mjs
cargo xtask module validate profiles
cargo xtask module test profiles
```
