### PR TITLE
feat(index): compile projection plans to PostgreSQL

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (planning started; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (controlled SQL compiler added; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -52,18 +52,20 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - Real retained PostgreSQL packet execution: `open`
 - M4 deterministic executable query planning: `complete`
 - M4 stable explicit-link relation aliases: `complete`
+- M4 controlled PostgreSQL query compilation: `complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
   admitted archive manifest generation, saved-manifest verification, recursive
-  filesystem integrity checks, and database-independent query planning are
-  implemented; one retained admitted packet, SQL query adapter, and production
-  partition lifecycle remain open
+  filesystem integrity checks, database-independent query planning, and controlled
+  projection SQL compilation are implemented; one retained admitted packet, typed
+  query execution adapter, and production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
 lifecycle management, measured partition admission that emits shadow bootstrap
-plans only, and an M4 structural query planner with deterministic relation aliases.
+plans only, an M4 structural query planner with deterministic relation aliases, and
+a controlled PostgreSQL compiler for the explicitly supported projection subset.
 Owner-operated evidence tools live under `ops/benches`; they do not become runtime
 storage code.
 
@@ -96,6 +98,7 @@ crates/rustok-index/src/
   domain/
   application/
     planner.rs
+    postgres_compiler.rs
   migrations/
   infrastructure/postgres/
     mutation_store.rs
@@ -289,7 +292,7 @@ relations.
 
 - [x] Produce deterministic executable plans from validated queries.
 - [x] Resolve explicit link paths and assign stable aliases.
-- [ ] Compile plans through SeaQuery or controlled SQL.
+- [x] Compile plans through SeaQuery or controlled SQL.
 - [ ] Support nested projection, filtering, sorting, exact count, and keyset
       pagination.
 - [ ] Keep offset pagination bounded and compatibility-only.
@@ -299,8 +302,19 @@ The first M4 slice is database independent. `SchemaRegistry::plan_query` validat
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
 prefixes, binds projection and ordering to those aliases, retains typed filters and
 pagination for the compiler, and publishes a versioned SHA-256 plan fingerprint.
-SQL execution, cursor predicate compilation, query-port composition, and consumer
-cutover remain open.
+
+The second M4 slice adds `ExecutableQueryPlan::compile_postgres`. It emits one
+controlled PostgreSQL statement, ordered typed bind values, deterministic root/link
+identity columns, projected tagged JSONB values, exact tenant/schema/locale/live-row
+scope, and projection-only one-cardinality `LEFT JOIN` traversal. Caller values,
+link/schema identities, field names, and page limits remain bind parameters. The
+compiler also revalidates the complete path-to-alias mapping before SQL construction.
+
+Filters, explicit ordering, exact count, cursor continuation, bounded offset, and
+many-link aggregation return typed pending errors rather than guessed semantics.
+Typed filter/order/count/keyset compilation remains the next bounded M4 slice.
+SQL execution, result decoding, persisted-schema readiness, query-port composition,
+and consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
@@ -370,6 +384,7 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo nextest run --workspace --all-targets --all-features
 cargo test --workspace --doc --all-features
 cargo test -p rustok-index planner_tests -- --nocapture
+cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -407,6 +422,7 @@ node scripts/verify/verify-index-partition-cutover-evidence.mjs
 node scripts/verify/verify-index-partition-full-capture.mjs
 node scripts/verify/verify-index-partition-post-inspection-drift.mjs
 node scripts/verify/verify-index-query-planner.mjs
+node scripts/verify/verify-index-postgres-query-compiler.mjs
 ```
 
 ## Progress log
@@ -423,9 +439,10 @@ node scripts/verify/verify-index-query-planner.mjs
   owner orchestration with PostgreSQL identity-bound capture finalization, read-only
   retained bundle review, admitted archive manifest generation, saved-manifest
   verification receipts, and exact recursive filesystem snapshot enforcement.
-- 2026-07-29: rechecked the merged M3 source boundary and completed the first M4
-  source slice: validated structural plans, deterministic explicit-link aliases, and
-  a versioned query-plan fingerprint. SQL compilation remains the next bounded slice.
+- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic M4
+  structural planning and aliases, then added controlled projection SQL compilation
+  with ordered typed binds, alias-map revalidation, and fail-closed pending semantics.
+  Typed filter/order/count/keyset compilation remains the next bounded source slice.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition
   lifecycle work begins.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -1,0 +1,70 @@
+# M4 controlled PostgreSQL query compiler
+
+This slice compiles the database-independent `ExecutableQueryPlan` into one
+controlled PostgreSQL statement plus an ordered typed bind list. It does not
+execute SQL or publish an `IndexQueryPort`.
+
+## Accepted subset
+
+`ExecutableQueryPlan::compile_postgres` currently accepts:
+
+- root-field projection;
+- projection through explicit one-cardinality links;
+- a fresh bounded cursor page with no continuation token;
+- tenant, module, entity, schema-version, locale, and live-row scope;
+- deterministic root/entity identity columns for later result assembly.
+
+Every runtime value is a bind parameter:
+
+- tenant UUID;
+- module/entity names and schema versions;
+- locale key;
+- link name and exact target schema identity;
+- projected field names;
+- page limit.
+
+Only fixed table/column names and planner-owned aliases are emitted into SQL.
+Relation aliases must match `t` followed by decimal digits. The compiler also
+rechecks the complete path-to-alias map before SQL construction. Link aliases are
+compiler-owned `l1`, `l2`, and so on.
+
+## Join contract
+
+A one-cardinality link projection uses two `LEFT JOIN` operations:
+
+1. source entity to `index_links`, including exact source version and link name;
+2. link target identity to a live `index_entities` target.
+
+The target module, entity, and schema version are separately bound from the
+planned schema contract. Missing links therefore preserve the root entity while
+returning null linked identity/field columns.
+
+## Fail-closed pending semantics
+
+The compiler returns typed pending errors instead of guessing semantics for:
+
+- filters;
+- explicit ordering;
+- exact count;
+- cursor continuation;
+- offset pagination;
+- many-cardinality link projection/aggregation.
+
+Those features remain the next bounded M4 slice. Cursor bytes are not decoded by
+this compiler, and no caller-controlled string is interpolated into SQL.
+
+## Non-claims
+
+This source slice does not:
+
+- connect to PostgreSQL;
+- execute or prepare a statement;
+- decode result rows;
+- authorize a caller;
+- verify persisted schema readiness;
+- implement filter, sort, count, keyset, offset, or many-link semantics;
+- read source-module tables;
+- change migrations or partition lifecycle state.
+
+The repository owner runs compilation, unit tests, static verifiers, and later
+PostgreSQL/reference-engine equivalence evidence.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -6,9 +6,9 @@ This note actualizes the live `rustok-index` implementation plan after recheckin
 
 ## Recheck result
 
-The M3 source implementation is complete through retained bundle review, archive manifest generation, saved-manifest verification, and recursive filesystem drift detection. The repository owner still needs to execute and admit one fresh real PostgreSQL partition packet. That owner gate continues to block production partition lifecycle design, but it does not require query-planning source work to remain idle.
+The M3 source implementation is complete through retained bundle review, archive manifest generation, saved-manifest verification, and recursive filesystem drift detection. The repository owner still needs to execute and admit one fresh real PostgreSQL partition packet. That owner gate continues to block production partition lifecycle design, but it does not require query-planning or controlled SQL source work to remain idle.
 
-No surviving remote branch whose name contains `index` was found before this slice. The new work therefore starts from current `main` rather than carrying an older branch forward.
+No surviving remote branch whose name contains `index` was found before the planner slice. The M4 chain therefore started from current `main` rather than carrying an older branch forward.
 
 ## Actualized status
 
@@ -16,7 +16,8 @@ No surviving remote branch whose name contains `index` was found before this sli
 - M3 production partition lifecycle: `blocked_by_retained_packet`.
 - M4 deterministic executable query planning: `source_complete_execution_pending`.
 - M4 stable relation aliases for explicit link paths: `source_complete_execution_pending`.
-- M4 SQL compilation: `open`.
+- M4 controlled PostgreSQL query compilation: `source_complete_execution_pending`.
+- M4 typed filter/order/count/keyset semantics: `open`.
 - M4 PostgreSQL/reference-engine equivalence: `open`.
 
 ## Completed M4 slice 1
@@ -33,16 +34,23 @@ No surviving remote branch whose name contains `index` was found before this sli
 
 The planner remains database independent and source-domain agnostic. It does not read source tables, execute SQL, bypass tenant/locale validation, decode cursors, or authorize callers.
 
+## Completed M4 slice 2
+
+`ExecutableQueryPlan::compile_postgres` now emits controlled SQL, ordered typed bind values, deterministic identity/projection columns, exact root scope, and one-cardinality projection joins. It binds tenant, schema, locale, link, target schema, projected field, and limit values rather than interpolating them. It also rechecks the planner path-to-alias mapping before constructing SQL.
+
+The compiler deliberately returns typed pending errors for filters, explicit ordering, exact count, cursor continuation, offset pagination, and many-link aggregation. It does not connect to PostgreSQL or execute statements.
+
 ## Next bounded slice
 
-Compile `ExecutableQueryPlan` through controlled SeaQuery/PostgreSQL SQL while preserving:
+Typed filter/order/count/keyset compilation remains the next bounded M4 slice. It must preserve:
 
 - tenant and locale predicates as non-optional scope constraints;
 - deterministic aliases and parameter order;
-- typed JSONB field extraction;
-- nested link projection and filtering;
-- exact count and bounded offset compatibility;
+- typed JSONB scalar/list extraction aligned with secondary indexes;
+- nested link filtering and projection semantics;
+- exact count without pagination leakage;
 - keyset cursor predicates with an entity-id tie-breaker;
+- bounded offset compatibility as a separate explicit path;
 - SQL/parameter snapshots and reference-engine equivalence fixtures.
 
 Production query-port composition and consumer cutover remain later slices.
@@ -55,7 +63,9 @@ Suggested commands:
 
 ```bash
 cargo test -p rustok-index planner_tests -- --nocapture
+cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo check -p rustok-index --all-targets
 node scripts/verify/verify-index-query-planner.mjs
+node scripts/verify/verify-index-postgres-query-compiler.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,10 +1,13 @@
 mod cursor;
 mod planner;
+mod postgres_compiler;
 mod registry;
 mod validation;
 
 #[cfg(test)]
 mod planner_tests;
+#[cfg(test)]
+mod postgres_compiler_tests;
 #[cfg(test)]
 mod reference;
 
@@ -12,6 +15,9 @@ pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCurs
 pub use planner::{
     ExecutableQueryPlan, PlannedField, PlannedJoin, PlannedOrder, QueryPlanError,
     QueryPlanFingerprint,
+};
+pub use postgres_compiler::{
+    CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue, PostgresQueryCompileError,
 };
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -1,0 +1,264 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{LinkCardinality, Pagination};
+
+use super::{ExecutableQueryPlan, PlannedField, QueryPlanFingerprint};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum PostgresBindValue {
+    Uuid(Uuid),
+    Text(String),
+    Integer(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CompiledQueryColumn {
+    EntityId {
+        output_alias: String,
+        relation_alias: String,
+    },
+    Field {
+        output_alias: String,
+        field: PlannedField,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledPostgresQuery {
+    pub sql: String,
+    pub binds: Vec<PostgresBindValue>,
+    pub columns: Vec<CompiledQueryColumn>,
+    pub plan_fingerprint: QueryPlanFingerprint,
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresQueryCompileError {
+    #[error("query filters require the next M4 typed predicate compiler slice")]
+    FilterPending,
+    #[error("query ordering requires the next M4 typed ordering compiler slice")]
+    OrderingPending,
+    #[error("exact count requires the next M4 count compiler slice")]
+    ExactCountPending,
+    #[error("cursor continuation requires the next M4 keyset predicate compiler slice")]
+    CursorContinuationPending,
+    #[error("offset pagination requires the bounded compatibility compiler slice")]
+    OffsetPaginationPending,
+    #[error("many-cardinality link projection requires nested result aggregation")]
+    ManyLinkProjectionPending,
+    #[error("query plan relation aliases do not match the path-alias map")]
+    AliasMappingMismatch,
+    #[error("query plan contains an invalid relation alias: {0}")]
+    InvalidRelationAlias(String),
+    #[error("query plan fingerprint serialization failed: {0}")]
+    Fingerprint(#[from] postcard::Error),
+}
+
+impl ExecutableQueryPlan {
+    /// Compile the currently executable M4 subset into controlled PostgreSQL SQL.
+    ///
+    /// This slice intentionally accepts projection-only plans with root or
+    /// one-cardinality link fields and a fresh cursor page. Typed predicates,
+    /// explicit ordering, exact count, cursor continuation, many-link aggregation,
+    /// and offset compatibility remain fail-closed follow-up work.
+    pub fn compile_postgres(&self) -> Result<CompiledPostgresQuery, PostgresQueryCompileError> {
+        self.validate_compiler_subset()?;
+
+        let mut bindings = Bindings::default();
+        let root_alias = quote_identifier(&self.root_alias);
+        let tenant = bindings.push(PostgresBindValue::Uuid(self.scope.tenant_id));
+        let module = bindings.push(PostgresBindValue::Text(
+            self.root_schema.module.as_str().to_owned(),
+        ));
+        let entity = bindings.push(PostgresBindValue::Text(
+            self.root_schema.entity.as_str().to_owned(),
+        ));
+        let version = bindings.push(PostgresBindValue::Integer(i64::from(
+            self.root_schema.version.get(),
+        )));
+        let locale = bindings.push(PostgresBindValue::Text(
+            self.scope
+                .locale
+                .as_ref()
+                .map_or_else(String::new, |locale| locale.as_str().to_owned()),
+        ));
+
+        let mut select = Vec::new();
+        let mut columns = Vec::new();
+        push_identity_column(
+            &mut select,
+            &mut columns,
+            &self.root_alias,
+            &root_alias,
+        );
+
+        let mut joins = Vec::new();
+        for (index, join) in self.joins.iter().enumerate() {
+            let source_alias = quote_identifier(&join.source_alias);
+            let target_alias = quote_identifier(&join.alias);
+            let link_alias = format!("l{}", index + 1);
+            let link_alias_q = quote_identifier(&link_alias);
+            let link_name = bindings.push(PostgresBindValue::Text(join.link.as_str().to_owned()));
+            let target_module = bindings.push(PostgresBindValue::Text(
+                join.target_schema.module.as_str().to_owned(),
+            ));
+            let target_entity = bindings.push(PostgresBindValue::Text(
+                join.target_schema.entity.as_str().to_owned(),
+            ));
+            let target_version = bindings.push(PostgresBindValue::Integer(i64::from(
+                join.target_schema.version.get(),
+            )));
+
+            joins.push(format!(
+                "LEFT JOIN index_links AS {link_alias_q} ON {link_alias_q}.tenant_id = {source_alias}.tenant_id AND {link_alias_q}.source_module = {source_alias}.module_name AND {link_alias_q}.source_entity = {source_alias}.entity_name AND {link_alias_q}.source_schema_version = {source_alias}.schema_version AND {link_alias_q}.source_entity_id = {source_alias}.entity_id AND {link_alias_q}.source_locale_key = {source_alias}.locale_key AND {link_alias_q}.source_version = {source_alias}.source_version AND {link_alias_q}.link_name = {link_name} AND {link_alias_q}.target_module = {target_module} AND {link_alias_q}.target_entity = {target_entity} AND {link_alias_q}.target_schema_version = {target_version} LEFT JOIN index_entities AS {target_alias} ON {target_alias}.tenant_id = {link_alias_q}.tenant_id AND {target_alias}.module_name = {link_alias_q}.target_module AND {target_alias}.entity_name = {link_alias_q}.target_entity AND {target_alias}.schema_version = {link_alias_q}.target_schema_version AND {target_alias}.entity_id = {link_alias_q}.target_entity_id AND {target_alias}.locale_key = {link_alias_q}.target_locale_key AND {target_alias}.is_deleted = FALSE",
+            ));
+            push_identity_column(
+                &mut select,
+                &mut columns,
+                &join.alias,
+                &target_alias,
+            );
+        }
+
+        for (index, field) in self.projection.iter().enumerate() {
+            let relation_alias = quote_identifier(&field.relation_alias);
+            let field_name = bindings.push(PostgresBindValue::Text(
+                field.path.field().as_str().to_owned(),
+            ));
+            let output_alias = format!("f{index}");
+            select.push(format!(
+                "jsonb_extract_path({relation_alias}.payload, {field_name}::text) AS {}",
+                quote_identifier(&output_alias),
+            ));
+            columns.push(CompiledQueryColumn::Field {
+                output_alias,
+                field: field.clone(),
+            });
+        }
+
+        let limit = match &self.pagination {
+            Pagination::Cursor { first, after: None } => {
+                bindings.push(PostgresBindValue::Integer(i64::from(*first)))
+            }
+            Pagination::Cursor { after: Some(_), .. } => {
+                return Err(PostgresQueryCompileError::CursorContinuationPending);
+            }
+            Pagination::Offset { .. } => {
+                return Err(PostgresQueryCompileError::OffsetPaginationPending);
+            }
+        };
+
+        let mut sql = format!(
+            "SELECT {} FROM index_entities AS {root_alias}",
+            select.join(", ")
+        );
+        if !joins.is_empty() {
+            sql.push(' ');
+            sql.push_str(&joins.join(" "));
+        }
+        sql.push_str(&format!(
+            " WHERE {root_alias}.tenant_id = {tenant} AND {root_alias}.module_name = {module} AND {root_alias}.entity_name = {entity} AND {root_alias}.schema_version = {version} AND {root_alias}.locale_key = {locale} AND {root_alias}.is_deleted = FALSE ORDER BY {root_alias}.entity_id ASC LIMIT {limit}"
+        ));
+
+        Ok(CompiledPostgresQuery {
+            sql,
+            binds: bindings.values,
+            columns,
+            plan_fingerprint: self.fingerprint()?,
+        })
+    }
+
+    fn validate_compiler_subset(&self) -> Result<(), PostgresQueryCompileError> {
+        validate_alias(&self.root_alias)?;
+        if self.path_aliases.get(&Vec::new()).map(String::as_str)
+            != Some(self.root_alias.as_str())
+        {
+            return Err(PostgresQueryCompileError::AliasMappingMismatch);
+        }
+        if self.filter.is_some() {
+            return Err(PostgresQueryCompileError::FilterPending);
+        }
+        if !self.order_by.is_empty() {
+            return Err(PostgresQueryCompileError::OrderingPending);
+        }
+        if self.include_exact_count {
+            return Err(PostgresQueryCompileError::ExactCountPending);
+        }
+        for join in &self.joins {
+            validate_alias(&join.source_alias)?;
+            validate_alias(&join.alias)?;
+            if join.path.is_empty() {
+                return Err(PostgresQueryCompileError::AliasMappingMismatch);
+            }
+            let parent_path = join.path[..join.path.len() - 1].to_vec();
+            if self.path_aliases.get(&parent_path).map(String::as_str)
+                != Some(join.source_alias.as_str())
+                || self.path_aliases.get(&join.path).map(String::as_str)
+                    != Some(join.alias.as_str())
+            {
+                return Err(PostgresQueryCompileError::AliasMappingMismatch);
+            }
+            if join.cardinality == LinkCardinality::Many {
+                return Err(PostgresQueryCompileError::ManyLinkProjectionPending);
+            }
+        }
+        for field in &self.projection {
+            validate_alias(&field.relation_alias)?;
+            if self.path_aliases.get(field.path.links()).map(String::as_str)
+                != Some(field.relation_alias.as_str())
+            {
+                return Err(PostgresQueryCompileError::AliasMappingMismatch);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct Bindings {
+    values: Vec<PostgresBindValue>,
+}
+
+impl Bindings {
+    fn push(&mut self, value: PostgresBindValue) -> String {
+        self.values.push(value);
+        format!("${}", self.values.len())
+    }
+}
+
+fn push_identity_column(
+    select: &mut Vec<String>,
+    columns: &mut Vec<CompiledQueryColumn>,
+    relation_alias: &str,
+    relation_alias_q: &str,
+) {
+    let output_alias = format!("__{relation_alias}_entity_id");
+    select.push(format!(
+        "{relation_alias_q}.entity_id AS {}",
+        quote_identifier(&output_alias)
+    ));
+    columns.push(CompiledQueryColumn::EntityId {
+        output_alias,
+        relation_alias: relation_alias.to_owned(),
+    });
+}
+
+fn validate_alias(alias: &str) -> Result<(), PostgresQueryCompileError> {
+    let valid = alias.strip_prefix('t').is_some_and(|suffix| {
+        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(PostgresQueryCompileError::InvalidRelationAlias(
+            alias.to_owned(),
+        ))
+    }
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}

--- a/crates/rustok-index/src/application/postgres_compiler_tests.rs
+++ b/crates/rustok-index/src/application/postgres_compiler_tests.rs
@@ -1,0 +1,227 @@
+use uuid::Uuid;
+
+use super::{
+    CompiledQueryColumn, PostgresBindValue, PostgresQueryCompileError, SchemaRegistry,
+};
+use crate::domain::{
+    EntityName, FieldCardinality, FieldName, FieldPath, FilterExpr, IndexField, IndexLink,
+    IndexQuery, IndexQueryScope, IndexSchema, IndexValue, IndexValueType, LinkCardinality,
+    LinkName, LocaleKey, LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaRef,
+    SchemaVersion,
+};
+
+fn schema_ref(entity: &str) -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new(entity).unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn field(name: &str, sortable: bool) -> IndexField {
+    IndexField {
+        name: FieldName::new(name).unwrap(),
+        value_type: IndexValueType::Uuid,
+        cardinality: FieldCardinality::One,
+        nullable: false,
+        selectable: true,
+        filterable: true,
+        sortable,
+    }
+}
+
+fn registry(link_cardinality: LinkCardinality) -> SchemaRegistry {
+    let channel = IndexSchema {
+        reference: schema_ref("sales_channel"),
+        locale_mode: LocaleMode::None,
+        fields: vec![field("id", true)],
+        links: Vec::new(),
+    };
+    let product = IndexSchema {
+        reference: schema_ref("product"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field("id", true), field("sales_channel_id", false)],
+        links: vec![IndexLink {
+            name: LinkName::new("sales_channel").unwrap(),
+            source_fields: vec![FieldName::new("sales_channel_id").unwrap()],
+            target_schema: channel.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: link_cardinality,
+        }],
+    };
+
+    let mut registry = SchemaRegistry::new();
+    registry.register_batch([product, channel]).unwrap();
+    registry
+}
+
+fn root_query(tenant_id: Uuid) -> IndexQuery {
+    IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id,
+            locale: Some(LocaleKey::new("en-US").unwrap()),
+        },
+        schema: schema_ref("product"),
+        fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+        filter: None,
+        order_by: Vec::new(),
+        pagination: Pagination::Cursor {
+            first: 20,
+            after: None,
+        },
+        include_exact_count: false,
+    }
+}
+
+#[test]
+fn compiles_root_projection_with_bound_scope_and_limit() {
+    let registry = registry(LinkCardinality::One);
+    let tenant_id = Uuid::new_v4();
+    let plan = registry.plan_query(&root_query(tenant_id)).unwrap();
+    let compiled = plan.compile_postgres().unwrap();
+
+    assert!(compiled.sql.starts_with(
+        "SELECT \"t0\".entity_id AS \"__t0_entity_id\", jsonb_extract_path(\"t0\".payload, $6::text) AS \"f0\" FROM index_entities AS \"t0\""
+    ));
+    assert!(compiled.sql.contains("\"t0\".tenant_id = $1"));
+    assert!(compiled.sql.contains("\"t0\".locale_key = $5"));
+    assert!(compiled.sql.ends_with("ORDER BY \"t0\".entity_id ASC LIMIT $7"));
+    assert!(!compiled.sql.contains(&tenant_id.to_string()));
+    assert_eq!(
+        compiled.binds,
+        vec![
+            PostgresBindValue::Uuid(tenant_id),
+            PostgresBindValue::Text("rustok-product".to_owned()),
+            PostgresBindValue::Text("product".to_owned()),
+            PostgresBindValue::Integer(1),
+            PostgresBindValue::Text("en-US".to_owned()),
+            PostgresBindValue::Text("id".to_owned()),
+            PostgresBindValue::Integer(20),
+        ]
+    );
+    assert_eq!(compiled.columns.len(), 2);
+    assert!(matches!(
+        &compiled.columns[0],
+        CompiledQueryColumn::EntityId { relation_alias, .. } if relation_alias == "t0"
+    ));
+    assert_eq!(compiled.plan_fingerprint, plan.fingerprint().unwrap());
+}
+
+#[test]
+fn compiles_one_link_projection_without_interpolating_contract_values() {
+    let registry = registry(LinkCardinality::One);
+    let tenant_id = Uuid::new_v4();
+    let mut query = root_query(tenant_id);
+    query.fields.insert(
+        0,
+        FieldPath::linked(
+            [LinkName::new("sales_channel").unwrap()],
+            FieldName::new("id").unwrap(),
+        ),
+    );
+
+    let compiled = registry
+        .plan_query(&query)
+        .unwrap()
+        .compile_postgres()
+        .unwrap();
+
+    assert!(compiled.sql.contains("LEFT JOIN index_links AS \"l1\""));
+    assert!(compiled.sql.contains("\"l1\".source_version = \"t0\".source_version"));
+    assert!(compiled.sql.contains("LEFT JOIN index_entities AS \"t1\""));
+    assert!(compiled.sql.contains("\"t1\".is_deleted = FALSE"));
+    assert!(!compiled.sql.contains("sales_channel"));
+    assert_eq!(
+        &compiled.binds[5..9],
+        &[
+            PostgresBindValue::Text("sales_channel".to_owned()),
+            PostgresBindValue::Text("rustok-product".to_owned()),
+            PostgresBindValue::Text("sales_channel".to_owned()),
+            PostgresBindValue::Integer(1),
+        ]
+    );
+    assert_eq!(compiled.columns.len(), 4);
+    assert!(matches!(
+        &compiled.columns[1],
+        CompiledQueryColumn::EntityId { relation_alias, .. } if relation_alias == "t1"
+    ));
+}
+
+#[test]
+fn rejects_semantics_reserved_for_follow_up_compiler_slices() {
+    let registry = registry(LinkCardinality::One);
+    let mut query = root_query(Uuid::new_v4());
+    query.filter = Some(FilterExpr::Eq(
+        FieldPath::new(FieldName::new("id").unwrap()),
+        IndexValue::Uuid(Uuid::new_v4()),
+    ));
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::FilterPending)
+    ));
+
+    query.filter = None;
+    query.order_by = vec![OrderExpr {
+        field: FieldPath::new(FieldName::new("id").unwrap()),
+        direction: OrderDirection::Asc,
+    }];
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::OrderingPending)
+    ));
+
+    query.order_by.clear();
+    query.include_exact_count = true;
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::ExactCountPending)
+    ));
+
+    query.include_exact_count = false;
+    query.pagination = Pagination::Cursor {
+        first: 20,
+        after: Some("opaque-cursor".to_owned()),
+    };
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::CursorContinuationPending)
+    ));
+
+    query.pagination = Pagination::Offset {
+        limit: 20,
+        offset: 0,
+    };
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::OffsetPaginationPending)
+    ));
+}
+
+#[test]
+fn rejects_many_link_projection_before_sql_is_emitted() {
+    let registry = registry(LinkCardinality::Many);
+    let mut query = root_query(Uuid::new_v4());
+    query.fields = vec![FieldPath::linked(
+        [LinkName::new("sales_channel").unwrap()],
+        FieldName::new("id").unwrap(),
+    )];
+
+    assert!(matches!(
+        registry.plan_query(&query).unwrap().compile_postgres(),
+        Err(PostgresQueryCompileError::ManyLinkProjectionPending)
+    ));
+}
+
+#[test]
+fn rejects_tampered_path_alias_mapping() {
+    let registry = registry(LinkCardinality::One);
+    let mut plan = registry
+        .plan_query(&root_query(Uuid::new_v4()))
+        .unwrap();
+    plan.projection[0].relation_alias = "t9".to_owned();
+
+    assert!(matches!(
+        plan.compile_postgres(),
+        Err(PostgresQueryCompileError::AliasMappingMismatch)
+    ));
+}

--- a/scripts/verify/verify-index-postgres-query-compiler.mjs
+++ b/scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -28,6 +28,7 @@ const compiler = requireMarkers(compilerPath, [
   'PostgresBindValue::Uuid(self.scope.tenant_id)',
   'PostgresBindValue::Text(join.link.as_str().to_owned())',
   'PostgresBindValue::Text(field.path.field().as_str().to_owned())',
+  'format!("${}", self.values.len())',
   'LEFT JOIN index_links AS',
   '.source_version =',
   '.target_schema_version =',
@@ -48,9 +49,31 @@ const compiler = requireMarkers(compilerPath, [
 ]);
 
 const validatePosition = compiler.indexOf('self.validate_compiler_subset()?;');
+const tenantBindPosition = compiler.indexOf('PostgresBindValue::Uuid(self.scope.tenant_id)');
+const joinBindPosition = compiler.indexOf('PostgresBindValue::Text(join.link.as_str().to_owned())');
+const fieldBindPosition = compiler.indexOf(
+  'PostgresBindValue::Text(\n                field.path.field().as_str().to_owned()',
+);
+const limitBindPosition = compiler.indexOf(
+  'bindings.push(PostgresBindValue::Integer(i64::from(*first)))',
+);
 const sqlPosition = compiler.indexOf('let mut sql = format!(');
 if (validatePosition < 0 || sqlPosition < 0 || validatePosition >= sqlPosition) {
   fail('compiler subset validation must precede SQL construction');
+}
+if (
+  tenantBindPosition < 0 ||
+  joinBindPosition < 0 ||
+  fieldBindPosition < 0 ||
+  limitBindPosition < 0 ||
+  !(
+    tenantBindPosition < joinBindPosition &&
+    joinBindPosition < fieldBindPosition &&
+    fieldBindPosition < limitBindPosition &&
+    limitBindPosition < sqlPosition
+  )
+) {
+  fail('scope, join, projection, and limit binds must remain deterministically ordered');
 }
 
 for (const forbidden of [
@@ -58,7 +81,6 @@ for (const forbidden of [
   'rustok_content',
   'rustok_flex',
   'SELECT *',
-  'format!("${',
   'query_one(',
   'query_all(',
   'execute(',

--- a/scripts/verify/verify-index-postgres-query-compiler.mjs
+++ b/scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-postgres-query-compiler] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
+const compiler = requireMarkers(compilerPath, [
+  'pub enum PostgresBindValue',
+  'pub struct CompiledPostgresQuery',
+  'pub enum PostgresQueryCompileError',
+  'pub fn compile_postgres(&self)',
+  'self.validate_compiler_subset()?;',
+  'PostgresBindValue::Uuid(self.scope.tenant_id)',
+  'PostgresBindValue::Text(join.link.as_str().to_owned())',
+  'PostgresBindValue::Text(field.path.field().as_str().to_owned())',
+  'LEFT JOIN index_links AS',
+  '.source_version =',
+  '.target_schema_version =',
+  'LEFT JOIN index_entities AS',
+  '.is_deleted = FALSE',
+  'jsonb_extract_path(',
+  'ORDER BY {root_alias}.entity_id ASC LIMIT {limit}',
+  'FilterPending',
+  'OrderingPending',
+  'ExactCountPending',
+  'CursorContinuationPending',
+  'OffsetPaginationPending',
+  'ManyLinkProjectionPending',
+  'AliasMappingMismatch',
+  'self.path_aliases.get(&Vec::new())',
+  'validate_alias(&self.root_alias)?;',
+  'quote_identifier',
+]);
+
+const validatePosition = compiler.indexOf('self.validate_compiler_subset()?;');
+const sqlPosition = compiler.indexOf('let mut sql = format!(');
+if (validatePosition < 0 || sqlPosition < 0 || validatePosition >= sqlPosition) {
+  fail('compiler subset validation must precede SQL construction');
+}
+
+for (const forbidden of [
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+  'SELECT *',
+  'format!("${',
+  'query_one(',
+  'query_all(',
+  'execute(',
+  'DatabaseConnection',
+  'Statement::from_sql',
+]) {
+  if (compiler.includes(forbidden)) fail(`${compilerPath} contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-index/src/application/postgres_compiler_tests.rs', [
+  'compiles_root_projection_with_bound_scope_and_limit',
+  'compiles_one_link_projection_without_interpolating_contract_values',
+  'rejects_semantics_reserved_for_follow_up_compiler_slices',
+  'rejects_many_link_projection_before_sql_is_emitted',
+  'rejects_tampered_path_alias_mapping',
+  'assert!(!compiled.sql.contains(&tenant_id.to_string()))',
+  'assert!(!compiled.sql.contains("sales_channel"))',
+]);
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod postgres_compiler;',
+  'mod postgres_compiler_tests;',
+  'CompiledPostgresQuery',
+  'PostgresQueryCompileError',
+]);
+requireMarkers('crates/rustok-index/docs/m4-postgres-query-compiler.md', [
+  'controlled PostgreSQL statement plus an ordered typed bind list',
+  'projection through explicit one-cardinality links',
+  'Fail-closed pending semantics',
+  'does not execute SQL',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  'M4 controlled PostgreSQL query compilation: `complete`',
+  '- [x] Compile plans through SeaQuery or controlled SQL.',
+  'Typed filter/order/count/keyset compilation remains the next bounded M4 slice.',
+]);
+
+console.log('[verify-index-postgres-query-compiler] OK');

