### PR TITLE
feat(product): cut HTTP checkout to catalog runtime

### DIFF
--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -25,6 +25,7 @@ pub struct CommerceHttpRuntime {
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
+    product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
 
@@ -72,6 +73,12 @@ impl CommerceHttpRuntime {
         self.order_read_runtime.order_read_port()
     }
 
+    fn product_catalog_read_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_product::ProductCatalogReadPort> {
+        self.product_catalog_read_runtime.read_port()
+    }
+
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
             .operator_service(self.db_clone(), self.event_bus())
@@ -113,6 +120,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceOrderReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let product_catalog_read_runtime = runtime
+            .shared_get::<rustok_product::ProductCatalogReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require ProductCatalogReadRuntime in HostRuntimeContext"
+                )
+            })?;
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
@@ -132,6 +146,7 @@ impl CommerceHttpRuntime {
             shipping_option_read_runtime,
             fulfillment_lifecycle_read_runtime,
             order_read_runtime,
+            product_catalog_read_runtime,
             marketplace_financial_runtime,
         })
     }

--- a/crates/rustok-commerce/src/controllers/store/checkout.rs
+++ b/crates/rustok-commerce/src/controllers/store/checkout.rs
@@ -253,29 +253,29 @@ pub async fn complete_cart_checkout(
         runtime.db_clone(),
         runtime.event_bus(),
     );
-    let response =
-        crate::services::storefront_staged_checkout_runtime::complete_storefront_checkout_input(
-            &storefront_runtime,
-            runtime.payment_provider_registry(),
-            tenant.id,
-            &request_context,
-            auth.0,
-            idempotency_key,
-            checkout_input,
+    let response = crate::services::storefront_staged_checkout_runtime::complete_storefront_checkout_input_with_product_port(
+        &storefront_runtime,
+        runtime.payment_provider_registry(),
+        runtime.product_catalog_read_port(),
+        tenant.id,
+        &request_context,
+        auth.0,
+        idempotency_key,
+        checkout_input,
+    )
+    .await
+    .map_err(|error| {
+        storefront_checkout_http_error(
+            StorefrontCheckoutErrorContext::new(
+                tenant.id,
+                actor_id,
+                cart_id,
+                &request_context,
+                "complete_cart_checkout",
+            ),
+            error,
         )
-        .await
-        .map_err(|error| {
-            storefront_checkout_http_error(
-                StorefrontCheckoutErrorContext::new(
-                    tenant.id,
-                    actor_id,
-                    cart_id,
-                    &request_context,
-                    "complete_cart_checkout",
-                ),
-                error,
-            )
-        })?;
+    })?;
 
     Ok(Json(response))
 }

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -55,6 +55,7 @@
     "verifier": "scripts/verify/verify-ecommerce-fba-registries.mjs",
     "runtime_composition_verifier": "scripts/verify/verify-product-catalog-read-runtime-composition.mjs",
     "native_checkout_runtime_verifier": "scripts/verify/verify-product-native-checkout-catalog-runtime.mjs",
+    "http_checkout_runtime_verifier": "scripts/verify/verify-product-http-checkout-catalog-runtime.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
@@ -71,10 +72,10 @@
     "source_complete_consumers": [
       "ai-product",
       "marketplace-listing",
-      "order-storefront-native"
+      "order-storefront-native",
+      "commerce-checkout-http"
     ],
     "pending_consumers": [
-      "commerce-checkout-http",
       "commerce-checkout-graphql"
     ],
     "status": "source_complete_consumer_cutover_partial"

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -16,14 +16,14 @@ profile selector for `embedded_native` or `external` execution. The server
 preserves a runtime already installed in `HostRuntimeContext` or
 `ServerRuntimeContext`, otherwise composes the embedded provider once. AI and
 Marketplace Listing consume the same selected port rather than constructing
