### PR TITLE
feat(profiles): advance DLQ duplicate moving windows

### DIFF
--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dlq-duplicate-inspection-source",
   "status": "source_complete_runtime_evidence_pending",
@@ -86,15 +86,23 @@
     "result": "DlqDuplicateSummary"
   },
   "rolling_window": {
-    "status": "source_complete_scanner_integration_pending",
+    "status": "source_complete_moving_scan_integrated_server_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
     "result": "DlqDuplicateRollingWindowSnapshot",
     "complete_cycle_retention": true,
     "history_truncated_after_eviction": true,
     "identifier_export": false,
-    "moving_cursor": false,
-    "persistence": false
+    "moving_scanner": {
+      "status": "source_complete_server_composition_runtime_pending",
+      "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
+      "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+      "independent_process_local_partition_cursors": true,
+      "complete_cycle_atomicity": true,
+      "progress_persisted": false,
+      "restart_semantics": "reset_to_reviewed_initial_offset",
+      "cursor_values_exported": false
+    }
   },
   "alert_policy": {
     "status": "source_complete_server_observer_execution_pending",
@@ -131,15 +139,16 @@
       "external"
     ],
     "startup_failure_non_fatal": true,
-    "partition_fairness_claimed": false,
+    "moving_window_mode": "pending_explicit_opt_in",
     "readiness_dependency": false,
     "profiles_authorization": false
   },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
-    "partition_fairness_or_per_partition_budget_policy",
-    "moving_window_or_per_partition_cursor_policy",
-    "rolling_window_scanner_cursor_persistence_integration",
+    "compose_moving_window_server_observer",
+    "define_reviewed_moving_window_configuration",
+    "retain_moving_window_external_runtime_evidence",
+    "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",
     "operator_ack_delete_replay_workflow_outside_inspector",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "module": "iggy",
+  "packet": "dlq-duplicate-moving-window-scan-source",
+  "status": "source_complete_server_composition_runtime_pending",
+  "owner": "rustok-iggy",
+  "feature": "iggy",
+  "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+  "rolling_source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
+  "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "verifier": "scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs",
+  "documentation": "crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md",
+  "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md",
+  "public_exports": [
+    "IggyDlqDuplicateMovingWindowPolicy",
+    "IggyDlqDuplicateMovingWindowState",
+    "IggyDlqDuplicateMovingWindowSnapshot",
+    "IggyDlqDuplicateMovingWindowScanner",
+    "IggyDlqDuplicateMovingWindowError"
+  ],
+  "bounds": {
+    "maximum_partitions": 128,
+    "maximum_total_messages_per_cycle": 10000,
+    "maximum_batch_messages": 1000,
+    "equal_per_partition_message_budget": true,
+    "rolling_cycle_capacity_must_cover_fair_cycle": true,
+    "production_defaults": false
+  },
+  "cursor_semantics": {
+    "one_private_next_offset_per_partition": true,
+    "advance_only_after_complete_all_partition_cycle": true,
+    "empty_partition_cursor_unchanged": true,
+    "failed_cycle_preserves_all_cursors": true,
+    "explicit_offsets": true,
+    "auto_commit": false,
+    "stored_consumer_offsets": false
+  },
+  "rolling_integration": {
+    "complete_cycle_only": true,
+    "combined_observations_not_exported": true,
+    "failed_cycle_preserves_rolling_state": true,
+    "cross_cycle_ordinary_duplicate": true,
+    "cross_cycle_identity_conflict": true,
+    "history_truncated_delegated": true
+  },
+  "restart_semantics": {
+    "progress_persisted": false,
+    "rolling_state_persisted": false,
+    "new_process_starts_at_reviewed_initial_offset": true,
+    "explicit_reset_to_initial_offset": true,
+    "reset_clears_rolling_history": true,
+    "reset_generation_count_only": true,
+    "restart_safe_progress_claimed": false
+  },
+  "snapshot_fields": [
+    "rolling",
+    "partition_count",
+    "advanced_partitions",
+    "reset_generation"
+  ],
+  "privacy_boundary": {
+    "identifier_free_snapshot": true,
+    "payload_free_snapshot": true,
+    "cursor_values_not_exported": true,
+    "observations_not_exported": true,
+    "snapshot_excludes": [
+      "broker_address",
+      "stream",
+      "topic",
+      "partition_id",
+      "offset",
+      "broker_message_id",
+      "payload",
+      "payload_sha256",
+      "receipt_identity",
+      "publisher_identity",
+      "credential",
+      "timestamp",
+      "raw_iggy_error"
+    ]
+  },
+  "mutation_boundary": {
+    "store_consumer_offsets": false,
+    "acknowledge": false,
+    "publish": false,
+    "delete": false,
+    "purge": false,
+    "replay": false,
+    "retry": false,
+    "mutate_receipts": false,
+    "authorize_profiles": false
+  },
+  "stable_errors": {
+    "invalid_policy": "iggy.dlq_duplicate.moving_window_policy_invalid",
+    "poll_failed": "iggy.dlq_duplicate.moving_window_poll_failed",
+    "invalid_response": "iggy.dlq_duplicate.moving_window_response_invalid",
+    "offset_overflow": "iggy.dlq_duplicate.moving_window_offset_overflow",
+    "invalid_cycle": "iggy.dlq_duplicate.moving_window_cycle_invalid",
+    "count_overflow": "iggy.dlq_duplicate.moving_window_count_overflow",
+    "reset_overflow": "iggy.dlq_duplicate.moving_window_reset_overflow"
+  },
+  "required_source_tests": [
+    "policy_requires_complete_fair_cycle_to_fit_rolling_capacity",
+    "complete_cycle_advances_partition_cursors_independently",
+    "duplicate_split_across_advancing_cycles_remains_count_only",
+    "incomplete_cycle_preserves_cursors_and_rolling_state",
+    "explicit_reset_rewinds_cursors_and_clears_rolling_history"
+  ],
+  "integration_boundary": {
+    "mode_aware_server_observer": "pending",
+    "configuration_surface": "pending",
+    "external_iggy_runtime_evidence": "pending",
+    "retained_execution_packet": "pending",
+    "telemetry_and_health_projection": "pending"
+  },
+  "non_claims": [
+    "persisted_progress",
+    "restart_safe_progress",
+    "current_tail_coverage",
+    "complete_history",
+    "production_retention_sufficiency",
+    "server_observer_integration",
+    "external_iggy_execution",
+    "exactly_once",
+    "profiles_authorization"
+  ],
+  "remaining_work": [
+    "compose_explicit_opt_in_mode_aware_server_observer",
+    "define_reviewed_configuration_surface",
+    "retain_external_iggy_cross_cycle_runtime_evidence",
+    "define_persisted_cursor_store_only_if_restart_continuity_is_required",
+    "define_identifier_free_telemetry_and_health_projection"
+  ],
+  "execution_status": "source_not_run"
+}

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dlq-duplicate-rolling-window-source",
-  "status": "source_complete_scanner_integration_pending",
+  "status": "source_complete_moving_scan_integrated_server_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
   "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
@@ -90,16 +90,19 @@
     "oldest_complete_cycle_eviction_marks_history_truncated",
     "oversized_cycle_rejection_preserves_existing_state"
   ],
