### PR TITLE
feat(profiles): retain DLQ duplicates across scan cycles

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -85,6 +85,17 @@
     "auto_commit": false,
     "result": "DlqDuplicateSummary"
   },
+  "rolling_window": {
+    "status": "source_complete_scanner_integration_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
+    "result": "DlqDuplicateRollingWindowSnapshot",
+    "complete_cycle_retention": true,
+    "history_truncated_after_eviction": true,
+    "identifier_export": false,
+    "moving_cursor": false,
+    "persistence": false
+  },
   "alert_policy": {
     "status": "source_complete_server_observer_execution_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
@@ -127,6 +138,8 @@
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
     "partition_fairness_or_per_partition_budget_policy",
+    "moving_window_or_per_partition_cursor_policy",
+    "rolling_window_scanner_cursor_persistence_integration",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-rolling-window-source",
+  "status": "source_complete_scanner_integration_pending",
+  "owner": "rustok-iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
+  "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md",
+  "public_exports": [
+    "DlqDuplicateRollingWindowPolicy",
+    "DlqDuplicateRollingWindow",
+    "DlqDuplicateRollingWindowSnapshot",
+    "DlqDuplicateRollingWindowError"
+  ],
+  "bounds": {
+    "max_cycles_upper_bound": 128,
+    "total_observation_capacity_upper_bound": 10000,
+    "max_cycles_positive": true,
+    "max_observations_per_cycle_positive": true,
+    "checked_product_required": true,
+    "production_defaults": false
+  },
+  "cycle_semantics": {
+    "input": "one_complete_scan_cycle_of_opaque_duplicate_observations",
+    "empty_cycle_valid": true,
+    "oversized_cycle_rejected_transactionally": true,
+    "oldest_complete_cycle_evicted_at_capacity": true,
+    "duplicate_relationship_retained_across_cycles_while_present": true,
+    "identity_conflict_retained_across_cycles_while_present": true,
+    "partial_cycle_eviction": false
+  },
+  "snapshot_fields": [
+    "summary",
+    "retained_cycles",
+    "retained_observations",
+    "evicted_cycles",
+    "history_truncated"
+  ],
+  "truncation_semantics": {
+    "history_truncated_after_first_eviction": true,
+    "truncated_snapshot_is_complete_history": false,
+    "truncated_snapshot_is_current_tail": false,
+    "evicted_identity_relationship_can_be_lost": true
+  },
+  "privacy_boundary": {
+    "snapshot_excludes": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "error_code",
+      "publisher_identity",
+      "timestamp",
+      "credential"
+    ],
+    "observations_not_exported_from_state": true,
+    "identifier_free_snapshot": true,
+    "payload_free_snapshot": true
+  },
+  "mutation_boundary": {
+    "connect_to_broker": false,
+    "poll_messages": false,
+    "store_offsets": false,
+    "acknowledge": false,
+    "publish": false,
+    "delete": false,
+    "purge": false,
+    "replay": false,
+    "retry": false,
+    "mutate_receipts": false,
+    "authorize_profiles": false
+  },
+  "stable_errors": {
+    "invalid_policy": "iggy.dlq_duplicate.rolling_window_policy_invalid",
+    "cycle_too_large": "iggy.dlq_duplicate.rolling_window_cycle_too_large",
+    "count_overflow": "iggy.dlq_duplicate.rolling_window_count_overflow"
+  },
+  "required_source_tests": [
+    "invalid_policy_and_capacity_overflow_fail_closed",
+    "ordinary_duplicate_split_across_cycles_is_detected",
+    "identity_conflict_split_across_cycles_requires_manual_review",
+    "oldest_complete_cycle_eviction_marks_history_truncated",
+    "oversized_cycle_rejection_preserves_existing_state"
+  ],
+  "integration_boundary": {
+    "scanner_collection": "pending",
+    "per_partition_cursor_policy": "pending",
+    "cursor_persistence": false,
+    "restart_recovery": false,
+    "server_observer_composition": "pending",
+    "runtime_evidence": "pending"
+  },
+  "non_claims": [
+    "moving_cursor",
+    "persisted_progress",
+    "restart_safe_state",
+    "current_tail_coverage",
+    "complete_history",
+    "production_retention_sufficiency",
+    "server_observer_integration",
+    "profiles_authorization"
+  ],
+  "remaining_work": [
+    "feed_complete_scanner_cycles_without_identifier_export",
+    "define_per_partition_cursor_advancement",
+    "define_state_persistence_or_restart_reset_semantics",
+    "compose_mode_aware_server_observer",
+    "retain_external_iggy_cross_cycle_runtime_evidence",
+    "define_identifier_free_telemetry_and_health_projection"
+  ],
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,6 +1,6 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier, bounded scanner, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution and telemetry/health projection pending**.
+Status: **classifier, bounded scanner, bounded rolling state, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; scanner/cursor integration, runtime execution, and telemetry/health projection pending**.
 
 ## Purpose
 
