### PR TITLE
feat(index): decode query result pages

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -35,6 +35,13 @@ scheduler modules remain deleted.
 - `SchemaRegistryError`, `LinkPathStep`
 - `RecordValidationError`, `QueryValidationError`
 - `IndexCursor`, `CursorCodec`, `CursorCodecError`, `CursorValidationError`
+- `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedOrder`
+- `QueryPlanFingerprint`, `QueryPlanError`
+- `PostgresBindValue`, `CompiledQueryColumn`, `CompiledPostgresCount`
+- `CompiledPostgresQuery`, `PostgresQueryBuildError`, `PostgresQueryCompileError`
+- `CompiledPostgresCell`, `CompiledPostgresRow`, `CompiledPostgresPageQuery`
+- `IndexProjectedValue`, `IndexRelationIdentity`, `IndexQueryItem`, `IndexQueryPage`
+- `PostgresQueryPageBuildError`, `PostgresQueryDecodeError`
 
 ### Infrastructure
 
@@ -101,8 +108,16 @@ Partition admission requires an exact retained evidence identifier, complete
 query/mutation/maintenance/cutover measurement coverage, and an explicit policy
 before producing deterministic tenant-hash shadow relation names and bootstrap
 SQL. It does not execute copy, constraint/index attachment, dual-write/replay,
-cutover, or rollback. Multi-source catalog composition, batch ingestion, rebuild,
-query-port, partition cutover, and operator APIs remain later work.
+cutover, or rollback.
+
+M4 now provides validated typed executable plans, controlled PostgreSQL SQL and bind
+DTOs for root and explicit one-cardinality-link query semantics, query-scoped cursor
+continuation, one-row page lookahead, strict compiled-column/result decoding,
+exact-count decoding, `has_more`, and next-cursor construction. It still does not
+execute statements, adapt SeaORM rows directly, implement many-link semantics,
+publish `IndexQueryPort`, or claim PostgreSQL/reference-engine equivalence.
+Multi-source catalog composition, batch ingestion, rebuild, query-port, partition
+cutover, and operator APIs remain later work.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -130,9 +145,13 @@ APIs.
 - Reintroducing a catch-all JSON document as the public contract.
 - Implementing rebuild by collecting every source ID before processing.
 - Publishing unvalidated JSON filters instead of the typed query AST.
-- Accepting a cursor without checking tenant, schema, fingerprint, locale, and
-  order arity.
-- Sorting through a `many` link without an explicit aggregate policy.
+- Accepting a cursor without checking tenant, schema, fingerprint, locale, filter,
+  ordered fields/directions, order arity, and order-value types.
+- Executing a page query through raw `compile_postgres_query` instead of the
+  one-row-lookahead `compile_postgres_page_query` handoff.
+- Decoding rows without rechecking the plan fingerprint and exact compiled column
+  contract.
+- Sorting or projecting through a `many` link without an explicit aggregate policy.
 - Completing or heartbeating schema/index work without exact worker and attempt
   fencing.
 - Building expression indexes against `payload ->> field`; stored `IndexValue`
@@ -154,6 +173,10 @@ APIs.
 - `IndexSchema`, `IndexRecord`, `IndexMutation`, and `IndexQuery` are the current
   input contracts.
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
+- `SchemaRegistry::compile_postgres_page_query` is the page-execution compiler
+  handoff; it preserves SQL and increases only the validated limit bind by one.
+- `CompiledPostgresRow` is the narrow adapter handoff for compiler-owned UUID,
+  tagged JSON, SQL-null, and exact-count cells.
 - `PostgresSchemaRegistrationStore::register(tenant_id, schema)` binds one non-nil
   tenant to one validated exact schema contract and calculated fingerprint.
 - `SchemaApplicationLeaseRequest` binds one tenant, exact schema reference,
@@ -266,13 +289,34 @@ APIs.
 - Copy, constraints, indexes, replay/dual-write, cutover, rollback, durable global
   ownership, and PostgreSQL evidence remain mandatory future work.
 
+### Query Planning, Compilation, and Result Decoding
+
+- `SchemaRegistry::plan_query` validates first and captures deterministic aliases,
+  joins, typed referenced fields, projection, filters, ordering, pagination, and a
+  versioned plan fingerprint.
+- `compile_postgres_query` accepts only the supported root/one-link subset and emits
+  controlled SQL plus ordered bind DTOs; caller values and contract names remain
+  binds.
+- `compile_postgres_page_query` changes only the validated main-statement page-limit
+  bind from `N` to `N + 1`; offset and exact-count binds are preserved.
+- `decode_postgres_query_page` re-plans the query, compares the plan fingerprint and
+  complete column metadata, validates every tagged field value, and rejects more
+  than `N + 1` rows.
+- The lookahead row is removed. Cursor pages produce `has_more` and a scoped next
+  cursor from the last retained entity/order tuple; offset pages produce
+  `has_more` without a cursor.
+- SQL execution, SeaORM row adaptation, many-link semantics, and live equivalence
+  evidence remain separate future boundaries.
+
 ### Cursor Contract
 
-- Cursor format is explicitly versioned.
-- Payload uses postcard and URL-safe Base64.
+- Cursor formats are explicitly versioned.
+- Payloads use postcard and URL-safe Base64.
 - A checksum detects corruption.
-- Cursor application validates tenant, schema, schema fingerprint, locale,
-  ordering arity, and entity tie-breaker identity.
+- Production continuation tokens bind tenant, schema, locale, filter, ordered
+  fields, and directions through a query fingerprint.
+- Cursor application validates schema fingerprint, ordering arity, order-value
+  types, and non-nil entity tie-breaker identity.
 - Cursor integrity is not an authorization substitute; transport and query
   policy still enforce caller access.
 
@@ -299,7 +343,13 @@ APIs.
 - `RecordValidationError` and `QueryValidationError` define registry-backed data
   and query failures.
 - `CursorCodecError` and `CursorValidationError` separate malformed cursors from
-  scope/schema mismatches.
+  scope/schema/query-fingerprint/type mismatches.
+- `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError`
+  separate validation/planning failures from unsupported or corrupted compiler
+  contracts.
+- `PostgresQueryPageBuildError` rejects missing or mismatched pagination binds;
+  `PostgresQueryDecodeError` rejects plan/column/count mismatches, malformed cells,
+  invalid tagged values, unexpected nulls, and oversized result batches.
 - `MutationStorageError` separates validation, delivery identity conflict,
   in-progress/rejected replay, stored-version corruption, backend limits, and
   database failure. Its public display is generic; transport adapters must still
@@ -312,4 +362,5 @@ APIs.
 - `PartitionAdmissionError` separates invalid policy, invalid evidence, metric
   overflow, and unsupported hash modulus. Typed admission reasons explain every
   rejected evidence gate without exposing storage internals.
