### PR TITLE
test(product): cover remote consumer behavior

### DIFF
--- a/crates/rustok-ai-product/contracts/ai-product-fba-registry.json
+++ b/crates/rustok-ai-product/contracts/ai-product-fba-registry.json
@@ -19,7 +19,8 @@
       ],
       "required_profiles": [
         "in_process",
-        "remote_adapter_placeholder"
+        "remote_adapter_placeholder",
+        "grpc_loopback"
       ],
       "fallback_profiles": [
         "embedded_native"
@@ -66,7 +67,24 @@
     "central_registry": "docs/modules/registry.md",
     "verifier": "scripts/verify/verify-ai-product-fba.mjs",
     "static_matrix": "crates/rustok-ai-product/contracts/evidence/ai-product-consumer-static-matrix.json",
-    "runtime_fallback_smoke": "crates/rustok-ai-product/contracts/evidence/ai-product-runtime-fallback-smoke.json"
+    "runtime_fallback_smoke": "crates/rustok-ai-product/contracts/evidence/ai-product-runtime-fallback-smoke.json",
+    "remote_consumer_behavior_verifier": "scripts/verify/verify-product-remote-consumer-behavior.mjs"
+  },
+  "remote_consumer_behavior": {
+    "status": "source_complete_execution_pending",
+    "profile": "grpc_loopback",
+    "source": "crates/rustok-ai/src/direct_product_attributes.rs",
+    "failure_profiles": [
+      "unavailable",
+      "timeout"
+    ],
+    "assertions": [
+      "generate_from_prompt_only",
+      "skip_catalog_enrichment",
+      "require_operator_review",
+      "persistence_none",
+      "typed_port_error_preserved"
+    ]
   },
   "contract_tests": {
     "status": "planned_cases_locked",

--- a/crates/rustok-ai-product/docs/implementation-plan.md
+++ b/crates/rustok-ai-product/docs/implementation-plan.md
@@ -27,7 +27,9 @@ for complete tenant, locale, and persistence validation.
 - Evidence: `crates/rustok-ai-product/contracts/ai-product-fba-registry.json`,
   `crates/rustok-ai-product/contracts/evidence/ai-product-consumer-static-matrix.json`,
   `crates/rustok-ai-product/contracts/evidence/ai-product-runtime-fallback-smoke.json`,
-  and `scripts/verify/verify-ai-product-fba.mjs`.
+  `crates/rustok-ai/src/direct_product_attributes.rs`,
+  `scripts/verify/verify-product-remote-consumer-behavior.mjs`, and
+  `scripts/verify/verify-ai-product-fba.mjs`.
 
 ## Completed direct-execution evidence
 
@@ -49,13 +51,25 @@ typed degraded reason, skips catalog enrichment, and still cannot write product
 data. Applying an attribute remains an explicit owner-owned operator action
 rather than an implicit AI write.
 
+A source-complete gRPC loopback harness now exercises the same product-context
+function through `GrpcProductCatalogReadProvider` and an external
+`ProductCatalogReadRuntime`. Remote `Unavailable` and `Timeout` errors preserve
+their typed code and retryability while catalog enrichment is skipped. The
+production result remains review-required and non-persistent. This harness has
+not been executed by the implementation agent, so it is recorded as
+`source_complete_execution_pending` rather than new runtime evidence.
+
 ## Next results
 
 1. **Keep generated-output safety covered.** Product-copy has direct
    owner-persistence evidence that preserves a non-target locale; product
    attributes are explicitly review-only and cannot write a product. Extend
    these tests whenever a product-owned apply command is introduced.
-2. **Composed product-agent workflow evidence is covered.**
+2. **Execute the remote Product consumer harness.** Run
+   `cargo test -p rustok-ai --features server --lib remote_product_` and retain
+   the result with Product transport evidence. Do not promote the remote profile
+   based on source completeness alone.
+3. **Composed product-agent workflow evidence is covered.**
    `service::product_agent_workflow_persistence_tests::product_enrichment_workflow_persists_owner_bindings_and_approval_gates`
    creates the product-owned principals and capability-compatible model
    assignments, validates both owner inputs, and proves the durable approval,
@@ -77,8 +91,11 @@ keeps product AI as an adapter and prevents a second product-owned AI route.
 
 - `npm run verify:ai-product:fba`
 - `npm run verify:ai:domain-verticals`
+- `node scripts/verify/verify-product-remote-consumer-behavior.mjs`
+- `node scripts/verify/verify-product-remote-consumer-behavior.test.mjs`
 - `cargo test -p rustok-ai-product --lib`
 - `cargo test -p rustok-ai --features server --lib direct_product_attributes_`
+- `cargo test -p rustok-ai --features server --lib remote_product_`
 
 ## References
 

--- a/crates/rustok-ai/Cargo.toml
+++ b/crates/rustok-ai/Cargo.toml
@@ -91,4 +91,7 @@ uuid.workspace = true
 [dev-dependencies]
 rust_decimal.workspace = true
 rustok-test-utils.workspace = true
+rustok-product-transport = { path = "../rustok-product-transport" }
 tokio.workspace = true
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic.workspace = true

--- a/crates/rustok-ai/src/direct_product_attributes.rs
+++ b/crates/rustok-ai/src/direct_product_attributes.rs
@@ -172,3 +172,202 @@ impl DirectTaskHandler for ProductAttributesHandler {
         })
     }
 }
