### PR TITLE
feat(product): wire catalog gRPC deployment

### DIFF
--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -52,7 +52,7 @@ embed-storefront = ["dep:rustok-storefront"]
 # resolvers additionally check is_enabled(tenant_id) at runtime.
 mod-cart      = ["dep:rustok-cart", "rustok-distribution/mod-cart"]
 mod-customer  = ["dep:rustok-customer", "rustok-distribution/mod-customer"]
-mod-product   = ["dep:rustok-product", "mod-taxonomy", "rustok-distribution/mod-product"]
+mod-product   = ["dep:rustok-product", "dep:rustok-product-transport", "mod-taxonomy", "rustok-distribution/mod-product"]
 mod-profiles  = ["dep:rustok-profiles", "dep:rustok-media-transport", "mod-media", "mod-taxonomy", "rustok-distribution/mod-profiles"]
 mod-social_graph = ["rustok-social-graph/graphql", "rustok-social-graph/index-consumer"]
 mod-groups    = ["dep:rustok-groups", "rustok-groups/graphql", "rustok-distribution/mod-groups"]
@@ -112,6 +112,7 @@ rustok-storefront = { path = "../storefront", default-features = false, features
 rustok-cart      = { workspace = true, optional = true }
 rustok-customer  = { workspace = true, optional = true }
 rustok-product   = { workspace = true, optional = true }
+rustok-product-transport = { path = "../../crates/rustok-product-transport", optional = true }
 rustok-profiles  = { workspace = true, optional = true }
 rustok-social-graph = { path = "../../crates/rustok-social-graph" }
 rustok-groups = { path = "../../crates/rustok-groups", default-features = false, optional = true }

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -94,6 +94,7 @@ pub mod payment_provider_event_worker;
 #[cfg(feature = "mod-payment")]
 pub mod payment_provider_runtime;
 pub mod platform_composition;
+pub mod product_catalog_deployment;
 pub mod profile_media_public_image_deployment;
 pub mod profile_media_public_image_runtime;
 

--- a/apps/server/src/services/product_catalog_deployment.rs
+++ b/apps/server/src/services/product_catalog_deployment.rs
@@ -1,0 +1,239 @@
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::services::server_runtime_context::ServerRuntimeContext;
+
+const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER";
+const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT";
+const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN";
+const CONNECT_TIMEOUT_MS_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS";
+const ALLOW_INSECURE_LOOPBACK_ENV: &str =
+    "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK";
+const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 5_000;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum ProductCatalogDeployment {
+    Embedded,
+    Grpc(ProductCatalogGrpcDeployment),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ProductCatalogGrpcDeployment {
+    endpoint: String,
+    tls_domain: Option<String>,
+    connect_timeout_ms: u64,
+    allow_insecure_loopback: bool,
+}
+
+/// Selects and connects the deployment-owned Product catalog provider before host composition.
+///
+/// The default is the embedded owner service. When `grpc` is selected, invalid configuration or
+/// connection failure aborts startup; the server never silently falls back to embedded execution.
+pub async fn configure_product_catalog_deployment(ctx: &ServerRuntimeContext) -> Result<()> {
+    #[cfg(feature = "mod-product")]
+    {
+        use std::sync::Arc;
+
+        use rustok_product::ProductCatalogReadRuntime;
+        use rustok_product_transport::GrpcProductCatalogReadConnectionConfig;
+
+        let deployment = deployment_from_environment().map_err(Error::Message)?;
+        let ProductCatalogDeployment::Grpc(remote) = deployment else {
+            return Ok(());
+        };
+
+        let provider = GrpcProductCatalogReadConnectionConfig::new(remote.endpoint)
+            .with_tls_domain(remote.tls_domain)
+            .with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms))
+            .allow_insecure_loopback(remote.allow_insecure_loopback)
+            .connect()
+            .await
+            .map_err(|error| {
+                Error::Message(format!(
+                    "remote Product catalog provider initialization failed: {error}"
+                ))
+            })?;
+        ctx.shared_insert(ProductCatalogReadRuntime::external(Arc::new(provider)));
+
+        tracing::info!(
+            provider = "grpc",
+            insecure_loopback = remote.allow_insecure_loopback,
+            "Product catalog deployment provider initialized"
+        );
+        return Ok(());
+    }
+
+    #[cfg(not(feature = "mod-product"))]
+    {
+        let _ = ctx;
+        Ok(())
+    }
+}
+
+fn deployment_from_environment() -> std::result::Result<ProductCatalogDeployment, String> {
+    parse_deployment(
+        optional_env(PROVIDER_ENV).as_deref(),
+        optional_env(GRPC_ENDPOINT_ENV).as_deref(),
+        optional_env(TLS_DOMAIN_ENV).as_deref(),
+        optional_env(CONNECT_TIMEOUT_MS_ENV).as_deref(),
+        optional_env(ALLOW_INSECURE_LOOPBACK_ENV).as_deref(),
+    )
+}
+
+fn parse_deployment(
+    provider: Option<&str>,
+    endpoint: Option<&str>,
+    tls_domain: Option<&str>,
+    connect_timeout_ms: Option<&str>,
+    allow_insecure_loopback: Option<&str>,
+) -> std::result::Result<ProductCatalogDeployment, String> {
+    let provider = provider
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("embedded")
+        .to_ascii_lowercase();
+    let endpoint = normalize_optional(endpoint);
+    let tls_domain = normalize_optional(tls_domain);
+    let timeout = parse_timeout(connect_timeout_ms)?;
+    let allow_insecure_loopback_is_configured = allow_insecure_loopback
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    let allow_insecure_loopback =
+        parse_bool(allow_insecure_loopback, ALLOW_INSECURE_LOOPBACK_ENV, false)?;
+
+    match provider.as_str() {
+        "embedded" => {
+            if endpoint.is_some()
+                || tls_domain.is_some()
+                || connect_timeout_ms.is_some()
+                || allow_insecure_loopback_is_configured
+            {
+                return Err(format!(
+                    "remote Product catalog variables require {PROVIDER_ENV}=grpc"
+                ));
+            }
+            Ok(ProductCatalogDeployment::Embedded)
+        }
+        "grpc" => {
+            let endpoint = endpoint.ok_or_else(|| {
+                format!("{GRPC_ENDPOINT_ENV} is required when {PROVIDER_ENV}=grpc")
+            })?;
+            Ok(ProductCatalogDeployment::Grpc(
+                ProductCatalogGrpcDeployment {
+                    endpoint,
+                    tls_domain,
+                    connect_timeout_ms: timeout,
+                    allow_insecure_loopback,
+                },
+            ))
+        }
+        _ => Err(format!("{PROVIDER_ENV} must be either embedded or grpc")),
+    }
+}
+
+fn parse_timeout(value: Option<&str>) -> std::result::Result<u64, String> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(DEFAULT_CONNECT_TIMEOUT_MS);
+    };
+    value
+        .parse::<u64>()
+        .map_err(|_| format!("{CONNECT_TIMEOUT_MS_ENV} must be an integer number of milliseconds"))
+}
+
+fn parse_bool(value: Option<&str>, name: &str, default: bool) -> std::result::Result<bool, String> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(default);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        _ => Err(format!("{name} must be a boolean")),
+    }
+}
+
+fn normalize_optional(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn optional_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProductCatalogDeployment, ProductCatalogGrpcDeployment, parse_deployment};
+
+    #[test]
+    fn embedded_is_the_default() {
+        assert_eq!(
+            parse_deployment(None, None, None, None, None).unwrap(),
+            ProductCatalogDeployment::Embedded
+        );
+    }
+
+    #[test]
+    fn grpc_requires_an_endpoint() {
+        let error = parse_deployment(Some("grpc"), None, None, None, None)
+            .expect_err("remote Product deployment without endpoint must fail closed");
+        assert!(error.contains("RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT"));
+    }
+
+    #[test]
+    fn grpc_configuration_preserves_transport_inputs() {
+        assert_eq!(
+            parse_deployment(
+                Some("grpc"),
+                Some("https://product-catalog.internal:7443"),
+                Some("product-catalog.internal"),
+                Some("2500"),
+                Some("false"),
+            )
+            .unwrap(),
+            ProductCatalogDeployment::Grpc(ProductCatalogGrpcDeployment {
+                endpoint: "https://product-catalog.internal:7443".to_string(),
+                tls_domain: Some("product-catalog.internal".to_string()),
+                connect_timeout_ms: 2500,
+                allow_insecure_loopback: false,
+            })
+        );
+    }
+
+    #[test]
+    fn remote_variables_are_not_silently_ignored_in_embedded_mode() {
+        let error = parse_deployment(
+            Some("embedded"),
+            Some("https://product-catalog.internal"),
+            None,
+            None,
+            None,
+        )
+        .expect_err("remote Product variables in embedded mode must be rejected");
+        assert!(error.contains("require RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc"));
+    }
+
+    #[test]
+    fn explicit_loopback_flag_is_not_silently_ignored_in_embedded_mode() {
+        let error = parse_deployment(Some("embedded"), None, None, None, Some("false"))
+            .expect_err("explicit remote loopback configuration must require grpc mode");
+        assert!(error.contains("require RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc"));
+    }
+
+    #[test]
+    fn invalid_boolean_is_rejected() {
+        let error = parse_deployment(
+            Some("grpc"),
+            Some("https://product-catalog.internal"),
+            None,
+            None,
+            Some("maybe"),
+        )
+        .expect_err("invalid Product loopback flag must fail closed");
+        assert!(error.contains("must be a boolean"));
+    }
+}

