### PR TITLE
feat(product): fail closed on missing catalog schema

### DIFF
--- a/crates/rustok-product-catalog-service/README.md
+++ b/crates/rustok-product-catalog-service/README.md
@@ -6,7 +6,7 @@ The binary composes the canonical Product owner service and the replaceable toni
 
 ```text
 PostgreSQL
-   │
+   │ schema preflight
    ▼
 CatalogService
    │ ProductCatalogReadPort
@@ -28,6 +28,16 @@ It does not own Product DTOs, catalog policy, persistence queries, locale/channe
 | `RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR` | Server-owned identity assigned to authenticated calls, for example `rustok-server`. Caller-provided `PortContext.actor`, claims, and roles remain untrusted. |
 
 The database schema must already be migrated by the platform migration workflow. This service does not run migrations at startup.
+
+## Schema preflight
+
+After the PostgreSQL pool connects and before tonic starts listening, the host performs read probes through the canonical owner entities for:
+
+- `products`;
+- `product_variants`;
+- `sys_events`.
+
+This verifies that the Product catalog and transactional outbox schema are visible to the configured database principal. A missing table, incompatible schema, or insufficient read permission aborts startup with a sanitized migration-precondition error. The host does not create, alter, or repair schema and does not silently continue with partial readiness.
 
 ## Listener and TLS
 
@@ -72,4 +82,4 @@ RUSTOK_PRODUCT_CATALOG_SERVICE_ALLOW_INSECURE_LOOPBACK=true \
 cargo run -p rustok-product-catalog-service
 ```
 
-The implementation agent does not claim this command was executed. Product remains `boundary_ready` until the host and consumers are executed together and retained evidence is committed.
+The implementation agent does not claim this command was executed. Product remains `boundary_ready` until the schema preflight, host, and consumers are executed together and retained evidence is committed.

--- a/crates/rustok-product-catalog-service/src/main.rs
+++ b/crates/rustok-product-catalog-service/src/main.rs
@@ -8,13 +8,16 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 use rustok_api::PortActor;
-use rustok_outbox::{OutboxTransport, TransactionalEventBus};
-use rustok_product::CatalogService;
+use rustok_outbox::{OutboxTransport, SysEvents, TransactionalEventBus};
+use rustok_product::{
+    CatalogService,
+    entities::{Product, ProductVariant},
+};
 use rustok_product_transport::{
     ProductCatalogGrpcBearerInterceptor, ProductCatalogGrpcService,
     proto::product_catalog_read_service_server::ProductCatalogReadServiceServer,
 };
-use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm::{ConnectOptions, Database, DatabaseConnection, EntityTrait};
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 use url::Url;
 
@@ -23,6 +26,7 @@ const DEFAULT_DATABASE_CONNECT_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_DATABASE_MAX_CONNECTIONS: u32 = 20;
 const MAX_DATABASE_CONNECT_TIMEOUT_MS: u64 = 30_000;
 const MAX_DATABASE_CONNECTIONS: u32 = 200;
+const REQUIRED_SCHEMA_TABLES: [&str; 3] = ["products", "product_variants", "sys_events"];
 
 const BIND_ENV: &str = "RUSTOK_PRODUCT_CATALOG_SERVICE_BIND";
 const DATABASE_URL_ENV: &str = "RUSTOK_PRODUCT_CATALOG_DATABASE_URL";
@@ -120,9 +124,8 @@ impl ServiceConfig {
         }
 
         let bearer_token = RedactedSecret::new(required_secret_env(BEARER_TOKEN_ENV)?);