+
+#[cfg(test)]
+mod remote_profile_tests {
+    use std::{sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use rustok_api::{PortActor, PortContext, PortError};
+    use rustok_core::ModuleRegistry;
+    use rustok_outbox::{OutboxTransport, TransactionalEventBus};
+    use rustok_product::{
+        ProductCatalogReadPort, ProductCatalogReadProfile, ProductCatalogReadRuntime,
+        ProductProjectionRequest, PublishedProductsRequest, StorefrontProductList,
+        VariantProductProjectionRequest, dto::ProductResponse,
+    };
+    use rustok_product_transport::{
+        GrpcProductCatalogReadProvider, ProductCatalogGrpcOperation, ProductCatalogGrpcService,
+        TrustedProductCatalogAuthority,
+        proto::product_catalog_read_service_server::ProductCatalogReadServiceServer,
+    };
+    use rustok_secrets::SecretResolverRegistry;
+    use sea_orm::Database;
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::{Endpoint, Server};
+    use uuid::Uuid;
+
+    use super::product_context;
+    use crate::engine::{AiProviderTargetCatalog, ProviderEgressPolicy};
+    use crate::service::{AiHostRuntime, AiOperatorContext};
+
+    #[derive(Clone, Copy)]
+    enum RemoteFailure {
+        Unavailable,
+        Timeout,
+    }
+
+    impl RemoteFailure {
+        fn port_error(self) -> PortError {
+            match self {
+                Self::Unavailable => PortError::unavailable(
+                    "product.remote_unavailable",
+                    "remote Product catalog is unavailable",
+                ),
+                Self::Timeout => PortError::timeout(
+                    "product.remote_timeout",
+                    "remote Product catalog deadline was exceeded",
+                ),
+            }
+        }
+
+        const fn expected_kind(self) -> &'static str {
+            match self {
+                Self::Unavailable => "unavailable",
+                Self::Timeout => "timeout",
+            }
+        }
+
+        const fn expected_code(self) -> &'static str {
+            match self {
+                Self::Unavailable => "product.remote_unavailable",
+                Self::Timeout => "product.remote_timeout",
+            }
+        }
+    }
+
+    struct FailingProductCatalogReadPort {
+        failure: RemoteFailure,
+    }
+
+    #[async_trait]
+    impl ProductCatalogReadPort for FailingProductCatalogReadPort {
+        async fn read_product_projection(
+            &self,
+            _context: PortContext,
+            _request: ProductProjectionRequest,
+        ) -> Result<ProductResponse, PortError> {
+            Err(self.failure.port_error())
+        }
+
+        async fn read_variant_product_projection(
+            &self,
+            _context: PortContext,
+            _request: VariantProductProjectionRequest,
+        ) -> Result<ProductResponse, PortError> {
+            Err(self.failure.port_error())
+        }
+
+        async fn list_published_products(
+            &self,
+            _context: PortContext,
+            _request: PublishedProductsRequest,
+        ) -> Result<StorefrontProductList, PortError> {
+            Err(self.failure.port_error())
+        }
+    }
+
+    async fn runtime_with_remote_failure(
+        tenant_id: Uuid,
+        failure: RemoteFailure,
+    ) -> (
+        AiHostRuntime,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("loopback Product listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("loopback Product listener address should exist");
+        let incoming = TcpListenerStream::new(listener);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let authority = TrustedProductCatalogAuthority::new(
+            tenant_id.to_string(),
+            PortActor::service("trusted-ai-remote-profile"),
+        )
+        .allow_operation(ProductCatalogGrpcOperation::ReadProductProjection);
+        let service = ProductCatalogReadServiceServer::with_interceptor(
+            ProductCatalogGrpcService::new(Arc::new(FailingProductCatalogReadPort { failure })),
+            move |mut request: tonic::Request<()>| {
+                request.extensions_mut().insert(authority.clone());
+                Ok(request)
+            },
+        );
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(service)
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("loopback Product gRPC server should run");
+        });
+        let provider = GrpcProductCatalogReadProvider::connect(
+            Endpoint::from_shared(format!("http://{address}"))
+                .expect("loopback Product endpoint should parse")
+                .connect_timeout(Duration::from_secs(5)),
+        )
+        .await
+        .expect("loopback Product gRPC client should connect");
+        let product_runtime = ProductCatalogReadRuntime::external(Arc::new(provider));
+        assert_eq!(
+            product_runtime.profile(),
+            ProductCatalogReadProfile::External
+        );
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory AI database should connect");
+        let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+        let runtime = AiHostRuntime::new(
+            db,
+            event_bus,
+            ModuleRegistry::default(),
+            SecretResolverRegistry::builder().build(),
+            ProviderEgressPolicy::default(),
+            AiProviderTargetCatalog::default(),
+        )
+        .with_product_catalog_read_port(Some(product_runtime.read_port()));
+        (runtime, shutdown_tx, server)
+    }
+
+    async fn assert_remote_failure_degrades_ai_enrichment(failure: RemoteFailure) {
+        let tenant_id = Uuid::new_v4();
+        let product_id = Uuid::new_v4();
+        let (runtime, shutdown_tx, server) = runtime_with_remote_failure(tenant_id, failure).await;
+        let operator = AiOperatorContext {
+            tenant_id,
+            user_id: Uuid::new_v4(),
+            permissions: Vec::new(),
+            role_slugs: vec!["ai-operator".to_string()],
+            preferred_locale: Some("en".to_string()),
+        };
+
+        let (product, metadata) = product_context(&runtime, &operator, "en", product_id).await;
+        let _ = shutdown_tx.send(());
+        server
+            .await
+            .expect("loopback Product gRPC server task should stop");
+
+        assert!(product.is_none());
+        assert_eq!(metadata["source"], "degraded");
+        assert_eq!(metadata["catalog_enrichment"], "skipped");
+        assert_eq!(metadata["errors"][0]["kind"], failure.expected_kind());
+        assert_eq!(metadata["errors"][0]["code"], failure.expected_code());
+        assert_eq!(metadata["errors"][0]["retryable"], true);
+        assert_eq!(metadata["deadline_ms"], 3_000);
+    }
+
+    #[tokio::test]
+    async fn remote_product_unavailable_degrades_ai_enrichment() {
+        assert_remote_failure_degrades_ai_enrichment(RemoteFailure::Unavailable).await;
+    }
+
+    #[tokio::test]
+    async fn remote_product_timeout_degrades_ai_enrichment() {
+        assert_remote_failure_degrades_ai_enrichment(RemoteFailure::Timeout).await;
+    }
+}

--- a/crates/rustok-commerce/Cargo.toml
+++ b/crates/rustok-commerce/Cargo.toml
@@ -56,6 +56,9 @@ proptest = "1.11"
 rust_decimal_macros = "1.36"
 rustok-taxonomy.workspace = true
 sea-orm-migration.workspace = true
+rustok-product-transport = { path = "../rustok-product-transport" }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic.workspace = true
 
 # `autotests = false` in [package] combined with explicit test targets below prevents
 # support/mod.rs from being auto-discovered as a standalone integration-test root. Without this
@@ -132,6 +135,10 @@ path = "tests/pricing_service_test/main.rs"
 [[test]]
 name = "product_event_index_integration_test"
 path = "tests/product_event_index_integration_test.rs"
+
+[[test]]
+name = "product_remote_consumer_behavior"
+path = "tests/product_remote_consumer_behavior.rs"
 
 [[test]]
 name = "product_taxonomy_tags"