--- a/scripts/verify/verify-index-query-planner.mjs
+++ b/scripts/verify/verify-index-query-planner.mjs
@@ -70,13 +70,14 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
   'M4 deterministic executable query planning: `source_complete_execution_pending`',
   'M3 production partition lifecycle: `blocked_by_retained_packet`',
-  'Compile `ExecutableQueryPlan` through controlled SeaQuery/PostgreSQL SQL',
+  'M4 controlled PostgreSQL query compilation: `source_complete_execution_pending`',
+  'Typed filter/order/count/keyset compilation remains the next bounded M4 slice.',
   'Not run by the implementation agent',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '### M4 - Query engine v1',
-  '- [ ] Compile plans through SeaQuery or controlled SQL.',
+  '- [x] Compile plans through SeaQuery or controlled SQL.',
   'Partition cutover remains forbidden until one retained real',
 ]);
 


### PR DESCRIPTION
## Summary

- add controlled `ExecutableQueryPlan::compile_postgres` output with one PostgreSQL statement, ordered typed bind values, deterministic result-column metadata, and the source plan fingerprint
- bind tenant, root schema, locale, link name, target schema, projected field names, and page limit instead of interpolating runtime or contract values
- compile root projection plus explicit one-cardinality link projection through `index_links` and live target `index_entities`
- preserve root rows for absent optional links through `LEFT JOIN` and retain entity identities for later nested result assembly
- revalidate the complete planner path-to-alias mapping before SQL construction
- fail closed with typed pending errors for filters, explicit ordering, exact count, cursor continuation, offset pagination, and many-cardinality aggregation
- add focused source scenarios, a static compiler guard, compiler boundary documentation, and actualize the canonical M4 roadmap