-        let trusted_service_actor = validate_service_actor(required_env(
-            TRUSTED_SERVICE_ACTOR_ENV,
-        )?)?;
+        let trusted_service_actor =
+            validate_service_actor(required_env(TRUSTED_SERVICE_ACTOR_ENV)?)?;
         let transport = validate_transport_security(
             bind,
             optional_path_env(TLS_CERT_PATH_ENV),
@@ -167,6 +170,8 @@ async fn run() -> Result<()> {
     );
 
     let database = connect_database(&config).await?;
+    verify_required_schema(&database).await?;
+
     let outbox = Arc::new(OutboxTransport::new(database.clone()));
     let event_bus = TransactionalEventBus::new(outbox);
     let provider = Arc::new(CatalogService::new(database, event_bus));
@@ -212,6 +217,33 @@ async fn connect_database(config: &ServiceConfig) -> Result<DatabaseConnection> 
     Database::connect(options)
         .await
         .map_err(|_| anyhow!("Product catalog PostgreSQL connection failed"))
+}
+
+async fn verify_required_schema(database: &DatabaseConnection) -> Result<()> {
+    Product::find()
+        .one(database)
+        .await
+        .map_err(|_| schema_preflight_error("products"))?;
+    ProductVariant::find()
+        .one(database)
+        .await
+        .map_err(|_| schema_preflight_error("product_variants"))?;
+    SysEvents::find()
+        .one(database)
+        .await
+        .map_err(|_| schema_preflight_error("sys_events"))?;
+
+    tracing::info!(
+        required_tables = ?REQUIRED_SCHEMA_TABLES,
+        "Product catalog database schema preflight passed"
+    );
+    Ok(())
+}
+
+fn schema_preflight_error(table: &'static str) -> anyhow::Error {
+    anyhow!(
+        "Product catalog schema preflight failed for `{table}`; run platform migrations before starting the service"
+    )
 }
 
 async fn load_tls_identity(cert_path: &Path, key_path: &Path) -> Result<Identity> {
@@ -406,8 +438,8 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::{
-        RedactedSecret, ServiceTransport, validate_database_url, validate_service_actor,
-        validate_transport_security,
+        REQUIRED_SCHEMA_TABLES, RedactedSecret, ServiceTransport, validate_database_url,
+        validate_service_actor, validate_transport_security,
     };
     use std::{net::SocketAddr, path::PathBuf};
 
@@ -429,6 +461,14 @@ mod tests {
         assert!(!target.contains("catalog_password"));
         assert_eq!(format!("{secret:?}"), "[REDACTED]");
         assert!(validate_database_url("sqlite::memory:".to_string()).is_err());
+    }
+
+    #[test]
+    fn required_schema_tables_are_owner_and_outbox_tables() {
+        assert_eq!(
+            REQUIRED_SCHEMA_TABLES,
+            ["products", "product_variants", "sys_events"]
+        );
     }
 
     #[test]

--- a/crates/rustok-product/contracts/product-fba-registry.json
+++ b/crates/rustok-product/contracts/product-fba-registry.json
@@ -124,6 +124,13 @@
     "provider_host_authenticator": "ProductCatalogGrpcBearerInterceptor",
     "provider_host_trusted_actor_env": "RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR",
     "provider_host_migrations": "external_precondition",
+    "provider_host_schema_preflight_tables": [
+      "products",
+      "product_variants",
+      "sys_events"
+    ],
+    "provider_host_schema_preflight_order": "after_connect_before_owner_and_listener",
+    "provider_host_schema_preflight_status": "source_complete_execution_pending",
     "provider_host_status": "source_complete_execution_pending",
     "status": "runtime_wired_execution_pending"
   },

--- a/crates/rustok-product/docs/implementation-plan.md
+++ b/crates/rustok-product/docs/implementation-plan.md
@@ -71,6 +71,14 @@ server-side, SQL logging is disabled, and tonic shutdown is coordinated with
 Ctrl-C / `SIGTERM` plus platform telemetry shutdown. Provider schema migration
 remains an external deployment precondition.
 
+The provider schema preflight is source-complete. After the PostgreSQL pool
+connects and before `CatalogService`, outbox composition, or tonic listener
+creation, the host performs canonical SeaORM read probes for `products`,
+`product_variants`, and `sys_events`. A missing table, incompatible schema, or
+insufficient read permission aborts startup with a sanitized migration-precondition
+error. The host never creates or repairs schema and never enters a partially ready
+serving state.
+
 Remote consumer behavior is now source-complete through executable loopback
 harnesses. Commerce builds checkout plans with a real external gRPC runtime and
 asserts that remote `Unavailable` and `Timeout` errors remain typed, retryable
@@ -82,11 +90,13 @@ and performs no persistence. These harnesses have not been executed by the
 implementation agent.
 
 Adapter and production-wiring source are complete. Consumer-behavior,
