### PR TITLE
feat(forum): compose exact topic audience storefront reads

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-audience-exact-read.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-exact-read.json
@@ -43,7 +43,7 @@
     "owner_note_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API and the FORUM-20 ledger through FORUM-20BB, then record FORUM-20BC transport composition through a safe repository-local edit; the contents API requires complete replacement of both owner documents and the implementation plan is multi-thousand-line."
+    "synchronization_debt": "Advance CRATE_API and the FORUM-20 ledger through delivered FORUM-20BB and FORUM-20BC through a safe repository-local edit; the contents API requires complete replacement of both owner documents and the implementation plan is multi-thousand-line."
   },
   "compatibility": {
     "existing_topic_service_methods_changed": false,
@@ -54,15 +54,14 @@
     "external_fact_layers_require_exact_context_and_provider": true
   },
   "remaining_scope": [
-    "compose native and GraphQL selected-topic reads through the FORUM-20BB owner service",
-    "compose authenticated mark-read visibility recheck through the same exact owner service",
-    "migrate topic list pagination through an exact bounded richer-audience scope without count drift",
+    "migrate topic list and unread list pagination through an exact bounded richer-audience scope without count drift",
     "migrate exact reply and reply-list reads through parent-topic richer authorization",
-    "migrate remaining category reads, search/index, SEO, and deep-link authorization",
-    "synchronize CRATE_API and the canonical Forum plan through FORUM-20BB with a safe repository-local edit",
-    "capture maintainer-executed SQLite, PostgreSQL, and transport runtime evidence"
+    "migrate remaining category reads search index SEO and deep-link authorization",
+    "synchronize CRATE_API and the canonical Forum plan through FORUM-20BC with a safe repository-local edit",
+    "capture maintainer-executed SQLite PostgreSQL native and GraphQL runtime evidence"
   ],
   "downstream_task": "FORUM-20BC",