--- a/apps/server/src/services/server_bootstrap.rs
+++ b/apps/server/src/services/server_bootstrap.rs
@@ -10,6 +10,7 @@ use crate::services::app_router::compose_application_router;
 use crate::services::app_runtime::bootstrap_app_runtime;
 use crate::services::cache_runtime::ensure_cache_service;
 use crate::services::channel_cache_invalidation::start_channel_cache_invalidation_listener;
+use crate::services::product_catalog_deployment::configure_product_catalog_deployment;
 use crate::services::profile_media_public_image_deployment::configure_profile_media_public_image_deployment;
 use crate::services::rbac_cache_invalidation::start_rbac_cache_invalidation_listener;
 use crate::services::rbac_invalidation_generation::start_rbac_invalidation_generation_watchdog;
@@ -123,6 +124,7 @@ pub async fn bootstrap_application_router(
     rustok_settings: RustokSettings,
 ) -> Result<AxumRouter> {
     tracing::info!("RusTok application bootstrap started");
+    configure_product_catalog_deployment(&runtime_ctx).await?;
     configure_profile_media_public_image_deployment(&runtime_ctx).await?;
     let runtime =
         bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;

--- a/crates/rustok-product-transport/Cargo.toml
+++ b/crates/rustok-product-transport/Cargo.toml
@@ -14,8 +14,10 @@ rustok-api.workspace = true
 rustok-product.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 tonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }
 tonic-prost.workspace = true
+url.workspace = true
 
 [build-dependencies]
 protoc-bin-vendored.workspace = true

--- a/crates/rustok-product-transport/README.md
+++ b/crates/rustok-product-transport/README.md
@@ -5,6 +5,7 @@ Typed tonic gRPC framing for the Product-owned `ProductCatalogReadPort`.
 ## Public surface
 
 - `GrpcProductCatalogReadProvider` implements the owner port for consumers.
+- `GrpcProductCatalogReadConnectionConfig` validates and opens production client connections.
 - `ProductCatalogGrpcService<P>` exposes an owner-port provider over gRPC.
 - `TrustedProductCatalogAuthority` carries interceptor-authenticated tenant and principal authority.
 - `ProductCatalogGrpcOperation` declares the three authorized read operations.
@@ -12,9 +13,23 @@ Typed tonic gRPC framing for the Product-owned `ProductCatalogReadPort`.
 
 ## Boundary
 
-This crate owns protobuf/tonic framing, transport deadlines, gRPC status mapping, and trusted-authority adaptation. It does not own Product DTOs, catalog policy, persistence, locale/channel semantics, fallback decisions, or consumer composition.
+This crate owns protobuf/tonic framing, transport deadlines, gRPC status mapping, connection validation, and trusted-authority adaptation. It does not own Product DTOs, catalog policy, persistence, locale/channel semantics, fallback decisions, or consumer composition.
 
 Protobuf frames JSON-serialized Product-owned request/response types and `rustok_api::PortContext`. The server verifies the claimed tenant against interceptor authority and replaces untrusted actor, claims, and roles before invoking the owner port. Structured `PortError` values are carried in gRPC status details.
+
+Production connections require an absolute HTTPS service endpoint without credentials, path, query, or fragment. Plain HTTP is accepted only for an explicitly enabled loopback address. Connect timeout is limited to 1–30000 milliseconds.
+
+## Server deployment
+
+The RusToK server selects the Product catalog provider once at startup:
+
+- `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded` is the default;
+- `RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc` requires `RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT`;
+- `RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN` optionally overrides TLS SNI/domain validation;
+- `RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS` defaults to `5000`;
+- `RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true` permits only loopback HTTP for local execution.
+
+Remote variables are rejected in embedded mode. Invalid remote configuration or connection failure stops startup; the host does not silently fall back to the embedded provider.
 
 ## Evidence
 
