### PR TITLE
feat(product): add catalog gRPC transport adapter

### DIFF
--- a/crates/rustok-product-transport/Cargo.toml
+++ b/crates/rustok-product-transport/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rustok-product-transport"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Typed gRPC transport adapter for the RusToK Product catalog read port"
+
+[dependencies]
+async-trait.workspace = true
+bytes = "1.0"
+prost.workspace = true
+rustok-api.workspace = true
+rustok-product.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }
+tonic-prost.workspace = true
+
+[build-dependencies]
+protoc-bin-vendored.workspace = true
+tonic-prost-build.workspace = true
+
+[dev-dependencies]
+chrono.workspace = true
+tokio.workspace = true
+tokio-stream = { version = "0.1", features = ["net"] }
+uuid.workspace = true

--- a/crates/rustok-product-transport/README.md
+++ b/crates/rustok-product-transport/README.md
@@ -1,0 +1,27 @@
+# rustok-product-transport
+
+Typed tonic gRPC framing for the Product-owned `ProductCatalogReadPort`.
+
+## Public surface
+
+- `GrpcProductCatalogReadProvider` implements the owner port for consumers.
+- `ProductCatalogGrpcService<P>` exposes an owner-port provider over gRPC.
+- `TrustedProductCatalogAuthority` carries interceptor-authenticated tenant and principal authority.
+- `ProductCatalogGrpcOperation` declares the three authorized read operations.
+- Generated `ProductCatalogReadService` protobuf types define RPC framing only.
+
+## Boundary
+
+This crate owns protobuf/tonic framing, transport deadlines, gRPC status mapping, and trusted-authority adaptation. It does not own Product DTOs, catalog policy, persistence, locale/channel semantics, fallback decisions, or consumer composition.
+
+Protobuf frames JSON-serialized Product-owned request/response types and `rustok_api::PortContext`. The server verifies the claimed tenant against interceptor authority and replaces untrusted actor, claims, and roles before invoking the owner port. Structured `PortError` values are carried in gRPC status details.
+
+## Evidence
+
+The loopback conformance harness covers all three owner operations, typed not-found details, deadline-required semantics, and trusted actor replacement:
+
+```bash
+cargo test -p rustok-product-transport --test port_conformance
+```
+
+The implementation agent does not claim this command was executed. Until retained execution evidence exists and a production external profile is wired, Product remains `boundary_ready`.

--- a/crates/rustok-product-transport/build.rs
+++ b/crates/rustok-product-transport/build.rs
@@ -1,0 +1,12 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // Build generated code reproducibly without requiring a host Protobuf install.
+    unsafe {
+        std::env::set_var("PROTOC", protoc);
+    }
+    tonic_prost_build::configure().compile_protos(
+        &["proto/rustok/product/product_catalog.proto"],
+        &["proto"],
+    )?;
+    Ok(())
+}

--- a/crates/rustok-product-transport/proto/rustok/product/product_catalog.proto
+++ b/crates/rustok-product-transport/proto/rustok/product/product_catalog.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package rustok.product;
+
+// Product owns canonical request/response DTOs. Protobuf owns RPC identity,
+// framing, deadlines, and status semantics; JSON preserves the owner contract.
+service ProductCatalogReadService {
+  rpc ReadProductProjection(JsonRequest) returns (JsonResponse);
+  rpc ReadVariantProductProjection(JsonRequest) returns (JsonResponse);
+  rpc ListPublishedProducts(JsonRequest) returns (JsonResponse);
+}
+
+message JsonRequest {
+  bytes context_json = 1;
+  bytes input_json = 2;
+}
+
+message JsonResponse {
+  bytes output_json = 1;
+}