-- Later milestones add source catalog, retry, cancellation, and rebuild errors.
+- Later milestones add source catalog, retry, cancellation, rebuild, and query-port
+  execution errors.

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (typed root/one-link semantics added; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (deterministic result decoding added; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -54,21 +54,25 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 stable explicit-link relation aliases: `complete`
 - M4 controlled PostgreSQL query compilation: `complete`
 - M4 typed root/one-link query semantics: `complete`
+- M4 deterministic PostgreSQL result decoding: `complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
   admitted archive manifest generation, saved-manifest verification, recursive
   filesystem integrity checks, typed executable query planning, controlled projection,
-  filtering, ordering, exact-count, keyset, and bounded-offset SQL compilation are
-  implemented; one retained admitted packet, many-link semantics, query execution/row
-  decoding, and production partition lifecycle remain open
+  filtering, ordering, exact-count, keyset, bounded-offset SQL compilation, one-row
+  page lookahead, tagged row decoding, exact-count decoding, and scoped next-cursor
+  construction are implemented; one retained admitted packet, many-link semantics,
+  SQL execution composition, PostgreSQL/reference equivalence, and production
+  partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
 lifecycle management, measured partition admission that emits shadow bootstrap
 plans only, an M4 typed structural query planner with deterministic relation aliases,
-and a controlled PostgreSQL compiler for root and one-cardinality-link filtering,
-projection, ordering, exact count, keyset, and bounded offset semantics.
+a controlled PostgreSQL compiler for root and one-cardinality-link filtering,
+projection, ordering, exact count, keyset, and bounded offset semantics, and a
+strict compiled-row decoder with lookahead pagination and scoped cursor construction.
 Owner-operated evidence tools live under `ops/benches`; they do not become runtime
 storage code.
 
@@ -103,6 +107,7 @@ crates/rustok-index/src/
     planner.rs
     postgres_compiler.rs
     postgres_query_sql.rs
+    postgres_query_result.rs
   migrations/
   infrastructure/postgres/
     mutation_store.rs
@@ -301,9 +306,9 @@ relations.
 - [x] Support root and one-cardinality-link projection, filtering, sorting, exact
       count, and keyset pagination.
 - [x] Keep offset pagination bounded and compatibility-only.
+- [x] Add deterministic root/one-link result decoding and cursor construction.
 - [ ] Add explicit many-link `EXISTS` filtering and nested projection aggregation.
-- [ ] Add result decoding, plan/SQL snapshots, and PostgreSQL/reference-engine
-      equivalence tests.
+- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
 
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
@@ -319,10 +324,19 @@ separate exact-count statement without pagination leakage. Opaque continuation t
 must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
 schema fingerprint, order arity, and order-value types before SQL emission.
 
+The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
+the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
+fingerprint, deterministic compiled column contract, page size, row count, tagged
+`IndexValue` type/cardinality/nullability, relation identities, and optional count.
+It removes the lookahead row, reports `has_more`, preserves selection order, and emits
+a query-scoped cursor from the last retained root identity plus hidden order values.
+Offset pages use the same lookahead rule but do not synthesize a cursor.
+
 Many-cardinality paths remain fail-closed with `ManyLinkSemanticsPending`; ordinary
 joins would duplicate roots and corrupt negative filters, count, projection, and
-pagination. SQL execution, result decoding, persisted-schema readiness, query-port
-composition, consumer cutover, and PostgreSQL/reference-engine equivalence remain open.
+pagination. SQL execution, direct SeaORM row adaptation, persisted-schema readiness,
+query-port composition, consumer cutover, plan/SQL snapshots, and PostgreSQL/reference-
+engine equivalence remain open.
 
 ### M5 - Incremental ingestion
 
@@ -393,6 +407,7 @@ cargo nextest run --workspace --all-targets --all-features
 cargo test --workspace --doc --all-features
 cargo test -p rustok-index planner_tests -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
+cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -431,6 +446,7 @@ node scripts/verify/verify-index-partition-full-capture.mjs
 node scripts/verify/verify-index-partition-post-inspection-drift.mjs
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
+node scripts/verify/verify-index-query-result-decoder.mjs
 ```
 
 ## Progress log
@@ -449,8 +465,10 @@ node scripts/verify/verify-index-postgres-query-compiler.mjs
   verification receipts, and exact recursive filesystem snapshot enforcement.
 - 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
   M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
-  exact count, validated lexicographic keyset continuation, and bounded offset
-  compatibility. Many-link planning, result decoding, execution composition, and
+  exact count, validated lexicographic keyset continuation, bounded offset
+  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
+  count decoding, relation identity reconstruction, and scoped next-cursor creation.
+  Many-link planning, direct SQL execution/row adaptation, plan/SQL snapshots, and
   PostgreSQL/reference equivalence remain open.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -1,13 +1,13 @@
 # M4 controlled PostgreSQL query compiler
 
 This M4 chain compiles the database-independent `ExecutableQueryPlan` into
-controlled PostgreSQL statements plus ordered typed bind lists. It does not
-connect to PostgreSQL, execute SQL, decode result rows, or publish an
-`IndexQueryPort`.
+controlled PostgreSQL statements plus ordered typed bind lists. The compiler does not
+connect to PostgreSQL or execute SQL. Deterministic compiled-row decoding now lives in
+a separate application handoff; neither slice publishes an `IndexQueryPort`.
 
 ## Planner contract
 
-`SchemaRegistry::plan_query` now records every referenced field exactly once in
+`SchemaRegistry::plan_query` records every referenced field exactly once in
 `ExecutableQueryPlan::referenced_fields`. Each `PlannedField` carries:
 
 - the validated `FieldPath`;
@@ -17,7 +17,7 @@ connect to PostgreSQL, execute SQL, decode result rows, or publish an
 - nullability.
 
 The plan fingerprint domain is `rustok-index-query-plan-v2`, so plans produced
-before typed field contracts cannot be confused with the new compiler input.
+before typed field contracts cannot be confused with the compiler input.
 
 ## Supported query semantics
 
@@ -37,8 +37,8 @@ and validates any continuation cursor, and then compiles:
   without cursor, limit, or offset leakage.
 
 The main page statement selects hidden tagged JSONB order values when explicit
-ordering is present. A later result decoder can therefore construct the next
-`IndexCursor` even when an order field was not requested in the public
+ordering is present. `decode_postgres_query_page` uses those values to construct
+the next `IndexCursor` even when an order field was not requested in the public
 projection.
 
 ## Predicate and ordering contract
@@ -89,12 +89,28 @@ values, cursor values, limit, and offset are bind values. Only fixed
 `index_entities`/`index_links` table and column names plus compiler-owned `tN`
 and `lN` aliases appear in SQL.
 
-The compiler contract and SQL emission live in separate modules:
+The compiler contract, SQL emission, and page/result handoff live in separate
+modules:
 
-- `application/postgres_compiler.rs` owns public types, scoped cursor entry
-  points, and plan invariant checks;
+- `application/postgres_compiler.rs` owns public SQL/bind types, scoped cursor
+  entry points, and plan invariant checks;
 - `application/postgres_query_sql.rs` owns controlled SQL and deterministic bind
-  emission.
+  emission;
+- `application/postgres_query_result.rs` owns one-row lookahead wrapping, strict
+  compiled-column decoding, exact count, `has_more`, and scoped next cursors.
+
+## Page and result handoff
+
+`SchemaRegistry::compile_postgres_page_query` calls the validated compiler and
+changes only the main page-limit bind from `N` to `N + 1`. The SQL string,
+filters, ordering, keyset predicate, offset, plan fingerprint, and optional count
+statement remain unchanged.
+
+A later database adapter executes the compiled statements and maps driver values
+into `CompiledPostgresRow`. `decode_postgres_query_page` then rechecks the plan
+fingerprint and complete `CompiledQueryColumn` contract, validates tagged
+`IndexValue` type/cardinality/nullability, removes the lookahead row, and returns
+`IndexQueryPage`. It does not accept arbitrary column names or untyped JSON rows.
 
 ## Exact count
 
@@ -113,11 +129,11 @@ nested aggregation planning before that gate can be removed.
 
 ## Non-claims
 
-This source slice does not:
+This source chain does not:
 
 - prepare or execute a statement;
 - convert abstract bind values into SeaORM/sqlx parameters;
-- decode page, projection, count, or cursor rows;
+- decode directly from SeaORM `QueryResult`;
 - authorize callers;
 - verify persisted schema readiness;
 - support many-link filtering/projection/aggregation;

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -25,6 +25,8 @@ source work to remain idle.
 - M4 controlled PostgreSQL query compilation: `source_complete_execution_pending`.
 - M4 root/one-link filter/order/count/keyset/offset semantics: `source_complete_execution_pending`.
 - M4 query-scoped cursor envelopes: `source_complete_execution_pending`.
+- M4 deterministic compiled-row decoding: `source_complete_execution_pending`.
+- M4 one-row lookahead and next-cursor construction: `source_complete_execution_pending`.
 - M4 many-link query semantics: `open`.
 - M4 PostgreSQL/reference-engine equivalence: `open`.
 
@@ -47,7 +49,7 @@ contracts are part of the executable plan identity.
 
 ## Completed M4 slices 2 and 3
 
-The controlled PostgreSQL compiler now supports the validated root and explicit
+The controlled PostgreSQL compiler supports the validated root and explicit
 one-cardinality-link subset:
 
 - tagged JSONB projection and hidden order-value columns;
@@ -72,6 +74,20 @@ or order semantics produces `QueryFingerprintMismatch` before any keyset SQL is
 emitted. Legacy raw v1 envelopes remain limited to codec round trips and the
 test-only reference engine.
 
+## Completed M4 slice 4
+
+`SchemaRegistry::compile_postgres_page_query` wraps the controlled compiler and
+changes only the validated page-limit bind from `N` to `N + 1`. The SQL string,
+plan fingerprint, column metadata, filters, ordering, cursor predicate, offset,
+and optional exact-count statement remain unchanged.
+
+`decode_postgres_query_page` re-plans the query and verifies the plan fingerprint,
+complete deterministic column contract, requested page size, maximum row count,
+tagged `IndexValue` type/cardinality/nullability, relation identities, and exact
+count. It removes the one-row lookahead, preserves projection order, reports
+`has_more`, and creates a scoped next cursor from the last retained root and hidden
+order values. Offset pages report `has_more` without synthesizing a cursor.
+
 ## Remaining bounded M4 work
 
 Many-cardinality link paths remain fail-closed. The next source slice must add
@@ -80,7 +96,7 @@ an explicit semantic plan for:
 - `EXISTS`-based many-link filtering;
 - nested aggregation for many-link projection;
 - duplicate-free exact count and root pagination;
-- result decoding and scoped cursor construction;
+- direct SeaORM bind/row adaptation and execution composition;
 - SQL/parameter snapshots and PostgreSQL/reference-engine equivalence fixtures.
 
 Production query-port composition and consumer cutover remain later slices.
@@ -96,8 +112,10 @@ Suggested commands:
 ```bash
 cargo test -p rustok-index planner_tests -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
+cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo check -p rustok-index --all-targets
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
+node scripts/verify/verify-index-query-result-decoder.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-result-decoder.md
+++ b/crates/rustok-index/docs/m4-query-result-decoder.md
@@ -1,0 +1,85 @@
+# M4 PostgreSQL query result decoding
+
+This slice closes the database-independent handoff between the controlled M4
+PostgreSQL compiler and a later execution adapter. It does not execute SQL,
+prepare statements, own a database connection, or expose `IndexQueryPort`.
+
+## Page compilation contract
+
+`SchemaRegistry::compile_postgres_page_query` first calls the existing validated
+`compile_postgres_query` path. It then wraps the compiled statement in
+`CompiledPostgresPageQuery` and changes only the validated page-limit bind from
+`N` to `N + 1`.
+
+The SQL text, plan fingerprint, column metadata, scope predicates, filters,
+ordering, cursor predicates, and exact-count statement remain unchanged. The
+one-row lookahead is an execution detail used to determine `has_more`; it is not
+part of the public query semantics.
+
+Cursor and bounded-offset pages use the same lookahead rule. The original
+offset bind is rechecked and preserved.
+
+## Adapter row handoff
+
+A later SeaORM/PostgreSQL adapter converts returned driver rows into
+`CompiledPostgresRow`. Cells are intentionally limited to the shapes emitted by
+the compiler:
+
+- UUID or SQL null for relation identity columns;
+- tagged `IndexValue` JSON or SQL null for projection and hidden order columns;
+- a PostgreSQL bigint for the optional exact-count row.
+
+This DTO is not a generic SQL row abstraction. It is a narrow handoff for the
+controlled Index compiler output.
+
+## Decoder validation
+
+`SchemaRegistry::decode_postgres_query_page` re-plans the supplied query and
+fails closed unless all of the following match:
+
+1. the compiled plan fingerprint;
+2. the complete compiled column contract and deterministic output aliases;
+3. the requested page size;
+4. the optional exact-count contract;
+5. the maximum `requested + 1` result-row count.
+
+Every tagged projection/order value is deserialized back into `IndexValue` and
+validated against the planned type, cardinality, and nullability. A non-nullable
+linked field may decode as null only when that explicit one-cardinality relation
+identity is absent. A present relation with a missing non-nullable field is a
+typed corruption error.
+
+## Page output
+
+The decoder returns `IndexQueryPage` with:
+
+- root entity identities;
+- deterministic explicit-link relation identities;
+- projection values in query selection order;
+- optional exact count;
+- `has_more` derived only from the one-row lookahead;
+- an optional query-scoped continuation cursor.
+
+The lookahead row is never exposed. When a cursor page has an extra row, the
+last retained item and its hidden order values produce an `IndexCursor`, which
+is encoded through `CursorCodec::encode_for_query`. The resulting token remains
+bound to tenant, schema, locale, filter, ordered fields, and directions.
+Offset pages report `has_more` but do not synthesize a cursor.
+
+## Fail-closed boundaries
+
+Many-link semantics remain fail-closed in the compiler with
+`ManyLinkSemanticsPending`. This decoder handles only the already-supported root
+and explicit one-cardinality-link subset. It does not attempt to deduplicate
+roots or aggregate many-link projections after SQL execution.
+
+This slice also does not:
+
+- execute SQL or convert bind DTOs into driver parameters;
+- decode directly from SeaORM `QueryResult`;
+- verify persisted schema/index readiness;
+- authorize callers;
+- provide PostgreSQL/reference-engine equivalence evidence;
+- change migrations or production partition lifecycle state.
+
+The repository owner runs formatting, compilation, tests, and static verifiers.

--- a/crates/rustok-index/docs/m4-query-result-decoder.md
+++ b/crates/rustok-index/docs/m4-query-result-decoder.md
@@ -11,6 +11,10 @@ prepare statements, own a database connection, or expose `IndexQueryPort`.
 `CompiledPostgresPageQuery` and changes only the validated page-limit bind from
 `N` to `N + 1`.
 
+The page wrapper is opaque and deliberately does not implement serde. External
+bytes therefore cannot replace its controlled SQL, bind values, column metadata,
+or requested page size before execution.
+
 The SQL text, plan fingerprint, column metadata, scope predicates, filters,
 ordering, cursor predicates, and exact-count statement remain unchanged. The
 one-row lookahead is an execution detail used to determine `has_more`; it is not
@@ -47,7 +51,8 @@ Every tagged projection/order value is deserialized back into `IndexValue` and
 validated against the planned type, cardinality, and nullability. A non-nullable
 linked field may decode as null only when that explicit one-cardinality relation
 identity is absent. A present relation with a missing non-nullable field is a
-typed corruption error.
+typed corruption error. Conversely, an absent relation identity paired with a
+non-null field value is also rejected.
 
 ## Page output
 

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,6 +1,7 @@
 mod cursor;
 mod planner;
 mod postgres_compiler;
+mod postgres_query_result;
 mod postgres_query_sql;
 mod registry;
 mod validation;
@@ -9,6 +10,8 @@ mod validation;
 mod planner_tests;
 #[cfg(test)]
 mod postgres_compiler_tests;
+#[cfg(test)]
+mod postgres_query_result_tests;
 #[cfg(test)]
 mod reference;
 
@@ -20,6 +23,11 @@ pub use planner::{
 pub use postgres_compiler::{
     CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue,
     PostgresQueryBuildError, PostgresQueryCompileError,
+};
+pub use postgres_query_result::{
+    CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow, IndexProjectedValue,
+    IndexQueryItem, IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError,
+    PostgresQueryPageBuildError,
 };
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -57,7 +57,11 @@ impl CompiledPostgresRow {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Opaque page-execution contract produced only by `SchemaRegistry`.
+///
+/// The wrapper deliberately has no serde implementation so untrusted bytes cannot
+/// replace controlled SQL, bind values, or the requested page size before execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompiledPostgresPageQuery {
     compiled: CompiledPostgresQuery,
     requested_page_size: u32,
@@ -378,7 +382,7 @@ fn decode_row(
         }
     }
 
-    let root_entity_id = root_entity_id.ok_or_else(|| {
+    let root_entity_id = root_entity_id.flatten().ok_or_else(|| {
         PostgresQueryDecodeError::MissingColumn(identity_alias(&plan.root_alias))
     })?;
     let mut fields = Vec::with_capacity(plan.projection.len());

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -1,0 +1,503 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{
+    FieldCardinality, FieldPath, IndexQuery, IndexValue, LinkName, Pagination,
+};
+
+use super::{
+    CompiledPostgresQuery, CompiledQueryColumn, CursorCodec, CursorValidationError,
+    ExecutableQueryPlan, IndexCursor, PlannedField, PostgresBindValue, PostgresQueryBuildError,
+    QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
+};
+
+const EXACT_COUNT_ALIAS: &str = "__exact_count";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum CompiledPostgresCell {
+    Null,
+    Uuid(Uuid),
+    Json(JsonValue),
+    Integer(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CompiledPostgresRow {
+    values: BTreeMap<String, CompiledPostgresCell>,
+}
+
+impl CompiledPostgresRow {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_values(
+        values: impl IntoIterator<Item = (String, CompiledPostgresCell)>,
+    ) -> Self {
+        Self {
+            values: values.into_iter().collect(),
+        }
+    }
+
+    pub fn insert(
+        &mut self,
+        output_alias: impl Into<String>,
+        value: CompiledPostgresCell,
+    ) -> Option<CompiledPostgresCell> {
+        self.values.insert(output_alias.into(), value)
+    }
+
+    pub fn get(&self, output_alias: &str) -> Option<&CompiledPostgresCell> {
+        self.values.get(output_alias)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledPostgresPageQuery {
+    compiled: CompiledPostgresQuery,
+    requested_page_size: u32,
+}
+
+impl CompiledPostgresPageQuery {
+    pub fn compiled(&self) -> &CompiledPostgresQuery {
+        &self.compiled
+    }
+
+    pub fn requested_page_size(&self) -> u32 {
+        self.requested_page_size
+    }
+
+    pub fn into_compiled(self) -> CompiledPostgresQuery {
+        self.compiled
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexProjectedValue {
+    pub path: FieldPath,
+    pub value: IndexValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexRelationIdentity {
+    pub path: Vec<LinkName>,
+    pub entity_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexQueryItem {
+    pub entity_id: Uuid,
+    pub relations: Vec<IndexRelationIdentity>,
+    pub fields: Vec<IndexProjectedValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexQueryPage {
+    pub items: Vec<IndexQueryItem>,
+    pub exact_count: Option<u64>,
+    pub has_more: bool,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresQueryPageBuildError {
+    #[error(transparent)]
+    Query(#[from] PostgresQueryBuildError),
+    #[error("compiled query pagination bind is missing")]
+    PaginationBindMissing,
+    #[error("compiled query pagination binds do not match the validated query")]
+    PaginationBindMismatch,
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresQueryDecodeError {
+    #[error(transparent)]
+    Plan(#[from] QueryPlanError),
+    #[error(transparent)]
+    Cursor(#[from] CursorValidationError),
+    #[error("query plan fingerprint serialization failed: {0}")]
+    Fingerprint(#[from] postcard::Error),
+    #[error("compiled query plan {actual} does not match expected plan {expected}")]
+    PlanFingerprintMismatch {
+        expected: QueryPlanFingerprint,
+        actual: QueryPlanFingerprint,
+    },
+    #[error("compiled query column contract does not match the executable plan")]
+    ColumnContractMismatch,
+    #[error("compiled query exact-count contract does not match the query")]
+    ExactCountContractMismatch,
+    #[error("compiled page requested {compiled} rows but query requests {query}")]
+    PageSizeMismatch { compiled: u32, query: u32 },
+    #[error("compiled page returned {actual} rows; maximum lookahead size is {maximum}")]
+    TooManyRows { maximum: usize, actual: usize },
+    #[error("compiled row is missing output column {0}")]
+    MissingColumn(String),
+    #[error("compiled row column {alias} must contain {expected}")]
+    UnexpectedCellType {
+        alias: String,
+        expected: &'static str,
+    },
+    #[error("root entity identity column {0} is null")]
+    NullRootIdentity(String),
+    #[error("projected field {path:?} unexpectedly decoded as null")]
+    UnexpectedFieldNull { path: FieldPath },
+    #[error("projected field {path:?} contains an invalid value contract")]
+    InvalidFieldValue { path: FieldPath },
+    #[error("compiled row column {alias} contains invalid tagged IndexValue JSON")]
+    InvalidTaggedValue {
+        alias: String,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("exact-count value is negative: {0}")]
+    NegativeExactCount(i64),
+}
+
+impl SchemaRegistry {
+    /// Compile an execution-page query with one extra lookahead row.
+    ///
+    /// The underlying controlled SQL remains unchanged; only the validated page-limit
+    /// bind is increased by one. Result decoding then truncates to the requested size
+    /// and emits a continuation cursor only when the extra row exists.
+    pub fn compile_postgres_page_query(
+        &self,
+        query: &IndexQuery,
+    ) -> Result<CompiledPostgresPageQuery, PostgresQueryPageBuildError> {
+        let mut compiled = self.compile_postgres_query(query)?;
+        let requested_page_size = page_size(&query.pagination);
+        apply_lookahead_bind(&mut compiled, &query.pagination)?;
+        Ok(CompiledPostgresPageQuery {
+            compiled,
+            requested_page_size,
+        })
+    }
+
+    pub fn decode_postgres_query_page(
+        &self,
+        query: &IndexQuery,
+        page_query: &CompiledPostgresPageQuery,
+        rows: Vec<CompiledPostgresRow>,
+        exact_count_row: Option<CompiledPostgresRow>,
+    ) -> Result<IndexQueryPage, PostgresQueryDecodeError> {
+        let plan = self.plan_query(query)?;
+        let expected_fingerprint = plan.fingerprint()?;
+        let compiled = page_query.compiled();
+        if compiled.plan_fingerprint != expected_fingerprint {
+            return Err(PostgresQueryDecodeError::PlanFingerprintMismatch {
+                expected: expected_fingerprint,
+                actual: compiled.plan_fingerprint,
+            });
+        }
+        if compiled.columns != expected_columns(&plan) {
+            return Err(PostgresQueryDecodeError::ColumnContractMismatch);
+        }
+
+        let requested_page_size = page_size(&query.pagination);
+        if page_query.requested_page_size() != requested_page_size {
+            return Err(PostgresQueryDecodeError::PageSizeMismatch {
+                compiled: page_query.requested_page_size(),
+                query: requested_page_size,
+            });
+        }
+        let maximum = requested_page_size as usize + 1;
+        if rows.len() > maximum {
+            return Err(PostgresQueryDecodeError::TooManyRows {
+                maximum,
+                actual: rows.len(),
+            });
+        }
+
+        let exact_count = decode_exact_count(query, compiled, exact_count_row.as_ref())?;
+        let has_more = rows.len() > requested_page_size as usize;
+        let mut decoded = rows
+            .iter()
+            .take(requested_page_size as usize)
+            .map(|row| decode_row(&plan, compiled, row))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let next_cursor = if has_more && matches!(query.pagination, Pagination::Cursor { .. }) {
+            let last = decoded
+                .last()
+                .expect("lookahead requires at least one retained result row");
+            let registered = self
+                .get(&query.schema)
+                .expect("validated query schema must remain registered");
+            let cursor = IndexCursor {
+                tenant_id: query.scope.tenant_id,
+                schema: query.schema.clone(),
+                schema_fingerprint: registered.fingerprint,
+                locale: query.scope.locale.clone(),
+                order_values: last.order_values.clone(),
+                entity_id: last.item.entity_id,
+            };
+            Some(CursorCodec::encode_for_query(&cursor, query, self)?)
+        } else {
+            None
+        };
+
+        Ok(IndexQueryPage {
+            items: decoded.drain(..).map(|row| row.item).collect(),
+            exact_count,
+            has_more,
+            next_cursor,
+        })
+    }
+}
+
+fn apply_lookahead_bind(
+    compiled: &mut CompiledPostgresQuery,
+    pagination: &Pagination,
+) -> Result<(), PostgresQueryPageBuildError> {
+    let length = compiled.binds.len();
+    let (limit_index, expected_limit) = match pagination {
+        Pagination::Cursor { first, .. } => (
+            length
+                .checked_sub(1)
+                .ok_or(PostgresQueryPageBuildError::PaginationBindMissing)?,
+            i64::from(*first),
+        ),
+        Pagination::Offset { limit, offset } => {
+            let limit_index = length
+                .checked_sub(2)
+                .ok_or(PostgresQueryPageBuildError::PaginationBindMissing)?;
+            let offset_index = length
+                .checked_sub(1)
+                .ok_or(PostgresQueryPageBuildError::PaginationBindMissing)?;
+            if compiled.binds.get(offset_index)
+                != Some(&PostgresBindValue::Integer(*offset as i64))
+            {
+                return Err(PostgresQueryPageBuildError::PaginationBindMismatch);
+            }
+            (limit_index, i64::from(*limit))
+        }
+    };
+
+    match compiled.binds.get_mut(limit_index) {
+        Some(PostgresBindValue::Integer(value)) if *value == expected_limit => {
+            *value = expected_limit + 1;
+            Ok(())
+        }
+        Some(_) => Err(PostgresQueryPageBuildError::PaginationBindMismatch),
+        None => Err(PostgresQueryPageBuildError::PaginationBindMissing),
+    }
+}
+
+fn page_size(pagination: &Pagination) -> u32 {
+    match pagination {
+        Pagination::Cursor { first, .. } => *first,
+        Pagination::Offset { limit, .. } => *limit,
+    }
+}
+
+fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
+    let mut columns = Vec::new();
+    columns.push(CompiledQueryColumn::EntityId {
+        output_alias: identity_alias(&plan.root_alias),
+        relation_alias: plan.root_alias.clone(),
+    });
+    columns.extend(plan.joins.iter().map(|join| CompiledQueryColumn::EntityId {
+        output_alias: identity_alias(&join.alias),
+        relation_alias: join.alias.clone(),
+    }));
+    columns.extend(
+        plan.projection
+            .iter()
+            .enumerate()
+            .map(|(index, field)| CompiledQueryColumn::Field {
+                output_alias: format!("f{index}"),
+                field: field.clone(),
+            }),
+    );
+    columns.extend(
+        plan.order_by
+            .iter()
+            .enumerate()
+            .map(|(index, order)| CompiledQueryColumn::OrderValue {
+                output_alias: format!("__order_{index}"),
+                field: order.field.clone(),
+            }),
+    );
+    columns
+}
+
+fn identity_alias(relation_alias: &str) -> String {
+    format!("__{relation_alias}_entity_id")
+}
+
+struct DecodedRow {
+    item: IndexQueryItem,
+    order_values: Vec<IndexValue>,
+}
+
+fn decode_row(
+    plan: &ExecutableQueryPlan,
+    compiled: &CompiledPostgresQuery,
+    row: &CompiledPostgresRow,
+) -> Result<DecodedRow, PostgresQueryDecodeError> {
+    let mut root_entity_id = None;
+    let mut identities = BTreeMap::new();
+    let mut relations = Vec::new();
+
+    for column in &compiled.columns {
+        let CompiledQueryColumn::EntityId {
+            output_alias,
+            relation_alias,
+        } = column
+        else {
+            continue;
+        };
+        let identity = decode_identity(row, output_alias, relation_alias == &plan.root_alias)?;
+        identities.insert(relation_alias.clone(), identity);
+        if relation_alias == &plan.root_alias {
+            root_entity_id = identity;
+        } else {
+            let join = plan
+                .joins
+                .iter()
+                .find(|join| join.alias == *relation_alias)
+                .expect("validated column contract must resolve every join alias");
+            relations.push(IndexRelationIdentity {
+                path: join.path.clone(),
+                entity_id: identity,
+            });
+        }
+    }
+
+    let root_entity_id = root_entity_id.ok_or_else(|| {
+        PostgresQueryDecodeError::MissingColumn(identity_alias(&plan.root_alias))
+    })?;
+    let mut fields = Vec::with_capacity(plan.projection.len());
+    let mut order_values = Vec::with_capacity(plan.order_by.len());
+
+    for column in &compiled.columns {
+        match column {
+            CompiledQueryColumn::Field {
+                output_alias,
+                field,
+            } => fields.push(IndexProjectedValue {
+                path: field.path.clone(),
+                value: decode_field(row, output_alias, field, &identities)?,
+            }),
+            CompiledQueryColumn::OrderValue {
+                output_alias,
+                field,
+            } => order_values.push(decode_field(row, output_alias, field, &identities)?),
+            CompiledQueryColumn::EntityId { .. } => {}
+        }
+    }
+
+    Ok(DecodedRow {
+        item: IndexQueryItem {
+            entity_id: root_entity_id,
+            relations,
+            fields,
+        },
+        order_values,
+    })
+}
+
+fn decode_identity(
+    row: &CompiledPostgresRow,
+    output_alias: &str,
+    is_root: bool,
+) -> Result<Option<Uuid>, PostgresQueryDecodeError> {
+    match required_cell(row, output_alias)? {
+        CompiledPostgresCell::Uuid(value) => Ok(Some(*value)),
+        CompiledPostgresCell::Null if is_root => Err(PostgresQueryDecodeError::NullRootIdentity(
+            output_alias.to_owned(),
+        )),
+        CompiledPostgresCell::Null => Ok(None),
+        _ => Err(PostgresQueryDecodeError::UnexpectedCellType {
+            alias: output_alias.to_owned(),
+            expected: "a UUID or SQL null",
+        }),
+    }
+}
+
+fn decode_field(
+    row: &CompiledPostgresRow,
+    output_alias: &str,
+    field: &PlannedField,
+    identities: &BTreeMap<String, Option<Uuid>>,
+) -> Result<IndexValue, PostgresQueryDecodeError> {
+    let missing_relation = identities
+        .get(&field.relation_alias)
+        .is_some_and(Option::is_none);
+    let value = match required_cell(row, output_alias)? {
+        CompiledPostgresCell::Null => IndexValue::Null,
+        CompiledPostgresCell::Json(value) => serde_json::from_value(value.clone()).map_err(
+            |source| PostgresQueryDecodeError::InvalidTaggedValue {
+                alias: output_alias.to_owned(),
+                source,
+            },
+        )?,
+        _ => {
+            return Err(PostgresQueryDecodeError::UnexpectedCellType {
+                alias: output_alias.to_owned(),
+                expected: "tagged IndexValue JSON or SQL null",
+            });
+        }
+    };
+
+    if matches!(value, IndexValue::Null) && !field.nullable && !missing_relation {
+        return Err(PostgresQueryDecodeError::UnexpectedFieldNull {
+            path: field.path.clone(),
+        });
+    }
+    if !valid_field_value(field, &value, missing_relation) {
+        return Err(PostgresQueryDecodeError::InvalidFieldValue {
+            path: field.path.clone(),
+        });
+    }
+    Ok(value)
+}
+
+fn valid_field_value(field: &PlannedField, value: &IndexValue, missing_relation: bool) -> bool {
+    match value {
+        IndexValue::Null => field.nullable || missing_relation,
+        IndexValue::List(values) => {
+            field.cardinality == FieldCardinality::Many
+                && values
+                    .iter()
+                    .all(|value| value.value_type() == Some(field.value_type))
+        }
+        value => {
+            field.cardinality == FieldCardinality::One
+                && value.value_type() == Some(field.value_type)
+        }
+    }
+}
+
+fn required_cell<'a>(
+    row: &'a CompiledPostgresRow,
+    output_alias: &str,
+) -> Result<&'a CompiledPostgresCell, PostgresQueryDecodeError> {
+    row.get(output_alias)
+        .ok_or_else(|| PostgresQueryDecodeError::MissingColumn(output_alias.to_owned()))
+}
+
+fn decode_exact_count(
+    query: &IndexQuery,
+    compiled: &CompiledPostgresQuery,
+    row: Option<&CompiledPostgresRow>,
+) -> Result<Option<u64>, PostgresQueryDecodeError> {
+    match (query.include_exact_count, compiled.exact_count.is_some(), row) {
+        (false, false, None) => Ok(None),
+        (true, true, Some(row)) => match required_cell(row, EXACT_COUNT_ALIAS)? {
+            CompiledPostgresCell::Integer(value) if *value >= 0 => Ok(Some(*value as u64)),
+            CompiledPostgresCell::Integer(value) => {
+                Err(PostgresQueryDecodeError::NegativeExactCount(*value))
+            }
+            _ => Err(PostgresQueryDecodeError::UnexpectedCellType {
+                alias: EXACT_COUNT_ALIAS.to_owned(),
+                expected: "a non-negative bigint",
+            }),
+        },
+        _ => Err(PostgresQueryDecodeError::ExactCountContractMismatch),
+    }
+}

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -341,6 +341,12 @@ fn identity_alias(relation_alias: &str) -> String {
     format!("__{relation_alias}_entity_id")
 }
 
+fn join_is_projected(plan: &ExecutableQueryPlan, join_path: &[LinkName]) -> bool {
+    plan.projection
+        .iter()
+        .any(|field| field.path.links().starts_with(join_path))
+}
+
 struct DecodedRow {
     item: IndexQueryItem,
     order_values: Vec<IndexValue>,
@@ -375,10 +381,12 @@ fn decode_row(
                 .ok_or_else(|| {
                     PostgresQueryDecodeError::UnknownRelationAlias(relation_alias.clone())
                 })?;
-            relations.push(IndexRelationIdentity {
-                path: join.path.clone(),
-                entity_id: identity,
-            });
+            if join_is_projected(plan, &join.path) {
+                relations.push(IndexRelationIdentity {
+                    path: join.path.clone(),
+                    entity_id: identity,
+                });
+            }
         }
     }
 

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -12,7 +12,7 @@ use crate::domain::{
 use super::{
     CompiledPostgresQuery, CompiledQueryColumn, CursorCodec, CursorValidationError,
     ExecutableQueryPlan, IndexCursor, PlannedField, PostgresBindValue, PostgresQueryBuildError,
-    QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
+    QueryPlanError, QueryPlanFingerprint, SchemaRegistry, SchemaRegistryError,
 };
 
 const EXACT_COUNT_ALIAS: &str = "__exact_count";
@@ -144,6 +144,10 @@ pub enum PostgresQueryDecodeError {
     },
     #[error("root entity identity column {0} is null")]
     NullRootIdentity(String),
+    #[error("compiled column references unknown relation alias {0}")]
+    UnknownRelationAlias(String),
+    #[error("lookahead cursor construction has no retained item")]
+    MissingCursorItem,
     #[error("projected field {path:?} unexpectedly decoded as null")]
     UnexpectedFieldNull { path: FieldPath },
     #[error("projected field {path:?} contains an invalid value contract")]
@@ -214,19 +218,21 @@ impl SchemaRegistry {
 
         let exact_count = decode_exact_count(query, compiled, exact_count_row.as_ref())?;
         let has_more = rows.len() > requested_page_size as usize;
-        let mut decoded = rows
+        let decoded = rows
             .iter()
             .take(requested_page_size as usize)
             .map(|row| decode_row(&plan, compiled, row))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let next_cursor = if has_more && matches!(query.pagination, Pagination::Cursor { .. }) {
+        let next_cursor = if has_more && matches!(&query.pagination, Pagination::Cursor { .. }) {
             let last = decoded
                 .last()
-                .expect("lookahead requires at least one retained result row");
-            let registered = self
-                .get(&query.schema)
-                .expect("validated query schema must remain registered");
+                .ok_or(PostgresQueryDecodeError::MissingCursorItem)?;
+            let registered = self.get(&query.schema).ok_or_else(|| {
+                QueryPlanError::Registry(SchemaRegistryError::SchemaNotFound(
+                    query.schema.clone(),
+                ))
+            })?;
             let cursor = IndexCursor {
                 tenant_id: query.scope.tenant_id,
                 schema: query.schema.clone(),
@@ -241,7 +247,7 @@ impl SchemaRegistry {
         };
 
         Ok(IndexQueryPage {
-            items: decoded.drain(..).map(|row| row.item).collect(),
+            items: decoded.into_iter().map(|row| row.item).collect(),
             exact_count,
             has_more,
             next_cursor,
@@ -268,8 +274,10 @@ fn apply_lookahead_bind(
             let offset_index = length
                 .checked_sub(1)
                 .ok_or(PostgresQueryPageBuildError::PaginationBindMissing)?;
+            let expected_offset = i64::try_from(*offset)
+                .map_err(|_| PostgresQueryPageBuildError::PaginationBindMismatch)?;
             if compiled.binds.get(offset_index)
-                != Some(&PostgresBindValue::Integer(*offset as i64))
+                != Some(&PostgresBindValue::Integer(expected_offset))
             {
                 return Err(PostgresQueryPageBuildError::PaginationBindMismatch);
             }
@@ -360,7 +368,9 @@ fn decode_row(
                 .joins
                 .iter()
                 .find(|join| join.alias == *relation_alias)
-                .expect("validated column contract must resolve every join alias");
+                .ok_or_else(|| {
+                    PostgresQueryDecodeError::UnknownRelationAlias(relation_alias.clone())
+                })?;
             relations.push(IndexRelationIdentity {
                 path: join.path.clone(),
                 entity_id: identity,

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -472,8 +472,11 @@ fn decode_field(
 }
 
 fn valid_field_value(field: &PlannedField, value: &IndexValue, missing_relation: bool) -> bool {
+    if missing_relation {
+        return matches!(value, IndexValue::Null);
+    }
     match value {
-        IndexValue::Null => field.nullable || missing_relation,
+        IndexValue::Null => field.nullable,
         IndexValue::List(values) => {
             field.cardinality == FieldCardinality::Many
                 && values

--- a/crates/rustok-index/src/application/postgres_query_result_tests.rs
+++ b/crates/rustok-index/src/application/postgres_query_result_tests.rs
@@ -117,18 +117,18 @@ fn compiled_row(
                 } else {
                     linked_entity_id.map_or(CompiledPostgresCell::Null, CompiledPostgresCell::Uuid)
                 };
-                row.insert(output_alias.clone(), value);
+                let _ = row.insert(output_alias.clone(), value);
             }
             CompiledQueryColumn::Field { output_alias, .. } => {
                 let value = projected.next().expect("projection fixture arity");
-                row.insert(
+                let _ = row.insert(
                     output_alias.clone(),
                     CompiledPostgresCell::Json(serde_json::to_value(value).unwrap()),
                 );
             }
             CompiledQueryColumn::OrderValue { output_alias, .. } => {
                 let value = order_values.next().expect("order fixture arity");
-                row.insert(
+                let _ = row.insert(
                     output_alias.clone(),
                     CompiledPostgresCell::Json(serde_json::to_value(value).unwrap()),
                 );

--- a/crates/rustok-index/src/application/postgres_query_result_tests.rs
+++ b/crates/rustok-index/src/application/postgres_query_result_tests.rs
@@ -112,7 +112,7 @@ fn compiled_row(
                 output_alias,
                 relation_alias,
             } => {
-                let value = if relation_alias == "t0" {
+                let value = if relation_alias.as_str() == "t0" {
                     CompiledPostgresCell::Uuid(root_entity_id)
                 } else {
                     linked_entity_id.map_or(CompiledPostgresCell::Null, CompiledPostgresCell::Uuid)
@@ -161,6 +161,24 @@ fn page_compilation_adds_exactly_one_lookahead_row() {
     );
     assert_eq!(page.requested_page_size(), 2);
     assert_eq!(page.compiled().sql, raw.sql);
+}
+
+#[test]
+fn offset_page_compilation_preserves_offset_and_adds_lookahead() {
+    let registry = registry();
+    let mut query = query(Uuid::new_v4());
+    query.pagination = Pagination::Offset {
+        limit: 2,
+        offset: 5,
+    };
+    let page = registry.compile_postgres_page_query(&query).unwrap();
+    let binds = &page.compiled().binds;
+
+    assert_eq!(
+        binds.get(binds.len() - 2),
+        Some(&PostgresBindValue::Integer(3))
+    );
+    assert_eq!(binds.last(), Some(&PostgresBindValue::Integer(5)));
 }
 
 #[test]
@@ -269,7 +287,12 @@ fn rejects_page_compiled_for_different_query_semantics() {
     let page_query = registry.compile_postgres_page_query(&changed).unwrap();
 
     assert!(matches!(
-        registry.decode_postgres_query_page(&query, &page_query, Vec::new(), Some(exact_count_row(0))),
+        registry.decode_postgres_query_page(
+            &query,
+            &page_query,
+            Vec::new(),
+            Some(exact_count_row(0)),
+        ),
         Err(PostgresQueryDecodeError::PlanFingerprintMismatch { .. })
     ));
 }
@@ -294,8 +317,14 @@ fn rejects_invalid_tagged_field_contract() {
     );
 
     assert!(matches!(
-        registry.decode_postgres_query_page(&query, &page_query, vec![row], Some(exact_count_row(1))),
-        Err(PostgresQueryDecodeError::InvalidFieldValue { path }) if path == path("score")
+        registry.decode_postgres_query_page(
+            &query,
+            &page_query,
+            vec![row],
+            Some(exact_count_row(1)),
+        ),
+        Err(PostgresQueryDecodeError::InvalidFieldValue { path: field_path })
+            if field_path == path("score")
     ));
 }
 

--- a/crates/rustok-index/src/application/postgres_query_result_tests.rs
+++ b/crates/rustok-index/src/application/postgres_query_result_tests.rs
@@ -1,0 +1,316 @@
+use uuid::Uuid;
+
+use super::{
+    CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow, CompiledQueryColumn,
+    CursorCodec, IndexCursor, PostgresBindValue, PostgresQueryDecodeError, SchemaRegistry,
+};
+use crate::domain::{
+    EntityName, FieldCardinality, FieldName, FieldPath, IndexField, IndexLink, IndexQuery,
+    IndexQueryScope, IndexSchema, IndexValue, IndexValueType, LinkCardinality, LinkName, LocaleKey,
+    LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaRef, SchemaVersion,
+};
+
+fn schema_ref(entity: &str) -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new(entity).unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn field(
+    name: &str,
+    value_type: IndexValueType,
+    nullable: bool,
+    sortable: bool,
+) -> IndexField {
+    IndexField {
+        name: FieldName::new(name).unwrap(),
+        value_type,
+        cardinality: FieldCardinality::One,
+        nullable,
+        selectable: true,
+        filterable: true,
+        sortable,
+    }
+}
+
+fn registry() -> SchemaRegistry {
+    let channel = IndexSchema {
+        reference: schema_ref("sales_channel"),
+        locale_mode: LocaleMode::None,
+        fields: vec![field("id", IndexValueType::Uuid, false, true)],
+        links: Vec::new(),
+    };
+    let product = IndexSchema {
+        reference: schema_ref("product"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![
+            field("id", IndexValueType::Uuid, false, true),
+            field("score", IndexValueType::Integer, true, true),
+            field("sales_channel_id", IndexValueType::Uuid, false, false),
+        ],
+        links: vec![IndexLink {
+            name: LinkName::new("sales_channel").unwrap(),
+            source_fields: vec![FieldName::new("sales_channel_id").unwrap()],
+            target_schema: channel.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::One,
+        }],
+    };
+
+    let mut registry = SchemaRegistry::new();
+    registry.register_batch([product, channel]).unwrap();
+    registry
+}
+
+fn path(name: &str) -> FieldPath {
+    FieldPath::new(FieldName::new(name).unwrap())
+}
+
+fn linked_id() -> FieldPath {
+    FieldPath::linked(
+        [LinkName::new("sales_channel").unwrap()],
+        FieldName::new("id").unwrap(),
+    )
+}
+
+fn query(tenant_id: Uuid) -> IndexQuery {
+    IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id,
+            locale: Some(LocaleKey::new("en-US").unwrap()),
+        },
+        schema: schema_ref("product"),
+        fields: vec![path("id"), path("score"), linked_id()],
+        filter: None,
+        order_by: vec![OrderExpr {
+            field: path("score"),
+            direction: OrderDirection::Asc,
+        }],
+        pagination: Pagination::Cursor {
+            first: 2,
+            after: None,
+        },
+        include_exact_count: true,
+    }
+}
+
+fn compiled_row(
+    page_query: &CompiledPostgresPageQuery,
+    root_entity_id: Uuid,
+    linked_entity_id: Option<Uuid>,
+    projected: &[IndexValue],
+    order_values: &[IndexValue],
+) -> CompiledPostgresRow {
+    let mut row = CompiledPostgresRow::new();
+    let mut projected = projected.iter();
+    let mut order_values = order_values.iter();
+    for column in &page_query.compiled().columns {
+        match column {
+            CompiledQueryColumn::EntityId {
+                output_alias,
+                relation_alias,
+            } => {
+                let value = if relation_alias == "t0" {
+                    CompiledPostgresCell::Uuid(root_entity_id)
+                } else {
+                    linked_entity_id.map_or(CompiledPostgresCell::Null, CompiledPostgresCell::Uuid)
+                };
+                row.insert(output_alias.clone(), value);
+            }
+            CompiledQueryColumn::Field { output_alias, .. } => {
+                let value = projected.next().expect("projection fixture arity");
+                row.insert(
+                    output_alias.clone(),
+                    CompiledPostgresCell::Json(serde_json::to_value(value).unwrap()),
+                );
+            }
+            CompiledQueryColumn::OrderValue { output_alias, .. } => {
+                let value = order_values.next().expect("order fixture arity");
+                row.insert(
+                    output_alias.clone(),
+                    CompiledPostgresCell::Json(serde_json::to_value(value).unwrap()),
+                );
+            }
+        }
+    }
+    assert!(projected.next().is_none());
+    assert!(order_values.next().is_none());
+    row
+}
+
+fn exact_count_row(value: i64) -> CompiledPostgresRow {
+    CompiledPostgresRow::from_values([(
+        "__exact_count".to_owned(),
+        CompiledPostgresCell::Integer(value),
+    )])
+}
+
+#[test]
+fn page_compilation_adds_exactly_one_lookahead_row() {
+    let registry = registry();
+    let query = query(Uuid::new_v4());
+    let raw = registry.compile_postgres_query(&query).unwrap();
+    let page = registry.compile_postgres_page_query(&query).unwrap();
+
+    assert_eq!(raw.binds.last(), Some(&PostgresBindValue::Integer(2)));
+    assert_eq!(
+        page.compiled().binds.last(),
+        Some(&PostgresBindValue::Integer(3))
+    );
+    assert_eq!(page.requested_page_size(), 2);
+    assert_eq!(page.compiled().sql, raw.sql);
+}
+
+#[test]
+fn decodes_projection_relations_exact_count_and_next_cursor() {
+    let registry = registry();
+    let tenant_id = Uuid::new_v4();
+    let query = query(tenant_id);
+    let page_query = registry.compile_postgres_page_query(&query).unwrap();
+    let first_id = Uuid::new_v4();
+    let second_id = Uuid::new_v4();
+    let third_id = Uuid::new_v4();
+    let first_channel = Uuid::new_v4();
+    let third_channel = Uuid::new_v4();
+    let rows = vec![
+        compiled_row(
+            &page_query,
+            first_id,
+            Some(first_channel),
+            &[
+                IndexValue::Uuid(first_id),
+                IndexValue::Integer(10),
+                IndexValue::Uuid(first_channel),
+            ],
+            &[IndexValue::Integer(10)],
+        ),
+        compiled_row(
+            &page_query,
+            second_id,
+            None,
+            &[
+                IndexValue::Uuid(second_id),
+                IndexValue::Integer(20),
+                IndexValue::Null,
+            ],
+            &[IndexValue::Integer(20)],
+        ),
+        compiled_row(
+            &page_query,
+            third_id,
+            Some(third_channel),
+            &[
+                IndexValue::Uuid(third_id),
+                IndexValue::Integer(30),
+                IndexValue::Uuid(third_channel),
+            ],
+            &[IndexValue::Integer(30)],
+        ),
+    ];
+
+    let page = registry
+        .decode_postgres_query_page(&query, &page_query, rows, Some(exact_count_row(3)))
+        .unwrap();
+
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.exact_count, Some(3));
+    assert!(page.has_more);
+    assert_eq!(page.items[0].entity_id, first_id);
+    assert_eq!(page.items[0].relations[0].entity_id, Some(first_channel));
+    assert_eq!(page.items[1].relations[0].entity_id, None);
+    assert_eq!(page.items[1].fields[2].value, IndexValue::Null);
+
+    let cursor = CursorCodec::decode_scoped_for_query(
+        page.next_cursor.as_deref().expect("lookahead cursor"),
+        &query,
+        &registry,
+    )
+    .unwrap();
+    assert_eq!(cursor.entity_id, second_id);
+    assert_eq!(cursor.order_values, vec![IndexValue::Integer(20)]);
+}
+
+#[test]
+fn omits_next_cursor_when_no_lookahead_row_exists() {
+    let registry = registry();
+    let query = query(Uuid::new_v4());
+    let page_query = registry.compile_postgres_page_query(&query).unwrap();
+    let entity_id = Uuid::new_v4();
+    let channel_id = Uuid::new_v4();
+    let row = compiled_row(
+        &page_query,
+        entity_id,
+        Some(channel_id),
+        &[
+            IndexValue::Uuid(entity_id),
+            IndexValue::Integer(10),
+            IndexValue::Uuid(channel_id),
+        ],
+        &[IndexValue::Integer(10)],
+    );
+
+    let page = registry
+        .decode_postgres_query_page(&query, &page_query, vec![row], Some(exact_count_row(1)))
+        .unwrap();
+
+    assert!(!page.has_more);
+    assert!(page.next_cursor.is_none());
+}
+
+#[test]
+fn rejects_page_compiled_for_different_query_semantics() {
+    let registry = registry();
+    let tenant_id = Uuid::new_v4();
+    let query = query(tenant_id);
+    let mut changed = query.clone();
+    changed.order_by[0].direction = OrderDirection::Desc;
+    let page_query = registry.compile_postgres_page_query(&changed).unwrap();
+
+    assert!(matches!(
+        registry.decode_postgres_query_page(&query, &page_query, Vec::new(), Some(exact_count_row(0))),
+        Err(PostgresQueryDecodeError::PlanFingerprintMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_invalid_tagged_field_contract() {
+    let registry = registry();
+    let query = query(Uuid::new_v4());
+    let page_query = registry.compile_postgres_page_query(&query).unwrap();
+    let entity_id = Uuid::new_v4();
+    let channel_id = Uuid::new_v4();
+    let row = compiled_row(
+        &page_query,
+        entity_id,
+        Some(channel_id),
+        &[
+            IndexValue::Uuid(entity_id),
+            IndexValue::String("wrong-type".to_owned()),
+            IndexValue::Uuid(channel_id),
+        ],
+        &[IndexValue::Integer(10)],
+    );
+
+    assert!(matches!(
+        registry.decode_postgres_query_page(&query, &page_query, vec![row], Some(exact_count_row(1))),
+        Err(PostgresQueryDecodeError::InvalidFieldValue { path }) if path == path("score")
+    ));
+}
+
+#[test]
+fn scoped_cursor_fixture_remains_query_bound() {
+    let registry = registry();
+    let query = query(Uuid::new_v4());
+    let cursor = IndexCursor {
+        tenant_id: query.scope.tenant_id,
+        schema: query.schema.clone(),
+        schema_fingerprint: registry.get(&query.schema).unwrap().fingerprint,
+        locale: query.scope.locale.clone(),
+        order_values: vec![IndexValue::Integer(10)],
+        entity_id: Uuid::new_v4(),
+    };
+
+    assert!(CursorCodec::encode_for_query(&cursor, &query, &registry).is_ok());
+}

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -36,7 +36,6 @@ const decoder = requireMarkers(decoderPath, [
   'CursorCodec::encode_for_query(&cursor, query, self)?',
   'ExactCountContractMismatch',
   'InvalidTaggedValue',
-  'ManyLinkSemanticsPending',
 ]);
 
 const compilePosition = decoder.indexOf('let mut compiled = self.compile_postgres_query(query)?;');
@@ -71,6 +70,9 @@ for (const forbidden of [
   if (decoder.includes(forbidden)) fail(`${decoderPath} contains forbidden marker ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-index/src/application/postgres_compiler.rs', [
+  'ManyLinkSemanticsPending',
+]);
 requireMarkers('crates/rustok-index/src/application/postgres_query_result_tests.rs', [
   'page_compilation_adds_exactly_one_lookahead_row',
   'offset_page_compilation_preserves_offset_and_adds_lookahead',

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-query-result-decoder] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const decoderPath = 'crates/rustok-index/src/application/postgres_query_result.rs';
+const decoder = requireMarkers(decoderPath, [
+  'pub enum CompiledPostgresCell',
+  'pub struct CompiledPostgresRow',
+  'pub struct CompiledPostgresPageQuery',
+  'pub struct IndexQueryPage',
+  'pub enum PostgresQueryPageBuildError',
+  'pub enum PostgresQueryDecodeError',
+  'pub fn compile_postgres_page_query(',
+  'apply_lookahead_bind(&mut compiled, &query.pagination)?;',
+  '*value = expected_limit + 1;',
+  'pub fn decode_postgres_query_page(',
+  'compiled.columns != expected_columns(&plan)',
+  'PlanFingerprintMismatch',
+  'rows.len() > requested_page_size as usize',
+  'CursorCodec::encode_for_query(&cursor, query, self)?',
+  'ExactCountContractMismatch',
+  'InvalidTaggedValue',
+  'ManyLinkSemanticsPending',
+]);
+
+const compilePosition = decoder.indexOf('let mut compiled = self.compile_postgres_query(query)?;');
+const lookaheadPosition = decoder.indexOf('apply_lookahead_bind(&mut compiled, &query.pagination)?;');
+if (compilePosition < 0 || lookaheadPosition < 0 || compilePosition >= lookaheadPosition) {
+  fail('validated controlled compilation must precede lookahead bind adjustment');
+}
+
+const planPosition = decoder.indexOf('let plan = self.plan_query(query)?;');
+const columnPosition = decoder.indexOf('compiled.columns != expected_columns(&plan)');
+const rowPosition = decoder.indexOf('let decoded = rows');
+if (
+  planPosition < 0 ||
+  columnPosition < 0 ||
+  rowPosition < 0 ||
+  !(planPosition < columnPosition && columnPosition < rowPosition)
+) {
+  fail('plan fingerprint and column contract must be verified before row decoding');
+}
+
+for (const forbidden of [
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+  'DatabaseConnection',
+  'Statement::from_sql',
+  '.query_all(',
+  '.query_one(',
+  '.execute(',
+  'SELECT *',
+]) {
+  if (decoder.includes(forbidden)) fail(`${decoderPath} contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-index/src/application/postgres_query_result_tests.rs', [
+  'page_compilation_adds_exactly_one_lookahead_row',
+  'offset_page_compilation_preserves_offset_and_adds_lookahead',
+  'decodes_projection_relations_exact_count_and_next_cursor',
+  'omits_next_cursor_when_no_lookahead_row_exists',
+  'rejects_page_compiled_for_different_query_semantics',
+  'rejects_invalid_tagged_field_contract',
+]);
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod postgres_query_result;',
+  'mod postgres_query_result_tests;',
+  'CompiledPostgresPageQuery',
+  'IndexQueryPage',
+  'PostgresQueryDecodeError',
+]);
+requireMarkers('crates/rustok-index/docs/m4-query-result-decoder.md', [
+  'one-row lookahead',
+  'compiled column contract',
+  'query-scoped continuation cursor',
+  'does not execute SQL',
+  'Many-link semantics remain fail-closed',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  'M4 deterministic PostgreSQL result decoding: `complete`',
+  '- [x] Add deterministic root/one-link result decoding and cursor construction.',
+  '- [ ] Add explicit many-link `EXISTS` filtering and nested projection aggregation.',
+]);
+
+console.log('[verify-index-query-result-decoder] OK');

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -37,6 +37,8 @@ const decoder = requireMarkers(decoderPath, [
   'CursorCodec::encode_for_query(&cursor, query, self)?',
   'root_entity_id.flatten()',
   'if missing_relation {',
+  'fn join_is_projected(',
+  'if join_is_projected(plan, &join.path)',
   'ExactCountContractMismatch',
   'InvalidTaggedValue',
 ]);

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -23,6 +23,7 @@ const decoder = requireMarkers(decoderPath, [
   'pub enum CompiledPostgresCell',
   'pub struct CompiledPostgresRow',
   'pub struct CompiledPostgresPageQuery',
+  'The wrapper deliberately has no serde implementation',
   'pub struct IndexQueryPage',
   'pub enum PostgresQueryPageBuildError',
   'pub enum PostgresQueryDecodeError',
@@ -34,9 +35,18 @@ const decoder = requireMarkers(decoderPath, [
   'PlanFingerprintMismatch',
   'rows.len() > requested_page_size as usize',
   'CursorCodec::encode_for_query(&cursor, query, self)?',
+  'root_entity_id.flatten()',
+  'if missing_relation {',
   'ExactCountContractMismatch',
   'InvalidTaggedValue',
 ]);
+
+const pageWrapper = decoder.match(
+  /#\[derive\(([^)]*)\)\]\s*pub struct CompiledPostgresPageQuery/u,
+);
+if (!pageWrapper || pageWrapper[1].includes('Serialize') || pageWrapper[1].includes('Deserialize')) {
+  fail('CompiledPostgresPageQuery must remain an opaque non-serde execution contract');
+}
 
 const compilePosition = decoder.indexOf('let mut compiled = self.compile_postgres_query(query)?;');
 const lookaheadPosition = decoder.indexOf('apply_lookahead_bind(&mut compiled, &query.pagination)?;');


### PR DESCRIPTION
## Summary

- add an opaque `CompiledPostgresPageQuery` execution handoff produced only by `SchemaRegistry`
- preserve the controlled SQL text and change only the validated main page-limit bind from `N` to `N + 1`
- support the same one-row lookahead contract for cursor and bounded offset pages
- add narrow `CompiledPostgresCell` and `CompiledPostgresRow` adapter DTOs for UUID, tagged JSONB, SQL null, and bigint count values
- re-plan and verify the plan fingerprint, complete compiled column contract, requested page size, exact-count contract, and maximum `N + 1` result size before decoding
- validate every projected and hidden order value against planned type, cardinality, nullability, and relation presence
- reconstruct root identities, projected one-link identities, projection values, optional exact count, and `has_more`
- create a query-scoped next cursor from the last retained root/order tuple; never expose the lookahead row
- keep filter/order-only relation identities out of the public projection result
- keep the page wrapper non-serde so external bytes cannot replace controlled SQL or binds before execution
- add focused synthetic-row scenarios, a targeted static guard, M4 handoff documentation, `CRATE_API`, and canonical plan updates

## Recheck findings

The merged compiler used `LIMIT N`, which is insufficient to distinguish an exact-size terminal page from a page with more rows. This PR introduces a separate page compiler handoff that increases only the already validated limit bind to `N + 1`; it does not rebuild or interpolate SQL.

The compiler already emits deterministic identity, projection, and hidden order columns. The decoder now treats that metadata as a strict contract rather than accepting arbitrary row aliases or untyped JSON. Missing optional one-link relations may produce null linked fields, but present relations with invalid/missing non-nullable values and absent relations with non-null values fail closed.

The feature branch fell behind `main` while work was in progress. The intervening commits affect AI Product, Product, Core, Forum, Search, package metadata, and their verifiers; none overlap the nine files changed here. The PR can therefore be squash-applied to current `main` without an artificial merge commit.

## Boundary

This PR does not execute or prepare SQL, convert bind DTOs into SeaORM/sqlx parameters, decode directly from `QueryResult`, verify persisted schema/index readiness, authorize callers, publish `IndexQueryPort`, implement many-link `EXISTS`/aggregation semantics, claim PostgreSQL/reference-engine equivalence, change migrations, or begin production partition lifecycle work.

One fresh admitted real PostgreSQL partition packet remains an independent owner action and continues to block production partition lifecycle design.

## Validation

Not run by the implementation agent, per maintainer instruction.

Suggested commands:

```bash
cargo test -p rustok-index postgres_query_result_tests -- --nocapture
cargo test -p rustok-index postgres_compiler_tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-query-result-decoder.mjs
node scripts/verify/verify-index-query-planner.mjs
node scripts/verify/verify-index-postgres-query-compiler.mjs
cargo xtask module validate index
```