+  "downstream_contract": "crates/rustok-forum/contracts/forum-topic-audience-transport-composition.json",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [

--- a/crates/rustok-forum/contracts/forum-topic-audience-transport-composition.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-transport-composition.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BC",
+  "upstream_task": "FORUM-20BB",
+  "scope": "Compose the module-owned native and GraphQL selected-topic reads plus authenticated mark-read through the exact richer Forum topic audience owner",
+  "owner_service": "crates/rustok-forum/src/services/topic_audience_read.rs",
+  "read_state_owner": "crates/rustok-forum/src/services/storefront_read_state.rs",
+  "transport_context": "crates/rustok-forum/src/topic_read_transport.rs",
+  "graphql_query": "crates/rustok-forum/src/graphql/storefront_audience_topic.rs",
+  "graphql_mark_read": "crates/rustok-forum/src/graphql/storefront_read_state.rs",
+  "graphql_runtime": "crates/rustok-forum/src/graphql/runtime_data.rs",
+  "graphql_storefront_adapter": "crates/rustok-forum/storefront/src/transport/graphql_adapter.rs",
+  "native_storefront_adapter": "crates/rustok-forum/storefront/src/transport/native_server_adapter.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20bc-topic-audience-transport-composition.md",
+  "source_verifier": "scripts/verify/verify-forum-topic-audience-transport-composition.mjs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-topic-audience-exact-read.json",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "crate_api": "crates/rustok-forum/CRATE_API.md",
+  "transport_boundary": {
+    "native_selected_topic_uses_exact_owner": true,
+    "graphql_selected_topic_uses_exact_owner": true,
+    "graphql_storefront_adapter_uses_exact_field": true,
+    "native_mark_read_uses_exact_owner": true,
+    "graphql_mark_read_uses_exact_owner": true,
+    "authenticated_tenant_from_transport_context": true,
+    "authenticated_actor_from_transport_context": true,
+    "effective_locale_from_transport_context": true,
+    "route_channel_from_transport_context": true,
+    "claims_forwarded_to_owner_context": true,
+    "five_second_read_deadline": true,
+    "shared_optional_audience_facts_reused": true,
+    "public_selected_topic_skips_optional_facts": true,
+    "missing_and_denied_topic_non_oracular": true,
+    "replies_not_loaded_after_selected_topic_denial": true,
+    "topic_list_pagination_changed": false,
+    "unread_list_visibility_changed": false,
+    "reply_owner_read_changed": false,
+    "category_owner_read_changed": false,
+    "search_index_changed": false,
+    "seo_changed": false,
+    "deep_link_changed": false,
+    "migration_added": false,
+    "dependency_changed": false,
+    "public_dto_changed": false
+  },
+  "compatibility": {
+    "legacy_graphql_forum_storefront_topic_field_removed": false,
+    "legacy_mark_read_owner_method_removed": false,
+    "module_owned_graphql_adapter_migrated": true,
+    "module_owned_native_adapter_migrated": true,
+    "transport_request_identity_fields_added": false,
+    "categories_without_richer_layers_preserve_behavior": true,
+    "locally_decidable_layers_do_not_require_provider": true,
+    "external_fact_layers_fail_closed_without_provider": true
+  },
+  "documentation": {
+    "owner_note_updated": true,
+    "upstream_contract_updated": true,
+    "crate_api_updated": false,
+    "canonical_plan_updated": false,
+    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BC through a conflict-safe repository-local edit; the GitHub contents API replaces complete files and the canonical plan is multi-thousand-line."
+  },
+  "remaining_scope": [
+    "migrate topic list and unread list pagination through an exact bounded richer-audience scope without count drift",
+    "migrate exact reply and reply-list reads through parent-topic richer authorization",
+    "migrate remaining category reads search index SEO and deep-link authorization",
+    "add visibility-scoped category and all-read commands",
+    "synchronize CRATE_API and the canonical Forum plan through FORUM-20BC with a safe repository-local edit",
+    "capture maintainer-executed SQLite PostgreSQL native and GraphQL runtime evidence"
+  ],
+  "downstream_task": "FORUM-20BD",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum topic_read_transport -- --nocapture",
+      "cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-topic-audience-transport-composition.mjs",
+      "node scripts/verify/verify-forum-topic-audience-exact-read.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/docs/forum-20bc-topic-audience-transport-composition.md
+++ b/crates/rustok-forum/docs/forum-20bc-topic-audience-transport-composition.md
@@ -1,0 +1,73 @@
+# FORUM-20BC — exact topic audience transport composition
+
+`FORUM-20BC` composes the module-owned native and GraphQL selected-topic reads,
+and both authenticated mark-read transports, through the exact
+`ForumTopicAudienceReadService` delivered by `FORUM-20BB`.
+
+## Delivered boundary
+
+- `topic_read_audience_port_context` derives the exact tenant, authenticated user,
+  effective locale, route channel, permission claims, five-second read deadline,
+  and bounded correlation identity from trusted native or GraphQL transport
+  context. Topic IDs and locale remain request inputs; tenant and actor identity
+  cannot be selected by a storefront DTO.
+- `forumStorefrontAudienceTopic` is the module-owned GraphQL selected-topic field.
+  Public requests use the public owner viewer and do not call optional trust,
+  Channel, or Groups fact providers. Authenticated requests use the exact
+  `PortContext` and the host-published `SharedForumAudienceFactsPort` when a
+  still-required richer selector needs it.
+- The storefront GraphQL adapter now requests
+  `forumStorefrontAudienceTopic`. The older compatibility
+  `forumStorefrontTopic` field remains available but is no longer the
+  module-owned storefront selected-topic call site.
+- The native server function constructs the same public or authenticated owner
+  service from `HostRuntimeContext` and uses it for both an explicitly selected
+  topic and the first topic selected from the current list response.
+- `ForumStorefrontReadStateService::mark_topic_read_current_audience_visible`
+  reuses the exact topic owner before any read-state write. Native and GraphQL
+  mark-read transports both call this method with the same trusted context and
+  optional facts capability.
+- Missing, closed, route-channel denied, category-audience denied, topic-local
+  denied, and absent topics remain non-oracular. Replies are not requested or
+  returned when the exact selected-topic decision is unavailable.
+
+## Compatibility and degraded mode
+
+This slice adds no migration, dependency, request or response DTO field, route,
+OpenAPI shape, or UI state. Categories without richer audience layers preserve
+their previous behavior. Locally decidable roles and explicit-user rules do not
+need an optional provider. A still-required trust, Channel, or Groups fact fails
+closed when the host capability is absent.
+
+The legacy `ForumStorefrontReadStateService::mark_topic_read_current_visible`
+and the legacy GraphQL `forumStorefrontTopic` compatibility field remain for
+consumers that have not yet migrated. New module-owned storefront selected-topic
+and mark-read paths do not use them.
+
+## Explicitly not delivered
+
+`FORUM-20BC` does not migrate topic-list or unread-list pagination, exact reply
+or reply-list reads, category reads, search/index, SEO, deep links, or
+visibility-scoped category/all-read commands. Those remain bounded follow-up
+work beginning with `FORUM-20BD`.
+
+The canonical implementation plan and `CRATE_API.md` are not replaced through
+the GitHub contents API in this slice. That API requires complete-file
+replacement, and the canonical plan is multi-thousand-line; the conflict-safe
+repository-local documentation synchronization debt remains explicit in the
+machine contract.
+
+## Validation handoff
+
+The implementation agent did not run tests, Cargo commands, formatting,
+verifiers, workflows, or CI, per maintainer request.
+
+Suggested maintainer commands:
+
+```text
+cargo test -p rustok-forum topic_read_transport -- --nocapture
+cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture
+node scripts/verify/verify-forum-topic-audience-transport-composition.mjs
+node scripts/verify/verify-forum-topic-audience-exact-read.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -10,6 +10,7 @@ mod query;
 mod quote_commands;
 mod read_state;
 mod runtime_data;
+mod storefront_audience_topic;
 mod storefront_read_state;
 mod types;
 
@@ -46,6 +47,7 @@ pub struct ForumQuery(
     category_policy::ForumCategoryTopicPolicyQuery,
     read_state::ForumReadStateQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
+    storefront_audience_topic::ForumStorefrontAudienceTopicQuery,
 );
 
 #[derive(MergedObject, Default)]

--- a/crates/rustok-forum/src/graphql/runtime_data.rs
+++ b/crates/rustok-forum/src/graphql/runtime_data.rs
@@ -2,13 +2,17 @@ use rustok_api::graphql::GraphqlRuntimeInputs;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
-use crate::{ModerationService, ReplyService, SharedForumAudienceFactsPort, TopicService};
+use crate::{
+    ForumStorefrontReadStateService, ForumTopicAudienceReadService, ModerationService, ReplyService,
+    SharedForumAudienceFactsPort, TopicService,
+};
 
 /// Manifest-attached Forum GraphQL runtime capabilities.
 ///
 /// The optional facts port is published by the host runtime extension registry.
-/// Its absence is preserved so locally decidable create and moderation policies
-/// continue to work while trust, Channel, or Groups facts fail closed in owners.
+/// Its absence is preserved so locally decidable create, moderation, and read
+/// policies continue to work while trust, Channel, or Groups facts fail closed
+/// in owners.
 #[derive(Clone, Default)]
 pub struct ForumGraphqlRuntimeData {
     audience_facts: Option<SharedForumAudienceFactsPort>,
@@ -53,6 +57,30 @@ impl ForumGraphqlRuntimeData {
         match self.audience_facts.clone() {
             Some(facts) => ModerationService::with_audience_facts(db, event_bus, facts),
             None => ModerationService::new(db, event_bus),
+        }
+    }
+
+    pub(crate) fn topic_audience_read_service(
+        &self,
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> ForumTopicAudienceReadService {
+        match self.audience_facts.clone() {
+            Some(facts) => {
+                ForumTopicAudienceReadService::with_audience_facts(db, event_bus, facts)
+            }
+            None => ForumTopicAudienceReadService::new(db, event_bus),
+        }
+    }
+
+    pub(crate) fn storefront_read_state_service(
+        &self,
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> ForumStorefrontReadStateService {
+        match self.audience_facts.clone() {
+            Some(facts) => ForumStorefrontReadStateService::with_audience_facts(db, event_bus, facts),
+            None => ForumStorefrontReadStateService::new(db, event_bus),
         }
     }
 }

--- a/crates/rustok-forum/src/graphql/storefront_audience_topic.rs
+++ b/crates/rustok-forum/src/graphql/storefront_audience_topic.rs
@@ -1,0 +1,163 @@
+use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result};
+use rustok_api::{
+    AuthContext, RequestContext, TenantContext,
+    graphql::{GraphQLError, require_module_enabled, resolve_graphql_locale},
+};
+use rustok_channel::ChannelService;
+use rustok_core::SecurityContext;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{
+    ForumTopicReadOperation, ForumTopicReadTransport, TopicResponse,
+    topic_read_audience_port_context,
+};
+
+use super::{ForumGraphqlRuntimeData, GqlForumTopic};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub struct ForumStorefrontAudienceTopicQuery;
+
+#[Object]
+impl ForumStorefrontAudienceTopicQuery {
+    /// Exact module-owned storefront topic read through the canonical richer
+    /// category/topic audience owner. Missing and denied targets are both null.
+    async fn forum_storefront_audience_topic(
+        &self,
+        ctx: &Context<'_>,
+        id: Uuid,
+        tenant_id: Option<Uuid>,
+        locale: Option<String>,
+    ) -> Result<Option<GqlForumTopic>> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        require_public_forum_channel_enabled(ctx).await?;
+
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
+        let locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
+        let service = runtime.topic_audience_read_service(db.clone(), event_bus.clone());
+
+        let topic = if let Some(auth) = ctx.data_opt::<AuthContext>() {
+            let security = SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            );
+            let audience_context = topic_read_audience_port_context(
+                ForumTopicReadTransport::Graphql,
+                ForumTopicReadOperation::SelectedTopic,
+                tenant_id,
+                auth,
+                ctx.data_opt::<RequestContext>(),
+                locale.as_str(),
+            )?;
+            service
+                .get_authenticated_storefront_visible_with_audience_context(
+                    tenant_id,
+                    security,
+                    audience_context,
+                    id,
+                    Some(tenant.default_locale.as_str()),
+                )
+                .await?
+        } else {
+            service
+                .get_public_storefront_visible_with_locale_fallback(
+                    tenant_id,
+                    id,
+                    locale.as_str(),
+                    Some(tenant.default_locale.as_str()),
+                    public_channel_slug(ctx).as_deref(),
+                )
+                .await?
+        };
+
+        Ok(topic.map(map_topic_response))
+    }
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+async fn require_public_forum_channel_enabled(ctx: &Context<'_>) -> Result<()> {
+    if ctx.data_opt::<AuthContext>().is_some() {
+        return Ok(());
+    }
+
+    let Some(request_context) = ctx.data_opt::<RequestContext>() else {
+        return Ok(());
+    };
+    let Some(channel_id) = request_context.channel_id else {
+        return Ok(());
+    };
+
+    let db = ctx.data::<DatabaseConnection>()?;
+    let enabled = ChannelService::new(db.clone())
+        .is_module_enabled(channel_id, MODULE_SLUG)
+        .await
+        .map_err(|error| {
+            async_graphql::Error::new(format!("Channel module check failed: {error}"))
+                .extend_with(|_, ext| ext.set("code", "INTERNAL_SERVER_ERROR"))
+        })?;
+    if enabled {
+        return Ok(());
+    }
+
+    Err(
+        async_graphql::Error::new("Forum module is not enabled for this channel")
+            .extend_with(|_, ext| ext.set("code", "FORBIDDEN")),
+    )
+}
+
+fn public_channel_slug(ctx: &Context<'_>) -> Option<String> {
+    ctx.data_opt::<RequestContext>()
+        .and_then(|request| request.channel_slug.clone())
+}
+
+fn map_topic_response(topic: TopicResponse) -> GqlForumTopic {
+    GqlForumTopic {
+        id: topic.id,
+        requested_locale: topic.requested_locale,
+        locale: topic.locale,
+        effective_locale: topic.effective_locale,
+        available_locales: topic.available_locales,
+        category_id: topic.category_id,
+        author_id: topic.author_id,
+        author_profile: None,
+        title: topic.title,
+        slug: topic.slug,
+        body: topic.body,
+        body_format: topic.body_format,
+        content_json: topic.content_json,
+        metadata: topic.metadata,
+        status: topic.status,
+        tags: topic.tags,
+        channel_slugs: topic.channel_slugs,
+        vote_score: topic.vote_score,
+        current_user_vote: topic.current_user_vote,
+        is_subscribed: topic.is_subscribed,
+        solution_reply_id: topic.solution_reply_id,
+        is_pinned: topic.is_pinned,
+        is_locked: topic.is_locked,
+        reply_count: topic.reply_count,
+        created_at: topic.created_at,
+        updated_at: topic.updated_at,
+    }
+}

--- a/crates/rustok-forum/src/graphql/storefront_read_state.rs
+++ b/crates/rustok-forum/src/graphql/storefront_read_state.rs
@@ -9,9 +9,12 @@ use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::{
-    ForumError, ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumTopicReadState,
-    ListTopicsFilter,
+    ForumError, ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumTopicReadOperation,
+    ForumTopicReadState, ForumTopicReadTransport, ListTopicsFilter,
+    topic_read_audience_port_context,
 };
+
+use super::ForumGraphqlRuntimeData;
 
 const MODULE_SLUG: &str = "forum";
 const DEFAULT_STOREFRONT_UNREAD_LIMIT: u64 = 20;
@@ -124,17 +127,28 @@ impl ForumStorefrontReadStateMutation {
         )?;
         let tenant = ctx.data::<TenantContext>()?;
         let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
-        let request = ctx.data::<RequestContext>()?;
         let locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let audience_context = topic_read_audience_port_context(
+            ForumTopicReadTransport::Graphql,
+            ForumTopicReadOperation::MarkRead,
+            tenant_id,
+            &auth,
+            ctx.data_opt::<RequestContext>(),
+            locale.as_str(),
+        )?;
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
 
-        let state = match ForumStorefrontReadStateService::new(db.clone(), event_bus.clone())
-            .mark_topic_read_current_visible(
+        let state = match runtime
+            .storefront_read_state_service(db.clone(), event_bus.clone())
+            .mark_topic_read_current_audience_visible(
                 tenant_id,
                 topic_id,
                 forum_security(&auth),
-                locale.as_str(),
+                audience_context,
                 Some(tenant.default_locale.as_str()),
-                request.channel_slug.as_deref(),
             )
             .await
         {

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -28,6 +28,7 @@ pub mod services;
 pub mod state_machine;
 pub mod subscription;
 mod topic_create_transport;
+pub mod topic_read_transport;
 pub mod visibility;
 
 pub use audience::{
@@ -94,6 +95,9 @@ pub use services::{
 };
 pub use state_machine::{ReplyStatus, TopicStatus};
 pub use subscription::{ForumDigestMode, ForumSubscriptionLevel, ForumSubscriptionPreferences};
+pub use topic_read_transport::{
+    ForumTopicReadOperation, ForumTopicReadTransport, topic_read_audience_port_context,
+};
 pub use visibility::ForumCategoryVisibility;
 
 pub struct ForumModule;

--- a/crates/rustok-forum/src/services/storefront_read_state.rs
+++ b/crates/rustok-forum/src/services/storefront_read_state.rs
@@ -5,10 +5,11 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use rustok_api::{Action, Resource};
+use rustok_api::{Action, PortContext, Resource};
 use rustok_core::SecurityContext;
 use rustok_outbox::TransactionalEventBus;
 
+use crate::audience::SharedForumAudienceFactsPort;
 use crate::dto::{
     ListTopicsFilter, MAX_FORUM_READ_LIMIT, TopicListItem, TopicUnreadSummaryReadModel,
 };
@@ -19,6 +20,7 @@ use crate::services::read_model::ForumReadModelService;
 use crate::services::read_tracking::{
     ForumTopicReadState, ForumTopicReadStateService, MarkForumTopicReadInput,
 };
+use crate::services::topic_audience_read::ForumTopicAudienceReadService;
 use crate::services::topic_facade::TopicService;
 use crate::state_machine::ReplyStatus;
 
@@ -45,11 +47,32 @@ pub struct ForumStorefrontUnreadTopicPage {
 pub struct ForumStorefrontReadStateService {
     db: DatabaseConnection,
     event_bus: TransactionalEventBus,
+    audience_facts: Option<SharedForumAudienceFactsPort>,
 }
 
 impl ForumStorefrontReadStateService {
     pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
-        Self { db, event_bus }
+        Self::with_optional_audience_facts(db, event_bus, None)
+    }
+
+    pub fn with_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        audience_facts: SharedForumAudienceFactsPort,
+    ) -> Self {
+        Self::with_optional_audience_facts(db, event_bus, Some(audience_facts))
+    }
+
+    fn with_optional_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        audience_facts: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self {
+            db,
+            event_bus,
+            audience_facts,
+        }
     }
 
     /// Selects the storefront-visible topic page before enriching those exact IDs
@@ -110,8 +133,43 @@ impl ForumStorefrontReadStateService {
         Ok(ForumStorefrontUnreadTopicPage { items, total })
     }
 
-    /// Rechecks storefront visibility before marking the latest approved reply
-    /// position and immutable topic revision observed by the owner service.
+    /// Rechecks the exact richer audience decision before marking the latest
+    /// approved reply position and immutable topic revision observed by the owner.
+    pub async fn mark_topic_read_current_audience_visible(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<ForumTopicReadState> {
+        let service = match self.audience_facts.clone() {
+            Some(facts) => ForumTopicAudienceReadService::with_audience_facts(
+                self.db.clone(),
+                self.event_bus.clone(),
+                facts,
+            ),
+            None => ForumTopicAudienceReadService::new(self.db.clone(), self.event_bus.clone()),
+        };
+        let visible = service
+            .get_authenticated_storefront_visible_with_audience_context(
+                tenant_id,
+                security.clone(),
+                context,
+                topic_id,
+                fallback_locale,
+            )
+            .await?;
+        if visible.is_none() {
+            return Err(ForumError::TopicNotFound(topic_id));
+        }
+        self.mark_topic_read_current(tenant_id, topic_id, security)
+            .await
+    }
+
+    /// Compatibility path for consumers not yet migrated to richer audience
+    /// composition. New public transports must use
+    /// `mark_topic_read_current_audience_visible`.
     pub async fn mark_topic_read_current_visible(
         &self,
         tenant_id: Uuid,

--- a/crates/rustok-forum/src/topic_read_transport.rs
+++ b/crates/rustok-forum/src/topic_read_transport.rs
@@ -1,0 +1,234 @@
+use std::time::Duration;
+
+use rustok_api::{AuthContext, PortContext, RequestContext};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+const FORUM_TOPIC_READ_FACTS_DEADLINE: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForumTopicReadTransport {
+    Graphql,
+    NativeServer,
+}
+
+impl ForumTopicReadTransport {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Graphql => "graphql",
+            Self::NativeServer => "native",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForumTopicReadOperation {
+    SelectedTopic,
+    MarkRead,
+}
+
+impl ForumTopicReadOperation {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::SelectedTopic => "selected-topic",
+            Self::MarkRead => "mark-read",
+        }
+    }
+}
+
+/// Build the exact read-only caller context used by richer topic audience reads.
+///
+/// Tenant and user identity come only from authenticated transport extensions.
+/// Request DTOs never select either identity. The request snapshot, when
+/// available, must agree with the authenticated principal before an optional
+/// trust, Channel, or Groups facts provider can be called.
+pub fn topic_read_audience_port_context(
+    transport: ForumTopicReadTransport,
+    operation: ForumTopicReadOperation,
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request: Option<&RequestContext>,
+    effective_locale: &str,
+) -> ForumResult<PortContext> {
+    if tenant_id.is_nil() || auth.tenant_id != tenant_id {
+        return Err(ForumError::Validation(
+            "Forum topic-read authenticated tenant does not match the requested tenant"
+                .to_string(),
+        ));
+    }
+
+    if let Some(request) = request {
+        if request.tenant_id != tenant_id {
+            return Err(ForumError::Validation(
+                "Forum topic-read request tenant does not match the requested tenant".to_string(),
+            ));
+        }
+        if request.user_id != Some(auth.user_id) {
+            return Err(ForumError::Validation(
+                "Forum topic-read request actor does not match the authenticated user".to_string(),
+            ));
+        }
+    }
+
+    let locale = effective_locale.trim();
+    if locale.is_empty() {
+        return Err(ForumError::Validation(
+            "Forum topic-read request locale is unavailable".to_string(),
+        ));
+    }
+
+    let mut context = PortContext::new(
+        tenant_id.to_string(),
+        auth.port_actor(),
+        locale,
+        format!(
+            "forum-{}-{}-{}-{}",
+            transport.label(),
+            operation.label(),
+            auth.session_id,
+            Uuid::new_v4()
+        ),
+    )
+    .with_deadline(FORUM_TOPIC_READ_FACTS_DEADLINE);
+
+    for permission in &auth.permissions {
+        context = context.with_claim(permission.to_string());
+    }
+    if let Some(channel_slug) = request
+        .and_then(|request| request.channel_slug.as_deref())
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty())
+    {
+        context = context.with_channel(channel_slug.to_string());
+    }
+
+    Ok(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{Permission, PortActorKind};
+
+    use super::*;
+
+    fn auth(tenant_id: Uuid, user_id: Uuid) -> AuthContext {
+        AuthContext {
+            user_id,
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions: vec![Permission::FORUM_TOPICS_READ],
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn request(tenant_id: Uuid, user_id: Uuid) -> RequestContext {
+        RequestContext {
+            tenant_id,
+            user_id: Some(user_id),
+            channel_id: Some(Uuid::new_v4()),
+            channel_slug: Some("members".to_string()),
+            channel_resolution_source: None,
+            locale: "ru-RU".to_string(),
+        }
+    }
+
+    #[test]
+    fn exact_context_uses_authenticated_identity_deadline_claims_locale_and_channel() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+        let request = request(tenant_id, user_id);
+
+        let context = topic_read_audience_port_context(
+            ForumTopicReadTransport::NativeServer,
+            ForumTopicReadOperation::SelectedTopic,
+            tenant_id,
+            &auth,
+            Some(&request),
+            "de-DE",
+        )
+        .expect("trusted native context should compose");
+
+        assert_eq!(context.tenant_id, tenant_id.to_string());
+        assert_eq!(context.actor.kind, PortActorKind::User);
+        assert_eq!(context.actor.id, user_id.to_string());
+        assert_eq!(context.locale, "de-DE");
+        assert_eq!(context.channel.as_deref(), Some("members"));
+        assert_eq!(context.deadline_ms, Some(5_000));
+        assert_eq!(context.claims, vec![Permission::FORUM_TOPICS_READ.to_string()]);
+        assert!(
+            context
+                .correlation_id
+                .starts_with("forum-native-selected-topic-")
+        );
+    }
+
+    #[test]
+    fn graphql_context_without_http_request_preserves_effective_locale() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        let context = topic_read_audience_port_context(
+            ForumTopicReadTransport::Graphql,
+            ForumTopicReadOperation::MarkRead,
+            tenant_id,
+            &auth,
+            None,
+            "en",
+        )
+        .expect("GraphQL connection context should compose without an HTTP snapshot");
+
+        assert_eq!(context.locale, "en");
+        assert!(context.channel.is_none());
+        assert!(context.correlation_id.starts_with("forum-graphql-mark-read-"));
+    }
+
+    #[test]
+    fn mismatched_auth_request_tenant_or_user_fails_before_owner_facts() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        assert!(matches!(
+            topic_read_audience_port_context(
+                ForumTopicReadTransport::Graphql,
+                ForumTopicReadOperation::SelectedTopic,
+                Uuid::new_v4(),
+                &auth,
+                None,
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("authenticated tenant")
+        ));
+
+        let foreign_tenant_request = request(Uuid::new_v4(), user_id);
+        assert!(matches!(
+            topic_read_audience_port_context(
+                ForumTopicReadTransport::NativeServer,
+                ForumTopicReadOperation::SelectedTopic,
+                tenant_id,
+                &auth,
+                Some(&foreign_tenant_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request tenant")
+        ));
+
+        let foreign_user_request = request(tenant_id, Uuid::new_v4());
+        assert!(matches!(
+            topic_read_audience_port_context(
+                ForumTopicReadTransport::NativeServer,
+                ForumTopicReadOperation::MarkRead,
+                tenant_id,
+                &auth,
+                Some(&foreign_user_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request actor")
+        ));
+    }
+}

--- a/crates/rustok-forum/storefront/src/transport/graphql_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/graphql_adapter.rs
@@ -27,7 +27,7 @@ impl std::error::Error for ApiError {}
 const STOREFRONT_FORUM_CATEGORIES_QUERY: &str = "query StorefrontForumCategories($tenantId: UUID, $locale: String, $pagination: PaginationInput) { forumStorefrontCategories(tenantId: $tenantId, locale: $locale, pagination: $pagination) { total items { id effectiveLocale name slug description icon color topicCount replyCount } } }";
 const STOREFRONT_FORUM_TOPICS_QUERY: &str = "query StorefrontForumTopics($tenantId: UUID, $categoryId: UUID, $locale: String, $pagination: PaginationInput) { forumStorefrontTopics(tenantId: $tenantId, categoryId: $categoryId, locale: $locale, pagination: $pagination) { total items { id effectiveLocale categoryId title slug status isPinned isLocked replyCount createdAt } } }";
 const STOREFRONT_FORUM_UNREAD_TOPICS_QUERY: &str = "query StorefrontForumUnreadTopics($tenantId: UUID, $categoryId: UUID, $locale: String, $limit: Int) { forumStorefrontUnreadTopics(tenantId: $tenantId, categoryId: $categoryId, locale: $locale, limit: $limit) { total items { id effectiveLocale categoryId title slug status isPinned isLocked replyCount createdAt readStateExplicit lastReadPosition lastReadRevision unreadCount hasUnreadTopicRevision isUnread } } }";
-const STOREFRONT_FORUM_TOPIC_QUERY: &str = "query StorefrontForumTopic($tenantId: UUID, $id: UUID!, $locale: String) { forumStorefrontTopic(tenantId: $tenantId, id: $id, locale: $locale) { id effectiveLocale availableLocales categoryId title slug body bodyFormat status tags isPinned isLocked replyCount createdAt updatedAt } }";
+const STOREFRONT_FORUM_TOPIC_QUERY: &str = "query StorefrontForumTopic($tenantId: UUID, $id: UUID!, $locale: String) { forumStorefrontAudienceTopic(tenantId: $tenantId, id: $id, locale: $locale) { id effectiveLocale availableLocales categoryId title slug body bodyFormat status tags isPinned isLocked replyCount createdAt updatedAt } }";
 const STOREFRONT_FORUM_REPLIES_QUERY: &str = "query StorefrontForumReplies($tenantId: UUID, $topicId: UUID!, $locale: String, $pagination: PaginationInput) { forumStorefrontReplies(tenantId: $tenantId, topicId: $topicId, locale: $locale, pagination: $pagination) { total items { id effectiveLocale topicId content contentFormat status parentReplyId createdAt updatedAt } } }";
 const MARK_STOREFRONT_FORUM_TOPIC_READ_MUTATION: &str = "mutation MarkStorefrontForumTopicRead($tenantId: UUID, $topicId: UUID!, $locale: String) { markForumStorefrontTopicRead(tenantId: $tenantId, topicId: $topicId, locale: $locale) { topicId } }";
 
@@ -51,7 +51,7 @@ struct StorefrontForumUnreadTopicsResponse {
 
 #[derive(Debug, Deserialize)]
 struct StorefrontForumTopicResponse {
-    #[serde(rename = "forumStorefrontTopic")]
+    #[serde(rename = "forumStorefrontAudienceTopic")]
     forum_storefront_topic: Option<ForumTopicDetail>,
 }
 
@@ -304,21 +304,28 @@ pub async fn fetch_storefront_forum_graphql(
         }
     }
 
-    let replies = if let Some(topic_id) = resolved_topic_id.clone() {
-        let response: StorefrontForumRepliesResponse = request(
-            STOREFRONT_FORUM_REPLIES_QUERY,
-            RepliesVariables {
-                tenant_id: None,
-                topic_id,
-                locale,
-                pagination: PaginationInput {
-                    offset: 0,
-                    limit: 20,
+    let replies = if selected_topic.is_some() {
+        if let Some(topic_id) = resolved_topic_id.clone() {
+            let response: StorefrontForumRepliesResponse = request(
+                STOREFRONT_FORUM_REPLIES_QUERY,
+                RepliesVariables {
+                    tenant_id: None,
+                    topic_id,
+                    locale,
+                    pagination: PaginationInput {
+                        offset: 0,
+                        limit: 20,
+                    },
                 },
-            },
-        )
-        .await?;
-        response.forum_storefront_replies
+            )
+            .await?;
+            response.forum_storefront_replies
+        } else {
+            ForumReplyConnection {
+                items: Vec::new(),
+                total: 0,
+            }
+        }
     } else {
         ForumReplyConnection {
             items: Vec::new(),

--- a/crates/rustok-forum/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/native_server_adapter.rs
@@ -42,8 +42,9 @@ async fn storefront_forum_native(
         };
         use rustok_core::SecurityContext;
         use rustok_forum::{
-            CategoryService, ForumStorefrontReadStateService, ListRepliesFilter, ListTopicsFilter,
-            ReplyService, ReplyStatus, TopicService,
+            CategoryService, ForumStorefrontReadStateService, ForumTopicAudienceReadService,
+            ListRepliesFilter, ListTopicsFilter, ReplyService, ReplyStatus,
+            SharedForumAudienceFactsPort, TopicService,
         };
         use rustok_outbox::TransactionalEventBus;
 
@@ -53,7 +54,8 @@ async fn storefront_forum_native(
             .map_err(ServerFnError::new)?;
         let auth = leptos_axum::extract::<OptionalAuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(ServerFnError::new)?
+            .0;
         let request = leptos_axum::extract::<RequestContext>()
             .await
             .map_err(ServerFnError::new)?;
@@ -75,6 +77,16 @@ async fn storefront_forum_native(
         let category_service = CategoryService::new(db.clone());
         let topic_service = TopicService::new(db.clone(), event_bus.clone());
         let reply_service = ReplyService::new(db.clone(), event_bus.clone());
+        let topic_audience_service = match runtime_ctx
+            .shared_get::<SharedForumAudienceFactsPort>()
+        {
+            Some(facts) => ForumTopicAudienceReadService::with_audience_facts(
+                db.clone(),
+                event_bus.clone(),
+                facts,
+            ),
+            None => ForumTopicAudienceReadService::new(db.clone(), event_bus.clone()),
+        };
         let channel_slug = request.channel_slug.as_deref();
 
         let (categories, categories_total) = category_service
@@ -92,14 +104,14 @@ async fn storefront_forum_native(
         let requested_topic_id = parse_optional_uuid(selected_topic_id.as_deref(), "topic_id")?;
         let mut selected_topic = match requested_topic_id {
             Some(topic_id) => {
-                load_visible_topic(
-                    &topic_service,
+                load_audience_visible_topic(
+                    &topic_audience_service,
                     tenant.id,
-                    public_security.clone(),
+                    auth.as_ref(),
+                    &request,
                     topic_id,
                     effective_locale.as_str(),
                     tenant.default_locale.as_str(),
-                    channel_slug,
                 )
                 .await?
             }
@@ -119,7 +131,7 @@ async fn storefront_forum_native(
         };
 
         let (topic_items, topics_total, first_topic_id, read_state_available) = if let Some(auth) =
-            auth.0.filter(|auth| {
+            auth.as_ref().filter(|auth| {
                 has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_LIST])
             }) {
             let security =
@@ -164,14 +176,14 @@ async fn storefront_forum_native(
         let resolved_topic_id = requested_topic_id.or(first_topic_id);
         if selected_topic.is_none() {
             if let Some(topic_id) = resolved_topic_id {
-                selected_topic = load_visible_topic(
-                    &topic_service,
+                selected_topic = load_audience_visible_topic(
+                    &topic_audience_service,
                     tenant.id,
-                    public_security.clone(),
+                    auth.as_ref(),
+                    &request,
                     topic_id,
                     effective_locale.as_str(),
                     tenant.default_locale.as_str(),
-                    channel_slug,
                 )
                 .await?;
             }
@@ -239,7 +251,11 @@ async fn storefront_topic_mark_read_native(
     {
         use rustok_api::{HostRuntimeContext, OptionalAuthContext, RequestContext, TenantContext};
         use rustok_core::SecurityContext;
-        use rustok_forum::{ForumError, ForumStorefrontReadStateService};
+        use rustok_forum::{
+            ForumError, ForumStorefrontReadStateService, ForumTopicReadOperation,
+            ForumTopicReadTransport, SharedForumAudienceFactsPort,
+            topic_read_audience_port_context,
+        };
         use rustok_outbox::TransactionalEventBus;
 
         let runtime_ctx = expect_context::<HostRuntimeContext>();
@@ -271,15 +287,31 @@ async fn storefront_topic_mark_read_native(
         );
         let security =
             SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+        let audience_context = topic_read_audience_port_context(
+            ForumTopicReadTransport::NativeServer,
+            ForumTopicReadOperation::MarkRead,
+            tenant.id,
+            &auth,
+            Some(&request),
+            effective_locale.as_str(),
+        )
+        .map_err(server_error)?;
         let db = runtime_ctx.db_clone();
-        match ForumStorefrontReadStateService::new(db, event_bus)
-            .mark_topic_read_current_visible(
+        let service = match runtime_ctx.shared_get::<SharedForumAudienceFactsPort>() {
+            Some(facts) => ForumStorefrontReadStateService::with_audience_facts(
+                db,
+                event_bus,
+                facts,
+            ),
+            None => ForumStorefrontReadStateService::new(db, event_bus),
+        };
+        match service
+            .mark_topic_read_current_audience_visible(
                 tenant.id,
                 topic_id,
                 security,
-                effective_locale.as_str(),
+                audience_context,
                 Some(tenant.default_locale.as_str()),
-                request.channel_slug.as_deref(),
             )
             .await
         {
@@ -324,26 +356,51 @@ fn parse_optional_uuid(
 }
 
 #[cfg(feature = "ssr")]
-async fn load_visible_topic(
-    service: &rustok_forum::TopicService,
+async fn load_audience_visible_topic(
+    service: &rustok_forum::ForumTopicAudienceReadService,
     tenant_id: uuid::Uuid,
-    security: rustok_core::SecurityContext,
+    auth: Option<&rustok_api::AuthContext>,
+    request: &rustok_api::RequestContext,
     topic_id: uuid::Uuid,
     locale: &str,
     fallback_locale: &str,
-    channel_slug: Option<&str>,
 ) -> Result<Option<rustok_forum::TopicResponse>, ServerFnError> {
-    service
-        .get_storefront_visible_with_locale_fallback(
+    if let Some(auth) = auth {
+        let security = rustok_core::SecurityContext::from_permission_snapshot(
+            Some(auth.user_id),
+            &auth.permissions,
+        );
+        let context = rustok_forum::topic_read_audience_port_context(
+            rustok_forum::ForumTopicReadTransport::NativeServer,
+            rustok_forum::ForumTopicReadOperation::SelectedTopic,
             tenant_id,
-            security,
-            topic_id,
+            auth,
+            Some(request),
             locale,
-            Some(fallback_locale),
-            channel_slug,
         )
-        .await
-        .map_err(server_error)
+        .map_err(server_error)?;
+        service
+            .get_authenticated_storefront_visible_with_audience_context(
+                tenant_id,
+                security,
+                context,
+                topic_id,
+                Some(fallback_locale),
+            )
+            .await
+            .map_err(server_error)
+    } else {
+        service
+            .get_public_storefront_visible_with_locale_fallback(
+                tenant_id,
+                topic_id,
+                locale,
+                Some(fallback_locale),
+                request.channel_slug.as_deref(),
+            )
+            .await
+            .map_err(server_error)
+    }
 }
 
 #[cfg(feature = "ssr")]

--- a/scripts/verify/verify-forum-topic-audience-transport-composition.mjs
+++ b/scripts/verify/verify-forum-topic-audience-transport-composition.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath ?? "");
+  if (!relativePath || !existsSync(absolute)) {
+    failures.push(`${relativePath || "<missing path>"}: required file is missing`);
+    return "";
+  }
+  return readFileSync(absolute, "utf8");
+}
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function rejectText(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+function requireOrder(source, first, second, message) {
+  const firstIndex = source.indexOf(first);
+  const secondIndex = source.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex) {
+    failures.push(message);
+  }
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-topic-audience-transport-composition.json";
+const contract = JSON.parse(read(contractPath) || "{}");
+const context = read(contract.transport_context);
+const graphqlQuery = read(contract.graphql_query);
+const graphqlMarkRead = read(contract.graphql_mark_read);
+const graphqlRuntime = read(contract.graphql_runtime);
+const graphqlAdapter = read(contract.graphql_storefront_adapter);
+const nativeAdapter = read(contract.native_storefront_adapter);
+const readStateOwner = read(contract.read_state_owner);
+const ownerNote = read(contract.owner_note);
+const upstream = read(contract.upstream_contract);
+const crateRoot = read("crates/rustok-forum/src/lib.rs");
+const graphqlMod = read("crates/rustok-forum/src/graphql/mod.rs");
+
+if (
+  contract.schema_version !== 1 ||
+  contract.task !== "FORUM-20BC" ||
+  contract.upstream_task !== "FORUM-20BB" ||
+  contract.downstream_task !== "FORUM-20BD"
+) {
+  failures.push("FORUM-20BC contract identity is invalid");
+}
+
+for (const marker of [
+  "pub enum ForumTopicReadTransport",
+  "pub enum ForumTopicReadOperation",
+  "pub fn topic_read_audience_port_context(",
+  "const FORUM_TOPIC_READ_FACTS_DEADLINE: Duration = Duration::from_secs(5);",
+  "auth.tenant_id != tenant_id",
+  "request.user_id != Some(auth.user_id)",
+  ".with_deadline(FORUM_TOPIC_READ_FACTS_DEADLINE)",
+  "context = context.with_claim(permission.to_string())",
+  "context = context.with_channel(channel_slug.to_string())",
+]) {
+  requireText(context, marker, `topic read transport context is missing ${marker}`);
+}
+
+for (const marker of [
+  "async fn forum_storefront_audience_topic(",
+  "runtime.topic_audience_read_service",
+  "ForumTopicReadTransport::Graphql",
+  "ForumTopicReadOperation::SelectedTopic",
+  "get_authenticated_storefront_visible_with_audience_context",
+  "get_public_storefront_visible_with_locale_fallback",
+  "Ok(topic.map(map_topic_response))",
+]) {
+  requireText(graphqlQuery, marker, `GraphQL exact topic query is missing ${marker}`);
+}
+requireOrder(
+  graphqlQuery,
+  "topic_read_audience_port_context(",
+  "get_authenticated_storefront_visible_with_audience_context",
+  "GraphQL must build the trusted context before calling the authenticated owner",
+);
+
+for (const marker of [
+  "pub(crate) fn topic_audience_read_service(",
+  "pub(crate) fn storefront_read_state_service(",
+  "ForumTopicAudienceReadService::with_audience_facts",
+  "ForumStorefrontReadStateService::with_audience_facts",
+]) {
+  requireText(graphqlRuntime, marker, `GraphQL runtime composition is missing ${marker}`);
+}
+
+for (const marker of [
+  "mark_topic_read_current_audience_visible(",
+  "ForumTopicAudienceReadService::with_audience_facts",
+  "get_authenticated_storefront_visible_with_audience_context",
+  "return Err(ForumError::TopicNotFound(topic_id));",
+]) {
+  requireText(readStateOwner, marker, `audience-safe mark-read owner is missing ${marker}`);
+}
+requireOrder(
+  readStateOwner,
+  "get_authenticated_storefront_visible_with_audience_context",
+  "self.mark_topic_read_current(tenant_id, topic_id, security)",
+  "mark-read must authorize the exact target before writing read state",
+);
+
+for (const marker of [
+  "ForumTopicReadOperation::MarkRead",
+  "topic_read_audience_port_context(",
+  ".storefront_read_state_service(db.clone(), event_bus.clone())",
+  ".mark_topic_read_current_audience_visible(",
+]) {
+  requireText(graphqlMarkRead, marker, `GraphQL mark-read composition is missing ${marker}`);
+}
+rejectText(
+  graphqlMarkRead,
+  ".mark_topic_read_current_visible(",
+  "GraphQL mark-read still calls the compatibility visibility path",
+);
+
+for (const marker of [
+  "forumStorefrontAudienceTopic(tenantId: $tenantId, id: $id, locale: $locale)",
+  '#[serde(rename = "forumStorefrontAudienceTopic")]',
+  "if selected_topic.is_some()",
+  "markForumStorefrontTopicRead",
+]) {
+  requireText(graphqlAdapter, marker, `storefront GraphQL adapter is missing ${marker}`);
+}
+rejectText(
+  graphqlAdapter,
+  "{ forumStorefrontTopic(tenantId:",
+  "module-owned GraphQL adapter still requests the legacy selected-topic field",
+);
+
+for (const marker of [
+  "ForumTopicAudienceReadService::with_audience_facts",
+  "load_audience_visible_topic(",
+  "ForumTopicReadTransport::NativeServer",
+  "ForumTopicReadOperation::SelectedTopic",
+  "ForumTopicReadOperation::MarkRead",
+  ".mark_topic_read_current_audience_visible(",
+  "if selected_topic.is_some()",
+]) {
+  requireText(nativeAdapter, marker, `native storefront adapter is missing ${marker}`);
+}
+rejectText(
+  nativeAdapter,
+  ".mark_topic_read_current_visible(",
+  "native mark-read still calls the compatibility visibility path",
+);
+rejectText(
+  nativeAdapter,
+  ".get_storefront_visible_with_locale_fallback(",
+  "native selected-topic still calls the legacy visibility facade",
+);
+
+for (const marker of [
+  "pub mod topic_read_transport;",
+  "topic_read_audience_port_context",
+  "ForumTopicReadOperation",
+  "ForumTopicReadTransport",
+]) {
+  requireText(crateRoot, marker, `crate root is missing ${marker}`);
+}
+for (const marker of [
+  "mod storefront_audience_topic;",
+  "storefront_audience_topic::ForumStorefrontAudienceTopicQuery",
+]) {
+  requireText(graphqlMod, marker, `GraphQL module is missing ${marker}`);
+}
+
+for (const marker of [
+  "FORUM-20BC",
+  "ForumTopicAudienceReadService",
+  "forumStorefrontAudienceTopic",
+  "mark_topic_read_current_audience_visible",
+  "five-second read deadline",
+  "Replies are not requested or returned",
+  "FORUM-20BD",
+  "did not run tests",
+]) {
+  requireText(ownerNote, marker, `FORUM-20BC owner note is missing ${marker}`);
+}
+
+for (const marker of [
+  '"downstream_task": "FORUM-20BC"',
+  '"downstream_contract": "crates/rustok-forum/contracts/forum-topic-audience-transport-composition.json"',
+]) {
+  requireText(upstream, marker, `FORUM-20BB handoff is missing ${marker}`);
+}
+
+for (const [key, expected] of [
+  ["native_selected_topic_uses_exact_owner", true],
+  ["graphql_selected_topic_uses_exact_owner", true],
+  ["graphql_storefront_adapter_uses_exact_field", true],
+  ["native_mark_read_uses_exact_owner", true],
+  ["graphql_mark_read_uses_exact_owner", true],
+  ["authenticated_tenant_from_transport_context", true],
+  ["authenticated_actor_from_transport_context", true],
+  ["effective_locale_from_transport_context", true],
+  ["route_channel_from_transport_context", true],
+  ["claims_forwarded_to_owner_context", true],
+  ["five_second_read_deadline", true],
+  ["shared_optional_audience_facts_reused", true],
+  ["public_selected_topic_skips_optional_facts", true],
+  ["missing_and_denied_topic_non_oracular", true],
+  ["replies_not_loaded_after_selected_topic_denial", true],
+  ["topic_list_pagination_changed", false],
+  ["unread_list_visibility_changed", false],
+  ["reply_owner_read_changed", false],
+  ["category_owner_read_changed", false],
+  ["search_index_changed", false],
+  ["seo_changed", false],
+  ["deep_link_changed", false],
+  ["migration_added", false],
+  ["dependency_changed", false],
+  ["public_dto_changed", false],
+]) {
+  if (contract.transport_boundary?.[key] !== expected) {
+    failures.push(`FORUM-20BC transport_boundary.${key} must be ${expected}`);
+  }
+}
+
+if (
+  contract.documentation?.owner_note_updated !== true ||
+  contract.documentation?.upstream_contract_updated !== true ||
+  contract.documentation?.crate_api_updated !== false ||
+  contract.documentation?.canonical_plan_updated !== false ||
+  !contract.documentation?.synchronization_debt
+) {
+  failures.push("FORUM-20BC documentation handoff is incomplete");
+}
+
+if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+  failures.push("FORUM-20BC must not claim maintainer runtime execution");
+}
+
+if (failures.length > 0) {
+  console.error("Forum topic audience transport verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum topic audience transports are source-ready.");


### PR DESCRIPTION
## Summary

- add `FORUM-20BC` trusted topic-read transport context for selected-topic and mark-read operations
- compose a new GraphQL `forumStorefrontAudienceTopic` query through `ForumTopicAudienceReadService`
- switch the module-owned GraphQL storefront adapter to the exact richer-audience query
- compose native selected-topic reads through the same owner and host-published optional audience facts capability
- recheck exact richer visibility before native and GraphQL mark-read writes
- keep topic-list pagination, unread-list composition, reply/category reads, search/index, SEO, and deep links as explicit follow-up scope
- add a machine-readable contract, owner note, handoff update, and static verifier

## Recheck of prior work

PR #2413 (`FORUM-20BB`) was already merged. Its exact owner service and source-ready SQLite proof were reviewed; no review comments were outstanding. This PR completes its documented `FORUM-20BC` transport handoff.

## Compatibility

No migration, dependency, request DTO, response DTO, REST route, OpenAPI surface, or UI model changes are included. Existing compatibility resolvers remain available, while the module-owned storefront selected-topic and mark-read paths now use the exact richer owner boundary.

## Validation

Tests, formatting, Cargo commands, verifiers, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```text
cargo test -p rustok-forum topic_read_transport -- --nocapture
cargo test -p rustok-forum graphql::runtime_data -- --nocapture
node scripts/verify/verify-forum-topic-audience-transport-composition.mjs
node scripts/verify/verify-forum-topic-audience-exact-read.mjs
cargo xtask module validate forum
```

## Documentation debt

The canonical multi-thousand-line implementation plan and `CRATE_API.md` were not replaced through the GitHub Contents API. The new owner note and contract record `FORUM-20BC`; a repository-local documentation synchronization slice remains appropriate.