-parallel `CatalogService` instances. The Order storefront native checkout now
-reads the selected runtime from `HostRuntimeContext` and enters Commerce through
-`complete_storefront_checkout_with_product_port`; that composed function passes
-the selected port directly to `CheckoutPlanBuilder`. Backward-compatible HTTP and
-GraphQL wrappers still construct the embedded Product provider, so checkout
-transport cutover remains open for those two surfaces. A concrete external
-transport adapter has not yet been executed, so the provider remains
-`boundary_ready` rather than `transport_verified`.
+parallel `CatalogService` instances. The Order storefront native checkout and
+Commerce HTTP checkout now read the selected runtime from `HostRuntimeContext`
+and enter Commerce through composed staged entrypoints; both pass the selected
+port directly to `CheckoutPlanBuilder`. The backward-compatible GraphQL wrapper
+still constructs the embedded Product provider, so checkout transport cutover
+remains open only for that surface. A concrete external transport adapter has
+not yet been executed, so the provider remains `boundary_ready` rather than
+`transport_verified`.
 
 The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -116,9 +116,9 @@ rustok-pricing` dependency cycle.
 - FFA status: `in_progress` — both owner UI surfaces exist and must preserve
   the core/transport/UI split and native/GraphQL parity.
 - FBA status: `boundary_ready` — the read port, in-process persistence profile,
-  Product-owned runtime selector, AI/Marketplace host composition, and native
-  checkout source cutover are complete. External transport execution plus HTTP
-  and GraphQL checkout cutover remain open.
+  Product-owned runtime selector, AI/Marketplace host composition, native
+  checkout, and HTTP checkout source cutovers are complete. External transport
+  execution plus GraphQL checkout cutover remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
@@ -126,6 +126,7 @@ rustok-pricing` dependency cycle.
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
   `scripts/verify/verify-product-catalog-read-runtime-composition.mjs`,
   `scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`,
+  `scripts/verify/verify-product-http-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -141,8 +142,8 @@ rustok-pricing` dependency cycle.
    serialized `PortContext`, deadlines, typed `PortError`, tenant/locale/channel
    semantics, variant-to-product resolution, count, and pagination. Do not promote
    above `boundary_ready` from source markers alone.
-2. Complete Commerce HTTP and GraphQL checkout cutover. Both compositions must
-   receive `ProductCatalogReadRuntime::read_port()` and call the composed staged
+2. Complete Commerce GraphQL checkout cutover. GraphQL composition must receive
+   `ProductCatalogReadRuntime::read_port()` and call the composed staged
    entrypoint. Execute unavailable/deadline behavior as an explicit
    hard-dependency failure; do not invent a degraded cart-snapshot fallback.
 3. Keep Product richtext adoption explicitly deferred until the owner approves
@@ -157,7 +158,8 @@ rustok-pricing` dependency cycle.
 
 - [x] Compose one host-selected `ProductCatalogReadRuntime` and reuse it for AI and Marketplace Listing.
 - [x] Cut Order storefront native checkout over to the composed Product runtime.
-- [ ] Cut Commerce HTTP and GraphQL checkout over to the composed Product runtime.
+- [x] Cut Commerce HTTP checkout over to the composed Product runtime.
+- [ ] Cut Commerce GraphQL checkout over to the composed Product runtime.
 - [ ] Execute a concrete external Product catalog read adapter.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
@@ -168,6 +170,8 @@ rustok-pricing` dependency cycle.
 - `node scripts/verify/verify-product-catalog-read-runtime-composition.test.mjs`
 - `node scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`
 - `node scripts/verify/verify-product-native-checkout-catalog-runtime.test.mjs`
+- `node scripts/verify/verify-product-http-checkout-catalog-runtime.mjs`
+- `node scripts/verify/verify-product-http-checkout-catalog-runtime.test.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
 - `node scripts/verify/verify-product-admin-category-sort.mjs`
@@ -188,10 +192,11 @@ rustok-pricing` dependency cycle.
   `ProductCatalogReadRuntime` profile selection.
 - The host selects and shares one Product read runtime; consumers receive the
   public port and must not construct parallel owner services.