--- a/crates/rustok-product-transport/src/client.rs
+++ b/crates/rustok-product-transport/src/client.rs
@@ -1,0 +1,174 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError, PortErrorKind};
+use rustok_product::{
+    ProductCatalogReadPort, ProductProjectionRequest, PublishedProductsRequest,
+    StorefrontProductList, VariantProductProjectionRequest,
+    dto::ProductResponse,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tonic::{Code, Request, Status};
+
+use crate::proto::JsonRequest;
+use crate::proto::product_catalog_read_service_client::ProductCatalogReadServiceClient;
+
+/// Consumer-side gRPC adapter implementing the Product-owned catalog read port.
+pub struct GrpcProductCatalogReadProvider {
+    client: ProductCatalogReadServiceClient<Channel>,
+}
+
+impl GrpcProductCatalogReadProvider {
+    pub fn from_channel(channel: Channel) -> Self {
+        Self {
+            client: ProductCatalogReadServiceClient::new(channel),
+        }
+    }
+
+    pub async fn connect(endpoint: Endpoint) -> Result<Self, tonic::transport::Error> {
+        Ok(Self::from_channel(endpoint.connect().await?))
+    }
+
+    pub async fn connect_with_tls(
+        endpoint: Endpoint,
+        tls_config: ClientTlsConfig,
+    ) -> Result<Self, tonic::transport::Error> {
+        Ok(Self::from_channel(
+            endpoint.tls_config(tls_config)?.connect().await?,
+        ))
+    }
+}
+
+#[async_trait]
+impl ProductCatalogReadPort for GrpcProductCatalogReadProvider {
+    async fn read_product_projection(
+        &self,
+        context: PortContext,
+        request: ProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        let payload = JsonRequest {
+            context_json: encode(&context)?,
+            input_json: encode(&request)?,
+        };
+        let response = self
+            .client
+            .clone()
+            .read_product_projection(with_deadline(payload, &context))
+            .await
+            .map_err(status_to_port_error)?
+            .into_inner();
+        decode(&response.output_json)
+    }
+
+    async fn read_variant_product_projection(
+        &self,
+        context: PortContext,
+        request: VariantProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        let payload = JsonRequest {
+            context_json: encode(&context)?,
+            input_json: encode(&request)?,
+        };
+        let response = self
+            .client
+            .clone()
+            .read_variant_product_projection(with_deadline(payload, &context))
+            .await
+            .map_err(status_to_port_error)?
+            .into_inner();
+        decode(&response.output_json)
+    }
+
+    async fn list_published_products(
+        &self,
+        context: PortContext,
+        request: PublishedProductsRequest,
+    ) -> Result<StorefrontProductList, PortError> {
+        let payload = JsonRequest {
+            context_json: encode(&context)?,
+            input_json: encode(&request)?,
+        };
+        let response = self
+            .client
+            .clone()
+            .list_published_products(with_deadline(payload, &context))
+            .await
+            .map_err(status_to_port_error)?
+            .into_inner();
+        decode(&response.output_json)
+    }
+}
+
+fn with_deadline<T>(payload: T, context: &PortContext) -> Request<T> {
+    let mut request = Request::new(payload);
+    if let Some(deadline_ms) = context.deadline_ms.filter(|deadline| *deadline > 0) {
+        request.set_timeout(Duration::from_millis(deadline_ms));
+    }
+    request
+}
+
+fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, PortError> {
+    serde_json::to_vec(value).map_err(|error| {
+        PortError::invariant_violation("product.transport_encode", error.to_string())
+    })
+}
+
+fn decode<T: DeserializeOwned>(value: &[u8]) -> Result<T, PortError> {
+    serde_json::from_slice(value).map_err(|error| {
+        PortError::invariant_violation("product.transport_decode", error.to_string())
+    })
+}
+
+fn status_to_port_error(status: Status) -> PortError {
+    if !status.details().is_empty()
+        && let Ok(error) = serde_json::from_slice::<PortError>(status.details())
+    {
+        return error;
+    }
+
+    let kind = match status.code() {
+        Code::InvalidArgument => PortErrorKind::Validation,
+        Code::NotFound => PortErrorKind::NotFound,
+        Code::AlreadyExists | Code::Aborted | Code::FailedPrecondition => PortErrorKind::Conflict,
+        Code::PermissionDenied | Code::Unauthenticated => PortErrorKind::Forbidden,
+        Code::DeadlineExceeded => PortErrorKind::Timeout,
+        Code::Unavailable | Code::ResourceExhausted => PortErrorKind::Unavailable,
+        _ => PortErrorKind::InvariantViolation,
+    };
+    let retryable = matches!(kind, PortErrorKind::Timeout | PortErrorKind::Unavailable);
+    PortError::new(
+        kind,
+        format!(
+            "product.grpc.{}",
+            status.code().description().replace(' ', "_")
+        ),
+        status.message(),
+        retryable,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::status_to_port_error;
+    use rustok_api::{PortError, PortErrorKind};
+    use tonic::{Code, Status};
+
+    #[test]
+    fn typed_error_details_override_lossy_grpc_status_mapping() {
+        let expected = PortError::validation("product.exact", "exact owner error");
+        let status = Status::with_details(
+            Code::InvalidArgument,
+            expected.message.clone(),
+            serde_json::to_vec(&expected).unwrap().into(),
+        );
+        assert_eq!(status_to_port_error(status), expected);
+    }
+
+    #[test]
+    fn unstructured_transport_status_retains_retryability() {
+        let error = status_to_port_error(Status::unavailable("down"));
+        assert_eq!(error.kind, PortErrorKind::Unavailable);
+        assert!(error.retryable);
+    }
+}

--- a/crates/rustok-product-transport/src/lib.rs
+++ b/crates/rustok-product-transport/src/lib.rs
@@ -1,0 +1,17 @@
+//! Tonic gRPC framing for the Product-owned catalog read port.
+//!
+//! Canonical DTOs and policy remain in `rustok-product`. This crate supplies a
+//! replaceable external adapter and does not own catalog storage or semantics.
+
+pub mod client;
+pub mod server;
+
+pub mod proto {
+    tonic::include_proto!("rustok.product");
+}
+
+pub use client::GrpcProductCatalogReadProvider;
+pub use server::{
+    ProductCatalogGrpcOperation, ProductCatalogGrpcService, TrustedProductCatalogAuthority,
+};
+pub use tonic::transport::ClientTlsConfig;

--- a/crates/rustok-product-transport/src/server.rs
+++ b/crates/rustok-product-transport/src/server.rs
@@ -1,0 +1,270 @@
+use std::{collections::HashSet, sync::Arc};
+
+use bytes::Bytes;
+use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
+use rustok_product::{
+    ProductCatalogReadPort, ProductProjectionRequest, PublishedProductsRequest,
+    VariantProductProjectionRequest,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tonic::{Code, Request, Response, Status};
+
+use crate::proto::product_catalog_read_service_server::ProductCatalogReadService;
+use crate::proto::{JsonRequest, JsonResponse};
+
+/// Provider-side adapter. The wrapped Product owner port retains catalog policy and persistence.
+pub struct ProductCatalogGrpcService<P> {
+    provider: Arc<P>,
+}
+
+/// Authority established by a server-side authentication/authorization interceptor.
+///
+/// Network payloads may carry correlation, locale, channel, deadline, and idempotency metadata,
+/// but tenant and principal authority are replaced with this trusted value.
+#[derive(Clone, Debug)]
+pub struct TrustedProductCatalogAuthority {
+    pub tenant_id: String,
+    pub actor: PortActor,
+    pub claims: Vec<String>,
+    pub roles: Vec<String>,
+    allowed_operations: HashSet<ProductCatalogGrpcOperation>,
+}
+
+/// Product catalog operations authorized by the server-side authentication boundary.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ProductCatalogGrpcOperation {
+    ReadProductProjection,
+    ReadVariantProductProjection,
+    ListPublishedProducts,
+}
+
+impl TrustedProductCatalogAuthority {
+    pub fn new(tenant_id: impl Into<String>, actor: PortActor) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            actor,
+            claims: Vec::new(),
+            roles: Vec::new(),
+            allowed_operations: HashSet::new(),
+        }
+    }
+
+    pub fn with_claim(mut self, claim: impl Into<String>) -> Self {
+        self.claims.push(claim.into());
+        self
+    }
+
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.roles.push(role.into());
+        self
+    }
+
+    pub fn allow_operation(mut self, operation: ProductCatalogGrpcOperation) -> Self {
+        self.allowed_operations.insert(operation);
+        self
+    }
+
+    pub fn allow_operations(
+        mut self,
+        operations: impl IntoIterator<Item = ProductCatalogGrpcOperation>,
+    ) -> Self {
+        self.allowed_operations.extend(operations);
+        self
+    }
+}
+
+impl<P> ProductCatalogGrpcService<P> {
+    pub fn new(provider: Arc<P>) -> Self {
+        Self { provider }
+    }
+}
+
+#[tonic::async_trait]
+impl<P> ProductCatalogReadService for ProductCatalogGrpcService<P>
+where
+    P: ProductCatalogReadPort + 'static,
+{
+    async fn read_product_projection(
+        &self,
+        request: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        let context = trusted_context(
+            &request,
+            decode_context(&request.get_ref().context_json)?,
+            ProductCatalogGrpcOperation::ReadProductProjection,
+        )?;
+        let request = request.into_inner();
+        let input: ProductProjectionRequest = decode_input(&request.input_json)?;
+        let value = self
+            .provider
+            .read_product_projection(context, input)
+            .await
+            .map_err(port_error_to_status)?;
+        json_response(&value)
+    }
+
+    async fn read_variant_product_projection(
+        &self,
+        request: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        let context = trusted_context(
+            &request,
+            decode_context(&request.get_ref().context_json)?,
+            ProductCatalogGrpcOperation::ReadVariantProductProjection,
+        )?;
+        let request = request.into_inner();
+        let input: VariantProductProjectionRequest = decode_input(&request.input_json)?;
+        let value = self
+            .provider
+            .read_variant_product_projection(context, input)
+            .await
+            .map_err(port_error_to_status)?;
+        json_response(&value)
+    }
+
+    async fn list_published_products(
+        &self,
+        request: Request<JsonRequest>,
+    ) -> Result<Response<JsonResponse>, Status> {
+        let context = trusted_context(
+            &request,
+            decode_context(&request.get_ref().context_json)?,
+            ProductCatalogGrpcOperation::ListPublishedProducts,
+        )?;
+        let request = request.into_inner();
+        let input: PublishedProductsRequest = decode_input(&request.input_json)?;
+        let value = self
+            .provider
+            .list_published_products(context, input)
+            .await
+            .map_err(port_error_to_status)?;
+        json_response(&value)
+    }
+}
+
+fn trusted_context<T>(
+    request: &Request<T>,
+    mut claimed: PortContext,
+    operation: ProductCatalogGrpcOperation,
+) -> Result<PortContext, Status> {
+    let authority = request
+        .extensions()
+        .get::<TrustedProductCatalogAuthority>()
+        .ok_or_else(|| Status::unauthenticated("trusted Product catalog authority is missing"))?;
+    if !authority.allowed_operations.contains(&operation) {
+        return Err(Status::permission_denied(
+            "trusted Product catalog authority does not allow this operation",
+        ));
+    }
+    if claimed.tenant_id != authority.tenant_id {
+        return Err(Status::permission_denied(
+            "Product tenant does not match authenticated authority",
+        ));
+    }
+    claimed.tenant_id.clone_from(&authority.tenant_id);
+    claimed.actor = authority.actor.clone();
+    claimed.claims.clone_from(&authority.claims);
+    claimed.roles.clone_from(&authority.roles);
+    Ok(claimed)
+}
+
+fn decode_context(value: &[u8]) -> Result<PortContext, Status> {
+    decode_input(value)
+}
+
+fn decode_input<T: DeserializeOwned>(value: &[u8]) -> Result<T, Status> {
+    serde_json::from_slice(value).map_err(|error| {
+        port_error_to_status(PortError::validation(
+            "product.transport_invalid_json",
+            error.to_string(),
+        ))
+    })
+}
+
+fn json_response<T: Serialize>(value: &T) -> Result<Response<JsonResponse>, Status> {
+    let output_json = serde_json::to_vec(value).map_err(|error| {
+        port_error_to_status(PortError::invariant_violation(
+            "product.transport_encode",
+            error.to_string(),
+        ))
+    })?;
+    Ok(Response::new(JsonResponse { output_json }))
+}
+
+fn port_error_to_status(error: PortError) -> Status {
+    let code = match error.kind {
+        PortErrorKind::Validation => Code::InvalidArgument,
+        PortErrorKind::NotFound => Code::NotFound,
+        PortErrorKind::Conflict => Code::FailedPrecondition,
+        PortErrorKind::Forbidden => Code::PermissionDenied,
+        PortErrorKind::Unavailable => Code::Unavailable,
+        PortErrorKind::Timeout => Code::DeadlineExceeded,
+        PortErrorKind::InvariantViolation => Code::Internal,
+    };
+    let details = serde_json::to_vec(&error).unwrap_or_default();
+    Status::with_details(code, error.message, Bytes::from(details))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ProductCatalogGrpcOperation, TrustedProductCatalogAuthority, port_error_to_status,
+        trusted_context,
+    };
+    use rustok_api::{PortActor, PortContext, PortError};
+    use tonic::{Code, Request};
+
+    #[test]
+    fn owner_error_is_preserved_in_status_details() {
+        let error = PortError::not_found("product.not_found", "missing");
+        let status = port_error_to_status(error.clone());
+        assert_eq!(status.code(), Code::NotFound);
+        assert_eq!(
+            serde_json::from_slice::<PortError>(status.details()).unwrap(),
+            error
+        );
+    }
+
+    #[test]
+    fn remote_context_requires_server_side_authority() {
+        let request = Request::new(());
+        let context = PortContext::new(
+            "tenant-a",
+            PortActor::service("untrusted-client"),
+            "en",
+            "corr-a",
+        );
+        let status = trusted_context(
+            &request,
+            context,
+            ProductCatalogGrpcOperation::ReadProductProjection,
+        )
+        .expect_err("missing authority must fail closed");
+        assert_eq!(status.code(), Code::Unauthenticated);
+    }
+
+    #[test]
+    fn trusted_authority_replaces_untrusted_actor() {
+        let authority = TrustedProductCatalogAuthority::new(
+            "tenant-a",
+            PortActor::service("trusted-product-service"),
+        )
+        .allow_operation(ProductCatalogGrpcOperation::ReadProductProjection);
+        let mut request = Request::new(());
+        request.extensions_mut().insert(authority);
+        let context = PortContext::new(
+            "tenant-a",
+            PortActor::service("untrusted-client"),
+            "en",
+            "corr-b",
+        );
+        let trusted = trusted_context(
+            &request,
+            context,
+            ProductCatalogGrpcOperation::ReadProductProjection,
+        )
+        .expect("trusted authority should be accepted");
+        assert_eq!(trusted.tenant_id, "tenant-a");
+        assert_ne!(format!("{:?}", trusted.actor), "Service { id: \"untrusted-client\" }");
+    }
+}

