### PR TITLE
feat(forum): authorize exact reply audience reads

### DIFF
--- a/crates/rustok-forum/contracts/forum-reply-audience-read.json
+++ b/crates/rustok-forum/contracts/forum-reply-audience-read.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BF",
+  "upstream_task": "FORUM-20BE",
+  "scope": "Publish exact reply and reply-list owners through parent-topic richer audience authorization and compose REST plus final storefront outputs through them",
+  "topic_owner_visibility": "crates/rustok-forum/src/services/topic_audience_visibility.rs",
+  "reply_owner": "crates/rustok-forum/src/services/reply_audience_read.rs",
+  "transport_context": "crates/rustok-forum/src/reply_read_transport.rs",
+  "rest_transport": "crates/rustok-forum/src/controllers/replies.rs",
+  "graphql_query": "crates/rustok-forum/src/graphql/reply_audience_query.rs",
+  "graphql_runtime": "crates/rustok-forum/src/graphql/runtime_data.rs",
+  "graphql_storefront_adapter": "crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs",
+  "native_storefront_adapter": "crates/rustok-forum/storefront/src/transport/native_reply_audience_adapter.rs",
+  "transport_selector": "crates/rustok-forum/storefront/src/transport/mod.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20bf-reply-audience-read.md",
+  "source_verifier": "scripts/verify/verify-forum-reply-audience-read.mjs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-topic-audience-storefront-list-composition.json",
+  "read_boundary": {
+    "owner_topic_visibility_ignores_open_and_route_channel": true,
+    "owner_topic_visibility_enforces_category_and_richer_layers": true,
+    "storefront_topic_visibility_still_requires_open_and_route_channel": true,
+    "selected_reply_resolves_parent_topic_before_content": true,
+    "reply_list_resolves_parent_topic_before_pagination": true,
+    "authenticated_context_validated_before_optional_facts": true,
+    "rest_get_reply_uses_exact_owner": true,
+    "rest_list_replies_uses_exact_owner": true,
+    "rest_vote_read_preflight_uses_exact_owner": true,
+    "graphql_authenticated_exact_field_added": true,
+    "graphql_storefront_exact_field_added": true,
+    "native_storefront_final_replies_use_exact_owner": true,
+    "graphql_storefront_final_replies_use_exact_owner": true,
+    "legacy_graphql_forum_replies_replaced": false,
+    "legacy_graphql_storefront_replies_removed": false,
+    "legacy_base_storefront_reply_fetch_removed": false,
+    "category_owner_read_changed": false,
+    "search_index_changed": false,
+    "seo_changed": false,
+    "deep_link_changed": false,
+    "migration_added": false,
+    "dependency_changed": false,
+    "public_response_dto_changed": false
+  },
+  "compatibility": {
+    "existing_rest_routes_changed": false,
+    "existing_graphql_fields_removed": false,
+    "exact_graphql_fields_are_additive": true,
+    "storefront_model_changed": false,
+    "mark_read_paths_changed": false,
+    "base_storefront_reply_fetch_result_replaced_before_ui": true,
+    "external_fact_layers_fail_closed_without_provider": true,
+    "locally_decidable_layers_skip_optional_provider": true
+  },
+  "documentation": {
+    "owner_note_added": true,
+    "contract_added": true,
+    "upstream_contract_updated": true,
+    "crate_api_updated": false,
+    "canonical_plan_updated": false,
+    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BF through a conflict-safe repository-local edit."
+  },
+  "remaining_scope": [
+    "replace the legacy forumReplies field and remove the duplicate base storefront reply fetch",
+    "migrate remaining category reads search index SEO and deep-link authorization",
+    "add visibility-scoped category and all-read commands",
+    "capture maintainer-executed SQLite PostgreSQL REST native and GraphQL runtime evidence"
+  ],
+  "downstream_task": "FORUM-20BG",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum reply_read_transport -- --nocapture",
+      "cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-reply-audience-read.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/contracts/forum-topic-audience-storefront-list-composition.json
+++ b/crates/rustok-forum/contracts/forum-topic-audience-storefront-list-composition.json
@@ -13,6 +13,7 @@
   "owner_note": "crates/rustok-forum/docs/forum-20be-topic-audience-storefront-list-composition.md",
   "source_verifier": "scripts/verify/verify-forum-topic-audience-storefront-list-composition.mjs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-topic-audience-pagination.json",
+  "downstream_completion": "crates/rustok-forum/contracts/forum-reply-audience-read.json",
   "composition_boundary": {
     "native_authenticated_list_uses_exact_unread_owner": true,
     "native_authenticated_context_uses_topic_list_operation": true,
@@ -27,7 +28,7 @@
     "selected_topic_exact_owner_preserved": true,
     "mark_read_exact_owner_preserved": true,
     "replies_loaded_only_after_selected_topic_allow": true,
-    "reply_owner_read_changed": false,
+    "reply_owner_read_changed": true,
     "category_owner_read_changed": false,
     "search_index_changed": false,
     "seo_changed": false,
@@ -51,22 +52,24 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BE through a conflict-safe repository-local edit."
+    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BF through a conflict-safe repository-local edit."
   },
   "remaining_scope": [
-    "migrate exact reply and reply-list reads through parent-topic richer authorization",
+    "replace the legacy forumReplies field and remove the duplicate base storefront reply fetch",
     "migrate remaining category reads search index SEO and deep-link authorization",
     "add visibility-scoped category and all-read commands",
-    "capture maintainer-executed SQLite PostgreSQL native and GraphQL runtime evidence"
+    "capture maintainer-executed SQLite PostgreSQL REST native and GraphQL runtime evidence"
   ],
   "downstream_task": "FORUM-20BF",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
       "cargo test -p rustok-forum topic_read_transport -- --nocapture",
+      "cargo test -p rustok-forum reply_read_transport -- --nocapture",
       "cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture",
       "node scripts/verify/verify-forum-topic-audience-pagination.mjs",
       "node scripts/verify/verify-forum-topic-audience-storefront-list-composition.mjs",
+      "node scripts/verify/verify-forum-reply-audience-read.mjs",
       "cargo xtask module validate forum"
     ]
   }