@@ -24,4 +39,4 @@ The loopback conformance harness covers all three owner operations, typed not-fo
 cargo test -p rustok-product-transport --test port_conformance
 ```
 
-The implementation agent does not claim this command was executed. Until retained execution evidence exists and a production external profile is wired, Product remains `boundary_ready`.
+The implementation agent does not claim this command was executed. Until retained execution evidence exists, Product remains `boundary_ready`.

--- a/crates/rustok-product-transport/src/connection.rs
+++ b/crates/rustok-product-transport/src/connection.rs
@@ -1,0 +1,256 @@
+use std::{net::IpAddr, time::Duration};
+
+use thiserror::Error;
+use tonic::transport::{ClientTlsConfig, Endpoint};
+use url::{Host, Url};
+
+use crate::GrpcProductCatalogReadProvider;
+
+const MAX_CONNECT_TIMEOUT_MS: u64 = 30_000;
+
+/// Deployment-owned connection settings for the extracted Product catalog read service.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct GrpcProductCatalogReadConnectionConfig {
+    endpoint: String,
+    tls_domain: Option<String>,
+    connect_timeout: Duration,
+    allow_insecure_loopback: bool,
+}
+
+impl GrpcProductCatalogReadConnectionConfig {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            tls_domain: None,
+            connect_timeout: Duration::from_secs(5),
+            allow_insecure_loopback: false,
+        }
+    }
+
+    pub fn with_tls_domain(mut self, tls_domain: Option<String>) -> Self {
+        self.tls_domain = tls_domain;
+        self
+    }
+
+    pub fn with_connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.connect_timeout = connect_timeout;
+        self
+    }
+
+    pub fn allow_insecure_loopback(mut self, allow: bool) -> Self {
+        self.allow_insecure_loopback = allow;
+        self
+    }
+
+    pub fn validated(
+        &self,
+    ) -> Result<ValidatedGrpcProductCatalogReadConnection, GrpcProductCatalogReadConnectionError>
+    {
+        let endpoint = validate_endpoint(self.endpoint.as_str(), self.allow_insecure_loopback)?;
+        let tls_domain = normalize_tls_domain(self.tls_domain.as_deref())?;
+        let timeout_ms = u64::try_from(self.connect_timeout.as_millis()).unwrap_or(u64::MAX);
+        if timeout_ms == 0 || timeout_ms > MAX_CONNECT_TIMEOUT_MS {
+            return Err(GrpcProductCatalogReadConnectionError::InvalidConnectTimeout);
+        }
+
+        Ok(ValidatedGrpcProductCatalogReadConnection {
+            endpoint: endpoint.url,
+            endpoint_uses_tls: endpoint.uses_tls,
+            tls_domain,
+            connect_timeout: self.connect_timeout,
+        })
+    }
+
+    pub async fn connect(
+        &self,
+    ) -> Result<GrpcProductCatalogReadProvider, GrpcProductCatalogReadConnectionError> {
+        let validated = self.validated()?;
+        let mut endpoint = Endpoint::from_shared(validated.endpoint)
+            .map_err(|_| GrpcProductCatalogReadConnectionError::InvalidEndpoint)?
+            .connect_timeout(validated.connect_timeout)
+            .tcp_keepalive(Some(Duration::from_secs(30)));
+
+        if validated.endpoint_uses_tls {
+            let mut tls = ClientTlsConfig::new().with_webpki_roots();
+            if let Some(domain) = validated.tls_domain {
+                tls = tls.domain_name(domain);
+            }
+            endpoint = endpoint
+                .tls_config(tls)
+                .map_err(GrpcProductCatalogReadConnectionError::TransportConfiguration)?;
+        }
+
+        GrpcProductCatalogReadProvider::connect(endpoint)
+            .await
+            .map_err(GrpcProductCatalogReadConnectionError::Connection)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ValidatedGrpcProductCatalogReadConnection {
+    pub endpoint: String,
+    pub endpoint_uses_tls: bool,
+    pub tls_domain: Option<String>,
+    pub connect_timeout: Duration,
+}
+
+#[derive(Debug, Error)]
+pub enum GrpcProductCatalogReadConnectionError {
+    #[error(
+        "Product catalog gRPC endpoint must be an absolute http(s) service URL without credentials, query, fragment, or path"
+    )]
+    InvalidEndpoint,
+    #[error(
+        "insecure Product catalog gRPC endpoint is allowed only for an explicitly enabled loopback host"
+    )]
+    InsecureEndpointForbidden,
+    #[error("Product catalog gRPC TLS domain is invalid")]
+    InvalidTlsDomain,
+    #[error("Product catalog gRPC connect timeout must be between 1 and 30000 milliseconds")]
+    InvalidConnectTimeout,
+    #[error("Product catalog gRPC transport configuration failed")]
+    TransportConfiguration(#[source] tonic::transport::Error),
+    #[error("Product catalog gRPC connection failed")]
+    Connection(#[source] tonic::transport::Error),
+}
+
+#[derive(Debug)]
+struct ValidatedEndpoint {
+    url: String,
+    uses_tls: bool,
+}
+
+fn validate_endpoint(
+    value: &str,
+    allow_insecure_loopback: bool,
+) -> Result<ValidatedEndpoint, GrpcProductCatalogReadConnectionError> {
+    let parsed = Url::parse(value.trim())
+        .map_err(|_| GrpcProductCatalogReadConnectionError::InvalidEndpoint)?;
+    if parsed.host().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || !matches!(parsed.path(), "" | "/")
+    {
+        return Err(GrpcProductCatalogReadConnectionError::InvalidEndpoint);
+    }
+
+    let uses_tls = match parsed.scheme() {
+        "https" => true,
+        "http" if allow_insecure_loopback && is_loopback_host(parsed.host()) => false,
+        "http" => return Err(GrpcProductCatalogReadConnectionError::InsecureEndpointForbidden),
+        _ => return Err(GrpcProductCatalogReadConnectionError::InvalidEndpoint),
+    };
+
+    Ok(ValidatedEndpoint {
+        url: parsed.to_string(),
+        uses_tls,
+    })
+}
+
+fn normalize_tls_domain(
+    value: Option<&str>,
+) -> Result<Option<String>, GrpcProductCatalogReadConnectionError> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    if value.chars().any(char::is_control)
+        || value.contains('/')
+        || value.contains('@')
+        || Host::parse(value).is_err()
+    {
+        return Err(GrpcProductCatalogReadConnectionError::InvalidTlsDomain);
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn is_loopback_host(host: Option<Host<&str>>) -> bool {
+    match host {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => IpAddr::V4(address).is_loopback(),
+        Some(Host::Ipv6(address)) => IpAddr::V6(address).is_loopback(),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{
+        GrpcProductCatalogReadConnectionConfig, GrpcProductCatalogReadConnectionError,
+    };
+
+    #[test]
+    fn https_endpoint_is_accepted() {
+        let validated = GrpcProductCatalogReadConnectionConfig::new(
+            "https://product-catalog.internal:7443",
+        )
+        .with_tls_domain(Some("product-catalog.internal".to_string()))
+        .with_connect_timeout(Duration::from_millis(2_500))
+        .validated()
+        .expect("HTTPS Product endpoint should validate");
+
+        assert!(validated.endpoint_uses_tls);
+        assert_eq!(
+            validated.tls_domain.as_deref(),
+            Some("product-catalog.internal")
+        );
+        assert_eq!(validated.connect_timeout, Duration::from_millis(2_500));
+    }
+
+    #[test]
+    fn plaintext_requires_explicit_loopback() {
+        assert!(matches!(
+            GrpcProductCatalogReadConnectionConfig::new("http://127.0.0.1:7443").validated(),
+            Err(GrpcProductCatalogReadConnectionError::InsecureEndpointForbidden)
+        ));
+        assert!(
+            GrpcProductCatalogReadConnectionConfig::new("http://127.0.0.1:7443")
+                .allow_insecure_loopback(true)
+                .validated()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn non_loopback_plaintext_is_forbidden() {
+        assert!(matches!(
+            GrpcProductCatalogReadConnectionConfig::new("http://product.internal:7443")
+                .allow_insecure_loopback(true)
+                .validated(),
+            Err(GrpcProductCatalogReadConnectionError::InsecureEndpointForbidden)
+        ));
+    }
+
+    #[test]
+    fn credentials_and_paths_are_rejected() {
+        for endpoint in [
+            "https://user:secret@product.internal:7443",
+            "https://product.internal:7443/catalog",
+            "https://product.internal:7443?tenant=a",
+        ] {
+            assert!(matches!(
+                GrpcProductCatalogReadConnectionConfig::new(endpoint).validated(),
+                Err(GrpcProductCatalogReadConnectionError::InvalidEndpoint)
+            ));
+        }
+    }
+
+    #[test]
+    fn connect_timeout_is_bounded() {
+        assert!(matches!(
+            GrpcProductCatalogReadConnectionConfig::new("https://product.internal:7443")
+                .with_connect_timeout(Duration::ZERO)
+                .validated(),
+            Err(GrpcProductCatalogReadConnectionError::InvalidConnectTimeout)
+        ));
+        assert!(matches!(
+            GrpcProductCatalogReadConnectionConfig::new("https://product.internal:7443")
+                .with_connect_timeout(Duration::from_millis(30_001))
+                .validated(),
+            Err(GrpcProductCatalogReadConnectionError::InvalidConnectTimeout)
+        ));
+    }
+}

--- a/crates/rustok-product-transport/src/lib.rs
+++ b/crates/rustok-product-transport/src/lib.rs
@@ -4,6 +4,7 @@
 //! replaceable external adapter and does not own catalog storage or semantics.
 
 pub mod client;
+pub mod connection;
 pub mod server;
 
 pub mod proto {
@@ -11,6 +12,10 @@ pub mod proto {
 }
 
 pub use client::GrpcProductCatalogReadProvider;
+pub use connection::{
+    GrpcProductCatalogReadConnectionConfig, GrpcProductCatalogReadConnectionError,
+    ValidatedGrpcProductCatalogReadConnection,
+};
 pub use server::{
     ProductCatalogGrpcOperation, ProductCatalogGrpcService, TrustedProductCatalogAuthority,
 };

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -58,6 +58,7 @@
     "http_checkout_runtime_verifier": "scripts/verify/verify-product-http-checkout-catalog-runtime.mjs",
     "graphql_checkout_runtime_verifier": "scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs",
     "grpc_transport_verifier": "scripts/verify/verify-product-catalog-grpc-transport.mjs",
+    "grpc_deployment_verifier": "scripts/verify/verify-product-catalog-grpc-deployment.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
@@ -86,11 +87,16 @@
     "source": "crates/rustok-product-transport",
     "protocol": "tonic_grpc_json_owner_contract",
     "client": "GrpcProductCatalogReadProvider",
+    "connection_config": "GrpcProductCatalogReadConnectionConfig",
     "server": "ProductCatalogGrpcService",
     "trusted_authority": "TrustedProductCatalogAuthority",
     "proto": "crates/rustok-product-transport/proto/rustok/product/product_catalog.proto",
     "conformance_test": "crates/rustok-product-transport/tests/port_conformance.rs",
-    "status": "source_complete_execution_pending"
+    "host_deployment": "apps/server/src/services/product_catalog_deployment.rs",
+    "runtime_factory": "ProductCatalogReadRuntime::external",
+    "provider_selector_env": "RUSTOK_PRODUCT_CATALOG_PROVIDER",
+    "endpoint_env": "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+    "status": "runtime_wired_execution_pending"
   },
   "in_process_provider_impl": {
     "service": "CatalogService",

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -22,18 +22,30 @@ Product runtime into a resolver-scoped task-local; directly embedded schemas
 retain an explicit in-process compatibility fallback. The checkout consumer
 source cutover is complete.
 
-`rustok-product-transport` now supplies a concrete tonic gRPC client/server
-adapter for all three catalog-read operations. Protobuf owns RPC identity and
-framing while JSON preserves Product-owned request/response DTOs and
-`PortContext`. The client maps context deadlines to tonic timeouts and restores
-structured `PortError` details. The server requires interceptor-provided
+`rustok-product-transport` supplies a concrete tonic gRPC client/server adapter
+for all three catalog-read operations. Protobuf owns RPC identity and framing
+while JSON preserves Product-owned request/response DTOs and `PortContext`. The
+client maps context deadlines to tonic timeouts and restores structured
+`PortError` details. The server requires interceptor-provided
 `TrustedProductCatalogAuthority`, verifies tenant/operation authority, and
 replaces untrusted actor/claims/roles before invoking the owner port. A loopback
 conformance harness covers product projection, variant-first projection,
 published list pagination, typed not-found, deadline-required semantics, and
-trusted actor replacement. The adapter source is complete, but the harness has
-not been executed by the implementation agent, so Product remains
-`boundary_ready` rather than `transport_verified`.
+trusted actor replacement.
+
+The production host now owns explicit Product catalog deployment selection.
+`RUSTOK_PRODUCT_CATALOG_PROVIDER` defaults to `embedded`; `grpc` requires
+`RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT`. `GrpcProductCatalogReadConnectionConfig`
+requires HTTPS without credentials/path/query/fragment, permits plaintext only
+for an explicitly enabled loopback host, bounds connect timeout, and applies
+WebPKI TLS roots. The server connects before `bootstrap_app_runtime`, inserts
+`ProductCatalogReadRuntime::external(...)` into `ServerRuntimeContext`, and lets
+all existing composition surfaces reuse that same runtime. Invalid remote
+configuration or connection failure aborts startup and never silently falls back
+to embedded execution. Adapter and production-wiring source are complete, but
+neither the loopback harness nor a configured remote server execution has been
+run by the implementation agent, so Product remains `boundary_ready` rather than
+`transport_verified`.
 
 The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -126,9 +138,9 @@ rustok-pricing` dependency cycle.
 - FFA status: `in_progress` — both owner UI surfaces exist and must preserve
   the core/transport/UI split and native/GraphQL parity.
 - FBA status: `boundary_ready` — the owner port, in-process profile, host runtime,