--- a/crates/rustok-commerce/tests/product_remote_consumer_behavior.rs
+++ b/crates/rustok-commerce/tests/product_remote_consumer_behavior.rs
@@ -1,0 +1,289 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rust_decimal::Decimal;
+use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
+use rustok_cart::{
+    CartLineItemResponse, CartMarketplaceLineSnapshot, CartResponse,
+    ListMarketplaceCartLineSnapshotsRequest, MarketplaceCartSnapshotReadPort,
+    PreparedCartCheckoutSnapshot,
+};
+use rustok_commerce::{CheckoutError, CheckoutPlanBuilder, dto::CompleteCheckoutInput};
+use rustok_outbox::{OutboxTransport, TransactionalEventBus};
+use rustok_product::{
+    ProductCatalogReadPort, ProductCatalogReadProfile, ProductCatalogReadRuntime,
+    ProductProjectionRequest, PublishedProductsRequest, StorefrontProductList,
+    VariantProductProjectionRequest, dto::ProductResponse,
+};
+use rustok_product_transport::{
+    GrpcProductCatalogReadProvider, ProductCatalogGrpcOperation, ProductCatalogGrpcService,
+    TrustedProductCatalogAuthority,
+    proto::product_catalog_read_service_server::ProductCatalogReadServiceServer,
+};
+use sea_orm::Database;
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::{Endpoint, Server};
+use uuid::Uuid;
+
+#[derive(Clone, Copy)]
+enum RemoteFailure {
+    Unavailable,
+    Timeout,
+}
+
+impl RemoteFailure {
+    fn port_error(self) -> PortError {
+        match self {
+            Self::Unavailable => PortError::unavailable(
+                "product.remote_unavailable",
+                "remote Product catalog is unavailable",
+            ),
+            Self::Timeout => PortError::timeout(
+                "product.remote_timeout",
+                "remote Product catalog deadline was exceeded",
+            ),
+        }
+    }
+
+    const fn expected_kind(self) -> PortErrorKind {
+        match self {
+            Self::Unavailable => PortErrorKind::Unavailable,
+            Self::Timeout => PortErrorKind::Timeout,
+        }
+    }
+
+    const fn expected_code(self) -> &'static str {
+        match self {
+            Self::Unavailable => "product.remote_unavailable",
+            Self::Timeout => "product.remote_timeout",
+        }
+    }
+}
+
+struct FailingProductCatalogReadPort {
+    failure: RemoteFailure,
+}
+
+#[async_trait]
+impl ProductCatalogReadPort for FailingProductCatalogReadPort {
+    async fn read_product_projection(
+        &self,
+        _context: PortContext,
+        _request: ProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        Err(self.failure.port_error())
+    }
+
+    async fn read_variant_product_projection(
+        &self,
+        _context: PortContext,
+        _request: VariantProductProjectionRequest,
+    ) -> Result<ProductResponse, PortError> {
+        Err(self.failure.port_error())
+    }
+
+    async fn list_published_products(
+        &self,
+        _context: PortContext,
+        _request: PublishedProductsRequest,
+    ) -> Result<StorefrontProductList, PortError> {
+        Err(self.failure.port_error())
+    }
+}
+
+struct EmptyMarketplaceSnapshots;
+
+#[async_trait]
+impl MarketplaceCartSnapshotReadPort for EmptyMarketplaceSnapshots {
+    async fn list_marketplace_line_snapshots(
+        &self,
+        _context: PortContext,
+        _request: ListMarketplaceCartLineSnapshotsRequest,
+    ) -> Result<Vec<CartMarketplaceLineSnapshot>, PortError> {
+        Ok(Vec::new())
+    }
+}
+
+async fn remote_runtime(
+    tenant_id: Uuid,
+    failure: RemoteFailure,
+) -> (
+    ProductCatalogReadRuntime,
+    oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("loopback Product listener should bind");
+    let address = listener
+        .local_addr()
+        .expect("loopback Product listener address should exist");
+    let incoming = TcpListenerStream::new(listener);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let authority = TrustedProductCatalogAuthority::new(
+        tenant_id.to_string(),
+        PortActor::service("trusted-commerce-remote-profile"),
+    )
+    .allow_operations([
+        ProductCatalogGrpcOperation::ReadProductProjection,
+        ProductCatalogGrpcOperation::ReadVariantProductProjection,
+    ]);
+    let service = ProductCatalogReadServiceServer::with_interceptor(
+        ProductCatalogGrpcService::new(Arc::new(FailingProductCatalogReadPort { failure })),
+        move |mut request: tonic::Request<()>| {
+            request.extensions_mut().insert(authority.clone());
+            Ok(request)
+        },
+    );
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(incoming, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("loopback Product gRPC server should run");
+    });
+    let provider = GrpcProductCatalogReadProvider::connect(
+        Endpoint::from_shared(format!("http://{address}"))
+            .expect("loopback Product endpoint should parse")
+            .connect_timeout(Duration::from_secs(5)),
+    )
+    .await
+    .expect("loopback Product gRPC client should connect");
+    let runtime = ProductCatalogReadRuntime::external(Arc::new(provider));
+    assert_eq!(runtime.profile(), ProductCatalogReadProfile::External);
+    (runtime, shutdown_tx, server)
+}
+
+fn prepared_snapshot(tenant_id: Uuid, cart_id: Uuid, product_id: Uuid, variant_id: Uuid) -> PreparedCartCheckoutSnapshot {
+    let now = Utc::now();
+    let amount = Decimal::new(1000, 2);
+    let cart = CartResponse {
+        id: cart_id,
+        tenant_id,
+        channel_id: None,
+        channel_slug: Some("web".to_string()),
+        customer_id: None,
+        email: None,
+        region_id: None,
+        country_code: None,
+        locale_code: Some("en".to_string()),
+        selected_shipping_option_id: None,
+        status: "checking_out".to_string(),
+        currency_code: "USD".to_string(),
+        subtotal_amount: amount,
+        adjustment_total: Decimal::ZERO,
+        shipping_total: Decimal::ZERO,
+        total_amount: amount,
+        tax_total: Decimal::ZERO,
+        metadata: serde_json::json!({}),
+        created_at: now,
+        updated_at: now,
+        completed_at: None,
+        line_items: vec![CartLineItemResponse {
+            id: Uuid::new_v4(),
+            cart_id,
+            product_id: Some(product_id),
+            variant_id: Some(variant_id),
+            shipping_profile_slug: "default".to_string(),
+            seller_id: None,
+            seller_scope: None,
+            sku: Some("REMOTE-SKU".to_string()),
+            title: "Remote product".to_string(),
+            quantity: 1,
+            unit_price: amount,
+            total_price: amount,
+            currency_code: "USD".to_string(),
+            metadata: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        }],
+        adjustments: Vec::new(),
+        tax_lines: Vec::new(),
+        delivery_groups: Vec::new(),
+    };
+    PreparedCartCheckoutSnapshot {
+        cart,
+        shipping_address: None,
+        billing_address: None,
+        subtotal: amount,
+        discount_total: Decimal::ZERO,
+        tax_total: Decimal::ZERO,
+        total: amount,
+        snapshot_hash: "remote-product-consumer-snapshot".to_string(),
+        projection_hash: "remote-product-consumer-projection".to_string(),
+        status: "checking_out".to_string(),
+        locked: true,
+        delivery_groups: Vec::new(),
+        tax_context: None,
+        updated_at: now.fixed_offset(),
+    }
+}
+
+async fn assert_remote_failure_blocks_checkout(failure: RemoteFailure) {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let cart_id = Uuid::new_v4();
+    let product_id = Uuid::new_v4();
+    let variant_id = Uuid::new_v4();
+    let (product_runtime, shutdown_tx, server) = remote_runtime(tenant_id, failure).await;
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("in-memory Commerce database should connect");
+    let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+    let builder = CheckoutPlanBuilder::new(
+        db.clone(),
+        Arc::new(rustok_region::RegionService::new(db.clone())),
+        rustok_inventory::in_process_inventory_reservation_port(db, event_bus),
+        product_runtime.read_port(),
+    )
+    .with_marketplace_snapshot_read_port(Arc::new(EmptyMarketplaceSnapshots));
+    let snapshot = prepared_snapshot(tenant_id, cart_id, product_id, variant_id);
+    let input = CompleteCheckoutInput {
+        cart_id,
+        shipping_option_id: None,
+        shipping_selections: None,
+        region_id: None,
+        country_code: None,
+        locale: Some("en".to_string()),
+        create_fulfillment: false,
+        metadata: serde_json::json!({}),
+    };
+
+    let result = builder
+        .build(tenant_id, actor_id, Uuid::new_v4(), &input, &snapshot)
+        .await;
+    let _ = shutdown_tx.send(());
+    server
+        .await
+        .expect("loopback Product gRPC server task should stop");
+
+    match result.expect_err("remote Product failure must block checkout planning") {
+        CheckoutError::BoundaryFailure {
+            stage,
+            kind,
+            code,
+            retryable,
+            ..
+        } => {
+            assert_eq!(stage, "read_checkout_product_projection");
+            assert_eq!(kind, failure.expected_kind());
+            assert_eq!(code, failure.expected_code());
+            assert!(retryable);
+        }
+        error => panic!("expected Product boundary failure, got {error:?}"),
+    }
+}
+
+#[tokio::test]
+async fn remote_product_unavailable_blocks_checkout_without_snapshot_fallback() {
+    assert_remote_failure_blocks_checkout(RemoteFailure::Unavailable).await;
+}
+
+#[tokio::test]
+async fn remote_product_timeout_blocks_checkout_without_snapshot_fallback() {
+    assert_remote_failure_blocks_checkout(RemoteFailure::Timeout).await;
+}