## Recheck findings

The merged M3 source work remains complete through retained bundle review, archive verification, and recursive filesystem drift protection. One fresh admitted real PostgreSQL partition packet remains an owner action and continues to block production partition lifecycle design. It does not block this non-executing M4 compiler slice.

The first working branch was created from the previous Index merge. While this slice was being authored, `main` advanced by 25 parallel Forum/Product commits. The branch was therefore rebuilt from current `main` (`68c69eb990c8d37d3fa0af2f92df7c86d33f4cfd`) before opening this PR; it is not behind the target branch.

A final source recheck also found and corrected a static-guard self-conflict that would have rejected the compiler's own safe `$1`, `$2`, ... placeholder generator.

## Boundary

This PR does not connect to PostgreSQL, prepare or execute a statement, decode result rows, expose an `IndexQueryPort`, authorize callers, verify persisted schema readiness, decode cursor bytes, implement typed filter/order/count/keyset/offset/many-link semantics, read source-module tables, change migrations, or begin production partition lifecycle work.

## Validation

Not run by the implementation agent, per maintainer instruction.

Suggested commands:

```bash
cargo test -p rustok-index planner_tests -- --nocapture
cargo test -p rustok-index postgres_compiler_tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-query-planner.mjs
node scripts/verify/verify-index-postgres-query-compiler.mjs
cargo xtask module validate index
```