-  "integration_boundary": {
-    "scanner_collection": "pending",
-    "per_partition_cursor_policy": "pending",
-    "cursor_persistence": false,
-    "restart_recovery": false,
+  "moving_scan_integration": {
+    "status": "source_complete_server_composition_runtime_pending",
+    "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
+    "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+    "complete_cycle_feeding": true,
+    "independent_process_local_partition_cursors": true,
+    "cursor_values_exported": false,
+    "progress_persisted": false,
+    "restart_semantics": "reset_to_reviewed_initial_offset",
     "server_observer_composition": "pending",
     "runtime_evidence": "pending"
   },
   "non_claims": [
-    "moving_cursor",
     "persisted_progress",
     "restart_safe_state",
     "current_tail_coverage",
@@ -109,11 +112,10 @@
     "profiles_authorization"
   ],
   "remaining_work": [
-    "feed_complete_scanner_cycles_without_identifier_export",
-    "define_per_partition_cursor_advancement",
-    "define_state_persistence_or_restart_reset_semantics",
     "compose_mode_aware_server_observer",
+    "define_reviewed_moving_scan_configuration",
     "retain_external_iggy_cross_cycle_runtime_evidence",
+    "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
     "define_identifier_free_telemetry_and_health_projection"
   ],
   "execution_status": "source_not_run"

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,14 +1,12 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier, bounded scanner, bounded rolling state, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; scanner/cursor integration, runtime execution, and telemetry/health projection pending**.
+Status: **classifier, fixed scanners, bounded rolling state, moving scanner integration, runtime harnesses, retained tooling, alert policy, latest-value runtime, and fixed-window mode-aware observer source-complete; moving server composition, runtime execution, and telemetry/health projection pending**.
 
 ## Purpose
 
 The neutral poison receipt store answers whether a source delivery is reserved, publishing, published, or acknowledged. It does not answer how many physical copies currently exist in the physical `dlq` topic.
 
 Physical copies can exceed one when broker-side deterministic message-ID deduplication is disabled, expired, evicted, or not preserved by an unsupported path.
-
-The implementation is deliberately split:
 
 ```text
 physical observations
@@ -53,7 +51,7 @@ The summary excludes broker coordinates, UUIDs, payloads/digests, receipt identi
 
 ## Mutation boundary
 
-The classifier, rolling state, and scanner cannot acknowledge, store offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
+The classifier, rolling state, fixed scanners, and moving scanner cannot acknowledge, store consumer offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
 
 The alert policy cannot scan, route notifications, persist thresholds, or mutate state. The latest-value runtime cannot start workers, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
 
@@ -65,7 +63,7 @@ The alert policy cannot scan, route notifications, persist thresholds, or mutate
 
 `ConsumerPoisonReceiptInspector` remains an independent count-only PostgreSQL view. Receipt and physical duplicate summaries contain no identifiers and cannot be joined message by message.
 
-## Bounded Iggy scanner
+## Fixed bounded Iggy scanners
 
 `IggyDlqDuplicateScanner` polls only:
 
@@ -79,7 +77,7 @@ auto_commit = false
 
 One request permits at most 128 partition identifiers, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
 
-The global message budget is shared across the ordered partition allowlist. It may be exhausted before later partitions are polled, so the compatibility scanner makes no partition-fairness claim. The opt-in fair policy gives each selected partition one equal cap under the same checked 10,000-message total.
+The global message budget is shared across the ordered partition allowlist and can starve later partitions. The opt-in fair policy gives each selected partition one equal cap under the same checked 10,000-message total. Both fixed policies reuse configured explicit offsets and do not retain cross-cycle identity state.
 
 ## Bounded cross-cycle rolling state
 
@@ -95,9 +93,24 @@ history_truncated = true
 
 An evicted older copy can remove a previously visible duplicate relationship. The retained result is therefore not complete history, current-tail proof, or production retention evidence.
 
-The state does not connect to Iggy, move a broker cursor, persist offsets, serialize itself, or define restart semantics. Feeding complete scanner cycles and advancing independent per-partition cursors remain separate reviewed integration work.
+## Moving scanner integration
 
-## Count-only alert policy
+The moving scanner integration is source-complete in `dlq_duplicate_moving_window_scan.rs`.
+
+`IggyDlqDuplicateMovingWindowState` owns independent process-local per-partition cursors. `IggyDlqDuplicateMovingWindowScanner` applies one equal bounded budget per selected partition with explicit offsets and `auto_commit=false`.
+
+Complete-cycle atomicity is mandatory:
+
+1. every selected partition is polled into a temporary candidate;
+2. returned partition, count, offsets, UUID, and bounds are validated;
+3. the combined opaque observations are pushed as one complete rolling cycle;
+4. every private cursor is replaced together only after rolling acceptance.
+
+Any polling, response, offset, classification, or rolling error preserves all cursor and rolling state. Empty partitions are valid and keep their cursor unchanged. Public snapshots retain only rolling counts, partition count, advanced-partition count, and reset generation; no partition ID, cursor value, message identity, payload, or digest is exported.
+
+Progress persistence is deliberately absent. New process-local state starts at one reviewed initial offset. An explicit restart reset through `reset_to_initial_offset()` rewinds all cursors and clears rolling history. No restart-safe progress, current-tail, or complete-history claim is made. A persistent cursor owner remains separate work only if restart continuity is required.
+
+## Count-only alert policy and latest-value runtime
 
 `DlqDuplicateAlertPolicy` requires explicit warning and critical thresholds for duplicate messages, duplicate groups, and maximum copies for one message ID. It defines no production defaults.
 
@@ -111,17 +124,13 @@ no duplicate -> Clear
 
 The evaluation exposes only level and boolean reason flags.
 
-## Latest-value alert runtime
-
-`DlqDuplicateAlertRuntimePublisher` accepts an already-observed summary and a prevalidated policy.
-
-Initial state is generation `0`, unavailable, with no evaluation. Successful and unavailable transitions advance generation through checked arithmetic. `mark_unavailable()` clears the previous evaluation so stale severity is not shown as current.
+`DlqDuplicateAlertRuntimePublisher` accepts an already-observed summary and a prevalidated policy. Initial state is generation `0`, unavailable, with no evaluation. Successful and unavailable transitions advance generation through checked arithmetic. `mark_unavailable()` clears the previous evaluation so stale severity is not shown as current.
 
 The runtime is a latest-value channel, not an event log. It adds no serialization or persistence.
 
 ## Mode-aware server observer
 
-The host owns an explicit capability gate across every delivery/startup mode:
+The current host observer owns an explicit capability gate:
 
 ```text
 disabled      -> Disabled
@@ -131,46 +140,35 @@ outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
 ```
 
-For `memory` and `outbox_local`, no Iggy transport is requested, no broker connection is opened, and thresholds are not required. Not-applicable state is valid operation rather than a degraded condition.
+For `memory` and `outbox_local`, no Iggy transport is requested and no broker connection is opened. For `outbox_iggy`, the observer reuses the active bundled or external transport configuration and opens only a separate read-only SDK client. Startup and scan failures are non-fatal to event delivery and Profiles.
 
-For `outbox_iggy`, the observer reuses the exact active transport configuration and opens a separate read-only SDK client:
-
-- bundled mode connects to the existing validated loopback broker;
-- external mode uses the reviewed address list;
-- missing active Iggy mode fails closed;
-- no second transport or broker process is created;
-- connection/scan failure publishes unavailable state and retries later;
-- event delivery and module projection remain active.
-
-Observer-specific startup failures are non-fatal. Invalid observer configuration or a missing observer dependency records `Unavailable`, logs only a stable code, and returns success to server bootstrap.
-
-The observer includes every configured domain partition in the scanner request. Global mode may let an early partition consume the shared budget; fair mode attempts every selected partition under an equal cap.
-
-Each poll still reuses one configured explicit start offset. The current observer is a repeated bounded snapshot, not a moving cursor, current-tail monitor, or complete-history observer. The source-complete rolling state is not yet composed into the scanner or server observer.
+The current observer still runs fixed global or fair snapshots. Moving-window mode remains a pending explicit opt-in; this PR does not silently change server behavior or configuration defaults.
 
 ## Safe operational sequence
 
 1. resolve the active event delivery profile;
 2. return not-applicable before Iggy access for `memory` or `outbox_local`;
-3. for `outbox_iggy`, use the already-active bundled or external configuration;
-4. scan one bounded explicit-offset window with `auto_commit=false`;
-5. optionally retain complete cycles only through a separately composed bounded rolling state;
-6. evaluate through explicit thresholds;
-7. publish only the identifier-free latest snapshot;
-8. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
-9. keep cursor policy, persistence, telemetry, health, notification delivery, and destructive actions in separate owners.
+3. for `outbox_iggy`, reuse the active bundled or external configuration;
+4. select one explicitly configured fixed or future moving scan mode;
+5. poll with explicit offsets and `auto_commit=false`;
+6. for moving mode, atomically retain one complete all-partition cycle;
+7. evaluate through explicit thresholds;
+8. publish only the identifier-free latest snapshot;
+9. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
+10. keep persistent cursor ownership, telemetry, health, notification delivery, and destructive actions separate.
 
 ## Runtime and retained evidence status
 
-The opt-in external harness and privacy-safe retained tooling are source-complete. The canonical execution JSON remains absent until a maintainer runs the reviewed external-Iggy scenario successfully.
+The fixed external harnesses and privacy-safe retained tooling are source-complete. Canonical execution JSON remains absent until maintainers run reviewed external-Iggy scenarios.
 
-The bounded rolling state and mode-aware server observer are source-complete as separate components. Scanner-to-state integration, per-partition cursor semantics, persistence/restart behavior, cross-cycle external-Iggy execution, telemetry, optional operational health without readiness coupling, and retained server evidence remain pending.
+The rolling state and moving scanner integration are source-complete as library components. Moving server composition and reviewed configuration, cross-cycle external-Iggy execution, optional persistent cursor ownership, telemetry, operational health, and retained server evidence remain pending.
 
 ## Source verification
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
@@ -183,12 +181,13 @@ No tests, Cargo commands, formatters, verifiers, broker scans, server observers,
 
 ## Remaining work
 
-1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. feed complete fair scanner cycles into the rolling state without identifier export;
-3. define independent per-partition cursor advancement and persistence/restart semantics;
-4. prove cross-cycle behavior on external Iggy and compose the mode-aware observer;
-5. define identifier-free telemetry and optional operational health;
-6. retain mode-aware server observer execution evidence;
-7. define alert routing, cooldown, and suppression separately;
-8. design acknowledgement/delete/replay as a separately authorized operation;
-9. correlate aggregate receipt and duplicate health without exporting message identities.
+1. execute and retain the reviewed fixed external-Iggy duplicate scan packets;
+2. compose moving-window scanning as an explicit mode-aware server opt-in;
+3. define reviewed moving-window configuration and fail-closed validation;
+4. retain a real external-Iggy duplicate split across advancing cycles;
+5. add a persistent cursor owner only if restart continuity is required;
+6. define identifier-free telemetry and optional operational health;
+7. retain server observer execution evidence;
+8. define alert routing, cooldown, and suppression separately;
+9. design acknowledgement/delete/replay as a separately authorized operation;
+10. correlate aggregate receipt and duplicate health without exporting message identities.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -163,6 +163,8 @@ The fixed external harnesses and privacy-safe retained tooling are source-comple
 
 The rolling state and moving scanner integration are source-complete as library components. Moving server composition and reviewed configuration, cross-cycle external-Iggy execution, optional persistent cursor ownership, telemetry, operational health, and retained server evidence remain pending.
 
+Moving server composition and runtime evidence pending remain explicit non-claims.
+
 ## Source verification
 
 ```bash

--- a/crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
@@ -1,0 +1,115 @@
+# Moving physical DLQ duplicate window scan
+
+Status: **scanner, independent in-memory partition cursors, complete-cycle rolling integration, and explicit restart reset source-complete; server composition and runtime evidence pending**.
+
+## Purpose
+
+The fixed global and fair scanners classify one explicit-offset snapshot. The bounded rolling state retains opaque observations across complete cycles, but it does not collect those cycles or advance broker offsets.
+
+`IggyDlqDuplicateMovingWindowScanner` and `IggyDlqDuplicateMovingWindowState` compose those boundaries without exporting identifiers:
+
+```text
+independent private partition cursors
+  -> complete equal-budget read-only Iggy cycle
+  -> one atomic rolling-window push
+  -> identifier-free moving-window snapshot
+```
+
+The adapter is opt-in and does not replace the compatibility fixed-window scanner or the current server observer.
+
+## Explicit policy
+
+`IggyDlqDuplicateMovingWindowPolicy` requires:
+
+```text
+partitions
+initial_offset
+per_partition_messages
+batch_size
+DlqDuplicateRollingWindowPolicy
+```
+
+Rules:
+
+- 1 to 128 unique positive partitions;
+- positive equal per-partition message budget;
+- batch size no greater than 1,000 or the per-partition budget;
+- checked total `partition_count * per_partition_messages <= 10000`;
+- the rolling policy's per-cycle capacity must cover the full fair-cycle budget;
+- no production defaults.
+
+Every partition begins at the same reviewed `initial_offset`, then advances independently in process memory.
+
+## Complete-cycle atomicity
+
+One scan cycle polls every configured partition with:
+
+```text
+topic = dlq
+standalone consumer
+explicit partition
+PollingStrategy::offset(private_next_offset)
+auto_commit = false
+```
+
+The scanner validates returned partition, count, strictly increasing offsets, header UUID, and checked offset advancement.
+
+Nothing is committed while polling. Only after every partition succeeds does the state:
+
+1. validate the complete partition set and each expected start offset;
+2. combine opaque observations without exposing them;
+3. push one complete cycle into `DlqDuplicateRollingWindow`;
+4. replace every private cursor together.
+
+A polling, response, offset, classification, or rolling-window error leaves all cursors and rolling state unchanged. Empty partitions are successful and keep their cursor unchanged.
+
+## Count-only result
+
+`IggyDlqDuplicateMovingWindowSnapshot` exposes only:
+
+```text
+rolling
+partition_count
+advanced_partitions
+reset_generation
+```
+
+`rolling` is the existing identifier-free `DlqDuplicateRollingWindowSnapshot`. The moving snapshot does not expose partition IDs, cursor values, offsets, UUIDs, payloads or digests, endpoints, credentials, receipt identities, timestamps, or raw Iggy errors.
+
+## Restart and reset semantics
+
+Progress persistence is deliberately **not** part of this source slice.
+
+A newly constructed process-local state starts every partition at the reviewed `initial_offset` and starts with an empty rolling history. `reset_to_initial_offset()` performs the same transition explicitly and increments only a count-only reset generation.
+
+Therefore:
+
+- process restart may reread an earlier bounded region;
+- no restart-continuity or current-tail claim is made;
+- no cursor or rolling observation is serialized;
+- a deployment that requires restart continuity must add a separately reviewed persistent cursor owner;
+- `history_truncated` still means only that rolling cycles were evicted, not that broker history is complete.
+
+## Mutation and authorization boundary
+
+The moving scanner never stores consumer offsets, acknowledges, publishes, deletes, purges, retries, replays, mutates poison receipts, changes topology, or shuts down the caller's client.
+
+Its state never authorizes profile visibility, relationships, blocks, follows, storefront rendering, GraphQL presentation, or any Social Graph behavior.
+
+## Source verification
+
+```bash
+cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
+node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+```
+
+These commands were not run by the implementation agent.
+
+## Remaining work
+
+1. add an explicit opt-in mode to the mode-aware server observer;
+2. define reviewed environment/configuration fields for initial offset, fair budget, batch size, and rolling bounds;
+3. retain a real external-Iggy scenario with one duplicate split across advancing cycles;
+4. add a persistent cursor owner only if restart continuity is required;
+5. project identifier-free telemetry and optional operational health without readiness coupling.

--- a/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
@@ -1,6 +1,6 @@
 # Bounded physical DLQ duplicate rolling window
 
-Status: **transport-neutral rolling-window state source-complete; scanner, cursor, persistence, server integration, and runtime evidence pending**.
+Status: **transport-neutral rolling-window state and moving scanner integration source-complete; server composition and runtime evidence pending**.
 
 ## Purpose
 
@@ -82,32 +82,57 @@ evicted_cycles > 0
 
 The flag never returns to false for that in-memory state. An identity relationship can disappear when its older copy is evicted. Therefore a truncated snapshot describes only the currently retained bounded window and is not complete history, current-tail proof, or production retention evidence.
 
+## Moving scanner integration
+
+The moving scanner integration is source-complete in:
+
+```text
+crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
+crates/rustok-iggy/contracts/evidence/
+  dlq-duplicate-moving-window-scan-source.json
+```
+
+`IggyDlqDuplicateMovingWindowScanner` polls every selected partition under one equal per-partition budget. `IggyDlqDuplicateMovingWindowState` owns one private process-local per-partition cursor and feeds only a complete successful all-partition cycle into this rolling state.
+
+The integration is atomic:
+
+- all partition polls complete before state mutation;
+- invalid or incomplete cycles leave cursors and rolling state unchanged;
+- cursor values and observations are never exported;
+- the rolling per-cycle capacity must cover the full checked fair-cycle budget;
+- the scanner still uses explicit offsets and `auto_commit = false`.
+
+The restart choice is explicit reset, not implied persistence. A new state or `reset_to_initial_offset()` rewinds every cursor to the reviewed initial offset and clears rolling history. This does not provide restart-safe progress, current-tail coverage, or complete history.
+
+The transport-neutral rolling state itself still does not move a broker cursor; the feature-gated moving adapter owns collection and process-local cursor advancement.
+
 ## Source contract and verification
 
-Machine contract:
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/
   dlq-duplicate-rolling-window-source.json
+  dlq-duplicate-moving-window-scan-source.json
 ```
 
-Static verifier:
+Static verifiers:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 ```
 
-Focused unit scenarios cover invalid bounds, ordinary duplicates split across cycles, identity conflicts split across cycles, complete-cycle eviction, and transactional oversized-cycle rejection.
+Focused unit scenarios cover invalid bounds, ordinary duplicates split across cycles, identity conflicts split across cycles, complete-cycle eviction, transactional oversized-cycle rejection, independent cursor advancement, incomplete-cycle rollback, and explicit reset.
 
 ## Remaining integration
 
-Scanner integration remains pending. A later reviewed slice must:
+Moving scanner integration is source-complete. Remaining reviewed work must:
 
-1. feed one complete fair per-partition scan cycle into the state without exporting identifiers;
-2. define independent per-partition cursor advancement;
-3. choose explicit persistence or restart-reset semantics;
-4. compose the mode-aware server observer;
-5. prove cross-cycle behavior on external Iggy;
-6. publish only identifier-free telemetry or health.
+1. compose an explicit opt-in mode in the mode-aware server observer;
+2. define reviewed configuration for initial offset, fair budget, batch size, and rolling bounds;
+3. prove cross-cycle behavior on external Iggy;
+4. add a persistent cursor owner only if restart continuity is required;
+5. publish only identifier-free telemetry or health.
 
-No current API claims moving cursors, persisted progress, restart-safe state, current-tail coverage, complete history, production retention sufficiency, or exactly-once delivery.
+No current API claims persisted progress, restart-safe state, current-tail coverage, complete history, production retention sufficiency, server integration, runtime execution, or exactly-once delivery.

--- a/crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
@@ -1,0 +1,645 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use iggy::prelude::{
+    Consumer, ConsumerKind, Identifier, IggyClient, MessageClient, PollingStrategy,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::dlq_duplicate_inspection::{
+    DlqDuplicateInspectionError, DlqDuplicateObservation,
+};
+use crate::dlq_duplicate_rolling_window::{
+    DlqDuplicateRollingWindow, DlqDuplicateRollingWindowError,
+    DlqDuplicateRollingWindowPolicy, DlqDuplicateRollingWindowSnapshot,
+};
+
+const DLQ_TOPIC: &str = "dlq";
+const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-moving-readonly-v1";
+const MAX_SCAN_MESSAGES: u32 = 10_000;
+const MAX_BATCH_MESSAGES: u32 = 1_000;
+const MAX_SCAN_PARTITIONS: usize = 128;
+const MAX_STREAM_NAME_BYTES: usize = 255;
+
+/// Explicit bounded policy for one moving physical-DLQ duplicate window.
+///
+/// Every selected partition owns an independent in-memory next offset. The
+/// process starts and resets every cursor to `initial_offset`. No offset or
+/// rolling observation is serialized or persisted by this type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IggyDlqDuplicateMovingWindowPolicy {
+    partitions: Vec<u32>,
+    initial_offset: u64,
+    per_partition_messages: u32,
+    batch_size: u32,
+    total_message_budget: u32,
+    rolling_policy: DlqDuplicateRollingWindowPolicy,
+}
+
+impl IggyDlqDuplicateMovingWindowPolicy {
+    pub fn new(
+        partitions: Vec<u32>,
+        initial_offset: u64,
+        per_partition_messages: u32,
+        batch_size: u32,
+        rolling_policy: DlqDuplicateRollingWindowPolicy,
+    ) -> Result<Self, IggyDlqDuplicateMovingWindowError> {
+        validate_partitions(&partitions)?;
+        validate_message_bounds(per_partition_messages, batch_size)?;
+
+        let partition_count = u32::try_from(partitions.len())
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::InvalidPolicy)?;
+        let total_message_budget = per_partition_messages
+            .checked_mul(partition_count)
+            .filter(|total| *total <= MAX_SCAN_MESSAGES)
+            .ok_or(IggyDlqDuplicateMovingWindowError::InvalidPolicy)?;
+
+        if rolling_policy.max_observations_per_cycle() < total_message_budget {
+            return Err(IggyDlqDuplicateMovingWindowError::InvalidPolicy);
+        }
+
+        Ok(Self {
+            partitions,
+            initial_offset,
+            per_partition_messages,
+            batch_size,
+            total_message_budget,
+            rolling_policy,
+        })
+    }
+
+    pub fn partitions(&self) -> &[u32] {
+        &self.partitions
+    }
+
+    pub const fn initial_offset(&self) -> u64 {
+        self.initial_offset
+    }
+
+    pub const fn per_partition_messages(&self) -> u32 {
+        self.per_partition_messages
+    }
+
+    pub const fn batch_size(&self) -> u32 {
+        self.batch_size
+    }
+
+    pub const fn total_message_budget(&self) -> u32 {
+        self.total_message_budget
+    }
+
+    pub const fn rolling_policy(&self) -> DlqDuplicateRollingWindowPolicy {
+        self.rolling_policy
+    }
+
+    pub const fn progress_persisted(&self) -> bool {
+        false
+    }
+
+    pub const fn restart_resets_to_initial_offset(&self) -> bool {
+        true
+    }
+}
+
+/// Identifier-free result for one successful complete moving scan cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IggyDlqDuplicateMovingWindowSnapshot {
+    rolling: DlqDuplicateRollingWindowSnapshot,
+    partition_count: u32,
+    advanced_partitions: u32,
+    reset_generation: u64,
+}
+
+impl IggyDlqDuplicateMovingWindowSnapshot {
+    pub const fn rolling(&self) -> &DlqDuplicateRollingWindowSnapshot {
+        &self.rolling
+    }
+
+    pub const fn partition_count(&self) -> u32 {
+        self.partition_count
+    }
+
+    pub const fn advanced_partitions(&self) -> u32 {
+        self.advanced_partitions
+    }
+
+    pub const fn reset_generation(&self) -> u64 {
+        self.reset_generation
+    }
+
+    pub const fn progress_persisted(&self) -> bool {
+        false
+    }
+
+    pub const fn restart_resets_to_initial_offset(&self) -> bool {
+        true
+    }
+}
+
+/// Process-local moving scan state.
+///
+/// Cursors and opaque rolling observations are intentionally private. A state
+/// instance advances only after every selected partition has completed one
+/// bounded explicit-offset poll and the combined rolling candidate has been
+/// accepted. Any scan, validation, or rolling-window failure leaves both cursor
+/// and rolling state unchanged.
+pub struct IggyDlqDuplicateMovingWindowState {
+    policy: IggyDlqDuplicateMovingWindowPolicy,
+    cursors: BTreeMap<u32, u64>,
+    rolling: DlqDuplicateRollingWindow,
+    reset_generation: u64,
+}
+
+impl IggyDlqDuplicateMovingWindowState {
+    pub fn new(policy: IggyDlqDuplicateMovingWindowPolicy) -> Self {
+        let cursors = initial_cursors(&policy);
+        let rolling = DlqDuplicateRollingWindow::new(policy.rolling_policy());
+        Self {
+            policy,
+            cursors,
+            rolling,
+            reset_generation: 0,
+        }
+    }
+
+    pub fn policy(&self) -> &IggyDlqDuplicateMovingWindowPolicy {
+        &self.policy
+    }
+
+    pub fn snapshot(
+        &self,
+    ) -> Result<IggyDlqDuplicateMovingWindowSnapshot, IggyDlqDuplicateMovingWindowError> {
+        let partition_count = u32::try_from(self.policy.partitions.len())
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::CountOverflow)?;
+        Ok(IggyDlqDuplicateMovingWindowSnapshot {
+            rolling: self.rolling.snapshot()?,
+            partition_count,
+            advanced_partitions: 0,
+            reset_generation: self.reset_generation,
+        })
+    }
+
+    /// Explicitly discards process-local cursor and rolling state.
+    ///
+    /// This is also the documented process-restart behavior: a reconstructed
+    /// state starts again from the reviewed `initial_offset`. The reset is
+    /// transactional if the reset-generation counter is exhausted.
+    pub fn reset_to_initial_offset(
+        &mut self,
+    ) -> Result<IggyDlqDuplicateMovingWindowSnapshot, IggyDlqDuplicateMovingWindowError> {
+        let reset_generation = self
+            .reset_generation
+            .checked_add(1)
+            .ok_or(IggyDlqDuplicateMovingWindowError::ResetGenerationOverflow)?;
+        let cursors = initial_cursors(&self.policy);
+        let rolling = DlqDuplicateRollingWindow::new(self.policy.rolling_policy());
+        let partition_count = u32::try_from(self.policy.partitions.len())
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::CountOverflow)?;
+        let snapshot = IggyDlqDuplicateMovingWindowSnapshot {
+            rolling: rolling.snapshot()?,
+            partition_count,
+            advanced_partitions: 0,
+            reset_generation,
+        };
+
+        self.cursors = cursors;
+        self.rolling = rolling;
+        self.reset_generation = reset_generation;
+        Ok(snapshot)
+    }
+
+    fn next_offset(
+        &self,
+        partition_id: u32,
+    ) -> Result<u64, IggyDlqDuplicateMovingWindowError> {
+        self.cursors
+            .get(&partition_id)
+            .copied()
+            .ok_or(IggyDlqDuplicateMovingWindowError::InvalidCycle)
+    }
+
+    fn apply_complete_cycle(
+        &mut self,
+        partitions: Vec<CollectedPartitionCycle>,
+    ) -> Result<IggyDlqDuplicateMovingWindowSnapshot, IggyDlqDuplicateMovingWindowError> {
+        if partitions.len() != self.policy.partitions.len() {
+            return Err(IggyDlqDuplicateMovingWindowError::InvalidCycle);
+        }
+
+        let mut candidate_cursors = self.cursors.clone();
+        let mut observations =
+            Vec::with_capacity(self.policy.total_message_budget as usize);
+        let mut advanced_partitions = 0_u32;
+
+        for (&expected_partition, partition) in
+            self.policy.partitions.iter().zip(partitions)
+        {
+            let expected_offset = self.next_offset(expected_partition)?;
+            if partition.partition_id != expected_partition
+                || partition.start_offset != expected_offset
+                || partition.next_offset < partition.start_offset
+                || partition.observations.len()
+                    > self.policy.per_partition_messages as usize
+            {
+                return Err(IggyDlqDuplicateMovingWindowError::InvalidCycle);
+            }
+
+            if partition.next_offset > partition.start_offset {
+                advanced_partitions = advanced_partitions
+                    .checked_add(1)
+                    .ok_or(IggyDlqDuplicateMovingWindowError::CountOverflow)?;
+            }
+            candidate_cursors.insert(expected_partition, partition.next_offset);
+            observations.extend(partition.observations);
+        }
+
+        if observations.len() > self.policy.total_message_budget as usize {
+            return Err(IggyDlqDuplicateMovingWindowError::InvalidCycle);
+        }
+
+        let rolling = self.rolling.push_cycle(observations)?;
+        self.cursors = candidate_cursors;
+
+        let partition_count = u32::try_from(self.policy.partitions.len())
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::CountOverflow)?;
+        Ok(IggyDlqDuplicateMovingWindowSnapshot {
+            rolling,
+            partition_count,
+            advanced_partitions,
+            reset_generation: self.reset_generation,
+        })
+    }
+}
+
+/// Read-only external-Iggy collector for process-local moving windows.
+///
+/// The scanner uses a standalone consumer, explicit partition offsets, and
+/// `auto_commit = false`. It never stores consumer progress. A complete cycle is
+/// handed to [`IggyDlqDuplicateMovingWindowState`] only after every configured
+/// partition has been polled successfully.
+pub struct IggyDlqDuplicateMovingWindowScanner<'a> {
+    client: &'a IggyClient,
+    stream_id: Identifier,
+    topic_id: Identifier,
+    consumer: Consumer,
+}
+
+impl<'a> IggyDlqDuplicateMovingWindowScanner<'a> {
+    pub fn new(
+        client: &'a IggyClient,
+        stream_name: &str,
+    ) -> Result<Self, IggyDlqDuplicateMovingWindowError> {
+        validate_stream_name(stream_name)?;
+        let stream_id: Identifier = stream_name
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::InvalidPolicy)?;
+        let topic_id: Identifier = DLQ_TOPIC
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::InvalidPolicy)?;
+        let consumer_id: Identifier = READ_ONLY_CONSUMER
+            .to_owned()
+            .try_into()
+            .map_err(|_| IggyDlqDuplicateMovingWindowError::InvalidPolicy)?;
+
+        Ok(Self {
+            client,
+            stream_id,
+            topic_id,
+            consumer: Consumer {
+                kind: ConsumerKind::Consumer,
+                id: consumer_id,
+            },
+        })
+    }
+
+    pub async fn scan_cycle(
+        &self,
+        state: &mut IggyDlqDuplicateMovingWindowState,
+    ) -> Result<IggyDlqDuplicateMovingWindowSnapshot, IggyDlqDuplicateMovingWindowError> {
+        let policy = state.policy().clone();
+        let mut partitions = Vec::with_capacity(policy.partitions.len());
+
+        for &partition_id in &policy.partitions {
+            let start_offset = state.next_offset(partition_id)?;
+            partitions.push(
+                self.collect_partition(
+                    partition_id,
+                    start_offset,
+                    policy.per_partition_messages,
+                    policy.batch_size,
+                )
+                .await?,
+            );
+        }
+
+        state.apply_complete_cycle(partitions)
+    }
+
+    async fn collect_partition(
+        &self,
+        partition_id: u32,
+        start_offset: u64,
+        max_messages: u32,
+        batch_size: u32,
+    ) -> Result<CollectedPartitionCycle, IggyDlqDuplicateMovingWindowError> {
+        let mut remaining = max_messages;
+        let mut next_offset = start_offset;
+        let mut observations = Vec::with_capacity(max_messages as usize);
+
+        loop {
+            let requested_count = batch_size.min(remaining);
+            let polled = self
+                .client
+                .poll_messages(
+                    &self.stream_id,
+                    &self.topic_id,
+                    Some(partition_id),
+                    &self.consumer,
+                    &PollingStrategy::offset(next_offset),
+                    requested_count,
+                    false,
+                )
+                .await
+                .map_err(|_| IggyDlqDuplicateMovingWindowError::PollFailed)?;
+
+            if polled.partition_id != partition_id
+                || polled.count as usize != polled.messages.len()
+                || polled.count > requested_count
+            {
+                return Err(IggyDlqDuplicateMovingWindowError::InvalidBrokerResponse);
+            }
+            if polled.messages.is_empty() {
+                break;
+            }
+
+            let received_count = polled.count;
+            let mut previous_offset = None;
+            for message in polled.messages {
+                let offset = message.header.offset;
+                if offset < next_offset
+                    || previous_offset.is_some_and(|previous| offset <= previous)
+                {
+                    return Err(IggyDlqDuplicateMovingWindowError::InvalidBrokerResponse);
+                }
+                observations.push(DlqDuplicateObservation::from_payload(
+                    Uuid::from_u128(message.header.id),
+                    message.payload.as_ref(),
+                )?);
+                remaining = remaining
+                    .checked_sub(1)
+                    .ok_or(IggyDlqDuplicateMovingWindowError::InvalidBrokerResponse)?;
+                previous_offset = Some(offset);
+            }
+
+            let last_offset = previous_offset
+                .ok_or(IggyDlqDuplicateMovingWindowError::InvalidBrokerResponse)?;
+            next_offset = last_offset
+                .checked_add(1)
+                .ok_or(IggyDlqDuplicateMovingWindowError::OffsetOverflow)?;
+
+            if remaining == 0 || received_count < requested_count {
+                break;
+            }
+        }
+
+        Ok(CollectedPartitionCycle {
+            partition_id,
+            start_offset,
+            next_offset,
+            observations,
+        })
+    }
+}
+
+struct CollectedPartitionCycle {
+    partition_id: u32,
+    start_offset: u64,
+    next_offset: u64,
+    observations: Vec<DlqDuplicateObservation>,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum IggyDlqDuplicateMovingWindowError {
+    #[error("external Iggy DLQ moving-window policy is invalid")]
+    InvalidPolicy,
+    #[error("external Iggy DLQ moving-window polling failed")]
+    PollFailed,
+    #[error("external Iggy DLQ moving-window poll response is invalid")]
+    InvalidBrokerResponse,
+    #[error("external Iggy DLQ moving-window offset overflow")]
+    OffsetOverflow,
+    #[error("external Iggy DLQ moving-window complete cycle is invalid")]
+    InvalidCycle,
+    #[error("external Iggy DLQ moving-window count overflow")]
+    CountOverflow,
+    #[error("external Iggy DLQ moving-window reset generation overflow")]
+    ResetGenerationOverflow,
+    #[error(transparent)]
+    Inspection(#[from] DlqDuplicateInspectionError),
+    #[error(transparent)]
+    Rolling(#[from] DlqDuplicateRollingWindowError),
+}
+
+impl IggyDlqDuplicateMovingWindowError {
+    pub const fn stable_code(self) -> &'static str {
+        match self {
+            Self::InvalidPolicy => "iggy.dlq_duplicate.moving_window_policy_invalid",
+            Self::PollFailed => "iggy.dlq_duplicate.moving_window_poll_failed",
+            Self::InvalidBrokerResponse => {
+                "iggy.dlq_duplicate.moving_window_response_invalid"
+            }
+            Self::OffsetOverflow => "iggy.dlq_duplicate.moving_window_offset_overflow",
+            Self::InvalidCycle => "iggy.dlq_duplicate.moving_window_cycle_invalid",
+            Self::CountOverflow => "iggy.dlq_duplicate.moving_window_count_overflow",
+            Self::ResetGenerationOverflow => {
+                "iggy.dlq_duplicate.moving_window_reset_overflow"
+            }
+            Self::Inspection(error) => error.stable_code(),
+            Self::Rolling(error) => error.stable_code(),
+        }
+    }
+}
+
+fn initial_cursors(
+    policy: &IggyDlqDuplicateMovingWindowPolicy,
+) -> BTreeMap<u32, u64> {
+    policy
+        .partitions
+        .iter()
+        .map(|partition| (*partition, policy.initial_offset))
+        .collect()
+}
+
+fn validate_partitions(
+    partitions: &[u32],
+) -> Result<(), IggyDlqDuplicateMovingWindowError> {
+    if partitions.is_empty() || partitions.len() > MAX_SCAN_PARTITIONS {
+        return Err(IggyDlqDuplicateMovingWindowError::InvalidPolicy);
+    }
+    let mut unique = BTreeSet::new();
+    for &partition in partitions {
+        if partition == 0 || !unique.insert(partition) {
+            return Err(IggyDlqDuplicateMovingWindowError::InvalidPolicy);
+        }
+    }
+    Ok(())
+}
+
+fn validate_message_bounds(
+    max_messages: u32,
+    batch_size: u32,
+) -> Result<(), IggyDlqDuplicateMovingWindowError> {
+    if max_messages == 0
+        || max_messages > MAX_SCAN_MESSAGES
+        || batch_size == 0
+        || batch_size > MAX_BATCH_MESSAGES
+        || batch_size > max_messages
+    {
+        return Err(IggyDlqDuplicateMovingWindowError::InvalidPolicy);
+    }
+    Ok(())
+}
+
+fn validate_stream_name(
+    stream_name: &str,
+) -> Result<(), IggyDlqDuplicateMovingWindowError> {
+    if stream_name.is_empty()
+        || stream_name.trim() != stream_name
+        || stream_name.len() > MAX_STREAM_NAME_BYTES
+        || stream_name.chars().any(char::is_control)
+    {
+        return Err(IggyDlqDuplicateMovingWindowError::InvalidPolicy);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn observation(id: u128, payload: &[u8]) -> DlqDuplicateObservation {
+        DlqDuplicateObservation::from_payload(Uuid::from_u128(id), payload).unwrap()
+    }
+
+    fn policy() -> IggyDlqDuplicateMovingWindowPolicy {
+        let rolling = DlqDuplicateRollingWindowPolicy::new(3, 4).unwrap();
+        IggyDlqDuplicateMovingWindowPolicy::new(vec![1, 2], 10, 2, 1, rolling)
+            .unwrap()
+    }
+
+    fn partition(
+        partition_id: u32,
+        start_offset: u64,
+        next_offset: u64,
+        observations: Vec<DlqDuplicateObservation>,
+    ) -> CollectedPartitionCycle {
+        CollectedPartitionCycle {
+            partition_id,
+            start_offset,
+            next_offset,
+            observations,
+        }
+    }
+
+    #[test]
+    fn policy_requires_complete_fair_cycle_to_fit_rolling_capacity() {
+        let rolling = DlqDuplicateRollingWindowPolicy::new(2, 3).unwrap();
+        for result in [
+            IggyDlqDuplicateMovingWindowPolicy::new(vec![], 0, 1, 1, rolling),
+            IggyDlqDuplicateMovingWindowPolicy::new(vec![0], 0, 1, 1, rolling),
+            IggyDlqDuplicateMovingWindowPolicy::new(vec![1, 1], 0, 1, 1, rolling),
+            IggyDlqDuplicateMovingWindowPolicy::new(vec![1, 2], 0, 2, 1, rolling),
+        ] {
+            assert_eq!(
+                result.unwrap_err(),
+                IggyDlqDuplicateMovingWindowError::InvalidPolicy
+            );
+        }
+    }
+
+    #[test]
+    fn complete_cycle_advances_partition_cursors_independently() {
+        let mut state = IggyDlqDuplicateMovingWindowState::new(policy());
+        let snapshot = state
+            .apply_complete_cycle(vec![
+                partition(1, 10, 12, vec![observation(1, &[1])]),
+                partition(2, 10, 10, vec![]),
+            ])
+            .unwrap();
+
+        assert_eq!(snapshot.partition_count(), 2);
+        assert_eq!(snapshot.advanced_partitions(), 1);
+        assert_eq!(state.cursors.get(&1), Some(&12));
+        assert_eq!(state.cursors.get(&2), Some(&10));
+        assert!(!snapshot.progress_persisted());
+        assert!(snapshot.restart_resets_to_initial_offset());
+    }
+
+    #[test]
+    fn duplicate_split_across_advancing_cycles_remains_count_only() {
+        let mut state = IggyDlqDuplicateMovingWindowState::new(policy());
+        state
+            .apply_complete_cycle(vec![
+                partition(1, 10, 11, vec![observation(7, &[1])]),
+                partition(2, 10, 10, vec![]),
+            ])
+            .unwrap();
+
+        let snapshot = state
+            .apply_complete_cycle(vec![
+                partition(1, 11, 12, vec![observation(7, &[1])]),
+                partition(2, 10, 10, vec![]),
+            ])
+            .unwrap();
+
+        assert_eq!(snapshot.rolling().summary().duplicate_messages(), 1);
+        assert_eq!(snapshot.rolling().summary().duplicate_groups(), 1);
+        assert!(!snapshot.rolling().summary().requires_manual_review());
+    }
+
+    #[test]
+    fn incomplete_cycle_preserves_cursors_and_rolling_state() {
+        let mut state = IggyDlqDuplicateMovingWindowState::new(policy());
+        state
+            .apply_complete_cycle(vec![
+                partition(1, 10, 11, vec![observation(1, &[1])]),
+                partition(2, 10, 10, vec![]),
+            ])
+            .unwrap();
+        let before = state.snapshot().unwrap();
+        let cursors = state.cursors.clone();
+
+        let error = state
+            .apply_complete_cycle(vec![partition(1, 11, 12, vec![])])
+            .unwrap_err();
+
+        assert_eq!(error, IggyDlqDuplicateMovingWindowError::InvalidCycle);
+        assert_eq!(state.snapshot().unwrap(), before);
+        assert_eq!(state.cursors, cursors);
+    }
+
+    #[test]
+    fn explicit_reset_rewinds_cursors_and_clears_rolling_history() {
+        let mut state = IggyDlqDuplicateMovingWindowState::new(policy());
+        state
+            .apply_complete_cycle(vec![
+                partition(1, 10, 11, vec![observation(1, &[1])]),
+                partition(2, 10, 11, vec![observation(2, &[2])]),
+            ])
+            .unwrap();
+
+        let reset = state.reset_to_initial_offset().unwrap();
+
+        assert_eq!(reset.reset_generation(), 1);
+        assert_eq!(reset.rolling().retained_cycles(), 0);
+        assert_eq!(reset.rolling().retained_observations(), 0);
+        assert_eq!(state.cursors.get(&1), Some(&10));
+        assert_eq!(state.cursors.get(&2), Some(&10));
+        assert!(!reset.progress_persisted());
+        assert!(reset.restart_resets_to_initial_offset());
+    }
+}

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -70,6 +70,8 @@ pub mod dlq_duplicate_alert_runtime;
 #[cfg(feature = "iggy")]
 pub mod dlq_duplicate_external_scan;
 pub mod dlq_duplicate_inspection;
+#[cfg(feature = "iggy")]
+pub mod dlq_duplicate_moving_window_scan;
 pub mod dlq_duplicate_rolling_window;
 #[cfg(feature = "iggy")]
 mod dlq_publisher;
@@ -120,6 +122,12 @@ pub use dlq_duplicate_external_scan::{
 pub use dlq_duplicate_inspection::{
     DlqDuplicateInspectionError, DlqDuplicateObservation, DlqDuplicateSummary,
     summarize_dlq_duplicates,
+};
+#[cfg(feature = "iggy")]
+pub use dlq_duplicate_moving_window_scan::{
+    IggyDlqDuplicateMovingWindowError, IggyDlqDuplicateMovingWindowPolicy,
+    IggyDlqDuplicateMovingWindowScanner, IggyDlqDuplicateMovingWindowSnapshot,
+    IggyDlqDuplicateMovingWindowState,
 };
 pub use dlq_duplicate_rolling_window::{
     DlqDuplicateRollingWindow, DlqDuplicateRollingWindowError,

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -97,13 +97,17 @@ mutation retry.
   cap, detects ordinary and conflicting duplicates split across retained cycles,
   rejects oversized cycles transactionally, and reports permanent truncation
   after complete-cycle eviction.
+- The moving-window scanner integration is source-complete. It owns independent
+  process-local per-partition cursors, collects one complete equal-budget cycle
+  before mutation, atomically feeds that cycle into the rolling state, and
+  chooses explicit restart-reset semantics rather than implied persistence.
 - Canonical retained packets remain pending and must omit credentials and
   delivery-level facts, bind reviewed source/configuration/input digests, and
   become stale when any bound source or reviewed input changes.
 
 ## Physical DLQ duplicate inspection
 
-Two bounded scanner policies are source-complete:
+Two fixed bounded scanner policies are source-complete:
 
 - `global_budget`: one ordered partition allowlist and one shared cap. A busy
   early partition may prevent later partitions from being polled.
@@ -121,12 +125,20 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES=<positive cap>
 ```
 
 `memory` and `outbox_local` remain intentional not-applicable modes and do not
-resolve Iggy. Both scanner policies use explicit offsets and `auto_commit=false`.
-The current observer still reuses one configured start offset and does not own
-moving cursors, stored progress, current-tail coverage, or complete-history
-semantics. The separate rolling state can preserve relationships across complete
-cycles supplied by a future scanner integration, but it does not move or persist
-a cursor itself.
+resolve Iggy. Both fixed policies use explicit offsets and `auto_commit=false`.
+The current server observer still reuses one configured start offset and does not
+own moving progress, current-tail coverage, or complete-history semantics.
+
+A separate opt-in library adapter now composes moving collection with the bounded
+rolling state. It gives every selected partition one private process-local next
+offset, scans every partition under an equal bounded budget, and replaces all
+cursors only after the complete cycle has been accepted by the rolling window.
+It is not yet composed into the mode-aware server observer.
+
+The moving adapter deliberately persists neither cursors nor rolling observations.
+New state and explicit reset return every cursor to one reviewed initial offset
+and clear rolling history. This can reread an earlier bounded region and therefore
+makes no restart-safe progress or current-tail claim.
 
 ### Production partition invariant
 
@@ -150,7 +162,7 @@ partition 2: B1/B2 conflicting-payload duplicate
 With a cap of two messages per partition, the fair scan observes both duplicate
 groups and the conflict. The ordered global request with four total slots reads
 three messages from partition 1 and one from partition 2, producing a different
-summary. The fair policy runs twice from offset zero, and stored
+summary. The fixed fair policy runs twice from offset zero, and stored
 standalone-consumer offsets must remain absent on both partitions.
 
 ### Fair-window retained capture
@@ -215,21 +227,26 @@ payloads, or raw output. Publication is no-clobber.
 
 Runtime calibration and the canonical packet remain pending.
 
-### Bounded rolling duplicate window
+### Bounded rolling and moving duplicate window
 
 Source-complete paths:
 
 ```text
 crates/rustok-iggy/src/
   dlq_duplicate_rolling_window.rs
+  dlq_duplicate_moving_window_scan.rs
 crates/rustok-iggy/contracts/evidence/
   dlq-duplicate-rolling-window-source.json
+  dlq-duplicate-moving-window-scan-source.json
 scripts/verify/
   verify-iggy-dlq-duplicate-rolling-window.mjs
+  verify-iggy-dlq-duplicate-moving-window-scan.mjs
 crates/rustok-iggy/docs/
   dlq-duplicate-rolling-window.md
+  dlq-duplicate-moving-window-scan.md
 crates/rustok-profiles/docs/
   poison-duplicate-rolling-window-checkpoint.md
+  poison-duplicate-moving-window-scan-checkpoint.md
 ```
 
 `DlqDuplicateRollingWindowPolicy` requires positive explicit cycle and per-cycle
@@ -242,9 +259,26 @@ existing state unchanged. At capacity the oldest complete cycle is evicted, and
 all later snapshots report `history_truncated = true`; an evicted relationship
 may disappear, so the result is never complete-history or current-tail proof.
 
-Scanner collection, independent per-partition cursor advancement, persistence or
-restart-reset semantics, mode-aware server composition, and external-Iggy
-cross-cycle runtime evidence remain pending.
+`IggyDlqDuplicateMovingWindowPolicy` additionally requires one reviewed initial
+offset, equal per-partition message and batch bounds, and enough rolling capacity
+to contain the full checked fair cycle. It defines no production default.
+
+`IggyDlqDuplicateMovingWindowState` owns independent process-local per-partition
+cursors. A complete all-partition candidate is collected before any state change.
+Only after rolling classification succeeds are every cursor and the rolling cycle
+accepted together. Failed or incomplete cycles preserve the prior state.
+
+The public moving snapshot exposes only the rolling snapshot, partition count,
+advanced-partition count, and reset generation. It excludes partition IDs,
+cursor values, UUIDs, payloads/digests, broker coordinates, credentials, receipt
+identities, timestamps, and raw errors.
+
+Progress is not persisted. A new process or explicit reset starts at the reviewed
+initial offset and clears rolling history. A separately owned persistent cursor
+store remains optional future work only if restart continuity is required.
+
+Mode-aware server composition, reviewed environment/configuration fields, real
+external-Iggy cross-cycle runtime evidence, and retained execution remain pending.
 
 Detailed checkpoints:
 
@@ -253,11 +287,13 @@ Detailed checkpoints:
 - `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md`
+- `crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
 - `crates/rustok-iggy/docs/dedup-recovery-window-policy.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md`
+- `crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md`
 
 ## Results and next work
 
@@ -304,11 +340,12 @@ Detailed checkpoints:
    no-clobber packet; and repeat whenever a bound source, configuration, or input
    changes. A packet covers only that supplied model.
 
-10. **Integrate the bounded rolling duplicate window.**
-    Feed complete fair scanner cycles without exporting identifiers, define
-    independent per-partition cursor advancement, choose persistence or explicit
-    restart-reset semantics, compose the mode-aware observer, and retain real
-    cross-cycle Iggy evidence. Truncated state must remain visibly incomplete.
+10. **Compose the moving duplicate observer.**
+    Add an explicit opt-in mode to the existing mode-aware server observer,
+    define reviewed fail-closed configuration for initial offset, fair budget,
+    batch size, and rolling bounds, then retain a real duplicate split across
+    advancing external-Iggy cycles. Keep reset semantics explicit; add a
+    persistent cursor owner only if restart continuity is required.
 
 11. **Retain production operations.**
     Prove bundled mode, restart, TLS/auth/failover, reconnect, rebalance,
@@ -317,22 +354,25 @@ Detailed checkpoints:
 
 ## Recheck checkpoint — 2026-07-29
 
-- Rechecked the canonical plan and current `main` after the retained
-  recovery-window calibration tooling merge.
+- Rechecked the canonical plan and current `main` after the bounded rolling-window
+  merge and unrelated newer Product transport work.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
 - Reconfirmed deterministic same-ID colocation and the production-reachable
   fair/global comparison.
-- Rechecked the fixed scanner APIs and confirmed that returning one already
-  aggregated summary cannot preserve a duplicate relationship split across
-  advancing scan cycles.
-- Added a pure bounded complete-cycle rolling state with checked memory limits,
-  transactional oversized-cycle rejection, cross-cycle ordinary/conflicting
-  classification, complete-cycle eviction, and permanent truncation metadata.
-- Kept scanner observation feeding, per-partition cursor advancement, state
-  persistence/restart semantics, server composition, external runtime evidence,
-  telemetry/health, bundled/TLS/auth, failover, and multi-replica claims open.
+- Rechecked the fixed scanner APIs and confirmed that their already aggregated
+  summaries remain correct for fixed snapshots but cannot preserve relationships
+  across advancing cycles.
+- Added source-complete moving-window collection with independent process-local
+  per-partition cursors, equal bounded budgets, strict response/offset validation,
+  and complete-cycle atomicity across scanner cursors and rolling state.
+- Chose explicit restart-reset semantics: no cursor or observation persistence,
+  new state starts at one reviewed initial offset, reset clears rolling history,
+  and no restart-safe progress or current-tail claim is made.
+- Kept server opt-in/configuration, external runtime evidence, retained packets,
+  optional persistent cursor ownership, telemetry/health, bundled/TLS/auth,
+  failover, and multi-replica claims open.
 - Tests, Cargo commands, formatters, repository source verifiers, broker scans,
   server observers, retained capture, and multi-replica scenarios were not run
   per maintainer instruction.
@@ -346,7 +386,9 @@ cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
 RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
 cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
+cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
 cargo test -p rustok-iggy --test dedup_recovery_window_calibration
 node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -403,6 +445,12 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
     cycles; partial silent eviction is forbidden.
 17. Any cycle eviction permanently marks the in-memory history truncated, and a
     truncated snapshot is never current-tail or complete-history evidence.
-18. A sufficient recovery-window assessment covers only the supplied reviewed
+18. Moving scan cursors advance atomically only after every selected partition
+    succeeds and the complete rolling cycle is accepted.
+19. Cursor values, partition identities, message identities, payloads, digests,
+    and opaque observations never surface in public moving snapshots.
+20. Process restart resets moving cursors to one reviewed initial offset and
+    clears rolling history unless a separately reviewed persistent owner is added.
+21. A sufficient recovery-window assessment covers only the supplied reviewed
     model and never authorizes Profiles or proves exactly-once.
-19. Update Profiles and affected owner docs with every boundary change.
+22. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,6 +1,6 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **classifier, bounded scanner, bounded rolling state, runtime harness, retained tooling, alert policy, latest-value runtime, and mode-aware server observer source-complete; scanner/cursor integration, runtime execution, and telemetry/health projection pending**.
+Status: **classifier, fixed scanners, bounded rolling state, moving scanner integration, runtime harnesses, retained tooling, alert policy, latest-value runtime, and fixed-window mode-aware server observer source-complete; moving server composition, runtime execution, and telemetry/health projection pending**.
 
 ## Why this matters for Profiles
 
@@ -11,18 +11,19 @@ Profiles authorization remains independent of broker and receipt state. Downstre
 - one deterministic DLQ ID associated with conflicting exact bytes;
 - copies of the same physical duplicate observed in adjacent retained scan cycles.
 
-The Iggy-owned classifier exposes these distinctions without message identities or payloads. The bounded scanner supplies observations through explicit-offset polling without storing progress. The rolling state can preserve opaque relationships across complete retained cycles. The alert policy evaluates only the count-only summary. The latest-value runtime and server observer publish only identifier-free operational state. None becomes a Profiles authorization input.
+The Iggy-owned classifier exposes these distinctions without message identities or payloads. Fixed scanners provide bounded one-cycle snapshots. The rolling state preserves opaque relationships across retained cycles. The moving scanner integration is source-complete and supplies whole fair cycles through private process-local per-partition cursors. Alert/runtime/server projections remain identifier-free. None becomes a Profiles authorization input.
 
 ## Owner boundaries
 
 ```text
-classifier:      crates/rustok-iggy/src/dlq_duplicate_inspection.rs
-rolling state:   crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
-scanner:         crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
-policy:          crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
-runtime:         crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
-Iggy observer:   crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
-server observer: apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+classifier:          crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+rolling state:       crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+fixed scanner:       crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+moving scanner:      crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
+policy:              crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
+runtime:             crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
+Iggy observer:       crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+server observer:     apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 ```
 
 Machine contracts:
@@ -30,6 +31,7 @@ Machine contracts:
 ```text
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
+crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
@@ -41,6 +43,7 @@ Verifiers:
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
 scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
@@ -69,26 +72,15 @@ evicted_cycles
 history_truncated
 ```
 
-The policy evaluation exposes only:
+The moving snapshot adds only:
 
 ```text
-level
-physical_duplicates
-identity_conflict
-duplicate_messages_threshold_reached
-duplicate_groups_threshold_reached
-max_copies_threshold_reached
+partition_count
+advanced_partitions
+reset_generation
 ```
 
-The runtime snapshot exposes only:
-
-```text
-generation
-available
-evaluation
-```
-
-These projections exclude broker endpoints, stream coordinates, UUIDs, payloads/digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors. Policy/runtime projections also exclude source counts and raw threshold values.
+Policy and runtime continue to expose only level, reason flags, generation, availability, and evaluation. These projections exclude broker endpoints, stream coordinates, partition IDs, cursor values, UUIDs, payloads/digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors.
 
 ## Duplicate classification
 
@@ -96,9 +88,9 @@ An ordinary physical duplicate requires the same deterministic Iggy header UUID 
 
 A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
 
-## Bounded scan boundary
+## Fixed scan boundary
 
-The scanner borrows an already connected `IggyClient` and uses:
+Fixed global and fair scanners borrow an already connected `IggyClient` and use:
 
 ```text
 topic = dlq
@@ -110,15 +102,13 @@ auto_commit = false
 
 Global mode accepts no more than 128 unique positive partitions, 10,000 physical messages total, and batches of 1,000. Fair mode gives every selected partition one equal cap under the same checked 10,000-message total.
 
-Each current polling cycle reuses the configured explicit start offset. The observer therefore still measures a repeated bounded snapshot and does not own a moving cursor, tail coverage, or complete-history semantics.
-
-The scanner does not use a consumer group, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
+The current server observer still uses fixed snapshots and does not own moving progress. Fixed scanners do not use consumer groups, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
 
 ## Bounded cross-cycle state
 
 `DlqDuplicateRollingWindowPolicy` requires explicit positive `max_cycles` and `max_observations_per_cycle`. Cycle count is capped at 128 and their checked product cannot exceed 10,000. No production default is provided.
 
-`push_cycle` accepts one complete cycle of opaque observations. It detects ordinary and conflicting duplicates split across retained cycles. Oversized input fails without changing the current state.
+`push_cycle` accepts one complete cycle of opaque observations. It detects ordinary and conflicting duplicates split across retained cycles. Oversized input fails without changing current state.
 
 When cycle capacity is reached, the oldest complete cycle is evicted. Partial-cycle eviction is forbidden. Every later snapshot reports:
 
@@ -126,57 +116,31 @@ When cycle capacity is reached, the oldest complete cycle is evicted. Partial-cy
 history_truncated = true
 ```
 
-An evicted old copy can remove a relationship from the retained summary. The snapshot therefore represents only the bounded retained window and is not current-tail or complete-history evidence.
+An evicted old copy can remove a relationship from the retained summary. The snapshot represents only the bounded retained window and is not current-tail or complete-history evidence.
 
-The state does not connect to Iggy, move or store cursors, persist itself, define restart recovery, compose the server observer, or register telemetry. Those remain separate owners and follow-up evidence.
+## Moving scanner integration
 
-## Alert policy boundary
+The moving scanner integration is source-complete.
 
-The caller supplies warning and critical thresholds for duplicate messages, duplicate groups, and max copies per message ID. The library provides no production defaults.
+Every selected partition owns one private process-local per-partition cursor. A complete cycle:
 
-```text
-identity conflict -> Critical
-critical numeric threshold -> Critical
-warning numeric threshold -> Warning
-physical duplicate below warning -> Notice
-no duplicate -> Clear
-```
+1. polls every selected partition with one equal bounded budget;
+2. validates partition, count, strictly increasing offsets, UUID, and checked advancement;
+3. combines observations privately;
+4. pushes one complete rolling cycle;
+5. replaces every cursor together only after rolling acceptance.
 
-The policy does not choose notification routing, paging, cooldown, suppression, scan cadence, threshold persistence, or destructive action.
+A failed or incomplete cycle preserves all cursors and rolling state. Empty partitions are successful and keep their cursor unchanged.
 
-## Latest-value alert runtime
+Progress persistence is deliberately absent. New state starts from one reviewed initial offset. Explicit restart reset via `reset_to_initial_offset()` rewinds all cursors and clears rolling history while incrementing only a count-only generation. No restart-safe progress, current-tail, or complete-history claim is made.
 
-The runtime accepts an already observed summary and a prevalidated policy:
+A persistent cursor owner remains separate work only if restart continuity is required.
 
-```text
-summary -> policy evaluation -> latest snapshot -> read-only subscribers
-```
+## Alert and server boundaries
 
-The publisher is single-writer. Initial state is generation `0`, unavailable, with no evaluation. Every successful or unavailable transition increments generation through checked arithmetic.
+The caller supplies warning and critical thresholds; the library provides no production defaults. Identity conflicts are always critical. The latest-value runtime clears stale evaluation on unavailable transitions and is not an audit log.
 
-Unavailable publication clears the previous evaluation so stale severity does not remain current. The channel retains only the latest state and is not an audit log.
-
-## Mode-aware server observer
-
-The server handles every event-delivery and observer startup mode explicitly:
-
-```text
-disabled      -> Disabled
-startup issue -> Unavailable, no task or snapshot
-memory        -> NotApplicableMemory
-outbox_local  -> NotApplicableOutboxLocal
-outbox_iggy   -> IggyBundled or IggyExternal
-```
-
-For `memory` and `outbox_local`, absence of Iggy is expected platform behavior. For `outbox_iggy`, the observer reuses the active transport configuration and opens only a separate read-only SDK client. Observer-specific startup, connection, scan, and shutdown failures are non-fatal to event delivery and module projection.
-
-The source-complete rolling state is not yet composed into this observer. No second transport, persisted cursor, notification dispatch, or readiness dependency is introduced.
-
-## Runtime and retained status
-
-The external-Iggy harness and retained execution tooling are source-complete. The canonical retained execution packet remains absent until a maintainer performs the reviewed external-Iggy run.
-
-The rolling state is source-complete as a transport-neutral component. Scanner observation feeding, independent per-partition cursor advancement, persistence/restart semantics, cross-cycle external-Iggy evidence, mode-aware composition, telemetry, and optional operational health remain pending.
+The server handles disabled, startup-unavailable, memory, outbox-local, bundled-Iggy, and external-Iggy modes explicitly. The current observer remains fixed-window. Moving scan is not silently enabled; it requires a separate reviewed server observer mode and configuration surface.
 
 ## Relationship to receipt health
 
@@ -190,7 +154,7 @@ No profile visibility, relationship, block, mute, follow, friendship, audience, 
 
 - event delivery profile or Iggy deployment mode;
 - observer startup, applicability, availability, or generation;
-- partition ordering, fairness, fixed-window selection, or budget exhaustion;
+- partition ordering, fairness, private cursor position, or reset generation;
 - rolling retention or eviction state, including `history_truncated`;
 - physical DLQ copy or duplicate-group counts;
 - identity-conflict presence;
@@ -204,14 +168,15 @@ Profiles presentation continues to consume authorized owner-port results. These 
 
 ## Remaining work
 
-1. execute and retain the reviewed external-Iggy duplicate scan packet;
-2. feed complete fair scanner cycles into rolling state without identifier export;
-3. define independent per-partition cursor advancement and persistence/restart semantics;
-4. prove cross-cycle behavior on external Iggy and compose the mode-aware observer;
-5. define identifier-free telemetry and optional operational health without readiness coupling;
-6. retain mode-aware server observer execution evidence;
-7. define alert routing, cooldown, and suppression outside Profiles and the policy/runtime;
-8. define acknowledgement/delete/replay separately with explicit authorization;
-9. keep aggregate receipt and duplicate observations identifier-free.
+1. execute and retain the reviewed fixed external-Iggy duplicate scan packets;
+2. compose moving scanning as an explicit mode-aware server opt-in;
+3. define reviewed moving configuration and fail-closed startup validation;
+4. retain real external-Iggy cross-cycle evidence;
+5. add a persistent cursor owner only if restart continuity is required;
+6. define identifier-free telemetry and optional operational health;
+7. retain server observer execution evidence;
+8. define alert routing, cooldown, and suppression outside Profiles and policy/runtime;
+9. define acknowledgement/delete/replay separately with explicit authorization;
+10. keep aggregate receipt and duplicate observations identifier-free.
 
 Tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md
@@ -1,0 +1,76 @@
+# Profiles checkpoint: moving physical DLQ duplicate window scan
+
+Status: **Iggy moving scanner, independent process-local cursors, complete-cycle rolling integration, and explicit restart reset source-complete; server composition and runtime evidence pending**.
+
+## Why this matters for Profiles
+
+Profiles still never authorizes from broker, receipt, offset, duplicate, or evidence state. This source slice only improves operational detection when two physical DLQ copies appear in different advancing scan cycles.
+
+The Iggy owner now has a bounded opt-in path:
+
+```text
+private per-partition next offsets
+  -> one complete fair read-only cycle
+  -> bounded cross-cycle rolling classification
+  -> identifier-free snapshot
+```
+
+No delivery identity, payload, digest, partition, or offset crosses into Profiles.
+
+## Owner paths
+
+```text
+scanner/state:
+  crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
+rolling classifier:
+  crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+machine contract:
+  crates/rustok-iggy/contracts/evidence/
+    dlq-duplicate-moving-window-scan-source.json
+verifier:
+  scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+owner guide:
+  crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
+```
+
+## Independent cursor boundary
+
+Each selected partition owns one private in-memory next offset. A successful empty partition keeps its offset unchanged; a partition with messages advances to the checked last offset plus one.
+
+The complete set advances atomically only after every partition succeeds and the combined rolling cycle is accepted. Any incomplete or invalid cycle preserves every cursor and the previous rolling snapshot.
+
+The public snapshot exposes only partition count and how many partitions advanced, never their identities or cursor values.
+
+## Restart choice
+
+This slice intentionally chooses explicit reset rather than implied persistence:
+
+- state is process-local;
+- new construction starts every cursor at one reviewed initial offset;
+- rolling history starts empty;
+- `reset_to_initial_offset()` performs the same operation and increments a count-only generation;
+- no restart-safe progress or current-tail claim is made.
+
+A persistent cursor store remains separate work and should be added only when an operator requirement justifies its ownership, fencing, migration, and recovery semantics.
+
+## Profiles authorization boundary
+
+Profiles never authorizes, filters, ranks, hides, reveals, retries, or mutates from:
+
+- moving-window applicability or availability;
+- private cursor position or advancement;
+- reset generation;
+- rolling retention or `history_truncated`;
+- physical duplicate or identity-conflict counts;
+- scan failure or stable error code;
+- server mode, broker configuration, or retained evidence.
+
+Presentation continues to consume authoritative owner-port policy results only.
+
+## Remaining work
+
+1. compose the moving scanner as an explicit opt-in `outbox_iggy` server observer mode;
+2. define reviewed configuration and fail-closed startup validation;
+3. retain real external-Iggy cross-cycle evidence;
+4. decide separately whether restart continuity merits a persistent cursor owner;
+5. add identifier-free telemetry and optional operational health.

--- a/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
@@ -1,22 +1,24 @@
 # Profiles checkpoint: bounded physical DLQ duplicate rolling window
 
-Status: **cross-cycle rolling-window state source-complete; scanner/cursor integration and runtime evidence pending**.
+Status: **cross-cycle rolling-window state and moving scanner integration source-complete; server composition and runtime evidence pending**.
 
 ## Why this belongs in the Profiles improvement trail
 
 Profiles never authorizes presentation from broker, receipt, metric, evidence, or duplicate-inspection state. However, downstream processing reliability must not hide a physical duplicate merely because its copies were observed in adjacent scan cycles.
 
-The existing fixed scans classify one bounded result. `DlqDuplicateRollingWindow` adds bounded cross-cycle identity retention without exporting message identity or turning operational state into profile policy.
+The fixed scanners classify one bounded result. `DlqDuplicateRollingWindow` adds bounded cross-cycle identity retention, and the feature-gated moving scanner now supplies complete fair cycles with private process-local per-partition cursors. Neither exports message identity or turns operational state into profile policy.
 
 ## Delivered source boundary
 
-Owner source:
+Owner sources:
 
 ```text
-crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+crates/rustok-iggy/src/
+  dlq_duplicate_rolling_window.rs
+  dlq_duplicate_moving_window_scan.rs
 ```
 
-Public API:
+Public rolling API:
 
 ```text
 DlqDuplicateRollingWindowPolicy
@@ -25,23 +27,36 @@ DlqDuplicateRollingWindowSnapshot
 DlqDuplicateRollingWindowError
 ```
 
-Machine contract:
+Moving integration API:
+
+```text
+IggyDlqDuplicateMovingWindowPolicy
+IggyDlqDuplicateMovingWindowState
+IggyDlqDuplicateMovingWindowSnapshot
+IggyDlqDuplicateMovingWindowScanner
+IggyDlqDuplicateMovingWindowError
+```
+
+Machine contracts:
 
 ```text
 crates/rustok-iggy/contracts/evidence/
   dlq-duplicate-rolling-window-source.json
+  dlq-duplicate-moving-window-scan-source.json
 ```
 
-Verifier:
+Verifiers:
 
 ```text
 scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 ```
 
-Owner guide:
+Owner guides:
 
 ```text
 crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
+crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
 ```
 
 ## Bounded semantics
@@ -55,6 +70,23 @@ One successful `push_cycle` represents one complete scan cycle. The state:
 - rejects an oversized cycle without changing prior state;
 - evicts only the oldest complete cycle;
 - exposes only aggregate summary and retention counts.
+
+## Moving scanner integration
+
+The moving scanner integration is source-complete.
+
+Each selected partition has one private process-local per-partition cursor. Every cycle applies an equal bounded message budget, polls with explicit offsets and `auto_commit=false`, and advances all cursors only after every partition succeeds and the rolling state accepts the combined cycle.
+
+An incomplete, invalid, or failed cycle preserves all cursors and the previous rolling snapshot. Public results expose only partition count, advanced-partition count, reset generation, and the existing identifier-free rolling snapshot.
+
+Restart semantics are explicit reset:
+
+- no cursor or observation persistence;
+- new state starts from one reviewed initial offset;
+- `reset_to_initial_offset()` rewinds every cursor and clears rolling history;
+- no restart-safe progress, current-tail, or complete-history claim.
+
+A persistent cursor owner remains separate work and is not implied.
 
 ## Truncation boundary
 
@@ -73,7 +105,7 @@ Profiles never authorizes visibility, `followers_only`, follow controls, search 
 - rolling-window summary counts;
 - retained or evicted cycle counts;
 - `history_truncated`;
-- scan cadence or cursor position;
+- scan cadence, private cursor position, or reset generation;
 - Iggy deployment mode;
 - receipt state or retained evidence.
 
@@ -81,13 +113,12 @@ Privacy remains resolved through authoritative owner ports before localized and 
 
 ## Remaining integration
 
-The source-complete state deliberately does not yet define:
+Moving scanner integration is source-complete. Remaining work is:
 
-1. how the Iggy scanner feeds one complete cycle without identifier export;
-2. how each physical partition advances its cursor;
-3. whether state is persisted or reset on restart;
-4. how mode-aware server composition uses the rolling window;
-5. external-Iggy cross-cycle runtime evidence;
-6. identifier-free telemetry and health projection.
+1. compose it as an explicit opt-in mode in the mode-aware server observer;
+2. define reviewed configuration and fail-closed startup validation;
+3. retain external-Iggy cross-cycle runtime evidence;
+4. add a persistent cursor owner only if restart continuity is required;
+5. define identifier-free telemetry and health projection.
 
 Tests, Cargo commands, formatters, source verifiers, broker scans, server composition, telemetry registration, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -5,33 +5,86 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
-const contractPath =
-  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json";
-const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
-const adapterContractPath =
-  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
-const adapterSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
-const alertContractPath =
-  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
-const alertSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
-const alertRuntimeContractPath =
-  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
-const alertRuntimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
-const observerContractPath =
-  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
-const observerIggySourcePath =
-  "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
-const observerServerSourcePath =
-  "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
-const libPath = "crates/rustok-iggy/src/lib.rs";
-const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
-const transportPath = "crates/rustok-iggy/src/transport.rs";
-const receiptInspectorPath =
-  "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs";
-const expectedVerifier = "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs";
-const expectedDocumentation = "crates/rustok-iggy/docs/dlq-duplicate-inspection.md";
-const expectedProfilesCheckpoint =
-  "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md";
+const paths = {
+  contract: "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json",
+  source: "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  adapterContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json",
+  adapterSource: "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
+  rollingContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json",
+  rollingSource: "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
+  movingContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
+  movingSource: "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+  alertContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
+  alertSource: "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
+  alertRuntimeContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
+  alertRuntimeSource: "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
+  observerContract:
+    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
+  observerIggySource: "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+  observerServerSource:
+    "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
+  lib: "crates/rustok-iggy/src/lib.rs",
+  decodeFailure: "crates/rustok-iggy/src/contract_decode_failure.rs",
+  transport: "crates/rustok-iggy/src/transport.rs",
+  receiptInspector:
+    "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs",
+  documentation: "crates/rustok-iggy/docs/dlq-duplicate-inspection.md",
+  profilesCheckpoint:
+    "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md",
+  verifier: "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs",
+};
+
+function read(path) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+function readJson(path) {
+  return JSON.parse(read(path));
+}
+
+const contract = readJson(paths.contract);
+const adapterContract = readJson(paths.adapterContract);
+const rollingContract = readJson(paths.rollingContract);
+const movingContract = readJson(paths.movingContract);
+const alertContract = readJson(paths.alertContract);
+const alertRuntimeContract = readJson(paths.alertRuntimeContract);
+const observerContract = readJson(paths.observerContract);
+const source = read(paths.source);
+const adapterSource = read(paths.adapterSource);
+const rollingSource = read(paths.rollingSource);
+const movingSource = read(paths.movingSource);
+const alertSource = read(paths.alertSource);
+const alertRuntimeSource = read(paths.alertRuntimeSource);
+const observerIggySource = read(paths.observerIggySource);
+const observerServerSource = read(paths.observerServerSource);
+const lib = read(paths.lib);
+const decodeFailure = read(paths.decodeFailure);
+const transport = read(paths.transport);
+const receiptInspector = read(paths.receiptInspector);
+const documentation = read(paths.documentation);
+const profilesCheckpoint = read(paths.profilesCheckpoint);
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
 const expectedExports = [
   "DlqDuplicateObservation",
   "DlqDuplicateSummary",
@@ -53,181 +106,136 @@ const expectedTests = [
   "nil_message_id_is_rejected_with_stable_code",
 ];
 
-const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
-const adapterContract = JSON.parse(
-  readFileSync(resolve(repoRoot, adapterContractPath), "utf8"),
-);
-const alertContract = JSON.parse(
-  readFileSync(resolve(repoRoot, alertContractPath), "utf8"),
-);
-const alertRuntimeContract = JSON.parse(
-  readFileSync(resolve(repoRoot, alertRuntimeContractPath), "utf8"),
-);
-const observerContract = JSON.parse(
-  readFileSync(resolve(repoRoot, observerContractPath), "utf8"),
-);
-const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
-const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
-const alertSource = readFileSync(resolve(repoRoot, alertSourcePath), "utf8");
-const alertRuntimeSource = readFileSync(resolve(repoRoot, alertRuntimeSourcePath), "utf8");
-const observerIggySource = readFileSync(resolve(repoRoot, observerIggySourcePath), "utf8");
-const observerServerSource = readFileSync(resolve(repoRoot, observerServerSourcePath), "utf8");
-const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
-const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
-const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
-const receiptInspector = readFileSync(resolve(repoRoot, receiptInspectorPath), "utf8");
-const failures = [];
-
-function fail(message) {
-  failures.push(message);
-}
-
-function sameValue(actual, expected) {
-  return JSON.stringify(actual) === JSON.stringify(expected);
-}
-
-function requireText(name, text, marker) {
-  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
-}
-
-function forbidText(name, text, marker) {
-  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
-}
-
-function countText(text, marker) {
-  return text.split(marker).length - 1;
-}
-
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-inspection-source" ||
   contract.status !== "source_complete_runtime_evidence_pending" ||
   contract.owner !== "rustok-iggy" ||
-  contract.source !== sourcePath ||
+  contract.source !== paths.source ||
+  contract.verifier !== paths.verifier ||
+  contract.documentation !== paths.documentation ||
+  contract.profiles_checkpoint !== paths.profilesCheckpoint ||
   contract.execution_status !== "source_not_run"
 ) {
-  fail("DLQ duplicate inspection contract identity or source status drift");
+  fail("DLQ duplicate inspection contract identity or status drift");
 }
-if (!sameValue(contract.public_exports, expectedExports)) {
-  fail("DLQ duplicate inspection public export allowlist drift");
+if (!same(contract.public_exports, expectedExports)) {
+  fail("DLQ duplicate inspection export allowlist drift");
 }
-if (!sameValue(contract.summary_fields, expectedSummaryFields)) {
-  fail("DLQ duplicate inspection summary field allowlist drift");
+if (!same(contract.summary_fields, expectedSummaryFields)) {
+  fail("DLQ duplicate inspection summary allowlist drift");
 }
-if (!sameValue(contract.required_source_tests, expectedTests)) {
-  fail("DLQ duplicate inspection source test allowlist drift");
-}
-if (
-  contract.verifier !== expectedVerifier ||
-  contract.documentation !== expectedDocumentation ||
-  contract.profiles_checkpoint !== expectedProfilesCheckpoint
-) {
-  fail("DLQ duplicate inspection verifier or documentation path drift");
+if (!same(contract.required_source_tests, expectedTests)) {
+  fail("DLQ duplicate inspection test allowlist drift");
 }
 
 if (
   contract.identity?.input !== "non_nil_deterministic_iggy_message_header_uuid" ||
   contract.identity?.payload_comparison !== "domain_separated_sha256_in_memory_only" ||
   contract.identity?.empty_payload_valid !== true ||
-  contract.identity?.nil_uuid_rejected !== true
-) {
-  fail("DLQ duplicate inspection identity boundary drift");
-}
-if (
+  contract.identity?.nil_uuid_rejected !== true ||
   contract.semantics?.duplicate_message_formula !==
     "total_messages_minus_unique_message_ids" ||
   contract.semantics?.ordinary_duplicate !==
     "same_non_nil_message_id_and_same_exact_payload_digest" ||
   contract.semantics?.identity_conflict !==
     "same_non_nil_message_id_with_more_than_one_exact_payload_digest" ||
-  contract.semantics?.manual_review_required_for_identity_conflict !== true ||
-  contract.semantics?.empty_scan_returns_zero_summary !== true
+  contract.semantics?.manual_review_required_for_identity_conflict !== true
 ) {
-  fail("DLQ duplicate inspection semantic contract drift");
+  fail("DLQ duplicate inspection identity or semantic boundary drift");
 }
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
-  if (allowed !== false) fail(`DLQ duplicate inspection mutation became allowed: ${operation}`);
+  if (allowed !== false) fail(`inspection mutation became allowed: ${operation}`);
 }
 if (
   contract.privacy_boundary?.observation_exposes_digest !== false ||
   contract.privacy_boundary?.summary_exposes_identifiers !== false
 ) {
-  fail("DLQ duplicate inspection privacy flags drift");
+  fail("inspection privacy flags drift");
 }
 
 if (
   contract.runtime_adapter?.status !== "source_complete_runtime_pending" ||
-  contract.runtime_adapter?.contract !== adapterContractPath ||
-  contract.runtime_adapter?.source !== adapterSourcePath ||
+  contract.runtime_adapter?.contract !== paths.adapterContract ||
+  contract.runtime_adapter?.source !== paths.adapterSource ||
   contract.runtime_adapter?.auto_commit !== false ||
   contract.runtime_adapter?.result !== "DlqDuplicateSummary" ||
   adapterContract.packet !== "dlq-duplicate-external-scan-source" ||
-  adapterContract.source !== adapterSourcePath ||
-  adapterContract.classifier_source !== sourcePath
+  adapterContract.source !== paths.adapterSource ||
+  adapterContract.classifier_source !== paths.source
 ) {
-  fail("DLQ duplicate inspection runtime adapter relationship drift");
+  fail("fixed external scanner relationship drift");
 }
+
+const rolling = contract.rolling_window ?? {};
+const moving = rolling.moving_scanner ?? {};
 if (
-  contract.alert_policy?.status !== "source_complete_server_observer_execution_pending" ||
-  contract.alert_policy?.contract !== alertContractPath ||
-  contract.alert_policy?.source !== alertSourcePath ||
+  rolling.status !== "source_complete_moving_scan_integrated_server_pending" ||
+  rolling.contract !== paths.rollingContract ||
+  rolling.source !== paths.rollingSource ||
+  rolling.result !== "DlqDuplicateRollingWindowSnapshot" ||
+  rolling.complete_cycle_retention !== true ||
+  rolling.history_truncated_after_eviction !== true ||
+  rolling.identifier_export !== false ||
+  moving.status !== "source_complete_server_composition_runtime_pending" ||
+  moving.contract !== paths.movingContract ||
+  moving.source !== paths.movingSource ||
+  moving.independent_process_local_partition_cursors !== true ||
+  moving.complete_cycle_atomicity !== true ||
+  moving.progress_persisted !== false ||
+  moving.restart_semantics !== "reset_to_reviewed_initial_offset" ||
+  moving.cursor_values_exported !== false ||
+  rollingContract.packet !== "dlq-duplicate-rolling-window-source" ||
+  rollingContract.status !== "source_complete_moving_scan_integrated_server_pending" ||
+  movingContract.packet !== "dlq-duplicate-moving-window-scan-source" ||
+  movingContract.status !== "source_complete_server_composition_runtime_pending"
+) {
+  fail("rolling or moving scanner relationship drift");
+}
+
+if (
+  contract.alert_policy?.contract !== paths.alertContract ||
+  contract.alert_policy?.source !== paths.alertSource ||
   contract.alert_policy?.input !== "DlqDuplicateSummary" ||
-  contract.alert_policy?.result !== "DlqDuplicateAlertEvaluation" ||
   contract.alert_policy?.identity_conflict_always_critical !== true ||
   contract.alert_policy?.production_defaults !== false ||
-  contract.alert_policy?.notification_dispatch !== false ||
-  contract.alert_policy?.destructive_action !== false ||
-  alertContract.status !== "source_complete_server_observer_execution_pending" ||
-  alertContract.source !== alertSourcePath ||
-  alertContract.summary_source !== sourcePath
+  alertContract.source !== paths.alertSource ||
+  alertContract.summary_source !== paths.source
 ) {
-  fail("DLQ duplicate inspection alert policy relationship drift");
+  fail("duplicate alert policy relationship drift");
 }
 if (
-  contract.alert_runtime?.status !== "source_complete_server_observer_execution_pending" ||
-  contract.alert_runtime?.contract !== alertRuntimeContractPath ||
-  contract.alert_runtime?.source !== alertRuntimeSourcePath ||
-  contract.alert_runtime?.input !== "DlqDuplicateSummary" ||
-  contract.alert_runtime?.result !== "DlqDuplicateAlertRuntimeSnapshot" ||
+  contract.alert_runtime?.contract !== paths.alertRuntimeContract ||
+  contract.alert_runtime?.source !== paths.alertRuntimeSource ||
   contract.alert_runtime?.latest_value !== true ||
   contract.alert_runtime?.single_writer !== true ||
   contract.alert_runtime?.unavailable_clears_evaluation !== true ||
-  contract.alert_runtime?.notification_dispatch !== false ||
-  contract.alert_runtime?.destructive_action !== false ||
-  alertRuntimeContract.status !== "source_complete_server_observer_execution_pending" ||
-  alertRuntimeContract.source !== alertRuntimeSourcePath ||
-  alertRuntimeContract.policy_source !== alertSourcePath ||
-  alertRuntimeContract.summary_source !== sourcePath
+  alertRuntimeContract.source !== paths.alertRuntimeSource ||
+  alertRuntimeContract.policy_source !== paths.alertSource
 ) {
-  fail("DLQ duplicate inspection alert runtime relationship drift");
+  fail("duplicate alert runtime relationship drift");
 }
 if (
-  contract.server_observer?.status !== "source_complete_runtime_execution_pending" ||
-  contract.server_observer?.contract !== observerContractPath ||
-  contract.server_observer?.iggy_source !== observerIggySourcePath ||
-  contract.server_observer?.server_source !== observerServerSourcePath ||
+  contract.server_observer?.contract !== paths.observerContract ||
+  contract.server_observer?.iggy_source !== paths.observerIggySource ||
+  contract.server_observer?.server_source !== paths.observerServerSource ||
   contract.server_observer?.memory !== "not_applicable" ||
   contract.server_observer?.outbox_local !== "not_applicable" ||
-  !sameValue(contract.server_observer?.outbox_iggy_modes, ["bundled", "external"]) ||
+  !same(contract.server_observer?.outbox_iggy_modes, ["bundled", "external"]) ||
   contract.server_observer?.startup_failure_non_fatal !== true ||
-  contract.server_observer?.partition_fairness_claimed !== false ||
+  contract.server_observer?.moving_window_mode !== "pending_explicit_opt_in" ||
   contract.server_observer?.readiness_dependency !== false ||
   contract.server_observer?.profiles_authorization !== false ||
   observerContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
-  observerContract.status !== "source_complete_runtime_execution_pending" ||
-  observerContract.activation?.observer_startup_failure_is_non_fatal !== true ||
-  observerContract.scan?.partition_fairness_claimed !== false ||
   observerContract.scan?.moving_cursor !== false ||
   observerContract.scan?.current_tail_coverage_claimed !== false ||
-  observerContract.scan?.complete_history_claimed !== false ||
-  observerContract.iggy_source !== observerIggySourcePath ||
-  observerContract.server_source !== observerServerSourcePath
+  observerContract.scan?.complete_history_claimed !== false
 ) {
-  fail("DLQ duplicate inspection server observer relationship drift");
+  fail("server observer relationship or moving-mode pending boundary drift");
 }
 
-const requiredExcludedFields = new Set([
+const requiredExcluded = new Set([
   "broker_address",
   "stream",
   "topic",
@@ -243,12 +251,10 @@ const requiredExcludedFields = new Set([
   "credential",
 ]);
 for (const field of contract.privacy_boundary?.summary_excludes ?? []) {
-  requiredExcludedFields.delete(field);
+  requiredExcluded.delete(field);
 }
-if (requiredExcludedFields.size > 0) {
-  fail(`DLQ duplicate privacy exclusions are incomplete: ${[
-    ...requiredExcludedFields,
-  ].join(", ")}`);
+if (requiredExcluded.size > 0) {
+  fail(`inspection privacy exclusions incomplete: ${[...requiredExcluded].join(", ")}`);
 }
 
 for (const marker of [
@@ -258,34 +264,21 @@ for (const marker of [
   "payload_sha256: [u8; 32]",
   "pub fn from_payload(",
   "if broker_message_id.is_nil()",
-  "hash_part(&mut hasher, DLQ_PAYLOAD_DIGEST_DOMAIN);",
-  "hash_part(&mut hasher, payload);",
   "pub struct DlqDuplicateSummary",
-  "pub const fn total_messages(&self)",
-  "pub const fn unique_message_ids(&self)",
-  "pub const fn duplicate_messages(&self)",
-  "pub const fn duplicate_groups(&self)",
-  "pub const fn conflicting_payload_groups(&self)",
-  "pub const fn max_copies_per_message_id(&self)",
-  "pub const fn has_physical_duplicates(&self)",
-  "pub const fn has_identity_conflicts(&self)",
   "pub const fn requires_manual_review(&self)",
-  '"iggy.dlq_duplicate.identity_invalid"',
-  '"iggy.dlq_duplicate.count_overflow"',
   "BTreeMap::<Uuid, DuplicateGroup>::new()",
   "BTreeSet<[u8; 32]>",
-  ".checked_add(1)",
-  ".checked_sub(unique_message_ids)",
   "group.payload_sha256.len() > 1",
-  "Ok(DlqDuplicateSummary {",
+  '"iggy.dlq_duplicate.identity_invalid"',
+  '"iggy.dlq_duplicate.count_overflow"',
 ]) {
-  requireText("DLQ duplicate inspection source", source, marker);
+  requireText("inspection source", source, marker);
 }
 for (const testName of expectedTests) {
-  requireText("DLQ duplicate inspection source tests", source, `fn ${testName}()`);
+  requireText("inspection tests", source, `fn ${testName}()`);
 }
 if (countText(source, "#[test]") !== expectedTests.length) {
-  fail("DLQ duplicate inspection source must contain exactly four focused unit tests");
+  fail("inspection source must contain exactly four focused tests");
 }
 for (const marker of [
   "pub broker_message_id:",
@@ -297,65 +290,75 @@ for (const marker of [
   ".acknowledge(",
   ".delete(",
   ".replay(",
-  ".retry_entry(",
   ".reserve_and_claim(",
-  ".release_claim(",
   ".mark_published(",
-  ".mark_acknowledged(",
 ]) {
-  forbidText("DLQ duplicate inspection source", source, marker);
+  forbidText("inspection source", source, marker);
 }
 
 for (const marker of [
   "pub struct IggyDlqDuplicateScanner<'a>",
   ".poll_messages(",
   "&PollingStrategy::offset(next_offset)",
-  "requested_count,\n                        false,",
   "summarize_dlq_duplicates(observations)",
 ]) {
-  requireText("bounded external duplicate scan adapter", adapterSource, marker);
+  requireText("fixed scanner", adapterSource, marker);
+}
+for (const marker of [
+  "pub struct DlqDuplicateRollingWindow",
+  "pub fn push_cycle(",
+  "history_truncated: evicted_cycles > 0",
+]) {
+  requireText("rolling source", rollingSource, marker);
+}
+for (const marker of [
+  "pub struct IggyDlqDuplicateMovingWindowState",
+  "cursors: BTreeMap<u32, u64>",
+  "fn apply_complete_cycle(",
+  "let rolling = self.rolling.push_cycle(observations)?;",
+  "self.cursors = candidate_cursors;",
+  "pub fn reset_to_initial_offset(",
+]) {
+  requireText("moving scanner", movingSource, marker);
 }
 for (const marker of [
   "pub struct DlqDuplicateAlertPolicy",
-  "pub const fn evaluate(",
   "pub enum DlqDuplicateAlertLevel",
-  "pub struct DlqDuplicateAlertEvaluation",
 ]) {
-  requireText("count-only duplicate alert policy", alertSource, marker);
+  requireText("alert policy", alertSource, marker);
 }
 for (const marker of [
   "pub struct DlqDuplicateAlertRuntimePublisher",
-  "pub struct DlqDuplicateAlertRuntimeSnapshot",
   "pub fn mark_unavailable(",
   "evaluation: None",
 ]) {
-  requireText("latest-value alert runtime", alertRuntimeSource, marker);
+  requireText("alert runtime", alertRuntimeSource, marker);
 }
-for (const marker of [
+requireText(
+  "Iggy observer",
+  observerIggySource,
   "pub struct IggyDlqDuplicateAlertObserver",
-  "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
-]) {
-  requireText("Iggy alert observer", observerIggySource, marker);
-}
+);
 for (const marker of [
   "Unavailable",
   "NotApplicableMemory",
   "NotApplicableOutboxLocal",
   "IggyBundled",
   "IggyExternal",
-  "record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);",
-  "DlqDuplicateAlertRuntimePublisher::new(config.policy)",
   "publisher.mark_unavailable()",
 ]) {
-  requireText("server alert observer", observerServerSource, marker);
+  requireText("server observer", observerServerSource, marker);
 }
 
-requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_inspection;");
-requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_policy;");
-requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_runtime;");
-requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_alert_observer;");
+for (const marker of [
+  "pub mod dlq_duplicate_inspection;",
+  "pub mod dlq_duplicate_rolling_window;",
+  '#[cfg(feature = "iggy")]\npub mod dlq_duplicate_moving_window_scan;',
+]) {
+  requireText("rustok-iggy module list", lib, marker);
+}
 for (const exportName of expectedExports) {
-  requireText("rustok-iggy public exports", lib, exportName);
+  requireText("rustok-iggy exports", lib, exportName);
 }
 
 for (const marker of [
@@ -364,23 +367,39 @@ for (const marker of [
   "hash_part(&mut hasher, &self.raw_payload);",
   ".with_broker_message_id(delivery_id)",
 ]) {
-  requireText("raw poison deterministic identity", decodeFailure, marker);
+  requireText("raw poison identity", decodeFailure, marker);
 }
 for (const marker of [
   "if entry.broker_message_id().is_some()",
   "IggyDlqPublisher::connect",
   ".publish(&entry)",
 ]) {
-  requireText("production deterministic Iggy publisher", transport, marker);
+  requireText("deterministic publisher", transport, marker);
 }
 for (const marker of [
   "Bounded aggregate view of neutral poison-result progress",
   "The snapshot intentionally excludes delivery identifiers",
-  "Inspection never claims, releases, publishes, acknowledges, deletes, or repairs",
   "pub struct ConsumerPoisonReceiptSummary",
   "pub async fn summarize(",
 ]) {
-  requireText("count-only receipt inspector", receiptInspector, marker);
+  requireText("receipt inspector", receiptInspector, marker);
+}
+
+for (const marker of [
+  "moving scanner integration is source-complete",
+  "independent process-local per-partition cursors",
+  "explicit restart reset",
+  "server composition and runtime evidence pending",
+]) {
+  requireText("inspection documentation", documentation, marker);
+}
+for (const marker of [
+  "moving scanner integration is source-complete",
+  "private process-local per-partition cursors",
+  "restart reset",
+  "Profiles authorization boundary",
+]) {
+  requireText("Profiles operations checkpoint", profilesCheckpoint, marker);
 }
 
 if (
@@ -388,20 +407,20 @@ if (
     "ConsumedContractDecodeFailure::delivery_id" ||
   contract.production_relationship?.dlq_broker_message_id !==
     "ConsumedContractDecodeFailure::to_dlq_entry" ||
-  contract.production_relationship?.physical_publisher !==
-    "IggyTransport::move_to_dlq" ||
-  contract.production_relationship?.receipt_summary !==
-    "ConsumerPoisonReceiptInspector" ||
-  contract.production_relationship
-    ?.receipt_and_physical_duplicate_summaries_are_independent !== true
+  contract.production_relationship?.physical_publisher !== "IggyTransport::move_to_dlq" ||
+  contract.production_relationship?.receipt_summary !== "ConsumerPoisonReceiptInspector" ||
+  contract.production_relationship?.receipt_and_physical_duplicate_summaries_are_independent !==
+    true
 ) {
-  fail("DLQ duplicate inspection production relationship drift");
+  fail("production identity relationship drift");
 }
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
-  "partition_fairness_or_per_partition_budget_policy",
-  "moving_window_or_per_partition_cursor_policy",
+  "compose_moving_window_server_observer",
+  "define_reviewed_moving_window_configuration",
+  "retain_moving_window_external_runtime_evidence",
+  "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
   "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
   "operator_ack_delete_replay_workflow_outside_inspector",
@@ -409,9 +428,7 @@ const requiredRemaining = new Set([
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
 if (requiredRemaining.size > 0) {
-  fail(`DLQ duplicate inspection remaining work drift: ${[
-    ...requiredRemaining,
-  ].join(", ")}`);
+  fail(`inspection remaining work drift: ${[...requiredRemaining].join(", ")}`);
 }
 
 if (failures.length > 0) {
@@ -421,5 +438,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy boundary, bounded auto_commit=false scanning, explicit alert policy, single-writer latest-value runtime, and mode-aware Memory/OutboxLocal/OutboxIggy server observation with non-fatal startup and explicit fairness/moving-window non-claims are locked; retained execution and telemetry/health projection remain pending.",
+  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy, fixed and moving bounded scanners, complete-cycle atomic rolling integration, explicit non-persistent restart reset, alert/runtime/server boundaries, and Profiles non-authorization are locked; server moving-mode composition, runtime evidence, telemetry, and authorized operations remain pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
+const rollingPath = "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs";
+const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const documentationPath =
+  "crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md";
+const profilesCheckpointPath =
+  "crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md";
+const planPath = "crates/rustok-profiles/docs/implementation-plan.md";
+const verifierPath =
+  "scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs";
+
+const expectedExports = [
+  "IggyDlqDuplicateMovingWindowPolicy",
+  "IggyDlqDuplicateMovingWindowState",
+  "IggyDlqDuplicateMovingWindowSnapshot",
+  "IggyDlqDuplicateMovingWindowScanner",
+  "IggyDlqDuplicateMovingWindowError",
+];
+const expectedTests = [
+  "policy_requires_complete_fair_cycle_to_fit_rolling_capacity",
+  "complete_cycle_advances_partition_cursors_independently",
+  "duplicate_split_across_advancing_cycles_remains_count_only",
+  "incomplete_cycle_preserves_cursors_and_rolling_state",
+  "explicit_reset_rewinds_cursors_and_clears_rolling_history",
+];
+
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const rolling = readFileSync(resolve(repoRoot, rollingPath), "utf8");
+const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
+const profilesCheckpoint = readFileSync(
+  resolve(repoRoot, profilesCheckpointPath),
+  "utf8",
+);
+const plan = readFileSync(resolve(repoRoot, planPath), "utf8");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function same(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function requireText(name, text, marker) {
+  if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
+}
+
+function forbidText(name, text, marker) {
+  if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
+}
+
+function countText(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+if (
+  contract.schema_version !== 1 ||
+  contract.module !== "iggy" ||
+  contract.packet !== "dlq-duplicate-moving-window-scan-source" ||
+  contract.status !== "source_complete_server_composition_runtime_pending" ||
+  contract.owner !== "rustok-iggy" ||
+  contract.feature !== "iggy" ||
+  contract.source !== sourcePath ||
+  contract.rolling_source !== rollingPath ||
+  contract.classifier_source !== classifierPath ||
+  contract.verifier !== verifierPath ||
+  contract.documentation !== documentationPath ||
+  contract.profiles_checkpoint !== profilesCheckpointPath ||
+  contract.execution_status !== "source_not_run"
+) {
+  fail("moving-window scan contract identity or source status drift");
+}
+
+if (!same(contract.public_exports, expectedExports)) {
+  fail("moving-window scan public export allowlist drift");
+}
+if (!same(contract.required_source_tests, expectedTests)) {
+  fail("moving-window scan focused test allowlist drift");
+}
+
+if (
+  contract.bounds?.maximum_partitions !== 128 ||
+  contract.bounds?.maximum_total_messages_per_cycle !== 10000 ||
+  contract.bounds?.maximum_batch_messages !== 1000 ||
+  contract.bounds?.equal_per_partition_message_budget !== true ||
+  contract.bounds?.rolling_cycle_capacity_must_cover_fair_cycle !== true ||
+  contract.bounds?.production_defaults !== false
+) {
+  fail("moving-window scan bounds drift");
+}
+
+if (
+  contract.cursor_semantics?.one_private_next_offset_per_partition !== true ||
+  contract.cursor_semantics?.advance_only_after_complete_all_partition_cycle !== true ||
+  contract.cursor_semantics?.empty_partition_cursor_unchanged !== true ||
+  contract.cursor_semantics?.failed_cycle_preserves_all_cursors !== true ||
+  contract.cursor_semantics?.explicit_offsets !== true ||
+  contract.cursor_semantics?.auto_commit !== false ||
+  contract.cursor_semantics?.stored_consumer_offsets !== false
+) {
+  fail("moving-window cursor semantics drift");
+}
+
+if (
+  contract.rolling_integration?.complete_cycle_only !== true ||
+  contract.rolling_integration?.combined_observations_not_exported !== true ||
+  contract.rolling_integration?.failed_cycle_preserves_rolling_state !== true ||
+  contract.rolling_integration?.cross_cycle_ordinary_duplicate !== true ||
+  contract.rolling_integration?.cross_cycle_identity_conflict !== true ||
+  contract.rolling_integration?.history_truncated_delegated !== true
+) {
+  fail("moving-window rolling integration drift");
+}
+
+if (
+  contract.restart_semantics?.progress_persisted !== false ||
+  contract.restart_semantics?.rolling_state_persisted !== false ||
+  contract.restart_semantics?.new_process_starts_at_reviewed_initial_offset !== true ||
+  contract.restart_semantics?.explicit_reset_to_initial_offset !== true ||
+  contract.restart_semantics?.reset_clears_rolling_history !== true ||
+  contract.restart_semantics?.reset_generation_count_only !== true ||
+  contract.restart_semantics?.restart_safe_progress_claimed !== false
+) {
+  fail("moving-window restart/reset semantics drift");
+}
+
+if (
+  !same(contract.snapshot_fields, [
+    "rolling",
+    "partition_count",
+    "advanced_partitions",
+    "reset_generation",
+  ])
+) {
+  fail("moving-window snapshot field allowlist drift");
+}
+
+for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
+  if (allowed !== false) fail(`moving-window mutation became allowed: ${operation}`);
+}
+
+if (
+  contract.privacy_boundary?.identifier_free_snapshot !== true ||
+  contract.privacy_boundary?.payload_free_snapshot !== true ||
+  contract.privacy_boundary?.cursor_values_not_exported !== true ||
+  contract.privacy_boundary?.observations_not_exported !== true
+) {
+  fail("moving-window privacy flags drift");
+}
+
+const requiredExcluded = new Set([
+  "broker_address",
+  "stream",
+  "topic",
+  "partition_id",
+  "offset",
+  "broker_message_id",
+  "payload",
+  "payload_sha256",
+  "receipt_identity",
+  "publisher_identity",
+  "credential",
+  "timestamp",
+  "raw_iggy_error",
+]);
+for (const field of contract.privacy_boundary?.snapshot_excludes ?? []) {
+  requiredExcluded.delete(field);
+}
+if (requiredExcluded.size > 0) {
+  fail(`moving-window privacy exclusions are incomplete: ${[...requiredExcluded].join(", ")}`);
+}
+
+if (
+  !same(contract.stable_errors, {
+    invalid_policy: "iggy.dlq_duplicate.moving_window_policy_invalid",
+    poll_failed: "iggy.dlq_duplicate.moving_window_poll_failed",
+    invalid_response: "iggy.dlq_duplicate.moving_window_response_invalid",
+    offset_overflow: "iggy.dlq_duplicate.moving_window_offset_overflow",
+    invalid_cycle: "iggy.dlq_duplicate.moving_window_cycle_invalid",
+    count_overflow: "iggy.dlq_duplicate.moving_window_count_overflow",
+    reset_overflow: "iggy.dlq_duplicate.moving_window_reset_overflow",
+  })
+) {
+  fail("moving-window stable error code drift");
+}
+
+for (const marker of [
+  'const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-moving-readonly-v1";',
+  "pub struct IggyDlqDuplicateMovingWindowPolicy",
+  ".checked_mul(partition_count)",
+  ".filter(|total| *total <= MAX_SCAN_MESSAGES)",
+  "rolling_policy.max_observations_per_cycle() < total_message_budget",
+  "pub struct IggyDlqDuplicateMovingWindowSnapshot",
+  "pub const fn progress_persisted(&self) -> bool",
+  "pub const fn restart_resets_to_initial_offset(&self) -> bool",
+  "pub struct IggyDlqDuplicateMovingWindowState",
+  "cursors: BTreeMap<u32, u64>",
+  "pub fn reset_to_initial_offset(",
+  "fn apply_complete_cycle(",
+  "let mut candidate_cursors = self.cursors.clone();",
+  "let rolling = self.rolling.push_cycle(observations)?;",
+  "self.cursors = candidate_cursors;",
+  "pub struct IggyDlqDuplicateMovingWindowScanner<'a>",
+  "pub async fn scan_cycle(",
+  ".poll_messages(",
+  "&PollingStrategy::offset(next_offset)",
+  "requested_count,\n                    false,",
+  "pub enum IggyDlqDuplicateMovingWindowError",
+  '"iggy.dlq_duplicate.moving_window_policy_invalid"',
+  '"iggy.dlq_duplicate.moving_window_poll_failed"',
+  '"iggy.dlq_duplicate.moving_window_response_invalid"',
+  '"iggy.dlq_duplicate.moving_window_offset_overflow"',
+  '"iggy.dlq_duplicate.moving_window_cycle_invalid"',
+  '"iggy.dlq_duplicate.moving_window_count_overflow"',
+  '"iggy.dlq_duplicate.moving_window_reset_overflow"',
+]) {
+  requireText("moving-window scan source", source, marker);
+}
+
+for (const testName of expectedTests) {
+  requireText("moving-window scan source tests", source, `fn ${testName}()`);
+}
+if (countText(source, "#[test]") !== expectedTests.length) {
+  fail("moving-window scan source must contain exactly five focused unit tests");
+}
+
+for (const marker of [
+  "pub cursors:",
+  "pub observations:",
+  "pub partition_id:",
+  "pub start_offset:",
+  "pub next_offset:",
+  "Serialize",
+  "Deserialize",
+  "ConsumerKind::ConsumerGroup",
+  "PollingStrategy::next(",
+  ".store_consumer_offset(",
+  "ConsumerOffsetClient",
+  ".acknowledge(",
+  ".delete_stream(",
+  ".delete_topic(",
+  ".purge_topic(",
+  ".send_messages(",
+  ".move_to_dlq(",
+  ".retry_entry(",
+  ".reserve_and_claim(",
+  ".mark_published(",
+  ".mark_acknowledged(",
+  ".shutdown(",
+]) {
+  forbidText("moving-window scan source", source, marker);
+}
+
+for (const marker of [
+  "pub struct DlqDuplicateRollingWindow",
+  "pub fn push_cycle(",
+  "history_truncated: evicted_cycles > 0",
+]) {
+  requireText("rolling-window source", rolling, marker);
+}
+for (const marker of [
+  "pub struct DlqDuplicateObservation",
+  "pub struct DlqDuplicateSummary",
+  "pub fn summarize_dlq_duplicates(",
+]) {
+  requireText("duplicate classifier source", classifier, marker);
+}
+
+requireText(
+  "rustok-iggy module list",
+  lib,
+  '#[cfg(feature = "iggy")]\npub mod dlq_duplicate_moving_window_scan;',
+);
+for (const exportName of expectedExports) {
+  requireText("rustok-iggy public exports", lib, exportName);
+}
+
+for (const marker of [
+  "independent private partition cursors",
+  "Complete-cycle atomicity",
+  "Progress persistence is deliberately **not**",
+  "reset_to_initial_offset()",
+  "server composition and runtime evidence pending",
+]) {
+  requireText("moving-window owner guide", documentation, marker);
+}
+for (const marker of [
+  "Profiles still never authorizes",
+  "private per-partition next offsets",
+  "explicit reset",
+  "restart-safe progress",
+  "server observer mode",
+]) {
+  requireText("Profiles moving-window checkpoint", profilesCheckpoint, marker);
+}
+for (const marker of [
+  "moving-window scanner integration is source-complete",
+  "independent process-local per-partition cursors",
+  "restart-reset semantics",
+  "Compose the moving duplicate observer",
+  "verify-iggy-dlq-duplicate-moving-window-scan.mjs",
+]) {
+  requireText("canonical Profiles plan", plan, marker);
+}
+
+const requiredRemaining = new Set([
+  "compose_explicit_opt_in_mode_aware_server_observer",
+  "define_reviewed_configuration_surface",
+  "retain_external_iggy_cross_cycle_runtime_evidence",
+  "define_persisted_cursor_store_only_if_restart_continuity_is_required",
+  "define_identifier_free_telemetry_and_health_projection",
+]);
+for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
+if (requiredRemaining.size > 0) {
+  fail(`moving-window remaining work drift: ${[...requiredRemaining].join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("Iggy DLQ duplicate moving-window scan verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Iggy DLQ duplicate moving-window scan source verified: bounded equal-budget polling, private independent per-partition cursors, complete-cycle atomic rolling updates, explicit non-persistent restart reset, identifier-free snapshots, and no broker/receipt mutations are locked; server composition and external runtime evidence remain pending.",
+);

--- a/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
@@ -9,6 +9,10 @@ const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs";
 const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const movingContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
+const movingSourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const documentationPath = "crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md";
 const profilesCheckpointPath =
@@ -21,13 +25,6 @@ const expectedExports = [
   "DlqDuplicateRollingWindowSnapshot",
   "DlqDuplicateRollingWindowError",
 ];
-const expectedSnapshotFields = [
-  "summary",
-  "retained_cycles",
-  "retained_observations",
-  "evicted_cycles",
-  "history_truncated",
-];
 const expectedTests = [
   "invalid_policy_and_capacity_overflow_fail_closed",
   "ordinary_duplicate_split_across_cycles_is_detected",
@@ -37,8 +34,12 @@ const expectedTests = [
 ];
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const movingContract = JSON.parse(
+  readFileSync(resolve(repoRoot, movingContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const movingSource = readFileSync(resolve(repoRoot, movingSourcePath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
 const profilesCheckpoint = readFileSync(
@@ -50,28 +51,24 @@ const failures = [];
 function fail(message) {
   failures.push(message);
 }
-
 function same(actual, expected) {
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
-
 function requireText(name, text, marker) {
   if (!text.includes(marker)) fail(`${name} is missing required marker: ${marker}`);
 }
-
 function forbidText(name, text, marker) {
   if (text.includes(marker)) fail(`${name} contains forbidden marker: ${marker}`);
 }
-
 function countText(text, marker) {
   return text.split(marker).length - 1;
 }
 
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-rolling-window-source" ||
-  contract.status !== "source_complete_scanner_integration_pending" ||
+  contract.status !== "source_complete_moving_scan_integrated_server_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.classifier_source !== classifierPath ||
@@ -85,7 +82,15 @@ if (
 if (!same(contract.public_exports, expectedExports)) {
   fail("DLQ duplicate rolling-window public export allowlist drift");
 }
-if (!same(contract.snapshot_fields, expectedSnapshotFields)) {
+if (
+  !same(contract.snapshot_fields, [
+    "summary",
+    "retained_cycles",
+    "retained_observations",
+    "evicted_cycles",
+    "history_truncated",
+  ])
+) {
   fail("DLQ duplicate rolling-window snapshot field allowlist drift");
 }
 if (!same(contract.required_source_tests, expectedTests)) {
@@ -167,6 +172,24 @@ if (
   fail("DLQ duplicate rolling-window stable error codes drift");
 }
 
+const moving = contract.moving_scan_integration ?? {};
+if (
+  moving.status !== "source_complete_server_composition_runtime_pending" ||
+  moving.contract !== movingContractPath ||
+  moving.source !== movingSourcePath ||
+  moving.complete_cycle_feeding !== true ||
+  moving.independent_process_local_partition_cursors !== true ||
+  moving.cursor_values_exported !== false ||
+  moving.progress_persisted !== false ||
+  moving.restart_semantics !== "reset_to_reviewed_initial_offset" ||
+  moving.server_observer_composition !== "pending" ||
+  moving.runtime_evidence !== "pending" ||
+  movingContract.packet !== "dlq-duplicate-moving-window-scan-source" ||
+  movingContract.status !== "source_complete_server_composition_runtime_pending"
+) {
+  fail("DLQ duplicate moving-scan integration relationship drift");
+}
+
 for (const marker of [
   "const MAX_ROLLING_WINDOW_CYCLES: u32 = 128;",
   "const MAX_ROLLING_WINDOW_OBSERVATIONS: u32 = 10_000;",
@@ -197,7 +220,6 @@ for (const testName of expectedTests) {
 if (countText(source, "#[test]") !== expectedTests.length) {
   fail("DLQ duplicate rolling-window source must contain exactly five focused unit tests");
 }
-
 for (const marker of [
   "IggyClient",
   "IggyTransport",
@@ -229,10 +251,21 @@ for (const marker of [
 ]) {
   requireText("DLQ duplicate classifier", classifier, marker);
 }
+for (const marker of [
+  "pub struct IggyDlqDuplicateMovingWindowPolicy",
+  "pub struct IggyDlqDuplicateMovingWindowState",
+  "pub struct IggyDlqDuplicateMovingWindowScanner<'a>",
+  "let rolling = self.rolling.push_cycle(observations)?;",
+  "pub fn reset_to_initial_offset(",
+]) {
+  requireText("moving-window scan integration", movingSource, marker);
+}
+
+requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_rolling_window;");
 requireText(
   "rustok-iggy module list",
   lib,
-  "pub mod dlq_duplicate_rolling_window;",
+  '#[cfg(feature = "iggy")]\npub mod dlq_duplicate_moving_window_scan;',
 );
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
@@ -243,7 +276,7 @@ for (const marker of [
   "history_truncated",
   "does not move a broker cursor",
   "not complete history",
-  "scanner integration remains pending",
+  "moving scanner integration is source-complete",
 ]) {
   requireText("DLQ duplicate rolling-window documentation", documentation, marker);
 }
@@ -251,18 +284,17 @@ for (const marker of [
   "Profiles never authorizes",
   "cross-cycle",
   "history_truncated",
-  "per-partition cursor",
-  "source-complete",
+  "process-local per-partition cursor",
+  "moving scanner integration is source-complete",
 ]) {
   requireText("Profiles rolling-window checkpoint", profilesCheckpoint, marker);
 }
 
 const requiredRemaining = new Set([
-  "feed_complete_scanner_cycles_without_identifier_export",
-  "define_per_partition_cursor_advancement",
-  "define_state_persistence_or_restart_reset_semantics",
   "compose_mode_aware_server_observer",
+  "define_reviewed_moving_scan_configuration",
   "retain_external_iggy_cross_cycle_runtime_evidence",
+  "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
   "define_identifier_free_telemetry_and_health_projection",
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
@@ -279,5 +311,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate rolling-window source verified: explicit checked memory bounds, complete-cycle retention and eviction, transactional oversized-cycle rejection, cross-cycle ordinary/conflicting duplicate classification, identifier-free truncation metadata, no broker/receipt access, and explicit moving-cursor/current-tail/complete-history non-claims are locked; scanner, cursor, persistence, server, and runtime evidence integration remain pending.",
+  "Iggy DLQ duplicate rolling-window source verified: explicit checked memory bounds, complete-cycle retention and eviction, transactional oversized-cycle rejection, cross-cycle ordinary/conflicting classification, identifier-free truncation metadata, and source-complete moving scanner integration with private process-local cursors and explicit restart reset are locked; server composition and runtime evidence remain pending.",
 );


### PR DESCRIPTION
## Summary

- add a feature-gated external-Iggy moving duplicate scanner and process-local state
- give every selected partition one independent private next offset
- require equal bounded per-partition budgets with checked total messages `<= 10000`
- require the rolling window's per-cycle capacity to cover the full fair scan cycle
- collect every selected partition into a temporary candidate before changing state
- atomically accept the combined rolling cycle and every cursor only after complete success
- preserve all cursor and rolling state after polling, response, offset, classification, or rolling failure
- expose only rolling counts, partition count, advanced-partition count, and reset generation
- choose explicit non-persistent restart/reset semantics instead of implying durable progress
- update rolling and aggregate inspection contracts/verifiers, owner guides, Profiles checkpoints, and the canonical Profiles plan

## Recheck findings

The fixed global and fair scanners correctly classify one bounded explicit-offset snapshot, but they return an already aggregated summary. That loses the opaque identity relationship needed when one physical copy appears in one advancing cycle and another appears in a later cycle.

The rolling state merged in #2423 can preserve that relationship, but previously had no scanner collection or cursor owner. This PR supplies that missing library integration without silently changing the current server observer.

## Atomic cycle semantics

- 1 to 128 unique positive partitions
- equal positive per-partition message budget
- checked `partition_count * per_partition_messages <= 10000`
- batch size `<= 1000` and no greater than the per-partition budget
- rolling per-cycle capacity must cover the full fair-cycle budget
- every partition is polled with an explicit private offset and `auto_commit = false`
- empty partitions are successful and keep their cursor unchanged
- cursor replacement occurs only after the combined rolling cycle succeeds
- incomplete or invalid partition sets are rejected without mutation

## Restart/reset choice

Progress persistence is deliberately absent in this source slice:

- cursors and rolling observations remain process-local
- new state begins at one reviewed `initial_offset`
- `reset_to_initial_offset()` rewinds all cursors and clears rolling history
- reset exposes only a count-only generation
- restart may reread an earlier bounded region
- no restart-safe progress, current-tail, or complete-history claim
- a persistent cursor owner remains separate work only if restart continuity is required

## Privacy and mutation boundary

Public snapshots exclude partition IDs, cursor values, offsets, UUIDs, payloads/digests, endpoints, credentials, receipt identities, timestamps, and raw Iggy errors.

The moving scanner does not store consumer offsets, acknowledge, publish, delete, purge, replay, retry, mutate receipts, change topology, or authorize Profiles/Social Graph behavior.

## Deliberate non-claims

- no current server observer integration or default change
- no reviewed environment/configuration surface yet
- no persisted progress or restart continuity
- no current-tail or complete-history coverage
- no production retention-sufficiency claim
- no external-Iggy cross-cycle execution packet
- no telemetry/health projection
- no exactly-once claim

## Verification

Per maintainer instruction, tests, Cargo commands, formatters, repository source verifiers, broker scans, server observers, telemetry registration, and retained capture were not run.

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
cargo xtask module validate profiles
cargo xtask module test profiles
```
