### PR TITLE
feat(index): add deterministic query planning

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M3 - PostgreSQL storage engine`
+- Current milestone: `M4 - Query engine v1 (planning started; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -50,18 +50,22 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M3 admitted archive manifest: `complete`
 - M3 retained archive verification and filesystem snapshot: `complete`
 - Real retained PostgreSQL packet execution: `open`
+- M4 deterministic executable query planning: `complete`
+- M4 stable explicit-link relation aliases: `complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
-  admitted archive manifest generation, saved-manifest verification, and recursive
-  filesystem integrity checks are implemented; one retained admitted packet, query
-  adapter, and production partition lifecycle remain open
+  admitted archive manifest generation, saved-manifest verification, recursive
+  filesystem integrity checks, and database-independent query planning are
+  implemented; one retained admitted packet, SQL query adapter, and production
+  partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
-lifecycle management, and measured partition admission that emits shadow bootstrap
-plans only. Owner-operated evidence tools live under `ops/benches`; they do not
-become runtime storage code.
+lifecycle management, measured partition admission that emits shadow bootstrap
+plans only, and an M4 structural query planner with deterministic relation aliases.
+Owner-operated evidence tools live under `ops/benches`; they do not become runtime
+storage code.
 
 ## Ownership
 
@@ -91,6 +95,7 @@ source modules
 crates/rustok-index/src/
   domain/
   application/
+    planner.rs
   migrations/
   infrastructure/postgres/
     mutation_store.rs
@@ -282,13 +287,20 @@ relations.
 
 ### M4 - Query engine v1
 
-- [ ] Produce deterministic executable plans from validated queries.
-- [ ] Resolve explicit link paths and assign stable aliases.
+- [x] Produce deterministic executable plans from validated queries.
+- [x] Resolve explicit link paths and assign stable aliases.
 - [ ] Compile plans through SeaQuery or controlled SQL.
 - [ ] Support nested projection, filtering, sorting, exact count, and keyset
       pagination.
 - [ ] Keep offset pagination bounded and compatibility-only.
 - [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
+
+The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
+before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
+prefixes, binds projection and ordering to those aliases, retains typed filters and
+pagination for the compiler, and publishes a versioned SHA-256 plan fingerprint.
+SQL execution, cursor predicate compilation, query-port composition, and consumer
+cutover remain open.
 
 ### M5 - Incremental ingestion
 
@@ -357,6 +369,7 @@ cargo check --workspace --all-targets --all-features
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo nextest run --workspace --all-targets --all-features
 cargo test --workspace --doc --all-features
+cargo test -p rustok-index planner_tests -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -378,7 +391,7 @@ cargo test -p rustok-benchmarks partition_cutover
 cargo check -p rustok-benchmarks --bin index-partition-capture-finalize
 ```
 
-Targeted M3 guards:
+Targeted M3/M4 guards:
 
 ```bash
 node scripts/verify/verify-index-mutation-storage.mjs
@@ -393,6 +406,7 @@ node scripts/verify/verify-index-partition-maintenance-evidence.mjs
 node scripts/verify/verify-index-partition-cutover-evidence.mjs
 node scripts/verify/verify-index-partition-full-capture.mjs
 node scripts/verify/verify-index-partition-post-inspection-drift.mjs
+node scripts/verify/verify-index-query-planner.mjs
 ```
 
 ## Progress log
@@ -409,6 +423,9 @@ node scripts/verify/verify-index-partition-post-inspection-drift.mjs
   owner orchestration with PostgreSQL identity-bound capture finalization, read-only
   retained bundle review, admitted archive manifest generation, saved-manifest
   verification receipts, and exact recursive filesystem snapshot enforcement.
+- 2026-07-29: rechecked the merged M3 source boundary and completed the first M4
+  source slice: validated structural plans, deterministic explicit-link aliases, and
+  a versioned query-plan fingerprint. SQL compilation remains the next bounded slice.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition
   lifecycle work begins.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -1,0 +1,61 @@
+# M4 query planner actualization
+
+Date: 2026-07-29
+
+This note actualizes the live `rustok-index` implementation plan after rechecking the M3 storage and retained-evidence work already merged into `main`.
+
+## Recheck result
+
+The M3 source implementation is complete through retained bundle review, archive manifest generation, saved-manifest verification, and recursive filesystem drift detection. The repository owner still needs to execute and admit one fresh real PostgreSQL partition packet. That owner gate continues to block production partition lifecycle design, but it does not require query-planning source work to remain idle.
+
+No surviving remote branch whose name contains `index` was found before this slice. The new work therefore starts from current `main` rather than carrying an older branch forward.
+
+## Actualized status
+
+- M3 real retained PostgreSQL packet execution: `open_owner_action`.
+- M3 production partition lifecycle: `blocked_by_retained_packet`.
+- M4 deterministic executable query planning: `source_complete_execution_pending`.
+- M4 stable relation aliases for explicit link paths: `source_complete_execution_pending`.
+- M4 SQL compilation: `open`.
+- M4 PostgreSQL/reference-engine equivalence: `open`.
+
+## Completed M4 slice 1
+
+`SchemaRegistry::plan_query` now:
+
+1. runs the existing registry-backed query validation before planning;
+2. collects every referenced link prefix from projection, filters, and ordering;
+3. sorts link prefixes deterministically and assigns `t0`, `t1`, ... aliases;
+4. resolves each join against the registered schema contract;
+5. binds projected and ordered fields to the same relation aliases;
+6. retains the typed filter and pagination contracts for the SQL compiler;
+7. publishes a versioned SHA-256 plan fingerprint over deterministic postcard bytes.
+
+The planner remains database independent and source-domain agnostic. It does not read source tables, execute SQL, bypass tenant/locale validation, decode cursors, or authorize callers.
+
+## Next bounded slice
+
+Compile `ExecutableQueryPlan` through controlled SeaQuery/PostgreSQL SQL while preserving:
+
+- tenant and locale predicates as non-optional scope constraints;
+- deterministic aliases and parameter order;
+- typed JSONB field extraction;
+- nested link projection and filtering;
+- exact count and bounded offset compatibility;
+- keyset cursor predicates with an entity-id tie-breaker;
+- SQL/parameter snapshots and reference-engine equivalence fixtures.
+
+Production query-port composition and consumer cutover remain later slices.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-index planner_tests -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-query-planner.mjs
+cargo xtask module validate index
+```

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,4 +1,5 @@
 mod cursor;
+mod planner;
 mod registry;
 mod validation;
 
@@ -6,6 +7,10 @@ mod validation;
 mod reference;
 
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};
+pub use planner::{
+    ExecutableQueryPlan, PlannedField, PlannedJoin, PlannedOrder, QueryPlanError,
+    QueryPlanFingerprint,
+};
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
 };

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -4,6 +4,8 @@ mod registry;
 mod validation;
 
 #[cfg(test)]
+mod planner_tests;
+#[cfg(test)]
 mod reference;
 
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -1,0 +1,172 @@
+use std::{collections::{BTreeMap, BTreeSet}, fmt};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::domain::{
+    FieldName, FieldPath, FilterExpr, IndexQuery, IndexQueryScope, LinkCardinality, LinkName,
+    OrderDirection, Pagination, SchemaRef,
+};
+
+use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
+
+const ROOT_ALIAS: &str = "t0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct QueryPlanFingerprint([u8; 32]);
+
+impl QueryPlanFingerprint {
+    pub fn as_bytes(&self) -> &[u8; 32] { &self.0 }
+    pub fn to_hex(self) -> String { hex::encode(self.0) }
+}
+
+impl fmt::Display for QueryPlanFingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannedJoin {
+    pub path: Vec<LinkName>,
+    pub alias: String,
+    pub source_alias: String,
+    pub source_schema: SchemaRef,
+    pub link: LinkName,
+    pub target_schema: SchemaRef,
+    pub source_fields: Vec<FieldName>,
+    pub target_fields: Vec<FieldName>,
+    pub cardinality: LinkCardinality,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannedField {
+    pub path: FieldPath,
+    pub relation_alias: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannedOrder {
+    pub field: PlannedField,
+    pub direction: OrderDirection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutableQueryPlan {
+    pub scope: IndexQueryScope,
+    pub root_schema: SchemaRef,
+    pub root_alias: String,
+    pub path_aliases: BTreeMap<Vec<LinkName>, String>,
+    pub joins: Vec<PlannedJoin>,
+    pub projection: Vec<PlannedField>,
+    pub filter: Option<FilterExpr>,
+    pub order_by: Vec<PlannedOrder>,
+    pub pagination: Pagination,
+    pub include_exact_count: bool,
+}
+
+impl ExecutableQueryPlan {
+    pub fn relation_alias(&self, path: &FieldPath) -> Option<&str> {
+        self.path_aliases.get(path.links()).map(String::as_str)
+    }
+
+    pub fn fingerprint(&self) -> Result<QueryPlanFingerprint, postcard::Error> {
+        let bytes = postcard::to_stdvec(self)?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"rustok-index-query-plan-v1");
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+        Ok(QueryPlanFingerprint(hasher.finalize().into()))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum QueryPlanError {
+    #[error(transparent)]
+    Validation(#[from] QueryValidationError),
+    #[error(transparent)]
+    Registry(#[from] SchemaRegistryError),
+}
+
+impl SchemaRegistry {
+    pub fn plan_query(&self, query: &IndexQuery) -> Result<ExecutableQueryPlan, QueryPlanError> {
+        self.validate_query(query)?;
+
+        let paths = collect_link_prefixes(query);
+        let mut aliases = BTreeMap::from([(Vec::new(), ROOT_ALIAS.to_owned())]);
+        for (index, path) in paths.iter().enumerate() {
+            aliases.insert(path.clone(), format!("t{}", index + 1));
+        }
+
+        let mut schemas = BTreeMap::from([(Vec::new(), query.schema.clone())]);
+        let mut joins = Vec::with_capacity(paths.len());
+        for path in &paths {
+            let parent = path[..path.len() - 1].to_vec();
+            let source_schema = schemas.get(&parent).cloned().ok_or_else(|| {
+                SchemaRegistryError::SchemaNotFound(query.schema.clone())
+            })?;
+            let registered = self.get(&source_schema).ok_or_else(|| {
+                SchemaRegistryError::SchemaNotFound(source_schema.clone())
+            })?;
+            let link_name = path.last().cloned().ok_or_else(|| {
+                SchemaRegistryError::SchemaNotFound(source_schema.clone())
+            })?;
+            let link = registered.schema.links.iter().find(|item| item.name == link_name)
+                .ok_or_else(|| SchemaRegistryError::UnknownTargetSchema {
+                    source_schema: source_schema.clone(),
+                    link: link_name.clone(),
+                    target: source_schema.clone(),
+                })?;
+            let target_schema = link.target_schema.clone();
+            joins.push(PlannedJoin {
+                path: path.clone(),
+                alias: aliases[path].clone(),
+                source_alias: aliases[&parent].clone(),
+                source_schema,
+                link: link.name.clone(),
+                target_schema: target_schema.clone(),
+                source_fields: link.source_fields.clone(),
+                target_fields: link.target_fields.clone(),
+                cardinality: link.cardinality,
+            });
+            schemas.insert(path.clone(), target_schema);
+        }
+
+        let projection = query.fields.iter().cloned().map(|path| PlannedField {
+            relation_alias: aliases[path.links()].clone(),
+            path,
+        }).collect();
+        let order_by = query.order_by.iter().cloned().map(|order| PlannedOrder {
+            field: PlannedField {
+                relation_alias: aliases[order.field.links()].clone(),
+                path: order.field,
+            },
+            direction: order.direction,
+        }).collect();
+
+        Ok(ExecutableQueryPlan {
+            scope: query.scope.clone(),
+            root_schema: query.schema.clone(),
+            root_alias: ROOT_ALIAS.to_owned(),
+            path_aliases: aliases,
+            joins,
+            projection,
+            filter: query.filter.clone(),
+            order_by,
+            pagination: query.pagination.clone(),
+            include_exact_count: query.include_exact_count,
+        })
+    }
+}
+
+fn collect_link_prefixes(query: &IndexQuery) -> Vec<Vec<LinkName>> {
+    let mut prefixes = BTreeSet::new();
+    for path in query.referenced_paths() {
+        for depth in 1..=path.links().len() {
+            prefixes.insert(path.links()[..depth].to_vec());
+        }
+    }
+    prefixes.into_iter().collect()
+}

--- a/crates/rustok-index/src/application/planner_tests.rs
+++ b/crates/rustok-index/src/application/planner_tests.rs
@@ -1,0 +1,125 @@
+use uuid::Uuid;
+
+use super::{QueryPlanError, SchemaRegistry};
+use crate::domain::{
+    EntityName, FieldCardinality, FieldName, FieldPath, FilterExpr, IndexField, IndexLink,
+    IndexQuery, IndexQueryScope, IndexSchema, IndexValue, IndexValueType, LinkCardinality,
+    LinkName, LocaleKey, LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaRef,
+    SchemaVersion,
+};
+
+fn schema_ref(entity: &str) -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new(entity).unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn field(name: &str, sortable: bool) -> IndexField {
+    IndexField {
+        name: FieldName::new(name).unwrap(),
+        value_type: IndexValueType::Uuid,
+        cardinality: FieldCardinality::One,
+        nullable: false,
+        selectable: true,
+        filterable: true,
+        sortable,
+    }
+}
+
+fn registry() -> SchemaRegistry {
+    let channel = IndexSchema {
+        reference: schema_ref("sales_channel"),
+        locale_mode: LocaleMode::None,
+        fields: vec![field("id", true)],
+        links: Vec::new(),
+    };
+    let product = IndexSchema {
+        reference: schema_ref("product"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field("id", true), field("sales_channel_id", false)],
+        links: vec![IndexLink {
+            name: LinkName::new("sales_channel").unwrap(),
+            source_fields: vec![FieldName::new("sales_channel_id").unwrap()],
+            target_schema: channel.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::One,
+        }],
+    };
+
+    let mut registry = SchemaRegistry::new();
+    registry.register_batch([product, channel]).unwrap();
+    registry
+}
+
+fn query() -> IndexQuery {
+    let linked_id = FieldPath::linked(
+        [LinkName::new("sales_channel").unwrap()],
+        FieldName::new("id").unwrap(),
+    );
+    IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: Uuid::new_v4(),
+            locale: Some(LocaleKey::new("en-US").unwrap()),
+        },
+        schema: schema_ref("product"),
+        fields: vec![linked_id.clone(), FieldPath::new(FieldName::new("id").unwrap())],
+        filter: Some(FilterExpr::Eq(
+            linked_id.clone(),
+            IndexValue::Uuid(Uuid::new_v4()),
+        )),
+        order_by: vec![OrderExpr {
+            field: linked_id,
+            direction: OrderDirection::Asc,
+        }],
+        pagination: Pagination::Cursor {
+            first: 20,
+            after: None,
+        },
+        include_exact_count: true,
+    }
+}
+
+#[test]
+fn aliases_do_not_depend_on_reference_encounter_order() {
+    let registry = registry();
+    let first = query();
+    let mut second = first.clone();
+    second.fields.reverse();
+
+    let first = registry.plan_query(&first).unwrap();
+    let second = registry.plan_query(&second).unwrap();
+
+    assert_eq!(first.path_aliases, second.path_aliases);
+    assert_eq!(first.joins, second.joins);
+    assert_eq!(first.root_alias, "t0");
+    assert_eq!(first.joins[0].alias, "t1");
+    assert_eq!(first.order_by[0].field.relation_alias, "t1");
+}
+
+#[test]
+fn validation_precedes_plan_construction() {
+    let registry = registry();
+    let mut query = query();
+    query.fields = vec![FieldPath::new(FieldName::new("missing").unwrap())];
+
+    assert!(matches!(
+        registry.plan_query(&query),
+        Err(QueryPlanError::Validation(_))
+    ));
+}
+
+#[test]
+fn fingerprint_changes_with_order_semantics() {
+    let registry = registry();
+    let first = query();
+    let mut second = first.clone();
+    second.order_by[0].direction = OrderDirection::Desc;
+
+    let first = registry.plan_query(&first).unwrap().fingerprint().unwrap();
+    let second = registry.plan_query(&second).unwrap().fingerprint().unwrap();
+
+    assert_ne!(first, second);
+    assert_eq!(first.to_hex().len(), 64);
+}

--- a/scripts/verify/verify-index-query-planner.mjs
+++ b/scripts/verify/verify-index-query-planner.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-query-planner] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const plannerPath = 'crates/rustok-index/src/application/planner.rs';
+const planner = requireMarkers(plannerPath, [
+  'pub struct ExecutableQueryPlan',
+  'pub struct PlannedJoin',
+  'pub struct PlannedField',
+  'pub struct QueryPlanFingerprint',
+  'pub fn plan_query(&self, query: &IndexQuery)',
+  'self.validate_query(query)?;',
+  'collect_link_prefixes(query)',
+  'BTreeMap::from([(Vec::new(), ROOT_ALIAS.to_owned())])',
+  'format!("t{}", index + 1)',
+  'postcard::to_stdvec(self)?',
+  'rustok-index-query-plan-v1',
+]);
+
+const validation = planner.indexOf('self.validate_query(query)?;');
+const aliasing = planner.indexOf('collect_link_prefixes(query)');
+if (validation < 0 || aliasing < 0 || validation > aliasing) {
+  fail('query validation must run before link-path planning');
+}
+
+for (const forbidden of [
+  'rustok_product',
+  'rustok_content',
+  'rustok_forum',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+  'sea_orm::',
+]) {
+  if (planner.includes(forbidden)) fail(`${plannerPath} contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-index/src/application/planner_tests.rs', [
+  'aliases_do_not_depend_on_reference_encounter_order',
+  'validation_precedes_plan_construction',
+  'fingerprint_changes_with_order_semantics',
+  'assert_eq!(first.root_alias, "t0")',
+  'assert_eq!(first.joins[0].alias, "t1")',
+]);
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod planner;',
+  'mod planner_tests;',
+  'ExecutableQueryPlan',
+  'QueryPlanFingerprint',
+]);
+
+requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
+  'M4 deterministic executable query planning: `source_complete_execution_pending`',
+  'M3 production partition lifecycle: `blocked_by_retained_packet`',
+  'Compile `ExecutableQueryPlan` through controlled SeaQuery/PostgreSQL SQL',
+  'Not run by the implementation agent',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '### M4 - Query engine v1',
+  '- [ ] Compile plans through SeaQuery or controlled SQL.',
+  'Partition cutover remains forbidden until one retained real',
+]);
+
+console.log('[verify-index-query-planner] OK');