--- a/crates/rustok-forum/docs/forum-20bf-reply-audience-read.md
+++ b/crates/rustok-forum/docs/forum-20bf-reply-audience-read.md
@@ -1,0 +1,67 @@
+# FORUM-20BF — exact reply audience reads
+
+`FORUM-20BF` publishes a reply-read owner that authorizes every reply through
+its parent topic audience policy before reply content or pagination is returned.
+
+## Delivered boundary
+
+- `ForumTopicAudienceVisibilityService::is_topic_owner_visible` composes the
+  inherited category floor and all richer category/topic audience layers without
+  imposing storefront-only `open` or route-channel requirements. This preserves
+  authorized owner/admin reads of closed topics.
+- Existing `is_topic_visible` remains the storefront decision and still requires
+  an open topic plus the matching route channel.
+- `ForumReplyAudienceReadService` owns exact selected-reply, owner reply-list,
+  and storefront reply-list reads. Missing and denied resources use the same
+  absent semantics.
+- Authenticated reply contexts derive tenant, user, locale, route channel,
+  permission claims, session identity, correlation identity, and a five-second
+  facts deadline only from trusted transport extensions.
+- REST `GET /api/forum/replies/{id}` and
+  `GET /api/forum/topics/{id}/replies` now call the exact owner.
+- REST reply-vote commands perform an exact selected-reply preflight before the
+  side effect and use the same owner for the returned reply.
+- Additive GraphQL fields `forumAudienceReplies` and
+  `forumStorefrontAudienceReplies` expose exact owner and storefront lists.
+- The storefront transport selector replaces both native and GraphQL reply
+  results with pages returned by the exact owner before `StorefrontForumData`
+  reaches the UI.
+
+## Compatibility
+
+No migration, dependency, existing REST route, existing GraphQL field, request
+DTO, response DTO, storefront model, or mark-read path changes.
+
+The legacy `forumReplies` and `forumStorefrontReplies` fields remain available.
+The existing base storefront adapters still perform their compatibility reply
+fetch, but that result is replaced by the exact reply adapter before the final
+storefront data is returned. Removing the duplicate fetch and migrating the
+legacy authenticated field are explicit `FORUM-20BG` work.
+
+Public and authenticated storefront reads continue to expose only approved
+replies. Locally decidable audience layers do not call the optional facts port;
+trust, Channel, or Groups rules fail closed when their required facts are not
+available.
+
+## Explicitly not delivered
+
+`FORUM-20BF` does not migrate category reads, search/index, SEO, deep links,
+visibility-scoped category/all-read commands, or PostgreSQL runtime evidence.
+
+The canonical `implementation-plan.md` and `CRATE_API.md` are not replaced
+through the GitHub contents API in this slice. Their conflict-safe
+repository-local synchronization debt remains explicit in the machine contract.
+
+## Validation handoff
+
+The implementation agent did not run tests, Cargo commands, formatting,
+verifiers, workflows, or CI, per maintainer request.
+
+Suggested maintainer commands:
+
+```text
+cargo test -p rustok-forum reply_read_transport -- --nocapture
+cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture
+node scripts/verify/verify-forum-reply-audience-read.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/src/controllers/replies.rs
+++ b/crates/rustok-forum/src/controllers/replies.rs
@@ -11,8 +11,10 @@ use std::time::Instant;
 use uuid::Uuid;
 
 use crate::{
-    CreateReplyInput, ListRepliesFilter, ReplyListItem, ReplyResponse, ReplyService,
-    UpdateReplyInput, VoteService,
+    CreateReplyInput, ForumReplyAudienceReadService, ForumReplyReadOperation,
+    ForumReplyReadTransport, ListRepliesFilter, ReplyListItem, ReplyResponse,
+    SharedForumAudienceFactsPort, UpdateReplyInput, VoteService,
+    reply_read_audience_port_context,
 };
 use crate::reply_create_transport::{
     ForumReplyCreateTransport, reply_create_audience_port_context,
@@ -62,12 +64,26 @@ pub async fn list_replies(
     let requested_limit = Some(filter.per_page);
     let effective_limit = clamp_per_page(filter.per_page);
     filter.per_page = effective_limit;
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
+    let effective_locale = filter
+        .locale
+        .as_deref()
+        .unwrap_or(tenant.default_locale.as_str());
+    let audience_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::ReplyList,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        effective_locale,
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    let service = reply_audience_read_service(&runtime);
     let list_started_at = Instant::now();
     let (replies, _) = service
-        .list_for_topic_with_locale_fallback(
+        .list_authenticated_owner_visible_with_audience_context(
             tenant.id,
             forum_security(&auth),
+            audience_context,
             topic_id,
             filter,
             Some(tenant.default_locale.as_str()),
@@ -77,7 +93,7 @@ pub async fn list_replies(
     metrics::record_read_path_query(
         "http",
         "forum.list_replies",
-        "service_list",
+        "exact_reply_audience_owner",
         list_started_at.elapsed().as_secs_f64(),
         replies.len() as u64,
     );
@@ -137,13 +153,21 @@ pub async fn get_reply(
     let locale = filter
         .locale
         .unwrap_or_else(|| request_context.locale.clone());
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
-    let reply = service
-        .get_with_locale_fallback(
+    let audience_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::SelectedReply,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        &locale,
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    let reply = reply_audience_read_service(&runtime)
+        .get_authenticated_owner_visible_with_audience_context(
             tenant.id,
             forum_security(&auth),
+            audience_context,
             id,
-            &locale,
             Some(tenant.default_locale.as_str()),
         )
         .await
@@ -226,7 +250,7 @@ pub async fn update_reply(
         "Permission denied: forum_replies:update required",
     )?;
 
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
+    let service = runtime.reply_service();
     let reply = service
         .update(tenant.id, id, forum_security(&auth), input)
         .await
@@ -258,7 +282,7 @@ pub async fn delete_reply(
         "Permission denied: forum_replies:delete required",
     )?;
 
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
+    let service = runtime.reply_service();
     service
         .delete(tenant.id, id, forum_security(&auth))
         .await
@@ -293,18 +317,47 @@ pub async fn set_reply_vote(
         "Permission denied: forum_replies:read required",
     )?;
 
+    let read_service = reply_audience_read_service(&runtime);
+    let preflight_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::SelectedReply,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        request_context.locale.as_str(),
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    read_service
+        .get_authenticated_owner_visible_with_audience_context(
+            tenant.id,
+            forum_security(&auth),
+            preflight_context,
+            reply_id,
+            Some(tenant.default_locale.as_str()),
+        )
+        .await
+        .map_err(crate::controllers::map_forum_error)?;
+
     VoteService::new(runtime.db_clone())
         .set_reply_vote(tenant.id, reply_id, forum_security(&auth), value)
         .await
         .map_err(crate::controllers::map_forum_error)?;
 
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
-    let reply = service
-        .get_with_locale_fallback(
+    let response_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::SelectedReply,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        request_context.locale.as_str(),
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    let reply = read_service
+        .get_authenticated_owner_visible_with_audience_context(
             tenant.id,
             forum_security(&auth),
+            response_context,
             reply_id,
-            request_context.locale.as_str(),
             Some(tenant.default_locale.as_str()),
         )
         .await
@@ -336,23 +389,65 @@ pub async fn clear_reply_vote(
         "Permission denied: forum_replies:read required",
     )?;
 
+    let read_service = reply_audience_read_service(&runtime);
+    let preflight_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::SelectedReply,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        request_context.locale.as_str(),
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    read_service
+        .get_authenticated_owner_visible_with_audience_context(
+            tenant.id,
+            forum_security(&auth),
+            preflight_context,
+            reply_id,
+            Some(tenant.default_locale.as_str()),
+        )
+        .await
+        .map_err(crate::controllers::map_forum_error)?;
+
     VoteService::new(runtime.db_clone())
         .clear_reply_vote(tenant.id, reply_id, forum_security(&auth))
         .await
         .map_err(crate::controllers::map_forum_error)?;
 
-    let service = ReplyService::new(runtime.db_clone(), runtime.event_bus());
-    let reply = service
-        .get_with_locale_fallback(
+    let response_context = reply_read_audience_port_context(
+        ForumReplyReadTransport::Rest,
+        ForumReplyReadOperation::SelectedReply,
+        tenant.id,
+        &auth,
+        Some(&request_context),
+        request_context.locale.as_str(),
+    )
+    .map_err(crate::controllers::map_forum_error)?;
+    let reply = read_service
+        .get_authenticated_owner_visible_with_audience_context(
             tenant.id,
             forum_security(&auth),
+            response_context,
             reply_id,
-            request_context.locale.as_str(),
             Some(tenant.default_locale.as_str()),
         )
         .await
         .map_err(crate::controllers::map_forum_error)?;
     Ok(Json(reply))
+}
+
+fn reply_audience_read_service(
+    runtime: &crate::controllers::ForumHttpRuntime,
+) -> ForumReplyAudienceReadService {
+    match runtime.audience_facts.clone() {
+        Some(facts) => ForumReplyAudienceReadService::with_audience_facts(
+            runtime.db_clone(),
+            runtime.event_bus(),
+            facts,
+        ),
+        None => ForumReplyAudienceReadService::new(runtime.db_clone(), runtime.event_bus()),
+    }
 }
 
 fn ensure_forum_permission(

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -9,6 +9,7 @@ mod mutation;
 mod query;
 mod quote_commands;
 mod read_state;
+mod reply_audience_query;
 mod runtime_data;
 mod storefront_audience_topic;
 mod storefront_audience_topics;
@@ -47,6 +48,7 @@ pub struct ForumQuery(
     category_tree_query::ForumCategoryTreeQuery,
     category_policy::ForumCategoryTopicPolicyQuery,
     read_state::ForumReadStateQuery,
+    reply_audience_query::ForumReplyAudienceQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,
     storefront_audience_topics::ForumStorefrontAudienceTopicsQuery,

--- a/crates/rustok-forum/src/graphql/reply_audience_query.rs
+++ b/crates/rustok-forum/src/graphql/reply_audience_query.rs
@@ -1,0 +1,278 @@
+use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result};
+use rustok_api::{
+    AuthContext, Permission, RequestContext, TenantContext,
+    graphql::{GraphQLError, PaginationInput, require_module_enabled, resolve_graphql_locale},
+    has_any_effective_permission,
+};
+use rustok_channel::ChannelService;
+use rustok_core::SecurityContext;
+use rustok_outbox::TransactionalEventBus;
+use rustok_telemetry::metrics;
+use sea_orm::DatabaseConnection;
+use std::time::Instant;
+use uuid::Uuid;
+
+use crate::{
+    ForumReplyReadOperation, ForumReplyReadTransport, ReplyResponse, ReplyStatus,
+    reply_read_audience_port_context,
+};
+
+use super::{ForumGraphqlRuntimeData, ForumReplyConnection, GqlForumReply};
+
+const MODULE_SLUG: &str = "forum";
+const PUBLIC_REPLY_STATUSES: [ReplyStatus; 1] = [ReplyStatus::Approved];
+
+#[derive(Default)]
+pub struct ForumReplyAudienceQuery;
+
+#[Object]
+impl ForumReplyAudienceQuery {
+    /// Exact authenticated owner reply list. Parent-topic category and richer
+    /// audience layers are resolved before reply content is returned.
+    async fn forum_audience_replies(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        topic_id: Uuid,
+        locale: Option<String>,
+        #[graphql(default)] pagination: PaginationInput,
+    ) -> Result<ForumReplyConnection> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let auth = require_forum_permission(
+            ctx,
+            &[Permission::FORUM_REPLIES_LIST],
+            "Permission denied: forum_replies:list required",
+        )?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
+        let locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let requested_limit = pagination.requested_limit();
+        let (offset, limit) = pagination.normalize()?;
+        let context = reply_read_audience_port_context(
+            ForumReplyReadTransport::Graphql,
+            ForumReplyReadOperation::ReplyList,
+            tenant_id,
+            &auth,
+            ctx.data_opt::<RequestContext>(),
+            locale.as_str(),
+        )?;
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
+        let service = runtime.reply_audience_read_service(db.clone(), event_bus.clone());
+
+        let started_at = Instant::now();
+        let (replies, total) = service
+            .list_response_authenticated_owner_visible_with_audience_context(
+                tenant_id,
+                forum_security(&auth),
+                context,
+                topic_id,
+                crate::ListRepliesFilter {
+                    locale: Some(locale),
+                    page: (offset / limit + 1) as u64,
+                    per_page: limit as u64,
+                },
+                Some(tenant.default_locale.as_str()),
+                None,
+            )
+            .await?;
+        metrics::record_read_path_query(
+            "graphql",
+            "forum.audience_replies",
+            "exact_reply_audience_owner",
+            started_at.elapsed().as_secs_f64(),
+            total,
+        );
+
+        let items = replies.into_iter().map(map_reply_response).collect::<Vec<_>>();
+        metrics::record_read_path_budget(
+            "graphql",
+            "forum.audience_replies",
+            Some(requested_limit),
+            limit as u64,
+            items.len(),
+        );
+        Ok(ForumReplyConnection::new(
+            items,
+            total as i64,
+            offset,
+            limit,
+        ))
+    }
+
+    /// Exact storefront reply list through parent-topic storefront and richer
+    /// audience visibility. Missing and denied topics return an empty connection.
+    async fn forum_storefront_audience_replies(
+        &self,
+        ctx: &Context<'_>,
+        topic_id: Uuid,
+        tenant_id: Option<Uuid>,
+        locale: Option<String>,
+        #[graphql(default)] pagination: PaginationInput,
+    ) -> Result<ForumReplyConnection> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        require_public_forum_channel_enabled(ctx).await?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
+        let locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let requested_limit = pagination.requested_limit();
+        let (offset, limit) = pagination.normalize()?;
+        let runtime = ctx
+            .data_opt::<ForumGraphqlRuntimeData>()
+            .cloned()
+            .unwrap_or_default();
+        let service = runtime.reply_audience_read_service(db.clone(), event_bus.clone());
+        let filter = crate::ListRepliesFilter {
+            locale: Some(locale.clone()),
+            page: (offset / limit + 1) as u64,
+            per_page: limit as u64,
+        };
+
+        let started_at = Instant::now();
+        let (replies, total) = if let Some(auth) = ctx.data_opt::<AuthContext>() {
+            let context = reply_read_audience_port_context(
+                ForumReplyReadTransport::Graphql,
+                ForumReplyReadOperation::ReplyList,
+                tenant_id,
+                auth,
+                ctx.data_opt::<RequestContext>(),
+                locale.as_str(),
+            )?;
+            service
+                .list_authenticated_storefront_visible_with_audience_context(
+                    tenant_id,
+                    forum_security(auth),
+                    context,
+                    topic_id,
+                    filter,
+                    Some(tenant.default_locale.as_str()),
+                    Some(&PUBLIC_REPLY_STATUSES),
+                )
+                .await?
+        } else {
+            service
+                .list_public_storefront_visible_with_locale_fallback(
+                    tenant_id,
+                    topic_id,
+                    filter,
+                    Some(tenant.default_locale.as_str()),
+                    public_channel_slug(ctx).as_deref(),
+                    Some(&PUBLIC_REPLY_STATUSES),
+                )
+                .await?
+        };
+        metrics::record_read_path_query(
+            "graphql",
+            "forum.storefront_audience_replies",
+            "exact_reply_audience_owner",
+            started_at.elapsed().as_secs_f64(),
+            total,
+        );
+
+        let items = replies.into_iter().map(map_reply_response).collect::<Vec<_>>();
+        metrics::record_read_path_budget(
+            "graphql",
+            "forum.storefront_audience_replies",
+            Some(requested_limit),
+            limit as u64,
+            items.len(),
+        );
+        Ok(ForumReplyConnection::new(
+            items,
+            total as i64,
+            offset,
+            limit,
+        ))
+    }
+}
+
+fn require_forum_permission(
+    ctx: &Context<'_>,
+    permissions: &[Permission],
+    message: &str,
+) -> Result<AuthContext> {
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?
+        .clone();
+    if !has_any_effective_permission(&auth.permissions, permissions) {
+        return Err(<FieldError as GraphQLError>::permission_denied(message));
+    }
+    Ok(auth)
+}
+
+fn forum_security(auth: &AuthContext) -> SecurityContext {
+    SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+async fn require_public_forum_channel_enabled(ctx: &Context<'_>) -> Result<()> {
+    if ctx.data_opt::<AuthContext>().is_some() {
+        return Ok(());
+    }
+    let Some(request) = ctx.data_opt::<RequestContext>() else {
+        return Ok(());
+    };
+    let Some(channel_id) = request.channel_id else {
+        return Ok(());
+    };
+    let db = ctx.data::<DatabaseConnection>()?;
+    let enabled = ChannelService::new(db.clone())
+        .is_module_enabled(channel_id, MODULE_SLUG)
+        .await
+        .map_err(|error| {
+            async_graphql::Error::new(format!("Channel module check failed: {error}"))
+                .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
+        })?;
+    if enabled {
+        Ok(())
+    } else {
+        Err(
+            async_graphql::Error::new("Forum module is not enabled for this channel")
+                .extend_with(|_, extension| extension.set("code", "FORBIDDEN")),
+        )
+    }
+}
+
+fn public_channel_slug(ctx: &Context<'_>) -> Option<String> {
+    ctx.data_opt::<RequestContext>()
+        .and_then(|request| request.channel_slug.clone())
+}
+
+fn map_reply_response(reply: ReplyResponse) -> GqlForumReply {
+    GqlForumReply {
+        id: reply.id,
+        requested_locale: reply.requested_locale,
+        locale: reply.locale,
+        effective_locale: reply.effective_locale,
+        topic_id: reply.topic_id,
+        author_id: reply.author_id,
+        author_profile: None,
+        content: reply.content,
+        content_format: reply.content_format,
+        status: reply.status,
+        vote_score: reply.vote_score,
+        current_user_vote: reply.current_user_vote,
+        is_solution: reply.is_solution,
+        parent_reply_id: reply.parent_reply_id,
+        created_at: reply.created_at,
+        updated_at: reply.updated_at,
+    }
+}

--- a/crates/rustok-forum/src/graphql/runtime_data.rs
+++ b/crates/rustok-forum/src/graphql/runtime_data.rs
@@ -3,7 +3,8 @@ use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
 use crate::{
-    ForumStorefrontReadStateService, ForumTopicAudienceReadService, ModerationService, ReplyService,
+    ForumReplyAudienceReadService, ForumStorefrontReadStateService,
+    ForumTopicAudienceReadService, ModerationService, ReplyService,
     SharedForumAudienceFactsPort, TopicService,
 };
 
@@ -46,6 +47,19 @@ impl ForumGraphqlRuntimeData {
         match self.audience_facts.clone() {
             Some(facts) => ReplyService::with_audience_facts(db, event_bus, facts),
             None => ReplyService::new(db, event_bus),
+        }
+    }
+
+    pub(crate) fn reply_audience_read_service(
+        &self,
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> ForumReplyAudienceReadService {
+        match self.audience_facts.clone() {
+            Some(facts) => {
+                ForumReplyAudienceReadService::with_audience_facts(db, event_bus, facts)
+            }
+            None => ForumReplyAudienceReadService::new(db, event_bus),
         }
     }
 

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -23,6 +23,7 @@ pub mod notification_recipient;
 mod notification_source;
 pub mod openapi;
 mod reply_create_transport;
+pub mod reply_read_transport;
 mod seo_targets;
 pub mod services;
 pub mod state_machine;
@@ -51,6 +52,9 @@ pub use notification_recipient::{
     ForumNotificationRecipientContextPort, ForumNotificationRecipientContextRequest,
     ForumNotificationRecipientContextResolver, SharedForumNotificationRecipientContextPort,
 };
+pub use reply_read_transport::{
+    ForumReplyReadOperation, ForumReplyReadTransport, reply_read_audience_port_context,
+};
 pub use services::{
     CategoryService, ForumApprovedPostsFactPort, ForumCategoryAudiencePolicy,
     ForumCategoryAudiencePolicyLayer, ForumCategoryAudiencePolicyService,
@@ -69,7 +73,7 @@ pub use services::{
     ForumPostingPolicyOwnerFactResponse, ForumPostingPolicyOwnerFactValue, ForumPostingPolicyRules,
     ForumPostingPolicyUnavailableFact, ForumPostingTrustFactPort, ForumPostingWindowCount,
     ForumPostingWindowLimit, ForumQuoteCommandService, ForumReadModelService,
-    ForumRelationReadService, ForumReplyCreateAudienceAuthorization,
+    ForumRelationReadService, ForumReplyAudienceReadService, ForumReplyCreateAudienceAuthorization,
     ForumReplyCreateAudienceAuthorizationService, ForumReplyCreatesWindowFactPort,
     ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage,
     ForumTopicAudienceListService, ForumTopicAudiencePage, ForumTopicAudiencePolicy,

--- a/crates/rustok-forum/src/reply_read_transport.rs
+++ b/crates/rustok-forum/src/reply_read_transport.rs
@@ -1,0 +1,232 @@
+use std::time::Duration;
+
+use rustok_api::{AuthContext, PortContext, RequestContext};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+const FORUM_REPLY_READ_FACTS_DEADLINE: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForumReplyReadTransport {
+    Graphql,
+    NativeServer,
+    Rest,
+}
+
+impl ForumReplyReadTransport {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Graphql => "graphql",
+            Self::NativeServer => "native",
+            Self::Rest => "rest",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForumReplyReadOperation {
+    ReplyList,
+    SelectedReply,
+}
+
+impl ForumReplyReadOperation {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::ReplyList => "reply-list",
+            Self::SelectedReply => "selected-reply",
+        }
+    }
+}
+
+/// Build the exact read-only caller context used while authorizing a reply
+/// through its parent topic audience policy.
+///
+/// Tenant and user identity come only from authenticated transport extensions.
+/// An available request snapshot must agree with the authenticated principal
+/// before an optional facts provider can be called.
+pub fn reply_read_audience_port_context(
+    transport: ForumReplyReadTransport,
+    operation: ForumReplyReadOperation,
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request: Option<&RequestContext>,
+    effective_locale: &str,
+) -> ForumResult<PortContext> {
+    if tenant_id.is_nil() || auth.tenant_id != tenant_id {
+        return Err(ForumError::Validation(
+            "Forum reply-read authenticated tenant does not match the requested tenant"
+                .to_string(),
+        ));
+    }
+
+    if let Some(request) = request {
+        if request.tenant_id != tenant_id {
+            return Err(ForumError::Validation(
+                "Forum reply-read request tenant does not match the requested tenant".to_string(),
+            ));
+        }
+        if request.user_id != Some(auth.user_id) {
+            return Err(ForumError::Validation(
+                "Forum reply-read request actor does not match the authenticated user".to_string(),
+            ));
+        }
+    }
+
+    let locale = effective_locale.trim();
+    if locale.is_empty() {
+        return Err(ForumError::Validation(
+            "Forum reply-read request locale is unavailable".to_string(),
+        ));
+    }
+
+    let mut context = PortContext::new(
+        tenant_id.to_string(),
+        auth.port_actor(),
+        locale,
+        format!(
+            "forum-{}-{}-{}-{}",
+            transport.label(),
+            operation.label(),
+            auth.session_id,
+            Uuid::new_v4()
+        ),
+    )
+    .with_deadline(FORUM_REPLY_READ_FACTS_DEADLINE);
+
+    for permission in &auth.permissions {
+        context = context.with_claim(permission.to_string());
+    }
+    if let Some(channel_slug) = request
+        .and_then(|request| request.channel_slug.as_deref())
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty())
+    {
+        context = context.with_channel(channel_slug.to_string());
+    }
+
+    Ok(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{Permission, PortActorKind};
+
+    use super::*;
+
+    fn auth(tenant_id: Uuid, user_id: Uuid) -> AuthContext {
+        AuthContext {
+            user_id,
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions: vec![Permission::FORUM_REPLIES_READ],
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn request(tenant_id: Uuid, user_id: Uuid) -> RequestContext {
+        RequestContext {
+            tenant_id,
+            user_id: Some(user_id),
+            channel_id: Some(Uuid::new_v4()),
+            channel_slug: Some("members".to_string()),
+            channel_resolution_source: None,
+            locale: "ru-RU".to_string(),
+        }
+    }
+
+    #[test]
+    fn exact_context_uses_authenticated_identity_deadline_claims_locale_and_channel() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+        let request = request(tenant_id, user_id);
+
+        let context = reply_read_audience_port_context(
+            ForumReplyReadTransport::Rest,
+            ForumReplyReadOperation::SelectedReply,
+            tenant_id,
+            &auth,
+            Some(&request),
+            "de-DE",
+        )
+        .expect("trusted REST context should compose");
+
+        assert_eq!(context.tenant_id, tenant_id.to_string());
+        assert_eq!(context.actor.kind, PortActorKind::User);
+        assert_eq!(context.actor.id, user_id.to_string());
+        assert_eq!(context.locale, "de-DE");
+        assert_eq!(context.channel.as_deref(), Some("members"));
+        assert_eq!(context.deadline_ms, Some(5_000));
+        assert_eq!(context.claims, vec![Permission::FORUM_REPLIES_READ.to_string()]);
+        assert!(context.correlation_id.starts_with("forum-rest-selected-reply-"));
+    }
+
+    #[test]
+    fn graphql_context_without_http_request_preserves_effective_locale() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        let context = reply_read_audience_port_context(
+            ForumReplyReadTransport::Graphql,
+            ForumReplyReadOperation::ReplyList,
+            tenant_id,
+            &auth,
+            None,
+            "en",
+        )
+        .expect("GraphQL context should compose without an HTTP request snapshot");
+
+        assert_eq!(context.locale, "en");
+        assert!(context.channel.is_none());
+        assert!(context.correlation_id.starts_with("forum-graphql-reply-list-"));
+    }
+
+    #[test]
+    fn mismatched_auth_request_tenant_or_user_fails_before_owner_facts() {
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let auth = auth(tenant_id, user_id);
+
+        assert!(matches!(
+            reply_read_audience_port_context(
+                ForumReplyReadTransport::Graphql,
+                ForumReplyReadOperation::ReplyList,
+                Uuid::new_v4(),
+                &auth,
+                None,
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("authenticated tenant")
+        ));
+
+        let foreign_tenant_request = request(Uuid::new_v4(), user_id);
+        assert!(matches!(
+            reply_read_audience_port_context(
+                ForumReplyReadTransport::NativeServer,
+                ForumReplyReadOperation::ReplyList,
+                tenant_id,
+                &auth,
+                Some(&foreign_tenant_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request tenant")
+        ));
+
+        let foreign_user_request = request(tenant_id, Uuid::new_v4());
+        assert!(matches!(
+            reply_read_audience_port_context(
+                ForumReplyReadTransport::Rest,
+                ForumReplyReadOperation::SelectedReply,
+                tenant_id,
+                &auth,
+                Some(&foreign_user_request),
+                "en",
+            ),
+            Err(ForumError::Validation(message)) if message.contains("request actor")
+        ));
+    }
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -46,6 +46,7 @@ mod reply {
     include!("reply.rs");
     include!("reply_inline.rs");
 }
+mod reply_audience_read;
 mod reply_create_audience_authorization;
 mod reply_facade;
 mod reply_owner {
@@ -143,6 +144,7 @@ pub use read_tracking::{
     MarkForumTopicsReadBatchInput, MarkForumTopicsReadBatchResult,
 };
 pub use relation_read::ForumRelationReadService;
+pub use reply_audience_read::ForumReplyAudienceReadService;
 pub use reply_create_audience_authorization::{
     ForumReplyCreateAudienceAuthorization, ForumReplyCreateAudienceAuthorizationService,
 };

--- a/crates/rustok-forum/src/services/reply_audience_read.rs
+++ b/crates/rustok-forum/src/services/reply_audience_read.rs
@@ -1,0 +1,239 @@
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use rustok_api::{Action, PortContext, Resource};
+use rustok_core::SecurityContext;
+use rustok_outbox::TransactionalEventBus;
+
+use crate::audience::SharedForumAudienceFactsPort;
+use crate::dto::{ListRepliesFilter, ReplyListItem, ReplyResponse};
+use crate::error::{ForumError, ForumResult};
+use crate::state_machine::ReplyStatus;
+
+use super::rbac::enforce_scope;
+use super::reply_facade::ReplyService;
+use super::topic_audience_visibility::{
+    ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService,
+};
+
+/// Exact reply read owner. Every reply decision is derived from the audience
+/// policy of its parent topic before reply content or pagination is returned.
+pub struct ForumReplyAudienceReadService {
+    reply_service: ReplyService,
+    visibility: ForumTopicAudienceVisibilityService,
+}
+
+impl ForumReplyAudienceReadService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self::with_optional_audience_facts(db, event_bus, None)
+    }
+
+    pub fn with_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        facts_port: SharedForumAudienceFactsPort,
+    ) -> Self {
+        Self::with_optional_audience_facts(db, event_bus, Some(facts_port))
+    }
+
+    fn with_optional_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        facts_port: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self {
+            reply_service: ReplyService::new(db.clone(), event_bus),
+            visibility: ForumTopicAudienceVisibilityService::new(db, facts_port),
+        }
+    }
+
+    /// Exact authenticated owner read for one reply. Closed topics remain
+    /// readable to authorized owners, while every category/topic audience layer
+    /// is enforced before the reply body is loaded.
+    pub async fn get_authenticated_owner_visible_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        reply_id: Uuid,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<ReplyResponse> {
+        enforce_scope(&security, Resource::ForumReplies, Action::Read)?;
+        let locale = required_context_locale(&context)?;
+        let reply = self.reply_service.find_reply(tenant_id, reply_id).await?;
+        let viewer = ForumTopicAudienceViewer::authenticated(security.clone(), context)?;
+        if !self
+            .visibility
+            .is_topic_owner_visible(tenant_id, reply.topic_id, &viewer)
+            .await?
+        {
+            return Err(ForumError::ReplyNotFound(reply_id));
+        }
+
+        self.reply_service
+            .get_with_locale_fallback(
+                tenant_id,
+                security,
+                reply_id,
+                &locale,
+                fallback_locale,
+            )
+            .await
+    }
+
+    /// Exact authenticated REST-style reply list through parent-topic owner
+    /// visibility. Denied and missing parent topics both resolve as absent.
+    pub async fn list_authenticated_owner_visible_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        topic_id: Uuid,
+        mut filter: ListRepliesFilter,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<(Vec<ReplyListItem>, u64)> {
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        let locale = required_context_locale(&context)?;
+        let viewer = ForumTopicAudienceViewer::authenticated(security.clone(), context)?;
+        self.require_owner_topic_visible(tenant_id, topic_id, &viewer)
+            .await?;
+        filter.locale = Some(locale);
+        self.reply_service
+            .list_for_topic_with_locale_fallback(
+                tenant_id,
+                security,
+                topic_id,
+                filter,
+                fallback_locale,
+            )
+            .await
+    }
+
+    /// Exact authenticated GraphQL owner list returning full reply responses.
+    pub async fn list_response_authenticated_owner_visible_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        topic_id: Uuid,
+        mut filter: ListRepliesFilter,
+        fallback_locale: Option<&str>,
+        statuses: Option<&[ReplyStatus]>,
+    ) -> ForumResult<(Vec<ReplyResponse>, u64)> {
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        let locale = required_context_locale(&context)?;
+        let viewer = ForumTopicAudienceViewer::authenticated(security.clone(), context)?;
+        self.require_owner_topic_visible(tenant_id, topic_id, &viewer)
+            .await?;
+        filter.locale = Some(locale);
+        self.reply_service
+            .list_response_for_topic_by_statuses_with_locale_fallback(
+                tenant_id,
+                security,
+                topic_id,
+                filter,
+                fallback_locale,
+                statuses,
+            )
+            .await
+    }
+
+    /// Exact public storefront reply list. Missing, closed, channel-denied or
+    /// richer-audience-denied parent topics all return an empty connection.
+    pub async fn list_public_storefront_visible_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        filter: ListRepliesFilter,
+        fallback_locale: Option<&str>,
+        channel_slug: Option<&str>,
+        statuses: Option<&[ReplyStatus]>,
+    ) -> ForumResult<(Vec<ReplyResponse>, u64)> {
+        let security = SecurityContext::public_read();
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        let viewer = ForumTopicAudienceViewer::public();
+        if !self
+            .visibility
+            .is_topic_visible(tenant_id, topic_id, channel_slug, &viewer)
+            .await?
+        {
+            return Ok((Vec::new(), 0));
+        }
+
+        self.reply_service
+            .list_response_for_topic_by_statuses_with_locale_fallback(
+                tenant_id,
+                security,
+                topic_id,
+                filter,
+                fallback_locale,
+                statuses,
+            )
+            .await
+    }
+
+    /// Exact authenticated storefront reply list. The route channel and locale
+    /// come only from the validated caller context. Denied topics return an empty
+    /// connection without exposing the rejecting policy layer.
+    pub async fn list_authenticated_storefront_visible_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        topic_id: Uuid,
+        mut filter: ListRepliesFilter,
+        fallback_locale: Option<&str>,
+        statuses: Option<&[ReplyStatus]>,
+    ) -> ForumResult<(Vec<ReplyResponse>, u64)> {
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        let locale = required_context_locale(&context)?;
+        let channel_slug = context.channel.clone();
+        let viewer = ForumTopicAudienceViewer::authenticated(security.clone(), context)?;
+        if !self
+            .visibility
+            .is_topic_visible(tenant_id, topic_id, channel_slug.as_deref(), &viewer)
+            .await?
+        {
+            return Ok((Vec::new(), 0));
+        }
+        filter.locale = Some(locale);
+
+        self.reply_service
+            .list_response_for_topic_by_statuses_with_locale_fallback(
+                tenant_id,
+                security,
+                topic_id,
+                filter,
+                fallback_locale,
+                statuses,
+            )
+            .await
+    }
+
+    async fn require_owner_topic_visible(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
+    ) -> ForumResult<()> {
+        if self
+            .visibility
+            .is_topic_owner_visible(tenant_id, topic_id, viewer)
+            .await?
+        {
+            Ok(())
+        } else {
+            Err(ForumError::TopicNotFound(topic_id))
+        }
+    }
+}
+
+fn required_context_locale(context: &PortContext) -> ForumResult<String> {
+    let locale = context.locale.trim();
+    if locale.is_empty() {
+        return Err(ForumError::Validation(
+            "Forum reply audience read context locale is unavailable".to_string(),
+        ));
+    }
+    Ok(locale.to_string())
+}

--- a/crates/rustok-forum/src/services/topic_audience_visibility.rs
+++ b/crates/rustok-forum/src/services/topic_audience_visibility.rs
@@ -69,8 +69,8 @@ impl ForumTopicAudienceViewer {
     }
 }
 
-/// Exact topic visibility composition through the current storefront owner and
-/// every normalized richer category/topic audience layer.
+/// Exact topic visibility composition through the current owner and every
+/// normalized richer category/topic audience layer.
 pub struct ForumTopicAudienceVisibilityService {
     db: DatabaseConnection,
     facts_resolver: ForumAudienceFactsResolver,
@@ -114,6 +114,42 @@ impl ForumTopicAudienceVisibilityService {
             return Ok(false);
         }
 
+        self.policy_allows(tenant_id, topic_id, viewer).await
+    }
+
+    /// Exact owner-read visibility for a topic and resources owned by that topic.
+    ///
+    /// Unlike storefront visibility this intentionally does not require an open
+    /// topic or a matching route channel. It preserves owner/admin reads while
+    /// enforcing the inherited category floor and every richer category/topic
+    /// audience layer. Missing and denied topics both resolve to `false`.
+    pub async fn is_topic_owner_visible(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
+    ) -> ForumResult<bool> {
+        self.validate_viewer_context(tenant_id, viewer)?;
+        if !ForumTopicVisibilityService::new(self.db.clone())
+            .is_topic_category_visible_to_viewer(
+                tenant_id,
+                topic_id,
+                viewer.is_authenticated(),
+            )
+            .await?
+        {
+            return Ok(false);
+        }
+
+        self.policy_allows(tenant_id, topic_id, viewer).await
+    }
+
+    async fn policy_allows(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        viewer: &ForumTopicAudienceViewer,
+    ) -> ForumResult<bool> {
         let topic = match find_topic(&self.db, tenant_id, topic_id).await {
             Ok(topic) => topic,
             Err(ForumError::TopicNotFound(_)) => return Ok(false),

--- a/crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs
@@ -36,7 +36,7 @@ pub async fn fetch_storefront_replies_graphql(
         return Ok(empty_replies());
     };
 
-    let response = execute_graphql(
+    let response: StorefrontForumAudienceRepliesResponse = execute_graphql(
         &graphql_url(),
         GraphqlRequest::new(
             STOREFRONT_FORUM_AUDIENCE_REPLIES_QUERY,
@@ -57,7 +57,6 @@ pub async fn fetch_storefront_replies_graphql(
     .await
     .map_err(|error| ApiError::Graphql(error.to_string()))?;
 
-    let response: StorefrontForumAudienceRepliesResponse = response;
     Ok(response.forum_storefront_audience_replies)
 }
 

--- a/crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs
@@ -1,0 +1,104 @@
+use rustok_graphql::{GraphqlRequest, execute as execute_graphql};
+use serde::{Deserialize, Serialize};
+
+use super::graphql_adapter::ApiError;
+use crate::model::ForumReplyConnection;
+
+const STOREFRONT_FORUM_AUDIENCE_REPLIES_QUERY: &str = "query StorefrontForumAudienceReplies($tenantId: UUID, $topicId: UUID!, $locale: String, $pagination: PaginationInput) { forumStorefrontAudienceReplies(tenantId: $tenantId, topicId: $topicId, locale: $locale, pagination: $pagination) { total items { id effectiveLocale topicId content contentFormat status parentReplyId createdAt updatedAt } } }";
+
+#[derive(Debug, Deserialize)]
+struct StorefrontForumAudienceRepliesResponse {
+    #[serde(rename = "forumStorefrontAudienceReplies")]
+    forum_storefront_audience_replies: ForumReplyConnection,
+}
+
+#[derive(Debug, Serialize)]
+struct PaginationInput {
+    offset: i64,
+    limit: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct RepliesVariables {
+    #[serde(rename = "tenantId")]
+    tenant_id: Option<String>,
+    #[serde(rename = "topicId")]
+    topic_id: String,
+    locale: Option<String>,
+    pagination: PaginationInput,
+}
+
+pub async fn fetch_storefront_replies_graphql(
+    topic_id: Option<String>,
+    locale: Option<String>,
+) -> Result<ForumReplyConnection, ApiError> {
+    let Some(topic_id) = topic_id else {
+        return Ok(empty_replies());
+    };
+
+    let response = execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(
+            STOREFRONT_FORUM_AUDIENCE_REPLIES_QUERY,
+            Some(RepliesVariables {
+                tenant_id: None,
+                topic_id,
+                locale,
+                pagination: PaginationInput {
+                    offset: 0,
+                    limit: 20,
+                },
+            }),
+        ),
+        None,
+        configured_tenant_slug(),
+        None,
+    )
+    .await
+    .map_err(|error| ApiError::Graphql(error.to_string()))?;
+
+    let response: StorefrontForumAudienceRepliesResponse = response;
+    Ok(response.forum_storefront_audience_replies)
+}
+
+fn configured_tenant_slug() -> Option<String> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim().to_string();
+            (!value.is_empty()).then_some(value)
+        })
+    })
+}
+
+fn graphql_url() -> String {
+    if let Some(url) = option_env!("RUSTOK_GRAPHQL_URL") {
+        return url.to_string();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let origin = web_sys::window()
+            .and_then(|window| window.location().origin().ok())
+            .unwrap_or_else(|| "http://localhost:5150".to_string());
+        format!("{origin}/api/graphql")
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let base =
+            std::env::var("RUSTOK_API_URL").unwrap_or_else(|_| "http://localhost:5150".to_string());
+        format!("{base}/api/graphql")
+    }
+}
+
+fn empty_replies() -> ForumReplyConnection {
+    ForumReplyConnection {
+        items: Vec::new(),
+        total: 0,
+    }
+}

--- a/crates/rustok-forum/storefront/src/transport/mod.rs
+++ b/crates/rustok-forum/storefront/src/transport/mod.rs
@@ -1,4 +1,6 @@
 mod graphql_adapter;
+mod graphql_reply_audience_adapter;
+mod native_reply_audience_adapter;
 mod native_server_adapter;
 
 use crate::model::StorefrontForumData;
@@ -15,19 +17,31 @@ pub async fn fetch_storefront_forum(
     locale: Option<String>,
 ) -> Result<StorefrontForumData, TransportError> {
     if use_native_transport() {
-        native_server_adapter::fetch_storefront_forum_server(
+        let mut data = native_server_adapter::fetch_storefront_forum_server(
             selected_category_id,
             selected_topic_id,
+            locale.clone(),
+        )
+        .await?;
+        data.replies = native_reply_audience_adapter::fetch_storefront_replies_server(
+            data.selected_topic_id.clone(),
             locale,
         )
-        .await
+        .await?;
+        Ok(data)
     } else {
-        graphql_adapter::fetch_storefront_forum_graphql(
+        let mut data = graphql_adapter::fetch_storefront_forum_graphql(
             selected_category_id,
             selected_topic_id,
+            locale.clone(),
+        )
+        .await?;
+        data.replies = graphql_reply_audience_adapter::fetch_storefront_replies_graphql(
+            data.selected_topic_id.clone(),
             locale,
         )
-        .await
+        .await?;
+        Ok(data)
     }
 }
 

--- a/crates/rustok-forum/storefront/src/transport/native_reply_audience_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/native_reply_audience_adapter.rs
@@ -1,0 +1,171 @@
+use leptos::prelude::*;
+
+use super::graphql_adapter::ApiError;
+use crate::model::ForumReplyConnection;
+
+#[cfg(feature = "ssr")]
+use crate::model::ForumReplyDetail;
+
+pub async fn fetch_storefront_replies_server(
+    topic_id: Option<String>,
+    locale: Option<String>,
+) -> Result<ForumReplyConnection, ApiError> {
+    storefront_audience_replies_native(topic_id, locale)
+        .await
+        .map_err(|error| ApiError::ServerFn(error.to_string()))
+}
+
+#[server(prefix = "/api/fn", endpoint = "forum/storefront-audience-replies")]
+async fn storefront_audience_replies_native(
+    topic_id: Option<String>,
+    locale: Option<String>,
+) -> Result<ForumReplyConnection, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        use rustok_api::{
+            HostRuntimeContext, OptionalAuthContext, Permission, RequestContext, TenantContext,
+            has_any_effective_permission,
+        };
+        use rustok_core::SecurityContext;
+        use rustok_forum::{
+            ForumReplyAudienceReadService, ForumReplyReadOperation, ForumReplyReadTransport,
+            ListRepliesFilter, ReplyStatus, SharedForumAudienceFactsPort,
+            reply_read_audience_port_context,
+        };
+        use rustok_outbox::TransactionalEventBus;
+
+        let Some(topic_id) = topic_id else {
+            return Ok(empty_replies());
+        };
+        let topic_id = uuid::Uuid::parse_str(topic_id.trim())
+            .map_err(|_| ServerFnError::new("topic_id must be a valid UUID"))?;
+        let runtime_ctx = expect_context::<HostRuntimeContext>();
+        let tenant = leptos_axum::extract::<TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let auth = leptos_axum::extract::<OptionalAuthContext>()
+            .await
+            .map_err(ServerFnError::new)?
+            .0;
+        let request = leptos_axum::extract::<RequestContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let event_bus = runtime_ctx
+            .shared_get::<TransactionalEventBus>()
+            .ok_or_else(|| {
+                ServerFnError::new(
+                    "forum/storefront-audience-replies requires TransactionalEventBus in host runtime context",
+                )
+            })?;
+        let effective_locale = normalize_locale(
+            locale
+                .as_deref()
+                .or(Some(request.locale.as_str()))
+                .or(Some(tenant.default_locale.as_str())),
+        );
+        let db = runtime_ctx.db_clone();
+        let service = match runtime_ctx.shared_get::<SharedForumAudienceFactsPort>() {
+            Some(facts) => ForumReplyAudienceReadService::with_audience_facts(
+                db,
+                event_bus,
+                facts,
+            ),
+            None => ForumReplyAudienceReadService::new(db, event_bus),
+        };
+        let filter = ListRepliesFilter {
+            locale: Some(effective_locale.clone()),
+            page: 1,
+            per_page: 20,
+        };
+        let statuses = [ReplyStatus::Approved];
+
+        let (replies, total) = if let Some(auth) = auth.as_ref().filter(|auth| {
+            has_any_effective_permission(&auth.permissions, &[Permission::FORUM_REPLIES_LIST])
+        }) {
+            let context = reply_read_audience_port_context(
+                ForumReplyReadTransport::NativeServer,
+                ForumReplyReadOperation::ReplyList,
+                tenant.id,
+                auth,
+                Some(&request),
+                effective_locale.as_str(),
+            )
+            .map_err(server_error)?;
+            service
+                .list_authenticated_storefront_visible_with_audience_context(
+                    tenant.id,
+                    SecurityContext::from_permission_snapshot(
+                        Some(auth.user_id),
+                        &auth.permissions,
+                    ),
+                    context,
+                    topic_id,
+                    filter,
+                    Some(tenant.default_locale.as_str()),
+                    Some(&statuses),
+                )
+                .await
+                .map_err(server_error)?
+        } else {
+            service
+                .list_public_storefront_visible_with_locale_fallback(
+                    tenant.id,
+                    topic_id,
+                    filter,
+                    Some(tenant.default_locale.as_str()),
+                    request.channel_slug.as_deref(),
+                    Some(&statuses),
+                )
+                .await
+                .map_err(server_error)?
+        };
+
+        Ok(ForumReplyConnection {
+            items: replies.into_iter().map(map_reply).collect(),
+            total,
+        })
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = (topic_id, locale);
+        Err(ServerFnError::new(
+            "forum/storefront-audience-replies requires the `ssr` feature",
+        ))
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn normalize_locale(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(rustok_api::PLATFORM_FALLBACK_LOCALE)
+        .to_string()
+}
+
+#[cfg(feature = "ssr")]
+fn map_reply(value: rustok_forum::ReplyResponse) -> ForumReplyDetail {
+    ForumReplyDetail {
+        id: value.id.to_string(),
+        effective_locale: value.effective_locale,
+        topic_id: value.topic_id.to_string(),
+        content: value.content,
+        content_format: value.content_format,
+        status: value.status,
+        parent_reply_id: value.parent_reply_id.map(|id| id.to_string()),
+        created_at: value.created_at,
+        updated_at: value.updated_at,
+    }
+}
+
+fn empty_replies() -> ForumReplyConnection {
+    ForumReplyConnection {
+        items: Vec::new(),
+        total: 0,
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn server_error(error: impl std::fmt::Display) -> ServerFnError {
+    ServerFnError::new(error.to_string())
+}

--- a/scripts/verify/verify-forum-reply-audience-read.mjs
+++ b/scripts/verify/verify-forum-reply-audience-read.mjs
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const requireText = (source, needle, label) => {
+  if (!source.includes(needle)) {
+    throw new Error(`missing ${label}: ${needle}`);
+  }
+};
+
+const topicVisibility = read(
+  'crates/rustok-forum/src/services/topic_audience_visibility.rs',
+);
+const replyOwner = read(
+  'crates/rustok-forum/src/services/reply_audience_read.rs',
+);
+const transport = read('crates/rustok-forum/src/reply_read_transport.rs');
+const rest = read('crates/rustok-forum/src/controllers/replies.rs');
+const graphql = read('crates/rustok-forum/src/graphql/reply_audience_query.rs');
+const graphqlRuntime = read('crates/rustok-forum/src/graphql/runtime_data.rs');
+const selector = read('crates/rustok-forum/storefront/src/transport/mod.rs');
+const graphqlAdapter = read(
+  'crates/rustok-forum/storefront/src/transport/graphql_reply_audience_adapter.rs',
+);
+const nativeAdapter = read(
+  'crates/rustok-forum/storefront/src/transport/native_reply_audience_adapter.rs',
+);
+const contract = JSON.parse(
+  read('crates/rustok-forum/contracts/forum-reply-audience-read.json'),
+);
+
+requireText(
+  topicVisibility,
+  'pub async fn is_topic_owner_visible',
+  'owner topic audience visibility',
+);
+requireText(
+  topicVisibility,
+  '.is_topic_category_visible_to_viewer(',
+  'owner category floor',
+);
+requireText(
+  replyOwner,
+  'pub struct ForumReplyAudienceReadService',
+  'reply read owner',
+);
+requireText(
+  replyOwner,
+  '.is_topic_owner_visible(',
+  'reply owner parent-topic authorization',
+);
+requireText(
+  replyOwner,
+  '.is_topic_visible(',
+  'reply storefront parent-topic authorization',
+);
+requireText(
+  transport,
+  'ForumReplyReadOperation',
+  'reply read operation identity',
+);
+requireText(
+  transport,
+  'FORUM_REPLY_READ_FACTS_DEADLINE',
+  'reply facts deadline',
+);
+requireText(
+  rest,
+  '.list_authenticated_owner_visible_with_audience_context(',
+  'REST exact reply list',
+);
+requireText(
+  rest,
+  '.get_authenticated_owner_visible_with_audience_context(',
+  'REST exact selected reply',
+);
+requireText(
+  graphql,
+  'async fn forum_audience_replies',
+  'authenticated exact GraphQL field',
+);
+requireText(
+  graphql,
+  'async fn forum_storefront_audience_replies',
+  'storefront exact GraphQL field',
+);
+requireText(
+  graphqlRuntime,
+  'reply_audience_read_service',
+  'GraphQL runtime exact owner factory',
+);
+requireText(
+  graphqlAdapter,
+  'forumStorefrontAudienceReplies',
+  'GraphQL storefront exact reply query',
+);
+requireText(
+  nativeAdapter,
+  'list_authenticated_storefront_visible_with_audience_context',
+  'native authenticated exact reply owner',
+);
+requireText(
+  nativeAdapter,
+  'list_public_storefront_visible_with_locale_fallback',
+  'native public exact reply owner',
+);
+requireText(
+  selector,
+  'data.replies = native_reply_audience_adapter::fetch_storefront_replies_server',
+  'native final reply replacement',
+);
+requireText(
+  selector,
+  'data.replies = graphql_reply_audience_adapter::fetch_storefront_replies_graphql',
+  'GraphQL final reply replacement',
+);
+
+if (contract.task !== 'FORUM-20BF') throw new Error('unexpected task');
+for (const key of [
+  'owner_topic_visibility_enforces_category_and_richer_layers',
+  'selected_reply_resolves_parent_topic_before_content',
+  'reply_list_resolves_parent_topic_before_pagination',
+  'rest_get_reply_uses_exact_owner',
+  'rest_list_replies_uses_exact_owner',
+  'graphql_authenticated_exact_field_added',
+  'graphql_storefront_exact_field_added',
+  'native_storefront_final_replies_use_exact_owner',
+  'graphql_storefront_final_replies_use_exact_owner',
+]) {
+  if (!contract.read_boundary[key]) {
+    throw new Error(`contract must lock ${key}`);
+  }
+}
+if (contract.read_boundary.legacy_graphql_forum_replies_replaced) {
+  throw new Error('FORUM-20BF must not claim legacy forumReplies replacement');
+}
+if (contract.read_boundary.legacy_base_storefront_reply_fetch_removed) {
+  throw new Error('FORUM-20BF must not claim duplicate fetch removal');
+}
+if (contract.downstream_task !== 'FORUM-20BG') {
+  throw new Error('unexpected downstream task');
+}
+
+console.log('forum reply audience read composition verified');

--- a/scripts/verify/verify-forum-topic-audience-storefront-list-composition.mjs
+++ b/scripts/verify/verify-forum-topic-audience-storefront-list-composition.mjs
@@ -24,6 +24,9 @@ const contract = JSON.parse(
     'crates/rustok-forum/contracts/forum-topic-audience-storefront-list-composition.json',
   ),
 );
+const replyContract = JSON.parse(
+  read('crates/rustok-forum/contracts/forum-reply-audience-read.json'),
+);
 
 requireText(
   graphqlQuery,
@@ -103,10 +106,16 @@ if (!contract.compatibility.canonical_transport_adapters_updated) {
   throw new Error('contract must lock canonical adapter updates');
 }
 if (contract.compatibility.parallel_transport_adapters_added) {
-  throw new Error('FORUM-20BE must not retain parallel adapters');
+  throw new Error('FORUM-20BE must not retain parallel topic-list adapters');
 }
-if (contract.composition_boundary.reply_owner_read_changed) {
-  throw new Error('FORUM-20BE must not claim exact reply-owner migration');
+if (!contract.composition_boundary.reply_owner_read_changed) {
+  throw new Error('FORUM-20BE handoff must record delivered reply-owner migration');
+}
+if (contract.downstream_completion !== 'crates/rustok-forum/contracts/forum-reply-audience-read.json') {
+  throw new Error('FORUM-20BE handoff must point to the reply-read contract');
+}
+if (replyContract.task !== 'FORUM-20BF') {
+  throw new Error('unexpected reply-read completion task');
 }
 if (contract.downstream_task !== 'FORUM-20BF') {
   throw new Error('unexpected downstream task');


### PR DESCRIPTION
## Summary

- add `ForumTopicAudienceVisibilityService::is_topic_owner_visible` so owner reads enforce category and richer topic audience layers without storefront-only open/channel requirements
- add trusted reply-read transport contexts for GraphQL, native server, and REST
- publish `ForumReplyAudienceReadService` for selected reply, owner reply-list, and storefront reply-list authorization through the parent topic
- compose REST get/list reply reads and reply-vote read preflights through the exact owner
- add additive `forumAudienceReplies` and `forumStorefrontAudienceReplies` GraphQL fields backed by the exact owner and host-published audience facts
- replace final native and GraphQL storefront reply pages with exact owner results before data reaches the UI
- advance the FORUM-20BE handoff and add the FORUM-20BF contract, owner note, and source verifier

## Compatibility

- no migration or dependency change
- no existing REST route, GraphQL field, request DTO, response DTO, storefront model, or mark-read path removed or renamed
- legacy `forumReplies` / `forumStorefrontReplies` remain available; exact GraphQL fields are additive
- base storefront adapters still perform their compatibility reply fetch, but its result is replaced before final output; legacy field replacement and duplicate-fetch removal remain `FORUM-20BG`
- category/search/index/SEO/deep-link migration and scoped bulk read commands remain downstream
- `implementation-plan.md` and `CRATE_API.md` synchronization remains explicit conflict-safe repository-local documentation debt

## Validation

Not run by the implementation agent, per maintainer request: no tests, Cargo commands, formatting, verifiers, workflows, or CI.

Suggested maintainer commands:

```text
cargo test -p rustok-forum reply_read_transport -- --nocapture
cargo test -p rustok-forum --test topic_audience_exact_read_sqlite -- --nocapture
node scripts/verify/verify-forum-topic-audience-storefront-list-composition.mjs
node scripts/verify/verify-forum-reply-audience-read.mjs
cargo xtask module validate forum
```