--- a/crates/rustok-commerce/tests/product_remote_consumer_behavior.rs
+++ b/crates/rustok-commerce/tests/product_remote_consumer_behavior.rs
@@ -158,7 +158,12 @@ async fn remote_runtime(
     (runtime, shutdown_tx, server)
 }
 
-fn prepared_snapshot(tenant_id: Uuid, cart_id: Uuid, product_id: Uuid, variant_id: Uuid) -> PreparedCartCheckoutSnapshot {
+fn prepared_snapshot(
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    product_id: Uuid,
+    variant_id: Uuid,
+) -> PreparedCartCheckoutSnapshot {
     let now = Utc::now();
     let amount = Decimal::new(1000, 2);
     let cart = CartResponse {
@@ -180,8 +185,8 @@ fn prepared_snapshot(tenant_id: Uuid, cart_id: Uuid, product_id: Uuid, variant_i
         total_amount: amount,
         tax_total: Decimal::ZERO,
         metadata: serde_json::json!({}),
-        created_at: now,
-        updated_at: now,
+        created_at: now.clone(),
+        updated_at: now.clone(),
         completed_at: None,
         line_items: vec![CartLineItemResponse {
             id: Uuid::new_v4(),
@@ -198,8 +203,8 @@ fn prepared_snapshot(tenant_id: Uuid, cart_id: Uuid, product_id: Uuid, variant_i
             total_price: amount,
             currency_code: "USD".to_string(),
             metadata: serde_json::json!({}),
-            created_at: now,
-            updated_at: now,
+            created_at: now.clone(),
+            updated_at: now.clone(),
         }],
         adjustments: Vec::new(),
         tax_lines: Vec::new(),

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -59,6 +59,7 @@
     "graphql_checkout_runtime_verifier": "scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs",
     "grpc_transport_verifier": "scripts/verify/verify-product-catalog-grpc-transport.mjs",
     "grpc_deployment_verifier": "scripts/verify/verify-product-catalog-grpc-deployment.mjs",
+    "remote_consumer_behavior_verifier": "scripts/verify/verify-product-remote-consumer-behavior.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
     "runtime_fallback_smoke": "crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json",
@@ -97,6 +98,24 @@
     "provider_selector_env": "RUSTOK_PRODUCT_CATALOG_PROVIDER",
     "endpoint_env": "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
     "status": "runtime_wired_execution_pending"
+  },
+  "remote_consumer_behavior": {
+    "status": "source_complete_execution_pending",
+    "transport_profile": "grpc_loopback_external_runtime",
+    "commerce_test": "crates/rustok-commerce/tests/product_remote_consumer_behavior.rs",
+    "ai_source_test": "crates/rustok-ai/src/direct_product_attributes.rs",
+    "failure_profiles": [
+      "unavailable",
+      "timeout"
+    ],
+    "assertions": [
+      "commerce_hard_dependency_no_cart_snapshot_fallback",
+      "commerce_typed_boundary_error_preserved",
+      "ai_catalog_enrichment_skipped",
+      "ai_typed_degraded_error_preserved",
+      "ai_operator_review_required",
+      "ai_persistence_none"
+    ]
   },
   "in_process_provider_impl": {
     "service": "CatalogService",

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -54,10 +54,10 @@ typed degraded metadata. The production handler still requires operator review
 and performs no persistence. These harnesses have not been executed by the
 implementation agent.
 
-Adapter, production-wiring, and consumer-behavior source are complete, but the
-loopback conformance and remote consumer harnesses have not been run by the
-implementation agent, so Product remains `boundary_ready` rather than
-`transport_verified`.
+Adapter and production-wiring source are complete. Consumer-behavior source is
+also complete, but the loopback conformance and remote consumer harnesses have
+not been run by the implementation agent, so Product remains `boundary_ready`
+rather than `transport_verified`.
 
 The composed `rustok-ai` consumer has existing unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -42,12 +42,24 @@ WebPKI TLS roots. The server connects before `bootstrap_app_runtime`, inserts
 `ProductCatalogReadRuntime::external(...)` into `ServerRuntimeContext`, and lets
 all existing composition surfaces reuse that same runtime. Invalid remote
 configuration or connection failure aborts startup and never silently falls back
-to embedded execution. Adapter and production-wiring source are complete, but
-neither the loopback harness nor a configured remote server execution has been
-run by the implementation agent, so Product remains `boundary_ready` rather than
+to embedded execution.
+
+Remote consumer behavior is now source-complete through executable loopback
+harnesses. Commerce builds checkout plans with a real external gRPC runtime and
+asserts that remote `Unavailable` and `Timeout` errors remain typed, retryable
+`read_checkout_product_projection` boundary failures; it never substitutes the
+cart line snapshot for current Product authority. AI uses the same real gRPC
+adapter and asserts that both failures skip catalog enrichment while preserving
+typed degraded metadata. The production handler still requires operator review
+and performs no persistence. These harnesses have not been executed by the
+implementation agent.
+
+Adapter, production-wiring, and consumer-behavior source are complete, but the
+loopback conformance and remote consumer harnesses have not been run by the
+implementation agent, so Product remains `boundary_ready` rather than
 `transport_verified`.
 
-The composed `rustok-ai` consumer has live unavailable/deadline degraded-path
+The composed `rustok-ai` consumer has existing unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
 claim a cart-snapshot fallback that does not exist. The port resolves
 variant-first consumer input to the owning product projection, so consumers do
@@ -139,13 +151,16 @@ rustok-pricing` dependency cycle.
   the core/transport/UI split and native/GraphQL parity.
 - FBA status: `boundary_ready` — the owner port, in-process profile, host runtime,
   declared consumer source cutovers, external gRPC adapter, validated connection
-  policy, and production host wiring are source-complete. Loopback and configured
-  remote-profile execution evidence remain open.
+  policy, production host wiring, and Commerce/AI remote behavior harnesses are
+  source-complete. Loopback and configured remote-profile execution evidence
+  remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-fallback-smoke.json`,
   `crates/rustok-product-transport/tests/port_conformance.rs`,
+  `crates/rustok-commerce/tests/product_remote_consumer_behavior.rs`,
+  `crates/rustok-ai/src/direct_product_attributes.rs`,
   `scripts/verify/verify-product-runtime-fallback-smoke.mjs`,
   `scripts/verify/verify-product-catalog-read-runtime-composition.mjs`,
   `scripts/verify/verify-product-native-checkout-catalog-runtime.mjs`,
@@ -153,6 +168,7 @@ rustok-pricing` dependency cycle.
   `scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-catalog-grpc-transport.mjs`,
   `scripts/verify/verify-product-catalog-grpc-deployment.mjs`,
+  `scripts/verify/verify-product-remote-consumer-behavior.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
   `scripts/verify/verify-product-storefront-boundary.mjs`,
@@ -163,12 +179,15 @@ rustok-pricing` dependency cycle.
 
 ## Open results
 
-1. Execute `cargo test -p rustok-product-transport --test port_conformance` and
-   retain its result plus the generated `Cargo.lock` package entry as external
-   transport evidence. Then start the server with the gRPC deployment variables
-   against a real Product catalog service and execute Commerce hard-dependency
-   plus AI degraded behavior through the selected remote runtime. Promote above
-   `boundary_ready` only with retained runtime evidence for those paths.
+1. Execute and retain the external runtime evidence:
+   - `cargo test -p rustok-product-transport --test port_conformance`;
+   - `cargo test -p rustok-commerce --test product_remote_consumer_behavior`;
+   - `cargo test -p rustok-ai --features server --lib remote_product_`.
+   Retain the generated `Cargo.lock` package entry with the first successful Cargo
+   execution. Then start the server with the gRPC deployment variables against a
+   separately running Product catalog service and retain end-to-end Commerce and
+   AI evidence through the selected runtime. Promote above `boundary_ready` only
+   with those retained results.
 2. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
@@ -185,8 +204,10 @@ rustok-pricing` dependency cycle.
 - [x] Cut mounted Commerce GraphQL checkout over to the composed Product runtime.
 - [x] Implement the concrete Product catalog gRPC adapter and loopback conformance harness.
 - [x] Wire a fail-closed production external Product runtime profile.
+- [x] Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses.
 - [ ] Execute the Product catalog gRPC loopback conformance harness.
-- [ ] Execute Commerce and AI behavior through a configured remote Product runtime.
+- [ ] Execute the Commerce and AI remote consumer behavior harnesses.
+- [ ] Retain end-to-end Commerce and AI behavior through a separately configured Product service.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
 - [x] Connect storefront title search through typed UI state, native/GraphQL transports, and Product-owned server-side filtering.
 - [x] Connect storefront category and deterministic date sorting through typed UI state, native/GraphQL transports, and Product-owned server-side execution.
@@ -204,7 +225,11 @@ rustok-pricing` dependency cycle.
 - `node scripts/verify/verify-product-catalog-grpc-transport.test.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-deployment.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-deployment.test.mjs`
+- `node scripts/verify/verify-product-remote-consumer-behavior.mjs`
+- `node scripts/verify/verify-product-remote-consumer-behavior.test.mjs`
 - `cargo test -p rustok-product-transport --test port_conformance`
+- `cargo test -p rustok-commerce --test product_remote_consumer_behavior`
+- `cargo test -p rustok-ai --features server --lib remote_product_`
 - `node scripts/verify/verify-product-catalog-attribute-filters.mjs`
 - `node scripts/verify/verify-product-catalog-attribute-filters.test.mjs`
 - `node scripts/verify/verify-product-admin-category-sort.mjs`
@@ -231,6 +256,11 @@ rustok-pricing` dependency cycle.
   connection, and insertion of the selected runtime. It must fail closed for an
   invalid or unavailable configured remote provider and must not silently select
   embedded execution.
+- Commerce owns hard-dependency checkout behavior: a Product timeout or
+  unavailable result blocks planning and cannot be replaced by the cart snapshot.
+- AI owns advisory degradation: Product transport failures skip enrichment,
+  preserve typed degraded metadata, require operator review, and never persist
+  generated suggestions automatically.
 - The host selects and shares one Product read runtime; consumers receive the
   public port and must not construct parallel owner services.
 - Order native checkout, Commerce HTTP checkout, mounted Commerce GraphQL

--- a/scripts/verify/verify-product-remote-consumer-behavior.mjs
+++ b/scripts/verify/verify-product-remote-consumer-behavior.mjs
@@ -44,6 +44,10 @@ const registrySource = read(
   "crates/rustok-product/contracts/product-fba-registry.json",
 );
 const plan = read("crates/rustok-product/docs/implementation-plan.md");
+const aiProductRegistrySource = read(
+  "crates/rustok-ai-product/contracts/ai-product-fba-registry.json",
+);
+const aiProductPlan = read("crates/rustok-ai-product/docs/implementation-plan.md");
 
 requireAll(commerceCargo, [
   'rustok-product-transport = { path = "../rustok-product-transport" }',
@@ -160,6 +164,56 @@ if (registry) {
   }
 }
 
+let aiProductRegistry;
+try {
+  aiProductRegistry = JSON.parse(aiProductRegistrySource);
+} catch (error) {
+  failures.push(`AI-product FBA registry is invalid JSON: ${error.message}`);
+}
+if (aiProductRegistry) {
+  if (aiProductRegistry.status !== "boundary_ready") {
+    failures.push("AI-product must remain boundary_ready before remote behavior execution evidence");
+  }
+  const dependency = aiProductRegistry.provider_dependencies?.find(
+    (entry) => entry.module === "product",
+  );
+  if (!dependency?.required_profiles?.includes("grpc_loopback")) {
+    failures.push("AI-product Product dependency must include grpc_loopback");
+  }
+  const behavior = aiProductRegistry.remote_consumer_behavior ?? {};
+  if (behavior.status !== "source_complete_execution_pending") {
+    failures.push("AI-product remote behavior must remain source_complete_execution_pending");
+  }
+  if (behavior.profile !== "grpc_loopback") {
+    failures.push("AI-product remote behavior must identify grpc_loopback");
+  }
+  if (behavior.source !== "crates/rustok-ai/src/direct_product_attributes.rs") {
+    failures.push("AI-product remote behavior must identify the capability handler source");
+  }
+  for (const failureProfile of ["unavailable", "timeout"]) {
+    if (!behavior.failure_profiles?.includes(failureProfile)) {
+      failures.push(`AI-product remote behavior must include ${failureProfile}`);
+    }
+  }
+  for (const assertion of [
+    "generate_from_prompt_only",
+    "skip_catalog_enrichment",
+    "require_operator_review",
+    "persistence_none",
+    "typed_port_error_preserved",
+  ]) {
+    if (!behavior.assertions?.includes(assertion)) {
+      failures.push(`AI-product remote behavior must assert ${assertion}`);
+    }
+  }
+  if (
+    aiProductRegistry.evidence?.remote_consumer_behavior_verifier !==
+    "scripts/verify/verify-product-remote-consumer-behavior.mjs"
+  ) {
+    failures.push("AI-product registry must link the remote consumer behavior verifier");
+  }
+}
+
 requireAll(plan, [
   "Remote consumer behavior is now source-complete through executable loopback",
   "it never substitutes the",
@@ -174,6 +228,15 @@ requireAll(plan, [
   "cargo test -p rustok-ai --features server --lib remote_product_",
   "verify-product-remote-consumer-behavior.mjs",
 ], "Product remote consumer implementation plan");
+requireAll(aiProductPlan, [
+  "A source-complete gRPC loopback harness now exercises the same product-context",
+  "Remote `Unavailable` and `Timeout` errors preserve",
+  "review-required and non-persistent",
+  "source_complete_execution_pending",
+  "Execute the remote Product consumer harness",
+  "cargo test -p rustok-ai --features server --lib remote_product_",
+  "verify-product-remote-consumer-behavior.mjs",
+], "AI-product remote consumer implementation plan");
 
 if (failures.length > 0) {
   console.error("Product remote consumer behavior verification failed:");

--- a/scripts/verify/verify-product-remote-consumer-behavior.mjs
+++ b/scripts/verify/verify-product-remote-consumer-behavior.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required remote Product consumer behavior file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireAll(source, markers, description) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+  }
+}
+
+function forbidAll(source, markers, description) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
+  }
+}
+
+const commerceCargo = read("crates/rustok-commerce/Cargo.toml");
+const commerceBehavior = read(
+  "crates/rustok-commerce/tests/product_remote_consumer_behavior.rs",
+);
+const checkoutPlan = read(
+  "crates/rustok-commerce/src/services/checkout_plan_builder.rs",
+);
+const aiCargo = read("crates/rustok-ai/Cargo.toml");
+const aiBehavior = read("crates/rustok-ai/src/direct_product_attributes.rs");
+const registrySource = read(
+  "crates/rustok-product/contracts/product-fba-registry.json",
+);
+const plan = read("crates/rustok-product/docs/implementation-plan.md");
+
+requireAll(commerceCargo, [
+  'rustok-product-transport = { path = "../rustok-product-transport" }',
+  'tokio-stream = { version = "0.1", features = ["net"] }',
+  "tonic.workspace = true",
+  'name = "product_remote_consumer_behavior"',
+  'path = "tests/product_remote_consumer_behavior.rs"',
+], "Commerce remote behavior test registration");
+requireAll(commerceBehavior, [
+  "ProductCatalogReadServiceServer::with_interceptor",
+  "ProductCatalogGrpcService::new",
+  "GrpcProductCatalogReadProvider::connect",
+  "ProductCatalogReadRuntime::external",
+  "ProductCatalogReadProfile::External",
+  "CheckoutPlanBuilder::new",
+  ".build(tenant_id, actor_id, Uuid::new_v4(), &input, &snapshot)",
+  "CheckoutError::BoundaryFailure",
+  'assert_eq!(stage, "read_checkout_product_projection")',
+  '"product.remote_unavailable"',
+  '"product.remote_timeout"',
+  "assert!(retryable)",
+  "remote_product_unavailable_blocks_checkout_without_snapshot_fallback",
+  "remote_product_timeout_blocks_checkout_without_snapshot_fallback",
+], "Commerce remote Product hard-dependency harness");
+forbidAll(commerceBehavior, [
+  "CatalogService::new",
+  "fallback_to_cart_snapshot",
+  "use_cart_snapshot_fallback",
+], "Commerce remote Product fallback ownership");
+requireAll(checkoutPlan, [
+  "self.product_catalog_read_port",
+  ".read_product_projection(",
+  ".read_variant_product_projection(",
+  'boundary_error("read_checkout_product_projection", error)',
+], "Commerce checkout Product boundary");
+
+requireAll(aiCargo, [
+  'rustok-product-transport = { path = "../rustok-product-transport" }',
+  'tokio-stream = { version = "0.1", features = ["net"] }',
+  "tonic.workspace = true",
+], "AI remote behavior test dependencies");
+requireAll(aiBehavior, [
+  "mod remote_profile_tests",
+  "ProductCatalogReadServiceServer::with_interceptor",
+  "ProductCatalogGrpcService::new",
+  "GrpcProductCatalogReadProvider::connect",
+  "ProductCatalogReadRuntime::external",
+  "ProductCatalogReadProfile::External",
+  "runtime_with_remote_failure",
+  "remote_product_unavailable_degrades_ai_enrichment",
+  "remote_product_timeout_degrades_ai_enrichment",
+  '"product.remote_unavailable"',
+  '"product.remote_timeout"',
+  'assert_eq!(metadata["source"], "degraded")',
+  'assert_eq!(metadata["catalog_enrichment"], "skipped")',
+  'assert_eq!(metadata["errors"][0]["retryable"], true)',
+  '"review_required": true',
+  '"persistence": "none"',
+], "AI remote Product degraded-behavior harness");
+forbidAll(aiBehavior, [
+  "CatalogService::new",
+  "persist_generated_attributes",
+  "fallback_to_product_storage",
+], "AI remote Product advisory boundary");
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  if (registry.status !== "boundary_ready") {
+    failures.push("Product must remain boundary_ready before remote behavior execution evidence");
+  }
+  if (registry.external_transport?.status !== "runtime_wired_execution_pending") {
+    failures.push("Product external transport status must remain runtime_wired_execution_pending");
+  }
+  const behavior = registry.remote_consumer_behavior ?? {};
+  if (behavior.status !== "source_complete_execution_pending") {
+    failures.push("remote consumer behavior must remain source_complete_execution_pending");
+  }
+  if (
+    behavior.commerce_test !==
+    "crates/rustok-commerce/tests/product_remote_consumer_behavior.rs"
+  ) {
+    failures.push("remote consumer registry must identify the Commerce harness");
+  }
+  if (behavior.ai_source_test !== "crates/rustok-ai/src/direct_product_attributes.rs") {
+    failures.push("remote consumer registry must identify the AI source harness");
+  }
+  for (const failureProfile of ["unavailable", "timeout"]) {
+    if (!behavior.failure_profiles?.includes(failureProfile)) {
+      failures.push(`remote consumer behavior must include ${failureProfile}`);
+    }
+  }
+  for (const assertion of [
+    "commerce_hard_dependency_no_cart_snapshot_fallback",
+    "commerce_typed_boundary_error_preserved",
+    "ai_catalog_enrichment_skipped",
+    "ai_typed_degraded_error_preserved",
+    "ai_operator_review_required",
+    "ai_persistence_none",
+  ]) {
+    if (!behavior.assertions?.includes(assertion)) {
+      failures.push(`remote consumer behavior must assert ${assertion}`);
+    }
+  }
+  if (
+    registry.evidence?.remote_consumer_behavior_verifier !==
+    "scripts/verify/verify-product-remote-consumer-behavior.mjs"
+  ) {
+    failures.push("Product registry must link the remote consumer behavior verifier");
+  }
+}
+
+requireAll(plan, [
+  "Remote consumer behavior is now source-complete through executable loopback",
+  "it never substitutes the",
+  "cart line snapshot for current Product authority",
+  "both failures skip catalog enrichment",
+  "requires operator review",
+  "performs no persistence",
+  "Product remains `boundary_ready`",
+  "Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses",
+  "Execute the Commerce and AI remote consumer behavior harnesses",
+  "cargo test -p rustok-commerce --test product_remote_consumer_behavior",
+  "cargo test -p rustok-ai --features server --lib remote_product_",
+  "verify-product-remote-consumer-behavior.mjs",
+], "Product remote consumer implementation plan");
+
+if (failures.length > 0) {
+  console.error("Product remote consumer behavior verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Product remote consumer behavior source verification passed");

--- a/scripts/verify/verify-product-remote-consumer-behavior.test.mjs
+++ b/scripts/verify/verify-product-remote-consumer-behavior.test.mjs
@@ -98,6 +98,49 @@ function fixture(options = {}) {
       : "Remote consumer behavior is now source-complete through executable loopback harnesses. Commerce it never substitutes the cart line snapshot for current Product authority. AI both failures skip catalog enrichment, requires operator review, and performs no persistence. Product remains `boundary_ready`. Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses. Execute the Commerce and AI remote consumer behavior harnesses. cargo test -p rustok-commerce --test product_remote_consumer_behavior cargo test -p rustok-ai --features server --lib remote_product_ verify-product-remote-consumer-behavior.mjs",
   );
 
+  const aiProductProfiles = options.missingGrpcProfile
+    ? ["in_process", "remote_adapter_placeholder"]
+    : ["in_process", "remote_adapter_placeholder", "grpc_loopback"];
+  write(
+    root,
+    "crates/rustok-ai-product/contracts/ai-product-fba-registry.json",
+    JSON.stringify({
+      status: "boundary_ready",
+      provider_dependencies: [
+        {
+          module: "product",
+          required_profiles: aiProductProfiles,
+        },
+      ],
+      evidence: {
+        remote_consumer_behavior_verifier:
+          "scripts/verify/verify-product-remote-consumer-behavior.mjs",
+      },
+      remote_consumer_behavior: {
+        status: options.staleAiStatus
+          ? "runtime_verified"
+          : "source_complete_execution_pending",
+        profile: "grpc_loopback",
+        source: "crates/rustok-ai/src/direct_product_attributes.rs",
+        failure_profiles: ["unavailable", "timeout"],
+        assertions: [
+          "generate_from_prompt_only",
+          "skip_catalog_enrichment",
+          "require_operator_review",
+          "persistence_none",
+          "typed_port_error_preserved",
+        ],
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-ai-product/docs/implementation-plan.md",
+    options.missingAiProductPlan
+      ? "AI-product plan"
+      : "A source-complete gRPC loopback harness now exercises the same product-context function. Remote `Unavailable` and `Timeout` errors preserve typed behavior. The production result remains review-required and non-persistent. source_complete_execution_pending. Execute the remote Product consumer harness. cargo test -p rustok-ai --features server --lib remote_product_. verify-product-remote-consumer-behavior.mjs",
+  );
+
   return root;
 }
 
@@ -154,6 +197,18 @@ test("guard rejects false Product promotion", () => {
   reject({ falsePromotion: true }, /remain boundary_ready/);
 });
 
-test("guard rejects missing implementation-plan handoff", () => {
+test("guard rejects missing AI-product gRPC profile", () => {
+  reject({ missingGrpcProfile: true }, /must include grpc_loopback/);
+});
+
+test("guard rejects false AI-product runtime evidence", () => {
+  reject({ staleAiStatus: true }, /AI-product remote behavior must remain/);
+});
+
+test("guard rejects missing Product implementation-plan handoff", () => {
   reject({ missingPlan: true }, /Product remote consumer implementation plan/);
+});
+
+test("guard rejects missing AI-product implementation-plan handoff", () => {
+  reject({ missingAiProductPlan: true }, /AI-product remote consumer implementation plan/);
 });

--- a/scripts/verify/verify-product-remote-consumer-behavior.test.mjs
+++ b/scripts/verify/verify-product-remote-consumer-behavior.test.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-remote-consumer-behavior.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-remote-consumers-"));
+
+  write(
+    root,
+    "crates/rustok-commerce/Cargo.toml",
+    `rustok-product-transport = { path = "../rustok-product-transport" }\ntokio-stream = { version = "0.1", features = ["net"] }\ntonic.workspace = true\n[[test]]\nname = "product_remote_consumer_behavior"\npath = "tests/product_remote_consumer_behavior.rs"`,
+  );
+  const commerceTimeout = options.missingCommerceTimeout
+    ? ""
+    : `"product.remote_timeout" remote_product_timeout_blocks_checkout_without_snapshot_fallback`;
+  const fakeFallback = options.cartSnapshotFallback
+    ? "fallback_to_cart_snapshot"
+    : "";
+  write(
+    root,
+    "crates/rustok-commerce/tests/product_remote_consumer_behavior.rs",
+    `ProductCatalogReadServiceServer::with_interceptor ProductCatalogGrpcService::new GrpcProductCatalogReadProvider::connect ProductCatalogReadRuntime::external ProductCatalogReadProfile::External CheckoutPlanBuilder::new .build(tenant_id, actor_id, Uuid::new_v4(), &input, &snapshot) CheckoutError::BoundaryFailure assert_eq!(stage, "read_checkout_product_projection") "product.remote_unavailable" ${commerceTimeout} assert!(retryable) remote_product_unavailable_blocks_checkout_without_snapshot_fallback ${fakeFallback}`,
+  );
+  write(
+    root,
+    "crates/rustok-commerce/src/services/checkout_plan_builder.rs",
+    `self.product_catalog_read_port .read_product_projection( .read_variant_product_projection( boundary_error("read_checkout_product_projection", error)`,
+  );
+
+  write(
+    root,
+    "crates/rustok-ai/Cargo.toml",
+    `rustok-product-transport = { path = "../rustok-product-transport" }\ntokio-stream = { version = "0.1", features = ["net"] }\ntonic.workspace = true`,
+  );
+  const aiReview = options.missingAiReview ? "" : `"review_required": true`;
+  const aiTimeout = options.missingAiTimeout
+    ? ""
+    : `"product.remote_timeout" remote_product_timeout_degrades_ai_enrichment`;
+  write(
+    root,
+    "crates/rustok-ai/src/direct_product_attributes.rs",
+    `mod remote_profile_tests ProductCatalogReadServiceServer::with_interceptor ProductCatalogGrpcService::new GrpcProductCatalogReadProvider::connect ProductCatalogReadRuntime::external ProductCatalogReadProfile::External runtime_with_remote_failure remote_product_unavailable_degrades_ai_enrichment ${aiTimeout} "product.remote_unavailable" assert_eq!(metadata["source"], "degraded") assert_eq!(metadata["catalog_enrichment"], "skipped") assert_eq!(metadata["errors"][0]["retryable"], true) ${aiReview} "persistence": "none"`,
+  );
+
+  const falsePromotion = options.falsePromotion === true;
+  const staleStatus = options.staleStatus === true;
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      status: falsePromotion ? "transport_verified" : "boundary_ready",
+      evidence: {
+        remote_consumer_behavior_verifier:
+          "scripts/verify/verify-product-remote-consumer-behavior.mjs",
+      },
+      external_transport: {
+        status: "runtime_wired_execution_pending",
+      },
+      remote_consumer_behavior: {
+        status: staleStatus
+          ? "executed"
+          : "source_complete_execution_pending",
+        commerce_test:
+          "crates/rustok-commerce/tests/product_remote_consumer_behavior.rs",
+        ai_source_test: "crates/rustok-ai/src/direct_product_attributes.rs",
+        failure_profiles: ["unavailable", "timeout"],
+        assertions: [
+          "commerce_hard_dependency_no_cart_snapshot_fallback",
+          "commerce_typed_boundary_error_preserved",
+          "ai_catalog_enrichment_skipped",
+          "ai_typed_degraded_error_preserved",
+          "ai_operator_review_required",
+          "ai_persistence_none",
+        ],
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.missingPlan
+      ? "Product plan"
+      : "Remote consumer behavior is now source-complete through executable loopback harnesses. Commerce it never substitutes the cart line snapshot for current Product authority. AI both failures skip catalog enrichment, requires operator review, and performs no persistence. Product remains `boundary_ready`. Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses. Execute the Commerce and AI remote consumer behavior harnesses. cargo test -p rustok-commerce --test product_remote_consumer_behavior cargo test -p rustok-ai --features server --lib remote_product_ verify-product-remote-consumer-behavior.mjs",
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected remote consumer mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("remote consumer behavior guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("guard rejects missing Commerce timeout behavior", () => {
+  reject({ missingCommerceTimeout: true }, /Commerce remote Product hard-dependency harness/);
+});
+
+test("guard rejects cart snapshot fallback", () => {
+  reject({ cartSnapshotFallback: true }, /Commerce remote Product fallback ownership/);
+});
+
+test("guard rejects missing AI timeout degradation", () => {
+  reject({ missingAiTimeout: true }, /AI remote Product degraded-behavior harness/);
+});
+
+test("guard rejects missing AI operator review", () => {
+  reject({ missingAiReview: true }, /AI remote Product degraded-behavior harness/);
+});
+
+test("guard rejects stale executed status without evidence", () => {
+  reject({ staleStatus: true }, /source_complete_execution_pending/);
+});
+
+test("guard rejects false Product promotion", () => {
+  reject({ falsePromotion: true }, /remain boundary_ready/);
+});
+
+test("guard rejects missing implementation-plan handoff", () => {
+  reject({ missingPlan: true }, /Product remote consumer implementation plan/);
+});


### PR DESCRIPTION
## Summary
- add executable loopback gRPC behavior harnesses for Commerce and AI Product consumers
- prove Commerce treats remote Product unavailable/timeout as typed hard-dependency failures without cart snapshot fallback
- prove AI preserves advisory degraded behavior for the same remote failures with operator review and no persistence
- synchronize Product and ai-product FBA registries and implementation plans
- add source/mutation guardrails while keeping Product at `boundary_ready` and execution evidence pending

## Verification
Not run by the implementation agent per maintainer instruction.

Suggested commands:
- `cargo test -p rustok-commerce --test product_remote_consumer_behavior`
- `cargo test -p rustok-ai --features server --lib remote_product_`
- `node scripts/verify/verify-product-remote-consumer-behavior.mjs`
- `node scripts/verify/verify-product-remote-consumer-behavior.test.mjs`
- `npm run verify:ai-product:fba`
- `npm run verify:ecommerce:fba`