### PR TITLE
feat(forum): authorize exact public discovery and SEO

### DIFF
--- a/crates/rustok-forum/contracts/forum-category-audience-read.json
+++ b/crates/rustok-forum/contracts/forum-category-audience-read.json
@@ -19,6 +19,7 @@
   "owner_note": "crates/rustok-forum/docs/forum-20bh-category-audience-read.md",
   "source_verifier": "scripts/verify/verify-forum-category-audience-read.mjs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-reply-legacy-cutover.json",
+  "downstream_completion": "crates/rustok-forum/contracts/forum-public-discovery-seo.json",
   "read_boundary": {
     "base_public_authenticated_floor_preserved": true,
     "inherited_richer_category_layers_enforced": true,
@@ -40,9 +41,9 @@
     "native_storefront_categories_use_exact_owner": true,
     "native_requested_category_uses_exact_single_owner": true,
     "native_requested_category_is_not_limited_to_first_page": true,
-    "search_index_changed": false,
-    "seo_changed": false,
-    "deep_link_changed": false,
+    "search_index_changed": true,
+    "seo_changed": true,
+    "deep_link_changed": true,
     "bulk_read_commands_changed": false,
     "migration_added": false,
     "dependency_changed": false,
@@ -57,7 +58,9 @@
     "topic_reply_read_paths_changed": false,
     "mark_read_paths_changed": false,
     "canonical_graphql_runtime_uses_query_runtime": true,
-    "legacy_query_snapshot_is_uncompiled": true
+    "legacy_query_snapshot_is_uncompiled": true,
+    "search_change_is_route_contract_only": true,
+    "forum_search_projection_consumer_wired": false
   },
   "documentation": {
     "owner_note_added": true,
@@ -65,13 +68,14 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BH through a conflict-safe repository-local edit; delete the legacy query.rs snapshot only after source verifiers no longer depend on it."
+    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BI through a conflict-safe repository-local edit; delete the legacy query.rs snapshot only after source verifiers no longer depend on it."
   },
   "remaining_scope": [
-    "migrate search index SEO and deep-link authorization through exact category and topic audience owners",
+    "wire a Search-owned Forum projection consumer through exact public discovery without copying audience policy into Search SQL",
+    "reauthorize or remove projected Forum documents after current visibility policy changes",
     "add visibility-scoped category and all-read commands",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
-    "capture maintainer-executed SQLite PostgreSQL REST native and GraphQL runtime evidence"
+    "capture maintainer-executed PostgreSQL SQLite SEO Search and route runtime evidence"
   ],
   "downstream_task": "FORUM-20BI",
   "verification": {
@@ -80,8 +84,8 @@
       "cargo test -p rustok-forum category_read_transport -- --nocapture",
       "cargo test -p rustok-forum --test category_audience_policy_sqlite -- --nocapture",
       "cargo test -p rustok-forum --test category_owner_visibility_sqlite -- --nocapture",
-      "node scripts/verify/verify-forum-reply-legacy-cutover.mjs",
       "node scripts/verify/verify-forum-category-audience-read.mjs",
+      "node scripts/verify/verify-forum-public-discovery-seo.mjs",
       "cargo xtask module validate forum"
     ]
   }