@@ -12,7 +12,8 @@ The implementation is deliberately split:
 
 ```text
 physical observations
-  -> DlqDuplicateSummary
+  -> one-cycle DlqDuplicateSummary
+  -> optional bounded cross-cycle rolling state
   -> explicit alert policy
   -> latest-value runtime
   -> mode-aware server observer
@@ -52,7 +53,7 @@ The summary excludes broker coordinates, UUIDs, payloads/digests, receipt identi
 
 ## Mutation boundary
 
-The classifier and scanner cannot acknowledge, store offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
+The classifier, rolling state, and scanner cannot acknowledge, store offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
 
 The alert policy cannot scan, route notifications, persist thresholds, or mutate state. The latest-value runtime cannot start workers, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
 
@@ -78,7 +79,23 @@ auto_commit = false
 
 One request permits at most 128 partition identifiers, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
 
-The global message budget is shared across the ordered partition allowlist. It may be exhausted before later partitions are polled, so the scanner and observer make no partition-fairness claim.
+The global message budget is shared across the ordered partition allowlist. It may be exhausted before later partitions are polled, so the compatibility scanner makes no partition-fairness claim. The opt-in fair policy gives each selected partition one equal cap under the same checked 10,000-message total.
+
+## Bounded cross-cycle rolling state
+
+`DlqDuplicateRollingWindow` retains opaque observations across complete scan cycles so ordinary duplicates or conflicting payloads split across adjacent retained cycles can still be classified together.
+
+The caller supplies positive `max_cycles` and `max_observations_per_cycle`. Cycle count is capped at 128 and their checked product cannot exceed 10,000 observations. No production default is defined.
+
+An oversized cycle fails transactionally. At capacity, the oldest complete cycle is evicted; partial-cycle eviction is forbidden. After the first eviction every identifier-free snapshot reports:
+
+```text
+history_truncated = true
+```
+
+An evicted older copy can remove a previously visible duplicate relationship. The retained result is therefore not complete history, current-tail proof, or production retention evidence.
+
+The state does not connect to Iggy, move a broker cursor, persist offsets, serialize itself, or define restart semantics. Feeding complete scanner cycles and advancing independent per-partition cursors remain separate reviewed integration work.
 
 ## Count-only alert policy
 
@@ -127,9 +144,9 @@ For `outbox_iggy`, the observer reuses the exact active transport configuration 
 
 Observer-specific startup failures are non-fatal. Invalid observer configuration or a missing observer dependency records `Unavailable`, logs only a stable code, and returns success to server bootstrap.
 
-The observer includes every configured domain partition in the scanner request, but the single global budget may prevent later partitions from being polled.
+The observer includes every configured domain partition in the scanner request. Global mode may let an early partition consume the shared budget; fair mode attempts every selected partition under an equal cap.
 
-Each poll reuses the same configured explicit start offset. This is a repeated bounded window, not a moving cursor, current-tail monitor, or complete-history observer. Moving-window and per-partition cursor/fairness behavior remain separate design work.
+Each poll still reuses one configured explicit start offset. The current observer is a repeated bounded snapshot, not a moving cursor, current-tail monitor, or complete-history observer. The source-complete rolling state is not yet composed into the scanner or server observer.
 
 ## Safe operational sequence
 
@@ -137,21 +154,23 @@ Each poll reuses the same configured explicit start offset. This is a repeated b
 2. return not-applicable before Iggy access for `memory` or `outbox_local`;
 3. for `outbox_iggy`, use the already-active bundled or external configuration;
 4. scan one bounded explicit-offset window with `auto_commit=false`;
-5. evaluate through explicit thresholds;
-6. publish only the identifier-free latest snapshot;
-7. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
-8. keep cursor/fairness policy, telemetry, health, notification delivery, and destructive actions in separate owners.
+5. optionally retain complete cycles only through a separately composed bounded rolling state;
+6. evaluate through explicit thresholds;
+7. publish only the identifier-free latest snapshot;
+8. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
+9. keep cursor policy, persistence, telemetry, health, notification delivery, and destructive actions in separate owners.
 
 ## Runtime and retained evidence status
 
 The opt-in external harness and privacy-safe retained tooling are source-complete. The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
 
-The mode-aware server observer is source-complete. Runtime execution, moving-window/fairness semantics, identifier-free telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
+The bounded rolling state and mode-aware server observer are source-complete as separate components. Scanner-to-state integration, per-partition cursor semantics, persistence/restart behavior, cross-cycle external-Iggy execution, telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
 
 ## Source verification
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
@@ -165,9 +184,11 @@ No tests, Cargo commands, formatters, verifiers, broker scans, server observers,
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. define partition fairness/per-partition budgets and a moving-window or per-partition cursor policy;
-3. define identifier-free telemetry and optional operational health;
-4. retain mode-aware server observer execution evidence;
-5. define alert routing, cooldown, and suppression separately;
-6. design acknowledgement/delete/replay as a separately authorized operation;
-7. correlate aggregate receipt and duplicate health without exporting message identities.
+2. feed complete fair scanner cycles into the rolling state without identifier export;
+3. define independent per-partition cursor advancement and persistence/restart semantics;
+4. prove cross-cycle behavior on external Iggy and compose the mode-aware observer;
+5. define identifier-free telemetry and optional operational health;
+6. retain mode-aware server observer execution evidence;
+7. define alert routing, cooldown, and suppression separately;
+8. design acknowledgement/delete/replay as a separately authorized operation;
+9. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
@@ -1,0 +1,113 @@
+# Bounded physical DLQ duplicate rolling window
+
+Status: **transport-neutral rolling-window state source-complete; scanner, cursor, persistence, server integration, and runtime evidence pending**.
+
+## Purpose
+
+A fixed explicit-offset scan can classify duplicates that appear inside one scan result. It cannot relate one copy observed near the end of one cycle with another copy observed in a later cycle after the scanner advances.
+
+`DlqDuplicateRollingWindow` retains opaque duplicate observations across a bounded number of complete scan cycles. While both copies remain inside the retained window, the existing `DlqDuplicateSummary` classifier detects ordinary duplicates and conflicting payloads across cycle boundaries.
+
+The state does not move a broker cursor, connect to Iggy, poll messages, store offsets, persist itself, mutate receipts, or authorize Profiles.
+
+## Explicit bounds
+
+The caller constructs `DlqDuplicateRollingWindowPolicy` with:
+
+```text
+max_cycles
+max_observations_per_cycle
+```
+
+Both values must be positive. `max_cycles` is capped at 128, and the checked product must satisfy:
+
+```text
+max_cycles * max_observations_per_cycle <= 10000
+```
+
+The crate defines no production default for cadence, cycle count, observation count, or retention duration.
+
+## Complete-cycle semantics
+
+Each `push_cycle` call supplies one complete scan cycle of opaque `DlqDuplicateObservation` values.
+
+- empty successful cycles are valid;
+- an oversized cycle fails before state mutation;
+- the candidate window is classified before it replaces current state;
+- when cycle capacity is full, the oldest complete cycle is evicted;
+- partial-cycle eviction is not allowed.
+
+Keeping complete cycles makes the loss boundary explicit. It does not make the retained observations a complete history.
+
+## Identifier-free snapshot
+
+`DlqDuplicateRollingWindowSnapshot` exposes only:
+
+```text
+summary
+retained_cycles
+retained_observations
+evicted_cycles
+history_truncated
+```
+
+`summary` remains the existing count-only `DlqDuplicateSummary`. The snapshot exposes no UUID, payload digest, partition, offset, stream, endpoint, credential, receipt identity, timestamp, or raw error.
+
+## Cross-cycle classification
+
+The window combines all retained observations before calling `summarize_dlq_duplicates`.
+
+```text
+cycle 1: A1
+cycle 2: A2, same deterministic ID and exact bytes
+result: ordinary physical duplicate
+```
+
+```text
+cycle 1: B1
+cycle 2: B2, same deterministic ID and different exact bytes
+result: identity conflict requiring manual review
+```
+
+This relationship is preserved only while all relevant copies remain retained.
+
+## Truncation boundary
+
+After the first complete-cycle eviction:
+
+```text
+history_truncated = true
+evicted_cycles > 0
+```
+
+The flag never returns to false for that in-memory state. An identity relationship can disappear when its older copy is evicted. Therefore a truncated snapshot describes only the currently retained bounded window and is not complete history, current-tail proof, or production retention evidence.
+
+## Source contract and verification
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-rolling-window-source.json
+```
+
+Static verifier:
+
+```bash
+node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+```
+
+Focused unit scenarios cover invalid bounds, ordinary duplicates split across cycles, identity conflicts split across cycles, complete-cycle eviction, and transactional oversized-cycle rejection.
+
+## Remaining integration
+
+Scanner integration remains pending. A later reviewed slice must:
+
+1. feed one complete fair per-partition scan cycle into the state without exporting identifiers;
+2. define independent per-partition cursor advancement;
+3. choose explicit persistence or restart-reset semantics;
+4. compose the mode-aware server observer;
+5. prove cross-cycle behavior on external Iggy;
+6. publish only identifier-free telemetry or health.
+
+No current API claims moving cursors, persisted progress, restart-safe state, current-tail coverage, complete history, production retention sufficiency, or exactly-once delivery.

