### PR TITLE
feat(profiles): compose DLQ duplicate moving observer

### DIFF
--- a/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+++ b/apps/server/src/services/event_dlq_duplicate_alert_observer.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use rustok_iggy::{
     DlqDuplicateAlertPolicy, DlqDuplicateAlertRuntimePublisher,
     DlqDuplicateAlertRuntimeSnapshot, DlqDuplicateAlertRuntimeSubscriber,
-    IggyDlqDuplicateAlertObserver, IggyMode, IggyTransport,
+    IggyDlqDuplicateAlertMovingWindowConfig, IggyDlqDuplicateAlertObserver, IggyMode,
+    IggyTransport,
 };
 use tokio::task::JoinHandle;
 
@@ -23,6 +24,10 @@ const MAX_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES";
 const PER_PARTITION_MESSAGES_ENV: &str =
     "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES";
 const BATCH_SIZE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE";
+const ROLLING_MAX_CYCLES_ENV: &str =
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES";
+const ROLLING_MAX_OBSERVATIONS_PER_CYCLE_ENV: &str =
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE";
 const WARNING_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MESSAGES";
 const CRITICAL_MESSAGES_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MESSAGES";
 const WARNING_GROUPS_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_GROUPS";
@@ -48,15 +53,20 @@ pub enum EventDlqDuplicateAlertObserverMode {
     IggyExternal,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 enum EventDlqDuplicateAlertScanConfig {
     GlobalBudget {
+        start_offset: u64,
         max_messages: u32,
         batch_size: u32,
     },
     FairWindow {
+        start_offset: u64,
         per_partition_messages: u32,
         batch_size: u32,
+    },
+    MovingWindow {
+        moving: IggyDlqDuplicateAlertMovingWindowConfig,
     },
 }
 
@@ -82,7 +92,6 @@ impl EventDlqDuplicateAlertObserverHandle {
 
 struct EventDlqDuplicateAlertObserverConfig {
     poll: Duration,
-    start_offset: u64,
     scan: EventDlqDuplicateAlertScanConfig,
     policy: DlqDuplicateAlertPolicy,
 }
@@ -143,7 +152,7 @@ pub async fn start_event_dlq_duplicate_alert_observer(ctx: &ServerRuntimeContext
         return;
     };
     let iggy_config = transport.config().clone();
-    let config = match EventDlqDuplicateAlertObserverConfig::from_env() {
+    let config = match EventDlqDuplicateAlertObserverConfig::from_env(&iggy_config) {
         Ok(config) => config,
         Err(_) => {
             record_startup_unavailable(ctx, STARTUP_CONFIGURATION_INVALID);
@@ -204,28 +213,37 @@ async fn observer_loop(
         }
 
         if observer.is_none() {
-            let connection = match config.scan {
+            let connection = match &config.scan {
                 EventDlqDuplicateAlertScanConfig::GlobalBudget {
+                    start_offset,
                     max_messages,
                     batch_size,
                 } => {
                     IggyDlqDuplicateAlertObserver::connect(
                         &iggy_config,
-                        config.start_offset,
-                        max_messages,
-                        batch_size,
+                        *start_offset,
+                        *max_messages,
+                        *batch_size,
                     )
                     .await
                 }
                 EventDlqDuplicateAlertScanConfig::FairWindow {
+                    start_offset,
                     per_partition_messages,
                     batch_size,
                 } => {
                     IggyDlqDuplicateAlertObserver::connect_fair_window(
                         &iggy_config,
-                        config.start_offset,
-                        per_partition_messages,
-                        batch_size,
+                        *start_offset,
+                        *per_partition_messages,
+                        *batch_size,
+                    )
+                    .await
+                }
+                EventDlqDuplicateAlertScanConfig::MovingWindow { moving } => {
+                    IggyDlqDuplicateAlertObserver::connect_moving_window(
+                        &iggy_config,
+                        moving.clone(),
                     )
                     .await
                 }
@@ -242,7 +260,7 @@ async fn observer_loop(
             }
         }
 
-        if let Some(connected) = observer.take() {
+        if let Some(mut connected) = observer.take() {
             match connected.summarize().await {
                 Ok(summary) => {
                     match publisher.publish(&summary) {
@@ -258,11 +276,16 @@ async fn observer_loop(
                     observer = Some(connected);
                 }
                 Err(error) => {
+                    let preserve_state = connected.preserves_process_local_state_after_scan_error();
                     let _ = publisher.mark_unavailable();
                     tracing::warn!(
                         error_code = error.stable_code(),
-                        "Physical DLQ duplicate scan failed; reconnecting without affecting event delivery"
+                        preserves_process_local_state = preserve_state,
+                        "Physical DLQ duplicate scan failed; retry remains isolated from event delivery"
                     );
+                    if preserve_state {
+                        observer = Some(connected);
+                    }
                 }
             }
         }
@@ -293,16 +316,18 @@ fn record_snapshot(snapshot: DlqDuplicateAlertRuntimeSnapshot) {
 }
 
 impl EventDlqDuplicateAlertObserverConfig {
-    fn from_env() -> Result<Self> {
+    fn from_env(iggy_config: &rustok_iggy::IggyConfig) -> Result<Self> {
         let poll_ms = optional_u64_env(POLL_ENV, DEFAULT_POLL_MS)?;
         if poll_ms == 0 || poll_ms > MAX_POLL_MS {
             return Err(Error::Message(format!(
                 "{POLL_ENV} must be between 1 and {MAX_POLL_MS}"
             )));
         }
+
         let scan = match optional_scan_mode_env()? {
             EventDlqDuplicateAlertScanMode::GlobalBudget => {
                 EventDlqDuplicateAlertScanConfig::GlobalBudget {
+                    start_offset: optional_u64_env(START_OFFSET_ENV, 0)?,
                     max_messages: optional_u32_env(MAX_MESSAGES_ENV, DEFAULT_MAX_MESSAGES)?,
                     batch_size: optional_u32_env(BATCH_SIZE_ENV, DEFAULT_BATCH_SIZE)?,
                 }
@@ -310,6 +335,7 @@ impl EventDlqDuplicateAlertObserverConfig {
             EventDlqDuplicateAlertScanMode::FairWindow => {
                 let per_partition_messages = required_u32_env(PER_PARTITION_MESSAGES_ENV)?;
                 EventDlqDuplicateAlertScanConfig::FairWindow {
+                    start_offset: optional_u64_env(START_OFFSET_ENV, 0)?,
                     per_partition_messages,
                     batch_size: optional_u32_env(
                         BATCH_SIZE_ENV,
@@ -317,7 +343,16 @@ impl EventDlqDuplicateAlertObserverConfig {
                     )?,
                 }
             }
+            EventDlqDuplicateAlertScanMode::MovingWindow => moving_window_scan_config(
+                iggy_config,
+                required_u64_env(START_OFFSET_ENV)?,
+                required_u32_env(PER_PARTITION_MESSAGES_ENV)?,
+                required_u32_env(BATCH_SIZE_ENV)?,
+                required_u32_env(ROLLING_MAX_CYCLES_ENV)?,
+                required_u32_env(ROLLING_MAX_OBSERVATIONS_PER_CYCLE_ENV)?,
+            )?,
         };
+
         let policy = DlqDuplicateAlertPolicy::new(
             required_u64_env(WARNING_MESSAGES_ENV)?,
             required_u64_env(CRITICAL_MESSAGES_ENV)?,
@@ -330,17 +365,37 @@ impl EventDlqDuplicateAlertObserverConfig {
 
         Ok(Self {
             poll: Duration::from_millis(poll_ms),
-            start_offset: optional_u64_env(START_OFFSET_ENV, 0)?,
             scan,
             policy,
         })
     }
 }
 
+fn moving_window_scan_config(
+    iggy_config: &rustok_iggy::IggyConfig,
+    initial_offset: u64,
+    per_partition_messages: u32,
+    batch_size: u32,
+    rolling_max_cycles: u32,
+    rolling_max_observations_per_cycle: u32,
+) -> Result<EventDlqDuplicateAlertScanConfig> {
+    let moving = IggyDlqDuplicateAlertMovingWindowConfig::new(
+        iggy_config,
+        initial_offset,
+        per_partition_messages,
+        batch_size,
+        rolling_max_cycles,
+        rolling_max_observations_per_cycle,
+    )
+    .map_err(|error| Error::Message(error.stable_code().to_string()))?;
+    Ok(EventDlqDuplicateAlertScanConfig::MovingWindow { moving })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EventDlqDuplicateAlertScanMode {
     GlobalBudget,
     FairWindow,
+    MovingWindow,
 }
 
 fn optional_scan_mode_env() -> Result<EventDlqDuplicateAlertScanMode> {
@@ -359,8 +414,9 @@ fn parse_scan_mode(
     match value.trim().to_ascii_lowercase().as_str() {
         "global" | "global_budget" => Ok(EventDlqDuplicateAlertScanMode::GlobalBudget),
         "fair" | "fair_window" => Ok(EventDlqDuplicateAlertScanMode::FairWindow),
+        "moving" | "moving_window" => Ok(EventDlqDuplicateAlertScanMode::MovingWindow),
         _ => Err(format!(
-            "{SCAN_MODE_ENV} must be global_budget or fair_window"
+            "{SCAN_MODE_ENV} must be global_budget, fair_window, or moving_window"
         )),
     }
 }
@@ -482,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_mode_parser_preserves_global_default_and_explicit_fair_window() {
+    fn scan_mode_parser_preserves_global_default_and_explicit_opt_in_modes() {
         assert_eq!(
             parse_scan_mode("global_budget").unwrap(),
             EventDlqDuplicateAlertScanMode::GlobalBudget
@@ -491,7 +547,26 @@ mod tests {
             parse_scan_mode("fair_window").unwrap(),
             EventDlqDuplicateAlertScanMode::FairWindow
         );
+        assert_eq!(
+            parse_scan_mode("moving_window").unwrap(),
+            EventDlqDuplicateAlertScanMode::MovingWindow
+        );
         assert!(parse_scan_mode("moving_cursor").is_err());
+    }
+
+    #[test]
+    fn moving_window_configuration_is_explicit_and_fail_closed() {
+        let mut iggy_config = rustok_iggy::IggyConfig::default();
+        iggy_config.topology.domain_partitions = 2;
+        assert!(moving_window_scan_config(&iggy_config, 10, 2, 1, 3, 3).is_err());
+        let valid = moving_window_scan_config(&iggy_config, 10, 2, 1, 3, 4).unwrap();
+        let EventDlqDuplicateAlertScanConfig::MovingWindow { moving } = valid else {
+            panic!("expected moving-window configuration");
+        };
+        assert_eq!(moving.partition_count(), 2);
+        assert_eq!(moving.total_message_budget(), 4);
+        assert!(!moving.progress_persisted());
+        assert!(moving.restart_resets_to_initial_offset());
     }
 
     #[test]

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "event-delivery",
   "packet": "dlq-duplicate-alert-server-observer-source",
   "status": "source_complete_runtime_execution_pending",
@@ -8,10 +8,13 @@
     "rustok-iggy"
   ],
   "iggy_source": "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+  "moving_scan_source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+  "moving_scan_contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
   "server_source": "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
   "bootstrap_source": "apps/server/src/services/server_bootstrap.rs",
   "service_registry_source": "apps/server/src/services/mod.rs",
   "public_iggy_exports": [
+    "IggyDlqDuplicateAlertMovingWindowConfig",
     "IggyDlqDuplicateAlertObserver",
     "IggyDlqDuplicateAlertObserverError",
     "IggyDlqDuplicateAlertScanMode"
@@ -48,32 +51,59 @@
         "global",
         "global_budget"
       ],
+      "start_offset_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET",
+      "start_offset_default": 0,
       "max_messages_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES",
       "default_max_messages": 1000,
       "one_global_message_budget": true,
-      "later_partition_starvation_possible": true
+      "later_partition_starvation_possible": true,
+      "cross_cycle_accumulation": false
     },
     "fair_window_mode": {
       "accepted_values": [
         "fair",
         "fair_window"
       ],
+      "start_offset_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET",
+      "start_offset_default": 0,
       "per_partition_messages_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES",
       "per_partition_messages_required": true,
       "equal_per_partition_message_budget": true,
       "every_partition_attempted_on_successful_scan": true,
       "total_message_budget_checked_by_scanner": true,
       "maximum_total_messages": 10000,
-      "all_partition_observations_combined_before_classification": true
+      "all_partition_observations_combined_before_classification": true,
+      "cross_cycle_accumulation": false
+    },
+    "moving_window_mode": {
+      "accepted_values": [
+        "moving",
+        "moving_window"
+      ],
+      "explicit_opt_in": true,
+      "initial_offset_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET",
+      "initial_offset_required": true,
+      "per_partition_messages_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES",
+      "per_partition_messages_required": true,
+      "batch_size_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE",
+      "batch_size_required": true,
+      "rolling_max_cycles_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES",
+      "rolling_max_cycles_required": true,
+      "rolling_max_observations_per_cycle_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE",
+      "rolling_max_observations_per_cycle_required": true,
+      "production_defaults": false,
+      "one_private_next_offset_per_partition": true,
+      "complete_all_partition_cycle_before_mutation": true,
+      "rolling_cycle_capacity_must_cover_fair_cycle": true,
+      "cross_cycle_duplicate_accumulation": true,
+      "failed_cycle_preserves_process_local_state": true,
+      "progress_persisted": false,
+      "new_connection_or_process_starts_at_reviewed_initial_offset": true,
+      "current_tail_coverage_claimed": false,
+      "complete_history_claimed": false
     },
     "batch_size_env": "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE",
-    "default_batch_size": 100,
-    "explicit_start_offset": true,
-    "same_configured_start_offset_reused_each_poll": true,
-    "moving_cursor": false,
-    "cross_cycle_duplicate_accumulation": false,
-    "current_tail_coverage_claimed": false,
-    "complete_history_claimed": false,
+    "fixed_mode_default_batch_size": 100,
     "auto_commit": false,
     "stored_offset_polling": false
   },
@@ -81,11 +111,13 @@
     "publisher": "DlqDuplicateAlertRuntimePublisher",
     "initial_snapshot_unavailable": true,
     "success_publishes_identifier_free_evaluation": true,
+    "moving_snapshot_reduced_to_dlq_duplicate_summary": true,
     "startup_failure_records_unavailable_without_task": true,
     "connection_failure_marks_unavailable": true,
     "scan_failure_marks_unavailable": true,
+    "fixed_scan_failure_reconnects": true,
+    "moving_scan_failure_retries_same_state": true,
     "shutdown_marks_unavailable": true,
-    "reconnect_after_failure": true,
     "event_delivery_remains_active": true
   },
   "startup_stable_codes": {
@@ -112,8 +144,11 @@
       "credential",
       "raw_client_error",
       "raw_threshold_values",
-      "source_counts"
+      "source_counts",
+      "private_cursor_values",
+      "rolling_observations"
     ],
+    "moving_configuration_debug_excludes_initial_offset": true,
     "stable_error_codes_only": true,
     "serialization_added": false,
     "persistence_added": false
@@ -142,14 +177,16 @@
   "required_iggy_tests": [
     "bundled_mode_requires_matching_loopback_address",
     "all_configured_partitions_are_included_in_request",
-    "global_and_fair_scan_modes_remain_explicit",
+    "global_fair_and_moving_scan_modes_remain_explicit",
+    "moving_window_requires_complete_cycle_capacity",
     "invalid_partition_count_fails_closed",
     "stable_errors_expose_no_connection_details"
   ],
   "required_server_tests": [
     "every_event_delivery_profile_has_an_explicit_observer_mode",
     "startup_unavailable_state_has_no_task_or_snapshot",
-    "scan_mode_parser_preserves_global_default_and_explicit_fair_window",
+    "scan_mode_parser_preserves_global_default_and_explicit_opt_in_modes",
+    "moving_window_configuration_is_explicit_and_fail_closed",
     "boolean_parser_is_bounded"
   ],
   "verifier": "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs",
@@ -158,8 +195,9 @@
   "execution_status": "source_not_run",
   "remaining_work": [
     "fair_window_external_iggy_execution_evidence",
-    "moving_window_or_per_partition_cursor_policy",
-    "cross_cycle_duplicate_accumulation_policy",
+    "moving_window_external_iggy_cross_cycle_execution_evidence",
+    "review_reset_frequency_and_initial_offset_per_deployment",
+    "persisted_cursor_owner_only_if_restart_continuity_is_required",
     "telemetry_projection_outside_observer",
     "health_projection_without_readiness_coupling",
     "notification_delivery_and_suppression",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "iggy",
   "packet": "dlq-duplicate-inspection-source",
   "status": "source_complete_runtime_evidence_pending",
@@ -86,7 +86,7 @@
     "result": "DlqDuplicateSummary"
   },
   "rolling_window": {
-    "status": "source_complete_moving_scan_integrated_server_pending",
+    "status": "source_complete_server_composed_runtime_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
     "result": "DlqDuplicateRollingWindowSnapshot",
@@ -94,7 +94,7 @@
     "history_truncated_after_eviction": true,
     "identifier_export": false,
     "moving_scanner": {
-      "status": "source_complete_server_composition_runtime_pending",
+      "status": "source_complete_server_composed_runtime_pending",
       "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
       "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
       "independent_process_local_partition_cursors": true,
@@ -139,15 +139,22 @@
       "external"
     ],
     "startup_failure_non_fatal": true,
-    "moving_window_mode": "pending_explicit_opt_in",
+    "scan_modes": [
+      "global_budget",
+      "fair_window",
+      "moving_window"
+    ],
+    "default_scan_mode": "global_budget",
+    "moving_window_explicit_opt_in": true,
+    "moving_configuration_fail_closed": true,
+    "moving_scan_failure_preserves_process_local_state": true,
     "readiness_dependency": false,
     "profiles_authorization": false
   },
   "remaining_work": [
     "retained_external_iggy_duplicate_scan_evidence",
-    "compose_moving_window_server_observer",
-    "define_reviewed_moving_window_configuration",
     "retain_moving_window_external_runtime_evidence",
+    "review_reset_frequency_and_initial_offset_per_deployment",
     "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
     "telemetry_and_health_projection",
     "alert_delivery_and_suppression_outside_policy",

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
@@ -1,13 +1,16 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "iggy",
   "packet": "dlq-duplicate-moving-window-scan-source",
-  "status": "source_complete_server_composition_runtime_pending",
+  "status": "source_complete_server_composed_runtime_pending",
   "owner": "rustok-iggy",
   "feature": "iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
   "rolling_source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
   "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
+  "server_observer_contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
+  "iggy_observer_source": "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
+  "server_source": "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
   "verifier": "scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs",
   "documentation": "crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md",
   "profiles_checkpoint": "crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md",
@@ -106,12 +109,21 @@
     "incomplete_cycle_preserves_cursors_and_rolling_state",
     "explicit_reset_rewinds_cursors_and_clears_rolling_history"
   ],
-  "integration_boundary": {
-    "mode_aware_server_observer": "pending",
-    "configuration_surface": "pending",
-    "external_iggy_runtime_evidence": "pending",
-    "retained_execution_packet": "pending",
-    "telemetry_and_health_projection": "pending"
+  "server_composition": {
+    "status": "source_complete_runtime_pending",
+    "scan_mode": "moving_window",
+    "accepted_alias": "moving",
+    "default_mode": false,
+    "reviewed_configuration_required": true,
+    "initial_offset_required": true,
+    "per_partition_messages_required": true,
+    "batch_size_required": true,
+    "rolling_max_cycles_required": true,
+    "rolling_max_observations_per_cycle_required": true,
+    "moving_summary_reduced_to_count_only_alert_input": true,
+    "failed_cycle_retries_same_process_local_state": true,
+    "replacement_connection_resets_to_reviewed_initial_offset": true,
+    "runtime_execution_pending": true
   },
   "non_claims": [
     "persisted_progress",
@@ -119,17 +131,16 @@
     "current_tail_coverage",
     "complete_history",
     "production_retention_sufficiency",
-    "server_observer_integration",
     "external_iggy_execution",
     "exactly_once",
     "profiles_authorization"
   ],
   "remaining_work": [
-    "compose_explicit_opt_in_mode_aware_server_observer",
-    "define_reviewed_configuration_surface",
     "retain_external_iggy_cross_cycle_runtime_evidence",
+    "review_reset_frequency_and_initial_offset_per_deployment",
     "define_persisted_cursor_store_only_if_restart_continuity_is_required",
-    "define_identifier_free_telemetry_and_health_projection"
+    "define_identifier_free_telemetry_and_health_projection",
+    "retain_server_observer_execution_evidence"
   ],
   "execution_status": "source_not_run"
 }

--- a/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
+++ b/crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "iggy",
   "packet": "dlq-duplicate-rolling-window-source",
-  "status": "source_complete_moving_scan_integrated_server_pending",
+  "status": "source_complete_server_composed_runtime_pending",
   "owner": "rustok-iggy",
   "source": "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
   "classifier_source": "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
@@ -91,15 +91,17 @@
     "oversized_cycle_rejection_preserves_existing_state"
   ],
   "moving_scan_integration": {
-    "status": "source_complete_server_composition_runtime_pending",
+    "status": "source_complete_server_composed_runtime_pending",
     "contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
     "source": "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
+    "server_observer_contract": "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
     "complete_cycle_feeding": true,
     "independent_process_local_partition_cursors": true,
     "cursor_values_exported": false,
     "progress_persisted": false,
     "restart_semantics": "reset_to_reviewed_initial_offset",
-    "server_observer_composition": "pending",
+    "server_observer_composition": "source_complete",
+    "moving_mode_default": false,
     "runtime_evidence": "pending"
   },
   "non_claims": [
@@ -108,15 +110,15 @@
     "current_tail_coverage",
     "complete_history",
     "production_retention_sufficiency",
-    "server_observer_integration",
+    "external_iggy_execution",
     "profiles_authorization"
   ],
   "remaining_work": [
-    "compose_mode_aware_server_observer",
-    "define_reviewed_moving_scan_configuration",
     "retain_external_iggy_cross_cycle_runtime_evidence",
+    "review_reset_frequency_and_initial_offset_per_deployment",
     "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
-    "define_identifier_free_telemetry_and_health_projection"
+    "define_identifier_free_telemetry_and_health_projection",
+    "retain_server_observer_execution_evidence"
   ],
   "execution_status": "source_not_run"
 }

--- a/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md
@@ -1,10 +1,10 @@
 # Mode-aware physical DLQ duplicate alert observer
 
-Status: **server and Iggy source complete; runtime execution pending**.
+Status: **global, fixed fair-window, and moving-window server composition source complete; runtime execution pending**.
 
 ## Purpose
 
-The server composes the bounded physical DLQ scanner, explicit count-only alert policy, and latest-value runtime without assuming every event-delivery profile uses Iggy.
+The server composes bounded physical DLQ scanning, count-only duplicate classification, explicit alert policy, and the latest-value runtime without assuming every event-delivery profile uses Iggy.
 
 The observer is global event-delivery infrastructure. It is not owned by Social Graph, Profiles, or any one module because the physical `dlq` topic is transport-wide.
 
@@ -19,9 +19,7 @@ The observer is global event-delivery infrastructure. It is not owned by Social 
 | `outbox_iggy` + bundled | `IggyBundled` | yes |
 | `outbox_iggy` + external | `IggyExternal` | yes |
 
-`Memory` and `OutboxLocal` are not failures. The server records an intentional not-applicable mode and exits before asking for `Arc<IggyTransport>`.
-
-Only `OutboxIggy` resolves the shared transport created by `build_event_runtime`. A missing active Iggy mode is internally inconsistent and fails closed rather than defaulting to external.
+`Memory` and `OutboxLocal` are intentional not-applicable modes. The server exits before asking for `Arc<IggyTransport>`. Only `OutboxIggy` resolves the shared transport created by the event runtime. A missing active Iggy mode fails closed rather than being guessed.
 
 ## Activation and startup isolation
 
@@ -31,11 +29,7 @@ The observer is default-off:
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
 ```
 
-It also requires a runtime profile that runs background workers.
-
-When disabled, the server stores `Disabled` and starts no task or broker client. When enabled in a non-Iggy delivery profile, it stores the corresponding `NotApplicable` state and requires no thresholds.
-
-Observer-specific startup failures do **not** fail application bootstrap. Invalid enable/configuration values, a missing active Iggy mode, or a missing shared observer dependency produce `Unavailable` with no task or snapshot and return normally to the bootstrap caller.
+It also requires a runtime profile that runs background workers. Observer-specific startup failures do not fail application bootstrap. Invalid enable/configuration values, a missing active Iggy mode, or a missing shared dependency produce `Unavailable`, start no task, and return normally.
 
 Stable startup codes:
 
@@ -44,87 +38,102 @@ iggy.dlq_duplicate.alert_server_observer_configuration_invalid
 iggy.dlq_duplicate.alert_server_observer_runtime_unavailable
 ```
 
-Raw configuration values and raw dependency errors are not logged by this path. Event delivery and module projection continue.
+Raw configuration values and raw dependency errors are not logged. Event delivery and module projection continue.
 
 ## Iggy deployment modes
 
 ### Bundled
 
-The observer does not start another broker process. It connects to the already-running loopback endpoint through the credentials paired with the bundled connector.
-
-The configured address must be one loopback address using the configured bundled TCP port and plaintext TCP, matching the bundled connector contract.
+The observer connects to the already-running validated loopback broker. It does not start another broker process. The address must match the configured bundled TCP port and plaintext loopback contract.
 
 ### External
 
-The observer tries the reviewed external addresses in configured order. Credentials and TLS options are used to construct SDK connection strings but are never retained in the runtime snapshot or logs.
+The observer tries reviewed external addresses in configured order. Credentials and TLS options are used only to construct SDK connection strings and are never retained in snapshots or logs.
 
-## Scan modes
+## Scan-mode selection
 
 The scan mode is explicit:
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
 ```
 
-`global` and `fair` are accepted aliases. The default remains `global_budget`, preserving the previously published server behavior.
+`global`, `fair`, and `moving` are accepted aliases. `global_budget remains the default`, so existing deployments do not silently change semantics.
 
-Common controls:
+Common lifecycle control:
 
 ```text
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS       default 30000, max 300000
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET  default 0
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE    default 100
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_POLL_MS  default 30000, max 300000
 ```
 
-Both modes use:
-
-```text
-topic = dlq
-standalone consumer
-explicit start offset
-configured one-based partition allowlist
-auto_commit = false
-```
+All modes use the configured one-based domain partition allowlist, the physical `dlq` topic, a standalone consumer, explicit-offset polling, and `auto_commit=false`. No mode stores a broker consumer offset.
 
 ### Compatibility global budget
 
 ```text
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES  default 1000
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET  default 0
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES default 1000
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE   default 100
 ```
 
-One bounded budget is consumed across the ordered partition allowlist. A busy earlier partition may exhaust it before later partitions are polled.
+One bounded budget is consumed across the ordered partition allowlist. A busy earlier partition may exhaust it before later partitions are polled. Every poll reuses the configured start offset and retains no cross-cycle state.
 
-### Fair snapshot window
+### Fixed fair window
 
 ```text
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES  required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET          default 0
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE             default min(100, per-partition cap)
 ```
 
-Every configured partition receives the same message cap and is attempted on a successful scan. The scanner validates:
+Every configured partition receives the same message cap and is attempted during a successful scan. The checked total cannot exceed 10,000 messages. Observations are combined before one count-only classification, but every poll still reuses the configured start offset and retains no cross-cycle state.
+
+### Moving window
+
+Moving mode is an explicit opt-in with reviewed fail-closed configuration. It has no production defaults:
 
 ```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET                         required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES               required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE                            required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES                    required
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE   required
+```
+
+Startup validation constructs `IggyDlqDuplicateAlertMovingWindowConfig` before the task starts. Validation requires:
+
+```text
+1 <= partition_count <= 128
 partition_count * per_partition_messages <= 10000
-batch_size <= per_partition_messages
-partition_count <= 128
-batch_size <= 1000
+batch_size <= min(1000, per_partition_messages)
+rolling_max_cycles <= 128
+rolling_max_cycles * rolling_max_observations_per_cycle <= 10000
+rolling_max_observations_per_cycle >= complete fair-cycle budget
 ```
 
-Observations from all partitions are combined before classification, so a repeated deterministic header UUID or conflicting payload group spanning partitions remains visible in the aggregate summary.
+Every selected partition owns one private process-local next offset. One observer poll collects every partition into a temporary candidate. Only after the complete cycle is valid and accepted by `DlqDuplicateRollingWindow` are all private cursors and rolling state updated together.
 
-Fairness is limited to one fixed snapshot window. Every poll still reuses the same configured start offset. Neither mode adds:
+A failed moving cycle marks the public alert runtime unavailable but retains the connected observer's process-local cursors and rolling history for the next attempt. Fixed modes remain reconnectable snapshots and rebuild after scan failure.
 
-- a moving cursor;
-- persisted offsets;
-- cross-cycle identity or digest accumulation;
+## Restart and reconnect boundary
+
+Moving progress is deliberately not persisted. A newly connected observer, a process restart, or a replacement after connection failure starts from the reviewed initial offset with empty rolling history. This may reread an earlier bounded region.
+
+The current source therefore does not claim:
+
+- restart-safe progress;
 - current-tail coverage;
-- complete-history proof.
+- complete broker history;
+- production retention sufficiency;
+- exactly-once delivery.
 
-Moving a partition window without retaining bounded prior identity state could split copies across cycles and hide their relationship. That remains a separate reviewed design.
+A persistent cursor owner remains separate work only if an operator requirement justifies ownership, fencing, migration, and recovery semantics. Deployment review must explicitly choose the initial offset and acceptable reset frequency.
 
-## Explicit alert thresholds
+## Alert projection
 
-When the observer is active on `OutboxIggy`, all six threshold variables are required:
+All six warning and critical threshold variables remain required whenever the observer is active:
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MESSAGES
@@ -135,21 +144,15 @@ RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_WARNING_MAX_COPIES
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_CRITICAL_MAX_COPIES
 ```
 
-There are no production threshold defaults. Validation is delegated to `DlqDuplicateAlertPolicy` and fails closed into non-fatal `Unavailable` startup state.
+Moving snapshots are reduced to the existing `DlqDuplicateSummary` before policy evaluation. The shared latest-value runtime API is unchanged.
 
-## Runtime lifecycle
-
-The server creates one `DlqDuplicateAlertRuntimePublisher` and exposes its read-only subscriber through `EventDlqDuplicateAlertObserverHandle`.
-
-A successful scan publishes an identifier-free available snapshot. Connection failure, scan failure, or shutdown advances generation, marks the snapshot unavailable, and clears the prior evaluation. Event delivery and module projection continue.
-
-After connection or scan failure, the observer retries after the configured poll interval.
+A successful scan publishes an identifier-free available evaluation. Connection failure, scan failure, or shutdown advances runtime generation, marks the snapshot unavailable, and clears prior evaluation. Event delivery and module projection continue.
 
 ## Privacy boundary
 
-The shared snapshot and logs contain only generation, availability, alert-level stable code, and aggregate boolean reasons.
+The shared snapshot and logs contain only availability generation, alert-level stable code, aggregate reason booleans, and one boolean stating whether process-local moving state was preserved after a failed cycle.
 
-They exclude broker addresses, stream/topic/partition/offset, UUIDs, payloads/digests, receipt identities, credentials, raw client errors, raw thresholds, and source counts.
+They exclude broker addresses, stream/topic/partition/offset, private cursor values, UUIDs, payloads/digests, retained observations, receipt identities, credentials, raw client errors, raw thresholds, and source counts. The moving configuration's custom debug projection also excludes its initial offset.
 
 ## Lifecycle and mutation boundary
 
@@ -157,27 +160,29 @@ The observer does not:
 
 - create or stop an `IggyTransport`;
 - start or stop a bundled broker process;
-- become a server-bootstrap, readiness, or liveness dependency;
-- stop event delivery or module projection;
+- become a bootstrap, readiness, liveness, projection, or Profiles authorization dependency;
 - register notification routing, paging, cooldown, or suppression;
 - publish, acknowledge, commit offsets, delete, purge, replay, or retry broker messages;
-- claim or mark poison receipts;
-- alter Profiles authorization.
+- claim or mark poison receipts.
 
 ## Source verification
 
 ```bash
+cargo test -p rustok-iggy dlq_duplicate_alert_observer --features iggy -- --nocapture
+cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
 node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
 ```
 
-Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connections, alert delivery, and retained capture were not run while authoring this slice.
+Tests, Cargo commands, formatters, source verifiers, server startup, Iggy connections, alert delivery, and retained capture were not run while authoring this source slice.
 
 ## Remaining work
 
-1. execute fair-window scans against reviewed external Iggy partitions and retain evidence;
-2. design moving per-partition windows with bounded cross-cycle duplicate state, or explicitly reject them;
-3. project the shared snapshot into telemetry without exporting identifiers;
-4. expose optional operational health without readiness coupling;
-5. define alert routing, cooldown, and suppression separately;
-6. retain server-observer execution evidence for each applicable mode and unavailable startup state;
-7. keep destructive reconciliation in a separately authorized workflow.
+1. execute fixed fair-window evidence against reviewed external Iggy;
+2. retain a real duplicate split across advancing moving-window cycles;
+3. review initial offset and acceptable reset frequency per deployment;
+4. add a persistent cursor owner only if restart continuity is required;
+5. project identifier-free telemetry and optional operational health without readiness coupling;
+6. define notification routing, cooldown, and suppression separately;
+7. retain server-observer execution evidence for applicable and unavailable modes;
+8. keep destructive reconciliation in a separately authorized workflow.

--- a/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-inspection.md
@@ -1,34 +1,23 @@
 # Count-only physical DLQ duplicate inspection
 
-Status: **classifier, fixed scanners, bounded rolling state, moving scanner integration, runtime harnesses, retained tooling, alert policy, latest-value runtime, and fixed-window mode-aware observer source-complete; moving server composition, runtime execution, and telemetry/health projection pending**.
+Status: **classifier, fixed scanners, bounded rolling state, moving scanner, moving-window server composition, alert policy, and latest-value runtime source-complete; runtime execution pending**.
 
 ## Purpose
 
-The neutral poison receipt store answers whether a source delivery is reserved, publishing, published, or acknowledged. It does not answer how many physical copies currently exist in the physical `dlq` topic.
-
-Physical copies can exceed one when broker-side deterministic message-ID deduplication is disabled, expired, evicted, or not preserved by an unsupported path.
+Neutral poison receipts describe durable recovery progress. They do not describe how many physical copies exist in the transport-wide `dlq` topic. This boundary classifies physical copies without exporting identities or making broker state a Profiles authorization input.
 
 ```text
 physical observations
-  -> one-cycle DlqDuplicateSummary
-  -> optional bounded cross-cycle rolling state
+  -> DlqDuplicateSummary
+  -> optional bounded rolling state
+  -> fixed or moving Iggy observer
   -> explicit alert policy
-  -> latest-value runtime
-  -> mode-aware server observer
-  -> future telemetry/health or notification owners
+  -> identifier-free latest runtime snapshot
 ```
 
-## Input and identity boundary
+## Count-only classification
 
-Each observation accepts a non-nil deterministic Iggy header UUID and exact physical payload bytes. Bytes are immediately reduced to a domain-separated SHA-256 value in memory and are never exposed by the observation or summary.
-
-A nil UUID fails closed with:
-
-```text
-iggy.dlq_duplicate.identity_invalid
-```
-
-## Count-only result
+Each observation accepts a non-nil deterministic Iggy header UUID and exact payload bytes. Bytes are immediately reduced to a domain-separated SHA-256 digest in memory.
 
 `DlqDuplicateSummary` exposes only:
 
@@ -41,155 +30,66 @@ conflicting_payload_groups
 max_copies_per_message_id
 ```
 
-```text
-duplicate_messages = total_messages - unique_message_ids
-```
+An ordinary duplicate has the same deterministic ID and exact bytes. Reuse of one ID with different bytes is an identity conflict requiring manual review.
 
-An ordinary duplicate has the same deterministic ID and same exact bytes. Reuse of one ID with different exact bytes is an identity conflict and requires manual review.
+## Fixed scanners
 
-The summary excludes broker coordinates, UUIDs, payloads/digests, receipt identities, error classification, publisher identity, timestamps, and credentials.
+`global_budget` consumes one shared cap across the ordered partition allowlist. `fair_window` gives every selected partition one equal cap under a checked total of 10,000 messages. Both use explicit offsets and `auto_commit=false`, and both reuse one configured start offset on every poll.
 
-## Mutation boundary
+## Bounded rolling and moving state
 
-The classifier, rolling state, fixed scanners, and moving scanner cannot acknowledge, store consumer offsets, delete, purge, replay, retry, publish, repair broker state, mutate poison receipts, or choose operator policy.
+`DlqDuplicateRollingWindow` retains complete cycles under checked memory bounds and permanently marks `history_truncated` after the first cycle eviction.
 
-The alert policy cannot scan, route notifications, persist thresholds, or mutate state. The latest-value runtime cannot start workers, register telemetry/health, deliver notifications, or mutate broker/receipt/Profile state.
+`IggyDlqDuplicateMovingWindowState` owns private process-local per-partition cursors. One complete all-partition candidate is collected before mutation. Cursors and rolling history update together only after the combined cycle is accepted.
 
-## Production identity relationship
+No cursor or rolling observation is persisted. A new process or replacement connection starts at one reviewed initial offset with empty rolling history.
 
-`ConsumedContractDecodeFailure::delivery_id` derives one UUID from immutable source coordinates and exact raw bytes. Failure kind, retry count, process identity, time, and random values are excluded.
+## Moving-window server observer
 
-`to_dlq_entry` attaches that UUID as the Iggy broker message ID. `IggyTransport::move_to_dlq` uses the deterministic publisher path when this ID is present.
+The moving-window server composition is source-complete.
 
-`ConsumerPoisonReceiptInspector` remains an independent count-only PostgreSQL view. Receipt and physical duplicate summaries contain no identifiers and cannot be joined message by message.
-
-## Fixed bounded Iggy scanners
-
-`IggyDlqDuplicateScanner` polls only:
+The existing observer accepts explicit:
 
 ```text
-topic = dlq
-standalone consumer
-explicit positive partition
-PollingStrategy::offset(explicit_offset)
-auto_commit = false
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
 ```
 
-One request permits at most 128 partition identifiers, 10,000 messages globally, and batches of 1,000. It validates returned partition, count, monotonic offsets, and header identity before returning only `DlqDuplicateSummary`.
+`global_budget` remains the default. Moving mode requires reviewed fail-closed values for initial offset, per-partition cap, batch size, rolling maximum cycles, and rolling maximum observations per cycle. The complete fair-cycle budget must fit one rolling cycle.
 
-The global message budget is shared across the ordered partition allowlist and can starve later partitions. The opt-in fair policy gives each selected partition one equal cap under the same checked 10,000-message total. Both fixed policies reuse configured explicit offsets and do not retain cross-cycle identity state.
+The Iggy observer stores moving state internally, calls the moving scanner through `summarize(&mut self)`, and reduces a successful moving snapshot to the existing count-only summary before alert evaluation.
 
-## Bounded cross-cycle rolling state
+A failed moving cycle marks the public runtime unavailable but preserves connected private process-local per-partition cursors and rolling state for the next attempt. Fixed scan failures remain reconnectable snapshots.
 
-`DlqDuplicateRollingWindow` retains opaque observations across complete scan cycles so ordinary duplicates or conflicting payloads split across adjacent retained cycles can still be classified together.
+## Alert runtime
 
-The caller supplies positive `max_cycles` and `max_observations_per_cycle`. Cycle count is capped at 128 and their checked product cannot exceed 10,000 observations. No production default is defined.
+`DlqDuplicateAlertPolicy` requires six explicit warning/critical thresholds and has no production defaults. Identity conflict is always critical.
 
-An oversized cycle fails transactionally. At capacity, the oldest complete cycle is evicted; partial-cycle eviction is forbidden. After the first eviction every identifier-free snapshot reports:
+`DlqDuplicateAlertRuntimePublisher` retains only the latest identifier-free evaluation. Connection, scan, and shutdown failures mark it unavailable and clear stale evaluation. Event delivery and module projection remain active.
 
-```text
-history_truncated = true
-```
+## Privacy and mutation boundary
 
-An evicted older copy can remove a previously visible duplicate relationship. The retained result is therefore not complete history, current-tail proof, or production retention evidence.
+Snapshots and logs exclude endpoints, credentials, stream/topic/partition/offset, private cursor values, UUIDs, payloads/digests, rolling observations, receipt identities, raw errors, raw thresholds, and source counts.
 
-## Moving scanner integration
+The classifier, scanners, rolling state, and observer cannot store broker offsets, acknowledge, publish, delete, purge, replay, retry, mutate receipts, start/stop shared transport, or authorize Profiles.
 
-The moving scanner integration is source-complete in `dlq_duplicate_moving_window_scan.rs`.
+## Runtime evidence status
 
-`IggyDlqDuplicateMovingWindowState` owns independent process-local per-partition cursors. `IggyDlqDuplicateMovingWindowScanner` applies one equal bounded budget per selected partition with explicit offsets and `auto_commit=false`.
-
-Complete-cycle atomicity is mandatory:
-
-1. every selected partition is polled into a temporary candidate;
-2. returned partition, count, offsets, UUID, and bounds are validated;
-3. the combined opaque observations are pushed as one complete rolling cycle;
-4. every private cursor is replaced together only after rolling acceptance.
-
-Any polling, response, offset, classification, or rolling error preserves all cursor and rolling state. Empty partitions are valid and keep their cursor unchanged. Public snapshots retain only rolling counts, partition count, advanced-partition count, and reset generation; no partition ID, cursor value, message identity, payload, or digest is exported.
-
-Progress persistence is deliberately absent. New process-local state starts at one reviewed initial offset. An explicit restart reset through `reset_to_initial_offset()` rewinds all cursors and clears rolling history. No restart-safe progress, current-tail, or complete-history claim is made. A persistent cursor owner remains separate work only if restart continuity is required.
-
-## Count-only alert policy and latest-value runtime
-
-`DlqDuplicateAlertPolicy` requires explicit warning and critical thresholds for duplicate messages, duplicate groups, and maximum copies for one message ID. It defines no production defaults.
-
-```text
-identity conflict -> Critical
-critical numeric threshold -> Critical
-warning numeric threshold -> Warning
-physical duplicate below warning -> Notice
-no duplicate -> Clear
-```
-
-The evaluation exposes only level and boolean reason flags.
-
-`DlqDuplicateAlertRuntimePublisher` accepts an already-observed summary and a prevalidated policy. Initial state is generation `0`, unavailable, with no evaluation. Successful and unavailable transitions advance generation through checked arithmetic. `mark_unavailable()` clears the previous evaluation so stale severity is not shown as current.
-
-The runtime is a latest-value channel, not an event log. It adds no serialization or persistence.
-
-## Mode-aware server observer
-
-The current host observer owns an explicit capability gate:
-
-```text
-disabled      -> Disabled
-startup issue -> Unavailable, no task or snapshot
-memory        -> NotApplicableMemory
-outbox_local  -> NotApplicableOutboxLocal
-outbox_iggy   -> IggyBundled or IggyExternal
-```
-
-For `memory` and `outbox_local`, no Iggy transport is requested and no broker connection is opened. For `outbox_iggy`, the observer reuses the active bundled or external transport configuration and opens only a separate read-only SDK client. Startup and scan failures are non-fatal to event delivery and Profiles.
-
-The current observer still runs fixed global or fair snapshots. Moving-window mode remains a pending explicit opt-in; this PR does not silently change server behavior or configuration defaults.
-
-## Safe operational sequence
-
-1. resolve the active event delivery profile;
-2. return not-applicable before Iggy access for `memory` or `outbox_local`;
-3. for `outbox_iggy`, reuse the active bundled or external configuration;
-4. select one explicitly configured fixed or future moving scan mode;
-5. poll with explicit offsets and `auto_commit=false`;
-6. for moving mode, atomically retain one complete all-partition cycle;
-7. evaluate through explicit thresholds;
-8. publish only the identifier-free latest snapshot;
-9. mark unavailable after startup, connection, scan, or shutdown failures without stopping the host;
-10. keep persistent cursor ownership, telemetry, health, notification delivery, and destructive actions separate.
-
-## Runtime and retained evidence status
-
-The fixed external harnesses and privacy-safe retained tooling are source-complete. Canonical execution JSON remains absent until maintainers run reviewed external-Iggy scenarios.
-
-The rolling state and moving scanner integration are source-complete as library components. Moving server composition and reviewed configuration, cross-cycle external-Iggy execution, optional persistent cursor ownership, telemetry, operational health, and retained server evidence remain pending.
-
-Moving server composition and runtime evidence pending remain explicit non-claims.
-
-## Source verification
+Source verification paths:
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-external-scan-runtime.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-external-scan-retained.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
 node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-No tests, Cargo commands, formatters, verifiers, broker scans, server observers, telemetry registration, alert dispatch, or retained capture were run while defining these source slices.
+Tests, Cargo commands, formatters, verifiers, broker scans, server startup, alert delivery, and retained capture were not run while defining these source slices.
 
 ## Remaining work
 
-1. execute and retain the reviewed fixed external-Iggy duplicate scan packets;
-2. compose moving-window scanning as an explicit mode-aware server opt-in;
-3. define reviewed moving-window configuration and fail-closed validation;
-4. retain a real external-Iggy duplicate split across advancing cycles;
-5. add a persistent cursor owner only if restart continuity is required;
-6. define identifier-free telemetry and optional operational health;
-7. retain server observer execution evidence;
-8. define alert routing, cooldown, and suppression separately;
-9. design acknowledgement/delete/replay as a separately authorized operation;
-10. correlate aggregate receipt and duplicate health without exporting message identities.
+1. retain fixed and moving external-Iggy execution evidence;
+2. review moving initial offset and reset frequency per deployment;
+3. add persistent cursor ownership only if restart continuity is required;
+4. add identifier-free telemetry and optional health;
+5. retain server observer execution evidence;
+6. define notification delivery/suppression and destructive reconciliation separately.

--- a/crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
@@ -1,21 +1,20 @@
 # Moving physical DLQ duplicate window scan
 
-Status: **scanner, independent in-memory partition cursors, complete-cycle rolling integration, and explicit restart reset source-complete; server composition and runtime evidence pending**.
+Status: **scanner, independent process-local partition cursors, complete-cycle rolling integration, explicit restart reset, and server composition source-complete; external runtime evidence pending**.
 
 ## Purpose
 
-The fixed global and fair scanners classify one explicit-offset snapshot. The bounded rolling state retains opaque observations across complete cycles, but it does not collect those cycles or advance broker offsets.
-
-`IggyDlqDuplicateMovingWindowScanner` and `IggyDlqDuplicateMovingWindowState` compose those boundaries without exporting identifiers:
+The fixed global and fair scanners classify one explicit-offset snapshot. `IggyDlqDuplicateMovingWindowScanner` and `IggyDlqDuplicateMovingWindowState` retain opaque relationships across advancing cycles without exporting identifiers:
 
 ```text
 independent private partition cursors
   -> complete equal-budget read-only Iggy cycle
   -> one atomic rolling-window push
   -> identifier-free moving-window snapshot
+  -> count-only server alert input
 ```
 
-The adapter is opt-in and does not replace the compatibility fixed-window scanner or the current server observer.
+The mode is opt-in. `global_budget` remains the server default.
 
 ## Explicit policy
 
@@ -35,7 +34,7 @@ Rules:
 - positive equal per-partition message budget;
 - batch size no greater than 1,000 or the per-partition budget;
 - checked total `partition_count * per_partition_messages <= 10000`;
-- the rolling policy's per-cycle capacity must cover the full fair-cycle budget;
+- rolling per-cycle capacity covers the full fair-cycle budget;
 - no production defaults.
 
 Every partition begins at the same reviewed `initial_offset`, then advances independently in process memory.
@@ -52,16 +51,14 @@ PollingStrategy::offset(private_next_offset)
 auto_commit = false
 ```
 
-The scanner validates returned partition, count, strictly increasing offsets, header UUID, and checked offset advancement.
-
 Nothing is committed while polling. Only after every partition succeeds does the state:
 
 1. validate the complete partition set and each expected start offset;
-2. combine opaque observations without exposing them;
+2. combine opaque observations without exporting them;
 3. push one complete cycle into `DlqDuplicateRollingWindow`;
 4. replace every private cursor together.
 
-A polling, response, offset, classification, or rolling-window error leaves all cursors and rolling state unchanged. Empty partitions are successful and keep their cursor unchanged.
+A polling, response, offset, classification, or rolling-window error leaves all private cursor and rolling state unchanged. Empty partitions are successful and keep their cursor unchanged.
 
 ## Count-only result
 
@@ -74,42 +71,60 @@ advanced_partitions
 reset_generation
 ```
 
-`rolling` is the existing identifier-free `DlqDuplicateRollingWindowSnapshot`. The moving snapshot does not expose partition IDs, cursor values, offsets, UUIDs, payloads or digests, endpoints, credentials, receipt identities, timestamps, or raw Iggy errors.
+`rolling` is the existing identifier-free `DlqDuplicateRollingWindowSnapshot`. Partition IDs, cursor values, offsets, UUIDs, payloads/digests, endpoints, credentials, receipt identities, timestamps, and raw Iggy errors are excluded.
 
 ## Restart and reset semantics
 
-Progress persistence is deliberately **not** part of this source slice.
+Progress persistence is deliberately **not** part of this boundary.
 
-A newly constructed process-local state starts every partition at the reviewed `initial_offset` and starts with an empty rolling history. `reset_to_initial_offset()` performs the same transition explicitly and increments only a count-only reset generation.
+A newly constructed process-local state starts every partition at the reviewed initial offset and starts with empty rolling history. `reset_to_initial_offset()` performs the same transition explicitly and increments only a count-only reset generation.
 
 Therefore:
 
-- process restart may reread an earlier bounded region;
+- process or replacement connection may reread an earlier bounded region;
 - no restart-continuity or current-tail claim is made;
 - no cursor or rolling observation is serialized;
-- a deployment that requires restart continuity must add a separately reviewed persistent cursor owner;
-- `history_truncated` still means only that rolling cycles were evicted, not that broker history is complete.
+- a persistent cursor owner is separate work only if restart continuity is required;
+- `history_truncated` reports rolling-cycle eviction, not complete broker history.
+
+## Server composition
+
+The server composition is source-complete through:
+
+```text
+IggyDlqDuplicateAlertMovingWindowConfig
+IggyDlqDuplicateAlertObserver::connect_moving_window
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
+```
+
+`moving` is an accepted alias. Server startup requires explicit reviewed values for initial offset, per-partition budget, batch size, rolling maximum cycles, and rolling maximum observations per cycle. Invalid or incomplete values fail closed into the observer's non-fatal `Unavailable` startup mode.
+
+The Iggy observer retains moving state inside its scan enum. `summarize(&mut self)` executes one complete moving cycle and reduces the result to the existing count-only `DlqDuplicateSummary` before alert evaluation.
+
+A failed moving cycle keeps the connected observer and retries the same process-local cursors and rolling history. Fixed global/fair failures continue to rebuild reconnectable snapshots. A replacement connection still starts at the reviewed initial offset because durable progress is not claimed.
 
 ## Mutation and authorization boundary
 
-The moving scanner never stores consumer offsets, acknowledges, publishes, deletes, purges, retries, replays, mutates poison receipts, changes topology, or shuts down the caller's client.
+The moving scanner and observer never store consumer offsets, acknowledge, publish, delete, purge, retry, replay, mutate poison receipts, change topology, or shut down the caller's client or shared transport.
 
-Its state never authorizes profile visibility, relationships, blocks, follows, storefront rendering, GraphQL presentation, or any Social Graph behavior.
+Their state never authorizes profile visibility, relationships, blocks, follows, storefront rendering, GraphQL presentation, or Social Graph behavior.
 
 ## Source verification
 
 ```bash
 cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
+cargo test -p rustok-iggy dlq_duplicate_alert_observer --features iggy -- --nocapture
+cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
 node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
 These commands were not run by the implementation agent.
 
 ## Remaining work
 
-1. add an explicit opt-in mode to the mode-aware server observer;
-2. define reviewed environment/configuration fields for initial offset, fair budget, batch size, and rolling bounds;
-3. retain a real external-Iggy scenario with one duplicate split across advancing cycles;
-4. add a persistent cursor owner only if restart continuity is required;
+1. retain a real external-Iggy scenario with one duplicate split across advancing cycles;
+2. review initial offset and acceptable reset frequency per deployment;
+3. add a persistent cursor owner only if restart continuity is required;
+4. retain server observer execution evidence;
 5. project identifier-free telemetry and optional operational health without readiness coupling.

--- a/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
+++ b/crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
@@ -1,43 +1,37 @@
 # Bounded physical DLQ duplicate rolling window
 
-Status: **transport-neutral rolling-window state and moving scanner integration source-complete; server composition and runtime evidence pending**.
+Status: **transport-neutral rolling state plus moving scanner and server integration source-complete; external runtime evidence pending**.
 
 ## Purpose
 
-A fixed explicit-offset scan can classify duplicates that appear inside one scan result. It cannot relate one copy observed near the end of one cycle with another copy observed in a later cycle after the scanner advances.
+A fixed explicit-offset scan can classify copies inside one result but cannot relate one copy observed near the end of one advancing cycle with another copy in a later cycle.
 
-`DlqDuplicateRollingWindow` retains opaque duplicate observations across a bounded number of complete scan cycles. While both copies remain inside the retained window, the existing `DlqDuplicateSummary` classifier detects ordinary duplicates and conflicting payloads across cycle boundaries.
+`DlqDuplicateRollingWindow` retains opaque observations across complete scan cycles. While copies remain inside the retained window, the existing count-only classifier detects ordinary duplicates and conflicting payloads across cycle boundaries.
 
-The state does not move a broker cursor, connect to Iggy, poll messages, store offsets, persist itself, mutate receipts, or authorize Profiles.
+The transport-neutral state itself does not move a broker cursor, connect to Iggy, poll messages, store offsets, persist itself, mutate receipts, or authorize Profiles.
 
 ## Explicit bounds
 
-The caller constructs `DlqDuplicateRollingWindowPolicy` with:
+The caller supplies:
 
 ```text
 max_cycles
 max_observations_per_cycle
 ```
 
-Both values must be positive. `max_cycles` is capped at 128, and the checked product must satisfy:
-
-```text
-max_cycles * max_observations_per_cycle <= 10000
-```
-
-The crate defines no production default for cadence, cycle count, observation count, or retention duration.
+Both are positive. Cycle count is capped at 128, and the checked product cannot exceed 10,000 observations. No production default is defined.
 
 ## Complete-cycle semantics
 
-Each `push_cycle` call supplies one complete scan cycle of opaque `DlqDuplicateObservation` values.
+Each `push_cycle` supplies one complete scan cycle of opaque observations.
 
 - empty successful cycles are valid;
-- an oversized cycle fails before state mutation;
-- the candidate window is classified before it replaces current state;
-- when cycle capacity is full, the oldest complete cycle is evicted;
-- partial-cycle eviction is not allowed.
+- oversized cycles fail before mutation;
+- candidate classification succeeds before current state is replaced;
+- the oldest complete cycle is evicted at capacity;
+- partial-cycle eviction is forbidden.
 
-Keeping complete cycles makes the loss boundary explicit. It does not make the retained observations a complete history.
+Keeping complete scan cycles makes the loss boundary explicit. It does not make the retained result complete history.
 
 ## Identifier-free snapshot
 
@@ -51,25 +45,7 @@ evicted_cycles
 history_truncated
 ```
 
-`summary` remains the existing count-only `DlqDuplicateSummary`. The snapshot exposes no UUID, payload digest, partition, offset, stream, endpoint, credential, receipt identity, timestamp, or raw error.
-
-## Cross-cycle classification
-
-The window combines all retained observations before calling `summarize_dlq_duplicates`.
-
-```text
-cycle 1: A1
-cycle 2: A2, same deterministic ID and exact bytes
-result: ordinary physical duplicate
-```
-
-```text
-cycle 1: B1
-cycle 2: B2, same deterministic ID and different exact bytes
-result: identity conflict requiring manual review
-```
-
-This relationship is preserved only while all relevant copies remain retained.
+The snapshot excludes UUIDs, payloads/digests, partitions, offsets, endpoints, credentials, receipts, timestamps, and raw errors.
 
 ## Truncation boundary
 
@@ -77,62 +53,42 @@ After the first complete-cycle eviction:
 
 ```text
 history_truncated = true
-evicted_cycles > 0
 ```
 
-The flag never returns to false for that in-memory state. An identity relationship can disappear when its older copy is evicted. Therefore a truncated snapshot describes only the currently retained bounded window and is not complete history, current-tail proof, or production retention evidence.
+An evicted old copy can remove a previously visible relationship. A truncated result describes only the retained bounded window and is not complete history, current-tail proof, or production retention evidence.
 
-## Moving scanner integration
+## Moving scanner and server integration
 
-The moving scanner integration is source-complete in:
+The moving scanner and server integration are source-complete.
+
+`IggyDlqDuplicateMovingWindowState` owns independent process-local per-partition cursors. `IggyDlqDuplicateMovingWindowScanner` collects every selected partition into a temporary equal-budget candidate and feeds exactly one complete combined cycle into the rolling state.
+
+The server exposes this path only through explicit:
 
 ```text
-crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
-crates/rustok-iggy/contracts/evidence/
-  dlq-duplicate-moving-window-scan-source.json
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
 ```
 
-`IggyDlqDuplicateMovingWindowScanner` polls every selected partition under one equal per-partition budget. `IggyDlqDuplicateMovingWindowState` owns one private process-local per-partition cursor and feeds only a complete successful all-partition cycle into this rolling state.
+Moving configuration requires reviewed initial offset, per-partition cap, batch size, maximum cycles, and maximum observations per cycle. No moving default is provided. The rolling per-cycle capacity must cover the full fair-cycle budget.
 
-The integration is atomic:
+A failed moving cycle preserves connected process-local cursor and rolling state. A new process or replacement connection starts again at the reviewed initial offset with empty rolling history because persistence is deliberately absent.
 
-- all partition polls complete before state mutation;
-- invalid or incomplete cycles leave cursors and rolling state unchanged;
-- cursor values and observations are never exported;
-- the rolling per-cycle capacity must cover the full checked fair-cycle budget;
-- the scanner still uses explicit offsets and `auto_commit = false`.
+The server reduces each successful moving snapshot to the existing `DlqDuplicateSummary`; partition IDs, cursor values, and observations remain private.
 
-The restart choice is explicit reset, not implied persistence. A new state or `reset_to_initial_offset()` rewinds every cursor to the reviewed initial offset and clears rolling history. This does not provide restart-safe progress, current-tail coverage, or complete history.
-
-The transport-neutral rolling state itself still does not move a broker cursor; the feature-gated moving adapter owns collection and process-local cursor advancement.
-
-## Source contract and verification
-
-Machine contracts:
-
-```text
-crates/rustok-iggy/contracts/evidence/
-  dlq-duplicate-rolling-window-source.json
-  dlq-duplicate-moving-window-scan-source.json
-```
-
-Static verifiers:
+## Source verification
 
 ```bash
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-Focused unit scenarios cover invalid bounds, ordinary duplicates split across cycles, identity conflicts split across cycles, complete-cycle eviction, transactional oversized-cycle rejection, independent cursor advancement, incomplete-cycle rollback, and explicit reset.
+Tests, Cargo commands, formatters, verifiers, broker scans, server startup, and retained capture were not run while authoring these source slices.
 
-## Remaining integration
+## Remaining work
 
-Moving scanner integration is source-complete. Remaining reviewed work must:
-
-1. compose an explicit opt-in mode in the mode-aware server observer;
-2. define reviewed configuration for initial offset, fair budget, batch size, and rolling bounds;
-3. prove cross-cycle behavior on external Iggy;
-4. add a persistent cursor owner only if restart continuity is required;
-5. publish only identifier-free telemetry or health.
-
-No current API claims persisted progress, restart-safe state, current-tail coverage, complete history, production retention sufficiency, server integration, runtime execution, or exactly-once delivery.
+1. retain a real external-Iggy duplicate split across advancing cycles;
+2. review initial offset and acceptable reset frequency per deployment;
+3. add persistent cursor ownership only if restart continuity is required;
+4. retain server observer execution evidence;
+5. define identifier-free telemetry and optional health.

--- a/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+++ b/crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
@@ -7,17 +7,103 @@ use crate::dlq_duplicate_external_scan::{
     IggyDlqDuplicateScanWindowPolicy, IggyDlqDuplicateScanner,
 };
 use crate::dlq_duplicate_inspection::DlqDuplicateSummary;
+use crate::dlq_duplicate_moving_window_scan::{
+    IggyDlqDuplicateMovingWindowError, IggyDlqDuplicateMovingWindowPolicy,
+    IggyDlqDuplicateMovingWindowScanner, IggyDlqDuplicateMovingWindowState,
+};
+use crate::dlq_duplicate_rolling_window::DlqDuplicateRollingWindowPolicy;
 
 /// Active bounded physical DLQ scan policy for the connected observer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IggyDlqDuplicateAlertScanMode {
     GlobalBudget,
     FairWindow,
+    MovingWindow,
+}
+
+/// Reviewed fail-closed configuration for an opt-in moving observer.
+///
+/// The initial offset and private per-partition cursors remain encapsulated. The
+/// public debug projection includes only bounded counts and retention limits.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IggyDlqDuplicateAlertMovingWindowConfig {
+    policy: IggyDlqDuplicateMovingWindowPolicy,
+}
+
+impl IggyDlqDuplicateAlertMovingWindowConfig {
+    pub fn new(
+        config: &IggyConfig,
+        initial_offset: u64,
+        per_partition_messages: u32,
+        batch_size: u32,
+        rolling_max_cycles: u32,
+        rolling_max_observations_per_cycle: u32,
+    ) -> Result<Self, IggyDlqDuplicateAlertObserverError> {
+        let partitions = configured_partitions(config)?;
+        let rolling_policy = DlqDuplicateRollingWindowPolicy::new(
+            rolling_max_cycles,
+            rolling_max_observations_per_cycle,
+        )
+        .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        let policy = IggyDlqDuplicateMovingWindowPolicy::new(
+            partitions,
+            initial_offset,
+            per_partition_messages,
+            batch_size,
+            rolling_policy,
+        )
+        .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        Ok(Self { policy })
+    }
+
+    pub fn partition_count(&self) -> usize {
+        self.policy.partitions().len()
+    }
+
+    pub const fn total_message_budget(&self) -> u32 {
+        self.policy.total_message_budget()
+    }
+
+    pub const fn rolling_max_cycles(&self) -> u32 {
+        self.policy.rolling_policy().max_cycles()
+    }
+
+    pub const fn rolling_max_observations_per_cycle(&self) -> u32 {
+        self.policy
+            .rolling_policy()
+            .max_observations_per_cycle()
+    }
+
+    pub const fn progress_persisted(&self) -> bool {
+        false
+    }
+
+    pub const fn restart_resets_to_initial_offset(&self) -> bool {
+        true
+    }
+}
+
+impl std::fmt::Debug for IggyDlqDuplicateAlertMovingWindowConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IggyDlqDuplicateAlertMovingWindowConfig")
+            .field("partition_count", &self.partition_count())
+            .field("total_message_budget", &self.total_message_budget())
+            .field("rolling_max_cycles", &self.rolling_max_cycles())
+            .field(
+                "rolling_max_observations_per_cycle",
+                &self.rolling_max_observations_per_cycle(),
+            )
+            .field("progress_persisted", &false)
+            .field("restart_resets_to_initial_offset", &true)
+            .finish_non_exhaustive()
+    }
 }
 
 enum IggyDlqDuplicateAlertScan {
     Global(IggyDlqDuplicateScanRequest),
     FairWindow(IggyDlqDuplicateScanWindowPolicy),
+    MovingWindow(IggyDlqDuplicateMovingWindowState),
 }
 
 impl IggyDlqDuplicateAlertScan {
@@ -25,15 +111,20 @@ impl IggyDlqDuplicateAlertScan {
         match self {
             Self::Global(_) => IggyDlqDuplicateAlertScanMode::GlobalBudget,
             Self::FairWindow(_) => IggyDlqDuplicateAlertScanMode::FairWindow,
+            Self::MovingWindow(_) => IggyDlqDuplicateAlertScanMode::MovingWindow,
         }
+    }
+
+    const fn preserves_process_local_state_after_scan_error(&self) -> bool {
+        matches!(self, Self::MovingWindow(_))
     }
 }
 
 /// Connected read-only source for bounded physical DLQ duplicate summaries.
 ///
 /// This adapter connects to an already-running Iggy deployment. It never starts
-/// or stops a bundled broker, mutates offsets, publishes, acknowledges, deletes,
-/// purges, replays, or changes broker configuration.
+/// or stops a bundled broker, mutates stored consumer offsets, publishes,
+/// acknowledges, deletes, purges, replays, or changes broker configuration.
 pub struct IggyDlqDuplicateAlertObserver {
     client: IggyClient,
     stream_name: String,
@@ -59,7 +150,7 @@ impl IggyDlqDuplicateAlertObserver {
         Self::connect_with_scan(config, IggyDlqDuplicateAlertScan::Global(request)).await
     }
 
-    /// Connect with one equal per-partition snapshot budget.
+    /// Connect with one equal per-partition fixed snapshot budget.
     pub async fn connect_fair_window(
         config: &IggyConfig,
         start_offset: u64,
@@ -75,6 +166,19 @@ impl IggyDlqDuplicateAlertObserver {
         )
         .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
         Self::connect_with_scan(config, IggyDlqDuplicateAlertScan::FairWindow(policy)).await
+    }
+
+    /// Connect with an explicit process-local moving window.
+    pub async fn connect_moving_window(
+        config: &IggyConfig,
+        moving: IggyDlqDuplicateAlertMovingWindowConfig,
+    ) -> Result<Self, IggyDlqDuplicateAlertObserverError> {
+        let partitions = configured_partitions(config)?;
+        if moving.policy.partitions() != partitions.as_slice() {
+            return Err(IggyDlqDuplicateAlertObserverError::InvalidConfiguration);
+        }
+        let state = IggyDlqDuplicateMovingWindowState::new(moving.policy);
+        Self::connect_with_scan(config, IggyDlqDuplicateAlertScan::MovingWindow(state)).await
     }
 
     async fn connect_with_scan(
@@ -96,8 +200,16 @@ impl IggyDlqDuplicateAlertObserver {
 
         let client = connected.ok_or(IggyDlqDuplicateAlertObserverError::ConnectionUnavailable)?;
         let stream_name = config.topology.stream_name.clone();
-        IggyDlqDuplicateScanner::new(&client, &stream_name)
-            .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+        match &scan {
+            IggyDlqDuplicateAlertScan::Global(_) | IggyDlqDuplicateAlertScan::FairWindow(_) => {
+                IggyDlqDuplicateScanner::new(&client, &stream_name)
+                    .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+            }
+            IggyDlqDuplicateAlertScan::MovingWindow(_) => {
+                IggyDlqDuplicateMovingWindowScanner::new(&client, &stream_name)
+                    .map_err(|_| IggyDlqDuplicateAlertObserverError::InvalidConfiguration)?;
+            }
+        }
 
         Ok(Self {
             client,
@@ -110,18 +222,34 @@ impl IggyDlqDuplicateAlertObserver {
         self.scan.mode()
     }
 
+    /// Moving mode preserves its private cursors and rolling history after a
+    /// failed complete-cycle attempt. Fixed modes remain reconnectable snapshots.
+    pub const fn preserves_process_local_state_after_scan_error(&self) -> bool {
+        self.scan.preserves_process_local_state_after_scan_error()
+    }
+
     pub async fn summarize(
-        &self,
+        &mut self,
     ) -> Result<DlqDuplicateSummary, IggyDlqDuplicateAlertObserverError> {
-        let scanner = IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?;
-        match &self.scan {
+        let client = &self.client;
+        let stream_name = &self.stream_name;
+        match &mut self.scan {
             IggyDlqDuplicateAlertScan::Global(request) => {
+                let scanner = IggyDlqDuplicateScanner::new(client, stream_name)?;
                 scanner.summarize(request).await.map_err(Into::into)
             }
-            IggyDlqDuplicateAlertScan::FairWindow(policy) => scanner
-                .summarize_window(policy)
-                .await
-                .map_err(Into::into),
+            IggyDlqDuplicateAlertScan::FairWindow(policy) => {
+                let scanner = IggyDlqDuplicateScanner::new(client, stream_name)?;
+                scanner
+                    .summarize_window(policy)
+                    .await
+                    .map_err(Into::into)
+            }
+            IggyDlqDuplicateAlertScan::MovingWindow(state) => {
+                let scanner = IggyDlqDuplicateMovingWindowScanner::new(client, stream_name)?;
+                let snapshot = scanner.scan_cycle(state).await?;
+                Ok(*snapshot.rolling().summary())
+            }
         }
     }
 }
@@ -147,6 +275,19 @@ impl std::fmt::Debug for IggyDlqDuplicateAlertObserver {
                     .field("total_message_budget", &policy.total_message_budget())
                     .field("batch_size", &policy.batch_size());
             }
+            IggyDlqDuplicateAlertScan::MovingWindow(state) => {
+                let policy = state.policy();
+                debug
+                    .field("partition_count", &policy.partitions().len())
+                    .field("total_message_budget", &policy.total_message_budget())
+                    .field("rolling_max_cycles", &policy.rolling_policy().max_cycles())
+                    .field(
+                        "rolling_max_observations_per_cycle",
+                        &policy.rolling_policy().max_observations_per_cycle(),
+                    )
+                    .field("progress_persisted", &false)
+                    .field("restart_resets_to_initial_offset", &true);
+            }
         }
         debug.finish_non_exhaustive()
     }
@@ -160,6 +301,8 @@ pub enum IggyDlqDuplicateAlertObserverError {
     ConnectionUnavailable,
     #[error(transparent)]
     Scan(#[from] IggyDlqDuplicateScanError),
+    #[error(transparent)]
+    MovingScan(#[from] IggyDlqDuplicateMovingWindowError),
 }
 
 impl IggyDlqDuplicateAlertObserverError {
@@ -172,6 +315,7 @@ impl IggyDlqDuplicateAlertObserverError {
                 "iggy.dlq_duplicate.alert_observer_connection_unavailable"
             }
             Self::Scan(error) => error.stable_code(),
+            Self::MovingScan(error) => error.stable_code(),
         }
     }
 }
@@ -301,15 +445,46 @@ mod tests {
     }
 
     #[test]
-    fn global_and_fair_scan_modes_remain_explicit() {
+    fn global_fair_and_moving_scan_modes_remain_explicit() {
         let global = IggyDlqDuplicateAlertScan::Global(
             IggyDlqDuplicateScanRequest::new(vec![1, 2], 0, 100, 25).unwrap(),
         );
         let fair = IggyDlqDuplicateAlertScan::FairWindow(
             IggyDlqDuplicateScanWindowPolicy::new(vec![1, 2], 0, 50, 25).unwrap(),
         );
+        let mut config = IggyConfig::default();
+        config.topology.domain_partitions = 2;
+        let moving = IggyDlqDuplicateAlertMovingWindowConfig::new(
+            &config, 0, 2, 1, 3, 4,
+        )
+        .unwrap();
+        let moving = IggyDlqDuplicateAlertScan::MovingWindow(
+            IggyDlqDuplicateMovingWindowState::new(moving.policy),
+        );
+
         assert_eq!(global.mode(), IggyDlqDuplicateAlertScanMode::GlobalBudget);
         assert_eq!(fair.mode(), IggyDlqDuplicateAlertScanMode::FairWindow);
+        assert_eq!(moving.mode(), IggyDlqDuplicateAlertScanMode::MovingWindow);
+        assert!(!global.preserves_process_local_state_after_scan_error());
+        assert!(moving.preserves_process_local_state_after_scan_error());
+    }
+
+    #[test]
+    fn moving_window_requires_complete_cycle_capacity() {
+        let mut config = IggyConfig::default();
+        config.topology.domain_partitions = 2;
+        assert_eq!(
+            IggyDlqDuplicateAlertMovingWindowConfig::new(&config, 0, 2, 1, 3, 3)
+                .unwrap_err(),
+            IggyDlqDuplicateAlertObserverError::InvalidConfiguration
+        );
+        let valid =
+            IggyDlqDuplicateAlertMovingWindowConfig::new(&config, 0, 2, 1, 3, 4)
+                .unwrap();
+        assert_eq!(valid.partition_count(), 2);
+        assert_eq!(valid.total_message_budget(), 4);
+        assert!(!valid.progress_persisted());
+        assert!(valid.restart_resets_to_initial_offset());
     }
 
     #[test]

--- a/crates/rustok-iggy/src/lib.rs
+++ b/crates/rustok-iggy/src/lib.rs
@@ -103,8 +103,8 @@ pub use dedup_recovery_window_policy::{
 pub use dlq::{DlqEntry, DlqManager};
 #[cfg(feature = "iggy")]
 pub use dlq_duplicate_alert_observer::{
-    IggyDlqDuplicateAlertObserver, IggyDlqDuplicateAlertObserverError,
-    IggyDlqDuplicateAlertScanMode,
+    IggyDlqDuplicateAlertMovingWindowConfig, IggyDlqDuplicateAlertObserver,
+    IggyDlqDuplicateAlertObserverError, IggyDlqDuplicateAlertScanMode,
 };
 pub use dlq_duplicate_alert_policy::{
     DlqDuplicateAlertEvaluation, DlqDuplicateAlertLevel, DlqDuplicateAlertPolicy,

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -92,53 +92,64 @@ mutation retry.
   canonical privacy-safe projections; one exact Rust case must report a
   sufficient assessment from a clean unchanged commit before a no-clobber packet
   can be published.
-- A bounded physical-DLQ rolling window is source-complete. It retains opaque
-  observations across complete scan cycles under a checked 10,000-observation
-  cap, detects ordinary and conflicting duplicates split across retained cycles,
-  rejects oversized cycles transactionally, and reports permanent truncation
-  after complete-cycle eviction.
+- A bounded physical-DLQ rolling window is source-complete. It retains complete
+  opaque cycles under a checked 10,000-observation cap, rejects oversized input
+  transactionally, and permanently marks truncation after cycle eviction.
 - The moving-window scanner integration is source-complete. It owns independent
-  process-local per-partition cursors, collects one complete equal-budget cycle
-  before mutation, atomically feeds that cycle into the rolling state, and
-  chooses explicit restart-reset semantics rather than implied persistence.
+  process-local per-partition cursors and updates all cursors plus rolling state
+  only after one complete equal-budget cycle succeeds.
+- The moving-window server observer composition is source-complete. `moving_window`
+  is explicit opt-in, `global_budget` remains default, and reviewed fail-closed
+  configuration is required for initial offset, per-partition cap, batch size,
+  rolling maximum cycles, and rolling per-cycle observations.
 - Canonical retained packets remain pending and must omit credentials and
   delivery-level facts, bind reviewed source/configuration/input digests, and
   become stale when any bound source or reviewed input changes.
 
 ## Physical DLQ duplicate inspection
 
-Two fixed bounded scanner policies are source-complete:
+Three bounded server scan modes are source-complete:
 
 - `global_budget`: one ordered partition allowlist and one shared cap. A busy
   early partition may prevent later partitions from being polled.
 - `fair_window`: one equal cap for every selected partition, checked total
   `partition_count * per_partition_messages <= 10000`, and one combined
-  identifier-free classification.
+  identifier-free fixed-snapshot classification.
+- `moving_window`: one private process-local next offset per partition, one
+  complete equal-budget candidate before mutation, and one atomic rolling-cycle
+  update preserving duplicate relationships across advancing cycles.
 
-The event-delivery observer keeps `global_budget` as the compatibility default
-and accepts explicit `fair_window` only for `outbox_iggy`:
+The event-delivery observer keeps `global_budget` as the compatibility default:
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES=<positive cap>
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
 ```
 
 `memory` and `outbox_local` remain intentional not-applicable modes and do not
-resolve Iggy. Both fixed policies use explicit offsets and `auto_commit=false`.
-The current server observer still reuses one configured start offset and does not
-own moving progress, current-tail coverage, or complete-history semantics.
+resolve Iggy. All modes use explicit offsets and `auto_commit=false`; no broker
+consumer offset is stored.
 
-A separate opt-in library adapter now composes moving collection with the bounded
-rolling state. It gives every selected partition one private process-local next
-offset, scans every partition under an equal bounded budget, and replaces all
-cursors only after the complete cycle has been accepted by the rolling window.
-It is not yet composed into the mode-aware server observer.
+Moving mode has no production defaults and requires reviewed fail-closed
+configuration:
 
-The moving adapter deliberately persists neither cursors nor rolling observations.
-New state and explicit reset return every cursor to one reviewed initial offset
-and clear rolling history. This can reread an earlier bounded region and therefore
-makes no restart-safe progress or current-tail claim.
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE
+```
+
+The full checked fair-cycle budget must fit one rolling cycle. A failed moving
+cycle marks the public alert runtime unavailable but preserves the connected
+observer's process-local cursors and rolling history for the next attempt. A new
+process or replacement connection starts at the reviewed initial offset with
+empty rolling history because progress is not persisted.
+
+No mode claims restart-safe progress, current-tail coverage, complete history,
+production retention sufficiency, or exactly-once delivery.
 
 ### Production partition invariant
 
@@ -152,18 +163,16 @@ Production copies carrying the same broker UUID are therefore colocated in one
 partition. Runtime evidence must not claim that
 `IggyTransport::move_to_dlq` split one deterministic ID across partitions.
 
-The fair-window fixture is production-reachable:
+The fair-window fixture remains production-reachable:
 
 ```text
 partition 1: A/A ordinary duplicate plus one unique overflow message
 partition 2: B1/B2 conflicting-payload duplicate
 ```
 
-With a cap of two messages per partition, the fair scan observes both duplicate
-groups and the conflict. The ordered global request with four total slots reads
-three messages from partition 1 and one from partition 2, producing a different
-summary. The fixed fair policy runs twice from offset zero, and stored
-standalone-consumer offsets must remain absent on both partitions.
+The moving external-Iggy cross-cycle fixture must split copies across advancing
+cycles in the same production-selected partition, not invent cross-partition
+routing for one deterministic ID.
 
 ### Fair-window retained capture
 
@@ -182,18 +191,8 @@ scripts/verify/
 
 The runner requires a clean unchanged commit, one exact passing case, no skip,
 unchanged bound-source hashes, reviewed external Iggy and dedup-disabled
-configuration labels, and a clean worktree after the test.
-
-The packet retains fair/global summaries, four zero stored-offset counts over two
-checked partitions, bounded artifact/toolchain labels, source hashes,
-timestamps, and test-output digest/size. It excludes endpoints, paths,
-credentials, raw output, stream/partition/offset/UUID/payload facts, ack tokens,
-and raw Iggy errors.
-
-Publication is no-clobber: an exclusive temporary file is hard-linked to the
-canonical path, so existing reviewed evidence cannot be replaced.
-
-Runtime execution and the canonical packet remain pending.
+configuration labels, and a clean worktree after the test. Publication is
+no-clobber. Runtime execution and the canonical packet remain pending.
 
 ### Recovery-window retained calibration
 
@@ -212,22 +211,12 @@ scripts/verify/
   verify-iggy-dedup-recovery-window-retained.mjs
 ```
 
-The capture requires one reviewed versioned recovery-bounds JSON and one reviewed
-Iggy configuration outside the repository. The bounds projection retains the
-lease, restart, reconnect, operator-recovery, required per-partition entry count,
-capacity-basis label, checked required expiry, and canonical digest. The Iggy
-projection retains only enabled, `max_entries`, `expiry`, normalized milliseconds,
-and its canonical digest.
+The sufficient-only capture binds reviewed recovery bounds, reviewed enabled Iggy
+configuration, clean unchanged source, canonical privacy-safe projections, and
+no-clobber publication. Runtime calibration and the canonical packet remain
+pending.
 
-The exact Rust case is opt-in for ordinary test runs, but retained capture rejects
-a skip and requires `running 1 test`, the exact named pass, a sufficient status,
-an unchanged commit and source hash set, and a clean worktree. It retains no
-input paths, full files, endpoints, credentials, identifiers, broker coordinates,
-payloads, or raw output. Publication is no-clobber.
-
-Runtime calibration and the canonical packet remain pending.
-
-### Bounded rolling and moving duplicate window
+### Bounded rolling, moving scanner, and server observer
 
 Source-complete paths:
 
@@ -235,50 +224,24 @@ Source-complete paths:
 crates/rustok-iggy/src/
   dlq_duplicate_rolling_window.rs
   dlq_duplicate_moving_window_scan.rs
+  dlq_duplicate_alert_observer.rs
+apps/server/src/services/
+  event_dlq_duplicate_alert_observer.rs
 crates/rustok-iggy/contracts/evidence/
   dlq-duplicate-rolling-window-source.json
   dlq-duplicate-moving-window-scan-source.json
+  dlq-duplicate-alert-server-observer-source.json
 scripts/verify/
   verify-iggy-dlq-duplicate-rolling-window.mjs
   verify-iggy-dlq-duplicate-moving-window-scan.mjs
-crates/rustok-iggy/docs/
-  dlq-duplicate-rolling-window.md
-  dlq-duplicate-moving-window-scan.md
-crates/rustok-profiles/docs/
-  poison-duplicate-rolling-window-checkpoint.md
-  poison-duplicate-moving-window-scan-checkpoint.md
+  verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
-`DlqDuplicateRollingWindowPolicy` requires positive explicit cycle and per-cycle
-bounds, caps cycle count at 128, and requires their checked product not to exceed
-10,000 observations. No production default is embedded.
-
-`DlqDuplicateRollingWindow` retains complete cycles and combines all retained
-opaque observations before count-only classification. An oversized cycle leaves
-existing state unchanged. At capacity the oldest complete cycle is evicted, and
-all later snapshots report `history_truncated = true`; an evicted relationship
-may disappear, so the result is never complete-history or current-tail proof.
-
-`IggyDlqDuplicateMovingWindowPolicy` additionally requires one reviewed initial
-offset, equal per-partition message and batch bounds, and enough rolling capacity
-to contain the full checked fair cycle. It defines no production default.
-
-`IggyDlqDuplicateMovingWindowState` owns independent process-local per-partition
-cursors. A complete all-partition candidate is collected before any state change.
-Only after rolling classification succeeds are every cursor and the rolling cycle
-accepted together. Failed or incomplete cycles preserve the prior state.
-
-The public moving snapshot exposes only the rolling snapshot, partition count,
-advanced-partition count, and reset generation. It excludes partition IDs,
-cursor values, UUIDs, payloads/digests, broker coordinates, credentials, receipt
-identities, timestamps, and raw errors.
-
-Progress is not persisted. A new process or explicit reset starts at the reviewed
-initial offset and clears rolling history. A separately owned persistent cursor
-store remains optional future work only if restart continuity is required.
-
-Mode-aware server composition, reviewed environment/configuration fields, real
-external-Iggy cross-cycle runtime evidence, and retained execution remain pending.
+The moving scanner keeps partition IDs, cursor values, message identities,
+payloads/digests, and opaque observations private. The server reduces successful
+moving snapshots to the existing count-only duplicate summary before alert
+policy evaluation. Runtime execution and retained moving-window evidence remain
+pending.
 
 Detailed checkpoints:
 
@@ -287,7 +250,7 @@ Detailed checkpoints:
 - `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md`
-- `crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md`
+- `crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.dd
 - `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
@@ -340,12 +303,11 @@ Detailed checkpoints:
    no-clobber packet; and repeat whenever a bound source, configuration, or input
    changes. A packet covers only that supplied model.
 
-10. **Compose the moving duplicate observer.**
-    Add an explicit opt-in mode to the existing mode-aware server observer,
-    define reviewed fail-closed configuration for initial offset, fair budget,
-    batch size, and rolling bounds, then retain a real duplicate split across
-    advancing external-Iggy cycles. Keep reset semantics explicit; add a
-    persistent cursor owner only if restart continuity is required.
+10. **Execute moving duplicate observer evidence.**
+    Run a reviewed external-Iggy cross-cycle case through the explicit
+    `moving_window` server mode, retain privacy-safe evidence, and review initial
+    offset plus acceptable reset frequency per deployment. Add persistent cursor
+    ownership only if restart continuity is required.
 
 11. **Retain production operations.**
     Prove bundled mode, restart, TLS/auth/failover, reconnect, rebalance,
@@ -354,25 +316,22 @@ Detailed checkpoints:
 
 ## Recheck checkpoint — 2026-07-29
 
-- Rechecked the canonical plan and current `main` after the bounded rolling-window
-  merge and unrelated newer Product transport work.
+- Rechecked current `main` after the moving scanner merge and confirmed the next
+  source-complete gap was explicit server composition rather than cursor design.
 - Reconfirmed privacy-before-presentation, owner-scoped writes, Media ownership,
   fail-closed follower reads, no automatic mutation retry, and the rule that
   operational state never authorizes profile presentation.
-- Reconfirmed deterministic same-ID colocation and the production-reachable
-  fair/global comparison.
-- Rechecked the fixed scanner APIs and confirmed that their already aggregated
-  summaries remain correct for fixed snapshots but cannot preserve relationships
-  across advancing cycles.
-- Added source-complete moving-window collection with independent process-local
-  per-partition cursors, equal bounded budgets, strict response/offset validation,
-  and complete-cycle atomicity across scanner cursors and rolling state.
-- Chose explicit restart-reset semantics: no cursor or observation persistence,
-  new state starts at one reviewed initial offset, reset clears rolling history,
-  and no restart-safe progress or current-tail claim is made.
-- Kept server opt-in/configuration, external runtime evidence, retained packets,
-  optional persistent cursor ownership, telemetry/health, bundled/TLS/auth,
-  failover, and multi-replica claims open.
+- Added explicit `moving_window` server mode while preserving `global_budget` as
+  the default and fixed `fair_window` behavior.
+- Added reviewed fail-closed configuration for initial offset, equal
+  per-partition budget, batch size, rolling maximum cycles, and rolling
+  observations per cycle; moving mode defines no production defaults.
+- Kept complete-cycle atomicity and private process-local per-partition cursors.
+  Failed moving cycles preserve connected state; replacement connections and
+  process restart reset to the reviewed initial offset with empty rolling history.
+- Kept external-Iggy cross-cycle execution, retained packets, deployment reset
+  review, optional persistent cursor ownership, telemetry/health,
+  bundled/TLS/auth, failover, and multi-replica claims open.
 - Tests, Cargo commands, formatters, repository source verifiers, broker scans,
   server observers, retained capture, and multi-replica scenarios were not run
   per maintainer instruction.
@@ -384,11 +343,14 @@ cargo xtask module validate profiles
 cargo xtask module test profiles
 cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
-RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
+RUSTfLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
 cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
 cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
+cargo test -p rustok-iggy dlq_duplicate_alert_observer --features iggy -- --nocapture
+cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+node scripts/verify/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
 cargo test -p rustok-iggy --test dedup_recovery_window_calibration
 node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs
@@ -441,16 +403,16 @@ node scripts/verify/verify-profiles-storefront-boundary.mjs
     one-based modulo partition rule.
 15. Retained evidence is no-clobber, commit-bound, and stale after any bound
     source or reviewed input change.
-16. Cross-cycle duplicate state must be explicitly bounded and retain complete
-    cycles; partial silent eviction is forbidden.
-17. Any cycle eviction permanently marks the in-memory history truncated, and a
-    truncated snapshot is never current-tail or complete-history evidence.
-18. Moving scan cursors advance atomically only after every selected partition
-    succeeds and the complete rolling cycle is accepted.
+16. Cross-cycle duplicate state retains complete bounded cycles; partial silent
+    eviction is forbidden and any eviction permanently marks truncation.
+17. Moving cursors advance atomically only after every selected partition and the
+    complete rolling cycle succeed.
+18. Moving mode is explicit opt-in with reviewed fail-closed configuration;
+    `global_budget` remains the compatibility default.
 19. Cursor values, partition identities, message identities, payloads, digests,
-    and opaque observations never surface in public moving snapshots.
-20. Process restart resets moving cursors to one reviewed initial offset and
-    clears rolling history unless a separately reviewed persistent owner is added.
+    and observations never surface in public moving or alert snapshots.
+20. Replacement connection or process restart resets moving state to one reviewed
+    initial offset unless a separately reviewed persistent owner is added.
 21. A sufficient recovery-window assessment covers only the supplied reviewed
     model and never authorizes Profiles or proves exactly-once.
 22. Update Profiles and affected owner docs with every boundary change.

--- a/crates/rustok-profiles/docs/implementation-plan.md
+++ b/crates/rustok-profiles/docs/implementation-plan.md
@@ -250,7 +250,7 @@ Detailed checkpoints:
 - `crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-dedup-recovery-window-checkpoint.md`
 - `crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md`
-- `crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.dd
+- `crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-external-scan.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-fair-window-external-scan-runtime-evidence.md`
 - `crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md`
@@ -343,14 +343,14 @@ cargo xtask module validate profiles
 cargo xtask module test profiles
 cargo check -p rustok-profiles-storefront --all-targets
 cargo test -p rustok-profiles-storefront
-RUSTfLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
+RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
 cargo test -p rustok-iggy dlq_duplicate_rolling_window -- --nocapture
 cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
 cargo test -p rustok-iggy dlq_duplicate_alert_observer --features iggy -- --nocapture
 cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
 node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
 node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-node scripts/verify/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 cargo test -p rustok-iggy dedup_recovery_window_policy -- --nocapture
 cargo test -p rustok-iggy --test dedup_recovery_window_calibration
 node scripts/verify/verify-iggy-dedup-recovery-window-policy.mjs

--- a/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md
@@ -1,22 +1,22 @@
 # Profiles checkpoint: mode-aware physical DLQ duplicate alert observer
 
-Status: **global and fair-window server composition source complete; runtime execution pending**.
+Status: **global, fixed fair-window, and moving-window server composition source complete; runtime execution pending**.
 
 ## What changed
 
-The host has one global event-delivery observer composition for the physical DLQ duplicate alert path:
+The host now has one explicit event-delivery observer composition for all three physical DLQ duplicate scan modes:
 
 ```text
-bounded physical DLQ scan
+global_budget | fair_window | moving_window
   -> DlqDuplicateSummary
   -> explicit DlqDuplicateAlertPolicy
   -> DlqDuplicateAlertRuntimePublisher
   -> identifier-free latest snapshot
 ```
 
-The observer is intentionally not a Profiles service. Profiles remains a consumer of authoritative privacy and relationship owner ports only.
+The observer is not a Profiles service. Profiles continues to consume authoritative privacy, Media, and relationship owner ports only.
 
-## Delivery and startup modes are explicit
+## Delivery and startup modes
 
 ```text
 disabled      -> Disabled
@@ -26,106 +26,89 @@ outbox_local  -> NotApplicableOutboxLocal
 outbox_iggy   -> IggyBundled or IggyExternal
 ```
 
-For `memory` and `outbox_local`:
+For `memory` and `outbox_local`, no shared Iggy transport is requested, no broker connection is opened, and no alert thresholds are required. For `outbox_iggy`, the observer reuses the exact active transport configuration. Missing active mode or invalid observer configuration fails closed into non-fatal `Unavailable` state.
 
-- no `IggyTransport` is requested;
-- no broker connection is opened;
-- no alert thresholds are required;
-- not-applicable state is not an error or degraded Profiles condition.
+Event delivery and module projection remain active.
 
-For `outbox_iggy`, the observer uses the exact shared transport configuration activated by the event runtime. It does not create another transport or broker. Missing active Iggy mode fails closed rather than being guessed.
+## Scan modes
 
-Observer-specific startup errors are non-fatal. Invalid observer configuration or a missing observer dependency records `Unavailable`, logs only a stable code, and returns success to server bootstrap. Event delivery and module projection continue.
-
-```text
-iggy.dlq_duplicate.alert_server_observer_configuration_invalid
-iggy.dlq_duplicate.alert_server_observer_runtime_unavailable
-```
-
-## Bundled and external Iggy
-
-- bundled mode connects to the existing validated loopback broker and matching TCP port;
-- external mode connects to reviewed configured addresses and credentials.
-
-The observer never starts or owns the bundled process and never shuts down the shared event transport.
-
-## Bounded scan semantics
-
-The observer builds an allowlist containing every configured domain partition and uses explicit-offset, `auto_commit=false` polling.
-
-Two scan modes are available:
-
-```text
-global_budget  -> one compatibility budget across the ordered allowlist
-fair_window    -> one equal budget for every configured partition
-```
-
-`global_budget` remains the default, so existing deployments do not silently change semantics.
-
-`fair_window` requires an explicit `RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES`. The scanner checks the total budget against 10,000 messages and combines all partition observations before classification. A successful fair-window scan therefore attempts every configured partition under the same cap and preserves cross-partition duplicate or identity-conflict groups.
-
-The fair mode is one fixed snapshot only. Every poll reuses the same configured start offset. It does not provide a moving cursor, stored offsets, cross-cycle duplicate accumulation, current-tail coverage, or complete-history proof.
-
-No scan mode may become a Profiles input.
-
-## Activation and policy
-
-The observer is default-off:
-
-```text
-RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED=false
-```
-
-The scan mode is explicit:
+`global_budget` remains the compatibility default. `fair_window` and `moving_window` are explicit opt-ins.
 
 ```text
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=global_budget
 RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=fair_window
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
 ```
 
-When active on `outbox_iggy`, all warning and critical thresholds must be supplied explicitly. Invalid values enter non-fatal `Unavailable` state; the library and server do not invent production tolerance defaults.
+All modes poll the physical `dlq` topic through a standalone consumer, explicit offsets, and `auto_commit=false`. No broker-stored consumer offset is created.
+
+### Global and fixed fair modes
+
+Global mode shares one bounded budget across the ordered allowlist. Fixed fair mode gives every configured partition one equal cap. Both reuse one configured start offset on every poll and retain no cross-cycle identity state.
+
+### Moving mode
+
+Moving mode composes the source-complete moving scanner and rolling state. It requires reviewed fail-closed configuration for:
+
+```text
+initial offset
+per-partition message cap
+batch size
+rolling maximum cycles
+rolling maximum observations per cycle
+```
+
+There are no production defaults for these moving controls. Validation requires the full checked fair-cycle budget to fit one rolling cycle.
+
+Every partition owns one private cursor in process memory. A complete cycle is collected before mutation. All private cursors and rolling history update only after every partition succeeds and the combined rolling cycle is accepted.
+
+A failed cycle marks the alert runtime unavailable but preserves the connected moving observer's private cursor and rolling state for the next attempt. The public alert projection still receives only the count-only `DlqDuplicateSummary`.
+
+## Restart choice
+
+The server composition keeps the explicit reset choice from the moving scanner:
+
+- cursors and rolling observations are process-local;
+- a new connection or process starts from the reviewed initial offset;
+- replacement after connection failure starts with empty rolling history;
+- rereading an earlier bounded region is allowed;
+- no restart-safe progress, current-tail, complete-history, or exactly-once claim is made.
+
+A persistent cursor store remains a separate owner only if an operator requirement justifies its fencing and recovery semantics. Deployment review must choose the initial offset and acceptable reset frequency.
 
 ## Shared operational projection
 
-`EventDlqDuplicateAlertObserverHandle` exposes only:
+`EventDlqDuplicateAlertObserverHandle` still exposes only:
 
-- the explicit observer mode;
-- whether the task has finished;
-- the latest optional `DlqDuplicateAlertRuntimeSnapshot`.
+- explicit observer applicability/deployment mode;
+- whether its task has finished;
+- the latest optional identifier-free `DlqDuplicateAlertRuntimeSnapshot`.
 
-Startup-unavailable state has no task and no snapshot. After a task starts, connection failure, scan failure, or shutdown clears runtime availability and prior evaluation.
-
-This state may later feed telemetry or an operational health endpoint, but it must not become bootstrap, readiness, or authorization input.
+The runtime snapshot contains availability, generation, alert level, and aggregate boolean reasons. Moving-window partition IDs, private cursor values, offsets, UUIDs, payloads/digests, rolling observations, credentials, raw errors, raw thresholds, and source counts are excluded.
 
 ## Profiles authorization boundary
 
-No profile visibility, ownership, follower access, relationship, block, mute, audience, storefront presentation, author card, or privacy-port result may depend on:
+No profile visibility, ownership, follower access, relationship, block, mute, audience, storefront presentation, author card, privacy-port result, ranking, or mutation may depend on:
 
-- event delivery profile;
-- observer startup, applicability, availability, or generation;
-- Iggy bundled/external mode;
-- global or fair scan selection;
-- partition ordering, fairness, budget exhaustion, or fixed-window coverage;
-- duplicate alert level or threshold booleans;
-- scanner connection state;
-- retained observer evidence.
+- observer startup, availability, generation, or scan mode;
+- Iggy bundled/external deployment mode;
+- fixed or moving cursor behavior;
+- private cursor advancement or reset;
+- rolling retention or `history_truncated`;
+- duplicate counts, identity-conflict flags, or alert levels;
+- retained execution evidence.
 
-A missing or failed observer never changes Profiles data access. Event delivery and module projection remain active.
-
-## Privacy boundary
-
-The observer does not expose broker addresses/credentials, stream coordinates, UUIDs, payloads/digests, poison receipt identities, raw client errors, raw thresholds, or source counts.
-
-Logs and shared state retain only stable codes, mode, availability, generation, alert level, and aggregate boolean reasons.
+A missing or failed observer never changes Profiles data access. Operational state remains operational only.
 
 ## Mutation boundary
 
-The observer cannot publish/acknowledge messages, commit offsets, delete/purge/replay/retry DLQ entries, mutate poison receipts, start/stop bundled Iggy, change event delivery, dispatch notifications, or alter Profiles state.
+The observer cannot publish or acknowledge messages, store broker offsets, delete/purge/replay/retry DLQ entries, mutate poison receipts, start/stop bundled Iggy, change event delivery, dispatch notifications, or alter Profiles state.
 
 ## Source ownership
 
 ```text
 crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
 apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
 scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -133,12 +116,13 @@ scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 
 ## Remaining work
 
-1. execute and retain fair-window external-Iggy evidence;
-2. design moving windows plus bounded cross-cycle duplicate state, or keep fixed windows;
-3. add identifier-free telemetry projection;
-4. add optional operational health without readiness coupling;
-5. define notification routing, cooldown, and suppression separately;
-6. retain execution evidence for applicable Iggy and unavailable startup modes;
-7. keep destructive reconciliation separately authorized.
+1. execute and retain fixed fair-window external-Iggy evidence;
+2. retain real moving-window external-Iggy cross-cycle evidence;
+3. review initial offset and reset frequency per deployment;
+4. add persistent cursor ownership only if restart continuity is required;
+5. add identifier-free telemetry and optional health without readiness coupling;
+6. define notification routing and suppression separately;
+7. retain execution evidence for applicable and unavailable modes;
+8. keep destructive reconciliation separately authorized.
 
 Tests, Cargo commands, formatters, verifiers, server startup, broker connections, alert delivery, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md
@@ -1,182 +1,59 @@
 # Profiles checkpoint: physical DLQ duplicate operations
 
-Status: **classifier, fixed scanners, bounded rolling state, moving scanner integration, runtime harnesses, retained tooling, alert policy, latest-value runtime, and fixed-window mode-aware server observer source-complete; moving server composition, runtime execution, and telemetry/health projection pending**.
+Status: **count-only classifier, fixed scanners, rolling state, moving scanner, and moving-window server composition source-complete; runtime evidence pending**.
 
 ## Why this matters for Profiles
 
-Profiles authorization remains independent of broker and receipt state. Downstream processing must still distinguish:
-
-- one durable neutral result with one physical DLQ copy;
-- one durable neutral result with repeated identical physical copies;
-- one deterministic DLQ ID associated with conflicting exact bytes;
-- copies of the same physical duplicate observed in adjacent retained scan cycles.
-
-The Iggy-owned classifier exposes these distinctions without message identities or payloads. Fixed scanners provide bounded one-cycle snapshots. The rolling state preserves opaque relationships across retained cycles. The moving scanner integration is source-complete and supplies whole fair cycles through private process-local per-partition cursors. Alert/runtime/server projections remain identifier-free. None becomes a Profiles authorization input.
-
-## Owner boundaries
+Profiles authorization remains independent of broker and receipt state. Operational tooling must still distinguish unique physical copies, ordinary duplicates, conflicting bytes for one deterministic ID, and copies split across advancing cycles.
 
 ```text
-classifier:          crates/rustok-iggy/src/dlq_duplicate_inspection.rs
-rolling state:       crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
-fixed scanner:       crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
-moving scanner:      crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
-policy:              crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs
-runtime:             crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs
-Iggy observer:       crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
-server observer:     apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+physical DLQ scan
+  -> count-only duplicate summary
+  -> explicit alert policy
+  -> identifier-free latest snapshot
 ```
 
-Machine contracts:
+## Delivered boundaries
 
 ```text
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json
-crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json
+classifier:       crates/rustok-iggy/src/dlq_duplicate_inspection.rs
+fixed scanner:    crates/rustok-iggy/src/dlq_duplicate_external_scan.rs
+rolling state:    crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
+moving scanner:   crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
+Iggy observer:    crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+server observer:  apps/server/src/services/event_dlq_duplicate_alert_observer.rs
 ```
 
-Verifiers:
+The moving-window server composition is source-complete. `global_budget` remains default; `moving_window` is explicit opt-in with reviewed fail-closed configuration.
 
-```text
-scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
-scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
-scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-scripts/verify/verify-iggy-dlq-duplicate-external-scan.mjs
-scripts/verify/verify-iggy-dlq-duplicate-alert-policy.mjs
-scripts/verify/verify-iggy-dlq-duplicate-alert-runtime.mjs
-scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
-```
+## Moving semantics
 
-## Count-only projections
+Each selected partition owns one private cursor in process memory. A complete all-partition candidate is collected before mutation. Every cursor and rolling history update atomically only after acceptance.
 
-The physical summary exposes only aggregate counts:
+Failed moving cycles preserve connected private cursor and rolling state. A new process or replacement connection starts from the reviewed initial offset with empty rolling history. No restart-safe progress, current-tail, complete-history, or exactly-once claim is made.
 
-```text
-total_messages
-unique_message_ids
-duplicate_messages
-duplicate_groups
-conflicting_payload_groups
-max_copies_per_message_id
-```
-
-The rolling snapshot adds only:
-
-```text
-retained_cycles
-retained_observations
-evicted_cycles
-history_truncated
-```
-
-The moving snapshot adds only:
-
-```text
-partition_count
-advanced_partitions
-reset_generation
-```
-
-Policy and runtime continue to expose only level, reason flags, generation, availability, and evaluation. These projections exclude broker endpoints, stream coordinates, partition IDs, cursor values, UUIDs, payloads/digests, receipt identities, producer identities, credentials, timestamps, and raw Iggy errors.
-
-## Duplicate classification
-
-An ordinary physical duplicate requires the same deterministic Iggy header UUID and the same exact bytes. Bytes are compared through an in-memory domain-separated SHA-256 digest that is never exposed.
-
-A repeated UUID with different exact bytes increments `conflicting_payload_groups` and requires manual review. It is not silently collapsed into a normal duplicate.
-
-## Fixed scan boundary
-
-Fixed global and fair scanners borrow an already connected `IggyClient` and use:
-
-```text
-topic = dlq
-standalone consumer
-explicit partition
-explicit offset
-auto_commit = false
-```
-
-Global mode accepts no more than 128 unique positive partitions, 10,000 physical messages total, and batches of 1,000. Fair mode gives every selected partition one equal cap under the same checked 10,000-message total.
-
-The current server observer still uses fixed snapshots and does not own moving progress. Fixed scanners do not use consumer groups, stored-offset `next` polling, offset storage, acknowledgement, topology discovery, publication, delete/purge, replay/retry, receipt mutation, or client shutdown.
-
-## Bounded cross-cycle state
-
-`DlqDuplicateRollingWindowPolicy` requires explicit positive `max_cycles` and `max_observations_per_cycle`. Cycle count is capped at 128 and their checked product cannot exceed 10,000. No production default is provided.
-
-`push_cycle` accepts one complete cycle of opaque observations. It detects ordinary and conflicting duplicates split across retained cycles. Oversized input fails without changing current state.
-
-When cycle capacity is reached, the oldest complete cycle is evicted. Partial-cycle eviction is forbidden. Every later snapshot reports:
-
-```text
-history_truncated = true
-```
-
-An evicted old copy can remove a relationship from the retained summary. The snapshot represents only the bounded retained window and is not current-tail or complete-history evidence.
-
-## Moving scanner integration
-
-The moving scanner integration is source-complete.
-
-Every selected partition owns one private process-local per-partition cursor. A complete cycle:
-
-1. polls every selected partition with one equal bounded budget;
-2. validates partition, count, strictly increasing offsets, UUID, and checked advancement;
-3. combines observations privately;
-4. pushes one complete rolling cycle;
-5. replaces every cursor together only after rolling acceptance.
-
-A failed or incomplete cycle preserves all cursors and rolling state. Empty partitions are successful and keep their cursor unchanged.
-
-Progress persistence is deliberately absent. New state starts from one reviewed initial offset. Explicit restart reset via `reset_to_initial_offset()` rewinds all cursors and clears rolling history while incrementing only a count-only generation. No restart-safe progress, current-tail, or complete-history claim is made.
-
-A persistent cursor owner remains separate work only if restart continuity is required.
-
-## Alert and server boundaries
-
-The caller supplies warning and critical thresholds; the library provides no production defaults. Identity conflicts are always critical. The latest-value runtime clears stale evaluation on unavailable transitions and is not an audit log.
-
-The server handles disabled, startup-unavailable, memory, outbox-local, bundled-Iggy, and external-Iggy modes explicitly. The current observer remains fixed-window. Moving scan is not silently enabled; it requires a separate reviewed server observer mode and configuration surface.
-
-## Relationship to receipt health
-
-The PostgreSQL `ConsumerPoisonReceiptInspector` remains an independent count-only summary of receipt progress. Neither side exports identifiers, so the views cannot be joined message by message.
-
-Aggregate operational interpretation may compare trends, but those interpretations never become Profiles authorization inputs.
+The server publishes only the existing count-only alert evaluation. It does not expose partition identity, cursor values, offsets, message IDs, payloads/digests, observations, credentials, raw errors, thresholds, or source counts.
 
 ## Profiles authorization boundary
 
-No profile visibility, relationship, block, mute, follow, friendship, audience, storefront, GraphQL, author-card, or presentation decision may depend on:
+No profile visibility, ownership, follower access, relationship, block, mute, audience, storefront presentation, author card, ranking, retry, or mutation may depend on:
 
-- event delivery profile or Iggy deployment mode;
-- observer startup, applicability, availability, or generation;
-- partition ordering, fairness, private cursor position, or reset generation;
-- rolling retention or eviction state, including `history_truncated`;
-- physical DLQ copy or duplicate-group counts;
-- identity-conflict presence;
-- alert level or threshold flags;
-- scanner, runtime, telemetry, health, or alert-delivery state;
-- receipt recovery counts;
-- deduplication or alert-threshold configuration;
-- retained evidence metadata.
+- observer startup, availability, or generation;
+- fixed or moving scan selection;
+- private cursor position or reset;
+- rolling retention or `history_truncated`;
+- duplicate counts, conflicts, or alert level;
+- Iggy deployment or retained evidence.
 
-Profiles presentation continues to consume authorized owner-port results. These components only improve operational observability of downstream neutralization.
+Profiles presentation continues to consume authoritative owner-port policy results only.
 
 ## Remaining work
 
-1. execute and retain the reviewed fixed external-Iggy duplicate scan packets;
-2. compose moving scanning as an explicit mode-aware server opt-in;
-3. define reviewed moving configuration and fail-closed startup validation;
-4. retain real external-Iggy cross-cycle evidence;
-5. add a persistent cursor owner only if restart continuity is required;
-6. define identifier-free telemetry and optional operational health;
-7. retain server observer execution evidence;
-8. define alert routing, cooldown, and suppression outside Profiles and policy/runtime;
-9. define acknowledgement/delete/replay separately with explicit authorization;
-10. keep aggregate receipt and duplicate observations identifier-free.
+1. retain fixed and moving external-Iggy runtime evidence;
+2. review initial offset and reset frequency per deployment;
+3. add persistent cursor ownership only if restart continuity is required;
+4. add identifier-free telemetry and optional health;
+5. retain server observer execution evidence;
+6. keep notification delivery and destructive reconciliation separate.
 
-Tests, Cargo commands, formatters, verifiers, server observers, external-Iggy scans, telemetry registration, alert dispatch, and retained capture were not run by the implementation agent.
+Tests, Cargo commands, formatters, verifiers, server startup, external-Iggy scans, alert delivery, telemetry, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-moving-window-scan-checkpoint.md
@@ -1,18 +1,17 @@
 # Profiles checkpoint: moving physical DLQ duplicate window scan
 
-Status: **Iggy moving scanner, independent process-local cursors, complete-cycle rolling integration, and explicit restart reset source-complete; server composition and runtime evidence pending**.
+Status: **Iggy moving scanner, independent process-local cursors, complete-cycle rolling integration, explicit reset, and server observer mode source-complete; external runtime evidence pending**.
 
 ## Why this matters for Profiles
 
-Profiles still never authorizes from broker, receipt, offset, duplicate, or evidence state. This source slice only improves operational detection when two physical DLQ copies appear in different advancing scan cycles.
-
-The Iggy owner now has a bounded opt-in path:
+Profiles still never authorizes from broker, receipt, offset, duplicate, alert, or evidence state. This boundary only improves operational detection when physical DLQ copies appear in different advancing scan cycles.
 
 ```text
 private per-partition next offsets
   -> one complete fair read-only cycle
   -> bounded cross-cycle rolling classification
-  -> identifier-free snapshot
+  -> count-only alert summary
+  -> identifier-free server snapshot
 ```
 
 No delivery identity, payload, digest, partition, or offset crosses into Profiles.
@@ -22,36 +21,52 @@ No delivery identity, payload, digest, partition, or offset crosses into Profile
 ```text
 scanner/state:
   crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs
-rolling classifier:
-  crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs
-machine contract:
+Iggy observer composition:
+  crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs
+server composition:
+  apps/server/src/services/event_dlq_duplicate_alert_observer.rs
+machine contracts:
   crates/rustok-iggy/contracts/evidence/
     dlq-duplicate-moving-window-scan-source.json
-verifier:
+    dlq-duplicate-alert-server-observer-source.json
+verifiers:
   scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-owner guide:
-  crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
+  scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
 ```
 
 ## Independent cursor boundary
 
-Each selected partition owns one private in-memory next offset. A successful empty partition keeps its offset unchanged; a partition with messages advances to the checked last offset plus one.
+Each selected partition owns one private in-memory next offset. A successful empty partition keeps its offset unchanged; a partition with messages advances to checked last offset plus one.
 
-The complete set advances atomically only after every partition succeeds and the combined rolling cycle is accepted. Any incomplete or invalid cycle preserves every cursor and the previous rolling snapshot.
+The complete set advances atomically only after every partition succeeds and the combined rolling cycle is accepted. Any incomplete or invalid cycle preserves every private cursor and the prior rolling snapshot.
 
-The public snapshot exposes only partition count and how many partitions advanced, never their identities or cursor values.
+The public moving snapshot exposes only partition count and how many partitions advanced, never their identities or cursor values.
+
+## Server observer mode
+
+The server observer mode is source-complete as explicit opt-in:
+
+```text
+RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window
+```
+
+Moving mode requires reviewed fail-closed values for initial offset, per-partition message cap, batch size, rolling maximum cycles, and rolling maximum observations per cycle. There are no moving production defaults.
+
+The server validates configuration before spawning the observer task. Moving scan results are reduced to the existing `DlqDuplicateSummary`, so the alert policy and latest-value runtime remain count-only.
+
+A failed moving cycle publishes unavailable state but preserves the connected observer's process-local cursor and rolling state for the next attempt. Fixed modes remain reconnectable snapshots.
 
 ## Restart choice
 
-This slice intentionally chooses explicit reset rather than implied persistence:
+This boundary keeps explicit reset rather than implied persistence:
 
 - state is process-local;
-- new construction starts every cursor at one reviewed initial offset;
+- new construction or replacement connection starts every cursor at one reviewed initial offset;
 - rolling history starts empty;
-- `reset_to_initial_offset()` performs the same operation and increments a count-only generation;
+- `reset_to_initial_offset()` performs the same transition in the library state;
 - no restart-safe progress or current-tail claim is made.
 
-A persistent cursor store remains separate work and should be added only when an operator requirement justifies its ownership, fencing, migration, and recovery semantics.
+A persistent cursor store remains separate work and should be added only when an operator requirement justifies ownership, fencing, migration, and recovery semantics. Deployment review must choose initial offset and acceptable reset frequency.
 
 ## Profiles authorization boundary
 
@@ -59,7 +74,7 @@ Profiles never authorizes, filters, ranks, hides, reveals, retries, or mutates f
 
 - moving-window applicability or availability;
 - private cursor position or advancement;
-- reset generation;
+- reset or replacement frequency;
 - rolling retention or `history_truncated`;
 - physical duplicate or identity-conflict counts;
 - scan failure or stable error code;
@@ -69,8 +84,10 @@ Presentation continues to consume authoritative owner-port policy results only.
 
 ## Remaining work
 
-1. compose the moving scanner as an explicit opt-in `outbox_iggy` server observer mode;
-2. define reviewed configuration and fail-closed startup validation;
-3. retain real external-Iggy cross-cycle evidence;
-4. decide separately whether restart continuity merits a persistent cursor owner;
+1. retain real external-Iggy cross-cycle evidence;
+2. review deployment initial offset and reset frequency;
+3. decide separately whether restart continuity merits persistent cursor ownership;
+4. retain server observer execution evidence;
 5. add identifier-free telemetry and optional operational health.
+
+Tests, Cargo commands, formatters, verifiers, server startup, external-Iggy scans, telemetry registration, and retained capture were not run by the implementation agent.

--- a/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
+++ b/crates/rustok-profiles/docs/poison-duplicate-rolling-window-checkpoint.md
@@ -1,124 +1,62 @@
 # Profiles checkpoint: bounded physical DLQ duplicate rolling window
 
-Status: **cross-cycle rolling-window state and moving scanner integration source-complete; server composition and runtime evidence pending**.
+Status: **cross-cycle rolling state plus moving scanner and server integration source-complete; external runtime evidence pending**.
 
 ## Why this belongs in the Profiles improvement trail
 
-Profiles never authorizes presentation from broker, receipt, metric, evidence, or duplicate-inspection state. However, downstream processing reliability must not hide a physical duplicate merely because its copies were observed in adjacent scan cycles.
-
-The fixed scanners classify one bounded result. `DlqDuplicateRollingWindow` adds bounded cross-cycle identity retention, and the feature-gated moving scanner now supplies complete fair cycles with private process-local per-partition cursors. Neither exports message identity or turns operational state into profile policy.
-
-## Delivered source boundary
-
-Owner sources:
+Profiles never authorizes presentation from broker, receipt, metric, evidence, duplicate, cursor, or rolling state. Downstream reliability still must not hide a physical duplicate merely because copies were observed in adjacent advancing scan cycles.
 
 ```text
-crates/rustok-iggy/src/
-  dlq_duplicate_rolling_window.rs
-  dlq_duplicate_moving_window_scan.rs
-```
-
-Public rolling API:
-
-```text
-DlqDuplicateRollingWindowPolicy
-DlqDuplicateRollingWindow
-DlqDuplicateRollingWindowSnapshot
-DlqDuplicateRollingWindowError
-```
-
-Moving integration API:
-
-```text
-IggyDlqDuplicateMovingWindowPolicy
-IggyDlqDuplicateMovingWindowState
-IggyDlqDuplicateMovingWindowSnapshot
-IggyDlqDuplicateMovingWindowScanner
-IggyDlqDuplicateMovingWindowError
-```
-
-Machine contracts:
-
-```text
-crates/rustok-iggy/contracts/evidence/
-  dlq-duplicate-rolling-window-source.json
-  dlq-duplicate-moving-window-scan-source.json
-```
-
-Verifiers:
-
-```text
-scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
-scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
-```
-
-Owner guides:
-
-```text
-crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md
-crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md
+complete cross-cycle observations
+  -> bounded rolling classification
+  -> count-only alert summary
+  -> identifier-free server snapshot
 ```
 
 ## Bounded semantics
 
-The caller explicitly supplies a positive cycle count and positive per-cycle observation bound. Their checked product cannot exceed 10,000, and no production default is provided.
+`DlqDuplicateRollingWindowPolicy` requires explicit positive cycle and per-cycle observation bounds. Their checked product cannot exceed 10,000, and no production default is provided.
 
-One successful `push_cycle` represents one complete scan cycle. The state:
+One `push_cycle` represents one complete cycle. The state:
 
-- detects an ordinary duplicate split across retained cycles;
-- detects conflicting exact bytes for one deterministic ID split across retained cycles;
-- rejects an oversized cycle without changing prior state;
+- detects ordinary or conflicting copies split across retained cycles;
+- rejects oversized input without changing prior state;
 - evicts only the oldest complete cycle;
 - exposes only aggregate summary and retention counts.
 
-## Moving scanner integration
-
-The moving scanner integration is source-complete.
-
-Each selected partition has one private process-local per-partition cursor. Every cycle applies an equal bounded message budget, polls with explicit offsets and `auto_commit=false`, and advances all cursors only after every partition succeeds and the rolling state accepts the combined cycle.
-
-An incomplete, invalid, or failed cycle preserves all cursors and the previous rolling snapshot. Public results expose only partition count, advanced-partition count, reset generation, and the existing identifier-free rolling snapshot.
-
-Restart semantics are explicit reset:
-
-- no cursor or observation persistence;
-- new state starts from one reviewed initial offset;
-- `reset_to_initial_offset()` rewinds every cursor and clears rolling history;
-- no restart-safe progress, current-tail, or complete-history claim.
-
-A persistent cursor owner remains separate work and is not implied.
-
 ## Truncation boundary
 
-After an eviction, every snapshot reports:
+After any eviction, every later snapshot reports `history_truncated = true`. An evicted copy can remove a relationship from the retained summary, so the result is never complete-history or current-tail evidence.
 
-```text
-history_truncated = true
-```
+## Moving scanner and server composition
 
-An older copy may have been removed, so a later retained summary may no longer show the original duplicate relationship. The snapshot is therefore not complete history, current-tail proof, or evidence that production retention is sufficient.
+The moving scanner and server integration are source-complete.
+
+Each selected partition owns one private process-local per-partition cursor. A complete equal-budget all-partition candidate is collected before mutation. Cursors and rolling state update together only after the combined cycle is accepted.
+
+The server mode is explicit opt-in through `moving_window`. Reviewed fail-closed configuration supplies initial offset, per-partition cap, batch size, rolling cycle count, and per-cycle observation capacity. Moving results are reduced to the existing identifier-free duplicate summary before alert policy evaluation.
+
+Failed moving cycles preserve connected process-local state. A replacement connection or process restart resets to the reviewed initial offset with empty rolling history. No restart-safe progress or current-tail claim is made.
 
 ## Profiles authorization boundary
 
 Profiles never authorizes visibility, `followers_only`, follow controls, search inclusion, storefront presentation, GraphQL output, or author cards from:
 
-- rolling-window summary counts;
-- retained or evicted cycle counts;
+- rolling summary or retention counts;
 - `history_truncated`;
-- scan cadence, private cursor position, or reset generation;
+- private cursor position, advancement, or reset;
+- moving observer mode or availability;
 - Iggy deployment mode;
 - receipt state or retained evidence.
 
-Privacy remains resolved through authoritative owner ports before localized and Media-backed presentation. Operational state remains operational only.
+Privacy remains resolved through authoritative owner ports before localized and Media-backed presentation.
 
-## Remaining integration
+## Remaining work
 
-Moving scanner integration is source-complete. Remaining work is:
+1. retain external-Iggy cross-cycle execution evidence;
+2. review initial offset and reset frequency per deployment;
+3. add persistent cursor ownership only if restart continuity is required;
+4. retain server observer execution evidence;
+5. add identifier-free telemetry and optional operational health.
 
-1. compose it as an explicit opt-in mode in the mode-aware server observer;
-2. define reviewed configuration and fail-closed startup validation;
-3. retain external-Iggy cross-cycle runtime evidence;
-4. add a persistent cursor owner only if restart continuity is required;
-5. define identifier-free telemetry and health projection.
-
-Tests, Cargo commands, formatters, source verifiers, broker scans, server composition, telemetry registration, and retained capture were not run by the implementation agent.
+Tests, Cargo commands, formatters, verifiers, broker scans, server composition execution, telemetry registration, and retained capture were not run by the implementation agent.

--- a/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
+++ b/scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
@@ -7,7 +7,11 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const movingContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
 const iggySourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const movingSourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
 const serverSourcePath =
   "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
 const bootstrapPath = "apps/server/src/services/server_bootstrap.rs";
@@ -15,22 +19,39 @@ const servicesPath = "apps/server/src/services/mod.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const runtimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
 const scannerSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+const documentationPath =
+  "crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md";
+const profilesCheckpointPath =
+  "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md";
+const planPath = "crates/rustok-profiles/docs/implementation-plan.md";
+const verifierPath =
+  "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs";
 
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const movingContract = JSON.parse(
+  readFileSync(resolve(repoRoot, movingContractPath), "utf8"),
+);
 const iggySource = readFileSync(resolve(repoRoot, iggySourcePath), "utf8");
+const movingSource = readFileSync(resolve(repoRoot, movingSourcePath), "utf8");
 const serverSource = readFileSync(resolve(repoRoot, serverSourcePath), "utf8");
 const bootstrap = readFileSync(resolve(repoRoot, bootstrapPath), "utf8");
 const services = readFileSync(resolve(repoRoot, servicesPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const runtimeSource = readFileSync(resolve(repoRoot, runtimeSourcePath), "utf8");
 const scannerSource = readFileSync(resolve(repoRoot, scannerSourcePath), "utf8");
+const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
+const profilesCheckpoint = readFileSync(
+  resolve(repoRoot, profilesCheckpointPath),
+  "utf8",
+);
+const plan = readFileSync(resolve(repoRoot, planPath), "utf8");
 const failures = [];
 
 function fail(message) {
   failures.push(message);
 }
 
-function sameValue(actual, expected) {
+function same(actual, expected) {
   return JSON.stringify(actual) === JSON.stringify(expected);
 }
 
@@ -47,27 +68,41 @@ function countText(text, marker) {
 }
 
 if (
-  contract.schema_version !== 2 ||
+  contract.schema_version !== 3 ||
   contract.module !== "event-delivery" ||
   contract.packet !== "dlq-duplicate-alert-server-observer-source" ||
   contract.status !== "source_complete_runtime_execution_pending" ||
-  !sameValue(contract.owners, ["rustok-server", "rustok-iggy"]) ||
+  !same(contract.owners, ["rustok-server", "rustok-iggy"]) ||
   contract.iggy_source !== iggySourcePath ||
+  contract.moving_scan_source !== movingSourcePath ||
+  contract.moving_scan_contract !== movingContractPath ||
   contract.server_source !== serverSourcePath ||
   contract.bootstrap_source !== bootstrapPath ||
   contract.service_registry_source !== servicesPath ||
+  contract.verifier !== verifierPath ||
+  contract.documentation !== documentationPath ||
+  contract.profiles_checkpoint !== profilesCheckpointPath ||
   contract.execution_status !== "source_not_run"
 ) {
   fail("DLQ duplicate alert server observer identity or status drift");
 }
 
 if (
-  !sameValue(contract.delivery_profiles, {
+  movingContract.packet !== "dlq-duplicate-moving-window-scan-source" ||
+  movingContract.status !== "source_complete_server_composed_runtime_pending" ||
+  movingContract.source !== movingSourcePath ||
+  movingContract.server_composition?.status !== "source_complete_runtime_pending"
+) {
+  fail("moving-window source contract relationship drift");
+}
+
+if (
+  !same(contract.delivery_profiles, {
     memory: "not_applicable",
     outbox_local: "not_applicable",
     outbox_iggy: "iggy_observer",
   }) ||
-  !sameValue(contract.iggy_modes, {
+  !same(contract.iggy_modes, {
     bundled: "connect_to_existing_loopback_broker",
     external: "connect_to_reviewed_external_addresses",
   })
@@ -92,34 +127,61 @@ if (
 }
 
 const scan = contract.scan ?? {};
+const globalMode = scan.global_budget_mode ?? {};
+const fairMode = scan.fair_window_mode ?? {};
+const movingMode = scan.moving_window_mode ?? {};
 if (
   scan.topic !== "dlq" ||
   scan.configured_domain_partition_allowlist !== true ||
   scan.scan_mode_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE" ||
   scan.default_scan_mode !== "global_budget" ||
-  !sameValue(scan.global_budget_mode?.accepted_values, ["global", "global_budget"]) ||
-  scan.global_budget_mode?.max_messages_env !==
-    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES" ||
-  scan.global_budget_mode?.default_max_messages !== 1000 ||
-  scan.global_budget_mode?.one_global_message_budget !== true ||
-  scan.global_budget_mode?.later_partition_starvation_possible !== true ||
-  !sameValue(scan.fair_window_mode?.accepted_values, ["fair", "fair_window"]) ||
-  scan.fair_window_mode?.per_partition_messages_env !==
+  !same(globalMode.accepted_values, ["global", "global_budget"]) ||
+  globalMode.start_offset_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET" ||
+  globalMode.start_offset_default !== 0 ||
+  globalMode.max_messages_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_MAX_MESSAGES" ||
+  globalMode.default_max_messages !== 1000 ||
+  globalMode.one_global_message_budget !== true ||
+  globalMode.later_partition_starvation_possible !== true ||
+  globalMode.cross_cycle_accumulation !== false ||
+  !same(fairMode.accepted_values, ["fair", "fair_window"]) ||
+  fairMode.start_offset_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET" ||
+  fairMode.start_offset_default !== 0 ||
+  fairMode.per_partition_messages_env !==
     "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES" ||
-  scan.fair_window_mode?.per_partition_messages_required !== true ||
-  scan.fair_window_mode?.equal_per_partition_message_budget !== true ||
-  scan.fair_window_mode?.every_partition_attempted_on_successful_scan !== true ||
-  scan.fair_window_mode?.total_message_budget_checked_by_scanner !== true ||
-  scan.fair_window_mode?.maximum_total_messages !== 10000 ||
-  scan.fair_window_mode?.all_partition_observations_combined_before_classification !== true ||
+  fairMode.per_partition_messages_required !== true ||
+  fairMode.equal_per_partition_message_budget !== true ||
+  fairMode.every_partition_attempted_on_successful_scan !== true ||
+  fairMode.total_message_budget_checked_by_scanner !== true ||
+  fairMode.maximum_total_messages !== 10000 ||
+  fairMode.all_partition_observations_combined_before_classification !== true ||
+  fairMode.cross_cycle_accumulation !== false ||
+  !same(movingMode.accepted_values, ["moving", "moving_window"]) ||
+  movingMode.explicit_opt_in !== true ||
+  movingMode.initial_offset_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET" ||
+  movingMode.initial_offset_required !== true ||
+  movingMode.per_partition_messages_env !==
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES" ||
+  movingMode.per_partition_messages_required !== true ||
+  movingMode.batch_size_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE" ||
+  movingMode.batch_size_required !== true ||
+  movingMode.rolling_max_cycles_env !==
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES" ||
+  movingMode.rolling_max_cycles_required !== true ||
+  movingMode.rolling_max_observations_per_cycle_env !==
+    "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE" ||
+  movingMode.rolling_max_observations_per_cycle_required !== true ||
+  movingMode.production_defaults !== false ||
+  movingMode.one_private_next_offset_per_partition !== true ||
+  movingMode.complete_all_partition_cycle_before_mutation !== true ||
+  movingMode.rolling_cycle_capacity_must_cover_fair_cycle !== true ||
+  movingMode.cross_cycle_duplicate_accumulation !== true ||
+  movingMode.failed_cycle_preserves_process_local_state !== true ||
+  movingMode.progress_persisted !== false ||
+  movingMode.new_connection_or_process_starts_at_reviewed_initial_offset !== true ||
+  movingMode.current_tail_coverage_claimed !== false ||
+  movingMode.complete_history_claimed !== false ||
   scan.batch_size_env !== "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE" ||
-  scan.default_batch_size !== 100 ||
-  scan.explicit_start_offset !== true ||
-  scan.same_configured_start_offset_reused_each_poll !== true ||
-  scan.moving_cursor !== false ||
-  scan.cross_cycle_duplicate_accumulation !== false ||
-  scan.current_tail_coverage_claimed !== false ||
-  scan.complete_history_claimed !== false ||
+  scan.fixed_mode_default_batch_size !== 100 ||
   scan.auto_commit !== false ||
   scan.stored_offset_polling !== false
 ) {
@@ -130,18 +192,20 @@ if (
   contract.runtime?.publisher !== "DlqDuplicateAlertRuntimePublisher" ||
   contract.runtime?.initial_snapshot_unavailable !== true ||
   contract.runtime?.success_publishes_identifier_free_evaluation !== true ||
+  contract.runtime?.moving_snapshot_reduced_to_dlq_duplicate_summary !== true ||
   contract.runtime?.startup_failure_records_unavailable_without_task !== true ||
   contract.runtime?.connection_failure_marks_unavailable !== true ||
   contract.runtime?.scan_failure_marks_unavailable !== true ||
+  contract.runtime?.fixed_scan_failure_reconnects !== true ||
+  contract.runtime?.moving_scan_failure_retries_same_state !== true ||
   contract.runtime?.shutdown_marks_unavailable !== true ||
-  contract.runtime?.reconnect_after_failure !== true ||
   contract.runtime?.event_delivery_remains_active !== true
 ) {
   fail("DLQ duplicate observer runtime boundary drift");
 }
 
 if (
-  !sameValue(contract.startup_stable_codes, {
+  !same(contract.startup_stable_codes, {
     configuration_invalid:
       "iggy.dlq_duplicate.alert_server_observer_configuration_invalid",
     runtime_unavailable:
@@ -170,20 +234,22 @@ if (
 const expectedIggyTests = [
   "bundled_mode_requires_matching_loopback_address",
   "all_configured_partitions_are_included_in_request",
-  "global_and_fair_scan_modes_remain_explicit",
+  "global_fair_and_moving_scan_modes_remain_explicit",
+  "moving_window_requires_complete_cycle_capacity",
   "invalid_partition_count_fails_closed",
   "stable_errors_expose_no_connection_details",
 ];
 const expectedServerTests = [
   "every_event_delivery_profile_has_an_explicit_observer_mode",
   "startup_unavailable_state_has_no_task_or_snapshot",
-  "scan_mode_parser_preserves_global_default_and_explicit_fair_window",
+  "scan_mode_parser_preserves_global_default_and_explicit_opt_in_modes",
+  "moving_window_configuration_is_explicit_and_fail_closed",
   "boolean_parser_is_bounded",
 ];
-if (!sameValue(contract.required_iggy_tests, expectedIggyTests)) {
+if (!same(contract.required_iggy_tests, expectedIggyTests)) {
   fail("Iggy observer source test allowlist drift");
 }
-if (!sameValue(contract.required_server_tests, expectedServerTests)) {
+if (!same(contract.required_server_tests, expectedServerTests)) {
   fail("server observer source test allowlist drift");
 }
 for (const testName of expectedIggyTests) {
@@ -193,26 +259,31 @@ for (const testName of expectedServerTests) {
   requireText("server observer tests", serverSource, `fn ${testName}()`);
 }
 if (countText(iggySource, "#[test]") !== expectedIggyTests.length) {
-  fail("Iggy observer source must contain exactly five focused tests");
+  fail("Iggy observer source must contain exactly six focused tests");
 }
 if (countText(serverSource, "#[test]") !== expectedServerTests.length) {
-  fail("server observer source must contain exactly four focused tests");
+  fail("server observer source must contain exactly five focused tests");
 }
 
 for (const marker of [
   "pub enum IggyDlqDuplicateAlertScanMode",
   "GlobalBudget",
   "FairWindow",
+  "MovingWindow",
+  "pub struct IggyDlqDuplicateAlertMovingWindowConfig",
+  "DlqDuplicateRollingWindowPolicy::new(",
+  "IggyDlqDuplicateMovingWindowPolicy::new(",
   "pub struct IggyDlqDuplicateAlertObserver",
   "scan: IggyDlqDuplicateAlertScan",
   "pub async fn connect(",
-  "IggyDlqDuplicateScanRequest::new(",
   "pub async fn connect_fair_window(",
-  "IggyDlqDuplicateScanWindowPolicy::new(",
-  "Self::connect_with_scan(",
-  "IggyDlqDuplicateScanner::new(&self.client, &self.stream_name)?",
-  "scanner.summarize(request)",
-  ".summarize_window(policy)",
+  "pub async fn connect_moving_window(",
+  "IggyDlqDuplicateMovingWindowState::new(",
+  "pub const fn preserves_process_local_state_after_scan_error",
+  "pub async fn summarize(",
+  "IggyDlqDuplicateMovingWindowScanner::new(client, stream_name)?",
+  "scanner.scan_cycle(state).await?",
+  "Ok(*snapshot.rolling().summary())",
   "config.mode == IggyMode::Bundled",
   "is_bundled_loopback_address(",
   "config.topology.domain_partitions > 128",
@@ -226,6 +297,8 @@ for (const marker of [
   'const ENABLE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ENABLED";',
   'const SCAN_MODE_ENV: &str = "RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE";',
   '"RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES"',
+  '"RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES"',
+  '"RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE"',
   '"iggy.dlq_duplicate.alert_server_observer_configuration_invalid"',
   '"iggy.dlq_duplicate.alert_server_observer_runtime_unavailable"',
   "pub enum EventDlqDuplicateAlertObserverMode",
@@ -235,16 +308,23 @@ for (const marker of [
   "IggyExternal",
   "EventDlqDuplicateAlertScanConfig::GlobalBudget",
   "EventDlqDuplicateAlertScanConfig::FairWindow",
+  "EventDlqDuplicateAlertScanConfig::MovingWindow",
   "IggyDlqDuplicateAlertObserver::connect(",
   "IggyDlqDuplicateAlertObserver::connect_fair_window(",
+  "IggyDlqDuplicateAlertObserver::connect_moving_window(",
   '"global" | "global_budget"',
   '"fair" | "fair_window"',
-  "required_u32_env(PER_PARTITION_MESSAGES_ENV)",
+  '"moving" | "moving_window"',
+  "required_u64_env(START_OFFSET_ENV)",
+  "required_u32_env(ROLLING_MAX_CYCLES_ENV)",
+  "required_u32_env(ROLLING_MAX_OBSERVATIONS_PER_CYCLE_ENV)",
   "connected.summarize().await",
+  "connected.preserves_process_local_state_after_scan_error()",
+  "preserves_process_local_state = preserve_state",
   "publisher.publish(&summary)",
   "publisher.mark_unavailable()",
   "event delivery remains active",
-  "reconnecting without affecting event delivery",
+  "retry remains isolated from event delivery",
 ]) {
   requireText("mode-aware server observer", serverSource, marker);
 }
@@ -287,6 +367,8 @@ for (const marker of [
   "broker_address",
   "payload_sha256",
   "raw_client_error",
+  "pub initial_offset:",
+  "pub cursors:",
 ]) {
   forbidText("runtime observer structs", `${iggySource}\n${serverSource}`, marker);
 }
@@ -298,11 +380,20 @@ requireText(
 );
 requireText("runtime composition", runtimeSource, "pub fn mark_unavailable(");
 requireText(
-  "bounded scanner",
+  "bounded fixed scanner",
   scannerSource,
   "pub struct IggyDlqDuplicateScanWindowPolicy",
 );
-requireText("bounded scanner", scannerSource, "pub async fn summarize_window(");
+requireText(
+  "moving scanner",
+  movingSource,
+  "pub struct IggyDlqDuplicateMovingWindowState",
+);
+requireText(
+  "moving scanner",
+  movingSource,
+  "pub async fn scan_cycle(",
+);
 requireText(
   "Iggy module registry",
   lib,
@@ -336,6 +427,8 @@ const requiredPrivacyExclusions = new Set([
   "raw_client_error",
   "raw_threshold_values",
   "source_counts",
+  "private_cursor_values",
+  "rolling_observations",
 ]);
 for (const field of contract.privacy_boundary?.logs_and_snapshots_exclude ?? []) {
   requiredPrivacyExclusions.delete(field);
@@ -348,6 +441,7 @@ if (requiredPrivacyExclusions.size > 0) {
   );
 }
 if (
+  contract.privacy_boundary?.moving_configuration_debug_excludes_initial_offset !== true ||
   contract.privacy_boundary?.stable_error_codes_only !== true ||
   contract.privacy_boundary?.serialization_added !== false ||
   contract.privacy_boundary?.persistence_added !== false
@@ -355,21 +449,39 @@ if (
   fail("observer privacy flags drift");
 }
 
-if (
-  contract.verifier !==
-    "scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs" ||
-  contract.documentation !==
-    "crates/rustok-iggy/docs/dlq-duplicate-alert-server-observer.md" ||
-  contract.profiles_checkpoint !==
-    "crates/rustok-profiles/docs/poison-duplicate-alert-server-observer-checkpoint.md"
-) {
-  fail("observer verifier or documentation path drift");
+for (const marker of [
+  "moving_window",
+  "ROLLING_MAX_CYCLES",
+  "process-local",
+  "complete cycle",
+  "global_budget remains the default",
+  "runtime execution pending",
+]) {
+  requireText("observer documentation", documentation, marker);
+}
+for (const marker of [
+  "moving_window",
+  "Profiles authorization",
+  "private cursor",
+  "restart",
+  "source complete",
+]) {
+  requireText("Profiles observer checkpoint", profilesCheckpoint, marker);
+}
+for (const marker of [
+  "moving-window server observer composition is source-complete",
+  "reviewed fail-closed configuration",
+  "external-Iggy cross-cycle",
+  "Execute moving duplicate observer evidence",
+]) {
+  requireText("canonical Profiles plan", plan, marker);
 }
 
 const requiredRemaining = new Set([
   "fair_window_external_iggy_execution_evidence",
-  "moving_window_or_per_partition_cursor_policy",
-  "cross_cycle_duplicate_accumulation_policy",
+  "moving_window_external_iggy_cross_cycle_execution_evidence",
+  "review_reset_frequency_and_initial_offset_per_deployment",
+  "persisted_cursor_owner_only_if_restart_continuity_is_required",
   "telemetry_projection_outside_observer",
   "health_projection_without_readiness_coupling",
   "notification_delivery_and_suppression",
@@ -388,5 +500,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup state, fail-closed OutboxIggy mode selection, compatibility global-budget scans, explicit fair-window per-partition scans, bounded total budget, auto_commit=false, identifier-free latest-value publication, unavailable/reconnect lifecycle, and no event-delivery/readiness/Profile mutation are locked; runtime execution remains pending.",
+  "Event DLQ duplicate alert server observer source verified: default-off activation, explicit Memory/OutboxLocal not-applicable handling, non-fatal Unavailable startup, compatibility global and fixed fair scans, explicit moving-window configuration with independent process-local cursors and atomic rolling cycles, identifier-free summary publication, moving-state preservation after failed cycles, and no event-delivery/readiness/Profile mutation are locked; external runtime execution remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
@@ -5,68 +5,77 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
-const paths = {
-  contract: "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json",
-  source: "crates/rustok-iggy/src/dlq_duplicate_inspection.rs",
-  adapterContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json",
-  adapterSource: "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs",
-  rollingContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json",
-  rollingSource: "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs",
-  movingContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json",
-  movingSource: "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs",
-  alertContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json",
-  alertSource: "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs",
-  alertRuntimeContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json",
-  alertRuntimeSource: "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs",
-  observerContract:
-    "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json",
-  observerIggySource: "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs",
-  observerServerSource:
-    "apps/server/src/services/event_dlq_duplicate_alert_observer.rs",
-  lib: "crates/rustok-iggy/src/lib.rs",
-  decodeFailure: "crates/rustok-iggy/src/contract_decode_failure.rs",
-  transport: "crates/rustok-iggy/src/transport.rs",
-  receiptInspector:
-    "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs",
-  documentation: "crates/rustok-iggy/docs/dlq-duplicate-inspection.md",
-  profilesCheckpoint:
-    "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md",
-  verifier: "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs",
-};
+const contractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-inspection-source.json";
+const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const adapterContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-external-scan-source.json";
+const adapterSourcePath = "crates/rustok-iggy/src/dlq_duplicate_external_scan.rs";
+const rollingContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-rolling-window-source.json";
+const rollingSourcePath = "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs";
+const movingContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
+const movingSourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
+const alertContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-policy-source.json";
+const alertSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_policy.rs";
+const alertRuntimeContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-runtime-source.json";
+const alertRuntimeSourcePath = "crates/rustok-iggy/src/dlq_duplicate_alert_runtime.rs";
+const observerContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const observerIggySourcePath =
+  "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const observerServerSourcePath =
+  "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
+const libPath = "crates/rustok-iggy/src/lib.rs";
+const decodeFailurePath = "crates/rustok-iggy/src/contract_decode_failure.rs";
+const transportPath = "crates/rustok-iggy/src/transport.rs";
+const receiptInspectorPath =
+  "crates/rustok-iggy-connector/src/consumer_poison_inspection.rs";
+const documentationPath = "crates/rustok-iggy/docs/dlq-duplicate-inspection.md";
+const profilesCheckpointPath =
+  "crates/rustok-profiles/docs/poison-duplicate-dlq-operations-checkpoint.md";
+const verifierPath = "scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs";
 
-function read(path) {
-  return readFileSync(resolve(repoRoot, path), "utf8");
-}
-function readJson(path) {
-  return JSON.parse(read(path));
-}
-
-const contract = readJson(paths.contract);
-const adapterContract = readJson(paths.adapterContract);
-const rollingContract = readJson(paths.rollingContract);
-const movingContract = readJson(paths.movingContract);
-const alertContract = readJson(paths.alertContract);
-const alertRuntimeContract = readJson(paths.alertRuntimeContract);
-const observerContract = readJson(paths.observerContract);
-const source = read(paths.source);
-const adapterSource = read(paths.adapterSource);
-const rollingSource = read(paths.rollingSource);
-const movingSource = read(paths.movingSource);
-const alertSource = read(paths.alertSource);
-const alertRuntimeSource = read(paths.alertRuntimeSource);
-const observerIggySource = read(paths.observerIggySource);
-const observerServerSource = read(paths.observerServerSource);
-const lib = read(paths.lib);
-const decodeFailure = read(paths.decodeFailure);
-const transport = read(paths.transport);
-const receiptInspector = read(paths.receiptInspector);
-const documentation = read(paths.documentation);
-const profilesCheckpoint = read(paths.profilesCheckpoint);
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const adapterContract = JSON.parse(
+  readFileSync(resolve(repoRoot, adapterContractPath), "utf8"),
+);
+const rollingContract = JSON.parse(
+  readFileSync(resolve(repoRoot, rollingContractPath), "utf8"),
+);
+const movingContract = JSON.parse(
+  readFileSync(resolve(repoRoot, movingContractPath), "utf8"),
+);
+const alertContract = JSON.parse(
+  readFileSync(resolve(repoRoot, alertContractPath), "utf8"),
+);
+const alertRuntimeContract = JSON.parse(
+  readFileSync(resolve(repoRoot, alertRuntimeContractPath), "utf8"),
+);
+const observerContract = JSON.parse(
+  readFileSync(resolve(repoRoot, observerContractPath), "utf8"),
+);
+const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+const adapterSource = readFileSync(resolve(repoRoot, adapterSourcePath), "utf8");
+const rollingSource = readFileSync(resolve(repoRoot, rollingSourcePath), "utf8");
+const movingSource = readFileSync(resolve(repoRoot, movingSourcePath), "utf8");
+const alertSource = readFileSync(resolve(repoRoot, alertSourcePath), "utf8");
+const alertRuntimeSource = readFileSync(resolve(repoRoot, alertRuntimeSourcePath), "utf8");
+const observerIggySource = readFileSync(resolve(repoRoot, observerIggySourcePath), "utf8");
+const observerServerSource = readFileSync(resolve(repoRoot, observerServerSourcePath), "utf8");
+const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
+const decodeFailure = readFileSync(resolve(repoRoot, decodeFailurePath), "utf8");
+const transport = readFileSync(resolve(repoRoot, transportPath), "utf8");
+const receiptInspector = readFileSync(resolve(repoRoot, receiptInspectorPath), "utf8");
+const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
+const profilesCheckpoint = readFileSync(
+  resolve(repoRoot, profilesCheckpointPath),
+  "utf8",
+);
 const failures = [];
 
 function fail(message) {
@@ -107,27 +116,27 @@ const expectedTests = [
 ];
 
 if (
-  contract.schema_version !== 2 ||
+  contract.schema_version !== 3 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-inspection-source" ||
   contract.status !== "source_complete_runtime_evidence_pending" ||
   contract.owner !== "rustok-iggy" ||
-  contract.source !== paths.source ||
-  contract.verifier !== paths.verifier ||
-  contract.documentation !== paths.documentation ||
-  contract.profiles_checkpoint !== paths.profilesCheckpoint ||
+  contract.source !== sourcePath ||
+  contract.verifier !== verifierPath ||
+  contract.documentation !== documentationPath ||
+  contract.profiles_checkpoint !== profilesCheckpointPath ||
   contract.execution_status !== "source_not_run"
 ) {
   fail("DLQ duplicate inspection contract identity or status drift");
 }
 if (!same(contract.public_exports, expectedExports)) {
-  fail("DLQ duplicate inspection export allowlist drift");
+  fail("DLQ duplicate inspection public export allowlist drift");
 }
 if (!same(contract.summary_fields, expectedSummaryFields)) {
-  fail("DLQ duplicate inspection summary allowlist drift");
+  fail("DLQ duplicate inspection summary field allowlist drift");
 }
 if (!same(contract.required_source_tests, expectedTests)) {
-  fail("DLQ duplicate inspection test allowlist drift");
+  fail("DLQ duplicate inspection source test allowlist drift");
 }
 
 if (
@@ -141,101 +150,117 @@ if (
     "same_non_nil_message_id_and_same_exact_payload_digest" ||
   contract.semantics?.identity_conflict !==
     "same_non_nil_message_id_with_more_than_one_exact_payload_digest" ||
-  contract.semantics?.manual_review_required_for_identity_conflict !== true
+  contract.semantics?.manual_review_required_for_identity_conflict !== true ||
+  contract.semantics?.empty_scan_returns_zero_summary !== true
 ) {
   fail("DLQ duplicate inspection identity or semantic boundary drift");
 }
 for (const [operation, allowed] of Object.entries(contract.mutation_boundary ?? {})) {
-  if (allowed !== false) fail(`inspection mutation became allowed: ${operation}`);
+  if (allowed !== false) fail(`DLQ duplicate inspection mutation became allowed: ${operation}`);
 }
 if (
   contract.privacy_boundary?.observation_exposes_digest !== false ||
   contract.privacy_boundary?.summary_exposes_identifiers !== false
 ) {
-  fail("inspection privacy flags drift");
+  fail("DLQ duplicate inspection privacy flags drift");
 }
 
 if (
   contract.runtime_adapter?.status !== "source_complete_runtime_pending" ||
-  contract.runtime_adapter?.contract !== paths.adapterContract ||
-  contract.runtime_adapter?.source !== paths.adapterSource ||
+  contract.runtime_adapter?.contract !== adapterContractPath ||
+  contract.runtime_adapter?.source !== adapterSourcePath ||
   contract.runtime_adapter?.auto_commit !== false ||
   contract.runtime_adapter?.result !== "DlqDuplicateSummary" ||
   adapterContract.packet !== "dlq-duplicate-external-scan-source" ||
-  adapterContract.source !== paths.adapterSource ||
-  adapterContract.classifier_source !== paths.source
+  adapterContract.source !== adapterSourcePath ||
+  adapterContract.classifier_source !== sourcePath
 ) {
-  fail("fixed external scanner relationship drift");
+  fail("fixed external duplicate scan relationship drift");
 }
 
 const rolling = contract.rolling_window ?? {};
 const moving = rolling.moving_scanner ?? {};
 if (
-  rolling.status !== "source_complete_moving_scan_integrated_server_pending" ||
-  rolling.contract !== paths.rollingContract ||
-  rolling.source !== paths.rollingSource ||
+  rolling.status !== "source_complete_server_composed_runtime_pending" ||
+  rolling.contract !== rollingContractPath ||
+  rolling.source !== rollingSourcePath ||
   rolling.result !== "DlqDuplicateRollingWindowSnapshot" ||
   rolling.complete_cycle_retention !== true ||
   rolling.history_truncated_after_eviction !== true ||
   rolling.identifier_export !== false ||
-  moving.status !== "source_complete_server_composition_runtime_pending" ||
-  moving.contract !== paths.movingContract ||
-  moving.source !== paths.movingSource ||
+  moving.status !== "source_complete_server_composed_runtime_pending" ||
+  moving.contract !== movingContractPath ||
+  moving.source !== movingSourcePath ||
   moving.independent_process_local_partition_cursors !== true ||
   moving.complete_cycle_atomicity !== true ||
   moving.progress_persisted !== false ||
   moving.restart_semantics !== "reset_to_reviewed_initial_offset" ||
   moving.cursor_values_exported !== false ||
-  rollingContract.packet !== "dlq-duplicate-rolling-window-source" ||
-  rollingContract.status !== "source_complete_moving_scan_integrated_server_pending" ||
-  movingContract.packet !== "dlq-duplicate-moving-window-scan-source" ||
-  movingContract.status !== "source_complete_server_composition_runtime_pending"
+  rollingContract.status !== "source_complete_server_composed_runtime_pending" ||
+  movingContract.status !== "source_complete_server_composed_runtime_pending"
 ) {
-  fail("rolling or moving scanner relationship drift");
+  fail("rolling and moving duplicate relationship drift");
 }
 
 if (
-  contract.alert_policy?.contract !== paths.alertContract ||
-  contract.alert_policy?.source !== paths.alertSource ||
+  contract.alert_policy?.status !== "source_complete_server_observer_execution_pending" ||
+  contract.alert_policy?.contract !== alertContractPath ||
+  contract.alert_policy?.source !== alertSourcePath ||
   contract.alert_policy?.input !== "DlqDuplicateSummary" ||
+  contract.alert_policy?.result !== "DlqDuplicateAlertEvaluation" ||
   contract.alert_policy?.identity_conflict_always_critical !== true ||
   contract.alert_policy?.production_defaults !== false ||
-  alertContract.source !== paths.alertSource ||
-  alertContract.summary_source !== paths.source
+  contract.alert_policy?.notification_dispatch !== false ||
+  contract.alert_policy?.destructive_action !== false ||
+  alertContract.source !== alertSourcePath ||
+  alertContract.summary_source !== sourcePath
 ) {
-  fail("duplicate alert policy relationship drift");
+  fail("DLQ duplicate alert policy relationship drift");
 }
+
 if (
-  contract.alert_runtime?.contract !== paths.alertRuntimeContract ||
-  contract.alert_runtime?.source !== paths.alertRuntimeSource ||
+  contract.alert_runtime?.status !== "source_complete_server_observer_execution_pending" ||
+  contract.alert_runtime?.contract !== alertRuntimeContractPath ||
+  contract.alert_runtime?.source !== alertRuntimeSourcePath ||
+  contract.alert_runtime?.input !== "DlqDuplicateSummary" ||
+  contract.alert_runtime?.result !== "DlqDuplicateAlertRuntimeSnapshot" ||
   contract.alert_runtime?.latest_value !== true ||
   contract.alert_runtime?.single_writer !== true ||
   contract.alert_runtime?.unavailable_clears_evaluation !== true ||
-  alertRuntimeContract.source !== paths.alertRuntimeSource ||
-  alertRuntimeContract.policy_source !== paths.alertSource
+  contract.alert_runtime?.notification_dispatch !== false ||
+  contract.alert_runtime?.destructive_action !== false ||
+  alertRuntimeContract.source !== alertRuntimeSourcePath ||
+  alertRuntimeContract.policy_source !== alertSourcePath ||
+  alertRuntimeContract.summary_source !== sourcePath
 ) {
-  fail("duplicate alert runtime relationship drift");
-}
-if (
-  contract.server_observer?.contract !== paths.observerContract ||
-  contract.server_observer?.iggy_source !== paths.observerIggySource ||
-  contract.server_observer?.server_source !== paths.observerServerSource ||
-  contract.server_observer?.memory !== "not_applicable" ||
-  contract.server_observer?.outbox_local !== "not_applicable" ||
-  !same(contract.server_observer?.outbox_iggy_modes, ["bundled", "external"]) ||
-  contract.server_observer?.startup_failure_non_fatal !== true ||
-  contract.server_observer?.moving_window_mode !== "pending_explicit_opt_in" ||
-  contract.server_observer?.readiness_dependency !== false ||
-  contract.server_observer?.profiles_authorization !== false ||
-  observerContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
-  observerContract.scan?.moving_cursor !== false ||
-  observerContract.scan?.current_tail_coverage_claimed !== false ||
-  observerContract.scan?.complete_history_claimed !== false
-) {
-  fail("server observer relationship or moving-mode pending boundary drift");
+  fail("DLQ duplicate alert runtime relationship drift");
 }
 
-const requiredExcluded = new Set([
+const observer = contract.server_observer ?? {};
+if (
+  observer.status !== "source_complete_runtime_execution_pending" ||
+  observer.contract !== observerContractPath ||
+  observer.iggy_source !== observerIggySourcePath ||
+  observer.server_source !== observerServerSourcePath ||
+  observer.memory !== "not_applicable" ||
+  observer.outbox_local !== "not_applicable" ||
+  !same(observer.outbox_iggy_modes, ["bundled", "external"]) ||
+  observer.startup_failure_non_fatal !== true ||
+  !same(observer.scan_modes, ["global_budget", "fair_window", "moving_window"]) ||
+  observer.default_scan_mode !== "global_budget" ||
+  observer.moving_window_explicit_opt_in !== true ||
+  observer.moving_configuration_fail_closed !== true ||
+  observer.moving_scan_failure_preserves_process_local_state !== true ||
+  observer.readiness_dependency !== false ||
+  observer.profiles_authorization !== false ||
+  observerContract.schema_version !== 3 ||
+  observerContract.scan?.moving_window_mode?.explicit_opt_in !== true ||
+  observerContract.runtime?.moving_scan_failure_retries_same_state !== true
+) {
+  fail("DLQ duplicate server observer relationship drift");
+}
+
+const requiredExcludedFields = new Set([
   "broker_address",
   "stream",
   "topic",
@@ -251,10 +276,12 @@ const requiredExcluded = new Set([
   "credential",
 ]);
 for (const field of contract.privacy_boundary?.summary_excludes ?? []) {
-  requiredExcluded.delete(field);
+  requiredExcludedFields.delete(field);
 }
-if (requiredExcluded.size > 0) {
-  fail(`inspection privacy exclusions incomplete: ${[...requiredExcluded].join(", ")}`);
+if (requiredExcludedFields.size > 0) {
+  fail(`DLQ duplicate privacy exclusions are incomplete: ${[
+    ...requiredExcludedFields,
+  ].join(", ")}`);
 }
 
 for (const marker of [
@@ -264,21 +291,28 @@ for (const marker of [
   "payload_sha256: [u8; 32]",
   "pub fn from_payload(",
   "if broker_message_id.is_nil()",
+  "hash_part(&mut hasher, DLQ_PAYLOAD_DIGEST_DOMAIN);",
+  "hash_part(&mut hasher, payload);",
   "pub struct DlqDuplicateSummary",
-  "pub const fn requires_manual_review(&self)",
-  "BTreeMap::<Uuid, DuplicateGroup>::new()",
-  "BTreeSet<[u8; 32]>",
-  "group.payload_sha256.len() > 1",
+  "pub const fn total_messages(&self)",
+  "pub const fn unique_message_ids(&self)",
+  "pub const fn duplicate_messages(&self)",
+  "pub const fn duplicate_groups(&self)",
+  "pub const fn conflicting_payload_groups(&self)",
+  "pub const fn max_copies_per_message_id(&self)",
   '"iggy.dlq_duplicate.identity_invalid"',
   '"iggy.dlq_duplicate.count_overflow"',
+  "BTreeMap::<Uuid, DuplicateGroup>::new()",
+  "BTreeSet<[u8; 32]>",
+  "Ok(DlqDuplicateSummary {",
 ]) {
-  requireText("inspection source", source, marker);
+  requireText("DLQ duplicate inspection source", source, marker);
 }
 for (const testName of expectedTests) {
-  requireText("inspection tests", source, `fn ${testName}()`);
+  requireText("DLQ duplicate inspection source tests", source, `fn ${testName}()`);
 }
 if (countText(source, "#[test]") !== expectedTests.length) {
-  fail("inspection source must contain exactly four focused tests");
+  fail("DLQ duplicate inspection source must contain exactly four focused tests");
 }
 for (const marker of [
   "pub broker_message_id:",
@@ -290,136 +324,89 @@ for (const marker of [
   ".acknowledge(",
   ".delete(",
   ".replay(",
+  ".retry_entry(",
   ".reserve_and_claim(",
+  ".release_claim(",
   ".mark_published(",
+  ".mark_acknowledged(",
 ]) {
-  forbidText("inspection source", source, marker);
+  forbidText("DLQ duplicate inspection source", source, marker);
 }
 
 for (const marker of [
   "pub struct IggyDlqDuplicateScanner<'a>",
   ".poll_messages(",
-  "&PollingStrategy::offset(next_offset)",
   "summarize_dlq_duplicates(observations)",
 ]) {
-  requireText("fixed scanner", adapterSource, marker);
+  requireText("fixed duplicate scan adapter", adapterSource, marker);
 }
 for (const marker of [
   "pub struct DlqDuplicateRollingWindow",
   "pub fn push_cycle(",
   "history_truncated: evicted_cycles > 0",
 ]) {
-  requireText("rolling source", rollingSource, marker);
+  requireText("rolling duplicate state", rollingSource, marker);
 }
 for (const marker of [
   "pub struct IggyDlqDuplicateMovingWindowState",
-  "cursors: BTreeMap<u32, u64>",
-  "fn apply_complete_cycle(",
+  "pub async fn scan_cycle(",
   "let rolling = self.rolling.push_cycle(observations)?;",
-  "self.cursors = candidate_cursors;",
-  "pub fn reset_to_initial_offset(",
 ]) {
-  requireText("moving scanner", movingSource, marker);
+  requireText("moving duplicate scanner", movingSource, marker);
 }
 for (const marker of [
-  "pub struct DlqDuplicateAlertPolicy",
-  "pub enum DlqDuplicateAlertLevel",
+  "pub struct IggyDlqDuplicateAlertMovingWindowConfig",
+  "pub async fn connect_moving_window(",
+  "scanner.scan_cycle(state).await?",
 ]) {
-  requireText("alert policy", alertSource, marker);
+  requireText("Iggy alert observer", observerIggySource, marker);
 }
 for (const marker of [
-  "pub struct DlqDuplicateAlertRuntimePublisher",
-  "pub fn mark_unavailable(",
-  "evaluation: None",
+  '"moving" | "moving_window"',
+  "EventDlqDuplicateAlertScanConfig::MovingWindow",
+  "connected.preserves_process_local_state_after_scan_error()",
 ]) {
-  requireText("alert runtime", alertRuntimeSource, marker);
+  requireText("server alert observer", observerServerSource, marker);
 }
+
+for (const marker of [
+  "ConsumedContractDecodeFailure",
+  "delivery_id",
+  "to_dlq_entry",
+]) {
+  requireText("decode-failure identity source", decodeFailure, marker);
+}
+requireText("physical DLQ publisher", transport, "move_to_dlq");
 requireText(
-  "Iggy observer",
-  observerIggySource,
-  "pub struct IggyDlqDuplicateAlertObserver",
+  "count-only poison receipt inspector",
+  receiptInspector,
+  "ConsumerPoisonReceiptInspector",
 );
-for (const marker of [
-  "Unavailable",
-  "NotApplicableMemory",
-  "NotApplicableOutboxLocal",
-  "IggyBundled",
-  "IggyExternal",
-  "publisher.mark_unavailable()",
-]) {
-  requireText("server observer", observerServerSource, marker);
-}
+requireText("rustok-iggy exports", lib, "DlqDuplicateSummary");
+requireText("rustok-iggy exports", lib, "IggyDlqDuplicateAlertMovingWindowConfig");
 
 for (const marker of [
-  "pub mod dlq_duplicate_inspection;",
-  "pub mod dlq_duplicate_rolling_window;",
-  '#[cfg(feature = "iggy")]\npub mod dlq_duplicate_moving_window_scan;',
-]) {
-  requireText("rustok-iggy module list", lib, marker);
-}
-for (const exportName of expectedExports) {
-  requireText("rustok-iggy exports", lib, exportName);
-}
-
-for (const marker of [
-  "Failure kind, retry count, time, process identity, and random values are excluded",
-  "pub fn delivery_id(&self) -> Uuid",
-  "hash_part(&mut hasher, &self.raw_payload);",
-  ".with_broker_message_id(delivery_id)",
-]) {
-  requireText("raw poison identity", decodeFailure, marker);
-}
-for (const marker of [
-  "if entry.broker_message_id().is_some()",
-  "IggyDlqPublisher::connect",
-  ".publish(&entry)",
-]) {
-  requireText("deterministic publisher", transport, marker);
-}
-for (const marker of [
-  "Bounded aggregate view of neutral poison-result progress",
-  "The snapshot intentionally excludes delivery identifiers",
-  "pub struct ConsumerPoisonReceiptSummary",
-  "pub async fn summarize(",
-]) {
-  requireText("receipt inspector", receiptInspector, marker);
-}
-
-for (const marker of [
-  "moving scanner integration is source-complete",
-  "independent process-local per-partition cursors",
-  "explicit restart reset",
-  "server composition and runtime evidence pending",
-]) {
-  requireText("inspection documentation", documentation, marker);
-}
-for (const marker of [
-  "moving scanner integration is source-complete",
+  "moving-window server composition is source-complete",
   "private process-local per-partition cursors",
-  "restart reset",
-  "Profiles authorization boundary",
+  "global_budget",
+  "moving_window",
+  "runtime execution pending",
 ]) {
-  requireText("Profiles operations checkpoint", profilesCheckpoint, marker);
+  requireText("duplicate inspection documentation", documentation, marker);
 }
-
-if (
-  contract.production_relationship?.raw_poison_delivery_id !==
-    "ConsumedContractDecodeFailure::delivery_id" ||
-  contract.production_relationship?.dlq_broker_message_id !==
-    "ConsumedContractDecodeFailure::to_dlq_entry" ||
-  contract.production_relationship?.physical_publisher !== "IggyTransport::move_to_dlq" ||
-  contract.production_relationship?.receipt_summary !== "ConsumerPoisonReceiptInspector" ||
-  contract.production_relationship?.receipt_and_physical_duplicate_summaries_are_independent !==
-    true
-) {
-  fail("production identity relationship drift");
+for (const marker of [
+  "moving-window server composition is source-complete",
+  "Profiles authorization boundary",
+  "private cursor",
+  "runtime evidence pending",
+]) {
+  requireText("Profiles duplicate operations checkpoint", profilesCheckpoint, marker);
 }
 
 const requiredRemaining = new Set([
   "retained_external_iggy_duplicate_scan_evidence",
-  "compose_moving_window_server_observer",
-  "define_reviewed_moving_window_configuration",
   "retain_moving_window_external_runtime_evidence",
+  "review_reset_frequency_and_initial_offset_per_deployment",
   "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
   "telemetry_and_health_projection",
   "alert_delivery_and_suppression_outside_policy",
@@ -428,7 +415,9 @@ const requiredRemaining = new Set([
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
 if (requiredRemaining.size > 0) {
-  fail(`inspection remaining work drift: ${[...requiredRemaining].join(", ")}`);
+  fail(`DLQ duplicate inspection remaining work drift: ${[
+    ...requiredRemaining,
+  ].join(", ")}`);
 }
 
 if (failures.length > 0) {
@@ -438,5 +427,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate inspection source verified: deterministic header identity, in-memory exact-byte digest comparison, count-only privacy, fixed and moving bounded scanners, complete-cycle atomic rolling integration, explicit non-persistent restart reset, alert/runtime/server boundaries, and Profiles non-authorization are locked; server moving-mode composition, runtime evidence, telemetry, and authorized operations remain pending.",
+  "Iggy physical DLQ duplicate inspection source verified: count-only identity classification, fixed scanners, bounded rolling state, independent moving cursors, explicit server moving-window composition, fail-closed reviewed configuration, latest-value alert publication, privacy boundaries, and no Profiles authorization or destructive mutation are locked; runtime evidence remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
@@ -7,9 +7,13 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const contractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
+const serverContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
 const sourcePath = "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
 const rollingPath = "crates/rustok-iggy/src/dlq_duplicate_rolling_window.rs";
 const classifierPath = "crates/rustok-iggy/src/dlq_duplicate_inspection.rs";
+const iggyObserverPath = "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const serverPath = "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const documentationPath =
   "crates/rustok-iggy/docs/dlq-duplicate-moving-window-scan.md";
@@ -19,25 +23,15 @@ const planPath = "crates/rustok-profiles/docs/implementation-plan.md";
 const verifierPath =
   "scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs";
 
-const expectedExports = [
-  "IggyDlqDuplicateMovingWindowPolicy",
-  "IggyDlqDuplicateMovingWindowState",
-  "IggyDlqDuplicateMovingWindowSnapshot",
-  "IggyDlqDuplicateMovingWindowScanner",
-  "IggyDlqDuplicateMovingWindowError",
-];
-const expectedTests = [
-  "policy_requires_complete_fair_cycle_to_fit_rolling_capacity",
-  "complete_cycle_advances_partition_cursors_independently",
-  "duplicate_split_across_advancing_cycles_remains_count_only",
-  "incomplete_cycle_preserves_cursors_and_rolling_state",
-  "explicit_reset_rewinds_cursors_and_clears_rolling_history",
-];
-
 const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const serverContract = JSON.parse(
+  readFileSync(resolve(repoRoot, serverContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const rolling = readFileSync(resolve(repoRoot, rollingPath), "utf8");
 const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
+const iggyObserver = readFileSync(resolve(repoRoot, iggyObserverPath), "utf8");
+const server = readFileSync(resolve(repoRoot, serverPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
 const profilesCheckpoint = readFileSync(
@@ -67,22 +61,40 @@ function countText(text, marker) {
   return text.split(marker).length - 1;
 }
 
+const expectedExports = [
+  "IggyDlqDuplicateMovingWindowPolicy",
+  "IggyDlqDuplicateMovingWindowState",
+  "IggyDlqDuplicateMovingWindowSnapshot",
+  "IggyDlqDuplicateMovingWindowScanner",
+  "IggyDlqDuplicateMovingWindowError",
+];
+const expectedTests = [
+  "policy_requires_complete_fair_cycle_to_fit_rolling_capacity",
+  "complete_cycle_advances_partition_cursors_independently",
+  "duplicate_split_across_advancing_cycles_remains_count_only",
+  "incomplete_cycle_preserves_cursors_and_rolling_state",
+  "explicit_reset_rewinds_cursors_and_clears_rolling_history",
+];
+
 if (
-  contract.schema_version !== 1 ||
+  contract.schema_version !== 2 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-moving-window-scan-source" ||
-  contract.status !== "source_complete_server_composition_runtime_pending" ||
+  contract.status !== "source_complete_server_composed_runtime_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.feature !== "iggy" ||
   contract.source !== sourcePath ||
   contract.rolling_source !== rollingPath ||
   contract.classifier_source !== classifierPath ||
+  contract.server_observer_contract !== serverContractPath ||
+  contract.iggy_observer_source !== iggyObserverPath ||
+  contract.server_source !== serverPath ||
   contract.verifier !== verifierPath ||
   contract.documentation !== documentationPath ||
   contract.profiles_checkpoint !== profilesCheckpointPath ||
   contract.execution_status !== "source_not_run"
 ) {
-  fail("moving-window scan contract identity or source status drift");
+  fail("moving-window scan contract identity or status drift");
 }
 
 if (!same(contract.public_exports, expectedExports)) {
@@ -198,6 +210,31 @@ if (
   fail("moving-window stable error code drift");
 }
 
+const serverComposition = contract.server_composition ?? {};
+if (
+  serverComposition.status !== "source_complete_runtime_pending" ||
+  serverComposition.scan_mode !== "moving_window" ||
+  serverComposition.accepted_alias !== "moving" ||
+  serverComposition.default_mode !== false ||
+  serverComposition.reviewed_configuration_required !== true ||
+  serverComposition.initial_offset_required !== true ||
+  serverComposition.per_partition_messages_required !== true ||
+  serverComposition.batch_size_required !== true ||
+  serverComposition.rolling_max_cycles_required !== true ||
+  serverComposition.rolling_max_observations_per_cycle_required !== true ||
+  serverComposition.moving_summary_reduced_to_count_only_alert_input !== true ||
+  serverComposition.failed_cycle_retries_same_process_local_state !== true ||
+  serverComposition.replacement_connection_resets_to_reviewed_initial_offset !== true ||
+  serverComposition.runtime_execution_pending !== true ||
+  serverContract.schema_version !== 3 ||
+  serverContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  serverContract.moving_scan_contract !== contractPath ||
+  serverContract.scan?.moving_window_mode?.explicit_opt_in !== true ||
+  serverContract.runtime?.moving_scan_failure_retries_same_state !== true
+) {
+  fail("moving-window server composition relationship drift");
+}
+
 for (const marker of [
   'const READ_ONLY_CONSUMER: &str = "rustok-dlq-duplicate-moving-readonly-v1";',
   "pub struct IggyDlqDuplicateMovingWindowPolicy",
@@ -220,17 +257,9 @@ for (const marker of [
   "&PollingStrategy::offset(next_offset)",
   "requested_count,\n                    false,",
   "pub enum IggyDlqDuplicateMovingWindowError",
-  '"iggy.dlq_duplicate.moving_window_policy_invalid"',
-  '"iggy.dlq_duplicate.moving_window_poll_failed"',
-  '"iggy.dlq_duplicate.moving_window_response_invalid"',
-  '"iggy.dlq_duplicate.moving_window_offset_overflow"',
-  '"iggy.dlq_duplicate.moving_window_cycle_invalid"',
-  '"iggy.dlq_duplicate.moving_window_count_overflow"',
-  '"iggy.dlq_duplicate.moving_window_reset_overflow"',
 ]) {
   requireText("moving-window scan source", source, marker);
 }
-
 for (const testName of expectedTests) {
   requireText("moving-window scan source tests", source, `fn ${testName}()`);
 }
@@ -280,6 +309,27 @@ for (const marker of [
   requireText("duplicate classifier source", classifier, marker);
 }
 
+for (const marker of [
+  "pub struct IggyDlqDuplicateAlertMovingWindowConfig",
+  "pub async fn connect_moving_window(",
+  "IggyDlqDuplicateMovingWindowState::new(",
+  "pub const fn preserves_process_local_state_after_scan_error",
+  "scanner.scan_cycle(state).await?",
+  "Ok(*snapshot.rolling().summary())",
+]) {
+  requireText("Iggy observer moving composition", iggyObserver, marker);
+}
+for (const marker of [
+  '"moving" | "moving_window"',
+  "EventDlqDuplicateAlertScanConfig::MovingWindow",
+  "required_u64_env(START_OFFSET_ENV)",
+  "required_u32_env(ROLLING_MAX_CYCLES_ENV)",
+  "IggyDlqDuplicateAlertObserver::connect_moving_window(",
+  "connected.preserves_process_local_state_after_scan_error()",
+]) {
+  requireText("server moving composition", server, marker);
+}
+
 requireText(
   "rustok-iggy module list",
   lib,
@@ -288,13 +338,18 @@ requireText(
 for (const exportName of expectedExports) {
   requireText("rustok-iggy public exports", lib, exportName);
 }
+requireText(
+  "rustok-iggy public exports",
+  lib,
+  "IggyDlqDuplicateAlertMovingWindowConfig",
+);
 
 for (const marker of [
   "independent private partition cursors",
   "Complete-cycle atomicity",
   "Progress persistence is deliberately **not**",
   "reset_to_initial_offset()",
-  "server composition and runtime evidence pending",
+  "server composition is source-complete",
 ]) {
   requireText("moving-window owner guide", documentation, marker);
 }
@@ -303,26 +358,25 @@ for (const marker of [
   "private per-partition next offsets",
   "explicit reset",
   "restart-safe progress",
-  "server observer mode",
+  "server observer mode is source-complete",
 ]) {
   requireText("Profiles moving-window checkpoint", profilesCheckpoint, marker);
 }
 for (const marker of [
-  "moving-window scanner integration is source-complete",
-  "independent process-local per-partition cursors",
-  "restart-reset semantics",
-  "Compose the moving duplicate observer",
+  "moving-window server observer composition is source-complete",
+  "reviewed fail-closed configuration",
+  "Execute moving duplicate observer evidence",
   "verify-iggy-dlq-duplicate-moving-window-scan.mjs",
 ]) {
   requireText("canonical Profiles plan", plan, marker);
 }
 
 const requiredRemaining = new Set([
-  "compose_explicit_opt_in_mode_aware_server_observer",
-  "define_reviewed_configuration_surface",
   "retain_external_iggy_cross_cycle_runtime_evidence",
+  "review_reset_frequency_and_initial_offset_per_deployment",
   "define_persisted_cursor_store_only_if_restart_continuity_is_required",
   "define_identifier_free_telemetry_and_health_projection",
+  "retain_server_observer_execution_evidence",
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
 if (requiredRemaining.size > 0) {
@@ -336,5 +390,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate moving-window scan source verified: bounded equal-budget polling, private independent per-partition cursors, complete-cycle atomic rolling updates, explicit non-persistent restart reset, identifier-free snapshots, and no broker/receipt mutations are locked; server composition and external runtime evidence remain pending.",
+  "Iggy DLQ duplicate moving-window scan source verified: bounded equal-budget polling, private independent per-partition cursors, complete-cycle atomic rolling updates, explicit non-persistent restart reset, identifier-free snapshots, explicit server moving-window composition, fail-closed reviewed configuration, and no broker/receipt mutations are locked; external runtime evidence remains pending.",
 );

--- a/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
+++ b/scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
@@ -13,6 +13,10 @@ const movingContractPath =
   "crates/rustok-iggy/contracts/evidence/dlq-duplicate-moving-window-scan-source.json";
 const movingSourcePath =
   "crates/rustok-iggy/src/dlq_duplicate_moving_window_scan.rs";
+const serverContractPath =
+  "crates/rustok-iggy/contracts/evidence/dlq-duplicate-alert-server-observer-source.json";
+const iggyObserverPath = "crates/rustok-iggy/src/dlq_duplicate_alert_observer.rs";
+const serverPath = "apps/server/src/services/event_dlq_duplicate_alert_observer.rs";
 const libPath = "crates/rustok-iggy/src/lib.rs";
 const documentationPath = "crates/rustok-iggy/docs/dlq-duplicate-rolling-window.md";
 const profilesCheckpointPath =
@@ -37,9 +41,14 @@ const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"
 const movingContract = JSON.parse(
   readFileSync(resolve(repoRoot, movingContractPath), "utf8"),
 );
+const serverContract = JSON.parse(
+  readFileSync(resolve(repoRoot, serverContractPath), "utf8"),
+);
 const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
 const classifier = readFileSync(resolve(repoRoot, classifierPath), "utf8");
 const movingSource = readFileSync(resolve(repoRoot, movingSourcePath), "utf8");
+const iggyObserver = readFileSync(resolve(repoRoot, iggyObserverPath), "utf8");
+const server = readFileSync(resolve(repoRoot, serverPath), "utf8");
 const lib = readFileSync(resolve(repoRoot, libPath), "utf8");
 const documentation = readFileSync(resolve(repoRoot, documentationPath), "utf8");
 const profilesCheckpoint = readFileSync(
@@ -65,10 +74,10 @@ function countText(text, marker) {
 }
 
 if (
-  contract.schema_version !== 2 ||
+  contract.schema_version !== 3 ||
   contract.module !== "iggy" ||
   contract.packet !== "dlq-duplicate-rolling-window-source" ||
-  contract.status !== "source_complete_moving_scan_integrated_server_pending" ||
+  contract.status !== "source_complete_server_composed_runtime_pending" ||
   contract.owner !== "rustok-iggy" ||
   contract.source !== sourcePath ||
   contract.classifier_source !== classifierPath ||
@@ -174,20 +183,25 @@ if (
 
 const moving = contract.moving_scan_integration ?? {};
 if (
-  moving.status !== "source_complete_server_composition_runtime_pending" ||
+  moving.status !== "source_complete_server_composed_runtime_pending" ||
   moving.contract !== movingContractPath ||
   moving.source !== movingSourcePath ||
+  moving.server_observer_contract !== serverContractPath ||
   moving.complete_cycle_feeding !== true ||
   moving.independent_process_local_partition_cursors !== true ||
   moving.cursor_values_exported !== false ||
   moving.progress_persisted !== false ||
   moving.restart_semantics !== "reset_to_reviewed_initial_offset" ||
-  moving.server_observer_composition !== "pending" ||
+  moving.server_observer_composition !== "source_complete" ||
+  moving.moving_mode_default !== false ||
   moving.runtime_evidence !== "pending" ||
   movingContract.packet !== "dlq-duplicate-moving-window-scan-source" ||
-  movingContract.status !== "source_complete_server_composition_runtime_pending"
+  movingContract.status !== "source_complete_server_composed_runtime_pending" ||
+  serverContract.packet !== "dlq-duplicate-alert-server-observer-source" ||
+  serverContract.schema_version !== 3 ||
+  serverContract.scan?.moving_window_mode?.explicit_opt_in !== true
 ) {
-  fail("DLQ duplicate moving-scan integration relationship drift");
+  fail("DLQ duplicate moving-scan/server integration relationship drift");
 }
 
 for (const marker of [
@@ -208,9 +222,6 @@ for (const marker of [
   "flat_map(|cycle| cycle.iter().cloned())",
   "history_truncated: evicted_cycles > 0",
   "pub enum DlqDuplicateRollingWindowError",
-  'Self::InvalidPolicy => "iggy.dlq_duplicate.rolling_window_policy_invalid"',
-  'Self::CycleTooLarge => "iggy.dlq_duplicate.rolling_window_cycle_too_large"',
-  'Self::CountOverflow => "iggy.dlq_duplicate.rolling_window_count_overflow"',
 ]) {
   requireText("DLQ duplicate rolling-window source", source, marker);
 }
@@ -260,6 +271,20 @@ for (const marker of [
 ]) {
   requireText("moving-window scan integration", movingSource, marker);
 }
+for (const marker of [
+  "pub struct IggyDlqDuplicateAlertMovingWindowConfig",
+  "pub async fn connect_moving_window(",
+  "scanner.scan_cycle(state).await?",
+]) {
+  requireText("moving-window Iggy observer composition", iggyObserver, marker);
+}
+for (const marker of [
+  '"moving" | "moving_window"',
+  "EventDlqDuplicateAlertScanConfig::MovingWindow",
+  "required_u32_env(ROLLING_MAX_CYCLES_ENV)",
+]) {
+  requireText("moving-window server composition", server, marker);
+}
 
 requireText("rustok-iggy module list", lib, "pub mod dlq_duplicate_rolling_window;");
 requireText(
@@ -276,7 +301,7 @@ for (const marker of [
   "history_truncated",
   "does not move a broker cursor",
   "not complete history",
-  "moving scanner integration is source-complete",
+  "moving scanner and server integration are source-complete",
 ]) {
   requireText("DLQ duplicate rolling-window documentation", documentation, marker);
 }
@@ -285,17 +310,17 @@ for (const marker of [
   "cross-cycle",
   "history_truncated",
   "process-local per-partition cursor",
-  "moving scanner integration is source-complete",
+  "moving scanner and server integration are source-complete",
 ]) {
   requireText("Profiles rolling-window checkpoint", profilesCheckpoint, marker);
 }
 
 const requiredRemaining = new Set([
-  "compose_mode_aware_server_observer",
-  "define_reviewed_moving_scan_configuration",
   "retain_external_iggy_cross_cycle_runtime_evidence",
+  "review_reset_frequency_and_initial_offset_per_deployment",
   "define_persistent_cursor_owner_only_if_restart_continuity_is_required",
   "define_identifier_free_telemetry_and_health_projection",
+  "retain_server_observer_execution_evidence",
 ]);
 for (const item of contract.remaining_work ?? []) requiredRemaining.delete(item);
 if (requiredRemaining.size > 0) {
@@ -311,5 +336,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Iggy DLQ duplicate rolling-window source verified: explicit checked memory bounds, complete-cycle retention and eviction, transactional oversized-cycle rejection, cross-cycle ordinary/conflicting classification, identifier-free truncation metadata, and source-complete moving scanner integration with private process-local cursors and explicit restart reset are locked; server composition and runtime evidence remain pending.",
+  "Iggy DLQ duplicate rolling-window source verified: explicit checked memory bounds, complete-cycle retention and eviction, transactional oversized-cycle rejection, cross-cycle ordinary/conflicting classification, identifier-free truncation metadata, source-complete moving scanner and explicit server observer composition, private process-local cursors, and explicit restart reset are locked; external runtime evidence remains pending.",
 );


### PR DESCRIPTION
## Summary

- add explicit `moving_window` scan mode to the existing mode-aware physical DLQ duplicate observer
- preserve `global_budget` as the compatibility default and fixed `fair_window` behavior
- add reviewed fail-closed moving configuration for initial offset, equal per-partition cap, batch size, rolling maximum cycles, and rolling observations per cycle
- keep all moving configuration fields required with no production defaults
- retain one private process-local cursor per selected partition and update cursors plus rolling history only after one complete all-partition cycle succeeds
- reduce successful moving snapshots to the existing count-only `DlqDuplicateSummary` before alert policy evaluation
- mark the public runtime unavailable after a failed moving cycle while preserving the connected observer's process-local cursors and rolling history for the next attempt
- keep replacement connection and process restart semantics explicit: reset to the reviewed initial offset with empty rolling history
- update aggregate inspection/rolling/moving contracts, source verifiers, owner guides, Profiles checkpoints, and the canonical Profiles plan

## Recheck findings

The moving scanner merged in #2426 supplied independent bounded per-partition cursors and atomic rolling-cycle updates, but the server observer still exposed only fixed global and fair snapshots. The next plan gap was therefore explicit server composition rather than new cursor design.

This PR composes the existing library state without silently changing deployments. `moving_window` is explicit opt-in and requires complete reviewed configuration before the task starts.

## Moving configuration

Required when `RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_SCAN_MODE=moving_window`:

```text
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_START_OFFSET
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_PER_PARTITION_MESSAGES
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_BATCH_SIZE
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_CYCLES
RUSTOK_EVENT_DLQ_DUPLICATE_ALERT_ROLLING_MAX_OBSERVATIONS_PER_CYCLE
```

Validation retains the existing hard bounds:

- 1 to 128 configured partitions
- checked total messages per cycle `<= 10000`
- batch size `<= 1000` and no greater than the per-partition cap
- rolling cycle count `<= 128`
- checked total retained observations `<= 10000`
- rolling per-cycle capacity covers the full fair-cycle budget

## Failure and restart semantics

- incomplete, invalid, or failed moving cycles preserve connected process-local cursor and rolling state
- the latest public alert runtime becomes unavailable and clears stale evaluation
- the next poll retries the same connected moving state
- a replacement connection or process restart begins at the reviewed initial offset with empty rolling history
- progress and rolling observations are not persisted
- no restart-safe progress, current-tail, complete-history, retention-sufficiency, exactly-once, or Profiles authorization claim

## Privacy and mutation boundary

Public snapshots and logs exclude partition IDs, private cursor values, offsets, UUIDs, payloads/digests, retained observations, endpoints, credentials, receipt identities, raw client errors, raw thresholds, and source counts.

The observer does not store broker offsets, acknowledge, publish, delete, purge, replay, retry, mutate poison receipts, start or stop the shared transport/bundled broker, dispatch notifications, couple readiness, or change Profiles/Social Graph behavior.

## Verification

Per maintainer instruction, tests, Cargo commands, formatters, repository source verifiers, server startup, broker scans, telemetry registration, and retained capture were not run.

Local artifact checks performed while composing the change:

- updated JSON files parsed successfully
- updated `.mjs` files passed `node --check`
- Rust source delimiters were checked with a lexer-aware structural pass

Suggested maintainer commands:

```bash
RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets
cargo test -p rustok-iggy dlq_duplicate_moving_window_scan --features iggy -- --nocapture
cargo test -p rustok-iggy dlq_duplicate_alert_observer --features iggy -- --nocapture
cargo test -p rustok-server event_dlq_duplicate_alert_observer -- --nocapture
node scripts/verify/verify-iggy-dlq-duplicate-moving-window-scan.mjs
node scripts/verify/verify-iggy-dlq-duplicate-rolling-window.mjs
node scripts/verify/verify-event-dlq-duplicate-alert-server-observer.mjs
node scripts/verify/verify-iggy-dlq-duplicate-inspection.mjs
cargo xtask module validate profiles
cargo xtask module test profiles
```
