### PR TITLE
feat(product): authenticate catalog gRPC calls

### DIFF
--- a/apps/server/src/services/product_catalog_deployment.rs
+++ b/apps/server/src/services/product_catalog_deployment.rs
@@ -1,10 +1,11 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use crate::error::{Error, Result};
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
 const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER";
 const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT";
+const GRPC_BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN";
 const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN";
 const CONNECT_TIMEOUT_MS_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS";
 const ALLOW_INSECURE_LOOPBACK_ENV: &str =
@@ -17,9 +18,29 @@ enum ProductCatalogDeployment {
     Grpc(ProductCatalogGrpcDeployment),
 }
 
+#[derive(Clone, Eq, PartialEq)]
+struct ProductCatalogBearerSecret(String);
+
+impl ProductCatalogBearerSecret {
+    fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    fn expose(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Debug for ProductCatalogBearerSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED]")
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct ProductCatalogGrpcDeployment {
     endpoint: String,
+    bearer_token: ProductCatalogBearerSecret,
     tls_domain: Option<String>,
     connect_timeout_ms: u64,
     allow_insecure_loopback: bool,
@@ -27,21 +48,30 @@ struct ProductCatalogGrpcDeployment {
 
 /// Selects and connects the deployment-owned Product catalog provider before host composition.
 ///
-/// The default is the embedded owner service. When `grpc` is selected, invalid configuration or
-/// connection failure aborts startup; the server never silently falls back to embedded execution.
+/// The default is the embedded owner service. When `grpc` is selected, invalid configuration,
+/// authentication, or connection failure aborts startup; the server never silently falls back to
+/// embedded execution.
 pub async fn configure_product_catalog_deployment(ctx: &ServerRuntimeContext) -> Result<()> {
     #[cfg(feature = "mod-product")]
     {
         use std::sync::Arc;
 
         use rustok_product::ProductCatalogReadRuntime;
-        use rustok_product_transport::GrpcProductCatalogReadConnectionConfig;
+        use rustok_product_transport::{
+            GrpcProductCatalogReadConnectionConfig, ProductCatalogGrpcBearerToken,
+        };
 
         let deployment = deployment_from_environment().map_err(Error::Message)?;
         let ProductCatalogDeployment::Grpc(remote) = deployment else {
             return Ok(());
         };
 
+        let authentication = ProductCatalogGrpcBearerToken::new(remote.bearer_token.expose())
+            .map_err(|error| {
+                Error::Message(format!(
+                    "remote Product catalog authentication configuration failed: {error}"
+                ))
+            })?;
         let provider = GrpcProductCatalogReadConnectionConfig::new(remote.endpoint)
             .with_tls_domain(remote.tls_domain)
             .with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms))
@@ -52,11 +82,13 @@ pub async fn configure_product_catalog_deployment(ctx: &ServerRuntimeContext) ->
                 Error::Message(format!(
                     "remote Product catalog provider initialization failed: {error}"
                 ))
-            })?;
+            })?
+            .with_authentication(authentication);
         ctx.shared_insert(ProductCatalogReadRuntime::external(Arc::new(provider)));
 
         tracing::info!(
             provider = "grpc",
+            authentication = "bearer",
             insecure_loopback = remote.allow_insecure_loopback,
             "Product catalog deployment provider initialized"
         );