-  declared consumer source cutovers, and external gRPC adapter source are
-  complete. Loopback execution evidence and production external-profile wiring
-  remain open.
+  declared consumer source cutovers, external gRPC adapter, validated connection
+  policy, and production host wiring are source-complete. Loopback and configured
+  remote-profile execution evidence remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
@@ -140,6 +152,7 @@ rustok-pricing` dependency cycle.
   `scripts/verify/verify-product-http-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-catalog-grpc-transport.mjs`,
+  `scripts/verify/verify-product-catalog-grpc-deployment.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -151,11 +164,11 @@ rustok-pricing` dependency cycle.
 ## Open results
 
 1. Execute `cargo test -p rustok-product-transport --test port_conformance` and
-   retain the result as external transport evidence. After successful execution,
-   wire a production configuration path that creates
-   `ProductCatalogReadRuntime::external(Arc::new(GrpcProductCatalogReadProvider))`
-   and prove Commerce hard-dependency plus AI degraded behavior against the remote
-   profile. Promote above `boundary_ready` only with that runtime evidence.
+   retain its result plus the generated `Cargo.lock` package entry as external
+   transport evidence. Then start the server with the gRPC deployment variables
+   against a real Product catalog service and execute Commerce hard-dependency
+   plus AI degraded behavior through the selected remote runtime. Promote above
+   `boundary_ready` only with retained runtime evidence for those paths.
 2. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
@@ -171,8 +184,9 @@ rustok-pricing` dependency cycle.
 - [x] Cut Commerce HTTP checkout over to the composed Product runtime.
 - [x] Cut mounted Commerce GraphQL checkout over to the composed Product runtime.
 - [x] Implement the concrete Product catalog gRPC adapter and loopback conformance harness.