-authentication, and provider-host source are complete, but the service-host unit,
-loopback conformance, authenticated transport, and remote consumer harnesses have
-not been run by the implementation agent, so Product remains `boundary_ready`
-rather than `transport_verified`. Configured remote-profile execution evidence
-remain open. Provider-host execution evidence remains open.
+authentication, provider-host, and schema-preflight source are complete, but the
+service-host unit, PostgreSQL schema preflight, loopback conformance,
+authenticated transport, and remote consumer harnesses have not been run by the
+implementation agent, so Product remains `boundary_ready` rather than
+`transport_verified`. Configured remote-profile execution evidence remain open.
+Provider-host execution evidence remains open. Schema-preflight execution evidence
+remains open.
 
 The composed `rustok-ai` consumer has existing unavailable/deadline degraded-path
 evidence. Commerce checkout treats Product as a hard dependency and must not
@@ -181,8 +191,9 @@ rustok-pricing` dependency cycle.
 - FBA status: `boundary_ready` — the owner port, in-process profile, host runtime,
   declared consumer source cutovers, external gRPC adapter, validated connection
   policy, production client wiring, service-to-service authentication, standalone
-  provider host, and Commerce/AI remote behavior harnesses are source-complete.
-  Provider-host and authenticated end-to-end execution evidence remain open.
+  provider host, startup schema preflight, and Commerce/AI remote behavior
+  harnesses are source-complete. Provider-host, schema-preflight, and authenticated
+  end-to-end execution evidence remain open.
 - Structural shape: `core_transport_ui`
 - Evidence: `crates/rustok-product/contracts/product-fba-registry.json`,
   `crates/rustok-product/contracts/evidence/product-runtime-contract-smoke.json`,
@@ -219,10 +230,11 @@ rustok-pricing` dependency cycle.
    - `cargo test -p rustok-ai --features server --lib remote_product_`.
    Retain the generated `Cargo.lock` package entry with the first successful Cargo
    execution. Run `cargo run -p rustok-product-catalog-service` against the
-   migrated PostgreSQL schema, then start the server with the matching authenticated
-   gRPC deployment variables and retain end-to-end Commerce and AI evidence through
-   the selected runtime. Promote above `boundary_ready` only with those retained
-   results.
+   migrated PostgreSQL schema and retain the successful `products`,
+   `product_variants`, and `sys_events` preflight evidence. Then start the server
+   with the matching authenticated gRPC deployment variables and retain end-to-end
+   Commerce and AI evidence through the selected runtime. Promote above
+   `boundary_ready` only with those retained results.
 2. Keep Product richtext adoption explicitly deferred until the owner approves
    a typed storage/API/index migration. `product_translations.description` and
    catalog attributes currently named `richtext` are scalar text, so replacing
@@ -242,7 +254,8 @@ rustok-pricing` dependency cycle.
 - [x] Add service-to-service bearer authentication and trusted tenant metadata.
 - [x] Add executable Commerce hard-dependency and AI degraded-behavior gRPC harnesses.
 - [x] Implement a standalone Product catalog service host.
-- [ ] Execute the Product catalog service-host, authentication, and loopback conformance harnesses.
+- [x] Fail closed on missing Product/outbox schema before owner composition or listener startup.
+- [ ] Execute the Product catalog service-host, schema preflight, authentication, and loopback conformance harnesses.
 - [ ] Execute the Commerce and AI remote consumer behavior harnesses.
 - [ ] Retain end-to-end Commerce and AI behavior through a separately configured Product service.
 - [x] Connect storefront/admin UI controls to optional catalog filters/sorts.
@@ -302,11 +315,13 @@ rustok-pricing` dependency cycle.
   or an unavailable configured remote provider and must not silently select
   embedded execution.
 - The standalone provider host owns only deployment composition: PostgreSQL pool,