-- Order native checkout, Marketplace Listing, and AI consume Product's public
-  read contract through host composition. Commerce HTTP/GraphQL checkout remain
-  explicit embedded compatibility paths until their cutover PR. Pricing uses
-  Product's public embedded service contract and does not claim a read-port
-  fallback profile. None regain Product DTO, entity, or storage ownership.
+- Order native checkout, Commerce HTTP checkout, Marketplace Listing, and AI
+  consume Product's public read contract through host composition. Commerce
+  GraphQL checkout remains an explicit embedded compatibility path until its
+  cutover PR. Pricing uses Product's public embedded service contract and does
+  not claim a read-port fallback profile. None regain Product DTO, entity, or
+  storage ownership.
 - Hosts compose product UI packages and pass the effective locale and runtime
   context without adding a package-local locale or transport fallback.

--- a/scripts/verify/verify-product-http-checkout-catalog-runtime.mjs
+++ b/scripts/verify/verify-product-http-checkout-catalog-runtime.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required HTTP checkout runtime file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireText(source, marker, description) {
+  if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+}
+
+function findFunctionBody(source, functionName) {
+  const signature = new RegExp(`(?:pub\\s+)?(?:async\\s+)?fn\\s+${functionName}\\s*\\(`, "g");
+  const match = signature.exec(source);
+  if (!match) return null;
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace === -1) return null;
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace + 1, index);
+    }
+  }
+  return null;
+}
+
+const runtimePath = "crates/rustok-commerce/src/controllers/mod.rs";
+const checkoutPath = "crates/rustok-commerce/src/controllers/store/checkout.rs";
+const stagedPath = "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs";
+const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
+const planPath = "crates/rustok-product/docs/implementation-plan.md";
+const runtime = read(runtimePath);
+const checkout = read(checkoutPath);
+const staged = read(stagedPath);
+const registrySource = read(registryPath);
+const plan = read(planPath);
+
+for (const marker of [
+  "product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime",
+  "shared_get::<rustok_product::ProductCatalogReadRuntime>()",
+  "Commerce HTTP routes require ProductCatalogReadRuntime in HostRuntimeContext",
+  "fn product_catalog_read_port",
+  "self.product_catalog_read_runtime.read_port()",
+]) {
+  requireText(runtime, marker, "Commerce HTTP runtime");
+}
+
+const handlerBody = findFunctionBody(checkout, "complete_cart_checkout");
+if (!handlerBody) {
+  failures.push("Commerce HTTP checkout handler body is missing");
+} else {
+  requireText(
+    handlerBody,
+    "complete_storefront_checkout_input_with_product_port",
+    "Commerce HTTP checkout handler",
+  );
+  requireText(
+    handlerBody,
+    "runtime.product_catalog_read_port()",
+    "Commerce HTTP checkout handler",
+  );
+  if (handlerBody.includes("complete_storefront_checkout_input(")) {
+    failures.push("Commerce HTTP checkout must not call the embedded compatibility wrapper");
+  }
+  if (handlerBody.includes("CatalogService::new")) {
+    failures.push("Commerce HTTP checkout must not construct CatalogService");
+  }
+}
+
+const composedBody = findFunctionBody(
+  staged,
+  "complete_storefront_checkout_input_with_product_port",
+);
+if (!composedBody) {
+  failures.push("Commerce composed staged checkout body is missing");
+} else if (composedBody.includes("CatalogService::new")) {
+  failures.push("Commerce composed staged checkout must not construct CatalogService");
+}
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  const composition = registry.runtime_composition ?? {};
+  const complete = composition.source_complete_consumers ?? [];
+  const pending = composition.pending_consumers ?? [];
+  if (!complete.includes("commerce-checkout-http")) {
+    failures.push("Product FBA registry must mark commerce-checkout-http source-complete");
+  }
+  if (pending.includes("commerce-checkout-http")) {
+    failures.push("Product FBA registry must remove commerce-checkout-http from pending consumers");
+  }
+  if (!pending.includes("commerce-checkout-graphql")) {
+    failures.push("Product FBA registry must keep commerce-checkout-graphql pending");
+  }
+  if (composition.status !== "source_complete_consumer_cutover_partial") {
+    failures.push("Product FBA registry must retain partial consumer-cutover status");
+  }
+}
+
+for (const marker of [
+  "Commerce HTTP checkout",
+  "Commerce GraphQL checkout",
+  "verify-product-http-checkout-catalog-runtime.mjs",
+  "remains open only for that surface",
+]) {
+  requireText(plan, marker, "Product implementation plan");
+}
+
+if (failures.length > 0) {
+  console.error("product HTTP checkout catalog runtime verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("product HTTP checkout catalog runtime verification passed");

--- a/scripts/verify/verify-product-http-checkout-catalog-runtime.test.mjs
+++ b/scripts/verify/verify-product-http-checkout-catalog-runtime.test.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-http-checkout-catalog-runtime.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-http-checkout-"));
+  write(
+    root,
+    "crates/rustok-commerce/src/controllers/mod.rs",
+    options.missingRuntime
+      ? "struct CommerceHttpRuntime {}"
+      : `
+        struct CommerceHttpRuntime { product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime }
+        fn from_host() { shared_get::<rustok_product::ProductCatalogReadRuntime>(); "Commerce HTTP routes require ProductCatalogReadRuntime in HostRuntimeContext"; }
+        fn product_catalog_read_port(&self) { self.product_catalog_read_runtime.read_port(); }
+      `,
+  );
+  const handlerCall = options.embeddedHandler
+    ? "complete_storefront_checkout_input("
+    : "complete_storefront_checkout_input_with_product_port(runtime.product_catalog_read_port(),";
+  write(
+    root,
+    "crates/rustok-commerce/src/controllers/store/checkout.rs",
+    `pub async fn complete_cart_checkout() { ${handlerCall} }`,
+  );
+  write(
+    root,
+    "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs",
+    options.composedCatalog
+      ? "pub async fn complete_storefront_checkout_input_with_product_port() { CatalogService::new; }"
+      : "pub async fn complete_storefront_checkout_input_with_product_port() { product_catalog_read_port; }",
+  );
+  const complete = options.registryPending
+    ? ["ai-product", "marketplace-listing", "order-storefront-native"]
+    : [
+        "ai-product",
+        "marketplace-listing",
+        "order-storefront-native",
+        "commerce-checkout-http",
+      ];
+  const pending = options.registryPending
+    ? ["commerce-checkout-http", "commerce-checkout-graphql"]
+    : ["commerce-checkout-graphql"];
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      runtime_composition: {
+        source_complete_consumers: complete,
+        pending_consumers: pending,
+        status: "source_complete_consumer_cutover_partial",
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.omitPlan
+      ? "Product plan"
+      : "Commerce HTTP checkout Commerce GraphQL checkout verify-product-http-checkout-catalog-runtime.mjs remains open only for that surface",
+  );
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected HTTP checkout mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("HTTP checkout runtime guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("HTTP checkout guard rejects missing host runtime", () => {
+  reject({ missingRuntime: true }, /Commerce HTTP runtime/);
+});
+
+test("HTTP checkout guard rejects embedded compatibility call", () => {
+  reject({ embeddedHandler: true }, /embedded compatibility wrapper/);
+});
+
+test("HTTP checkout guard rejects Product construction in composed body", () => {
+  reject({ composedCatalog: true }, /must not construct CatalogService/);
+});
+
+test("HTTP checkout guard rejects stale registry pending state", () => {
+  reject({ registryPending: true }, /commerce-checkout-http/);
+});
+
+test("HTTP checkout guard rejects missing plan handoff", () => {
+  reject({ omitPlan: true }, /Product implementation plan/);
+});


### PR DESCRIPTION
## Summary

- require `ProductCatalogReadRuntime` in `CommerceHttpRuntime` when mounting Axum routes;
- expose the selected `ProductCatalogReadPort` from the HTTP runtime;
- route storefront REST checkout through `complete_storefront_checkout_input_with_product_port`;
- preserve the existing REST path, input, idempotency header, and public error mapping;
- record Commerce HTTP checkout as source-complete while keeping GraphQL as the only pending checkout consumer;
- update the Product implementation plan and add a focused source/mutation guard.

## Boundary

This PR does not change GraphQL checkout and does not implement or execute an external Product transport adapter. Product remains `boundary_ready`.

## Testing

Not run by the implementation agent, following the maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-http-checkout-catalog-runtime.mjs
node scripts/verify/verify-product-http-checkout-catalog-runtime.test.mjs
node scripts/verify/verify-product-native-checkout-catalog-runtime.mjs
npm run verify:ecommerce:fba
```