+- [x] Wire a fail-closed production external Product runtime profile.
 - [ ] Execute the Product catalog gRPC loopback conformance harness.
-- [ ] Wire and execute a production external Product runtime profile.
+- [ ] Execute Commerce and AI behavior through a configured remote Product runtime.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
@@ -188,6 +202,8 @@ rustok-pricing` dependency cycle.
 - `node scripts/verify/verify-product-graphql-checkout-catalog-runtime.test.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-transport.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-transport.test.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-deployment.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-deployment.test.mjs`
 - `cargo test -p rustok-product-transport --test port_conformance`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
@@ -207,9 +223,14 @@ rustok-pricing` dependency cycle.
 
 - Product owns catalog data, `ProductCatalogReadPort`, and
   `ProductCatalogReadRuntime` profile selection.
-- `rustok-product-transport` owns only tonic/protobuf framing, deadline/status
-  mapping, and trusted-authority adaptation. It must not own Product policy,
-  persistence, DTOs, locale/channel rules, or fallback decisions.
+- `rustok-product-transport` owns only tonic/protobuf framing, validated client
+  connection policy, deadline/status mapping, and trusted-authority adaptation.
+  It must not own Product policy, persistence, DTOs, locale/channel rules, or
+  fallback decisions.
+- The server host owns deployment variables, endpoint/TLS selection, startup
+  connection, and insertion of the selected runtime. It must fail closed for an
+  invalid or unavailable configured remote provider and must not silently select
+  embedded execution.
 - The host selects and shares one Product read runtime; consumers receive the
   public port and must not construct parallel owner services.
 - Order native checkout, Commerce HTTP checkout, mounted Commerce GraphQL

--- a/scripts/verify/verify-product-catalog-grpc-deployment.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-deployment.mjs
@@ -179,7 +179,7 @@ requireAll(plan, [
   "Invalid remote configuration or connection failure aborts startup",
   "Adapter and production-wiring source are complete",
   "Product remains `boundary_ready` rather than",
-  "configured remote-profile execution evidence remain open",
+  "remote-profile execution evidence remain open",
   "Wire a fail-closed production external Product runtime profile",
   "verify-product-catalog-grpc-deployment.mjs",
 ], "Product implementation plan");