--- a/crates/rustok-forum/contracts/forum-public-discovery-seo.json
+++ b/crates/rustok-forum/contracts/forum-public-discovery-seo.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BI",
+  "upstream_task": "FORUM-20BH",
+  "scope": "Publish one exact anonymous Forum discovery owner, authorize public SEO and route surfaces through it, and add canonical Forum Search result routes without duplicating audience policy in Search SQL",
+  "public_discovery_owner": "crates/rustok-forum/src/services/public_discovery.rs",
+  "category_read_owner": "crates/rustok-forum/src/services/category_audience_read.rs",
+  "topic_read_owner": "crates/rustok-forum/src/services/topic_audience_read.rs",
+  "seo_exact_wrapper": "crates/rustok-forum/src/seo_audience_targets.rs",
+  "seo_legacy_mapper": "crates/rustok-forum/src/seo_targets.rs",
+  "seo_registration": "crates/rustok-forum/src/lib.rs",
+  "search_route_contract": "crates/rustok-search/src/engine.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20bi-public-discovery-seo.md",
+  "source_verifier": "scripts/verify/verify-forum-public-discovery-seo.mjs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-category-audience-read.json",
+  "discovery_boundary": {
+    "anonymous_public_only": true,
+    "category_inherited_base_floor_enforced": true,
+    "category_richer_layers_enforced": true,
+    "topic_open_status_enforced": true,
+    "topic_route_channel_enforced": true,
+    "topic_inherited_category_layers_enforced": true,
+    "topic_local_narrowing_enforced": true,
+    "authentication_role_trust_group_and_explicit_user_targets_absent": true,
+    "missing_foreign_and_denied_targets_are_indistinguishable": true,
+    "cross_consumer_policy_copy_added": false
+  },
+  "seo_boundary": {
+    "authoring_scope_preserves_managed_legacy_load": true,
+    "public_target_load_uses_exact_discovery": true,
+    "public_route_resolution_uses_exact_discovery": true,
+    "bulk_summaries_filter_exact_public_targets": true,
+    "sitemap_candidates_filter_exact_public_targets": true,
+    "category_target_slug_changed": false,
+    "topic_target_slug_changed": false,
+    "legacy_mapping_and_schema_payload_preserved": true
+  },
+  "search_boundary": {
+    "forum_category_result_route_added": true,
+    "forum_topic_result_route_added": true,
+    "canonical_source_entity_pair_required": true,
+    "spoofed_source_entity_pairs_fail_closed": true,
+    "forum_storefront_query_keys_reused": true,
+    "forum_projection_consumer_wired": false,
+    "forum_search_documents_written": false,
+    "forum_index_storage_changed": false,
+    "forum_event_ingestion_changed": false
+  },
+  "compatibility": {
+    "existing_forum_rest_routes_changed": false,
+    "existing_forum_graphql_fields_changed": false,
+    "existing_seo_target_slugs_changed": false,
+    "existing_seo_authoring_scope_changed": false,
+    "existing_forum_storefront_route_changed": false,
+    "existing_search_product_content_blog_routes_changed": false,
+    "migration_added": false,
+    "dependency_changed": false,
+    "public_response_dto_changed": false,
+    "legacy_graphql_snapshot_changed": false
+  },
+  "documentation": {
+    "owner_note_added": true,
+    "contract_added": true,
+    "upstream_contract_updated": true,
+    "crate_api_updated": false,
+    "canonical_plan_updated": false,
+    "synchronization_debt": "Advance CRATE_API and the canonical FORUM-20 ledger through FORUM-20BI through a conflict-safe repository-local edit after maintainer validation."
+  },
+  "remaining_scope": [
+    "wire a Search-owned Forum projection consumer through the exact public discovery capability without copying audience policy into Search SQL",
+    "reauthorize or remove projected Forum documents after visibility policy changes and owner revision changes",
+    "add visibility-scoped category and all-read commands",
+    "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
+    "capture maintainer-executed PostgreSQL SQLite SEO Search and route runtime evidence"
+  ],
+  "downstream_task": "FORUM-20BJ",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum seo_audience_targets -- --nocapture",
+      "cargo test -p rustok-search canonical_url_derives_forum -- --nocapture",
+      "node scripts/verify/verify-forum-category-audience-read.mjs",
+      "node scripts/verify/verify-forum-public-discovery-seo.mjs",
+      "node scripts/verify/verify-search-canonical-url-contract.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/docs/forum-20bi-public-discovery-seo.md
+++ b/crates/rustok-forum/docs/forum-20bi-public-discovery-seo.md
@@ -1,0 +1,68 @@
+# FORUM-20BI — exact public discovery, SEO, and Search routes
+
+`FORUM-20BI` publishes one anonymous public-discovery owner for Forum
+cross-consumer surfaces. SEO and route resolution no longer infer public access
+from system reads or transport-local open/channel checks.
+
+## Delivered boundary
+
+- `ForumPublicDiscoveryService` composes the exact category and topic audience
+  read owners for anonymous consumers.
+- Public category discovery enforces the inherited public/authenticated floor
+  and every richer category audience layer.
+- Public topic discovery additionally enforces open status, route-channel
+  visibility, inherited category layers, and optional topic-local narrowing.
+- Missing, foreign, closed, route-channel-denied, inherited-policy-denied, and
+  topic-policy-denied targets are all represented as absent.
+- Authentication-, role-, trust-, Groups-, explicit-user-, and unavailable
+  Channel-dependent targets cannot be weakened into public SEO visibility.
+- Existing Forum SEO authoring loads retain the legacy managed/system read so
+  editors may administer targets independently of public publication.
+- Public SEO target loads, route resolution, bulk summaries, and sitemap
+  candidates are filtered through exact anonymous discovery.
+- Existing SEO target slugs, record mapping, Open Graph fields, structured data,
+  canonical route shape, and alternate locale mapping remain owned by the
+  existing mapper in `seo_targets.rs`.
+- Search now recognizes only canonical `forum/forum_category` and
+  `forum/forum_topic` result pairs and maps them to the module-owned storefront
+  query keys `category` and `topic`.
+- Spoofed source/entity pairs and Forum replies without a delivered storefront
+  deep-link contract remain non-navigable.
+
+## Search/index scope
+
+This slice does not insert Forum rows into `search_documents`, subscribe the
+Search ingestion handler to Forum events, or duplicate Forum audience policy in
+Search SQL. The exact public-discovery owner and canonical URL contract are the
+required admission and navigation boundaries for that downstream consumer.
+
+The full Search-owned Forum projection must consume a neutral exact-discovery
+capability, remove or reauthorize documents after policy changes, and preserve
+owner revision ordering. That work remains `FORUM-20BJ` and the broader
+`FORUM-23` projection program.
+
+## Compatibility
+
+No migration, dependency, REST route, GraphQL field, SEO target slug, Forum
+storefront route, public DTO, or legacy product/content/blog Search URL changed.
+The old GraphQL `query.rs` snapshot and bulk read commands are untouched.
+
+The canonical `implementation-plan.md` and `CRATE_API.md` are not replaced
+through the GitHub contents API in this slice. Their conflict-safe
+repository-local synchronization debt is recorded in the machine contract.
+
+## Validation handoff
+
+The implementation agent did not run tests, Cargo commands, formatting,
+verifiers, workflows, or CI, per maintainer request.
+
+Suggested maintainer commands:
+
+```text
+cargo test -p rustok-forum seo_audience_targets -- --nocapture
+cargo test -p rustok-search canonical_url_derives_forum -- --nocapture
+node scripts/verify/verify-forum-category-audience-read.mjs
+node scripts/verify/verify-forum-public-discovery-seo.mjs
+node scripts/verify/verify-search-canonical-url-contract.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -25,7 +25,9 @@ mod notification_source;
 pub mod openapi;
 mod reply_create_transport;
 pub mod reply_read_transport;
-mod seo_targets;
+mod seo_audience_targets;
+#[path = "seo_targets.rs"]
+mod seo_targets_legacy;
 pub mod services;
 pub mod state_machine;
 pub mod subscription;
@@ -78,19 +80,19 @@ pub use services::{
     ForumPostingPolicyOutcome, ForumPostingPolicyOwnerFactPort, ForumPostingPolicyOwnerFactRequest,
     ForumPostingPolicyOwnerFactResponse, ForumPostingPolicyOwnerFactValue, ForumPostingPolicyRules,
     ForumPostingPolicyUnavailableFact, ForumPostingTrustFactPort, ForumPostingWindowCount,
-    ForumPostingWindowLimit, ForumQuoteCommandService, ForumReadModelService,
-    ForumRelationReadService, ForumReplyAudienceReadService, ForumReplyCreateAudienceAuthorization,
-    ForumReplyCreateAudienceAuthorizationService, ForumReplyCreatesWindowFactPort,
-    ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage,
-    ForumTopicAudienceListService, ForumTopicAudiencePage, ForumTopicAudiencePolicy,
-    ForumTopicAudiencePolicyService, ForumTopicAudienceReadService, ForumTopicAudienceViewer,
-    ForumTopicAudienceVisibilityService, ForumTopicCreateAudienceAuthorization,
-    ForumTopicCreateAudienceAuthorizationService, ForumTopicCreatesWindowFactPort,
-    ForumTopicReadPostingFactPort, ForumTopicReadState, ForumTopicReadStateService,
-    ForumTopicReplyCreateAudiencePolicy, ForumTopicReplyCreateAudiencePolicyService,
-    ForumTopicUnreadSummary, ForumTopicVisibilityScope, ForumTopicVisibilityService,
-    ForumUserTrustAudienceFactsPort, ForumUserTrustChange, ForumUserTrustRevision,
-    ForumUserTrustRevisionPage, ForumUserTrustService, ForumUserTrustState,
+    ForumPostingWindowLimit, ForumPublicDiscoveryService, ForumQuoteCommandService,
+    ForumReadModelService, ForumRelationReadService, ForumReplyAudienceReadService,
+    ForumReplyCreateAudienceAuthorization, ForumReplyCreateAudienceAuthorizationService,
+    ForumReplyCreatesWindowFactPort, ForumStorefrontReadStateService, ForumStorefrontUnreadTopic,
+    ForumStorefrontUnreadTopicPage, ForumTopicAudienceListService, ForumTopicAudiencePage,
+    ForumTopicAudiencePolicy, ForumTopicAudiencePolicyService, ForumTopicAudienceReadService,
+    ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService,
+    ForumTopicCreateAudienceAuthorization, ForumTopicCreateAudienceAuthorizationService,
+    ForumTopicCreatesWindowFactPort, ForumTopicReadPostingFactPort, ForumTopicReadState,
+    ForumTopicReadStateService, ForumTopicReplyCreateAudiencePolicy,
+    ForumTopicReplyCreateAudiencePolicyService, ForumTopicUnreadSummary, ForumTopicVisibilityScope,
+    ForumTopicVisibilityService, ForumUserTrustAudienceFactsPort, ForumUserTrustChange,
+    ForumUserTrustRevision, ForumUserTrustRevisionPage, ForumUserTrustService, ForumUserTrustState,
     ForumWidgetContractService, SharedForumPostingPolicyOwnerFactPort,
     FORUM_POSTING_POLICY_FACTS_CAPABILITY, FORUM_POSTING_POLICY_FACTS_CAPABILITY_UNAVAILABLE,
     FORUM_POSTING_POLICY_PRECEDENCE, MAX_FORUM_POSTING_POLICY_FACTS,
@@ -163,18 +165,24 @@ impl RusToKModule for ForumModule {
         &self,
         extensions: &mut ModuleRuntimeExtensions,
     ) -> rustok_core::Result<()> {
-        register_seo_target_provider(extensions, seo_targets::ForumCategorySeoTargetProvider)
-            .map_err(|error| {
-                rustok_core::Error::Validation(format!(
-                    "forum category SEO target registration failed: {error}"
-                ))
-            })?;
-        register_seo_target_provider(extensions, seo_targets::ForumTopicSeoTargetProvider)
-            .map_err(|error| {
-                rustok_core::Error::Validation(format!(
-                    "forum topic SEO target registration failed: {error}"
-                ))
-            })?;
+        register_seo_target_provider(
+            extensions,
+            seo_audience_targets::ForumCategorySeoTargetProvider,
+        )
+        .map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "forum category SEO target registration failed: {error}"
+            ))
+        })?;
+        register_seo_target_provider(
+            extensions,
+            seo_audience_targets::ForumTopicSeoTargetProvider,
+        )
+        .map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "forum topic SEO target registration failed: {error}"
+            ))
+        })?;
         register_notification_source_provider_factory(
             extensions,
             notification_source::ForumNotificationSourceProviderFactory,

--- a/crates/rustok-forum/src/seo_audience_targets.rs
+++ b/crates/rustok-forum/src/seo_audience_targets.rs
@@ -1,0 +1,279 @@
+use anyhow::Result as AnyResult;
+use async_trait::async_trait;
+use rustok_seo_targets::{
+    SeoBulkSummaryRecord, SeoLoadedTargetRecord, SeoRouteMatchRecord, SeoSitemapCandidateRecord,
+    SeoTargetBulkListRequest, SeoTargetCapabilities, SeoTargetLoadRequest, SeoTargetLoadScope,
+    SeoTargetProvider, SeoTargetRouteResolveRequest, SeoTargetRuntimeContext,
+    SeoTargetSitemapRequest, SeoTargetSlug,
+};
+
+use crate::ForumPublicDiscoveryService;
+
+#[derive(Clone, Default)]
+pub struct ForumCategorySeoTargetProvider;
+
+#[derive(Clone, Default)]
+pub struct ForumTopicSeoTargetProvider;
+
+#[async_trait]
+impl SeoTargetProvider for ForumCategorySeoTargetProvider {
+    fn slug(&self) -> SeoTargetSlug {
+        legacy_category().slug()
+    }
+
+    fn display_name(&self) -> &'static str {
+        legacy_category().display_name()
+    }
+
+    fn owner_module_slug(&self) -> &'static str {
+        legacy_category().owner_module_slug()
+    }
+
+    fn capabilities(&self) -> SeoTargetCapabilities {
+        legacy_category().capabilities()
+    }
+
+    async fn load_target(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetLoadRequest<'_>,
+    ) -> AnyResult<Option<SeoLoadedTargetRecord>> {
+        if matches!(request.scope, SeoTargetLoadScope::Authoring) {
+            return legacy_category().load_target(runtime, request).await;
+        }
+
+        let discovery = public_discovery(runtime);
+        if discovery
+            .get_public_category_with_locale_fallback(
+                request.tenant_id,
+                request.target_id,
+                request.locale,
+                Some(request.default_locale),
+            )
+            .await?
+            .is_none()
+        {
+            return Ok(None);
+        }
+
+        legacy_category().load_target(runtime, request).await
+    }
+
+    async fn resolve_route(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetRouteResolveRequest<'_>,
+    ) -> AnyResult<Option<SeoRouteMatchRecord>> {
+        let Some(candidate) = legacy_category().resolve_route(runtime, request).await? else {
+            return Ok(None);
+        };
+        let visible = self
+            .load_target(
+                runtime,
+                SeoTargetLoadRequest {
+                    tenant_id: request.tenant_id,
+                    default_locale: request.default_locale,
+                    locale: request.locale,
+                    target_id: candidate.target_id,
+                    scope: SeoTargetLoadScope::PublicRoute,
+                    channel_slug: request.channel_slug,
+                },
+            )
+            .await?;
+        Ok(visible.map(|record| SeoRouteMatchRecord {
+            target_kind: record.target_kind,
+            target_id: record.target_id,
+        }))
+    }
+
+    async fn list_bulk_summaries(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetBulkListRequest<'_>,
+    ) -> AnyResult<Vec<SeoBulkSummaryRecord>> {
+        let candidates = legacy_category()
+            .list_bulk_summaries(runtime, request)
+            .await?;
+        let discovery = public_discovery(runtime);
+        let mut visible = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if discovery
+                .get_public_category_with_locale_fallback(
+                    request.tenant_id,
+                    candidate.target_id,
+                    request.locale,
+                    Some(request.default_locale),
+                )
+                .await?
+                .is_some()
+            {
+                visible.push(candidate);
+            }
+        }
+        Ok(visible)
+    }
+
+    async fn sitemap_candidates(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetSitemapRequest<'_>,
+    ) -> AnyResult<Vec<SeoSitemapCandidateRecord>> {
+        let candidates = legacy_category()
+            .sitemap_candidates(runtime, request)
+            .await?;
+        let discovery = public_discovery(runtime);
+        let mut visible = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if discovery
+                .get_public_category_with_locale_fallback(
+                    request.tenant_id,
+                    candidate.target_id,
+                    candidate.locale.as_str(),
+                    Some(request.default_locale),
+                )
+                .await?
+                .is_some()
+            {
+                visible.push(candidate);
+            }
+        }
+        Ok(visible)
+    }
+}
+
+#[async_trait]
+impl SeoTargetProvider for ForumTopicSeoTargetProvider {
+    fn slug(&self) -> SeoTargetSlug {
+        legacy_topic().slug()
+    }
+
+    fn display_name(&self) -> &'static str {
+        legacy_topic().display_name()
+    }
+
+    fn owner_module_slug(&self) -> &'static str {
+        legacy_topic().owner_module_slug()
+    }
+
+    fn capabilities(&self) -> SeoTargetCapabilities {
+        legacy_topic().capabilities()
+    }
+
+    async fn load_target(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetLoadRequest<'_>,
+    ) -> AnyResult<Option<SeoLoadedTargetRecord>> {
+        if matches!(request.scope, SeoTargetLoadScope::Authoring) {
+            return legacy_topic().load_target(runtime, request).await;
+        }
+
+        let discovery = public_discovery(runtime);
+        if discovery
+            .get_public_topic_with_locale_fallback(
+                request.tenant_id,
+                request.target_id,
+                request.locale,
+                Some(request.default_locale),
+                request.channel_slug,
+            )
+            .await?
+            .is_none()
+        {
+            return Ok(None);
+        }
+
+        legacy_topic().load_target(runtime, request).await
+    }
+
+    async fn resolve_route(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetRouteResolveRequest<'_>,
+    ) -> AnyResult<Option<SeoRouteMatchRecord>> {
+        let Some(candidate) = legacy_topic().resolve_route(runtime, request).await? else {
+            return Ok(None);
+        };
+        let visible = self
+            .load_target(
+                runtime,
+                SeoTargetLoadRequest {
+                    tenant_id: request.tenant_id,
+                    default_locale: request.default_locale,
+                    locale: request.locale,
+                    target_id: candidate.target_id,
+                    scope: SeoTargetLoadScope::PublicRoute,
+                    channel_slug: request.channel_slug,
+                },
+            )
+            .await?;
+        Ok(visible.map(|record| SeoRouteMatchRecord {
+            target_kind: record.target_kind,
+            target_id: record.target_id,
+        }))
+    }
+
+    async fn list_bulk_summaries(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetBulkListRequest<'_>,
+    ) -> AnyResult<Vec<SeoBulkSummaryRecord>> {
+        let candidates = legacy_topic().list_bulk_summaries(runtime, request).await?;
+        let discovery = public_discovery(runtime);
+        let mut visible = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if discovery
+                .get_public_topic_with_locale_fallback(
+                    request.tenant_id,
+                    candidate.target_id,
+                    request.locale,
+                    Some(request.default_locale),
+                    None,
+                )
+                .await?
+                .is_some()
+            {
+                visible.push(candidate);
+            }
+        }
+        Ok(visible)
+    }
+
+    async fn sitemap_candidates(
+        &self,
+        runtime: &SeoTargetRuntimeContext,
+        request: SeoTargetSitemapRequest<'_>,
+    ) -> AnyResult<Vec<SeoSitemapCandidateRecord>> {
+        let candidates = legacy_topic().sitemap_candidates(runtime, request).await?;
+        let discovery = public_discovery(runtime);
+        let mut visible = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if discovery
+                .get_public_topic_with_locale_fallback(
+                    request.tenant_id,
+                    candidate.target_id,
+                    candidate.locale.as_str(),
+                    Some(request.default_locale),
+                    None,
+                )
+                .await?
+                .is_some()
+            {
+                visible.push(candidate);
+            }
+        }
+        Ok(visible)
+    }
+}
+
+fn public_discovery(runtime: &SeoTargetRuntimeContext) -> ForumPublicDiscoveryService {
+    ForumPublicDiscoveryService::new(runtime.db.clone(), runtime.event_bus.clone())
+}
+
+fn legacy_category() -> crate::seo_targets_legacy::ForumCategorySeoTargetProvider {
+    crate::seo_targets_legacy::ForumCategorySeoTargetProvider
+}
+
+fn legacy_topic() -> crate::seo_targets_legacy::ForumTopicSeoTargetProvider {
+    crate::seo_targets_legacy::ForumTopicSeoTargetProvider
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -40,6 +40,7 @@ mod posting_policy_create_window_facts;
 mod posting_policy_evaluator;
 mod posting_policy_facts;
 mod posting_policy_reading_facts;
+mod public_discovery;
 mod quote_command;
 mod rbac;
 pub mod read_model;
@@ -148,6 +149,7 @@ pub use posting_policy_facts::{
     FORUM_POSTING_POLICY_FACTS_CAPABILITY_UNAVAILABLE,
 };
 pub use posting_policy_reading_facts::ForumTopicReadPostingFactPort;
+pub use public_discovery::ForumPublicDiscoveryService;
 pub use quote_command::ForumQuoteCommandService;
 pub use read_model::ForumReadModelService;
 pub use read_tracking::{

--- a/crates/rustok-forum/src/services/public_discovery.rs
+++ b/crates/rustok-forum/src/services/public_discovery.rs
@@ -1,0 +1,78 @@
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::dto::{CategoryResponse, TopicResponse};
+use crate::error::{ForumError, ForumResult};
+
+use super::{ForumCategoryAudienceReadService, ForumTopicAudienceReadService};
+
+/// Canonical public discovery owner for cross-consumer surfaces such as SEO,
+/// route resolution and future Search projection materialization.
+///
+/// The owner deliberately exposes only the anonymous public decision. Content
+/// requiring authentication, trust, Groups, explicit users, roles, inherited
+/// category selectors, or an unavailable route channel is absent rather than
+/// downgraded to a weaker public approximation.
+pub struct ForumPublicDiscoveryService {
+    categories: ForumCategoryAudienceReadService,
+    topics: ForumTopicAudienceReadService,
+}
+
+impl ForumPublicDiscoveryService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            categories: ForumCategoryAudienceReadService::new(db.clone()),
+            topics: ForumTopicAudienceReadService::new(db, event_bus),
+        }
+    }
+
+    /// Returns a category only when it is visible to an anonymous public
+    /// consumer through the inherited base floor and every richer category
+    /// audience layer.
+    pub async fn get_public_category_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<Option<CategoryResponse>> {
+        match self
+            .categories
+            .get_public_storefront_visible_with_locale_fallback(
+                tenant_id,
+                category_id,
+                locale,
+                fallback_locale,
+            )
+            .await
+        {
+            Ok(category) => Ok(Some(category)),
+            Err(ForumError::CategoryNotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Returns a topic only when the exact current public decision allows the
+    /// topic for the supplied route channel. Closed, foreign, inherited-policy
+    /// denied, topic-policy denied and route-channel denied targets are all
+    /// represented by `None`.
+    pub async fn get_public_topic_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        channel_slug: Option<&str>,
+    ) -> ForumResult<Option<TopicResponse>> {
+        self.topics
+            .get_public_storefront_visible_with_locale_fallback(
+                tenant_id,
+                topic_id,
+                locale,
+                fallback_locale,
+                channel_slug,
+            )
+            .await
+    }
+}

--- a/crates/rustok-search/src/engine.rs
+++ b/crates/rustok-search/src/engine.rs
@@ -9,6 +9,10 @@ const BLOG_SOURCE_MODULE: &str = "blog";
 const BLOG_ENTITY_TYPE: &str = "blog_post";
 const BLOG_STOREFRONT_ROUTE: &str = "/modules/blog";
 const MAX_BLOG_SLUG_LEN: usize = 200;
+const FORUM_SOURCE_MODULE: &str = "forum";
+const FORUM_CATEGORY_ENTITY_TYPE: &str = "forum_category";
+const FORUM_TOPIC_ENTITY_TYPE: &str = "forum_topic";
+const FORUM_STOREFRONT_ROUTE: &str = "/modules/forum";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -117,9 +121,9 @@ pub struct SearchResultItem {
 /// Resolves the canonical application URL for a normalized Search result.
 ///
 /// URL ownership lives in the Search contract so GraphQL, native server
-/// functions, remote connectors, and future consumers cannot drift. Blog URLs
-/// are derived only for the canonical Blog source/entity pair and only from a
-/// bounded safe owner-projected slug. Invalid payloads fail closed.
+/// functions, remote connectors, and future consumers cannot drift. Forum URLs
+/// are emitted only for canonical Forum source/entity pairs and use the same
+/// stable query keys as the module-owned storefront. Invalid pairs fail closed.
 pub fn canonical_search_result_url(value: &SearchResultItem) -> Option<String> {
     match value.entity_type.as_str() {
         "product" => Some(format!("/store/products/{}", value.id)),
@@ -130,6 +134,13 @@ pub fn canonical_search_result_url(value: &SearchResultItem) -> Option<String> {
         )),
         BLOG_ENTITY_TYPE if value.source_module == BLOG_SOURCE_MODULE => {
             canonical_blog_result_url(&value.payload)
+        }
+        FORUM_CATEGORY_ENTITY_TYPE if value.source_module == FORUM_SOURCE_MODULE => Some(format!(
+            "{FORUM_STOREFRONT_ROUTE}?category={}",
+            value.id
+        )),
+        FORUM_TOPIC_ENTITY_TYPE if value.source_module == FORUM_SOURCE_MODULE => {
+            Some(format!("{FORUM_STOREFRONT_ROUTE}?topic={}", value.id))
         }
         _ => None,
     }
@@ -251,6 +262,32 @@ mod tests {
             item("blog_post", "blog", json!({ "slug": "hello world" })),
             item("blog_post", "blog", json!({ "slug": 7 })),
             item("blog_post", "blog", json!({})),
+        ] {
+            assert_eq!(canonical_search_result_url(&value), None);
+        }
+    }
+
+    #[test]
+    fn canonical_url_derives_forum_category_and_topic_routes() {
+        let category = item("forum_category", "forum", json!({}));
+        let topic = item("forum_topic", "forum", json!({}));
+
+        assert_eq!(
+            canonical_search_result_url(&category).as_deref(),
+            Some("/modules/forum?category=00000000-0000-0000-0000-000000000001")
+        );
+        assert_eq!(
+            canonical_search_result_url(&topic).as_deref(),
+            Some("/modules/forum?topic=00000000-0000-0000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn canonical_url_rejects_spoofed_forum_source_entity_pairs() {
+        for value in [
+            item("forum_category", "content", json!({})),
+            item("forum_topic", "blog", json!({})),
+            item("forum_reply", "forum", json!({})),
         ] {
             assert_eq!(canonical_search_result_url(&value), None);
         }

--- a/scripts/verify/verify-forum-public-discovery-seo.mjs
+++ b/scripts/verify/verify-forum-public-discovery-seo.mjs
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const requireText = (source, needle, label) => {
+  if (!source.includes(needle)) {
+    throw new Error(`missing ${label}: ${needle}`);
+  }
+};
+const rejectText = (source, needle, label) => {
+  if (source.includes(needle)) {
+    throw new Error(`forbidden ${label}: ${needle}`);
+  }
+};
+
+const owner = read('crates/rustok-forum/src/services/public_discovery.rs');
+const services = read('crates/rustok-forum/src/services/mod.rs');
+const lib = read('crates/rustok-forum/src/lib.rs');
+const seo = read('crates/rustok-forum/src/seo_audience_targets.rs');
+const legacySeo = read('crates/rustok-forum/src/seo_targets.rs');
+const searchEngine = read('crates/rustok-search/src/engine.rs');
+const searchIngestion = read('crates/rustok-search/src/ingestion.rs');
+const storefrontCore = read('crates/rustok-forum/storefront/src/core.rs');
+const contract = JSON.parse(
+  read('crates/rustok-forum/contracts/forum-public-discovery-seo.json'),
+);
+const upstream = JSON.parse(
+  read('crates/rustok-forum/contracts/forum-category-audience-read.json'),
+);
+
+for (const marker of [
+  'pub struct ForumPublicDiscoveryService',
+  'ForumCategoryAudienceReadService',
+  'ForumTopicAudienceReadService',
+  'get_public_category_with_locale_fallback',
+  'get_public_topic_with_locale_fallback',
+  'get_public_storefront_visible_with_locale_fallback',
+]) {
+  requireText(owner, marker, 'exact public discovery owner');
+}
+requireText(services, 'mod public_discovery;', 'public discovery module');
+requireText(
+  services,
+  'pub use public_discovery::ForumPublicDiscoveryService;',
+  'public discovery service export',
+);
+requireText(lib, 'ForumPublicDiscoveryService', 'crate public discovery export');
+requireText(
+  lib,
+  'mod seo_audience_targets;',
+  'exact SEO wrapper module',
+);
+requireText(
+  lib,
+  '#[path = "seo_targets.rs"]',
+  'legacy SEO mapper path preservation',
+);
+requireText(
+  lib,
+  'seo_audience_targets::ForumCategorySeoTargetProvider',
+  'exact category SEO registration',
+);
+requireText(
+  lib,
+  'seo_audience_targets::ForumTopicSeoTargetProvider',
+  'exact topic SEO registration',
+);
+
+for (const marker of [
+  'SeoTargetLoadScope::Authoring',
+  'get_public_category_with_locale_fallback',
+  'get_public_topic_with_locale_fallback',
+  'async fn resolve_route(',
+  'async fn list_bulk_summaries(',
+  'async fn sitemap_candidates(',
+  'legacy_category().load_target',
+  'legacy_topic().load_target',
+]) {
+  requireText(seo, marker, 'exact SEO wrapper');
+}
+for (const forbidden of ['CategoryService', 'TopicService', 'SecurityContext::system()']) {
+  rejectText(seo, forbidden, 'SEO wrapper policy duplication');
+}
+for (const marker of [
+  'pub struct ForumCategorySeoTargetProvider',
+  'pub struct ForumTopicSeoTargetProvider',
+  'map_category_response',
+  'map_topic_response',
+  'parse_forum_route',
+]) {
+  requireText(legacySeo, marker, 'legacy SEO mapping preservation');
+}
+
+for (const marker of [
+  'const FORUM_SOURCE_MODULE: &str = "forum"',
+  'const FORUM_CATEGORY_ENTITY_TYPE: &str = "forum_category"',
+  'const FORUM_TOPIC_ENTITY_TYPE: &str = "forum_topic"',
+  'const FORUM_STOREFRONT_ROUTE: &str = "/modules/forum"',
+  'value.source_module == FORUM_SOURCE_MODULE',
+  '?category={}',
+  '?topic={}',
+  'canonical_url_derives_forum_category_and_topic_routes',
+  'canonical_url_rejects_spoofed_forum_source_entity_pairs',
+]) {
+  requireText(searchEngine, marker, 'canonical Forum Search result routes');
+}
+requireText(storefrontCore, '?category={category_id}', 'Forum category query key');
+requireText(storefrontCore, '?topic={topic_id}', 'Forum topic query key');
+rejectText(
+  searchIngestion,
+  'DomainEvent::ForumTopicCreated',
+  'undelivered Forum Search projection ingestion',
+);
+
+if (contract.task !== 'FORUM-20BI') throw new Error('unexpected task');
+for (const key of [
+  'anonymous_public_only',
+  'category_inherited_base_floor_enforced',
+  'category_richer_layers_enforced',
+  'topic_open_status_enforced',
+  'topic_route_channel_enforced',
+  'topic_inherited_category_layers_enforced',
+  'topic_local_narrowing_enforced',
+  'authentication_role_trust_group_and_explicit_user_targets_absent',
+  'missing_foreign_and_denied_targets_are_indistinguishable',
+]) {
+  if (!contract.discovery_boundary[key]) {
+    throw new Error(`contract must lock discovery boundary ${key}`);
+  }
+}
+for (const key of [
+  'authoring_scope_preserves_managed_legacy_load',
+  'public_target_load_uses_exact_discovery',
+  'public_route_resolution_uses_exact_discovery',
+  'bulk_summaries_filter_exact_public_targets',
+  'sitemap_candidates_filter_exact_public_targets',
+  'legacy_mapping_and_schema_payload_preserved',
+]) {
+  if (!contract.seo_boundary[key]) {
+    throw new Error(`contract must lock SEO boundary ${key}`);
+  }
+}
+for (const key of [
+  'forum_category_result_route_added',
+  'forum_topic_result_route_added',
+  'canonical_source_entity_pair_required',
+  'spoofed_source_entity_pairs_fail_closed',
+  'forum_storefront_query_keys_reused',
+]) {
+  if (!contract.search_boundary[key]) {
+    throw new Error(`contract must lock Search boundary ${key}`);
+  }
+}
+for (const key of [
+  'forum_projection_consumer_wired',
+  'forum_search_documents_written',
+  'forum_index_storage_changed',
+  'forum_event_ingestion_changed',
+]) {
+  if (contract.search_boundary[key]) {
+    throw new Error(`contract must keep undelivered Search boundary false: ${key}`);
+  }
+}
+if (
+  upstream.downstream_completion !==
+  'crates/rustok-forum/contracts/forum-public-discovery-seo.json'
+) {
+  throw new Error('category-read handoff must point to FORUM-20BI completion');
+}
+for (const key of ['search_index_changed', 'seo_changed', 'deep_link_changed']) {
+  if (!upstream.read_boundary[key]) {
+    throw new Error(`upstream contract must advance ${key}`);
+  }
+}
+if (!upstream.compatibility.search_change_is_route_contract_only) {
+  throw new Error('upstream contract must bound Search change to route contract');
+}
+if (upstream.compatibility.forum_search_projection_consumer_wired) {
+  throw new Error('upstream contract must not claim Forum Search projection wiring');
+}
+if (contract.downstream_task !== 'FORUM-20BJ') {
+  throw new Error('unexpected downstream task');
+}
+
+console.log('forum exact public discovery and SEO composition verified');


### PR DESCRIPTION
## Summary

- publish `ForumPublicDiscoveryService` over the exact anonymous category and topic audience owners
- preserve managed SEO authoring reads while cutting public target loads, route resolution, bulk summaries, and sitemap candidates over to exact public discovery
- keep existing Forum SEO target slugs, mapping, Open Graph, structured data, canonical routes, and locale alternates
- register exact SEO wrappers while retaining the existing `seo_targets.rs` mapper as an internal legacy mapping module
- add canonical Search result routes for trusted `forum/forum_category` and `forum/forum_topic` pairs using the Forum storefront `category` and `topic` query keys
- reject spoofed Forum source/entity pairs and leave reply deep links unavailable
- advance the FORUM-20BH handoff and add the FORUM-20BI contract, owner note, and source verifier

## Search/index boundary

This slice does not write Forum `search_documents`, subscribe Search ingestion to Forum events, or copy Forum audience policy into Search SQL. It establishes the exact public admission owner and canonical navigation contract required by a downstream Search-owned projection consumer (`FORUM-20BJ` / broader `FORUM-23`).

## Compatibility

- no migration or dependency change
- no REST route, GraphQL field, SEO target slug, Forum storefront route, public DTO, or legacy product/content/blog Search URL changed
- SEO authoring remains available through the existing managed/system owner path
- the uncompiled GraphQL `query.rs` snapshot and visibility-scoped bulk read commands remain downstream
- `implementation-plan.md` and `CRATE_API.md` synchronization remains explicit conflict-safe repository-local documentation debt

## Validation

Not run by the implementation agent, per maintainer request: no tests, Cargo commands, formatting, verifiers, workflows, or CI.

Suggested maintainer commands:

```text
cargo test -p rustok-forum seo_audience_targets -- --nocapture
cargo test -p rustok-search canonical_url_derives_forum -- --nocapture
node scripts/verify/verify-forum-category-audience-read.mjs
node scripts/verify/verify-forum-public-discovery-seo.mjs
node scripts/verify/verify-search-canonical-url-contract.mjs
cargo xtask module validate forum
```