-  canonical `CatalogService`, `OutboxTransport`, tonic TLS/listener lifecycle,
-  bearer interceptor configuration, telemetry, and graceful shutdown. It does not
-  run migrations, expose write RPCs, relay outbox rows, or duplicate Product
-  policy/persistence. It configures the trusted service actor server-side and
-  never trusts actor/claims/roles supplied in `PortContext`.
+  required-schema read probes, canonical `CatalogService`, `OutboxTransport`,
+  tonic TLS/listener lifecycle, bearer interceptor configuration, telemetry, and
+  graceful shutdown. It does not run migrations, issue DDL, expose write RPCs,
+  relay outbox rows, or duplicate Product policy/persistence. It configures the
+  trusted service actor server-side, verifies `products`, `product_variants`, and
+  `sys_events` before serving, and never trusts actor/claims/roles supplied in
+  `PortContext`.
 - Commerce owns hard-dependency checkout behavior: a Product timeout or
   unavailable result blocks planning and cannot be replaced by the cart snapshot.
 - AI owns advisory degradation: Product transport failures skip enrichment,

--- a/scripts/verify/verify-product-catalog-grpc-authentication.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.mjs
@@ -191,7 +191,7 @@ requireAll(plan, [
   "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN",
   "constant-time",
   "trusted service actor",
-  "authentication source",
+  "authentication, provider-host, and schema-preflight source are complete",
   "Product remains `boundary_ready`",
   "standalone Product catalog service host is source-complete",
   "verify-product-catalog-grpc-authentication.mjs",

--- a/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-authentication.test.mjs
@@ -98,7 +98,7 @@ function fixture(options = {}) {
     "crates/rustok-product/docs/implementation-plan.md",
     options.missingPlan
       ? "Product plan"
-      : "service-to-service bearer authentication RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN constant-time trusted service actor authentication source Product remains `boundary_ready` standalone Product catalog service host is source-complete verify-product-catalog-grpc-authentication.mjs",
+      : "service-to-service bearer authentication RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN constant-time trusted service actor authentication, provider-host, and schema-preflight source are complete Product remains `boundary_ready` standalone Product catalog service host is source-complete verify-product-catalog-grpc-authentication.mjs",
   );
   return root;
 }

--- a/scripts/verify/verify-product-catalog-grpc-service-host.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-service-host.mjs
@@ -228,7 +228,7 @@ requireAll(plan, [
   "products",
   "product_variants",
   "sys_events",
-  "schema-preflight execution evidence remains open",
+  "Schema-preflight execution evidence remains open",
   "host execution evidence remains open",
   "Product remains `boundary_ready`",
   "cargo run -p rustok-product-catalog-service",

--- a/scripts/verify/verify-product-catalog-grpc-service-host.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-service-host.mjs
@@ -25,6 +25,18 @@ function requireAll(source, markers, description) {
   }
 }
 
+function requireOrder(source, markers, description) {
+  let cursor = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, cursor + 1);
+    if (index < 0) {
+      failures.push(`${description}: missing or out-of-order ${marker}`);
+      return;
+    }
+    cursor = index;
+  }
+}
+
 function forbidAll(source, markers, description) {
   for (const marker of markers) {
     if (source.includes(marker)) failures.push(`${description}: forbidden ${marker}`);
@@ -83,6 +95,27 @@ requireAll(source, [
   "Product catalog service TLS is required unless explicit loopback plaintext is enabled",
 ], "Product service fail-closed configuration");
 requireAll(source, [
+  "SysEvents",
+  "entities::{Product, ProductVariant}",
+  "EntityTrait",
+  'REQUIRED_SCHEMA_TABLES: [&str; 3] = ["products", "product_variants", "sys_events"]',
+  "async fn verify_required_schema(database: &DatabaseConnection)",
+  "Product::find()",
+  "ProductVariant::find()",
+  "SysEvents::find()",
+  'schema_preflight_error("products")',
+  'schema_preflight_error("product_variants")',
+  'schema_preflight_error("sys_events")',
+  "run platform migrations before starting the service",
+  "Product catalog database schema preflight passed",
+], "Product service schema preflight");
+requireOrder(source, [
+  "let database = connect_database(&config).await?;",
+  "verify_required_schema(&database).await?;",
+  "let outbox = Arc::new(OutboxTransport::new(database.clone()));",
+  "let mut server = Server::builder();",
+], "Product service startup preflight order");
+requireAll(source, [
   "struct RedactedSecret(String)",
   'formatter.write_str("[REDACTED]")',
   "database_target = %config.database_target",
@@ -102,6 +135,7 @@ requireAll(source, [
 requireAll(source, [
   "secrets_are_redacted_from_debug_output",
   "database_must_be_postgresql_and_debug_target_excludes_credentials",
+  "required_schema_tables_are_owner_and_outbox_tables",
   "plaintext_requires_explicit_loopback_bind",
   "tls_requires_certificate_and_key_as_a_pair",
   "trusted_service_actor_is_server_configured_and_bounded",
@@ -111,6 +145,8 @@ forbidAll(source, [
   "ProductCatalogReadRuntime::in_process",
   "MigrationTrait",
   "Migrator::up",
+  "CREATE TABLE",
+  "ALTER TABLE",
   "axum::",
   "async_graphql",
   "NoopEvent",
@@ -129,6 +165,12 @@ requireAll(readme, [
   "OutboxTransport",
   "read-only",
   "does not run migrations at startup",
+  "## Schema preflight",
+  "products",
+  "product_variants",
+  "sys_events",
+  "before tonic starts listening",
+  "does not silently continue with partial readiness",
   "RUSTOK_PRODUCT_CATALOG_SERVICE_TLS_CERT_PATH",
   "RUSTOK_PRODUCT_CATALOG_SERVICE_ALLOW_INSECURE_LOOPBACK=true",
   "RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR",
@@ -156,12 +198,18 @@ if (registry) {
     provider_host_transport_security: "tls_or_explicit_loopback",
     provider_host_authenticator: "ProductCatalogGrpcBearerInterceptor",
     provider_host_trusted_actor_env: "RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR",
+    provider_host_schema_preflight_order: "after_connect_before_owner_and_listener",
+    provider_host_schema_preflight_status: "source_complete_execution_pending",
     provider_host_status: "source_complete_execution_pending",
   };
   for (const [key, value] of Object.entries(expected)) {
     if (external[key] !== value) {
       failures.push(`Product registry ${key} must be ${value}`);
     }
+  }
+  const expectedTables = ["products", "product_variants", "sys_events"];
+  if (JSON.stringify(external.provider_host_schema_preflight_tables) !== JSON.stringify(expectedTables)) {
+    failures.push("Product registry provider_host_schema_preflight_tables drift");
   }
   if (
     registry.evidence?.grpc_service_host_verifier !==
@@ -176,6 +224,11 @@ requireAll(plan, [
   "rustok-product-catalog-service",
   "OutboxTransport",
   "TLS-by-default",
+  "schema preflight is source-complete",
+  "products",
+  "product_variants",
+  "sys_events",
+  "schema-preflight execution evidence remains open",
   "host execution evidence remains open",
   "Product remains `boundary_ready`",
   "cargo run -p rustok-product-catalog-service",

--- a/scripts/verify/verify-product-catalog-grpc-service-host.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-service-host.test.mjs
@@ -42,6 +42,23 @@ tonic = { workspace = true, features = ["tls-ring"] }`,
   const security = options.insecurePublicPlaintext
     ? ""
     : `TLS_CERT_PATH_ENV} and {TLS_KEY_PATH_ENV} must be configured together bind.ip().is_loopback() Product catalog service TLS is required unless explicit loopback plaintext is enabled`;
+  const schemaPreflight = options.missingSchemaPreflight
+    ? ""
+    : `SysEvents entities::{Product, ProductVariant} EntityTrait
+REQUIRED_SCHEMA_TABLES: [&str; 3] = ["products", "product_variants", "sys_events"]
+async fn verify_required_schema(database: &DatabaseConnection)
+Product::find() ProductVariant::find() SysEvents::find()
+schema_preflight_error("products") schema_preflight_error("product_variants") schema_preflight_error("sys_events")
+run platform migrations before starting the service Product catalog database schema preflight passed`;
+  const startupOrder = options.misorderedSchemaPreflight
+    ? `verify_required_schema(&database).await?;
+let database = connect_database(&config).await?;
+let outbox = Arc::new(OutboxTransport::new(database.clone()));
+let mut server = Server::builder();`
+    : `let database = connect_database(&config).await?;
+verify_required_schema(&database).await?;
+let outbox = Arc::new(OutboxTransport::new(database.clone()));
+let mut server = Server::builder();`;
   const secretLeak = options.leakedSecret ? "bearer_token = %token" : "";
   write(
     root,
@@ -50,8 +67,10 @@ tonic = { workspace = true, features = ["tls-ring"] }`,
 ${ownerComposition}
 ${authentication}
 ${security}
+${schemaPreflight}
+${startupOrder}
 ${secretLeak}
-Server::builder() ServerTlsConfig::new().identity(identity) .serve_with_shutdown(config.bind, shutdown_signal())
+ServerTlsConfig::new().identity(identity) .serve_with_shutdown(config.bind, shutdown_signal())
 DATABASE_URL_ENV: &str = "RUSTOK_PRODUCT_CATALOG_DATABASE_URL"
 BEARER_TOKEN_ENV: &str = "RUSTOK_PRODUCT_CATALOG_GRPC_BEARER_TOKEN"
 TRUSTED_SERVICE_ACTOR_ENV: &str = "RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR"
@@ -63,13 +82,13 @@ struct RedactedSecret(String) formatter.write_str("[REDACTED]") database_target 
 map_err(|_| anyhow!("Product catalog PostgreSQL connection failed"))
 service_name: "rustok-product-catalog-service".to_string() rustok_telemetry::init(telemetry_config)? rustok_telemetry::otel::shutdown().await
 tokio::signal::ctrl_c() SignalKind::terminate() Product catalog gRPC service shutdown requested
-secrets_are_redacted_from_debug_output database_must_be_postgresql_and_debug_target_excludes_credentials plaintext_requires_explicit_loopback_bind tls_requires_certificate_and_key_as_a_pair trusted_service_actor_is_server_configured_and_bounded
+secrets_are_redacted_from_debug_output database_must_be_postgresql_and_debug_target_excludes_credentials required_schema_tables_are_owner_and_outbox_tables plaintext_requires_explicit_loopback_bind tls_requires_certificate_and_key_as_a_pair trusted_service_actor_is_server_configured_and_bounded
 `,
   );
   write(
     root,
     "crates/rustok-product-catalog-service/README.md",
-    `standalone provider-side deployment unit CatalogService ProductCatalogGrpcService ProductCatalogGrpcBearerInterceptor OutboxTransport read-only does not run migrations at startup RUSTOK_PRODUCT_CATALOG_SERVICE_TLS_CERT_PATH RUSTOK_PRODUCT_CATALOG_SERVICE_ALLOW_INSECURE_LOOPBACK=true RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR cargo run -p rustok-product-catalog-service does not claim this command was executed boundary_ready`,
+    `standalone provider-side deployment unit CatalogService ProductCatalogGrpcService ProductCatalogGrpcBearerInterceptor OutboxTransport read-only does not run migrations at startup ## Schema preflight products product_variants sys_events before tonic starts listening does not silently continue with partial readiness RUSTOK_PRODUCT_CATALOG_SERVICE_TLS_CERT_PATH RUSTOK_PRODUCT_CATALOG_SERVICE_ALLOW_INSECURE_LOOPBACK=true RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR cargo run -p rustok-product-catalog-service does not claim this command was executed boundary_ready`,
   );
 
   write(
@@ -91,6 +110,16 @@ secrets_are_redacted_from_debug_output database_must_be_postgresql_and_debug_tar
         provider_host_authenticator: "ProductCatalogGrpcBearerInterceptor",
         provider_host_trusted_actor_env:
           "RUSTOK_PRODUCT_CATALOG_TRUSTED_SERVICE_ACTOR",
+        provider_host_schema_preflight_tables: [
+          "products",
+          "product_variants",
+          "sys_events",
+        ],
+        provider_host_schema_preflight_order:
+          "after_connect_before_owner_and_listener",
+        provider_host_schema_preflight_status: options.falseSchemaExecution
+          ? "runtime_verified"
+          : "source_complete_execution_pending",
         provider_host_status: options.falseExecution
           ? "runtime_verified"
           : "source_complete_execution_pending",
@@ -102,7 +131,7 @@ secrets_are_redacted_from_debug_output database_must_be_postgresql_and_debug_tar
     "crates/rustok-product/docs/implementation-plan.md",
     options.missingPlan
       ? "Product plan"
-      : "standalone Product catalog service host is source-complete rustok-product-catalog-service OutboxTransport TLS-by-default provider-host execution evidence remains open Product remains `boundary_ready` cargo run -p rustok-product-catalog-service verify-product-catalog-grpc-service-host.mjs",
+      : "standalone Product catalog service host is source-complete rustok-product-catalog-service OutboxTransport TLS-by-default schema preflight is source-complete products product_variants sys_events schema-preflight execution evidence remains open provider-host execution evidence remains open Product remains `boundary_ready` cargo run -p rustok-product-catalog-service verify-product-catalog-grpc-service-host.mjs",
   );
   return root;
 }
@@ -148,8 +177,20 @@ test("guard rejects unauthenticated provider host", () => {
   reject({ missingAuthentication: true }, /owner gRPC host composition|secret and authority/);
 });
 
+test("guard rejects missing schema preflight", () => {
+  reject({ missingSchemaPreflight: true }, /Product service schema preflight/);
+});
+
+test("guard rejects schema preflight after owner composition", () => {
+  reject({ misorderedSchemaPreflight: true }, /startup preflight order/);
+});
+
 test("guard rejects credential logging", () => {
   reject({ leakedSecret: true }, /ownership and secret boundary/);
+});
+
+test("guard rejects premature schema-preflight execution claim", () => {
+  reject({ falseSchemaExecution: true }, /provider_host_schema_preflight_status/);
 });
 
 test("guard rejects premature host execution claim", () => {

--- a/scripts/verify/verify-product-catalog-grpc-service-host.test.mjs
+++ b/scripts/verify/verify-product-catalog-grpc-service-host.test.mjs
@@ -131,7 +131,7 @@ secrets_are_redacted_from_debug_output database_must_be_postgresql_and_debug_tar
     "crates/rustok-product/docs/implementation-plan.md",
     options.missingPlan
       ? "Product plan"
-      : "standalone Product catalog service host is source-complete rustok-product-catalog-service OutboxTransport TLS-by-default schema preflight is source-complete products product_variants sys_events schema-preflight execution evidence remains open provider-host execution evidence remains open Product remains `boundary_ready` cargo run -p rustok-product-catalog-service verify-product-catalog-grpc-service-host.mjs",
+      : "standalone Product catalog service host is source-complete rustok-product-catalog-service OutboxTransport TLS-by-default schema preflight is source-complete products product_variants sys_events Schema-preflight execution evidence remains open provider-host execution evidence remains open Product remains `boundary_ready` cargo run -p rustok-product-catalog-service verify-product-catalog-grpc-service-host.mjs",
   );
   return root;
 }


### PR DESCRIPTION
## Summary
- add a startup schema preflight to `rustok-product-catalog-service`
- verify `products`, `product_variants`, and `sys_events` through canonical SeaORM owner entities
- run the probes after PostgreSQL connect and before owner/outbox composition or tonic listener startup
- abort startup on missing/incompatible schema or insufficient read permission without running migrations or DDL
- keep error output sanitized and retain the existing redacted database/credential handling
- document the migration precondition and partial-readiness prohibition
- synchronize Product FBA registry and implementation plan with source-complete/execution-pending schema-preflight evidence
- extend service-host and authentication plan guards plus mutation fixtures
- keep Product at `boundary_ready`

## Verification
Not run by the implementation agent per maintainer instruction.

Suggested commands:
- `node scripts/verify/verify-product-catalog-grpc-service-host.mjs`
- `node scripts/verify/verify-product-catalog-grpc-service-host.test.mjs`
- `node scripts/verify/verify-product-catalog-grpc-authentication.mjs`
- `node scripts/verify/verify-product-catalog-grpc-authentication.test.mjs`
- `cargo test -p rustok-product-catalog-service`

Then run `cargo run -p rustok-product-catalog-service` against a migrated PostgreSQL schema and retain the successful schema-preflight log before collecting authenticated Commerce/AI end-to-end evidence.