### PR DESCRIPTION
## Summary

- add database-independent `SchemaRegistry::plan_query` after the existing registry-backed validation boundary
- collect all explicit link prefixes from projection, filters, and ordering and assign stable `t0`, `t1`, ... relation aliases
- publish `ExecutableQueryPlan`, resolved join metadata, projected/ordered field bindings, and a versioned SHA-256 plan fingerprint
- add focused unit scenarios for alias determinism, validation-before-planning, and semantic fingerprint changes
- add a source/mutation guard for the planner boundary
- actualize the canonical `rustok-index` roadmap: the first two M4 items are complete while SQL compilation remains the next bounded slice

## Recheck findings

The merged M3 source work is complete through retained bundle review, archive verification, and filesystem drift protection. One fresh real PostgreSQL packet remains an owner action and continues to block production partition lifecycle design. It does not block the database-independent M4 planning slice.

No existing remote branch containing `index` was found before creating this branch, so the work starts from current `main` without carrying stale branch state forward.

## Boundary

This PR does not execute SQL, add a query port, read source-module tables, decode cursors, change migrations, authorize callers, or begin production partition lifecycle work. Filters and pagination remain typed inputs for the next controlled SeaQuery/PostgreSQL compiler slice.

## Validation

Not run by the implementation agent, per maintainer instruction.

Suggested commands:

```bash
cargo test -p rustok-index planner_tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-query-planner.mjs
cargo xtask module validate index
```