--- a/crates/rustok-product-transport/src/server.rs
+++ b/crates/rustok-product-transport/src/server.rs
@@ -265,6 +265,6 @@ mod tests {
         )
         .expect("trusted authority should be accepted");
         assert_eq!(trusted.tenant_id, "tenant-a");
-        assert_ne!(format!("{:?}", trusted.actor), "Service { id: \"untrusted-client\" }");
+        assert_eq!(trusted.actor, PortActor::service("trusted-product-service"));
     }
 }

--- a/crates/rustok-product-transport/tests/port_conformance.rs
+++ b/crates/rustok-product-transport/tests/port_conformance.rs
@@ -1,0 +1,270 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortActor, PortCallPolicy, PortContext, PortError, PortErrorKind};
+use rustok_product::{
+    ProductCatalogReadPort, ProductProjectionRequest, PublishedProductsRequest,
+    StorefrontProductList, StorefrontProductListItem, VariantProductProjectionRequest,
+    dto::ProductResponse,
+    entities::product::ProductStatus,
+};
+use rustok_product_transport::{
+    GrpcProductCatalogReadProvider, ProductCatalogGrpcOperation, ProductCatalogGrpcService,
+    TrustedProductCatalogAuthority,
+    proto::product_catalog_read_service_server::ProductCatalogReadServiceServer,
+};
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::{Endpoint, Server};
+use uuid::Uuid;
+
+struct MockProductCatalogReadPort {
+    tenant_id: Uuid,
+    product_id: Uuid,
+    variant_id: Uuid,
+}
+
+impl MockProductCatalogReadPort {
+    fn validate_context(&self, context: &PortContext) -> Result<(), PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        assert_eq!(context.tenant_id, self.tenant_id.to_string());
+        assert_eq!(
+            context.actor,
+            PortActor::service("trusted-product-catalog-conformance")
+        );
+        assert_eq!(context.channel.as_deref(), Some("web"));
+        Ok(())
+    }
+
+    fn product(&self) -> ProductResponse {
+        let now = Utc::now();
+        ProductResponse {
+            id: self.product_id,
+            tenant_id: self.tenant_id,
+            status: ProductStatus::Active,
+            seller_id: None,
+            vendor: Some("RusToK".to_string()),
+            product_type: Some("demo".to_string()),
+            shipping_profile_slug: Some("default".to_string()),
+            primary_category_id: None,
+            tags: vec!["remote".to_string()],
+            metadata: serde_json::json!({"transport": "grpc"}),
+            created_at: now,
+            updated_at: now,
+            published_at: Some(now),
+            translations: Vec::new(),
+            options: Vec::new(),
+            variants: Vec::new(),
+            images: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ProductCatalogReadPort for MockProductCatalogReadPort {
+    async fn read_product_projection(
+        &self,
+        context: PortContext,
+        request: ProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        self.validate_context(&context)?;
+        if request.product_id != self.product_id {
+            return Err(PortError::not_found(
+                "product.product_not_found",
+                "product was not found",
+            ));
+        }
+        Ok(self.product())
+    }
+
+    async fn read_variant_product_projection(
+        &self,
+        context: PortContext,
+        request: VariantProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        self.validate_context(&context)?;
+        if request.variant_id != self.variant_id {
+            return Err(PortError::not_found(
+                "product.variant_not_found",
+                "product variant was not found",
+            ));
+        }
+        Ok(self.product())
+    }
+
+    async fn list_published_products(
+        &self,
+        context: PortContext,
+        request: PublishedProductsRequest,
+    ) -> Result<StorefrontProductList, PortError> {
+        self.validate_context(&context)?;
+        assert_eq!(request.public_channel_slug.as_deref(), Some("web"));
+        let product = self.product();
+        Ok(StorefrontProductList {
+            items: vec![StorefrontProductListItem {
+                id: product.id,
+                status: product.status,
+                title: "Remote product".to_string(),
+                handle: "remote-product".to_string(),
+                seller_id: product.seller_id,
+                vendor: product.vendor,
+                product_type: product.product_type,
+                tags: product.tags,
+                created_at: product.created_at,
+                published_at: product.published_at,
+            }],
+            total: 1,
+            page: request.page,
+            per_page: request.per_page,
+            has_next: false,
+        })
+    }
+}
+
+fn read_context(tenant_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service("untrusted-product-client"),
+        "en",
+        Uuid::new_v4().to_string(),
+    )
+    .with_channel("web")
+    .with_deadline(Duration::from_secs(5))
+}
+
+#[tokio::test]
+async fn loopback_grpc_provider_executes_the_product_catalog_port_contract() {
+    let tenant_id = Uuid::new_v4();
+    let product_id = Uuid::new_v4();
+    let variant_id = Uuid::new_v4();
+    let provider = Arc::new(MockProductCatalogReadPort {
+        tenant_id,
+        product_id,
+        variant_id,
+    });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("loopback listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("loopback listener address should exist");
+    let incoming = TcpListenerStream::new(listener);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let authority = TrustedProductCatalogAuthority::new(
+        tenant_id.to_string(),
+        PortActor::service("trusted-product-catalog-conformance"),
+    )
+    .allow_operations([
+        ProductCatalogGrpcOperation::ReadProductProjection,
+        ProductCatalogGrpcOperation::ReadVariantProductProjection,
+        ProductCatalogGrpcOperation::ListPublishedProducts,
+    ]);
+    let server_service = ProductCatalogReadServiceServer::with_interceptor(
+        ProductCatalogGrpcService::new(provider),
+        move |mut request: tonic::Request<()>| {
+            request.extensions_mut().insert(authority.clone());
+            Ok(request)
+        },
+    );
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(server_service)
+            .serve_with_incoming_shutdown(incoming, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("loopback Product gRPC server should run");
+    });
+    let remote = GrpcProductCatalogReadProvider::connect(
+        Endpoint::from_shared(format!("http://{address}"))
+            .expect("loopback endpoint should parse")
+            .connect_timeout(Duration::from_secs(5)),
+    )
+    .await
+    .expect("loopback Product gRPC client should connect");
+
+    let product = remote
+        .read_product_projection(
+            read_context(tenant_id),
+            ProductProjectionRequest {
+                product_id,
+                locale: Some("en".to_string()),
+                fallback_locale: None,
+            },
+        )
+        .await
+        .expect("product projection should cross gRPC");
+    assert_eq!(product.id, product_id);
+    assert_eq!(product.tenant_id, tenant_id);
+
+    let variant_product = remote
+        .read_variant_product_projection(
+            read_context(tenant_id),
+            VariantProductProjectionRequest {
+                variant_id,
+                locale: Some("en".to_string()),
+                fallback_locale: None,
+            },
+        )
+        .await
+        .expect("variant-first projection should cross gRPC");
+    assert_eq!(variant_product.id, product_id);
+
+    let page = remote
+        .list_published_products(
+            read_context(tenant_id),
+            PublishedProductsRequest {
+                locale: Some("en".to_string()),
+                fallback_locale: None,
+                public_channel_slug: Some("web".to_string()),
+                page: 1,
+                per_page: 24,
+            },
+        )
+        .await
+        .expect("published products should cross gRPC");
+    assert_eq!(page.total, 1);
+    assert_eq!(page.items[0].id, product_id);
+
+    let missing = remote
+        .read_product_projection(
+            read_context(tenant_id),
+            ProductProjectionRequest {
+                product_id: Uuid::new_v4(),
+                locale: None,
+                fallback_locale: None,
+            },
+        )
+        .await
+        .expect_err("typed owner errors should cross gRPC details");
+    assert_eq!(missing.kind, PortErrorKind::NotFound);
+    assert_eq!(missing.code, "product.product_not_found");
+
+    let missing_deadline = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service("untrusted-product-client"),
+        "en",
+        Uuid::new_v4().to_string(),
+    )
+    .with_channel("web");
+    let deadline_error = remote
+        .list_published_products(
+            missing_deadline,
+            PublishedProductsRequest {
+                locale: None,
+                fallback_locale: None,
+                public_channel_slug: Some("web".to_string()),
+                page: 1,
+                per_page: 24,
+            },
+        )
+        .await
+        .expect_err("deadline policy should cross gRPC details");
+    assert_eq!(deadline_error.kind, PortErrorKind::Timeout);
+    assert_eq!(deadline_error.code, "port.deadline_required");
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("loopback Product gRPC server task should stop");
+}

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -57,6 +57,7 @@
     "native_checkout_runtime_verifier": "scripts/verify/verify-product-native-checkout-catalog-runtime.mjs",
     "http_checkout_runtime_verifier": "scripts/verify/verify-product-http-checkout-catalog-runtime.mjs",
     "graphql_checkout_runtime_verifier": "scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs",