--- a/crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
@@ -1,0 +1,327 @@
+use std::collections::VecDeque;
+
+use thiserror::Error;
+
+use crate::dlq_duplicate_inspection::{
+    DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
+    summarize_dlq_duplicates,
+};
+
+const MAX_ROLLING_WINDOW_CYCLES: u32 = 128;
+const MAX_ROLLING_WINDOW_OBSERVATIONS: u32 = 10_000;
+
+/// Explicit memory bounds for retaining complete physical-DLQ scan cycles.
+///
+/// The checked product of `max_cycles` and `max_observations_per_cycle` must
+/// not exceed 10,000 observations. The policy defines no scan cadence,
+/// partition cursor, persistence format, or production default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlqDuplicateRollingWindowPolicy {
+    max_cycles: u32,
+    max_observations_per_cycle: u32,
+    total_observation_capacity: u32,
+}
+
+impl DlqDuplicateRollingWindowPolicy {
+    pub fn new(
+        max_cycles: u32,
+        max_observations_per_cycle: u32,
+    ) -> Result<Self, DlqDuplicateRollingWindowError> {
+        if max_cycles == 0
+            || max_cycles > MAX_ROLLING_WINDOW_CYCLES
+            || max_observations_per_cycle == 0
+        {
+            return Err(DlqDuplicateRollingWindowError::InvalidPolicy);
+        }
+
+        let total_observation_capacity = max_cycles
+            .checked_mul(max_observations_per_cycle)
+            .filter(|total| *total <= MAX_ROLLING_WINDOW_OBSERVATIONS)
+            .ok_or(DlqDuplicateRollingWindowError::InvalidPolicy)?;
+
+        Ok(Self {
+            max_cycles,
+            max_observations_per_cycle,
+            total_observation_capacity,
+        })
+    }
+
+    pub const fn max_cycles(&self) -> u32 {
+        self.max_cycles
+    }
+
+    pub const fn max_observations_per_cycle(&self) -> u32 {
+        self.max_observations_per_cycle
+    }
+
+    pub const fn total_observation_capacity(&self) -> u32 {
+        self.total_observation_capacity
+    }
+}
+
+/// Identifier-free view of one bounded rolling duplicate window.
+///
+/// `history_truncated` becomes true after any complete retained cycle is
+/// evicted. A truncated snapshot remains useful for the currently retained
+/// window but must not be presented as complete history or current-tail proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlqDuplicateRollingWindowSnapshot {
+    summary: DlqDuplicateSummary,
+    retained_cycles: u32,
+    retained_observations: u32,
+    evicted_cycles: u64,
+    history_truncated: bool,
+}
+
+impl DlqDuplicateRollingWindowSnapshot {
+    pub const fn summary(&self) -> &DlqDuplicateSummary {
+        &self.summary
+    }
+
+    pub const fn retained_cycles(&self) -> u32 {
+        self.retained_cycles
+    }
+
+    pub const fn retained_observations(&self) -> u32 {
+        self.retained_observations
+    }
+
+    pub const fn evicted_cycles(&self) -> u64 {
+        self.evicted_cycles
+    }
+
+    pub const fn history_truncated(&self) -> bool {
+        self.history_truncated
+    }
+}
+
+/// Bounded in-memory state that preserves duplicate identity relationships
+/// across complete scan cycles while they remain inside the configured window.
+///
+/// The state exposes no observation, UUID, payload digest, partition, offset,
+/// endpoint, credential, or receipt fact. It does not move or persist broker
+/// cursors. When capacity is reached, the oldest complete cycle is evicted and
+/// every later snapshot reports `history_truncated = true`.
+pub struct DlqDuplicateRollingWindow {
+    policy: DlqDuplicateRollingWindowPolicy,
+    cycles: VecDeque<Vec<DlqDuplicateObservation>>,
+    retained_observations: u32,
+    evicted_cycles: u64,
+}
+
+impl DlqDuplicateRollingWindow {
+    pub fn new(policy: DlqDuplicateRollingWindowPolicy) -> Self {
+        Self {
+            policy,
+            cycles: VecDeque::new(),
+            retained_observations: 0,
+            evicted_cycles: 0,
+        }
+    }
+
+    pub const fn policy(&self) -> DlqDuplicateRollingWindowPolicy {
+        self.policy
+    }
+
+    /// Adds one complete scan cycle transactionally.
+    ///
+    /// Empty successful cycles are retained and may eventually evict older
+    /// cycles. An oversized cycle or arithmetic/classification error leaves the
+    /// existing state unchanged.
+    pub fn push_cycle(
+        &mut self,
+        observations: impl IntoIterator<Item = DlqDuplicateObservation>,
+    ) -> Result<DlqDuplicateRollingWindowSnapshot, DlqDuplicateRollingWindowError> {
+        let maximum = self.policy.max_observations_per_cycle as usize;
+        let mut incoming = Vec::new();
+        for observation in observations {
+            if incoming.len() >= maximum {
+                return Err(DlqDuplicateRollingWindowError::CycleTooLarge);
+            }
+            incoming.push(observation);
+        }
+
+        let incoming_count = u32::try_from(incoming.len())
+            .map_err(|_| DlqDuplicateRollingWindowError::CountOverflow)?;
+        let mut candidate_cycles = self.cycles.clone();
+        let mut candidate_retained = self.retained_observations;
+        let mut candidate_evicted = self.evicted_cycles;
+
+        if candidate_cycles.len() == self.policy.max_cycles as usize {
+            let evicted = candidate_cycles
+                .pop_front()
+                .ok_or(DlqDuplicateRollingWindowError::CountOverflow)?;
+            let evicted_count = u32::try_from(evicted.len())
+                .map_err(|_| DlqDuplicateRollingWindowError::CountOverflow)?;
+            candidate_retained = candidate_retained
+                .checked_sub(evicted_count)
+                .ok_or(DlqDuplicateRollingWindowError::CountOverflow)?;
+            candidate_evicted = candidate_evicted
+                .checked_add(1)
+                .ok_or(DlqDuplicateRollingWindowError::CountOverflow)?;
+        }
+
+        candidate_retained = candidate_retained
+            .checked_add(incoming_count)
+            .filter(|count| *count <= self.policy.total_observation_capacity)
+            .ok_or(DlqDuplicateRollingWindowError::CountOverflow)?;
+        candidate_cycles.push_back(incoming);
+
+        let snapshot = summarize_window(
+            &candidate_cycles,
+            candidate_retained,
+            candidate_evicted,
+        )?;
+
+        self.cycles = candidate_cycles;
+        self.retained_observations = candidate_retained;
+        self.evicted_cycles = candidate_evicted;
+        Ok(snapshot)
+    }
+
+    pub fn snapshot(
+        &self,
+    ) -> Result<DlqDuplicateRollingWindowSnapshot, DlqDuplicateRollingWindowError> {
+        summarize_window(
+            &self.cycles,
+            self.retained_observations,
+            self.evicted_cycles,
+        )
+    }
+}
+
+fn summarize_window(
+    cycles: &VecDeque<Vec<DlqDuplicateObservation>>,
+    retained_observations: u32,
+    evicted_cycles: u64,
+) -> Result<DlqDuplicateRollingWindowSnapshot, DlqDuplicateRollingWindowError> {
+    let retained_cycles = u32::try_from(cycles.len())
+        .map_err(|_| DlqDuplicateRollingWindowError::CountOverflow)?;
+    let summary = summarize_dlq_duplicates(
+        cycles
+            .iter()
+            .flat_map(|cycle| cycle.iter().cloned()),
+    )?;
+
+    Ok(DlqDuplicateRollingWindowSnapshot {
+        summary,
+        retained_cycles,
+        retained_observations,
+        evicted_cycles,
+        history_truncated: evicted_cycles > 0,
+    })
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum DlqDuplicateRollingWindowError {
+    #[error("physical DLQ duplicate rolling-window policy is invalid")]
+    InvalidPolicy,
+    #[error("physical DLQ duplicate scan cycle exceeds its configured bound")]
+    CycleTooLarge,
+    #[error("physical DLQ duplicate rolling-window count overflow")]
+    CountOverflow,
+    #[error(transparent)]
+    Inspection(#[from] DlqDuplicateInspectionError),
+}
+
+impl DlqDuplicateRollingWindowError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidPolicy => "iggy.dlq_duplicate.rolling_window_policy_invalid",
+            Self::CycleTooLarge => "iggy.dlq_duplicate.rolling_window_cycle_too_large",
+            Self::CountOverflow => "iggy.dlq_duplicate.rolling_window_count_overflow",
+            Self::Inspection(error) => error.stable_code(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn observation(id: u128, payload: &[u8]) -> DlqDuplicateObservation {
+        DlqDuplicateObservation::from_payload(Uuid::from_u128(id), payload).unwrap()
+    }
+
+    #[test]
+    fn invalid_policy_and_capacity_overflow_fail_closed() {
+        for candidate in [
+            DlqDuplicateRollingWindowPolicy::new(0, 1),
+            DlqDuplicateRollingWindowPolicy::new(1, 0),
+            DlqDuplicateRollingWindowPolicy::new(MAX_ROLLING_WINDOW_CYCLES + 1, 1),
+            DlqDuplicateRollingWindowPolicy::new(128, 79),
+        ] {
+            let error = candidate.unwrap_err();
+            assert_eq!(error, DlqDuplicateRollingWindowError::InvalidPolicy);
+            assert_eq!(
+                error.stable_code(),
+                "iggy.dlq_duplicate.rolling_window_policy_invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_duplicate_split_across_cycles_is_detected() {
+        let policy = DlqDuplicateRollingWindowPolicy::new(2, 2).unwrap();
+        let mut window = DlqDuplicateRollingWindow::new(policy);
+
+        let first = window.push_cycle([observation(1, &[1])]).unwrap();
+        assert!(!first.summary().has_physical_duplicates());
+
+        let second = window.push_cycle([observation(1, &[1])]).unwrap();
+        assert_eq!(second.retained_cycles(), 2);
+        assert_eq!(second.retained_observations(), 2);
+        assert_eq!(second.summary().duplicate_messages(), 1);
+        assert_eq!(second.summary().duplicate_groups(), 1);
+        assert!(!second.history_truncated());
+    }
+
+    #[test]
+    fn identity_conflict_split_across_cycles_requires_manual_review() {
+        let policy = DlqDuplicateRollingWindowPolicy::new(2, 1).unwrap();
+        let mut window = DlqDuplicateRollingWindow::new(policy);
+
+        window.push_cycle([observation(7, &[1])]).unwrap();
+        let snapshot = window.push_cycle([observation(7, &[2])]).unwrap();
+
+        assert_eq!(snapshot.summary().conflicting_payload_groups(), 1);
+        assert!(snapshot.summary().has_identity_conflicts());
+        assert!(snapshot.summary().requires_manual_review());
+    }
+
+    #[test]
+    fn oldest_complete_cycle_eviction_marks_history_truncated() {
+        let policy = DlqDuplicateRollingWindowPolicy::new(2, 1).unwrap();
+        let mut window = DlqDuplicateRollingWindow::new(policy);
+
+        window.push_cycle([observation(1, &[1])]).unwrap();
+        let duplicate = window.push_cycle([observation(1, &[1])]).unwrap();
+        assert_eq!(duplicate.summary().duplicate_messages(), 1);
+
+        let truncated = window.push_cycle([observation(2, &[2])]).unwrap();
+        assert_eq!(truncated.evicted_cycles(), 1);
+        assert!(truncated.history_truncated());
+        assert_eq!(truncated.retained_cycles(), 2);
+        assert_eq!(truncated.summary().duplicate_messages(), 0);
+    }
+
+    #[test]
+    fn oversized_cycle_rejection_preserves_existing_state() {
+        let policy = DlqDuplicateRollingWindowPolicy::new(2, 1).unwrap();
+        let mut window = DlqDuplicateRollingWindow::new(policy);
+        window.push_cycle([observation(1, &[1])]).unwrap();
+        let before = window.snapshot().unwrap();
+
+        let error = window
+            .push_cycle([observation(2, &[2]), observation(3, &[3])])
+            .unwrap_err();
+        assert_eq!(error, DlqDuplicateRollingWindowError::CycleTooLarge);
+        assert_eq!(
+            error.stable_code(),
+            "iggy.dlq_duplicate.rolling_window_cycle_too_large"
+        );
+        assert_eq!(window.snapshot().unwrap(), before);
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -70,6 +70,7 @@ pub mod dlq_duplicate_alert_runtime;
 #[cfg(feature = "iggy")]
 pub mod dlq_duplicate_external_scan;
 pub mod dlq_duplicate_inspection;
+pub mod dlq_duplicate_rolling_window;
 #[cfg(feature = "iggy")]
 mod dlq_publisher;
 pub mod health;
@@ -119,6 +120,10 @@ pub use dlq_duplicate_external_scan::{
 pub use dlq_duplicate_inspection::{
     DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
     summarize_dlq_duplicates,
+};
+pub use dlq_duplicate_rolling_window::{
+    DlqDuplicateRollingWindow, DlqDuplicateRollingWindowError,
+    DlqDuplicateRollingWindowPolicy, DlqDuplicateRollingWindowSnapshot,
 };
 pub use health::{HealthCheckResult, HealthStatus, health_check};
 pub use partitioning::{calculate_partition, partition_key};

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -92,13 +92,18 @@ mutation retry.
   canonical privacy-safe projections; one exact Rust case must report a
   sufficient assessment from a clean unchanged commit before a no-clobber packet
   can be published.
+- A bounded physical-DLQ rolling window is source-complete. It retains opaque
+  observations across complete scan cycles under a checked 10,000-observation
+  cap, detects ordinary and conflicting duplicates split across retained cycles,
+  rejects oversized cycles transactionally, and reports permanent truncation
+  after complete-cycle eviction.
 - Canonical retained packets remain pending and must omit credentials and
   delivery-level facts, bind reviewed source/configuration/input digests, and
   become stale when any bound source or reviewed input changes.
 
 ## Physical DLQ duplicate inspection
 
-Two bounded policies are source-complete:
+Two bounded scanner policies are source-complete:
 
 - `global_budget`: one ordered partition allowlist and one shared cap. A busy
   early partition may prevent later partitions from being polled.
@@ -116,10 +121,12 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES=<positive cap>
 ```
 
 `memory` and `outbox_local` remain intentional not-applicable modes and do not
-resolve Iggy. Both policies use explicit offsets and `auto_commit=false`. Every
-observer cycle reuses the configured start offset; neither policy owns moving
-cursors, stored progress, cross-cycle duplicate state, current-tail coverage, or
-complete-history semantics.
+resolve Iggy. Both scanner policies use explicit offsets and `auto_commit=false`.
+The current observer still reuses one configured start offset and does not own
+moving cursors, stored progress, current-tail coverage, or complete-history
+semantics. The separate rolling state can preserve relationships across complete
+cycles supplied by a future scanner integration, but it does not move or persist
+a cursor itself.
 
 ### Production partition invariant
 
@@ -208,16 +215,49 @@ payloads, or raw output. Publication is no-clobber.
 
 Runtime calibration and the canonical packet remain pending.
 
+### Bounded rolling duplicate window
+
+Source-complete paths:
+
+```text
+crates/rustok-iggy/src/
+  dlq_duplicate_rolling_window.rs
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-rolling-window-source.json
+scripts/verify/
+  verify-iggy-dlq-duplicate-rolling-window.mjs
+crates/rustok-iggy/docs/
+  dlq-duplicate-rolling-window.md
+crates/rustok-profiles/docs/
+  poison-duplicate-rolling-window-checkpoint.md
+```
+
+`DlqDuplicateRollingWindowPolicy` requires positive explicit cycle and per-cycle
+bounds, caps cycle count at 128, and requires their checked product not to exceed
+10,000 observations. No production default is embedded.
+
+`DlqDuplicateRollingWindow` retains complete cycles and combines all retained
+opaque observations before count-only classification. An oversized cycle leaves
+existing state unchanged. At capacity the oldest complete cycle is evicted, and
+all later snapshots report `history_truncated = true`; an evicted relationship
+may disappear, so the result is never complete-history or current-tail proof.
+
+Scanner collection, independent per-partition cursor advancement, persistence or
+restart-reset semantics, mode-aware server composition, and external-Iggy
+cross-cycle runtime evidence remain pending.
+
 Detailed checkpoints:
 
 - `crates/rustok-profiles/docs/poison-duplicate-external-scan-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-fair-window-external-runtime-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md`
+- `crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
 - `crates/rustok-iggy/docs/dedup-recovery-window-policy.md`
+- `crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md`
 
 ## Results and next work
 
@@ -264,10 +304,11 @@ Detailed checkpoints:
    no-clobber packet; and repeat whenever a bound source, configuration, or input
    changes. A packet covers only that supplied model.
 
-10. **Design moving duplicate windows or keep fixed snapshots.**
-    A moving per-partition cursor must retain bounded prior identity/digest state
-    so copies split across cycles remain related. Fixed snapshots must not be
-    presented as current-tail or complete-history evidence.
+10. **Integrate the bounded rolling duplicate window.**
+    Feed complete fair scanner cycles without exporting identifiers, define
+    independent per-partition cursor advancement, choose persistence or explicit
+    restart-reset semantics, compose the mode-aware observer, and retain real
+    cross-cycle Iggy evidence. Truncated state must remain visibly incomplete.
 
 11. **Retain production operations.**
     Prove bundled mode, restart, TLS/auth/failover, reconnect, rebalance,
@@ -276,27 +317,25 @@ Detailed checkpoints:
 
 ## Recheck checkpoint — 2026-07-29
 
-- Rechecked the canonical plan and current `main` after the recovery-window
-  policy merge.
+- Rechecked the canonical plan and current `main` after the retained
+  recovery-window calibration tooling merge.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
 - Reconfirmed deterministic same-ID colocation and the production-reachable
   fair/global comparison.
-- Rechecked the external-Iggy dedup cases and confirmed that immediate,
-  capacity, and expiry sequences do not establish a production recovery window.
-- Reconfirmed the pure fail-closed recovery-window policy and added a locked
-  retained-calibration path around reviewed bounds and reviewed enabled Iggy
-  configuration.
-- Added one exact opt-in Rust calibration case, strict skip rejection, checked
-  reviewed-input projections and digests, current source hashes, clean-commit
-  requirements, a sufficient-only gate, and no-clobber packet publication.
-- Kept active configuration readback, correctness of the operator capacity
-  basis, runtime execution, canonical retained packets, moving-window state,
-  bundled/TLS/auth, failover, and multi-replica claims open.
-- Tests, Cargo commands, repository source verifiers, retained capture,
-  external/bundled Iggy, and multi-replica scenarios were not run per maintainer
-  instruction.
+- Rechecked the fixed scanner APIs and confirmed that returning one already
+  aggregated summary cannot preserve a duplicate relationship split across
+  advancing scan cycles.
+- Added a pure bounded complete-cycle rolling state with checked memory limits,
+  transactional oversized-cycle rejection, cross-cycle ordinary/conflicting
+  classification, complete-cycle eviction, and permanent truncation metadata.
+- Kept scanner observation feeding, per-partition cursor advancement, state
+  persistence/restart semantics, server composition, external runtime evidence,
+  telemetry/health, bundled/TLS/auth, failover, and multi-replica claims open.
+- Tests, Cargo commands, formatters, repository source verifiers, broker scans,
+  server observers, retained capture, and multi-replica scenarios were not run
+  per maintainer instruction.
 
 ## Verification backlog
 
@@ -306,6 +345,8 @@ cargo xtask module test profiles
 cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
+cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
+node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
 cargo test -p rustok-iggy --test dedup_recovery_window_calibration
 node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -338,7 +379,7 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
 3. Public GraphQL/storefront reads use the canonical visibility matrix.
 4. Presentation consumers use `ProfilePresentationService`; raw readers remain
    internal.
-5. `followers_only` resolves through bounded fail-closed Social Graph owner ports.
+5. `followers_only` resolves through bounded fail-closed Social Graph ports.
 6. Profile media resolves through Media owner ports only.
 7. Follow controls use owner ports, unique idempotency, optimistic revision, and
    no automatic retry.
@@ -358,7 +399,10 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
     one-based modulo partition rule.
 15. Retained evidence is no-clobber, commit-bound, and stale after any bound
     source or reviewed input change.
-16. Moving duplicate windows require bounded cross-cycle identity state.
-17. A sufficient recovery-window assessment covers only the supplied reviewed
+16. Cross-cycle duplicate state must be explicitly bounded and retain complete
+    cycles; partial silent eviction is forbidden.
+17. Any cycle eviction permanently marks the in-memory history truncated, and a
+    truncated snapshot is never current-tail or complete-history evidence.
+18. A sufficient recovery-window assessment covers only the supplied reviewed
     model and never authorizes Profiles or proves exactly-once.
-18. Update Profiles and affected owner docs with every boundary change.
+19. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **classifier, bounded scanner, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; runtime execution and telemetry/health projection pending**.
+Status: **classifier, bounded scanner, bounded rolling state, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; scanner/cursor integration, runtime execution, and telemetry/health projection pending**.
 
 ## Why this matters for Profiles
 
@@ -8,14 +8,16 @@ Profiles authorization remains independent of broker and receipt state. Downstre
 
 - one durable neutral result with one physical DLQ copy;
 - one durable neutral result with repeated identical physical copies;
-- one deterministic DLQ ID associated with conflicting exact bytes.
+- one deterministic DLQ ID associated with conflicting exact bytes;
+- copies of the same physical duplicate observed in adjacent retained scan cycles.
 
-The Iggy-owned classifier exposes this distinction without message identities or payloads. The bounded scanner supplies observations through explicit-offset polling without storing progress. The alert policy evaluates only the count-only summary. The latest-value runtime and server observer publish only identifier-free operational state. None becomes a Profiles authorization input.
+The Iggy-owned classifier exposes these distinctions without message identities or payloads. The bounded scanner supplies observations through explicit-offset polling without storing progress. The rolling state can preserve opaque relationships across complete retained cycles. The alert policy evaluates only the count-only summary. The latest-value runtime and server observer publish only identifier-free operational state. None becomes a Profiles authorization input.
 
 ## Owner boundaries
 
 ```text
 classifier:      crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+rolling state:   crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
 scanner:         crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
 policy:          crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
 runtime:         crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
@@ -27,6 +29,7 @@ Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
@@ -37,6 +40,7 @@ Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
@@ -54,6 +58,15 @@ duplicate_messages
 duplicate_groups
 conflicting_payload_groups
 max_copies_per_message_id
+```
+
+The rolling snapshot adds only:
+
+```text
+retained_cycles
+retained_observations
+evicted_cycles
+history_truncated
 ```
 
 The policy evaluation exposes only:
@@ -95,13 +108,27 @@ explicit offset
 auto_commit = false
 ```
 
-It accepts no more than 128 unique positive partitions, 10,000 physical messages globally, and batches of 1,000. It validates returned partition/count and monotonic offsets before returning only `DlqDuplicateSummary`.
+Global mode accepts no more than 128 unique positive partitions, 10,000 physical messages total, and batches of 1,000. Fair mode gives every selected partition one equal cap under the same checked 10,000-message total.
 
-The server observer places every configured domain partition into the request allowlist, but the scanner has one global message budget across the ordered list. An earlier busy partition may exhaust that budget before later partitions are polled. No fairness or complete-partition claim is made.
-
-Each polling cycle reuses the same configured explicit start offset. The current observer therefore measures a repeated bounded window; it does not own a moving cursor, tail coverage, or complete-history semantics. A future per-partition budget or moving-window policy requires a separate source contract.
+Each current polling cycle reuses the configured explicit start offset. The observer therefore still measures a repeated bounded snapshot and does not own a moving cursor, tail coverage, or complete-history semantics.
 
 The scanner does not use a consumer group, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
+
+## Bounded cross-cycle state
+
+`DlqDuplicateRollingWindowPolicy` requires explicit positive `max_cycles` and `max_observations_per_cycle`. Cycle count is capped at 128 and their checked product cannot exceed 10,000. No production default is provided.
+
+`push_cycle` accepts one complete cycle of opaque observations. It detects ordinary and conflicting duplicates split across retained cycles. Oversized input fails without changing the current state.
+
+When cycle capacity is reached, the oldest complete cycle is evicted. Partial-cycle eviction is forbidden. Every later snapshot reports:
+
+```text
+history_truncated = true
+```
+
+An evicted old copy can remove a relationship from the retained summary. The snapshot therefore represents only the bounded retained window and is not current-tail or complete-history evidence.
+
+The state does not connect to Iggy, move or store cursors, persist itself, define restart recovery, compose the server observer, or register telemetry. Those remain separate owners and follow-up evidence.
 
 ## Alert policy boundary
 
@@ -141,24 +168,15 @@ outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
 ```
 
-For `memory` and `outbox_local`, absence of Iggy is expected platform behavior:
+For `memory` and `outbox_local`, absence of Iggy is expected platform behavior. For `outbox_iggy`, the observer reuses the active transport configuration and opens only a separate read-only SDK client. Observer-specific startup, connection, scan, and shutdown failures are non-fatal to event delivery and module projection.
 
-- no shared `IggyTransport` is requested;
-- no broker client is opened;
-- no alert thresholds are required;
-- not-applicable state is not an error, readiness failure, or Profiles degradation.
-
-For `outbox_iggy`, the observer reuses the exact active transport configuration and opens only a separate read-only SDK client. Bundled mode connects to the existing validated loopback broker; external mode uses the reviewed address list. A missing active Iggy mode fails closed instead of being guessed.
-
-Observer-specific startup failures are non-fatal: invalid configuration or missing observer dependencies produce `Unavailable`, log a stable code, and return success to application bootstrap. Connection failure, scan failure, and shutdown publish unavailable state while event delivery and module projection remain active.
-
-The observer does not create a second transport, start or stop a bundled process, commit offsets, or dispatch notifications.
+The source-complete rolling state is not yet composed into this observer. No second transport, persisted cursor, notification dispatch, or readiness dependency is introduced.
 
 ## Runtime and retained status
 
-The external-Iggy harness and retained execution tooling are source-complete. The harness creates controlled ordinary-duplicate and identity-conflict fixtures through production publication, scans the same explicit offset twice, and requires no stored consumer offset before or after either scan.
+The external-Iggy harness and retained execution tooling are source-complete. The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run.
 
-The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run. The mode-aware server observer is source-complete; telemetry, optional operational health, moving-window/fairness policy, and retained server execution evidence remain pending.
+The rolling state is source-complete as a transport-neutral component. Scanner observation feeding, independent per-partition cursor advancement, persistence/restart semantics, cross-cycle external-Iggy evidence, mode-aware composition, telemetry, and optional operational health remain pending.
 
 ## Relationship to receipt health
 
@@ -173,6 +191,7 @@ No profile visibility, relationship, block, mute, follow, friendship, audience, 
 - event delivery profile or Iggy deployment mode;
 - observer startup, applicability, availability, or generation;
 - partition ordering, fairness, fixed-window selection, or budget exhaustion;
+- rolling retention or eviction state, including `history_truncated`;
 - physical DLQ copy or duplicate-group counts;
 - identity-conflict presence;
 - alert level or threshold flags;
@@ -186,11 +205,13 @@ Profiles presentation continues to consume authorized owner-port results. These 
 ## Remaining work
 
 1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. define partition fairness/per-partition budgets and a moving-window or per-partition cursor policy;
-3. define identifier-free telemetry and optional operational health without readiness coupling;
-4. retain mode-aware server observer execution evidence;
-5. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
-6. define acknowledgement/delete/replay separately with explicit authorization;
-7. keep aggregate receipt and duplicate observations identifier-free.
+2. feed complete fair scanner cycles into rolling state without identifier export;
+3. define independent per-partition cursor advancement and persistence/restart semantics;
+4. prove cross-cycle behavior on external Iggy and compose the mode-aware observer;
+5. define identifier-free telemetry and optional operational health without readiness coupling;
+6. retain mode-aware server observer execution evidence;
+7. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
+8. define acknowledgement/delete/replay separately with explicit authorization;
+9. keep aggregate receipt and duplicate observations identifier-free.
 
 Tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
@@ -1,0 +1,93 @@
+# Profiles checkpoint: bounded physical DLQ duplicate rolling window
+
+Status: **cross-cycle rolling-window state source-complete; scanner/cursor integration and runtime evidence pending**.
+
+## Why this belongs in the Profiles improvement trail
+
+Profiles never authorizes presentation from broker, receipt, metric, evidence, or duplicate-inspection state. However, downstream processing reliability must not hide a physical duplicate merely because its copies were observed in adjacent scan cycles.
+
+The existing fixed scans classify one bounded result. `DlqDuplicateRollingWindow` adds bounded cross-cycle identity retention without exporting message identity or turning operational state into profile policy.
+
+## Delivered source boundary
+
+Owner source:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+```
+
+Public API:
+
+```text
+DlqDuplicateRollingWindowPolicy
+DlqDuplicateRollingWindow
+DlqDuplicateRollingWindowSnapshot
+DlqDuplicateRollingWindowError
+```
+
+Machine contract:
+
+```text
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-rolling-window-source.json
+```
+
+Verifier:
+
+```text
+scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+```
+
+Owner guide:
+
+```text
+crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
+```
+
+## Bounded semantics
+
+The caller explicitly supplies a positive cycle count and positive per-cycle observation bound. Their checked product cannot exceed 10,000, and no production default is provided.
+
+One successful `push_cycle` represents one complete scan cycle. The state:
+
+- detects an ordinary duplicate split across retained cycles;
+- detects conflicting exact bytes for one deterministic ID split across retained cycles;
+- rejects an oversized cycle without changing prior state;
+- evicts only the oldest complete cycle;
+- exposes only aggregate summary and retention counts.
+
+## Truncation boundary
+
+After an eviction, every snapshot reports:
+
+```text
+history_truncated = true
+```
+
+An older copy may have been removed, so a later retained summary may no longer show the original duplicate relationship. The snapshot is therefore not complete history, current-tail proof, or evidence that production retention is sufficient.
+
+## Profiles authorization boundary
+
+Profiles never authorizes visibility, `followers_only`, follow controls, search inclusion, storefront presentation, GraphQL output, or author cards from:
+
+- rolling-window summary counts;
+- retained or evicted cycle counts;
+- `history_truncated`;
+- scan cadence or cursor position;
+- Iggy deployment mode;
+- receipt state or retained evidence.
+
+Privacy remains resolved through authoritative owner ports before localized and Media-backed presentation. Operational state remains operational only.
+
+## Remaining integration
+
+The source-complete state deliberately does not yet define:
+
+1. how the Iggy scanner feeds one complete cycle without identifier export;
+2. how each physical partition advances its cursor;
+3. whether state is persisted or reset on restart;
+4. how mode-aware server composition uses the rolling window;
+5. external-Iggy cross-cycle runtime evidence;
+6. identifier-free telemetry and health projection.
+
+Tests, Cargo commands, formatters, source verifiers, broker scans, server composition, telemetry registration, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
@@ -179,7 +179,7 @@ for (const marker of [
   "cycles: VecDeque<Vec<DlqDuplicateObservation>>",
   "pub fn push_cycle(",
   "let mut candidate_cycles = self.cycles.clone();",
-  "candidate_cycles.pop_front()",
+  ".pop_front()",
   "candidate_cycles.push_back(incoming);",
   "self.cycles = candidate_cycles;",
   "flat_map(|cycle| cycle.iter().cloned())",

--- a/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs";
+const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const documentationPath = "crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md";
+const profilesCheckpointPath =
+  "crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md";
+const verifierPath = "scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs";
+
+const expectedExports = [
+  "DlqDuplicateRollingWindowPolicy",
+  "DlqDuplicateRollingWindow",
+  "DlqDuplicateRollingWindowSnapshot",
+  "DlqDuplicateRollingWindowError",
+];
+const expectedSnapshotFields = [
+  "summary",
+  "retained_cycles",
+  "retained_observations",
+  "evicted_cycles",
+  "history_truncated",
+];
+const expectedTests = [
+  "invalid_policy_and_capacity_overflow_fail_closed",
+  "ordinary_duplicate_split_across_cycles_is_detected",
+  "identity_conflict_split_across_cycles_requires_manual_review",
+  "oldest_complete_cycle_eviction_marks_history_truncated",
+  "oversized_cycle_rejection_preserves_existing_state",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
+const profilesCheckpoint = readFileSync(
+  resolve(repoRoot, profilesCheckpointPath),
+  "utf8",
+);
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-rolling-window-source" ||
+  contract.status !== "source_complete_scanner_integration_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.source !== sourcePath ||
+  contract.classifier_source !== classifierPath ||
+  contract.verifier !== verifierPath ||
+  contract.documentation !== documentationPath ||
+  contract.profiles_checkpoint !== profilesCheckpointPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("DLQ duplicate rolling-window contract identity or status drift");
+}
+if (!same(contract.public_exports, expectedExports)) {
+  fail("DLQ duplicate rolling-window public export allowlist drift");
+}
+if (!same(contract.snapshot_fields, expectedSnapshotFields)) {
+  fail("DLQ duplicate rolling-window snapshot field allowlist drift");
+}
+if (!same(contract.required_source_tests, expectedTests)) {
+  fail("DLQ duplicate rolling-window focused test allowlist drift");
+}
+
+if (
+  contract.bounds?.max_cycles_upper_bound !== 128 ||
+  contract.bounds?.total_observation_capacity_upper_bound !== 10000 ||
+  contract.bounds?.max_cycles_positive !== true ||
+  contract.bounds?.max_observations_per_cycle_positive !== true ||
+  contract.bounds?.checked_product_required !== true ||
+  contract.bounds?.production_defaults !== false
+) {
+  fail("DLQ duplicate rolling-window bound contract drift");
+}
+if (
+  contract.cycle_semantics?.input !==
+    "one_complete_scan_cycle_of_opaque_duplicate_observations" ||
+  contract.cycle_semantics?.empty_cycle_valid !== true ||
+  contract.cycle_semantics?.oversized_cycle_rejected_transactionally !== true ||
+  contract.cycle_semantics?.oldest_complete_cycle_evicted_at_capacity !== true ||
+  contract.cycle_semantics?.duplicate_relationship_retained_across_cycles_while_present !==
+    true ||
+  contract.cycle_semantics?.identity_conflict_retained_across_cycles_while_present !==
+    true ||
+  contract.cycle_semantics?.partial_cycle_eviction !== false
+) {
+  fail("DLQ duplicate rolling-window cycle semantics drift");
+}
+if (
+  contract.truncation_semantics?.history_truncated_after_first_eviction !== true ||
+  contract.truncation_semantics?.truncated_snapshot_is_complete_history !== false ||
+  contract.truncation_semantics?.truncated_snapshot_is_current_tail !== false ||
+  contract.truncation_semantics?.evicted_identity_relationship_can_be_lost !== true
+) {
+  fail("DLQ duplicate rolling-window truncation semantics drift");
+}
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`rolling-window external operation became allowed: ${operation}`);
+}
+if (
+  contract.privacy_boundary?.observations_not_exported_from_state !== true ||
+  contract.privacy_boundary?.identifier_free_snapshot !== true ||
+  contract.privacy_boundary?.payload_free_snapshot !== true
+) {
+  fail("DLQ duplicate rolling-window privacy flags drift");
+}
+
+const requiredExcluded = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "error_code",
+  "publisher_identity",
+  "timestamp",
+  "credential",
+]);
+for (const field of contract.privacy_boundary?.snapshot_excludes ?? []) {
+  requiredExcluded.delete(field);
+}
+if (requiredExcluded.size > 0) {
+  fail(`rolling-window privacy exclusions are incomplete: ${[...requiredExcluded].join(", ")}`);
+}
+
+if (
+  !same(contract.stable_errors, {
+    invalid_policy: "iggy.dlq_duplicate.rolling_window_policy_invalid",
+    cycle_too_large: "iggy.dlq_duplicate.rolling_window_cycle_too_large",
+    count_overflow: "iggy.dlq_duplicate.rolling_window_count_overflow",
+  })
+) {
+  fail("DLQ duplicate rolling-window stable error codes drift");
+}
+
+for (const marker of [
+  "const MAX_ROLLING_WINDOW_CYCLES: u32 = 128;",
+  "const MAX_ROLLING_WINDOW_OBSERVATIONS: u32 = 10_000;",
+  "pub struct DlqDuplicateRollingWindowPolicy",
+  ".checked_mul(max_observations_per_cycle)",
+  ".filter(|total| *total <= MAX_ROLLING_WINDOW_OBSERVATIONS)",
+  "pub struct DlqDuplicateRollingWindowSnapshot",
+  "pub const fn history_truncated(&self) -> bool",
+  "pub struct DlqDuplicateRollingWindow {",
+  "cycles: VecDeque<Vec<DlqDuplicateObservation>>",
+  "pub fn push_cycle(",
+  "let mut candidate_cycles = self.cycles.clone();",
+  "candidate_cycles.pop_front()",
+  "candidate_cycles.push_back(incoming);",
+  "self.cycles = candidate_cycles;",
+  "flat_map(|cycle| cycle.iter().cloned())",
+  "history_truncated: evicted_cycles > 0",
+  "pub enum DlqDuplicateRollingWindowError",
+  'Self::InvalidPolicy => "iggy.dlq_duplicate.rolling_window_policy_invalid"',
+  'Self::CycleTooLarge => "iggy.dlq_duplicate.rolling_window_cycle_too_large"',
+  'Self::CountOverflow => "iggy.dlq_duplicate.rolling_window_count_overflow"',
+]) {
+  requireText("DLQ duplicate rolling-window source", source, marker);
+}
+for (const testName of expectedTests) {
+  requireText("DLQ duplicate rolling-window tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("DLQ duplicate rolling-window source must contain exactly five focused unit tests");
+}
+
+for (const marker of [
+  "IggyClient",
+  "IggyTransport",
+  "ConsumerPoisonReceipt",
+  "Serialize",
+  "Deserialize",
+  ".connect(",
+  ".poll_messages(",
+  ".move_to_dlq(",
+  ".acknowledge(",
+  ".delete(",
+  ".purge(",
+  ".replay(",
+  ".retry_entry(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  "pub cycles:",
+  "pub broker_message_id:",
+  "pub payload_sha256:",
+]) {
+  forbidText("DLQ duplicate rolling-window source", source, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateObservation",
+  "pub struct DlqDuplicateSummary",
+  "pub fn summarize_dlq_duplicates(",
+  "same exact bytes are ordinary physical copies",
+]) {
+  requireText("DLQ duplicate classifier", classifier, marker);
+}
+requireText(
+  "rustok-iggy module list",
+  lib,
+  "pub mod dlq_duplicate_rolling_window;",
+);
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+for (const marker of [
+  "complete scan cycles",
+  "history_truncated",
+  "does not move a broker cursor",
+  "not complete history",
+  "scanner integration remains pending",
+]) {
+  requireText("DLQ duplicate rolling-window documentation", documentation, marker);
+}
+for (const marker of [
+  "Profiles never authorizes",
+  "cross-cycle",
+  "history_truncated",
+  "per-partition cursor",
+  "source-complete",
+]) {
+  requireText("Profiles rolling-window checkpoint", profilesCheckpoint, marker);
+}
+
+const requiredRemaining = new Set([
+  "feed_complete_scanner_cycles_without_identifier_export",
+  "define_per_partition_cursor_advancement",
+  "define_state_persistence_or_restart_reset_semantics",
+  "compose_mode_aware_server_observer",
+  "retain_external_iggy_cross_cycle_runtime_evidence",
+  "define_identifier_free_telemetry_and_health_projection",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`DLQ duplicate rolling-window remaining work drift: ${[
+    ...requiredRemaining,
+  ].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy DLQ duplicate rolling-window verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy DLQ duplicate rolling-window source verified: explicit checked memory bounds, complete-cycle retention and eviction, transactional oversized-cycle rejection, cross-cycle ordinary/conflicting duplicate classification, identifier-free truncation metadata, no broker/receipt access, and explicit moving-cursor/current-tail/complete-history non-claims are locked; scanner, cursor, persistence, server, and runtime evidence integration remain pending.",
+);


### PR DESCRIPTION
## Summary

- add a transport-neutral `DlqDuplicateRollingWindow` for bounded cross-cycle physical-DLQ classification
- require explicit positive cycle and per-cycle observation bounds with checked total capacity `<= 10000`
- retain complete cycles only and evict the oldest complete cycle at capacity
- detect ordinary duplicates and conflicting payloads split across retained scan cycles
- reject an oversized incoming cycle transactionally without changing existing state
- expose only count-only summary plus retained/evicted cycle counts and `history_truncated`
- publish stable fail-closed error codes and five focused unit scenarios
- add a source contract, static verifier, Iggy owner guide, Profiles checkpoint, and actualized canonical Profiles plan
- link the rolling source into the aggregate duplicate-inspection contract
- fix the pre-existing aggregate contract/verifier drift for `moving_window_or_per_partition_cursor_policy`

## Recheck findings

The current global and fair scanner APIs return an already aggregated `DlqDuplicateSummary`. That is correct for one fixed snapshot but cannot preserve a relationship when one physical copy appears in one advancing cycle and another copy appears in a later cycle.

This PR adds only the bounded transport-neutral state needed for that relationship. It deliberately does not change scanner polling, offsets, server lifecycle, or alert delivery.

## Bounded semantics

- `max_cycles <= 128`
- `max_cycles * max_observations_per_cycle <= 10000`
- no production defaults
- empty successful cycles are valid
- partial-cycle eviction is forbidden
- state replacement occurs only after candidate classification succeeds
- after the first eviction, `history_truncated` remains true
- an evicted old copy may remove a previously visible relationship

## Privacy and safety boundary

The snapshot excludes broker endpoints, stream/topic/partition/offset coordinates, UUIDs, payloads/digests, receipt identities, publisher identities, credentials, timestamps, and raw errors.

The rolling state does not:

- connect to Iggy or poll messages
- move or store a broker cursor
- serialize or persist itself
- mutate receipts, offsets, topology, or DLQ entries
- acknowledge, publish, delete, purge, retry, or replay
- authorize Profiles or Social Graph behavior

## Deliberate non-claims

- no moving cursor yet
- no persisted progress or restart-safe state
- no current-tail or complete-history coverage
- no production retention-sufficiency claim
- no scanner or mode-aware server integration
- no external-Iggy cross-cycle execution evidence
- no exactly-once claim

## Verification

Per maintainer instruction, tests, Cargo commands, formatters, repository source verifiers, broker scans, server observers, telemetry registration, and retained capture were not run.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
cargo xtask module validate profiles
cargo xtask module test profiles
```