@@ -74,6 +106,7 @@ fn deployment_from_environment() -> std::result::Result<ProductCatalogDeployment
     parse_deployment(
         optional_env(PROVIDER_ENV).as_deref(),
         optional_env(GRPC_ENDPOINT_ENV).as_deref(),
+        optional_secret_env(GRPC_BEARER_TOKEN_ENV).as_deref(),
         optional_env(TLS_DOMAIN_ENV).as_deref(),
         optional_env(CONNECT_TIMEOUT_MS_ENV).as_deref(),
         optional_env(ALLOW_INSECURE_LOOPBACK_ENV).as_deref(),
@@ -83,6 +116,7 @@ fn deployment_from_environment() -> std::result::Result<ProductCatalogDeployment
 fn parse_deployment(
     provider: Option<&str>,
     endpoint: Option<&str>,
+    bearer_token: Option<&str>,
     tls_domain: Option<&str>,
     connect_timeout_ms: Option<&str>,
     allow_insecure_loopback: Option<&str>,
@@ -93,6 +127,9 @@ fn parse_deployment(
         .unwrap_or("embedded")
         .to_ascii_lowercase();
     let endpoint = normalize_optional(endpoint);
+    let bearer_token = bearer_token
+        .filter(|value| !value.is_empty())
+        .map(|value| ProductCatalogBearerSecret::new(value.to_string()));
     let tls_domain = normalize_optional(tls_domain);
     let timeout = parse_timeout(connect_timeout_ms)?;
     let allow_insecure_loopback_is_configured = allow_insecure_loopback
@@ -104,6 +141,7 @@ fn parse_deployment(
     match provider.as_str() {
         "embedded" => {
             if endpoint.is_some()
+                || bearer_token.is_some()
                 || tls_domain.is_some()
                 || connect_timeout_ms.is_some()
                 || allow_insecure_loopback_is_configured
@@ -118,9 +156,13 @@ fn parse_deployment(
             let endpoint = endpoint.ok_or_else(|| {
                 format!("{GRPC_ENDPOINT_ENV} is required when {PROVIDER_ENV}=grpc")
             })?;
+            let bearer_token = bearer_token.ok_or_else(|| {
+                format!("{GRPC_BEARER_TOKEN_ENV} is required when {PROVIDER_ENV}=grpc")
+            })?;
             Ok(ProductCatalogDeployment::Grpc(
                 ProductCatalogGrpcDeployment {
                     endpoint,
+                    bearer_token,
                     tls_domain,
                     connect_timeout_ms: timeout,
                     allow_insecure_loopback,
@@ -165,23 +207,51 @@ fn optional_env(name: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn optional_secret_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ProductCatalogDeployment, ProductCatalogGrpcDeployment, parse_deployment};
+    use super::{
+        ProductCatalogBearerSecret, ProductCatalogDeployment, ProductCatalogGrpcDeployment,
+        parse_deployment,
+    };
 
     #[test]
     fn embedded_is_the_default() {
         assert_eq!(
-            parse_deployment(None, None, None, None, None).unwrap(),
+            parse_deployment(None, None, None, None, None, None).unwrap(),
             ProductCatalogDeployment::Embedded
         );
     }
 
     #[test]
     fn grpc_requires_an_endpoint() {
-        let error = parse_deployment(Some("grpc"), None, None, None, None)
-            .expect_err("remote Product deployment without endpoint must fail closed");
+        let error = parse_deployment(
+            Some("grpc"),
+            None,
+            Some("catalog-secret"),
+            None,
+            None,
+            None,
+        )
+        .expect_err("remote Product deployment without endpoint must fail closed");
         assert!(error.contains("RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT"));
+    }
+
+    #[test]
+    fn grpc_requires_a_bearer_token() {
+        let error = parse_deployment(
+            Some("grpc"),
+            Some("https://product-catalog.internal"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("remote Product deployment without credential must fail closed");
+        assert!(error.contains("RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN"));
     }
 
     #[test]
@@ -190,6 +260,7 @@ mod tests {
             parse_deployment(
                 Some("grpc"),
                 Some("https://product-catalog.internal:7443"),
+                Some("catalog-secret"),
                 Some("product-catalog.internal"),
                 Some("2500"),
                 Some("false"),
@@ -197,11 +268,28 @@ mod tests {
             .unwrap(),
             ProductCatalogDeployment::Grpc(ProductCatalogGrpcDeployment {
                 endpoint: "https://product-catalog.internal:7443".to_string(),
+                bearer_token: ProductCatalogBearerSecret::new("catalog-secret"),
                 tls_domain: Some("product-catalog.internal".to_string()),
                 connect_timeout_ms: 2500,
                 allow_insecure_loopback: false,
             })
         );
+    }
+
+    #[test]
+    fn bearer_secret_debug_is_redacted() {
+        let deployment = parse_deployment(
+            Some("grpc"),
+            Some("https://product-catalog.internal:7443"),
+            Some("catalog-secret"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let debug = format!("{deployment:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("catalog-secret"));
     }
 
     #[test]
@@ -212,15 +300,37 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .expect_err("remote Product variables in embedded mode must be rejected");
         assert!(error.contains("require RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc"));
     }
 
     #[test]
+    fn bearer_token_is_not_silently_ignored_in_embedded_mode() {
+        let error = parse_deployment(
+            Some("embedded"),
+            None,
+            Some("catalog-secret"),
+            None,
+            None,
+            None,
+        )
+        .expect_err("remote Product credential in embedded mode must be rejected");
+        assert!(error.contains("require RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc"));
+    }
+
+    #[test]
     fn explicit_loopback_flag_is_not_silently_ignored_in_embedded_mode() {
-        let error = parse_deployment(Some("embedded"), None, None, None, Some("false"))
-            .expect_err("explicit remote loopback configuration must require grpc mode");
+        let error = parse_deployment(
+            Some("embedded"),
+            None,
+            None,
+            None,
+            None,
+            Some("false"),
+        )
+        .expect_err("explicit remote loopback configuration must require grpc mode");
         assert!(error.contains("require RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc"));
     }
 
@@ -229,6 +339,7 @@ mod tests {
         let error = parse_deployment(
             Some("grpc"),
             Some("https://product-catalog.internal"),
+            Some("catalog-secret"),
             None,
             None,
             Some("maybe"),

--- a/crates/rustok-product-transport/Cargo.toml
+++ b/crates/rustok-product-transport/Cargo.toml
@@ -14,6 +14,7 @@ rustok-api.workspace = true
 rustok-product.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 subtle = "2"
 thiserror.workspace = true
 tonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }

--- a/crates/rustok-product-transport/Cargo.toml
+++ b/crates/rustok-product-transport/Cargo.toml
@@ -14,10 +14,12 @@ rustok-api.workspace = true
 rustok-product.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+subtle = "2"
 thiserror.workspace = true
 tonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }
 tonic-prost.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 protoc-bin-vendored.workspace = true
@@ -27,4 +29,3 @@ tonic-prost-build.workspace = true
 chrono.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
-uuid.workspace = true

--- a/crates/rustok-product-transport/README.md
+++ b/crates/rustok-product-transport/README.md
@@ -52,4 +52,4 @@ node scripts/verify/verify-product-catalog-grpc-authentication.mjs
 node scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
 ```
 
-The implementation agent does not claim these commands were executed. Until retained execution evidence exists, Product remains `boundary_ready`.
+The implementation agent does not claim this command was executed, and does not claim the authentication verifier commands were executed. Until retained execution evidence exists, Product remains `boundary_ready`.

--- a/crates/rustok-product-transport/README.md
+++ b/crates/rustok-product-transport/README.md
@@ -6,6 +6,8 @@ Typed tonic gRPC framing for the Product-owned `ProductCatalogReadPort`.
 
 - `GrpcProductCatalogReadProvider` implements the owner port for consumers.
 - `GrpcProductCatalogReadConnectionConfig` validates and opens production client connections.
+- `ProductCatalogGrpcBearerToken` stores a prevalidated, debug-redacted service credential.
+- `ProductCatalogGrpcBearerInterceptor` authenticates bearer and tenant metadata before installing trusted authority.
 - `ProductCatalogGrpcService<P>` exposes an owner-port provider over gRPC.
 - `TrustedProductCatalogAuthority` carries interceptor-authenticated tenant and principal authority.
 - `ProductCatalogGrpcOperation` declares the three authorized read operations.
@@ -13,9 +15,11 @@ Typed tonic gRPC framing for the Product-owned `ProductCatalogReadPort`.
 
 ## Boundary
 
-This crate owns protobuf/tonic framing, transport deadlines, gRPC status mapping, connection validation, and trusted-authority adaptation. It does not own Product DTOs, catalog policy, persistence, locale/channel semantics, fallback decisions, or consumer composition.
+This crate owns protobuf/tonic framing, transport deadlines, gRPC status mapping, connection validation, service authentication, and trusted-authority adaptation. It does not own Product DTOs, catalog policy, persistence, locale/channel semantics, fallback decisions, or consumer composition.
 
-Protobuf frames JSON-serialized Product-owned request/response types and `rustok_api::PortContext`. The server verifies the claimed tenant against interceptor authority and replaces untrusted actor, claims, and roles before invoking the owner port. Structured `PortError` values are carried in gRPC status details.
+Protobuf frames JSON-serialized Product-owned request/response types and `rustok_api::PortContext`. An authenticated client sends `Authorization: Bearer ...` and `x-rustok-tenant-id` metadata for each RPC. The server compares the complete authorization value in constant time, validates the tenant as a UUID, installs a configured trusted service actor, verifies the claimed tenant against that authority, and replaces untrusted actor, claims, and roles before invoking the owner port. Structured `PortError` values are carried in gRPC status details.
+
+The bearer credential is a deployment secret. Its `Debug` representation is redacted, authentication failures never echo it, and production deployments must deliver it through secret management rather than source control or endpoint URLs. TLS and authentication solve separate problems: production connections still require HTTPS, while the token establishes caller identity.
 
 Production connections require an absolute HTTPS service endpoint without credentials, path, query, or fragment. Plain HTTP is accepted only for an explicitly enabled loopback address. Connect timeout is limited to 1–30000 milliseconds.
 
@@ -24,12 +28,14 @@ Production connections require an absolute HTTPS service endpoint without creden
 The RusToK server selects the Product catalog provider once at startup:
 
 - `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded` is the default;
-- `RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc` requires `RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT`;
+- `RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc` requires both `RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT` and `RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN`;
 - `RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN` optionally overrides TLS SNI/domain validation;
 - `RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS` defaults to `5000`;
 - `RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true` permits only loopback HTTP for local execution.
 
-Remote variables are rejected in embedded mode. Invalid remote configuration or connection failure stops startup; the host does not silently fall back to the embedded provider.
+All remote variables, including the bearer token, are rejected in embedded mode. Invalid authentication configuration, remote connection failure, or invalid transport configuration stops startup; the host does not silently fall back to the embedded provider.
+
+The future standalone Product catalog service host must use `ProductCatalogGrpcBearerInterceptor` (or an equivalent stronger authenticator that installs `TrustedProductCatalogAuthority`) and configure its trusted service actor server-side. The caller-supplied actor in `PortContext` is never authoritative.
 
 ## Evidence
 
@@ -39,4 +45,11 @@ The loopback conformance harness covers all three owner operations, typed not-fo
 cargo test -p rustok-product-transport --test port_conformance
 ```
 
-The implementation agent does not claim this command was executed. Until retained execution evidence exists, Product remains `boundary_ready`.
+Authentication source and mutation guards are available separately:
+
+```bash
+node scripts/verify/verify-product-catalog-grpc-authentication.mjs
+node scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
+```
+
+The implementation agent does not claim these commands were executed. Until retained execution evidence exists, Product remains `boundary_ready`.

--- a/crates/rustok-product-transport/src/auth.rs
+++ b/crates/rustok-product-transport/src/auth.rs
@@ -32,7 +32,8 @@ impl ProductCatalogGrpcBearerToken {
             return Err(ProductCatalogGrpcAuthenticationError::InvalidBearerToken);
         }
 
-        let authorization = MetadataValue::try_from(format!("Bearer {secret}"))
+        let authorization = format!("Bearer {secret}");
+        let authorization = MetadataValue::try_from(authorization.as_str())
             .map_err(|_| ProductCatalogGrpcAuthenticationError::InvalidBearerToken)?;
         Ok(Self { authorization })
     }
@@ -42,10 +43,7 @@ impl ProductCatalogGrpcBearerToken {
     }
 
     pub(crate) fn matches_authorization(&self, candidate: &[u8]) -> bool {
-        self.authorization
-            .as_bytes()
-            .ct_eq(candidate)
-            .into()
+        bool::from(self.authorization.as_bytes().ct_eq(candidate))
     }
 }
 

--- a/crates/rustok-product-transport/src/auth.rs
+++ b/crates/rustok-product-transport/src/auth.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use thiserror::Error;
 use tonic::metadata::{Ascii, MetadataValue};
@@ -7,6 +8,7 @@ use tonic::metadata::{Ascii, MetadataValue};
 pub(crate) const AUTHORIZATION_METADATA: &str = "authorization";
 pub(crate) const TENANT_ID_METADATA: &str = "x-rustok-tenant-id";
 const MAX_BEARER_TOKEN_BYTES: usize = 4_096;
+const AUTHORIZATION_DIGEST_BYTES: usize = 32;
 
 /// Deployment-provided service credential for the Product catalog gRPC boundary.
 ///
@@ -16,6 +18,7 @@ const MAX_BEARER_TOKEN_BYTES: usize = 4_096;
 #[derive(Clone, Eq, PartialEq)]
 pub struct ProductCatalogGrpcBearerToken {
     authorization: MetadataValue<Ascii>,
+    authorization_digest: [u8; AUTHORIZATION_DIGEST_BYTES],
 }
 
 impl ProductCatalogGrpcBearerToken {
@@ -33,9 +36,13 @@ impl ProductCatalogGrpcBearerToken {
         }
 
         let authorization = format!("Bearer {secret}");
+        let authorization_digest = authorization_digest(authorization.as_bytes());
         let authorization = MetadataValue::try_from(authorization.as_str())
             .map_err(|_| ProductCatalogGrpcAuthenticationError::InvalidBearerToken)?;
-        Ok(Self { authorization })
+        Ok(Self {
+            authorization,
+            authorization_digest,
+        })
     }
 
     pub(crate) fn authorization_value(&self) -> MetadataValue<Ascii> {
@@ -43,8 +50,16 @@ impl ProductCatalogGrpcBearerToken {
     }
 
     pub(crate) fn matches_authorization(&self, candidate: &[u8]) -> bool {
-        bool::from(self.authorization.as_bytes().ct_eq(candidate))
+        let candidate_digest = authorization_digest(candidate);
+        bool::from(self.authorization_digest.ct_eq(&candidate_digest))
     }
+}
+
+fn authorization_digest(value: &[u8]) -> [u8; AUTHORIZATION_DIGEST_BYTES] {
+    let digest = Sha256::digest(value);
+    let mut output = [0_u8; AUTHORIZATION_DIGEST_BYTES];
+    output.copy_from_slice(&digest);
+    output
 }
 
 impl fmt::Debug for ProductCatalogGrpcBearerToken {
@@ -93,5 +108,6 @@ mod tests {
             .expect("valid bearer token should be accepted");
         assert!(token.matches_authorization(b"Bearer catalog-secret"));
         assert!(!token.matches_authorization(b"Bearer catalog-other"));
+        assert!(!token.matches_authorization(b"short"));
     }
 }

--- a/crates/rustok-product-transport/src/auth.rs
+++ b/crates/rustok-product-transport/src/auth.rs
@@ -1,0 +1,99 @@
+use std::fmt;
+
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use tonic::metadata::{Ascii, MetadataValue};
+
+pub(crate) const AUTHORIZATION_METADATA: &str = "authorization";
+pub(crate) const TENANT_ID_METADATA: &str = "x-rustok-tenant-id";
+const MAX_BEARER_TOKEN_BYTES: usize = 4_096;
+
+/// Deployment-provided service credential for the Product catalog gRPC boundary.
+///
+/// The value is stored as a prevalidated `Authorization` metadata value. Its
+/// `Debug` representation is always redacted, and no API exposes the original
+/// secret text.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProductCatalogGrpcBearerToken {
+    authorization: MetadataValue<Ascii>,
+}
+
+impl ProductCatalogGrpcBearerToken {
+    pub fn new(secret: impl AsRef<str>) -> Result<Self, ProductCatalogGrpcAuthenticationError> {
+        let secret = secret.as_ref();
+        if secret.is_empty()
+            || secret.len() > MAX_BEARER_TOKEN_BYTES
+            || !secret.is_ascii()
+            || secret
+                .as_bytes()
+                .iter()
+                .any(|byte| *byte <= b' ' || *byte == 0x7f)
+        {
+            return Err(ProductCatalogGrpcAuthenticationError::InvalidBearerToken);
+        }
+
+        let authorization = MetadataValue::try_from(format!("Bearer {secret}"))
+            .map_err(|_| ProductCatalogGrpcAuthenticationError::InvalidBearerToken)?;
+        Ok(Self { authorization })
+    }
+
+    pub(crate) fn authorization_value(&self) -> MetadataValue<Ascii> {
+        self.authorization.clone()
+    }
+
+    pub(crate) fn matches_authorization(&self, candidate: &[u8]) -> bool {
+        self.authorization
+            .as_bytes()
+            .ct_eq(candidate)
+            .into()
+    }
+}
+
+impl fmt::Debug for ProductCatalogGrpcBearerToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProductCatalogGrpcBearerToken")
+            .field("authorization", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, Error, PartialEq)]
+pub enum ProductCatalogGrpcAuthenticationError {
+    #[error(
+        "Product catalog gRPC bearer token must be 1..=4096 visible non-whitespace ASCII bytes"
+    )]
+    InvalidBearerToken,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProductCatalogGrpcAuthenticationError, ProductCatalogGrpcBearerToken};
+
+    #[test]
+    fn bearer_token_debug_is_redacted() {
+        let token = ProductCatalogGrpcBearerToken::new("catalog-secret")
+            .expect("valid bearer token should be accepted");
+        let debug = format!("{token:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("catalog-secret"));
+    }
+
+    #[test]
+    fn bearer_token_rejects_whitespace_and_control_bytes() {
+        for token in ["", "has space", " leading", "trailing ", "line\nbreak"] {
+            assert_eq!(
+                ProductCatalogGrpcBearerToken::new(token),
+                Err(ProductCatalogGrpcAuthenticationError::InvalidBearerToken)
+            );
+        }
+    }
+
+    #[test]
+    fn bearer_token_comparison_matches_full_authorization_value() {
+        let token = ProductCatalogGrpcBearerToken::new("catalog-secret")
+            .expect("valid bearer token should be accepted");
+        assert!(token.matches_authorization(b"Bearer catalog-secret"));
+        assert!(!token.matches_authorization(b"Bearer catalog-other"));
+    }
+}

--- a/crates/rustok-product-transport/src/client.rs
+++ b/crates/rustok-product-transport/src/client.rs
@@ -8,21 +8,27 @@ use rustok_product::{
     dto::ProductResponse,
 };
 use serde::{Serialize, de::DeserializeOwned};
+use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tonic::{Code, Request, Status};
+use uuid::Uuid;
 
+use crate::auth::{AUTHORIZATION_METADATA, TENANT_ID_METADATA};
 use crate::proto::JsonRequest;
 use crate::proto::product_catalog_read_service_client::ProductCatalogReadServiceClient;
+use crate::{ProductCatalogGrpcAuthenticationError, ProductCatalogGrpcBearerToken};
 
 /// Consumer-side gRPC adapter implementing the Product-owned catalog read port.
 pub struct GrpcProductCatalogReadProvider {
     client: ProductCatalogReadServiceClient<Channel>,
+    authentication: Option<ProductCatalogGrpcBearerToken>,
 }
 
 impl GrpcProductCatalogReadProvider {
     pub fn from_channel(channel: Channel) -> Self {
         Self {
             client: ProductCatalogReadServiceClient::new(channel),
+            authentication: None,
         }
     }
 
@@ -37,6 +43,20 @@ impl GrpcProductCatalogReadProvider {
         Ok(Self::from_channel(
             endpoint.tls_config(tls_config)?.connect().await?,
         ))
+    }
+
+    /// Installs a prevalidated deployment credential without exposing its secret value.
+    pub fn with_authentication(mut self, authentication: ProductCatalogGrpcBearerToken) -> Self {
+        self.authentication = Some(authentication);
+        self
+    }
+
+    /// Validates and installs the deployment bearer credential used for every RPC.
+    pub fn with_bearer_token(
+        self,
+        secret: impl AsRef<str>,
+    ) -> Result<Self, ProductCatalogGrpcAuthenticationError> {
+        Ok(self.with_authentication(ProductCatalogGrpcBearerToken::new(secret)?))
     }
 }
 
@@ -54,7 +74,11 @@ impl ProductCatalogReadPort for GrpcProductCatalogReadProvider {
         let response = self
             .client
             .clone()
-            .read_product_projection(with_deadline(payload, &context))
+            .read_product_projection(grpc_request(
+                payload,
+                &context,
+                self.authentication.as_ref(),
+            )?)
             .await
             .map_err(status_to_port_error)?
             .into_inner();
@@ -73,7 +97,11 @@ impl ProductCatalogReadPort for GrpcProductCatalogReadProvider {
         let response = self
             .client
             .clone()
-            .read_variant_product_projection(with_deadline(payload, &context))
+            .read_variant_product_projection(grpc_request(
+                payload,
+                &context,
+                self.authentication.as_ref(),
+            )?)
             .await
             .map_err(status_to_port_error)?
             .into_inner();
@@ -92,7 +120,11 @@ impl ProductCatalogReadPort for GrpcProductCatalogReadProvider {
         let response = self
             .client
             .clone()
-            .list_published_products(with_deadline(payload, &context))
+            .list_published_products(grpc_request(
+                payload,
+                &context,
+                self.authentication.as_ref(),
+            )?)
             .await
             .map_err(status_to_port_error)?
             .into_inner();
@@ -100,12 +132,40 @@ impl ProductCatalogReadPort for GrpcProductCatalogReadProvider {
     }
 }
 
-fn with_deadline<T>(payload: T, context: &PortContext) -> Request<T> {
+fn grpc_request<T>(
+    payload: T,
+    context: &PortContext,
+    authentication: Option<&ProductCatalogGrpcBearerToken>,
+) -> Result<Request<T>, PortError> {
     let mut request = Request::new(payload);
     if let Some(deadline_ms) = context.deadline_ms.filter(|deadline| *deadline > 0) {
         request.set_timeout(Duration::from_millis(deadline_ms));
     }
+
+    let Some(authentication) = authentication else {
+        return Ok(request);
+    };
+    if context.tenant_id != context.tenant_id.trim()
+        || Uuid::parse_str(context.tenant_id.as_str()).is_err()
+    {
+        return Err(PortError::validation(
+            "product.grpc_tenant_id_invalid",
+            "Product gRPC tenant context is invalid",
+        ));
+    }
+    let tenant_id = MetadataValue::<Ascii>::try_from(context.tenant_id.as_str()).map_err(|_| {
+        PortError::validation(
+            "product.grpc_tenant_id_invalid",
+            "Product gRPC tenant context is invalid",
+        )
+    })?;
     request
+        .metadata_mut()
+        .insert(AUTHORIZATION_METADATA, authentication.authorization_value());
+    request
+        .metadata_mut()
+        .insert(TENANT_ID_METADATA, tenant_id);
+    Ok(request)
 }
 
 fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, PortError> {
@@ -150,9 +210,12 @@ fn status_to_port_error(status: Status) -> PortError {
 
 #[cfg(test)]
 mod tests {
-    use super::status_to_port_error;
-    use rustok_api::{PortError, PortErrorKind};
+    use super::{grpc_request, status_to_port_error};
+    use crate::auth::{AUTHORIZATION_METADATA, TENANT_ID_METADATA};
+    use crate::ProductCatalogGrpcBearerToken;
+    use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
     use tonic::{Code, Status};
+    use uuid::Uuid;
 
     #[test]
     fn typed_error_details_override_lossy_grpc_status_mapping() {
@@ -170,5 +233,51 @@ mod tests {
         let error = status_to_port_error(Status::unavailable("down"));
         assert_eq!(error.kind, PortErrorKind::Unavailable);
         assert!(error.retryable);
+    }
+
+    #[test]
+    fn authenticated_request_carries_bearer_and_tenant_metadata() {
+        let tenant_id = Uuid::new_v4().to_string();
+        let context = PortContext::new(
+            tenant_id.clone(),
+            PortActor::service("rustok-server"),
+            "en",
+            "corr-auth",
+        );
+        let authentication = ProductCatalogGrpcBearerToken::new("catalog-secret")
+            .expect("valid bearer token should be accepted");
+        let request = grpc_request((), &context, Some(&authentication))
+            .expect("authenticated request should be created");
+
+        assert_eq!(
+            request
+                .metadata()
+                .get(AUTHORIZATION_METADATA)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer catalog-secret")
+        );
+        assert_eq!(
+            request
+                .metadata()
+                .get(TENANT_ID_METADATA)
+                .and_then(|value| value.to_str().ok()),
+            Some(tenant_id.as_str())
+        );
+    }
+
+    #[test]
+    fn authenticated_request_rejects_invalid_tenant_metadata() {
+        let context = PortContext::new(
+            "tenant-not-a-uuid",
+            PortActor::service("rustok-server"),
+            "en",
+            "corr-invalid-tenant",
+        );
+        let authentication = ProductCatalogGrpcBearerToken::new("catalog-secret")
+            .expect("valid bearer token should be accepted");
+        let error = grpc_request((), &context, Some(&authentication))
+            .expect_err("invalid Product tenant must fail before transport");
+        assert_eq!(error.kind, PortErrorKind::Validation);
+        assert_eq!(error.code, "product.grpc_tenant_id_invalid");
     }
 }

--- a/crates/rustok-product-transport/src/lib.rs
+++ b/crates/rustok-product-transport/src/lib.rs
@@ -3,6 +3,7 @@
 //! Canonical DTOs and policy remain in `rustok-product`. This crate supplies a
 //! replaceable external adapter and does not own catalog storage or semantics.
 
+pub mod auth;
 pub mod client;
 pub mod connection;
 pub mod server;
@@ -11,12 +12,16 @@ pub mod proto {
     tonic::include_proto!("rustok.product");
 }
 
+pub use auth::{
+    ProductCatalogGrpcAuthenticationError, ProductCatalogGrpcBearerToken,
+};
 pub use client::GrpcProductCatalogReadProvider;
 pub use connection::{
     GrpcProductCatalogReadConnectionConfig, GrpcProductCatalogReadConnectionError,
     ValidatedGrpcProductCatalogReadConnection,
 };
 pub use server::{
+    ProductCatalogGrpcBearerAuthenticator, ProductCatalogGrpcBearerInterceptor,
     ProductCatalogGrpcOperation, ProductCatalogGrpcService, TrustedProductCatalogAuthority,
 };
 pub use tonic::transport::ClientTlsConfig;

--- a/crates/rustok-product-transport/src/server.rs
+++ b/crates/rustok-product-transport/src/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, fmt, sync::Arc};
 
 use bytes::Bytes;
 use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
@@ -7,8 +7,14 @@ use rustok_product::{
     VariantProductProjectionRequest,
 };
 use serde::{Serialize, de::DeserializeOwned};
+use tonic::service::Interceptor;
 use tonic::{Code, Request, Response, Status};
+use uuid::Uuid;
 
+use crate::auth::{
+    AUTHORIZATION_METADATA, ProductCatalogGrpcAuthenticationError,
+    ProductCatalogGrpcBearerToken, TENANT_ID_METADATA,
+};
 use crate::proto::product_catalog_read_service_server::ProductCatalogReadService;
 use crate::proto::{JsonRequest, JsonResponse};
 
@@ -36,6 +42,14 @@ pub enum ProductCatalogGrpcOperation {
     ReadProductProjection,
     ReadVariantProductProjection,
     ListPublishedProducts,
+}
+
+impl ProductCatalogGrpcOperation {
+    pub const ALL: [Self; 3] = [
+        Self::ReadProductProjection,
+        Self::ReadVariantProductProjection,
+        Self::ListPublishedProducts,
+    ];
 }
 
 impl TrustedProductCatalogAuthority {
@@ -71,6 +85,136 @@ impl TrustedProductCatalogAuthority {
         self.allowed_operations.extend(operations);
         self
     }
+}
+
+/// Static service-to-service bearer authenticator for the Product read boundary.
+///
+/// A valid token authorizes the configured service actor to access the tenant
+/// carried in trusted gRPC metadata. The token itself is never included in
+/// `Debug`, status messages, or tracing fields.
+#[derive(Clone)]
+pub struct ProductCatalogGrpcBearerAuthenticator {
+    token: ProductCatalogGrpcBearerToken,
+    actor: PortActor,
+    claims: Vec<String>,
+    roles: Vec<String>,
+    allowed_operations: HashSet<ProductCatalogGrpcOperation>,
+}
+
+impl ProductCatalogGrpcBearerAuthenticator {
+    pub fn new(
+        secret: impl AsRef<str>,
+        actor: PortActor,
+    ) -> Result<Self, ProductCatalogGrpcAuthenticationError> {
+        Ok(Self::from_token(
+            ProductCatalogGrpcBearerToken::new(secret)?,
+            actor,
+        ))
+    }
+
+    pub fn from_token(token: ProductCatalogGrpcBearerToken, actor: PortActor) -> Self {
+        Self {
+            token,
+            actor,
+            claims: Vec::new(),
+            roles: Vec::new(),
+            allowed_operations: HashSet::from(ProductCatalogGrpcOperation::ALL),
+        }
+    }
+
+    pub fn with_claim(mut self, claim: impl Into<String>) -> Self {
+        self.claims.push(claim.into());
+        self
+    }
+
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.roles.push(role.into());
+        self
+    }
+
+    pub fn with_allowed_operations(
+        mut self,
+        operations: impl IntoIterator<Item = ProductCatalogGrpcOperation>,
+    ) -> Self {
+        self.allowed_operations = operations.into_iter().collect();
+        self
+    }
+
+    fn authenticate(
+        &self,
+        request: &Request<()>,
+    ) -> Result<TrustedProductCatalogAuthority, Status> {
+        let authorization = request
+            .metadata()
+            .get(AUTHORIZATION_METADATA)
+            .ok_or_else(authentication_failed)?;
+        if !self.token.matches_authorization(authorization.as_bytes()) {
+            return Err(authentication_failed());
+        }
+
+        let tenant_id = request
+            .metadata()
+            .get(TENANT_ID_METADATA)
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(authentication_failed)?;
+        if tenant_id != tenant_id.trim() || Uuid::parse_str(tenant_id).is_err() {
+            return Err(authentication_failed());
+        }
+
+        Ok(TrustedProductCatalogAuthority {
+            tenant_id: tenant_id.to_string(),
+            actor: self.actor.clone(),
+            claims: self.claims.clone(),
+            roles: self.roles.clone(),
+            allowed_operations: self.allowed_operations.clone(),
+        })
+    }
+}
+
+impl fmt::Debug for ProductCatalogGrpcBearerAuthenticator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProductCatalogGrpcBearerAuthenticator")
+            .field("token", &"[REDACTED]")
+            .field("actor", &self.actor)
+            .field("claims", &self.claims)
+            .field("roles", &self.roles)
+            .field("allowed_operations", &self.allowed_operations)
+            .finish()
+    }
+}
+
+/// Tonic interceptor that converts authenticated metadata into trusted Product authority.
+#[derive(Clone, Debug)]
+pub struct ProductCatalogGrpcBearerInterceptor {
+    authenticator: ProductCatalogGrpcBearerAuthenticator,
+}
+
+impl ProductCatalogGrpcBearerInterceptor {
+    pub fn new(authenticator: ProductCatalogGrpcBearerAuthenticator) -> Self {
+        Self { authenticator }
+    }
+
+    pub fn from_bearer_token(
+        secret: impl AsRef<str>,
+        actor: PortActor,
+    ) -> Result<Self, ProductCatalogGrpcAuthenticationError> {
+        Ok(Self::new(ProductCatalogGrpcBearerAuthenticator::new(
+            secret, actor,
+        )?))
+    }
+}
+
+impl Interceptor for ProductCatalogGrpcBearerInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        let authority = self.authenticator.authenticate(&request)?;
+        request.extensions_mut().insert(authority);
+        Ok(request)
+    }
+}
+
+fn authentication_failed() -> Status {
+    Status::unauthenticated("Product catalog service authentication failed")
 }
 
 impl<P> ProductCatalogGrpcService<P> {
@@ -208,11 +352,16 @@ fn port_error_to_status(error: PortError) -> Status {
 #[cfg(test)]
 mod tests {
     use super::{
-        ProductCatalogGrpcOperation, TrustedProductCatalogAuthority, port_error_to_status,
-        trusted_context,
+        ProductCatalogGrpcBearerInterceptor, ProductCatalogGrpcOperation,
+        TrustedProductCatalogAuthority, port_error_to_status, trusted_context,
     };
     use rustok_api::{PortActor, PortContext, PortError};
+    use tonic::metadata::MetadataValue;
+    use tonic::service::Interceptor;
     use tonic::{Code, Request};
+    use uuid::Uuid;
+
+    use crate::auth::{AUTHORIZATION_METADATA, TENANT_ID_METADATA};
 
     #[test]
     fn owner_error_is_preserved_in_status_details() {
@@ -266,5 +415,86 @@ mod tests {
         .expect("trusted authority should be accepted");
         assert_eq!(trusted.tenant_id, "tenant-a");
         assert_eq!(trusted.actor, PortActor::service("trusted-product-service"));
+    }
+
+    #[test]
+    fn bearer_interceptor_authenticates_tenant_and_service_actor() {
+        let tenant_id = Uuid::new_v4().to_string();
+        let mut interceptor = ProductCatalogGrpcBearerInterceptor::from_bearer_token(
+            "catalog-secret",
+            PortActor::service("rustok-server"),
+        )
+        .expect("valid service credential should be accepted");
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            AUTHORIZATION_METADATA,
+            MetadataValue::try_from("Bearer catalog-secret").unwrap(),
+        );
+        request.metadata_mut().insert(
+            TENANT_ID_METADATA,
+            MetadataValue::try_from(tenant_id.as_str()).unwrap(),
+        );
+
+        let request = interceptor
+            .call(request)
+            .expect("valid service metadata should authenticate");
+        let authority = request
+            .extensions()
+            .get::<TrustedProductCatalogAuthority>()
+            .expect("trusted authority should be installed");
+        assert_eq!(authority.tenant_id, tenant_id);
+        assert_eq!(authority.actor, PortActor::service("rustok-server"));
+        for operation in ProductCatalogGrpcOperation::ALL {
+            assert!(authority.allowed_operations.contains(&operation));
+        }
+    }
+
+    #[test]
+    fn bearer_interceptor_rejects_missing_or_wrong_token() {
+        let mut interceptor = ProductCatalogGrpcBearerInterceptor::from_bearer_token(
+            "catalog-secret",
+            PortActor::service("rustok-server"),
+        )
+        .expect("valid service credential should be accepted");
+        let missing = interceptor
+            .call(Request::new(()))
+            .expect_err("missing credential must fail closed");
+        assert_eq!(missing.code(), Code::Unauthenticated);
+
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            AUTHORIZATION_METADATA,
+            MetadataValue::try_from("Bearer wrong-secret").unwrap(),
+        );
+        request.metadata_mut().insert(
+            TENANT_ID_METADATA,
+            MetadataValue::try_from(Uuid::new_v4().to_string()).unwrap(),
+        );
+        let wrong = interceptor
+            .call(request)
+            .expect_err("wrong credential must fail closed");
+        assert_eq!(wrong.code(), Code::Unauthenticated);
+    }
+
+    #[test]
+    fn bearer_interceptor_rejects_invalid_tenant_metadata() {
+        let mut interceptor = ProductCatalogGrpcBearerInterceptor::from_bearer_token(
+            "catalog-secret",
+            PortActor::service("rustok-server"),
+        )
+        .expect("valid service credential should be accepted");
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            AUTHORIZATION_METADATA,
+            MetadataValue::try_from("Bearer catalog-secret").unwrap(),
+        );
+        request.metadata_mut().insert(
+            TENANT_ID_METADATA,
+            MetadataValue::try_from("tenant-not-a-uuid").unwrap(),
+        );
+        let status = interceptor
+            .call(request)
+            .expect_err("invalid tenant metadata must fail closed");
+        assert_eq!(status.code(), Code::Unauthenticated);
     }
 }

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -59,6 +59,7 @@
     "graphql_checkout_runtime_verifier": "scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs",
     "grpc_transport_verifier": "scripts/verify/verify-product-catalog-grpc-transport.mjs",
     "grpc_deployment_verifier": "scripts/verify/verify-product-catalog-grpc-deployment.mjs",
+    "grpc_authentication_verifier": "scripts/verify/verify-product-catalog-grpc-authentication.mjs",
     "remote_consumer_behavior_verifier": "scripts/verify/verify-product-remote-consumer-behavior.mjs",
     "runtime_contract_smoke": "crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json",
     "runtime_contract_smoke_runner": "scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs",
@@ -89,14 +90,29 @@
     "protocol": "tonic_grpc_json_owner_contract",
     "client": "GrpcProductCatalogReadProvider",
     "connection_config": "GrpcProductCatalogReadConnectionConfig",
+    "client_authentication": "ProductCatalogGrpcBearerToken",
     "server": "ProductCatalogGrpcService",
+    "server_authenticator": "ProductCatalogGrpcBearerInterceptor",
     "trusted_authority": "TrustedProductCatalogAuthority",
+    "authentication_metadata": [
+      "authorization",
+      "x-rustok-tenant-id"
+    ],
+    "authentication_assertions": [
+      "constant_time_complete_authorization_compare",
+      "tenant_uuid_validated",
+      "trusted_service_actor_server_configured",
+      "secret_debug_redacted",
+      "authentication_failure_secret_not_echoed"
+    ],
     "proto": "crates/rustok-product-transport/proto/rustok/product/product_catalog.proto",
     "conformance_test": "crates/rustok-product-transport/tests/port_conformance.rs",
     "host_deployment": "apps/server/src/services/product_catalog_deployment.rs",
     "runtime_factory": "ProductCatalogReadRuntime::external",
     "provider_selector_env": "RUSTOK_PRODUCT_CATALOG_PROVIDER",
     "endpoint_env": "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+    "bearer_token_env": "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
+    "authentication_status": "source_complete_execution_pending",
     "status": "runtime_wired_execution_pending"
   },
   "remote_consumer_behavior": {

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -33,16 +33,31 @@ conformance harness covers product projection, variant-first projection,
 published list pagination, typed not-found, deadline-required semantics, and
 trusted actor replacement.
 
+The transport now has a concrete service-to-service bearer authentication
+boundary. `ProductCatalogGrpcBearerToken` validates visible non-whitespace ASCII,
+redacts its `Debug` representation, and compares the complete `Authorization`
+metadata value in constant-time. Authenticated clients attach both
+`authorization` and `x-rustok-tenant-id`; the server interceptor validates the
+tenant UUID, installs a server-configured trusted service actor, and authorizes
+only Product catalog read operations. Authentication failures use one generic
+message and never echo the credential. TLS protects the channel while bearer
+authentication establishes caller identity; neither substitutes for the other.
+
 The production host now owns explicit Product catalog deployment selection.
-`RUSTOK_PRODUCT_CATALOG_PROVIDER` defaults to `embedded`; `grpc` requires
-`RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT`. `GrpcProductCatalogReadConnectionConfig`
-requires HTTPS without credentials/path/query/fragment, permits plaintext only
-for an explicitly enabled loopback host, bounds connect timeout, and applies
-WebPKI TLS roots. The server connects before `bootstrap_app_runtime`, inserts
-`ProductCatalogReadRuntime::external(...)` into `ServerRuntimeContext`, and lets
-all existing composition surfaces reuse that same runtime. Invalid remote
-configuration or connection failure aborts startup and never silently falls back
-to embedded execution.
+`RUSTOK_PRODUCT_CATALOG_PROVIDER` defaults to `embedded`; `grpc` requires both
+`RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT` and
+`RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN`.
+`GrpcProductCatalogReadConnectionConfig` requires HTTPS without
+credentials/path/query/fragment, permits plaintext only for an explicitly
+enabled loopback host, bounds connect timeout, and applies WebPKI TLS roots. The
+server validates authentication before connecting, connects before
+`bootstrap_app_runtime`, inserts `ProductCatalogReadRuntime::external(...)` into
+`ServerRuntimeContext`, and lets all existing composition surfaces reuse that
+same runtime. Invalid remote configuration or connection failure aborts startup
+and never silently falls back to embedded execution. Invalid authentication
+configuration also aborts startup before the network connection is opened.
+Remote variables, including the bearer credential, are rejected in embedded
+mode.
 
 Remote consumer behavior is now source-complete through executable loopback
 harnesses. Commerce builds checkout plans with a real external gRPC runtime and
@@ -54,10 +69,13 @@ typed degraded metadata. The production handler still requires operator review
 and performs no persistence. These harnesses have not been executed by the
 implementation agent.
 
-Adapter and production-wiring source are complete. Consumer-behavior source is
-also complete, but the loopback conformance and remote consumer harnesses have
-not been run by the implementation agent, so Product remains `boundary_ready`
-rather than `transport_verified`.
+Adapter and production-wiring source are complete. Consumer-behavior and
+authentication source are complete, but the loopback conformance, authenticated
+transport, and remote consumer harnesses have not been run by the implementation
+agent, so Product remains `boundary_ready` rather than `transport_verified`.
+Configured remote-profile execution evidence remain open. A standalone Product
+catalog service host is still required before the repository contains a complete
+provider-side deployment unit.
 
 The composed `rustok-ai` consumer has existing unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -151,9 +169,9 @@ rustok-pricing` dependency cycle.
   the core/transport/UI split and native/GraphQL parity.
 - FBA status: `boundary_ready` — the owner port, in-process profile, host runtime,
   declared consumer source cutovers, external gRPC adapter, validated connection
-  policy, production host wiring, and Commerce/AI remote behavior harnesses are
-  source-complete. Loopback and configured remote-profile execution evidence
-  remain open.
+  policy, production client wiring, service-to-service authentication, and
+  Commerce/AI remote behavior harnesses are source-complete. The standalone
+  provider host plus authenticated runtime execution evidence remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
@@ -168,6 +186,7 @@ rustok-pricing` dependency cycle.
   `scripts/verify/verify-product-graphql-checkout-catalog-runtime.mjs`,
   `scripts/verify/verify-product-catalog-grpc-transport.mjs`,
   `scripts/verify/verify-product-catalog-grpc-deployment.mjs`,
+  `scripts/verify/verify-product-catalog-grpc-authentication.mjs`,
   `scripts/verify/verify-product-remote-consumer-behavior.mjs`,
   `scripts/verify/verify-product-admin-boundary.mjs`,
   `scripts/verify/verify-product-admin-category-sort.mjs`,
@@ -179,16 +198,23 @@ rustok-pricing` dependency cycle.
 
 ## Open results
 
-1. Execute and retain the external runtime evidence:
+1. Implement a standalone Product catalog service host that composes
+   `CatalogService`, PostgreSQL, `ProductCatalogGrpcService`, TLS, and
+   `ProductCatalogGrpcBearerInterceptor`. The host must configure the trusted
+   service actor server-side, use the same bearer credential as the client
+   deployment, expose graceful shutdown/telemetry, and must not introduce a
+   second Product policy or persistence implementation.
+2. Execute and retain the external runtime evidence:
+   - `cargo test -p rustok-product-transport --lib`;
    - `cargo test -p rustok-product-transport --test port_conformance`;
    - `cargo test -p rustok-commerce --test product_remote_consumer_behavior`;
    - `cargo test -p rustok-ai --features server --lib remote_product_`.
    Retain the generated `Cargo.lock` package entry with the first successful Cargo
    execution. Then start the server with the gRPC deployment variables against a
-   separately running Product catalog service and retain end-to-end Commerce and
-   AI evidence through the selected runtime. Promote above `boundary_ready` only
-   with those retained results.
-2. Keep Product richtext adoption explicitly deferred until the owner approves
+   separately running authenticated Product catalog service and retain end-to-end
+   Commerce and AI evidence through the selected runtime. Promote above
+   `boundary_ready` only with those retained results.
+3. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
    their textarea alone would create a false contract. When approved, use the
@@ -204,8 +230,10 @@ rustok-pricing` dependency cycle.
 - [x] Cut mounted Commerce GraphQL checkout over to the composed Product runtime.
 - [x] Implement the concrete Product catalog gRPC adapter and loopback conformance harness.
 - [x] Wire a fail-closed production external Product runtime profile.
+- [x] Add service-to-service bearer authentication and trusted tenant metadata.
 - [x] Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses.
-- [ ] Execute the Product catalog gRPC loopback conformance harness.
+- [ ] Implement a standalone Product catalog service host.
+- [ ] Execute the Product catalog gRPC authentication and loopback conformance harnesses.
 - [ ] Execute the Commerce and AI remote consumer behavior harnesses.
 - [ ] Retain end-to-end Commerce and AI behavior through a separately configured Product service.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
@@ -225,8 +253,11 @@ rustok-pricing` dependency cycle.
 - `node scripts/verify/verify-product-catalog-grpc-transport.test.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-deployment.mjs`
 - `node scripts/verify/verify-product-catalog-grpc-deployment.test.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-authentication.mjs`
+- `node scripts/verify/verify-product-catalog-grpc-authentication.test.mjs`
 - `node scripts/verify/verify-product-remote-consumer-behavior.mjs`
 - `node scripts/verify/verify-product-remote-consumer-behavior.test.mjs`
+- `cargo test -p rustok-product-transport --lib`
 - `cargo test -p rustok-product-transport --test port_conformance`
 - `cargo test -p rustok-commerce --test product_remote_consumer_behavior`
 - `cargo test -p rustok-ai --features server --lib remote_product_`
@@ -248,14 +279,19 @@ rustok-pricing` dependency cycle.
 
 - Product owns catalog data, `ProductCatalogReadPort`, and
   `ProductCatalogReadRuntime` profile selection.
-- `rustok-product-transport` owns only tonic/protobuf framing, validated client
-  connection policy, deadline/status mapping, and trusted-authority adaptation.
-  It must not own Product policy, persistence, DTOs, locale/channel rules, or
-  fallback decisions.
-- The server host owns deployment variables, endpoint/TLS selection, startup
-  connection, and insertion of the selected runtime. It must fail closed for an
-  invalid or unavailable configured remote provider and must not silently select
+- `rustok-product-transport` owns tonic/protobuf framing, validated client
+  connection policy, deadline/status mapping, bearer metadata, constant-time
+  credential comparison, and trusted-authority adaptation. It must not own
+  Product policy, persistence, DTOs, locale/channel rules, fallback decisions,
+  or deployment secret storage.
+- The consumer server host owns deployment variables, endpoint/TLS selection,
+  bearer credential injection, startup connection, and insertion of the selected
+  runtime. It must fail closed for invalid authentication, invalid configuration,
+  or an unavailable configured remote provider and must not silently select
   embedded execution.
+- The standalone provider host must compose the Product owner service and the
+  exported bearer interceptor, configure the trusted service actor server-side,
+  and never trust actor/claims/roles supplied in `PortContext`.
 - Commerce owns hard-dependency checkout behavior: a Product timeout or
   unavailable result blocks planning and cannot be replaced by the cart snapshot.
 - AI owns advisory degradation: Product transport failures skip enrichment,

--- a/scripts/verify/verify-product-catalog-grpc-authentication.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required Product gRPC authentication file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireAll(source, markers, description) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${description}: missing ${marker}`);
+  }
+}
+
+function forbidAll(source, markers, description) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
+  }
+}
+
+const cargo = read("crates/rustok-product-transport/Cargo.toml");
+const lib = read("crates/rustok-product-transport/src/lib.rs");
+const auth = read("crates/rustok-product-transport/src/auth.rs");
+const client = read("crates/rustok-product-transport/src/client.rs");
+const server = read("crates/rustok-product-transport/src/server.rs");
+const deployment = read("apps/server/src/services/product_catalog_deployment.rs");
+const readme = read("crates/rustok-product-transport/README.md");
+const registrySource = read("crates/rustok-product/contracts/product-fba-registry.json");
+const plan = read("crates/rustok-product/docs/implementation-plan.md");
+
+requireAll(cargo, [
+  'subtle = "2"',
+  "uuid.workspace = true",
+], "Product transport authentication dependencies");
+requireAll(lib, [
+  "pub mod auth;",
+  "ProductCatalogGrpcAuthenticationError",
+  "ProductCatalogGrpcBearerToken",
+  "ProductCatalogGrpcBearerAuthenticator",
+  "ProductCatalogGrpcBearerInterceptor",
+], "Product transport authentication exports");
+requireAll(auth, [
+  'AUTHORIZATION_METADATA: &str = "authorization"',
+  'TENANT_ID_METADATA: &str = "x-rustok-tenant-id"',
+  "MAX_BEARER_TOKEN_BYTES",
+  "ConstantTimeEq",
+  ".ct_eq(candidate)",
+  'field("authorization", &"[REDACTED]")',
+  "InvalidBearerToken",
+  "bearer_token_debug_is_redacted",
+], "Product bearer credential contract");
+forbidAll(auth, [
+  "pub fn authorization_value",
+  "pub fn matches_authorization",
+  "println!",
+  "eprintln!",
+], "Product bearer secret exposure");
+
+requireAll(client, [
+  "authentication: Option<ProductCatalogGrpcBearerToken>",
+  "pub fn with_authentication(",
+  "pub fn with_bearer_token(",
+  "AUTHORIZATION_METADATA",
+  "TENANT_ID_METADATA",
+  "Uuid::parse_str(context.tenant_id.as_str())",
+  ".insert(AUTHORIZATION_METADATA, authentication.authorization_value())",
+  ".insert(TENANT_ID_METADATA, tenant_id)",
+  "authenticated_request_carries_bearer_and_tenant_metadata",
+  "authenticated_request_rejects_invalid_tenant_metadata",
+], "Product authenticated gRPC client");
+forbidAll(client, [
+  "tracing::info!(authentication",
+  "tracing::debug!(authentication",
+  "format!(\"Bearer {secret}\")",
+], "Product client credential logging");
+
+requireAll(server, [
+  "pub struct ProductCatalogGrpcBearerAuthenticator",
+  "pub struct ProductCatalogGrpcBearerInterceptor",
+  "ProductCatalogGrpcOperation::ALL",
+  "self.token.matches_authorization(authorization.as_bytes())",
+  "Uuid::parse_str(tenant_id)",
+  "actor: self.actor.clone()",
+  "allowed_operations: self.allowed_operations.clone()",
+  'Status::unauthenticated("Product catalog service authentication failed")',
+  "request.extensions_mut().insert(authority)",
+  "bearer_interceptor_authenticates_tenant_and_service_actor",
+  "bearer_interceptor_rejects_missing_or_wrong_token",
+  "bearer_interceptor_rejects_invalid_tenant_metadata",
+], "Product authenticated gRPC server");
+forbidAll(server, [
+  "authorization = %authorization",
+  "token = %self.token",
+  "secret = %",
+], "Product server credential logging");
+
+requireAll(deployment, [
+  'GRPC_BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN"',
+  "struct ProductCatalogBearerSecret(String)",
+  'formatter.write_str("[REDACTED]")',
+  "optional_secret_env(GRPC_BEARER_TOKEN_ENV)",
+  "ProductCatalogGrpcBearerToken::new(remote.bearer_token.expose())",
+  ".with_authentication(authentication)",
+  "remote Product catalog authentication configuration failed",
+  "bearer_token_is_not_silently_ignored_in_embedded_mode",
+  "grpc_requires_a_bearer_token",
+  "bearer_secret_debug_is_redacted",
+], "Product server authentication deployment");
+forbidAll(deployment, [
+  "value.trim().to_string() // secret",
+  "bearer_token = %",
+  "bearer_token = ?",
+], "Product deployment credential exposure");
+
+requireAll(readme, [
+  "ProductCatalogGrpcBearerToken",
+  "ProductCatalogGrpcBearerInterceptor",
+  "Authorization: Bearer ...",
+  "x-rustok-tenant-id",
+  "compares the complete authorization value in constant time",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
+  "TLS and authentication solve separate problems",
+  "must use `ProductCatalogGrpcBearerInterceptor`",
+], "Product authentication documentation");
+
+let registry;
+try {
+  registry = JSON.parse(registrySource);
+} catch (error) {
+  failures.push(`Product FBA registry is invalid JSON: ${error.message}`);
+}
+if (registry) {
+  if (registry.status !== "boundary_ready") {
+    failures.push("Product must remain boundary_ready before authenticated runtime evidence");
+  }
+  const external = registry.external_transport ?? {};
+  if (external.client_authentication !== "ProductCatalogGrpcBearerToken") {
+    failures.push("Product registry client authentication identity drift");
+  }
+  if (external.server_authenticator !== "ProductCatalogGrpcBearerInterceptor") {
+    failures.push("Product registry server authenticator identity drift");
+  }
+  if (external.bearer_token_env !== "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN") {
+    failures.push("Product registry bearer token environment drift");
+  }
+  if (external.authentication_status !== "source_complete_execution_pending") {
+    failures.push("Product authentication must remain source_complete_execution_pending");
+  }
+  for (const metadata of ["authorization", "x-rustok-tenant-id"]) {
+    if (!external.authentication_metadata?.includes(metadata)) {
+      failures.push(`Product authentication metadata must include ${metadata}`);
+    }
+  }
+  for (const assertion of [
+    "constant_time_complete_authorization_compare",
+    "tenant_uuid_validated",
+    "trusted_service_actor_server_configured",
+    "secret_debug_redacted",
+    "authentication_failure_secret_not_echoed",
+  ]) {
+    if (!external.authentication_assertions?.includes(assertion)) {
+      failures.push(`Product authentication must assert ${assertion}`);
+    }
+  }
+  if (
+    registry.evidence?.grpc_authentication_verifier !==
+    "scripts/verify/verify-product-catalog-grpc-authentication.mjs"
+  ) {
+    failures.push("Product registry must link the gRPC authentication verifier");
+  }
+}
+
+requireAll(plan, [
+  "service-to-service bearer authentication",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
+  "constant-time",
+  "trusted service actor",
+  "authentication source is complete",
+  "Product remains `boundary_ready`",
+  "Implement a standalone Product catalog service host",
+  "verify-product-catalog-grpc-authentication.mjs",
+], "Product authentication implementation plan");
+
+if (failures.length > 0) {
+  console.error("Product catalog gRPC authentication verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Product catalog gRPC authentication source verification passed");

--- a/scripts/verify/verify-product-catalog-grpc-authentication.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.mjs
@@ -58,7 +58,7 @@ requireAll(auth, [
   'TENANT_ID_METADATA: &str = "x-rustok-tenant-id"',
   "MAX_BEARER_TOKEN_BYTES",
   "Sha256::digest(value)",
-  "Sha256::digest(candidate)",
+  "authorization_digest(candidate)",
   "ConstantTimeEq",
   ".ct_eq(&candidate_digest)",
   'field("authorization", &"[REDACTED]")',

--- a/scripts/verify/verify-product-catalog-grpc-authentication.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.mjs
@@ -42,6 +42,7 @@ const registrySource = read("crates/rustok-product/contracts/product-fba-registr
 const plan = read("crates/rustok-product/docs/implementation-plan.md");
 
 requireAll(cargo, [
+  "sha2.workspace = true",
   'subtle = "2"',
   "uuid.workspace = true",
 ], "Product transport authentication dependencies");
@@ -56,8 +57,10 @@ requireAll(auth, [
   'AUTHORIZATION_METADATA: &str = "authorization"',
   'TENANT_ID_METADATA: &str = "x-rustok-tenant-id"',
   "MAX_BEARER_TOKEN_BYTES",
+  "Sha256::digest(value)",
+  "Sha256::digest(candidate)",
   "ConstantTimeEq",
-  ".ct_eq(candidate)",
+  ".ct_eq(&candidate_digest)",
   'field("authorization", &"[REDACTED]")',
   "InvalidBearerToken",
   "bearer_token_debug_is_redacted",
@@ -188,7 +191,7 @@ requireAll(plan, [
   "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
   "constant-time",
   "trusted service actor",
-  "authentication source is complete",
+  "authentication source",
   "Product remains `boundary_ready`",
   "Implement a standalone Product catalog service host",
   "verify-product-catalog-grpc-authentication.mjs",

--- a/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
@@ -22,14 +22,16 @@ function fixture(options = {}) {
   write(
     root,
     "crates/rustok-product-transport/Cargo.toml",
-    `subtle = "2"\nuuid.workspace = true`,
+    `sha2.workspace = true\nsubtle = "2"\nuuid.workspace = true`,
   );
   write(
     root,
     "crates/rustok-product-transport/src/lib.rs",
     `pub mod auth; ProductCatalogGrpcAuthenticationError ProductCatalogGrpcBearerToken ProductCatalogGrpcBearerAuthenticator ProductCatalogGrpcBearerInterceptor`,
   );
-  const compare = options.missingConstantTime ? "" : ".ct_eq(candidate)";
+  const compare = options.missingConstantTime
+    ? ""
+    : "Sha256::digest(value) Sha256::digest(candidate) .ct_eq(&candidate_digest)";
   const redaction = options.leakedCredential
     ? `field("authorization", &self.authorization)`
     : `field("authorization", &"[REDACTED]")`;
@@ -96,7 +98,7 @@ function fixture(options = {}) {
     "crates/rustok-product/docs/implementation-plan.md",
     options.missingPlan
       ? "Product plan"
-      : "service-to-service bearer authentication RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN constant-time trusted service actor authentication source is complete Product remains `boundary_ready` Implement a standalone Product catalog service host verify-product-catalog-grpc-authentication.mjs",
+      : "service-to-service bearer authentication RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN constant-time trusted service actor authentication source Product remains `boundary_ready` Implement a standalone Product catalog service host verify-product-catalog-grpc-authentication.mjs",
   );
   return root;
 }

--- a/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
@@ -31,7 +31,7 @@ function fixture(options = {}) {
   );
   const compare = options.missingConstantTime
     ? ""
-    : "Sha256::digest(value) Sha256::digest(candidate) .ct_eq(&candidate_digest)";
+    : "Sha256::digest(value) authorization_digest(candidate) .ct_eq(&candidate_digest)";
   const redaction = options.leakedCredential
     ? `field("authorization", &self.authorization)`
     : `field("authorization", &"[REDACTED]")`;

--- a/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const scriptPath = path.resolve(
+  "scripts/verify/verify-product-catalog-grpc-authentication.mjs",
+);
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function fixture(options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "rustok-product-grpc-auth-"));
+  write(
+    root,
+    "crates/rustok-product-transport/Cargo.toml",
+    `subtle = "2"\nuuid.workspace = true`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/lib.rs",
+    `pub mod auth; ProductCatalogGrpcAuthenticationError ProductCatalogGrpcBearerToken ProductCatalogGrpcBearerAuthenticator ProductCatalogGrpcBearerInterceptor`,
+  );
+  const compare = options.missingConstantTime ? "" : ".ct_eq(candidate)";
+  const redaction = options.leakedCredential
+    ? `field("authorization", &self.authorization)`
+    : `field("authorization", &"[REDACTED]")`;
+  write(
+    root,
+    "crates/rustok-product-transport/src/auth.rs",
+    `AUTHORIZATION_METADATA: &str = "authorization" TENANT_ID_METADATA: &str = "x-rustok-tenant-id" MAX_BEARER_TOKEN_BYTES ConstantTimeEq ${compare} ${redaction} InvalidBearerToken bearer_token_debug_is_redacted`,
+  );
+  const tenantInsert = options.missingTenantMetadata
+    ? ""
+    : `.insert(TENANT_ID_METADATA, tenant_id)`;
+  write(
+    root,
+    "crates/rustok-product-transport/src/client.rs",
+    `authentication: Option<ProductCatalogGrpcBearerToken> pub fn with_authentication( pub fn with_bearer_token( AUTHORIZATION_METADATA TENANT_ID_METADATA Uuid::parse_str(context.tenant_id.as_str()) .insert(AUTHORIZATION_METADATA, authentication.authorization_value()) ${tenantInsert} authenticated_request_carries_bearer_and_tenant_metadata authenticated_request_rejects_invalid_tenant_metadata`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/src/server.rs",
+    `pub struct ProductCatalogGrpcBearerAuthenticator pub struct ProductCatalogGrpcBearerInterceptor ProductCatalogGrpcOperation::ALL self.token.matches_authorization(authorization.as_bytes()) Uuid::parse_str(tenant_id) actor: self.actor.clone() allowed_operations: self.allowed_operations.clone() Status::unauthenticated("Product catalog service authentication failed") request.extensions_mut().insert(authority) bearer_interceptor_authenticates_tenant_and_service_actor bearer_interceptor_rejects_missing_or_wrong_token bearer_interceptor_rejects_invalid_tenant_metadata`,
+  );
+  const tokenRequirement = options.missingDeploymentToken
+    ? ""
+    : `GRPC_BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN" optional_secret_env(GRPC_BEARER_TOKEN_ENV) ProductCatalogGrpcBearerToken::new(remote.bearer_token.expose()) .with_authentication(authentication) grpc_requires_a_bearer_token bearer_token_is_not_silently_ignored_in_embedded_mode`;
+  write(
+    root,
+    "apps/server/src/services/product_catalog_deployment.rs",
+    `struct ProductCatalogBearerSecret(String) formatter.write_str("[REDACTED]") ${tokenRequirement} remote Product catalog authentication configuration failed bearer_secret_debug_is_redacted`,
+  );
+  write(
+    root,
+    "crates/rustok-product-transport/README.md",
+    `ProductCatalogGrpcBearerToken ProductCatalogGrpcBearerInterceptor Authorization: Bearer ... x-rustok-tenant-id compares the complete authorization value in constant time RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN TLS and authentication solve separate problems must use \`ProductCatalogGrpcBearerInterceptor\``,
+  );
+  write(
+    root,
+    "crates/rustok-product/contracts/product-fba-registry.json",
+    JSON.stringify({
+      status: options.falsePromotion ? "transport_verified" : "boundary_ready",
+      evidence: {
+        grpc_authentication_verifier:
+          "scripts/verify/verify-product-catalog-grpc-authentication.mjs",
+      },
+      external_transport: {
+        client_authentication: "ProductCatalogGrpcBearerToken",
+        server_authenticator: "ProductCatalogGrpcBearerInterceptor",
+        bearer_token_env: "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
+        authentication_status: options.falseExecution
+          ? "runtime_verified"
+          : "source_complete_execution_pending",
+        authentication_metadata: ["authorization", "x-rustok-tenant-id"],
+        authentication_assertions: [
+          "constant_time_complete_authorization_compare",
+          "tenant_uuid_validated",
+          "trusted_service_actor_server_configured",
+          "secret_debug_redacted",
+          "authentication_failure_secret_not_echoed",
+        ],
+      },
+    }),
+  );
+  write(
+    root,
+    "crates/rustok-product/docs/implementation-plan.md",
+    options.missingPlan
+      ? "Product plan"
+      : "service-to-service bearer authentication RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN constant-time trusted service actor authentication source is complete Product remains `boundary_ready` Implement a standalone Product catalog service host verify-product-catalog-grpc-authentication.mjs",
+  );
+  return root;
+}
+
+function run(root) {
+  return spawnSync("node", [scriptPath], {
+    cwd: path.resolve("."),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+function reject(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0, "expected authentication mutation to fail");
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("authentication guard accepts canonical fixture", () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("guard rejects non-constant-time token comparison", () => {
+  reject({ missingConstantTime: true }, /Product bearer credential contract/);
+});
+
+test("guard rejects credential exposure in Debug", () => {
+  reject({ leakedCredential: true }, /Product bearer credential contract/);
+});
+
+test("guard rejects missing tenant metadata", () => {
+  reject({ missingTenantMetadata: true }, /Product authenticated gRPC client/);
+});
+
+test("guard rejects deployment without required bearer token", () => {
+  reject({ missingDeploymentToken: true }, /Product server authentication deployment/);
+});
+
+test("guard rejects premature authentication execution claim", () => {
+  reject({ falseExecution: true }, /source_complete_execution_pending/);
+});
+
+test("guard rejects premature Product promotion", () => {
+  reject({ falsePromotion: true }, /remain boundary_ready/);
+});
+
+test("guard rejects missing implementation-plan handoff", () => {
+  reject({ missingPlan: true }, /Product authentication implementation plan/);
+});

--- a/scripts/verify/verify-product-catalog-grpc-deployment.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-deployment.mjs
@@ -47,12 +47,16 @@ requireAll(transportCargo, [
   "thiserror.workspace = true",
   "url.workspace = true",
   'features = ["tls-ring", "tls-webpki-roots"]',
+  "sha2.workspace = true",
+  'subtle = "2"',
 ], "Product transport connection dependencies");
 requireAll(transportLib, [
+  "pub mod auth;",
   "pub mod connection;",
   "GrpcProductCatalogReadConnectionConfig",
   "GrpcProductCatalogReadConnectionError",
   "ValidatedGrpcProductCatalogReadConnection",
+  "ProductCatalogGrpcBearerToken",
 ], "Product transport connection exports");
 requireAll(connection, [
   "pub struct GrpcProductCatalogReadConnectionConfig",
@@ -84,27 +88,36 @@ requireAll(services, ["pub mod product_catalog_deployment;"], "server service ex
 requireAll(deployment, [
   'const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER";',
   'const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT";',
+  'const GRPC_BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN";',
   'const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN";',
   '"RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS"',
   '"RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK"',
   'unwrap_or("embedded")',
   '"grpc" => {',
+  "ProductCatalogGrpcBearerToken::new(remote.bearer_token.expose())",
   "GrpcProductCatalogReadConnectionConfig::new(remote.endpoint)",
   ".with_tls_domain(remote.tls_domain)",
   ".with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms))",
   ".allow_insecure_loopback(remote.allow_insecure_loopback)",
   ".connect()",
+  ".with_authentication(authentication)",
   "ProductCatalogReadRuntime::external(Arc::new(provider))",
   "ctx.shared_insert(",
+  "remote Product catalog authentication configuration failed",
   "remote Product catalog provider initialization failed",
   "remote Product catalog variables require {PROVIDER_ENV}=grpc",
   "is required when {PROVIDER_ENV}=grpc",
   "must be either embedded or grpc",
+  "grpc_requires_a_bearer_token",
+  "bearer_token_is_not_silently_ignored_in_embedded_mode",
+  "bearer_secret_debug_is_redacted",
 ], "server Product catalog deployment");
 forbidAll(deployment, [
   "ProductCatalogReadRuntime::in_process",
   "CatalogService::new",
   "unwrap_or_else(|_|",
+  "bearer_token = %",
+  "bearer_token = ?",
 ], "server Product catalog fail-closed deployment");
 
 requireAll(bootstrap, [
@@ -133,6 +146,7 @@ requireAll(readme, [
   "RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded",
   "RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc",
   "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
   "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true",
   "does not silently fall back to the embedded provider",
 ], "Product transport deployment documentation");
@@ -151,6 +165,9 @@ if (registry) {
   if (external.connection_config !== "GrpcProductCatalogReadConnectionConfig") {
     failures.push("Product registry must identify the validated connection config");
   }
+  if (external.client_authentication !== "ProductCatalogGrpcBearerToken") {
+    failures.push("Product registry must identify authenticated client metadata");
+  }
   if (external.host_deployment !== "apps/server/src/services/product_catalog_deployment.rs") {
     failures.push("Product registry must identify the server deployment source");
   }
@@ -162,6 +179,12 @@ if (registry) {
   }
   if (external.endpoint_env !== "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT") {
     failures.push("Product registry must identify the endpoint environment variable");
+  }
+  if (external.bearer_token_env !== "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN") {
+    failures.push("Product registry must identify the bearer token environment variable");
+  }
+  if (external.authentication_status !== "source_complete_execution_pending") {
+    failures.push("Product registry must retain authentication execution-pending status");
   }
   if (external.status !== "runtime_wired_execution_pending") {
     failures.push("Product registry must retain runtime_wired_execution_pending status");
@@ -177,6 +200,7 @@ if (registry) {
 requireAll(plan, [
   "The production host now owns explicit Product catalog deployment selection",
   "Invalid remote configuration or connection failure aborts startup",
+  "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
   "Adapter and production-wiring source are complete",
   "Product remains `boundary_ready` rather than",
   "remote-profile execution evidence remain open",

--- a/scripts/verify/verify-product-catalog-grpc-deployment.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-deployment.test.mjs
@@ -23,12 +23,12 @@ function fixture(options = {}) {
   write(
     root,
     "crates/rustok-product-transport/Cargo.toml",
-    `thiserror.workspace = true\nurl.workspace = true\ntonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }`,
+    `thiserror.workspace = true\nurl.workspace = true\nsha2.workspace = true\nsubtle = "2"\ntonic = { workspace = true, features = ["tls-ring", "tls-webpki-roots"] }`,
   );
   write(
     root,
     "crates/rustok-product-transport/src/lib.rs",
-    `pub mod connection; GrpcProductCatalogReadConnectionConfig GrpcProductCatalogReadConnectionError ValidatedGrpcProductCatalogReadConnection`,
+    `pub mod auth; pub mod connection; GrpcProductCatalogReadConnectionConfig GrpcProductCatalogReadConnectionError ValidatedGrpcProductCatalogReadConnection ProductCatalogGrpcBearerToken`,
   );
   const connection = options.missingTls
     ? `pub struct GrpcProductCatalogReadConnectionConfig; pub fn validated( Url::parse(value.trim()) !parsed.username().is_empty() parsed.password().is_some() parsed.query().is_some() parsed.fragment().is_some() !matches!(parsed.path(), "" | "/") "http" if allow_insecure_loopback && is_loopback_host(parsed.host()) => false InsecureEndpointForbidden MAX_CONNECT_TIMEOUT_MS timeout_ms == 0 || timeout_ms > MAX_CONNECT_TIMEOUT_MS .connect_timeout(validated.connect_timeout) .tcp_keepalive(Some(Duration::from_secs(30))) pub async fn connect(`
@@ -37,7 +37,7 @@ function fixture(options = {}) {
   write(
     root,
     "crates/rustok-product-transport/README.md",
-    `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true does not silently fall back to the embedded provider`,
+    `RUSTOK_PRODUCT_CATALOG_PROVIDER=embedded RUSTOK_PRODUCT_CATALOG_PROVIDER=grpc RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK=true does not silently fall back to the embedded provider`,
   );
 
   write(
@@ -53,10 +53,13 @@ function fixture(options = {}) {
   const fallback = options.silentFallback
     ? `ProductCatalogReadRuntime::in_process unwrap_or_else(|_|`
     : "";
+  const authentication = options.missingAuthentication
+    ? ""
+    : `const GRPC_BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN"; ProductCatalogGrpcBearerToken::new(remote.bearer_token.expose()) .with_authentication(authentication) remote Product catalog authentication configuration failed grpc_requires_a_bearer_token bearer_token_is_not_silently_ignored_in_embedded_mode bearer_secret_debug_is_redacted`;
   write(
     root,
     "apps/server/src/services/product_catalog_deployment.rs",
-    `const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER"; const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT"; const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN"; "RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS" "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK" unwrap_or("embedded") "grpc" => { GrpcProductCatalogReadConnectionConfig::new(remote.endpoint) .with_tls_domain(remote.tls_domain) .with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms)) .allow_insecure_loopback(remote.allow_insecure_loopback) .connect() ProductCatalogReadRuntime::external(Arc::new(provider)) ctx.shared_insert( remote Product catalog provider initialization failed remote Product catalog variables require {PROVIDER_ENV}=grpc is required when {PROVIDER_ENV}=grpc must be either embedded or grpc ${fallback}`,
+    `const PROVIDER_ENV: &str = "RUSTOK_PRODUCT_CATALOG_PROVIDER"; const GRPC_ENDPOINT_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT"; ${authentication} const TLS_DOMAIN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_TLS_DOMAIN"; "RUSTOK_PRODUCT_CATALOG_GRPC_CONNECT_TIMEOUT_MS" "RUSTOK_PRODUCT_CATALOG_GRPC_ALLOW_INSECURE_LOOPBACK" unwrap_or("embedded") "grpc" => { GrpcProductCatalogReadConnectionConfig::new(remote.endpoint) .with_tls_domain(remote.tls_domain) .with_connect_timeout(Duration::from_millis(remote.connect_timeout_ms)) .allow_insecure_loopback(remote.allow_insecure_loopback) .connect() ProductCatalogReadRuntime::external(Arc::new(provider)) ctx.shared_insert( remote Product catalog provider initialization failed remote Product catalog variables require {PROVIDER_ENV}=grpc is required when {PROVIDER_ENV}=grpc must be either embedded or grpc ${fallback}`,
   );
   const configure = "configure_product_catalog_deployment(&runtime_ctx).await?;";
   const appBootstrap =
@@ -87,10 +90,13 @@ function fixture(options = {}) {
       },
       external_transport: {
         connection_config: "GrpcProductCatalogReadConnectionConfig",
+        client_authentication: "ProductCatalogGrpcBearerToken",
         host_deployment: "apps/server/src/services/product_catalog_deployment.rs",
         runtime_factory: "ProductCatalogReadRuntime::external",
         provider_selector_env: "RUSTOK_PRODUCT_CATALOG_PROVIDER",
         endpoint_env: "RUSTOK_PRODUCT_CATALOG_GRPC_ENDPOINT",
+        bearer_token_env: "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
+        authentication_status: "source_complete_execution_pending",
         status: staleRegistry
           ? "source_complete_execution_pending"
           : falsePromotion
@@ -104,7 +110,7 @@ function fixture(options = {}) {
     "crates/rustok-product/docs/implementation-plan.md",
     options.missingPlan
       ? "Product plan"
-      : "The production host now owns explicit Product catalog deployment selection. Invalid remote configuration or connection failure aborts startup. Adapter and production-wiring source are complete. Product remains `boundary_ready` rather than `transport_verified`; configured remote-profile execution evidence remain open. Wire a fail-closed production external Product runtime profile. verify-product-catalog-grpc-deployment.mjs",
+      : "The production host now owns explicit Product catalog deployment selection. Invalid remote configuration or connection failure aborts startup. RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN. Adapter and production-wiring source are complete. Product remains `boundary_ready` rather than `transport_verified`; configured remote-profile execution evidence remain open. Wire a fail-closed production external Product runtime profile. verify-product-catalog-grpc-deployment.mjs",
   );
 
   return root;
@@ -141,6 +147,10 @@ test("Product catalog gRPC deployment guard accepts canonical fixture", () => {
 
 test("deployment guard rejects missing TLS policy", () => {
   reject({ missingTls: true }, /validated Product gRPC connection/);
+});
+
+test("deployment guard rejects missing authentication", () => {
+  reject({ missingAuthentication: true }, /server Product catalog deployment/);
 });
 
 test("deployment guard rejects silent embedded fallback", () => {


### PR DESCRIPTION
## Summary
- add a debug-redacted Product catalog bearer credential and fixed-length SHA-256 digest comparison with constant-time equality
- attach authenticated `authorization` and `x-rustok-tenant-id` metadata to external Product catalog RPCs
- add a server interceptor that validates the credential and tenant UUID, installs a configured trusted service actor, and authorizes only catalog-read operations
- require `RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN` for the production `grpc` deployment while rejecting all remote variables in embedded mode
- synchronize Product registry, implementation plan, documentation, deployment guards, and authentication mutation guards
- keep Product at `boundary_ready`; authenticated runtime execution and the standalone Product service host remain pending

## Verification
Not run by the implementation agent per maintainer instruction.

Suggested commands:
- `node scripts/verify/verify-product-catalog-grpc-authentication.mjs`
- `node scripts/verify/verify-product-catalog-grpc-authentication.test.mjs`
- `node scripts/verify/verify-product-catalog-grpc-transport.mjs`
- `node scripts/verify/verify-product-catalog-grpc-transport.test.mjs`
- `node scripts/verify/verify-product-catalog-grpc-deployment.mjs`
- `node scripts/verify/verify-product-catalog-grpc-deployment.test.mjs`
- `cargo test -p rustok-product-transport --lib`
- `cargo test -p rustok-product-transport --test port_conformance`