+    "grpc_transport_verifier": "scripts/verify/verify-product-catalog-grpc-transport.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
@@ -80,6 +81,17 @@
     "pending_consumers": [],
     "status": "source_complete_consumer_cutover_complete"
   },
+  "external_transport": {
+    "crate": "rustok-product-transport",
+    "source": "crates/rustok-product-transport",
+    "protocol": "tonic_grpc_json_owner_contract",
+    "client": "GrpcProductCatalogReadProvider",
+    "server": "ProductCatalogGrpcService",
+    "trusted_authority": "TrustedProductCatalogAuthority",
+    "proto": "crates/rustok-product-transport/proto/rustok/product/product_catalog.proto",
+    "conformance_test": "crates/rustok-product-transport/tests/port_conformance.rs",
+    "status": "source_complete_execution_pending"
+  },
   "in_process_provider_impl": {
     "service": "CatalogService",
     "runtime": "ProductCatalogReadRuntime",
@@ -93,41 +105,48 @@
     "runner": "scripts/verify/verify-ecommerce-fba-registries.mjs",
     "profiles": [
       "in_process",
-      "remote_adapter_placeholder"
+      "remote_adapter_placeholder",
+      "grpc_loopback"
     ],
     "cases": [
       {
         "operation": "read_product_projection",
         "profiles": [
           "in_process",
-          "remote_adapter_placeholder"
+          "remote_adapter_placeholder",
+          "grpc_loopback"
         ],
         "assertions": [
           "typed_port_error_mapping",
-          "context_deadline_preserved"
+          "context_deadline_preserved",
+          "trusted_authority_replaces_actor"
         ]
       },
       {
         "operation": "read_variant_product_projection",
         "profiles": [
           "in_process",
-          "remote_adapter_placeholder"
+          "remote_adapter_placeholder",
+          "grpc_loopback"
         ],
         "assertions": [
           "typed_port_error_mapping",
           "context_deadline_preserved",
-          "variant_to_product_owner_resolution"
+          "variant_to_product_owner_resolution",
+          "trusted_authority_replaces_actor"
         ]
       },
       {
         "operation": "list_published_products",
         "profiles": [
           "in_process",
-          "remote_adapter_placeholder"
+          "remote_adapter_placeholder",
+          "grpc_loopback"
         ],
         "assertions": [
           "typed_port_error_mapping",
-          "context_deadline_preserved"
+          "context_deadline_preserved",
+          "trusted_authority_replaces_actor"
         ]
       }
     ],

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -20,9 +20,20 @@ and mounted Commerce GraphQL checkout consume the host-selected port rather than
 constructing parallel `CatalogService` instances. GraphQL schema data carries the
 Product runtime into a resolver-scoped task-local; directly embedded schemas
 retain an explicit in-process compatibility fallback. The checkout consumer
-source cutover is complete. A concrete external transport adapter has not yet
-been executed, so the provider remains `boundary_ready` rather than
-`transport_verified`.
+source cutover is complete.
+
+`rustok-product-transport` now supplies a concrete tonic gRPC client/server
+adapter for all three catalog-read operations. Protobuf owns RPC identity and
+framing while JSON preserves Product-owned request/response DTOs and
+`PortContext`. The client maps context deadlines to tonic timeouts and restores
+structured `PortError` details. The server requires interceptor-provided
+`TrustedProductCatalogAuthority`, verifies tenant/operation authority, and
+replaces untrusted actor/claims/roles before invoking the owner port. A loopback
+conformance harness covers product projection, variant-first projection,
+published list pagination, typed not-found, deadline-required semantics, and
+trusted actor replacement. The adapter source is complete, but the harness has
+not been executed by the implementation agent, so Product remains
+`boundary_ready` rather than `transport_verified`.
 
 The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -85,8 +96,8 @@ isolation for category, attribute, and schema copy.
 `product_catalog_read_port_executes_against_postgres` exercises product,
 variant-first, and published-list operations with live price/inventory
 enrichment, tenant isolation, locale fallback, channel filtering, count, and
-pagination. A concrete external adapter execution remains required before
-promoting the transport status.
+pagination. The gRPC loopback harness mirrors the same public owner operations
+without taking ownership of Product persistence.
 `storefront_queries_use_indexes_at_representative_scales` seeds ten tenants at
 10k, 100k, and 1M total products and captures live
 `EXPLAIN (ANALYZE, BUFFERS)` plans for storefront page and count SQL. The
@@ -114,18 +125,21 @@ rustok-pricing` dependency cycle.
 
 - FFA status: `in_progress` — both owner UI surfaces exist and must preserve
   the core/transport/UI split and native/GraphQL parity.
-- FBA status: `boundary_ready` — the read port, in-process persistence profile,
-  Product-owned runtime selector, and all declared consumer source cutovers are
-  complete. Concrete external transport execution remains open.
+- FBA status: `boundary_ready` — the owner port, in-process profile, host runtime,
+  declared consumer source cutovers, and external gRPC adapter source are
+  complete. Loopback execution evidence and production external-profile wiring
+  remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json`,
+  `crates/rustok-product-transport/tests/port_conformance.rs`,
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
   `scripts/verify/verify-product-catalog-read-runtime-composition.mjs`,
   `scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-http-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs`,
+  `scripts/verify/verify-product-catalog-grpc-transport.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -136,13 +150,12 @@ rustok-pricing` dependency cycle.
 
 ## Open results
 
-1. Implement a concrete external `ProductCatalogReadPort` transport adapter in a
-   separate transport crate and execute all three operations through it. Preserve
-   serialized `PortContext`, deadlines, typed `PortError`, tenant/locale/channel
-   semantics, variant-to-product resolution, count, and pagination. Execute the
-   declared unavailable/deadline hard-dependency behavior for Commerce and the
-   reviewed degraded behavior for AI. Do not promote above `boundary_ready` from
-   source markers alone.
+1. Execute `cargo test -p rustok-product-transport --test port_conformance` and
+   retain the result as external transport evidence. After successful execution,
+   wire a production configuration path that creates
+   `ProductCatalogReadRuntime::external(Arc::new(GrpcProductCatalogReadProvider))`
+   and prove Commerce hard-dependency plus AI degraded behavior against the remote
+   profile. Promote above `boundary_ready` only with that runtime evidence.
 2. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
@@ -157,7 +170,9 @@ rustok-pricing` dependency cycle.
 - [x] Cut Order storefront native checkout over to the composed Product runtime.
 - [x] Cut Commerce HTTP checkout over to the composed Product runtime.
 - [x] Cut mounted Commerce GraphQL checkout over to the composed Product runtime.
-- [ ] Execute a concrete external Product catalog read adapter.
+- [x] Implement the concrete Product catalog gRPC adapter and loopback conformance harness.
+- [ ] Execute the Product catalog gRPC loopback conformance harness.
+- [ ] Wire and execute a production external Product runtime profile.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
@@ -171,6 +186,9 @@ rustok-pricing` dependency cycle.
 - `node scripts/verify/verify-product-http-checkout-catalog-runtime.test.mjs`
 - `node scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs`
 - `node scripts/verify/verify-product-graphql-checkout-catalog-runtime.test.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-transport.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-transport.test.mjs`
+- `cargo test -p rustok-product-transport --test port_conformance`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
 - `node scripts/verify/verify-product-admin-category-sort.mjs`
@@ -189,6 +207,9 @@ rustok-pricing` dependency cycle.
 
 - Product owns catalog data, `ProductCatalogReadPort`, and
   `ProductCatalogReadRuntime` profile selection.
+- `rustok-product-transport` owns only tonic/protobuf framing, deadline/status
+  mapping, and trusted-authority adaptation. It must not own Product policy,
+  persistence, DTOs, locale/channel rules, or fallback decisions.
 - The host selects and shares one Product read runtime; consumers receive the
   public port and must not construct parallel owner services.
 - Order native checkout, Commerce HTTP checkout, mounted Commerce GraphQL

--- a/scripts/verify/verify-product-catalog-grpc-transport.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.mjs
@@ -185,9 +185,8 @@ requireAll(plan, [
   "`rustok-product-transport` now supplies a concrete tonic gRPC client/server adapter",
   "source is complete",
   "has not been executed by the implementation agent",
-  "source_complete_execution_pending",
+  "Loopback execution evidence and production external-profile wiring",
   "cargo test -p rustok-product-transport --test port_conformance",
-  "production external-profile wiring",
   "ProductCatalogReadRuntime::external",
   "verify-product-catalog-grpc-transport.mjs",
 ], "Product implementation plan");

--- a/scripts/verify/verify-product-catalog-grpc-transport.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required Product catalog gRPC transport file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireAll(source, markers, description) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+  }
+}
+
+function forbidAll(source, markers, description) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
+  }
+}
+
+const crateRoot = "crates/rustok-product-transport";
+const cargo = read(`${crateRoot}/Cargo.toml`);
+const build = read(`${crateRoot}/build.rs`);
+const proto = read(`${crateRoot}/proto/rustok/product/product_catalog.proto`);
+const lib = read(`${crateRoot}/src/lib.rs`);
+const client = read(`${crateRoot}/src/client.rs`);
+const server = read(`${crateRoot}/src/server.rs`);
+const conformance = read(`${crateRoot}/tests/port_conformance.rs`);
+const readme = read(`${crateRoot}/README.md`);
+const registrySource = read("crates/rustok-product/contracts/product-fba-registry.json");
+const plan = read("crates/rustok-product/docs/implementation-plan.md");
+
+requireAll(cargo, [
+  'name = "rustok-product-transport"',
+  "rustok-api.workspace = true",
+  "rustok-product.workspace = true",
+  "tonic = { workspace = true",
+  "tonic-prost.workspace = true",
+  "protoc-bin-vendored.workspace = true",
+  "tonic-prost-build.workspace = true",
+  'tokio-stream = { version = "0.1", features = ["net"] }',
+], "transport Cargo manifest");
+forbidAll(cargo, ["sea-orm", "rustok-outbox", "rustok-pricing"], "transport Cargo ownership");
+
+requireAll(build, [
+  "protoc_bin_vendored::protoc_bin_path()",
+  'proto/rustok/product/product_catalog.proto',
+  "tonic_prost_build::configure()",
+], "transport build script");
+requireAll(proto, [
+  "package rustok.product;",
+  "service ProductCatalogReadService",
+  "rpc ReadProductProjection(JsonRequest) returns (JsonResponse);",
+  "rpc ReadVariantProductProjection(JsonRequest) returns (JsonResponse);",
+  "rpc ListPublishedProducts(JsonRequest) returns (JsonResponse);",
+  "bytes context_json = 1;",
+  "bytes input_json = 2;",
+  "bytes output_json = 1;",
+], "Product catalog protobuf");
+requireAll(lib, [
+  "pub mod client;",
+  "pub mod server;",
+  'tonic::include_proto!("rustok.product")',
+  "GrpcProductCatalogReadProvider",
+  "ProductCatalogGrpcService",
+  "TrustedProductCatalogAuthority",
+  "ProductCatalogGrpcOperation",
+], "transport public exports");
+
+requireAll(client, [
+  "impl ProductCatalogReadPort for GrpcProductCatalogReadProvider",
+  "async fn read_product_projection(",
+  "async fn read_variant_product_projection(",
+  "async fn list_published_products(",
+  "context_json: encode(&context)?",
+  "input_json: encode(&request)?",
+  "request.set_timeout(Duration::from_millis(deadline_ms))",
+  "serde_json::from_slice::<PortError>(status.details())",
+  "Code::DeadlineExceeded => PortErrorKind::Timeout",
+  "Code::Unavailable | Code::ResourceExhausted => PortErrorKind::Unavailable",
+], "gRPC client adapter");
+forbidAll(client, ["CatalogService", "sea_orm", "crate::entities"], "gRPC client ownership");
+
+requireAll(server, [
+  "impl<P> ProductCatalogReadService for ProductCatalogGrpcService<P>",
+  "P: ProductCatalogReadPort + 'static",
+  "TrustedProductCatalogAuthority",
+  "allowed_operations: HashSet<ProductCatalogGrpcOperation>",
+  "ReadProductProjection",
+  "ReadVariantProductProjection",
+  "ListPublishedProducts",
+  "trusted_context(",
+  "claimed.tenant_id != authority.tenant_id",
+  "claimed.actor = authority.actor.clone()",
+  "claimed.claims.clone_from(&authority.claims)",
+  "claimed.roles.clone_from(&authority.roles)",
+  "Status::with_details(code, error.message, Bytes::from(details))",
+  'Status::unauthenticated("trusted Product catalog authority is missing")',
+  "assert_eq!(trusted.actor, PortActor::service(\"trusted-product-service\"))",
+], "gRPC server adapter");
+forbidAll(server, ["CatalogService", "sea_orm", "crate::entities"], "gRPC server ownership");
+
+requireAll(conformance, [
+  "impl ProductCatalogReadPort for MockProductCatalogReadPort",
+  "ProductCatalogReadServiceServer::with_interceptor",
+  "GrpcProductCatalogReadProvider::connect",
+  "ProductCatalogGrpcOperation::ReadProductProjection",
+  "ProductCatalogGrpcOperation::ReadVariantProductProjection",
+  "ProductCatalogGrpcOperation::ListPublishedProducts",
+  "read_product_projection(",
+  "read_variant_product_projection(",
+  "list_published_products(",
+  "product.product_not_found",
+  "port.deadline_required",
+  'PortActor::service("trusted-product-catalog-conformance")',
+  "serve_with_incoming_shutdown",
+], "loopback conformance harness");
+requireAll(readme, [
+  "Typed tonic gRPC framing",
+  "does not own Product DTOs",
+  "TrustedProductCatalogAuthority",
+  "cargo test -p rustok-product-transport --test port_conformance",
+  "does not claim this command was executed",
+  "boundary_ready",
+], "transport README");
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  if (registry.status !== "boundary_ready") {
+    failures.push("Product FBA registry must remain boundary_ready before execution evidence");
+  }
+  const external = registry.external_transport ?? {};
+  if (external.crate !== "rustok-product-transport") {
+    failures.push("Product FBA registry must name rustok-product-transport");
+  }
+  if (external.status !== "source_complete_execution_pending") {
+    failures.push("Product external transport must remain source_complete_execution_pending");
+  }
+  if (external.client !== "GrpcProductCatalogReadProvider") {
+    failures.push("Product external transport client identity drift");
+  }
+  if (external.server !== "ProductCatalogGrpcService") {
+    failures.push("Product external transport server identity drift");
+  }
+  const profiles = registry.contract_tests?.profiles ?? [];
+  if (!profiles.includes("remote_adapter_placeholder") || !profiles.includes("grpc_loopback")) {
+    failures.push("Product contract profiles must retain placeholder and add grpc_loopback");
+  }
+  for (const operation of [
+    "read_product_projection",
+    "read_variant_product_projection",
+    "list_published_products",
+  ]) {
+    const testCase = registry.contract_tests?.cases?.find(
+      (entry) => entry.operation === operation,
+    );
+    if (!testCase?.profiles?.includes("grpc_loopback")) {
+      failures.push(`Product ${operation} contract case must include grpc_loopback`);
+    }
+    if (!testCase?.assertions?.includes("trusted_authority_replaces_actor")) {
+      failures.push(`Product ${operation} contract case must assert trusted authority`);
+    }
+  }
+}
+
+requireAll(plan, [
+  "`rustok-product-transport` now supplies a concrete tonic gRPC client/server adapter",
+  "source is complete",
+  "has not been executed by the implementation agent",
+  "source_complete_execution_pending",
+  "cargo test -p rustok-product-transport --test port_conformance",
+  "production external-profile wiring",
+  "ProductCatalogReadRuntime::external",
+  "verify-product-catalog-grpc-transport.mjs",
+], "Product implementation plan");
+
+if (failures.length > 0) {
+  console.error("Product catalog gRPC transport verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Product catalog gRPC transport source verification passed");

--- a/scripts/verify/verify-product-catalog-grpc-transport.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.test.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-catalog-grpc-transport.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-grpc-transport-"));
+  write(
+    root,
+    "crates/rustok-product-transport/Cargo.toml",
+    options.storageDependency
+      ? `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }\nsea-orm.workspace = true`
+      : `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/build.rs",
+    `protoc_bin_vendored::protoc_bin_path(); tonic_prost_build::configure(); "proto/rustok/product/product_catalog.proto";`,
+  );
+  const variantRpc = options.missingRpc
+    ? ""
+    : "rpc ReadVariantProductProjection(JsonRequest) returns (JsonResponse);";
+  write(
+    root,
+    "crates/rustok-product-transport/proto/rustok/product/product_catalog.proto",
+    `package rustok.product; service ProductCatalogReadService { rpc ReadProductProjection(JsonRequest) returns (JsonResponse); ${variantRpc} rpc ListPublishedProducts(JsonRequest) returns (JsonResponse); } message JsonRequest { bytes context_json = 1; bytes input_json = 2; } message JsonResponse { bytes output_json = 1; }`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/lib.rs",
+    `pub mod client; pub mod server; tonic::include_proto!("rustok.product"); GrpcProductCatalogReadProvider ProductCatalogGrpcService TrustedProductCatalogAuthority ProductCatalogGrpcOperation`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/client.rs",
+    `impl ProductCatalogReadPort for GrpcProductCatalogReadProvider { async fn read_product_projection( context_json: encode(&context)? input_json: encode(&request)? ); async fn read_variant_product_projection( context_json: encode(&context)? input_json: encode(&request)? ); async fn list_published_products( context_json: encode(&context)? input_json: encode(&request)? ); } request.set_timeout(Duration::from_millis(deadline_ms)); serde_json::from_slice::<PortError>(status.details()); Code::DeadlineExceeded => PortErrorKind::Timeout; Code::Unavailable | Code::ResourceExhausted => PortErrorKind::Unavailable;`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/server.rs",
+    options.missingAuthority
+      ? `impl<P> ProductCatalogReadService for ProductCatalogGrpcService<P> where P: ProductCatalogReadPort + 'static { }`
+      : `impl<P> ProductCatalogReadService for ProductCatalogGrpcService<P> where P: ProductCatalogReadPort + 'static { } TrustedProductCatalogAuthority allowed_operations: HashSet<ProductCatalogGrpcOperation> ReadProductProjection ReadVariantProductProjection ListPublishedProducts trusted_context( claimed.tenant_id != authority.tenant_id claimed.actor = authority.actor.clone() claimed.claims.clone_from(&authority.claims) claimed.roles.clone_from(&authority.roles) Status::with_details(code, error.message, Bytes::from(details)) Status::unauthenticated("trusted Product catalog authority is missing") assert_eq!(trusted.actor, PortActor::service("trusted-product-service"))`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/tests/port_conformance.rs",
+    `impl ProductCatalogReadPort for MockProductCatalogReadPort ProductCatalogReadServiceServer::with_interceptor GrpcProductCatalogReadProvider::connect ProductCatalogGrpcOperation::ReadProductProjection ProductCatalogGrpcOperation::ReadVariantProductProjection ProductCatalogGrpcOperation::ListPublishedProducts read_product_projection( read_variant_product_projection( list_published_products( product.product_not_found port.deadline_required PortActor::service("trusted-product-catalog-conformance") serve_with_incoming_shutdown`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/README.md",
+    `Typed tonic gRPC framing does not own Product DTOs TrustedProductCatalogAuthority cargo test -p rustok-product-transport --test port_conformance does not claim this command was executed boundary_ready`,
+  );
+  const falsePromotion = options.falsePromotion === true;
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      status: falsePromotion ? "transport_verified" : "boundary_ready",
+      evidence: {
+        grpc_transport_verifier:
+          "scripts/verify/verify-product-catalog-grpc-transport.mjs",
+      },
+      external_transport: {
+        crate: "rustok-product-transport",
+        client: "GrpcProductCatalogReadProvider",
+        server: "ProductCatalogGrpcService",
+        status: falsePromotion
+          ? "transport_verified"
+          : "source_complete_execution_pending",
+      },
+      contract_tests: {
+        profiles: ["in_process", "remote_adapter_placeholder", "grpc_loopback"],
+        cases: [
+          {
+            operation: "read_product_projection",
+            profiles: ["in_process", "remote_adapter_placeholder", "grpc_loopback"],
+            assertions: ["typed_port_error_mapping", "context_deadline_preserved", "trusted_authority_replaces_actor"],
+          },
+          {
+            operation: "read_variant_product_projection",
+            profiles: ["in_process", "remote_adapter_placeholder", "grpc_loopback"],
+            assertions: ["typed_port_error_mapping", "context_deadline_preserved", "trusted_authority_replaces_actor"],
+          },
+          {
+            operation: "list_published_products",
+            profiles: ["in_process", "remote_adapter_placeholder", "grpc_loopback"],
+            assertions: ["typed_port_error_mapping", "context_deadline_preserved", "trusted_authority_replaces_actor"],
+          },
+        ],
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.omitPlan
+      ? "Product plan"
+      : "`rustok-product-transport` now supplies a concrete tonic gRPC client/server adapter. The adapter source is complete, but has not been executed by the implementation agent. Loopback execution evidence and production external-profile wiring remain open. cargo test -p rustok-product-transport --test port_conformance ProductCatalogReadRuntime::external verify-product-catalog-grpc-transport.mjs",
+  );
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected gRPC transport mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("Product catalog gRPC transport guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("gRPC transport guard rejects missing owner RPC", () => {
+  reject({ missingRpc: true }, /Product catalog protobuf/);
+});
+
+test("gRPC transport guard rejects missing trusted authority", () => {
+  reject({ missingAuthority: true }, /gRPC server adapter/);
+});
+
+test("gRPC transport guard rejects Product storage ownership", () => {
+  reject({ storageDependency: true }, /transport Cargo ownership/);
+});
+
+test("gRPC transport guard rejects false transport promotion", () => {
+  reject({ falsePromotion: true }, /remain boundary_ready|source_complete_execution_pending/);
+});
+
+test("gRPC transport guard rejects missing plan handoff", () => {
+  reject({ omitPlan: true }, /Product implementation plan/);
+});