--- a/scripts/verify/verify-product-catalog-grpc-deployment.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-deployment.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required Product catalog deployment file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireAll(source, markers, description) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+  }
+}
+
+function forbidAll(source, markers, description) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
+  }
+}
+
+const transportCargo = read("crates/rustok-product-transport/Cargo.toml");
+const transportLib = read("crates/rustok-product-transport/src/lib.rs");
+const connection = read("crates/rustok-product-transport/src/connection.rs");
+const readme = read("crates/rustok-product-transport/README.md");
+const serverCargo = read("apps/server/Cargo.toml");
+const services = read("apps/server/src/services/mod.rs");
+const deployment = read("apps/server/src/services/product_catalog_deployment.rs");
+const bootstrap = read("apps/server/src/services/server_bootstrap.rs");
+const composition = read("apps/server/src/services/commerce_provider_runtime.rs");
+const registrySource = read("crates/rustok-product/contracts/product-fba-registry.json");
+const plan = read("crates/rustok-product/docs/implementation-plan.md");
+
+requireAll(transportCargo, [
+  "thiserror.workspace = true",
+  "url.workspace = true",
+  'features = ["tls-ring", "tls-webpki-roots"]',
+], "Product transport connection dependencies");
+requireAll(transportLib, [
+  "pub mod connection;",
+  "GrpcProductCatalogReadConnectionConfig",
+  "GrpcProductCatalogReadConnectionError",
+  "ValidatedGrpcProductCatalogReadConnection",
+], "Product transport connection exports");
+requireAll(connection, [
+  "pub struct GrpcProductCatalogReadConnectionConfig",
+  "pub fn validated(",
+  "pub async fn connect(",
+  "Url::parse(value.trim())",
+  "!parsed.username().is_empty()",
+  "parsed.password().is_some()",
+  "parsed.query().is_some()",
+  "parsed.fragment().is_some()",
+  '!matches!(parsed.path(), "" | "/")',
+  '"https" => true',
+  '"http" if allow_insecure_loopback && is_loopback_host(parsed.host()) => false',
+  "InsecureEndpointForbidden",
+  "MAX_CONNECT_TIMEOUT_MS",
+  "timeout_ms == 0 || timeout_ms > MAX_CONNECT_TIMEOUT_MS",
+  "ClientTlsConfig::new().with_webpki_roots()",
+  "tls.domain_name(domain)",
+  ".connect_timeout(validated.connect_timeout)",
+  ".tcp_keepalive(Some(Duration::from_secs(30)))",
+], "validated Product gRPC connection");
+forbidAll(connection, ["std::env::var", "CatalogService", "sea_orm"], "Product transport deployment ownership");
+
+requireAll(serverCargo, [
+  'mod-product   = ["dep:rustok-product", "dep:rustok-product-transport"',
+  'rustok-product-transport = { path = "../../crates/rustok-product-transport", optional = true }',
+], "server Product transport dependency");
+requireAll(services, ["pub mod product_catalog_deployment;"], "server service exports");
+requireAll(deployment, [
+  'const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER";',
+  'const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT";',
+  'const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN";',
+  '"RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS"',
+  '"RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK"',
+  'unwrap_or("embedded")',
+  '"grpc" => {',
+  "GrpcProductCatalogReadConnectionConfig::new(remote.endpoint)",
+  ".with_tls_domain(remote.tls_domain)",
+  ".with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms))",
+  ".allow_insecure_loopback(remote.allow_insecure_loopback)",
+  ".connect()",
+  "ProductCatalogReadRuntime::external(Arc::new(provider))",
+  "ctx.shared_insert(",
+  "remote Product catalog provider initialization failed",
+  "remote Product catalog variables require {PROVIDER_ENV}=grpc",
+  "is required when {PROVIDER_ENV}=grpc",
+  "must be either embedded or grpc",
+], "server Product catalog deployment");
+forbidAll(deployment, [
+  "ProductCatalogReadRuntime::in_process",
+  "CatalogService::new",
+  "unwrap_or_else(|_|",
+], "server Product catalog fail-closed deployment");
+
+requireAll(bootstrap, [
+  "configure_product_catalog_deployment(&runtime_ctx).await?;",
+  "bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;",
+], "server bootstrap Product deployment");
+const configureIndex = bootstrap.indexOf(
+  "configure_product_catalog_deployment(&runtime_ctx).await?;",
+);
+const bootstrapIndex = bootstrap.indexOf(
+  "bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;",
+);
+if (!(configureIndex >= 0 && bootstrapIndex >= 0 && configureIndex < bootstrapIndex)) {
+  failures.push("server bootstrap must configure Product deployment before app runtime composition");
+}
+
+requireAll(composition, [
+  ".shared_get::<rustok_product::ProductCatalogReadRuntime>()",
+  ".or_else(|| server.shared_get::<rustok_product::ProductCatalogReadRuntime>())",
+  "host.with_shared_value(runtime)",
+  "SharedAiProductCatalogReadPort(runtime.read_port())",
+  "ProductCatalogReadProfile::External",
+], "host-selected Product runtime composition");
+
+requireAll(readme, [
+  "RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded",
+  "RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true",
+  "does not silently fall back to the embedded provider",
+], "Product transport deployment documentation");
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  if (registry.status !== "boundary_ready") {
+    failures.push("Product FBA registry must remain boundary_ready before runtime execution evidence");
+  }
+  const external = registry.external_transport ?? {};
+  if (external.connection_config !== "GrpcProductCatalogReadConnectionConfig") {
+    failures.push("Product registry must identify the validated connection config");
+  }
+  if (external.host_deployment !== "apps/server/src/services/product_catalog_deployment.rs") {
+    failures.push("Product registry must identify the server deployment source");
+  }
+  if (external.runtime_factory !== "ProductCatalogReadRuntime::external") {
+    failures.push("Product registry must identify the external runtime factory");
+  }
+  if (external.provider_selector_env !== "RUSTOK_PRODUCT_CATALOG_PROVIDER") {
+    failures.push("Product registry must identify the provider selector environment variable");
+  }
+  if (external.endpoint_env !== "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT") {
+    failures.push("Product registry must identify the endpoint environment variable");
+  }
+  if (external.status !== "runtime_wired_execution_pending") {
+    failures.push("Product registry must retain runtime_wired_execution_pending status");
+  }
+  if (
+    registry.evidence?.grpc_deployment_verifier !==
+    "scripts/verify/verify-product-catalog-grpc-deployment.mjs"
+  ) {
+    failures.push("Product registry must link the gRPC deployment verifier");
+  }
+}
+
+requireAll(plan, [
+  "The production host now owns explicit Product catalog deployment selection",
+  "Invalid remote configuration or connection failure aborts startup",
+  "Adapter and production-wiring source are complete",
+  "Product remains `boundary_ready` rather than",
+  "configured remote-profile execution evidence remain open",
+  "Wire a fail-closed production external Product runtime profile",
+  "verify-product-catalog-grpc-deployment.mjs",
+], "Product implementation plan");
+
+if (failures.length > 0) {
+  console.error("Product catalog gRPC deployment verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Product catalog gRPC deployment source verification passed");

--- a/scripts/verify/verify-product-catalog-grpc-deployment.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-deployment.test.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-catalog-grpc-deployment.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-grpc-deployment-"));
+
+  write(
+    root,
+    "crates/rustok-product-transport/Cargo.toml",
+    `thiserror.workspace = true\nurl.workspace = true\ntonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/lib.rs",
+    `pub mod connection; GrpcProductCatalogReadConnectionConfig GrpcProductCatalogReadConnectionError ValidatedGrpcProductCatalogReadConnection`,
+  );
+  const connection = options.missingTls
+    ? `pub struct GrpcProductCatalogReadConnectionConfig; pub fn validated( Url::parse(value.trim()) !parsed.username().is_empty() parsed.password().is_some() parsed.query().is_some() parsed.fragment().is_some() !matches!(parsed.path(), "" | "/") "http" if allow_insecure_loopback && is_loopback_host(parsed.host()) => false InsecureEndpointForbidden MAX_CONNECT_TIMEOUT_MS timeout_ms == 0 || timeout_ms > MAX_CONNECT_TIMEOUT_MS .connect_timeout(validated.connect_timeout) .tcp_keepalive(Some(Duration::from_secs(30))) pub async fn connect(`
+    : `pub struct GrpcProductCatalogReadConnectionConfig; pub fn validated( Url::parse(value.trim()) !parsed.username().is_empty() parsed.password().is_some() parsed.query().is_some() parsed.fragment().is_some() !matches!(parsed.path(), "" | "/") "https" => true "http" if allow_insecure_loopback && is_loopback_host(parsed.host()) => false InsecureEndpointForbidden MAX_CONNECT_TIMEOUT_MS timeout_ms == 0 || timeout_ms > MAX_CONNECT_TIMEOUT_MS ClientTlsConfig::new().with_webpki_roots() tls.domain_name(domain) .connect_timeout(validated.connect_timeout) .tcp_keepalive(Some(Duration::from_secs(30))) pub async fn connect(`;
+  write(root, "crates/rustok-product-transport/src/connection.rs", connection);
+  write(
+    root,
+    "crates/rustok-product-transport/README.md",
+    `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true does not silently fall back to the embedded provider`,
+  );
+
+  write(
+    root,
+    "apps/server/Cargo.toml",
+    `mod-product   = ["dep:rustok-product", "dep:rustok-product-transport"\nrustok-product-transport = { path = "../../crates/rustok-product-transport", optional = true }`,
+  );
+  write(
+    root,
+    "apps/server/src/services/mod.rs",
+    `pub mod product_catalog_deployment;`,
+  );
+  const fallback = options.silentFallback
+    ? `ProductCatalogReadRuntime::in_process unwrap_or_else(|_|`
+    : "";
+  write(
+    root,
+    "apps/server/src/services/product_catalog_deployment.rs",
+    `const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER"; const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT"; const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN"; "RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS" "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK" unwrap_or("embedded") "grpc" => { GrpcProductCatalogReadConnectionConfig::new(remote.endpoint) .with_tls_domain(remote.tls_domain) .with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms)) .allow_insecure_loopback(remote.allow_insecure_loopback) .connect() ProductCatalogReadRuntime::external(Arc::new(provider)) ctx.shared_insert( remote Product catalog provider initialization failed remote Product catalog variables require {PROVIDER_ENV}=grpc is required when {PROVIDER_ENV}=grpc must be either embedded or grpc ${fallback}`,
+  );
+  const configure = "configure_product_catalog_deployment(&runtime_ctx).await?;";
+  const appBootstrap =
+    "bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;";
+  write(
+    root,
+    "apps/server/src/services/server_bootstrap.rs",
+    options.bootstrapAfter
+      ? `${appBootstrap} ${configure}`
+      : `${configure} ${appBootstrap}`,
+  );
+  write(
+    root,
+    "apps/server/src/services/commerce_provider_runtime.rs",
+    `.shared_get::<rustok_product::ProductCatalogReadRuntime>() .or_else(|| server.shared_get::<rustok_product::ProductCatalogReadRuntime>()) host.with_shared_value(runtime) SharedAiProductCatalogReadPort(runtime.read_port()) ProductCatalogReadProfile::External`,
+  );
+
+  const falsePromotion = options.falsePromotion === true;
+  const staleRegistry = options.staleRegistry === true;
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      status: falsePromotion ? "transport_verified" : "boundary_ready",
+      evidence: {
+        grpc_deployment_verifier:
+          "scripts/verify/verify-product-catalog-grpc-deployment.mjs",
+      },
+      external_transport: {
+        connection_config: "GrpcProductCatalogReadConnectionConfig",
+        host_deployment: "apps/server/src/services/product_catalog_deployment.rs",
+        runtime_factory: "ProductCatalogReadRuntime::external",
+        provider_selector_env: "RUSTOK_PRODUCT_CATALOG_PROVIDER",
+        endpoint_env: "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+        status: staleRegistry
+          ? "source_complete_execution_pending"
+          : falsePromotion
+            ? "transport_verified"
+            : "runtime_wired_execution_pending",
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.missingPlan
+      ? "Product plan"
+      : "The production host now owns explicit Product catalog deployment selection. Invalid remote configuration or connection failure aborts startup. Adapter and production-wiring source are complete. Product remains `boundary_ready` rather than `transport_verified`; configured remote-profile execution evidence remain open. Wire a fail-closed production external Product runtime profile. verify-product-catalog-grpc-deployment.mjs",
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected Product deployment mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("Product catalog gRPC deployment guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deployment guard rejects missing TLS policy", () => {
+  reject({ missingTls: true }, /validated Product gRPC connection/);
+});
+
+test("deployment guard rejects silent embedded fallback", () => {
+  reject({ silentFallback: true }, /fail-closed deployment/);
+});
+
+test("deployment guard rejects configuration after app bootstrap", () => {
+  reject({ bootstrapAfter: true }, /before app runtime composition/);
+});
+
+test("deployment guard rejects stale registry status", () => {
+  reject({ staleRegistry: true }, /runtime_wired_execution_pending/);
+});
+
+test("deployment guard rejects false transport promotion", () => {
+  reject({ falsePromotion: true }, /remain boundary_ready|runtime_wired_execution_pending/);
+});
+
+test("deployment guard rejects missing plan handoff", () => {
+  reject({ missingPlan: true }, /Product implementation plan/);
+});

--- a/scripts/verify/verify-product-catalog-grpc-transport.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.mjs
@@ -47,8 +47,10 @@ requireAll(cargo, [
   'name = "rustok-product-transport"',
   "rustok-api.workspace = true",
   "rustok-product.workspace = true",
+  "thiserror.workspace = true",
   "tonic = { workspace = true",
   "tonic-prost.workspace = true",
+  "url.workspace = true",
   "protoc-bin-vendored.workspace = true",
   "tonic-prost-build.workspace = true",
   'tokio-stream = { version = "0.1", features = ["net"] }',
@@ -72,9 +74,11 @@ requireAll(proto, [
 ], "Product catalog protobuf");
 requireAll(lib, [
   "pub mod client;",
+  "pub mod connection;",
   "pub mod server;",
   'tonic::include_proto!("rustok.product")',
   "GrpcProductCatalogReadProvider",
+  "GrpcProductCatalogReadConnectionConfig",
   "ProductCatalogGrpcService",
   "TrustedProductCatalogAuthority",
   "ProductCatalogGrpcOperation",
@@ -151,8 +155,8 @@ if (registry) {
   if (external.crate !== "rustok-product-transport") {
     failures.push("Product FBA registry must name rustok-product-transport");
   }
-  if (external.status !== "source_complete_execution_pending") {
-    failures.push("Product external transport must remain source_complete_execution_pending");
+  if (external.status !== "runtime_wired_execution_pending") {
+    failures.push("Product external transport must remain runtime_wired_execution_pending");
   }
   if (external.client !== "GrpcProductCatalogReadProvider") {
     failures.push("Product external transport client identity drift");
@@ -182,10 +186,10 @@ if (registry) {
 }
 
 requireAll(plan, [
-  "`rustok-product-transport` now supplies a concrete tonic gRPC client/server adapter",
-  "source is complete",
-  "has not been executed by the implementation agent",
-  "Loopback execution evidence and production external-profile wiring",
+  "`rustok-product-transport` supplies a concrete tonic gRPC client/server adapter",
+  "Adapter and production-wiring source are complete",
+  "has been run by the implementation agent",
+  "configured remote-profile execution evidence remain open",
   "cargo test -p rustok-product-transport --test port_conformance",
   "ProductCatalogReadRuntime::external",
   "verify-product-catalog-grpc-transport.mjs",

--- a/scripts/verify/verify-product-catalog-grpc-transport.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.mjs
@@ -188,8 +188,8 @@ if (registry) {
 requireAll(plan, [
   "`rustok-product-transport` supplies a concrete tonic gRPC client/server adapter",
   "Adapter and production-wiring source are complete",
-  "has been run by the implementation agent",
-  "configured remote-profile execution evidence remain open",
+  "run by the implementation agent",
+  "remote-profile execution evidence remain open",
   "cargo test -p rustok-product-transport --test port_conformance",
   "ProductCatalogReadRuntime::external",
   "verify-product-catalog-grpc-transport.mjs",

--- a/scripts/verify/verify-product-catalog-grpc-transport.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-transport.test.mjs
@@ -23,8 +23,8 @@ function fixture(options = {}) {
     root,
     "crates/rustok-product-transport/Cargo.toml",
     options.storageDependency
-      ? `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }\nsea-orm.workspace = true`
-      : `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }`,
+      ? `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\nthiserror.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nurl.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }\nsea-orm.workspace = true`
+      : `name = "rustok-product-transport"\nrustok-api.workspace = true\nrustok-product.workspace = true\nthiserror.workspace = true\ntonic = { workspace = true }\ntonic-prost.workspace = true\nurl.workspace = true\nprotoc-bin-vendored.workspace = true\ntonic-prost-build.workspace = true\ntokio-stream = { version = "0.1", features = ["net"] }`,
   );
   write(
     root,
@@ -42,7 +42,7 @@ function fixture(options = {}) {
   write(
     root,
     "crates/rustok-product-transport/src/lib.rs",
-    `pub mod client; pub mod server; tonic::include_proto!("rustok.product"); GrpcProductCatalogReadProvider ProductCatalogGrpcService TrustedProductCatalogAuthority ProductCatalogGrpcOperation`,
+    `pub mod client; pub mod connection; pub mod server; tonic::include_proto!("rustok.product"); GrpcProductCatalogReadProvider GrpcProductCatalogReadConnectionConfig ProductCatalogGrpcService TrustedProductCatalogAuthority ProductCatalogGrpcOperation`,
   );
   write(
     root,
@@ -82,7 +82,7 @@ function fixture(options = {}) {
         server: "ProductCatalogGrpcService",
         status: falsePromotion
           ? "transport_verified"
-          : "source_complete_execution_pending",
+          : "runtime_wired_execution_pending",
       },
       contract_tests: {
         profiles: ["in_process", "remote_adapter_placeholder", "grpc_loopback"],
@@ -111,7 +111,7 @@ function fixture(options = {}) {
     "crates/rustok-product/docs/implementation-plan.md",
     options.omitPlan
       ? "Product plan"
-      : "`rustok-product-transport` now supplies a concrete tonic gRPC client/server adapter. The adapter source is complete, but has not been executed by the implementation agent. Loopback execution evidence and production external-profile wiring remain open. cargo test -p rustok-product-transport --test port_conformance ProductCatalogReadRuntime::external verify-product-catalog-grpc-transport.mjs",
+      : "`rustok-product-transport` supplies a concrete tonic gRPC client/server adapter. Adapter and production-wiring source are complete, but neither path has been run by the implementation agent. Loopback and configured remote-profile execution evidence remain open. cargo test -p rustok-product-transport --test port_conformance ProductCatalogReadRuntime::external verify-product-catalog-grpc-transport.mjs",
   );
   return root;
 }
@@ -158,7 +158,7 @@ test("gRPC transport guard rejects Product storage ownership", () => {
 });
 
 test("gRPC transport guard rejects false transport promotion", () => {
-  reject({ falsePromotion: true }, /remain boundary_ready|source_complete_execution_pending/);
+  reject({ falsePromotion: true }, /remain boundary_ready|runtime_wired_execution_pending/);
 });
 
 test("gRPC transport guard rejects missing plan handoff", () => {


### PR DESCRIPTION
## Summary

- add `GrpcProductCatalogReadConnectionConfig` with validated HTTPS endpoint, optional TLS domain, bounded connect timeout, WebPKI roots, and explicit loopback-only plaintext support;
- add fail-closed server deployment selection through `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded|grpc` and Product catalog gRPC environment variables;
- connect the remote provider before app runtime composition and insert `ProductCatalogReadRuntime::external(...)` into `ServerRuntimeContext`;
- reuse the existing host composition so HTTP, GraphQL, native checkout, Marketplace Listing, and AI observe the same selected runtime;
- reject remote variables in embedded mode and abort startup for invalid configuration or connection failure instead of silently falling back;
- feature-gate the server dependency through `mod-product`;
- update the Product FBA registry and implementation plan while retaining `boundary_ready` and recording `runtime_wired_execution_pending`;
- synchronize the existing transport guard and add focused deployment source/mutation guards.

## Boundary

This PR completes production remote-profile source wiring. It does not claim that the loopback conformance harness, the server with a configured remote Product service, Commerce hard-dependency behavior, or AI degraded behavior were executed. Product remains `boundary_ready` until retained runtime evidence exists.

`Cargo.lock` is not regenerated by the implementation agent because the maintainer requested that Cargo/test commands be run locally. Retain the resulting lockfile update with the first successful execution evidence.

## Testing

Not run by the implementation agent, following the maintainer instruction.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-catalog-grpc-transport.mjs
node scripts/verify/verify-product-catalog-grpc-transport.test.mjs
node scripts/verify/verify-product-catalog-grpc-deployment.mjs
node scripts/verify/verify-product-catalog-grpc-deployment.test.mjs
cargo test -p rustok-product-transport --test port_conformance
```

For local remote-profile execution, use an explicit loopback endpoint only with:

```bash
RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc
RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT=http://127.0.0.1:<port>
RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true
```

Production endpoints require HTTPS by default.