### PR DESCRIPTION
## Summary

- add a standalone `rustok-product-transport` workspace crate;
- define three tonic RPCs for the Product-owned `ProductCatalogReadPort` while retaining Product request/response DTO ownership through JSON framing;
- implement `GrpcProductCatalogReadProvider` with serialized `PortContext`, tonic deadline propagation, TLS-capable connection helpers, and structured `PortError` detail restoration;
- implement `ProductCatalogGrpcService<P>` with interceptor-provided `TrustedProductCatalogAuthority`, operation allow-listing, tenant verification, and replacement of untrusted actor/claims/roles;
- add a loopback conformance harness for product projection, variant-first projection, published-list pagination, typed not-found, deadline-required semantics, and trusted actor replacement;
- register the adapter as `source_complete_execution_pending`, retain `remote_adapter_placeholder`, add `grpc_loopback`, and keep Product at `boundary_ready`;
- update the Product implementation plan and add source/mutation guards plus crate boundary documentation.

## Boundary

This PR does not claim the conformance harness was executed and does not wire a production remote endpoint. Product must not be promoted to `transport_verified` until retained execution evidence and production external-profile composition exist.

`Cargo.lock` is intentionally not regenerated by the implementation agent because the maintainer requested that Cargo/test commands be run locally. The first Cargo invocation may add the new workspace package entry; that lockfile update should be retained with the execution evidence.

## Testing

Not run by the implementation agent, following the maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-catalog-grpc-transport.mjs
node scripts/verify/verify-product-catalog-grpc-transport.test.mjs
cargo test -p rustok-product-transport --test port_conformance
```

After a successful run, retain the Cargo.lock change and test evidence before wiring `ProductCatalogReadRuntime::external(Arc::new(GrpcProductCatalogReadProvider))`.
