### PR TITLE
feat(index): compile many-link filters with EXISTS

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -110,14 +110,15 @@ before producing deterministic tenant-hash shadow relation names and bootstrap
 SQL. It does not execute copy, constraint/index attachment, dual-write/replay,
 cutover, or rollback.
 
-M4 now provides validated typed executable plans, controlled PostgreSQL SQL and bind
-DTOs for root and explicit one-cardinality-link query semantics, query-scoped cursor
-continuation, one-row page lookahead, strict compiled-column/result decoding,
-exact-count decoding, `has_more`, and next-cursor construction. It still does not
-execute statements, adapt SeaORM rows directly, implement many-link semantics,
-publish `IndexQueryPort`, or claim PostgreSQL/reference-engine equivalence.
-Multi-source catalog composition, batch ingestion, rebuild, query-port, partition
-cutover, and operator APIs remain later work.
+M4 provides validated typed executable plans, controlled PostgreSQL SQL and bind
+DTOs for root/one-link projection, filtering, ordering, counting and pagination,
+correlated many-link filtering, query-scoped cursor continuation, one-row page
+lookahead, strict compiled-column/result decoding, exact-count decoding, `has_more`,
+and next-cursor construction. It still does not execute statements, adapt SeaORM
+rows directly, aggregate many-link projections, publish `IndexQueryPort`, or claim
+PostgreSQL/reference-engine equivalence. Multi-source catalog composition, batch
+ingestion, rebuild, query-port, partition cutover, and operator APIs remain later
+work.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -151,6 +152,8 @@ APIs.
   one-row-lookahead `compile_postgres_page_query` handoff.
 - Decoding rows without rechecking the plan fingerprint and exact compiled column
   contract.
+- Compiling a many-link filter as an ordinary outer join; it must remain a correlated
+  predicate so child multiplicity cannot duplicate root rows or counts.
 - Sorting or projecting through a `many` link without an explicit aggregate policy.
 - Completing or heartbeating schema/index work without exact worker and attempt
   fencing.
@@ -209,6 +212,7 @@ APIs.
   and cardinality.
 - Selected, filtered, and ordered fields are resolved through typed link paths.
 - Query complexity, path depth, page size, and offset depth are bounded.
+- Filtering through `many` paths uses correlated existential semantics.
 - Sorting through a `many` link is rejected until aggregation is explicit.
 - Source versions and tombstones prevent stale mutation overwrite.
 - Generic engine types remain source-domain agnostic.
@@ -292,21 +296,25 @@ APIs.
 ### Query Planning, Compilation, and Result Decoding
 
 - `SchemaRegistry::plan_query` validates first and captures deterministic aliases,
-  joins, typed referenced fields, projection, filters, ordering, pagination, and a
-  versioned plan fingerprint.
-- `compile_postgres_query` accepts only the supported root/one-link subset and emits
-  controlled SQL plus ordered bind DTOs; caller values and contract names remain
-  binds.
+  joins, typed referenced fields, propagated `traverses_many`, projection, filters,
+  ordering, pagination, and a v3 plan fingerprint.
+- `compile_postgres_query` emits controlled SQL plus ordered bind DTOs for root and
+  one-link projection/ordering plus all validated filters; caller values and contract
+  names remain binds.
+- Every many-traversing atomic filter emits an independent nested correlated `EXISTS`
+  chain. No many join enters the outer rowset or identity-column contract.
+- Many-link `Ne` requires at least one stored reachable value and no reachable null or
+  equal value; `IsNull` tests the absence of any reachable non-null value.
 - `compile_postgres_page_query` changes only the validated main-statement page-limit
   bind from `N` to `N + 1`; offset and exact-count binds are preserved.
 - `decode_postgres_query_page` re-plans the query, compares the plan fingerprint and
-  complete column metadata, validates every tagged field value, and rejects more
-  than `N + 1` rows.
+  complete unique column metadata, validates every tagged field value, and rejects
+  more than `N + 1` rows.
 - The lookahead row is removed. Cursor pages produce `has_more` and a scoped next
   cursor from the last retained entity/order tuple; offset pages produce
   `has_more` without a cursor.
-- SQL execution, SeaORM row adaptation, many-link semantics, and live equivalence
-  evidence remain separate future boundaries.
+- Many-link projection/order, SQL execution, SeaORM row adaptation, and live
+  equivalence evidence remain separate future boundaries.
 
 ### Cursor Contract
 
@@ -346,7 +354,8 @@ APIs.
   scope/schema/query-fingerprint/type mismatches.
 - `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError`
   separate validation/planning failures from unsupported or corrupted compiler
-  contracts.
+  contracts. Many-link projection, ordering, missing join plans, and inconsistent
+  traversal metadata are distinct typed compiler failures.
 - `PostgresQueryPageBuildError` rejects missing or mismatched pagination binds;
   `PostgresQueryDecodeError` rejects plan/column/count mismatches, malformed cells,
   invalid tagged values, unexpected nulls, and oversized result batches.

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -201,7 +201,7 @@ unpartitioned until separate shadow evidence is retained and admitted.
 - [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow mutation and WAL evidence capture.
-- [x] Add owner-operated PostgreSQL ordinary-VACUUM maintenance evidence capture.
+- [x] Add owner-operated PostgreSQL baseline/shadow ordinary-VACUUM maintenance evidence capture.
 - [x] Add owner-operated PostgreSQL cutover/rollback rehearsal evidence capture.
 - [x] Add owner-operated full retained packet orchestration and capture finalization.
 - [x] Add read-only retained bundle review with recalculated assembly and admission.

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (deterministic result decoding added; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (many-link EXISTS filtering added; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -55,26 +55,27 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 controlled PostgreSQL query compilation: `complete`
 - M4 typed root/one-link query semantics: `complete`
 - M4 deterministic PostgreSQL result decoding: `complete`
+- M4 many-link `EXISTS` filtering: `complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
   admitted archive manifest generation, saved-manifest verification, recursive
   filesystem integrity checks, typed executable query planning, controlled projection,
-  filtering, ordering, exact-count, keyset, bounded-offset SQL compilation, one-row
-  page lookahead, tagged row decoding, exact-count decoding, and scoped next-cursor
-  construction are implemented; one retained admitted packet, many-link semantics,
-  SQL execution composition, PostgreSQL/reference equivalence, and production
-  partition lifecycle remain open
+  root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
+  compilation, correlated many-link filtering, one-row page lookahead, tagged row
+  decoding, exact-count decoding, and scoped next-cursor construction are implemented;
+  one retained admitted packet, many-link projection, SQL execution composition,
+  PostgreSQL/reference equivalence, and production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
 lifecycle management, measured partition admission that emits shadow bootstrap
 plans only, an M4 typed structural query planner with deterministic relation aliases,
-a controlled PostgreSQL compiler for root and one-cardinality-link filtering,
-projection, ordering, exact count, keyset, and bounded offset semantics, and a
-strict compiled-row decoder with lookahead pagination and scoped cursor construction.
-Owner-operated evidence tools live under `ops/benches`; they do not become runtime
-storage code.
+a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
+exact count, keyset and bounded offset plus duplicate-free correlated many-link
+filtering, and a strict compiled-row decoder with lookahead pagination and scoped
+cursor construction. Owner-operated evidence tools live under `ops/benches`; they do
+not become runtime storage code.
 
 ## Ownership
 
@@ -200,7 +201,7 @@ unpartitioned until separate shadow evidence is retained and admitted.
 - [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow mutation and WAL evidence capture.
-- [x] Add owner-operated PostgreSQL baseline/shadow ordinary-VACUUM maintenance evidence capture.
+- [x] Add owner-operated PostgreSQL ordinary-VACUUM maintenance evidence capture.
 - [x] Add owner-operated PostgreSQL cutover/rollback rehearsal evidence capture.
 - [x] Add owner-operated full retained packet orchestration and capture finalization.
 - [x] Add read-only retained bundle review with recalculated assembly and admission.
@@ -307,14 +308,15 @@ relations.
       count, and keyset pagination.
 - [x] Keep offset pagination bounded and compatibility-only.
 - [x] Add deterministic root/one-link result decoding and cursor construction.
-- [ ] Add explicit many-link `EXISTS` filtering and nested projection aggregation.
+- [x] Add explicit many-link `EXISTS` filtering.
+- [ ] Add nested many-link projection aggregation.
 - [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
 
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
 prefixes, and captures every referenced field with type, cardinality, nullability,
-path, and alias. The typed plan fingerprint uses the versioned
-`rustok-index-query-plan-v2` domain.
+path, alias, and propagated many-link traversal state. The typed plan fingerprint
+uses the versioned `rustok-index-query-plan-v3` domain.
 
 The controlled compiler emits ordered typed binds, deterministic identity/projection/
 order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
@@ -332,11 +334,18 @@ It removes the lookahead row, reports `has_more`, preserves selection order, and
 a query-scoped cursor from the last retained root identity plus hidden order values.
 Offset pages use the same lookahead rule but do not synthesize a cursor.
 
-Many-cardinality paths remain fail-closed with `ManyLinkSemanticsPending`; ordinary
-joins would duplicate roots and corrupt negative filters, count, projection, and
-pagination. SQL execution, direct SeaORM row adaptation, persisted-schema readiness,
-query-port composition, consumer cutover, plan/SQL snapshots, and PostgreSQL/reference-
-engine equivalence remain open.
+Many-link filtering compiles every atomic predicate through an independent nested
+correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
+lookahead, result decoding, and exact count stay duplicate free. Positive operators use
+any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
+`Ne` requires at least one stored reachable value and rejects any null or equal value.
+This matches the test-only reference engine's flattened path-value semantics.
+
+Many-link projection remains fail-closed with `ManyLinkProjectionPending` until a
+nested aggregation result shape is explicit. Many-link ordering remains rejected until
+an aggregate policy exists. SQL execution, direct SeaORM row adaptation,
+persisted-schema readiness, query-port composition, consumer cutover, plan/SQL
+snapshots, and PostgreSQL/reference-engine equivalence remain open.
 
 ### M5 - Incremental ingestion
 
@@ -447,6 +456,7 @@ node scripts/verify/verify-index-partition-post-inspection-drift.mjs
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
 node scripts/verify/verify-index-query-result-decoder.mjs
+node scripts/verify/verify-index-many-link-filtering.mjs
 ```
 
 ## Progress log
@@ -467,8 +477,9 @@ node scripts/verify/verify-index-query-result-decoder.mjs
   M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
   exact count, validated lexicographic keyset continuation, bounded offset
   compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
-  count decoding, relation identity reconstruction, and scoped next-cursor creation.
-  Many-link planning, direct SQL execution/row adaptation, plan/SQL snapshots, and
+  count decoding, relation identity reconstruction, scoped next-cursor creation, and
+  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination.
+  Many-link projection, direct SQL execution/row adaptation, plan/SQL snapshots, and
   PostgreSQL/reference equivalence remain open.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition

--- a/crates/rustok-index/docs/m4-many-link-filtering.md
+++ b/crates/rustok-index/docs/m4-many-link-filtering.md
@@ -1,8 +1,8 @@
 # M4 many-link `EXISTS` filtering
 
 This slice adds deterministic PostgreSQL filtering through explicit paths that cross one
-or more `many` links. It does not add many-link projection, ordering, SQL execution, or
-PostgreSQL/reference-engine equivalence evidence.
+or more `many` links. It does not execute SQL and does not add many-link projection,
+ordering, or PostgreSQL/reference-engine equivalence evidence.
 
 ## Plan contract
 

--- a/crates/rustok-index/docs/m4-many-link-filtering.md
+++ b/crates/rustok-index/docs/m4-many-link-filtering.md
@@ -1,0 +1,87 @@
+# M4 many-link `EXISTS` filtering
+
+This slice adds deterministic PostgreSQL filtering through explicit paths that cross one
+or more `many` links. It does not add many-link projection, ordering, SQL execution, or
+PostgreSQL/reference-engine equivalence evidence.
+
+## Plan contract
+
+`PlannedJoin` and `PlannedField` now carry `traverses_many`. The flag becomes true on
+the first `LinkCardinality::Many` step and remains true for every descendant join and
+field. The executable-plan fingerprint domain is therefore bumped to
+`rustok-index-query-plan-v3`.
+
+The compiler recalculates the propagation rule before SQL emission. Missing joins,
+inconsistent flags, invalid aliases, many-link projection, and many-link ordering fail
+closed with typed errors.
+
+## Outer rowset boundary
+
+Only joins whose full path does not traverse `many` are emitted into the main query
+`FROM` clause and compiled identity-column contract. Many-filter paths never become
+ordinary outer joins.
+
+This preserves exactly one main result row per root entity, so root ordering, keyset and
+offset pagination, one-row lookahead, result decoding, and `COUNT(*)` are not corrupted
+by child multiplicity.
+
+## Correlated path traversal
+
+Every atomic predicate on a many-traversing field compiles an independent nested
+correlated `EXISTS` chain. Each link step binds its link name and exact target module,
+entity, and schema version, correlates the complete source identity and source version,
+and joins only a live target `index_entities` row.
+
+Independent atomic subqueries are intentional. For example,
+`And(Eq(variants.color, red), Eq(variants.size, large))` may be satisfied by two
+different variants, matching the reference engine's flattened path-value semantics.
+
+## Operator semantics
+
+Positive operators use existential semantics over all reachable terminal values:
+
+- `Eq`, `In`, and range operators succeed when any reachable scalar matches;
+- `Contains` succeeds when any reachable list contains the requested value;
+- `IsNull(path, false)` succeeds when any reachable field value is non-null;
+- `IsNull(path, true)` is the negation of that non-null existence test, so an empty
+  path, missing fields, and all-null values are null.
+
+`Ne` is deliberately not compiled as `NOT EXISTS(Eq)`. It requires both:
+
+1. at least one reachable stored field value; and
+2. no reachable stored value that is tagged null, malformed, or equal to the requested
+   value.
+
+This matches the reference contract: an empty path is false, any null disqualifies the
+result, and every present value must differ.
+
+Logical `Not`, `And`, and `Or` wrap these total-boolean atomic expressions without SQL
+`NULL` leakage.
+
+## Bind and count guarantees
+
+Tenant, schema, locale, link metadata, terminal field names, and filter values remain
+ordered bind values. Source-domain names are never interpolated into SQL.
+
+The optional exact-count statement recompiles the same correlated filters with its own
+ordered bind list. It contains no many outer join, ordering, cursor predicate, limit, or
+offset, so each matching root contributes exactly one count row.
+
+## Remaining boundary
+
+Many-link projection remains rejected with `ManyLinkProjectionPending` until an explicit
+nested aggregation result shape is designed. Many-link ordering remains rejected until
+an aggregate ordering policy exists.
+
+This slice also does not:
+
+- prepare or execute PostgreSQL statements;
+- adapt SeaORM rows or bind values;
+- publish `IndexQueryPort`;
+- verify persisted schema/index readiness;
+- authorize callers;
+- claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence;
+- change migrations or partition lifecycle state.
+
+The repository owner runs formatting, compilation, tests, static verifiers, and later
+live equivalence evidence.

--- a/crates/rustok-index/docs/m4-many-link-filtering.md
+++ b/crates/rustok-index/docs/m4-many-link-filtering.md
@@ -49,8 +49,7 @@ Positive operators use existential semantics over all reachable terminal values:
 `Ne` is deliberately not compiled as `NOT EXISTS(Eq)`. It requires both:
 
 1. at least one reachable stored field value; and
-2. no reachable stored value that is tagged null, malformed, or equal to the requested
-   value.
+2. no reachable stored value that is tagged null or equal to the requested value.
 
 This matches the reference contract: an empty path is false, any null disqualifies the
 result, and every present value must differ.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -2,8 +2,8 @@
 
 This M4 chain compiles the database-independent `ExecutableQueryPlan` into
 controlled PostgreSQL statements plus ordered typed bind lists. The compiler does not
-connect to PostgreSQL or execute SQL. Deterministic compiled-row decoding now lives in
-a separate application handoff; neither slice publishes an `IndexQueryPort`.
+connect to PostgreSQL or execute SQL. Deterministic compiled-row decoding lives in a
+separate application handoff; neither slice publishes an `IndexQueryPort`.
 
 ## Planner contract
 
@@ -14,10 +14,12 @@ a separate application handoff; neither slice publishes an `IndexQueryPort`.
 - the deterministic relation alias;
 - `IndexValueType`;
 - field cardinality;
-- nullability.
+- nullability;
+- whether the path traverses at least one many-cardinality link.
 
-The plan fingerprint domain is `rustok-index-query-plan-v2`, so plans produced
-before typed field contracts cannot be confused with the compiler input.
+`PlannedJoin` carries the same propagated `traverses_many` boundary. The plan
+fingerprint domain is `rustok-index-query-plan-v3`, so plans without canonical
+many-traversal metadata cannot be confused with current compiler input.
 
 ## Supported query semantics
 
@@ -26,6 +28,7 @@ and validates any continuation cursor, and then compiles:
 
 - root projection and projection through explicit one-cardinality links;
 - `And`, `Or`, `Not`, `Eq`, `Ne`, `In`, range, `Contains`, and `IsNull` filters;
+- filtering through paths that cross one or more many-cardinality links;
 - typed PostgreSQL casts for boolean, integer, decimal, string, UUID, and
   timestamp fields;
 - deterministic multi-column ordering with explicit null placement;
@@ -52,13 +55,33 @@ fields, and tagged null values do not leak SQL `NULL` into `Not`, `And`, or
 `Or` semantics:
 
 - equality, membership, range, and containment use `COALESCE(..., FALSE)`;
-- `Ne` is true only for an existing non-null scalar that differs;
-- `IsNull` treats an absent field, missing linked row, or tagged null as null.
+- root/one-link `Ne` is true only for an existing non-null scalar that differs;
+- root/one-link `IsNull` treats an absent field, missing linked row, or tagged null as
+  null.
 
 Ascending order uses `NULLS LAST`; descending order uses `NULLS FIRST`, followed
 by the invariant ascending `entity_id` tie-breaker. PostgreSQL/reference-engine
 equivalence remains a later evidence slice rather than a claim of this source
 change.
+
+## Many-link filter boundary
+
+Many-traversing joins are excluded from the main `FROM` clause and compiled identity
+columns. Every atomic filter on such a field emits an independent nested correlated
+`EXISTS` chain over `index_links` and live `index_entities` targets. Complete source
+identity, source version, link name, and exact target schema identity are checked at
+each hop.
+
+Independent atomic subqueries preserve reference semantics when separate children
+satisfy separate logical branches. Positive operators use any-match behavior.
+`IsNull(path, true)` means no reachable non-null value exists.
+
+Many-link `Ne` is intentionally stricter than `NOT EXISTS(Eq)`: it requires at least
+one stored reachable value and also requires that no reachable value is null,
+malformed, or equal to the requested value.
+
+Because no many join enters the outer rowset, root keyset/offset pagination,
+one-row lookahead, and `COUNT(*)` remain duplicate free.
 
 ## Cursor boundary
 
@@ -86,16 +109,16 @@ Changing a filter, ordered field, or order direction therefore produces
 
 Tenant UUID, schema identities, locale, link metadata, field names, filter
 values, cursor values, limit, and offset are bind values. Only fixed
-`index_entities`/`index_links` table and column names plus compiler-owned `tN`
-and `lN` aliases appear in SQL.
+`index_entities`/`index_links` table and column names plus compiler-owned `tN`,
+`lN`, and `mx_*` aliases appear in SQL.
 
 The compiler contract, SQL emission, and page/result handoff live in separate
 modules:
 
 - `application/postgres_compiler.rs` owns public SQL/bind types, scoped cursor
   entry points, and plan invariant checks;
-- `application/postgres_query_sql.rs` owns controlled SQL and deterministic bind
-  emission;
+- `application/postgres_query_sql.rs` owns controlled SQL, correlated many-link
+  predicates, and deterministic bind emission;
 - `application/postgres_query_result.rs` owns one-row lookahead wrapping, strict
   compiled-column decoding, exact count, `has_more`, and scoped next cursors.
 
@@ -110,22 +133,24 @@ A later database adapter executes the compiled statements and maps driver values
 into `CompiledPostgresRow`. `decode_postgres_query_page` then rechecks the plan
 fingerprint and complete `CompiledQueryColumn` contract, validates tagged
 `IndexValue` type/cardinality/nullability, removes the lookahead row, and returns
-`IndexQueryPage`. It does not accept arbitrary column names or untyped JSON rows.
+`IndexQueryPage`. Many-filter paths do not add hidden relation columns because they
+are confined to correlated subqueries.
 
 ## Exact count
 
 `include_exact_count` produces `CompiledPostgresCount` as a separate controlled
 statement with its own ordered bind list. The count applies tenant/schema/locale,
-live-row, join, and filter predicates, but deliberately excludes keyset,
-ordering, limit, and offset.
+live-row, non-many outer joins, and all filters, but deliberately excludes keyset,
+ordering, limit, and offset. Many filters remain correlated subqueries, so child
+multiplicity cannot inflate the count.
 
 ## Fail-closed pending semantics
 
-Any path containing a many-cardinality link remains rejected with
-`ManyLinkSemanticsPending`. Compiling such paths through ordinary joins would
-risk duplicate roots and incorrect `Not`, `Ne`, count, projection, and
-pagination semantics. A later M4 slice must introduce explicit `EXISTS` and/or
-nested aggregation planning before that gate can be removed.
+Projection through a many-cardinality path remains rejected with
+`ManyLinkProjectionPending` until a nested aggregation result shape is explicit.
+Many-link ordering remains rejected until an aggregate ordering policy exists.
+Compiler validation recalculates propagated many metadata and rejects missing or
+inconsistent join/field contracts before SQL emission.
 
 ## Non-claims
 
@@ -136,7 +161,8 @@ This source chain does not:
 - decode directly from SeaORM `QueryResult`;
 - authorize callers;
 - verify persisted schema readiness;
-- support many-link filtering/projection/aggregation;
+- support many-link projection or aggregate ordering;
+- claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence;
 - read source-module tables;
 - change migrations or production partition lifecycle state.
 

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -77,8 +77,8 @@ satisfy separate logical branches. Positive operators use any-match behavior.
 `IsNull(path, true)` means no reachable non-null value exists.
 
 Many-link `Ne` is intentionally stricter than `NOT EXISTS(Eq)`: it requires at least
-one stored reachable value and also requires that no reachable value is null,
-malformed, or equal to the requested value.
+one stored reachable value and also requires that no reachable value is tagged null or
+equal to the requested value.
 
 Because no many join enters the outer rowset, root keyset/offset pagination,
 one-row lookahead, and `COUNT(*)` remain duplicate free.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -27,7 +27,8 @@ source work to remain idle.
 - M4 query-scoped cursor envelopes: `source_complete_execution_pending`.
 - M4 deterministic compiled-row decoding: `source_complete_execution_pending`.
 - M4 one-row lookahead and next-cursor construction: `source_complete_execution_pending`.
-- M4 many-link query semantics: `open`.
+- M4 many-link `EXISTS` filtering: `source_complete_execution_pending`.
+- M4 many-link nested projection aggregation: `open`.
 - M4 PostgreSQL/reference-engine equivalence: `open`.
 
 ## Completed M4 slice 1
@@ -38,14 +39,15 @@ source work to remain idle.
 2. collects every referenced link prefix from projection, filters, and ordering;
 3. sorts link prefixes deterministically and assigns `t0`, `t1`, ... aliases;
 4. resolves each join against the registered schema contract;
-5. records every referenced field with type, cardinality, nullability, path, and
-   relation alias;
+5. records every referenced field with type, cardinality, nullability, path,
+   relation alias, and propagated many-link traversal state;
 6. binds projected and ordered fields to those canonical field contracts;
 7. retains typed filters and pagination for the compiler;
 8. publishes a versioned SHA-256 fingerprint over deterministic postcard bytes.
 
-The fingerprint domain is now `rustok-index-query-plan-v2` because typed field
-contracts are part of the executable plan identity.
+The fingerprint domain is `rustok-index-query-plan-v3` because propagated
+`traverses_many` metadata is part of the executable plan identity and compiler
+safety boundary.
 
 ## Completed M4 slices 2 and 3
 
@@ -88,20 +90,36 @@ count. It removes the one-row lookahead, preserves projection order, reports
 `has_more`, and creates a scoped next cursor from the last retained root and hidden
 order values. Offset pages report `has_more` without synthesizing a cursor.
 
+## Completed M4 slice 5
+
+Many-traversing filter fields compile through independent nested correlated
+`EXISTS` chains rather than ordinary joins. `PlannedJoin` and `PlannedField`
+propagate `traverses_many`; only non-many joins enter the main rowset and compiled
+identity-column contract.
+
+Positive operators use existential matching across reachable values. `IsNull`
+checks for the absence of any non-null reachable value. `Ne` requires at least one
+stored value and rejects the root when any reachable value is null or equal. This
+matches the test-only reference engine's flattened path-value semantics, including
+logical expressions whose atomic branches may be satisfied by different children.
+
+Exact count recompiles the same correlated predicates without many outer joins,
+ordering, cursor, limit, or offset, so root rows and count values remain duplicate
+free.
+
 ## Remaining bounded M4 work
 
-Many-cardinality link paths remain fail-closed. The next source slice must add
-an explicit semantic plan for:
+Many-cardinality projection remains fail-closed with
+`ManyLinkProjectionPending`. The next source slices must define:
 
-- `EXISTS`-based many-link filtering;
-- nested aggregation for many-link projection;
-- duplicate-free exact count and root pagination;
+- nested aggregation and a stable public result shape for many-link projection;
 - direct SeaORM bind/row adaptation and execution composition;
-- SQL/parameter snapshots and PostgreSQL/reference-engine equivalence fixtures.
+- plan/SQL/parameter snapshots and PostgreSQL/reference-engine equivalence fixtures.
 
-Production query-port composition and consumer cutover remain later slices.
-The real retained PostgreSQL partition packet remains an independent owner gate
-for production partition lifecycle work.
+Many-link ordering remains rejected until an explicit aggregate ordering policy is
+introduced. Production query-port composition and consumer cutover remain later
+slices. The real retained PostgreSQL partition packet remains an independent owner
+gate for production partition lifecycle work.
 
 ## Owner validation
 
@@ -117,5 +135,6 @@ cargo check -p rustok-index --all-targets
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
 node scripts/verify/verify-index-query-result-decoder.mjs
+node scripts/verify/verify-index-many-link-filtering.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-result-decoder.md
+++ b/crates/rustok-index/docs/m4-query-result-decoder.md
@@ -29,7 +29,7 @@ A later SeaORM/PostgreSQL adapter converts returned driver rows into
 `CompiledPostgresRow`. Cells are intentionally limited to the shapes emitted by
 the compiler:
 
-- UUID or SQL null for relation identity columns;
+- UUID or SQL null for outer relation identity columns;
 - tagged `IndexValue` JSON or SQL null for projection and hidden order columns;
 - a PostgreSQL bigint for the optional exact-count row.
 
@@ -54,12 +54,16 @@ identity is absent. A present relation with a missing non-nullable field is a
 typed corruption error. Conversely, an absent relation identity paired with a
 non-null field value is also rejected.
 
+Many-link filter paths do not add result columns. Their joins are confined to
+correlated `EXISTS` subqueries, so `expected_columns` includes only the root and
+non-many outer joins plus projection and hidden ordering columns.
+
 ## Page output
 
 The decoder returns `IndexQueryPage` with:
 
 - root entity identities;
-- deterministic explicit-link relation identities;
+- deterministic projected one-link relation identities;
 - projection values in query selection order;
 - optional exact count;
 - `has_more` derived only from the one-row lookahead;
@@ -73,10 +77,11 @@ Offset pages report `has_more` but do not synthesize a cursor.
 
 ## Fail-closed boundaries
 
-Many-link semantics remain fail-closed in the compiler with
-`ManyLinkSemanticsPending`. This decoder handles only the already-supported root
-and explicit one-cardinality-link subset. It does not attempt to deduplicate
-roots or aggregate many-link projections after SQL execution.
+Many-link filtering is supported without changing the decoder result shape.
+Many-link projection remains rejected with `ManyLinkProjectionPending`; the
+decoder does not attempt to deduplicate roots or invent nested aggregation after
+SQL execution. Many-link ordering remains rejected until an aggregate policy is
+explicit.
 
 This slice also does not:
 

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -91,7 +91,9 @@ impl ExecutableQueryPlan {
     }
 
     pub(crate) fn join_for_path(&self, path: &[LinkName]) -> Option<&PlannedJoin> {
-        self.joins.iter().find(|join| join.path == path)
+        self.joins
+            .iter()
+            .find(|join| join.path.as_slice() == path)
     }
 
     pub(crate) fn outer_joins(&self) -> impl Iterator<Item = &PlannedJoin> {

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -47,6 +47,7 @@ pub struct PlannedJoin {
     pub source_fields: Vec<FieldName>,
     pub target_fields: Vec<FieldName>,
     pub cardinality: LinkCardinality,
+    pub traverses_many: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,6 +57,7 @@ pub struct PlannedField {
     pub value_type: IndexValueType,
     pub cardinality: FieldCardinality,
     pub nullable: bool,
+    pub traverses_many: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -88,10 +90,18 @@ impl ExecutableQueryPlan {
         self.referenced_fields.get(path)
     }
 
+    pub(crate) fn join_for_path(&self, path: &[LinkName]) -> Option<&PlannedJoin> {
+        self.joins.iter().find(|join| join.path == path)
+    }
+
+    pub(crate) fn outer_joins(&self) -> impl Iterator<Item = &PlannedJoin> {
+        self.joins.iter().filter(|join| !join.traverses_many)
+    }
+
     pub fn fingerprint(&self) -> Result<QueryPlanFingerprint, postcard::Error> {
         let bytes = postcard::to_stdvec(self)?;
         let mut hasher = Sha256::new();
-        hasher.update(b"rustok-index-query-plan-v2");
+        hasher.update(b"rustok-index-query-plan-v3");
         hasher.update((bytes.len() as u64).to_be_bytes());
         hasher.update(bytes);
         Ok(QueryPlanFingerprint(hasher.finalize().into()))
@@ -121,6 +131,7 @@ impl SchemaRegistry {
         }
 
         let mut schemas = BTreeMap::from([(Vec::new(), query.schema.clone())]);
+        let mut many_paths = BTreeMap::from([(Vec::new(), false)]);
         let mut joins = Vec::with_capacity(paths.len());
         for path in &paths {
             let parent = path[..path.len() - 1].to_vec();
@@ -146,6 +157,8 @@ impl SchemaRegistry {
                     target: source_schema.clone(),
                 })?;
             let target_schema = link.target_schema.clone();
+            let traverses_many = many_paths.get(&parent).copied().unwrap_or(false)
+                || link.cardinality == LinkCardinality::Many;
             joins.push(PlannedJoin {
                 path: path.clone(),
                 alias: aliases[path].clone(),
@@ -156,8 +169,10 @@ impl SchemaRegistry {
                 source_fields: link.source_fields.clone(),
                 target_fields: link.target_fields.clone(),
                 cardinality: link.cardinality,
+                traverses_many,
             });
             schemas.insert(path.clone(), target_schema);
+            many_paths.insert(path.clone(), traverses_many);
         }
 
         let referenced_paths = query
@@ -188,6 +203,10 @@ impl SchemaRegistry {
                 .get(&link_path)
                 .cloned()
                 .ok_or_else(|| QueryPlanError::ValidatedAliasMissing(path.clone()))?;
+            let traverses_many = many_paths
+                .get(&link_path)
+                .copied()
+                .ok_or_else(|| QueryPlanError::ValidatedAliasMissing(path.clone()))?;
             referenced_fields.insert(
                 path.clone(),
                 PlannedField {
@@ -196,6 +215,7 @@ impl SchemaRegistry {
                     value_type: field.value_type,
                     cardinality: field.cardinality,
                     nullable: field.nullable,
+                    traverses_many,
                 },
             );
         }

--- a/crates/rustok-index/src/application/planner_tests.rs
+++ b/crates/rustok-index/src/application/planner_tests.rs
@@ -53,6 +53,45 @@ fn registry() -> SchemaRegistry {
     registry
 }
 
+fn many_registry() -> SchemaRegistry {
+    let channel = IndexSchema {
+        reference: schema_ref("sales_channel"),
+        locale_mode: LocaleMode::None,
+        fields: vec![field("id", true)],
+        links: Vec::new(),
+    };
+    let variant = IndexSchema {
+        reference: schema_ref("variant"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field("id", true), field("sales_channel_id", false)],
+        links: vec![IndexLink {
+            name: LinkName::new("sales_channel").unwrap(),
+            source_fields: vec![FieldName::new("sales_channel_id").unwrap()],
+            target_schema: channel.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::One,
+        }],
+    };
+    let product = IndexSchema {
+        reference: schema_ref("product"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field("id", true)],
+        links: vec![IndexLink {
+            name: LinkName::new("variants").unwrap(),
+            source_fields: vec![FieldName::new("id").unwrap()],
+            target_schema: variant.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::Many,
+        }],
+    };
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register_batch([product, variant, channel])
+        .unwrap();
+    registry
+}
+
 fn query() -> IndexQuery {
     let linked_id = FieldPath::linked(
         [LinkName::new("sales_channel").unwrap()],
@@ -99,6 +138,7 @@ fn aliases_do_not_depend_on_reference_encounter_order() {
     assert_eq!(first.referenced_fields, second.referenced_fields);
     assert_eq!(first.root_alias, "t0");
     assert_eq!(first.joins[0].alias, "t1");
+    assert!(!first.joins[0].traverses_many);
     assert_eq!(first.order_by[0].field.relation_alias, "t1");
     assert_eq!(first.order_by[0].field.value_type, IndexValueType::Uuid);
     assert_eq!(
@@ -106,6 +146,44 @@ fn aliases_do_not_depend_on_reference_encounter_order() {
         FieldCardinality::One
     );
     assert!(!first.order_by[0].field.nullable);
+    assert!(!first.order_by[0].field.traverses_many);
+}
+
+#[test]
+fn many_traversal_propagates_through_descendant_joins_and_fields() {
+    let registry = many_registry();
+    let channel_id = FieldPath::linked(
+        [
+            LinkName::new("variants").unwrap(),
+            LinkName::new("sales_channel").unwrap(),
+        ],
+        FieldName::new("id").unwrap(),
+    );
+    let query = IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: Uuid::new_v4(),
+            locale: Some(LocaleKey::new("en-US").unwrap()),
+        },
+        schema: schema_ref("product"),
+        fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+        filter: Some(FilterExpr::Eq(
+            channel_id.clone(),
+            IndexValue::Uuid(Uuid::new_v4()),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Cursor {
+            first: 20,
+            after: None,
+        },
+        include_exact_count: true,
+    };
+
+    let plan = registry.plan_query(&query).unwrap();
+
+    assert_eq!(plan.joins.len(), 2);
+    assert!(plan.joins.iter().all(|join| join.traverses_many));
+    assert!(plan.field(&channel_id).unwrap().traverses_many);
+    assert_eq!(plan.outer_joins().count(), 0);
 }
 
 #[test]

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -5,7 +5,7 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::domain::{FieldPath, IndexQuery, LinkCardinality, Pagination};
+use crate::domain::{FieldPath, IndexQuery, LinkCardinality, LinkName, Pagination};
 
 use super::{
     CursorCodec, CursorValidationError, ExecutableQueryPlan, IndexCursor, PlannedField,
@@ -72,8 +72,14 @@ pub enum PostgresQueryCompileError {
     CursorContextRequired,
     #[error("decoded cursor context does not match query pagination")]
     CursorContextMismatch,
-    #[error("many-cardinality link query semantics require nested aggregation or EXISTS planning")]
-    ManyLinkSemanticsPending,
+    #[error("many-cardinality projection requires nested aggregation planning: {0:?}")]
+    ManyLinkProjectionPending(FieldPath),
+    #[error("many-cardinality ordering requires an explicit aggregate policy: {0:?}")]
+    ManyLinkOrderingPending(FieldPath),
+    #[error("query plan has no join contract for path {0:?}")]
+    MissingJoinPlan(Vec<LinkName>),
+    #[error("query plan many-link traversal metadata is inconsistent for path {0:?}")]
+    ManyTraversalMismatch(Vec<LinkName>),
     #[error("query plan relation aliases do not match the path-alias map")]
     AliasMappingMismatch,
     #[error("query plan has no typed field contract for {0:?}")]
@@ -162,8 +168,21 @@ impl ExecutableQueryPlan {
             {
                 return Err(PostgresQueryCompileError::AliasMappingMismatch);
             }
-            if join.cardinality == LinkCardinality::Many {
-                return Err(PostgresQueryCompileError::ManyLinkSemanticsPending);
+            let parent_traverses_many = if parent_path.is_empty() {
+                false
+            } else {
+                self.join_for_path(&parent_path)
+                    .ok_or_else(|| {
+                        PostgresQueryCompileError::MissingJoinPlan(parent_path.clone())
+                    })?
+                    .traverses_many
+            };
+            let expected_traverses_many =
+                parent_traverses_many || join.cardinality == LinkCardinality::Many;
+            if join.traverses_many != expected_traverses_many {
+                return Err(PostgresQueryCompileError::ManyTraversalMismatch(
+                    join.path.clone(),
+                ));
             }
         }
 
@@ -175,6 +194,20 @@ impl ExecutableQueryPlan {
             {
                 return Err(PostgresQueryCompileError::AliasMappingMismatch);
             }
+            let expected_traverses_many = if path.links().is_empty() {
+                false
+            } else {
+                self.join_for_path(path.links())
+                    .ok_or_else(|| {
+                        PostgresQueryCompileError::MissingJoinPlan(path.links().to_vec())
+                    })?
+                    .traverses_many
+            };
+            if field.traverses_many != expected_traverses_many {
+                return Err(PostgresQueryCompileError::ManyTraversalMismatch(
+                    path.links().to_vec(),
+                ));
+            }
         }
         for field in &self.projection {
             if self.referenced_fields.get(&field.path) != Some(field) {
@@ -182,10 +215,20 @@ impl ExecutableQueryPlan {
                     field.path.clone(),
                 ));
             }
+            if field.traverses_many {
+                return Err(PostgresQueryCompileError::ManyLinkProjectionPending(
+                    field.path.clone(),
+                ));
+            }
         }
         for order in &self.order_by {
             if self.referenced_fields.get(&order.field.path) != Some(&order.field) {
                 return Err(PostgresQueryCompileError::MissingFieldPlan(
+                    order.field.path.clone(),
+                ));
+            }
+            if order.field.traverses_many {
+                return Err(PostgresQueryCompileError::ManyLinkOrderingPending(
                     order.field.path.clone(),
                 ));
             }

--- a/crates/rustok-index/src/application/postgres_compiler_tests.rs
+++ b/crates/rustok-index/src/application/postgres_compiler_tests.rs
@@ -104,8 +104,105 @@ fn registry(link_cardinality: LinkCardinality) -> SchemaRegistry {
     registry
 }
 
+fn many_registry() -> SchemaRegistry {
+    let channel = IndexSchema {
+        reference: schema_ref("sales_channel"),
+        locale_mode: LocaleMode::None,
+        fields: vec![field(
+            "id",
+            IndexValueType::Uuid,
+            FieldCardinality::One,
+            false,
+            true,
+        )],
+        links: Vec::new(),
+    };
+    let variant = IndexSchema {
+        reference: schema_ref("variant"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![
+            field(
+                "id",
+                IndexValueType::Uuid,
+                FieldCardinality::One,
+                false,
+                true,
+            ),
+            field(
+                "score",
+                IndexValueType::Integer,
+                FieldCardinality::One,
+                true,
+                true,
+            ),
+            field(
+                "title",
+                IndexValueType::String,
+                FieldCardinality::One,
+                true,
+                true,
+            ),
+            field(
+                "tags",
+                IndexValueType::String,
+                FieldCardinality::Many,
+                false,
+                false,
+            ),
+            field(
+                "sales_channel_id",
+                IndexValueType::Uuid,
+                FieldCardinality::One,
+                false,
+                false,
+            ),
+        ],
+        links: vec![IndexLink {
+            name: LinkName::new("sales_channel").unwrap(),
+            source_fields: vec![FieldName::new("sales_channel_id").unwrap()],
+            target_schema: channel.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::One,
+        }],
+    };
+    let product = IndexSchema {
+        reference: schema_ref("product"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field(
+            "id",
+            IndexValueType::Uuid,
+            FieldCardinality::One,
+            false,
+            true,
+        )],
+        links: vec![IndexLink {
+            name: LinkName::new("variants").unwrap(),
+            source_fields: vec![FieldName::new("id").unwrap()],
+            target_schema: variant.reference.clone(),
+            target_fields: vec![FieldName::new("id").unwrap()],
+            cardinality: LinkCardinality::Many,
+        }],
+    };
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register_batch([product, variant, channel])
+        .unwrap();
+    registry
+}
+
 fn path(name: &str) -> FieldPath {
     FieldPath::new(FieldName::new(name).unwrap())
+}
+
+fn linked_path(links: &[&str], field: &str) -> FieldPath {
+    FieldPath::linked(
+        links
+            .iter()
+            .map(|link| LinkName::new(*link).unwrap())
+            .collect::<Vec<_>>(),
+        FieldName::new(field).unwrap(),
+    )
 }
 
 fn root_query(tenant_id: Uuid) -> IndexQuery {
@@ -368,19 +465,105 @@ fn rejects_cursor_reuse_across_query_semantics_before_sql_compilation() {
 }
 
 #[test]
-fn rejects_many_link_semantics_before_sql_is_emitted() {
+fn compiles_nested_many_link_filter_as_correlated_exists_without_outer_join() {
+    let registry = many_registry();
+    let tenant_id = Uuid::new_v4();
+    let expected_channel = Uuid::new_v4();
+    let mut query = root_query(tenant_id);
+    query.filter = Some(FilterExpr::Eq(
+        linked_path(&["variants", "sales_channel"], "id"),
+        IndexValue::Uuid(expected_channel),
+    ));
+    query.include_exact_count = true;
+
+    let compiled = registry.compile_postgres_query(&query).unwrap();
+
+    assert!(compiled
+        .sql
+        .contains("EXISTS (SELECT 1 FROM index_links AS \"mx_l1\""));
+    assert!(compiled
+        .sql
+        .contains("EXISTS (SELECT 1 FROM index_links AS \"mx_l2\""));
+    assert!(!compiled.sql.contains("LEFT JOIN index_links AS \"l1\""));
+    assert!(!compiled.sql.contains("__t1_entity_id"));
+    assert!(!compiled.sql.contains("variants"));
+    assert!(!compiled.sql.contains("sales_channel"));
+    assert_eq!(compiled.columns.len(), 2);
+    assert!(compiled
+        .binds
+        .contains(&PostgresBindValue::Text("variants".to_owned())));
+    assert!(compiled
+        .binds
+        .contains(&PostgresBindValue::Text("sales_channel".to_owned())));
+    assert!(compiled
+        .binds
+        .contains(&PostgresBindValue::Uuid(expected_channel)));
+
+    let count = compiled.exact_count.expect("many filter count");
+    assert!(count.sql.contains("EXISTS (SELECT 1 FROM index_links"));
+    assert!(!count.sql.contains("LEFT JOIN index_links AS \"l1\""));
+    assert!(!count.sql.contains("ORDER BY"));
+    assert!(!count.sql.contains("LIMIT"));
+}
+
+#[test]
+fn compiles_many_link_ne_and_is_null_with_reference_totality() {
+    let registry = many_registry();
+    let mut query = root_query(Uuid::new_v4());
+    query.filter = Some(FilterExpr::And(vec![
+        FilterExpr::Ne(
+            linked_path(&["variants"], "score"),
+            IndexValue::Integer(7),
+        ),
+        FilterExpr::IsNull(linked_path(&["variants"], "title"), true),
+        FilterExpr::Contains(
+            linked_path(&["variants"], "tags"),
+            IndexValue::String("featured".to_owned()),
+        ),
+    ]));
+
+    let compiled = registry.compile_postgres_query(&query).unwrap();
+
+    assert!(compiled.sql.matches("EXISTS (SELECT 1 FROM index_links").count() >= 4);
+    assert!(compiled.sql.contains("AND NOT (EXISTS"));
+    assert!(compiled.sql.contains("IS NULL OR"));
+    assert!(compiled.sql.contains("NOT (EXISTS"));
+    assert!(compiled.sql.contains(" @> "));
+    assert!(!compiled.sql.contains("LEFT JOIN index_links AS \"l1\""));
+}
+
+#[test]
+fn rejects_many_link_projection_until_nested_aggregation_exists() {
     let registry = registry(LinkCardinality::Many);
     let mut query = root_query(Uuid::new_v4());
-    query.fields = vec![FieldPath::linked(
+    let many_id = FieldPath::linked(
         [LinkName::new("sales_channel").unwrap()],
         FieldName::new("id").unwrap(),
-    )];
+    );
+    query.fields = vec![many_id.clone()];
 
     assert!(matches!(
         registry.compile_postgres_query(&query),
         Err(PostgresQueryBuildError::Compile(
-            PostgresQueryCompileError::ManyLinkSemanticsPending
-        ))
+            PostgresQueryCompileError::ManyLinkProjectionPending(path)
+        )) if path == many_id
+    ));
+}
+
+#[test]
+fn rejects_tampered_many_traversal_metadata() {
+    let registry = many_registry();
+    let mut query = root_query(Uuid::new_v4());
+    query.filter = Some(FilterExpr::Eq(
+        linked_path(&["variants"], "id"),
+        IndexValue::Uuid(Uuid::new_v4()),
+    ));
+    let mut plan = registry.plan_query(&query).unwrap();
+    plan.joins[0].traverses_many = false;
+
+    assert!(matches!(
+        plan.compile_postgres(),
+        Err(PostgresQueryCompileError::ManyTraversalMismatch(_))
     ));
 }
 

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -57,10 +57,6 @@ impl CompiledPostgresRow {
     }
 }
 
-/// Opaque page-execution contract produced only by `SchemaRegistry`.
-///
-/// The wrapper deliberately has no serde implementation so untrusted bytes cannot
-/// replace controlled SQL, bind values, or the requested page size before execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompiledPostgresPageQuery {
     compiled: CompiledPostgresQuery,
@@ -312,7 +308,7 @@ fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
         output_alias: identity_alias(&plan.root_alias),
         relation_alias: plan.root_alias.clone(),
     });
-    columns.extend(plan.joins.iter().map(|join| CompiledQueryColumn::EntityId {
+    columns.extend(plan.outer_joins().map(|join| CompiledQueryColumn::EntityId {
         output_alias: identity_alias(&join.alias),
         relation_alias: join.alias.clone(),
     }));
@@ -390,7 +386,7 @@ fn decode_row(
         }
     }
 
-    let root_entity_id = root_entity_id.flatten().ok_or_else(|| {
+    let root_entity_id = root_entity_id.ok_or_else(|| {
         PostgresQueryDecodeError::MissingColumn(identity_alias(&plan.root_alias))
     })?;
     let mut fields = Vec::with_capacity(plan.projection.len());
@@ -466,6 +462,11 @@ fn decode_field(
         }
     };
 
+    if missing_relation && !matches!(value, IndexValue::Null) {
+        return Err(PostgresQueryDecodeError::InvalidFieldValue {
+            path: field.path.clone(),
+        });
+    }
     if matches!(value, IndexValue::Null) && !field.nullable && !missing_relation {
         return Err(PostgresQueryDecodeError::UnexpectedFieldNull {
             path: field.path.clone(),
@@ -480,11 +481,8 @@ fn decode_field(
 }
 
 fn valid_field_value(field: &PlannedField, value: &IndexValue, missing_relation: bool) -> bool {
-    if missing_relation {
-        return matches!(value, IndexValue::Null);
-    }
     match value {
-        IndexValue::Null => field.nullable,
+        IndexValue::Null => field.nullable || missing_relation,
         IndexValue::List(values) => {
             field.cardinality == FieldCardinality::Many
                 && values

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -197,7 +197,14 @@ impl SchemaRegistry {
                 actual: compiled.plan_fingerprint,
             });
         }
-        if compiled.columns != expected_columns(&plan) {
+        let unique_aliases = compiled
+            .columns
+            .iter()
+            .map(column_output_alias)
+            .collect::<BTreeSet<_>>();
+        if unique_aliases.len() != compiled.columns.len()
+            || compiled.columns != expected_columns(&plan)
+        {
             return Err(PostgresQueryDecodeError::ColumnContractMismatch);
         }
 
@@ -331,6 +338,14 @@ fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
             }),
     );
     columns
+}
+
+fn column_output_alias(column: &CompiledQueryColumn) -> &str {
+    match column {
+        CompiledQueryColumn::EntityId { output_alias, .. }
+        | CompiledQueryColumn::Field { output_alias, .. }
+        | CompiledQueryColumn::OrderValue { output_alias, .. } => output_alias,
+    }
 }
 
 fn identity_alias(relation_alias: &str) -> String {

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -57,6 +57,10 @@ impl CompiledPostgresRow {
     }
 }
 
+/// Opaque page-execution contract produced only by `SchemaRegistry`.
+///
+/// The wrapper deliberately has no serde implementation so untrusted bytes cannot
+/// replace controlled SQL, bind values, or the requested page size before execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompiledPostgresPageQuery {
     compiled: CompiledPostgresQuery,

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -1,4 +1,6 @@
-use crate::domain::{FieldPath, FilterExpr, IndexValue, IndexValueType, OrderDirection, Pagination};
+use crate::domain::{
+    FieldPath, FilterExpr, IndexValue, IndexValueType, OrderDirection, Pagination,
+};
 
 use super::{
     cursor::IndexCursor,
@@ -23,7 +25,7 @@ pub(super) fn compile_postgres_plan(
         &plan.root_alias,
         &base.root_alias,
     );
-    for join in &plan.joins {
+    for join in plan.outer_joins() {
         push_identity_column(
             &mut select,
             &mut columns,
@@ -117,7 +119,7 @@ fn compile_base(plan: &ExecutableQueryPlan, bindings: &mut Bindings) -> Compiled
     ));
 
     let mut from_sql = format!("FROM index_entities AS {root_alias}");
-    for (index, join) in plan.joins.iter().enumerate() {
+    for (index, join) in plan.outer_joins().enumerate() {
         let source_alias = quote_identifier(&join.source_alias);
         let target_alias = quote_identifier(&join.alias);
         let link_alias = quote_identifier(&format!("l{}", index + 1));
@@ -157,24 +159,77 @@ fn compile_filter(
             "NOT ({})",
             compile_filter(plan, child, bindings)?
         )),
-        FilterExpr::Eq(path, value) => {
-            let field = planned_field(plan, path)?;
-            let sql = field_sql(field, bindings);
+        FilterExpr::Eq(path, value) => compile_eq(plan, path, value, bindings),
+        FilterExpr::Ne(path, value) => compile_ne(plan, path, value, bindings),
+        FilterExpr::In(path, values) => compile_in(plan, path, values, bindings),
+        FilterExpr::Gt(path, value) => compile_range(plan, path, value, ">", bindings),
+        FilterExpr::Gte(path, value) => compile_range(plan, path, value, ">=", bindings),
+        FilterExpr::Lt(path, value) => compile_range(plan, path, value, "<", bindings),
+        FilterExpr::Lte(path, value) => compile_range(plan, path, value, "<=", bindings),
+        FilterExpr::Contains(path, value) => compile_contains(plan, path, value, bindings),
+        FilterExpr::IsNull(path, expected_null) => {
+            compile_is_null(plan, path, *expected_null, bindings)
+        }
+    }
+}
+
+fn compile_eq(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    value: &IndexValue,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        compile_many_exists(plan, field, bindings, |sql, bindings| {
             let value = bindings.push(scalar_bind(path, value)?);
             Ok(format!("COALESCE({} = {value}, FALSE)", sql.scalar))
-        }
-        FilterExpr::Ne(path, value) => {
-            let field = planned_field(plan, path)?;
-            let sql = field_sql(field, bindings);
+        })
+    } else {
+        let sql = field_sql(field, bindings);
+        let value = bindings.push(scalar_bind(path, value)?);
+        Ok(format!("COALESCE({} = {value}, FALSE)", sql.scalar))
+    }
+}
+
+fn compile_ne(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    value: &IndexValue,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        let present = compile_many_exists(plan, field, bindings, |sql, _| {
+            Ok(format!("{} IS NOT NULL", sql.raw))
+        })?;
+        let disqualifying = compile_many_exists(plan, field, bindings, |sql, bindings| {
             let value = bindings.push(scalar_bind(path, value)?);
             Ok(format!(
-                "({} IS NOT NULL AND {} <> {value})",
-                sql.scalar, sql.scalar
+                "({} IS NOT NULL AND ({} IS NULL OR {} = 'null' OR COALESCE({} = {value}, FALSE)))",
+                sql.raw, sql.type_text, sql.type_text, sql.scalar,
             ))
-        }
-        FilterExpr::In(path, values) => {
-            let field = planned_field(plan, path)?;
-            let sql = field_sql(field, bindings);
+        })?;
+        Ok(format!("({present} AND NOT ({disqualifying}))"))
+    } else {
+        let sql = field_sql(field, bindings);
+        let value = bindings.push(scalar_bind(path, value)?);
+        Ok(format!(
+            "({} IS NOT NULL AND {} <> {value})",
+            sql.scalar, sql.scalar
+        ))
+    }
+}
+
+fn compile_in(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    values: &[IndexValue],
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        compile_many_exists(plan, field, bindings, |sql, bindings| {
             let values = values
                 .iter()
                 .map(|value| Ok(bindings.push(scalar_bind(path, value)?)))
@@ -184,37 +239,96 @@ fn compile_filter(
                 sql.scalar,
                 values.join(", ")
             ))
-        }
-        FilterExpr::Gt(path, value) => {
-            compile_range(plan, path, value, ">", bindings)
-        }
-        FilterExpr::Gte(path, value) => {
-            compile_range(plan, path, value, ">=", bindings)
-        }
-        FilterExpr::Lt(path, value) => {
-            compile_range(plan, path, value, "<", bindings)
-        }
-        FilterExpr::Lte(path, value) => {
-            compile_range(plan, path, value, "<=", bindings)
-        }
-        FilterExpr::Contains(path, value) => {
-            let field = planned_field(plan, path)?;
-            let sql = field_sql(field, bindings);
+        })
+    } else {
+        let sql = field_sql(field, bindings);
+        let values = values
+            .iter()
+            .map(|value| Ok(bindings.push(scalar_bind(path, value)?)))
+            .collect::<Result<Vec<_>, PostgresQueryCompileError>>()?;
+        Ok(format!(
+            "COALESCE({} IN ({}), FALSE)",
+            sql.scalar,
+            values.join(", ")
+        ))
+    }
+}
+
+fn compile_range(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    value: &IndexValue,
+    operator: &str,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        compile_many_exists(plan, field, bindings, |sql, bindings| {
+            let value = bindings.push(scalar_bind(path, value)?);
+            Ok(format!(
+                "COALESCE({} {operator} {value}, FALSE)",
+                sql.scalar
+            ))
+        })
+    } else {
+        let sql = field_sql(field, bindings);
+        let value = bindings.push(scalar_bind(path, value)?);
+        Ok(format!(
+            "COALESCE({} {operator} {value}, FALSE)",
+            sql.scalar
+        ))
+    }
+}
+
+fn compile_contains(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    value: &IndexValue,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        compile_many_exists(plan, field, bindings, |sql, bindings| {
             let encoded = serde_json::to_value(vec![value.clone()])?;
             let value = bindings.push(PostgresBindValue::Json(encoded));
             Ok(format!(
                 "COALESCE({} @> {value}::jsonb, FALSE)",
                 sql.list_values
             ))
+        })
+    } else {
+        let sql = field_sql(field, bindings);
+        let encoded = serde_json::to_value(vec![value.clone()])?;
+        let value = bindings.push(PostgresBindValue::Json(encoded));
+        Ok(format!(
+            "COALESCE({} @> {value}::jsonb, FALSE)",
+            sql.list_values
+        ))
+    }
+}
+
+fn compile_is_null(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    expected_null: bool,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        let non_null = compile_many_exists(plan, field, bindings, |sql, _| {
+            Ok(sql.non_null_predicate())
+        })?;
+        if expected_null {
+            Ok(format!("NOT ({non_null})"))
+        } else {
+            Ok(non_null)
         }
-        FilterExpr::IsNull(path, expected_null) => {
-            let field = planned_field(plan, path)?;
-            let sql = field_sql(field, bindings);
-            if *expected_null {
-                Ok(format!("({})", sql.null_predicate))
-            } else {
-                Ok(format!("NOT ({})", sql.null_predicate))
-            }
+    } else {
+        let sql = field_sql(field, bindings);
+        if expected_null {
+            Ok(format!("({})", sql.null_predicate))
+        } else {
+            Ok(format!("NOT ({})", sql.null_predicate))
         }
     }
 }
@@ -232,20 +346,54 @@ fn compile_logical(
     Ok(format!("({})", children.join(&format!(" {operator} "))))
 }
 
-fn compile_range(
+fn compile_many_exists(
     plan: &ExecutableQueryPlan,
-    path: &FieldPath,
-    value: &IndexValue,
-    operator: &str,
+    field: &PlannedField,
     bindings: &mut Bindings,
+    predicate: impl FnOnce(&FieldSql, &mut Bindings) -> Result<String, PostgresQueryCompileError>,
 ) -> Result<String, PostgresQueryCompileError> {
-    let field = planned_field(plan, path)?;
-    let sql = field_sql(field, bindings);
-    let value = bindings.push(scalar_bind(path, value)?);
-    Ok(format!(
-        "COALESCE({} {operator} {value}, FALSE)",
-        sql.scalar
-    ))
+    let mut path = Vec::new();
+    let mut source_alias = plan.root_alias.clone();
+    let mut wrappers = Vec::with_capacity(field.path.links().len());
+
+    for (index, link_name) in field.path.links().iter().enumerate() {
+        path.push(link_name.clone());
+        let join = plan
+            .join_for_path(&path)
+            .ok_or_else(|| PostgresQueryCompileError::MissingJoinPlan(path.clone()))?;
+        let link_alias_name = format!("mx_l{}", index + 1);
+        let target_alias_name = format!("mx_t{}", index + 1);
+        let source_alias_q = quote_identifier(&source_alias);
+        let link_alias = quote_identifier(&link_alias_name);
+        let target_alias = quote_identifier(&target_alias_name);
+        let link_name = bindings.push(PostgresBindValue::Text(join.link.as_str().to_owned()));
+        let target_module = bindings.push(PostgresBindValue::Text(
+            join.target_schema.module.as_str().to_owned(),
+        ));
+        let target_entity = bindings.push(PostgresBindValue::Text(
+            join.target_schema.entity.as_str().to_owned(),
+        ));
+        let target_version = bindings.push(PostgresBindValue::Integer(i64::from(
+            join.target_schema.version.get(),
+        )));
+        wrappers.push(format!(
+            "SELECT 1 FROM index_links AS {link_alias} JOIN index_entities AS {target_alias} ON {target_alias}.tenant_id = {link_alias}.tenant_id AND {target_alias}.module_name = {link_alias}.target_module AND {target_alias}.entity_name = {link_alias}.target_entity AND {target_alias}.schema_version = {link_alias}.target_schema_version AND {target_alias}.entity_id = {link_alias}.target_entity_id AND {target_alias}.locale_key = {link_alias}.target_locale_key AND {target_alias}.is_deleted = FALSE WHERE {link_alias}.tenant_id = {source_alias_q}.tenant_id AND {link_alias}.source_module = {source_alias_q}.module_name AND {link_alias}.source_entity = {source_alias_q}.entity_name AND {link_alias}.source_schema_version = {source_alias_q}.schema_version AND {link_alias}.source_entity_id = {source_alias_q}.entity_id AND {link_alias}.source_locale_key = {source_alias_q}.locale_key AND {link_alias}.source_version = {source_alias_q}.source_version AND {link_alias}.link_name = {link_name} AND {link_alias}.target_module = {target_module} AND {link_alias}.target_entity = {target_entity} AND {link_alias}.target_schema_version = {target_version} AND ",
+        ));
+        source_alias = target_alias_name;
+    }
+
+    if wrappers.is_empty() {
+        return Err(PostgresQueryCompileError::ManyTraversalMismatch(
+            field.path.links().to_vec(),
+        ));
+    }
+
+    let sql = field_sql_for_alias(field, &source_alias, bindings);
+    let mut expression = predicate(&sql, bindings)?;
+    for wrapper in wrappers.into_iter().rev() {
+        expression = format!("EXISTS ({wrapper}{expression})");
+    }
+    Ok(expression)
 }
 
 fn compile_keyset(
@@ -382,11 +530,29 @@ struct FieldSql {
     raw: String,
     scalar: String,
     list_values: String,
+    type_text: String,
     null_predicate: String,
 }
 
+impl FieldSql {
+    fn non_null_predicate(&self) -> String {
+        format!(
+            "({} IS NOT NULL AND {} IS NOT NULL AND {} <> 'null')",
+            self.raw, self.type_text, self.type_text
+        )
+    }
+}
+
 fn field_sql(field: &PlannedField, bindings: &mut Bindings) -> FieldSql {
-    let relation_alias = quote_identifier(&field.relation_alias);
+    field_sql_for_alias(field, &field.relation_alias, bindings)
+}
+
+fn field_sql_for_alias(
+    field: &PlannedField,
+    relation_alias: &str,
+    bindings: &mut Bindings,
+) -> FieldSql {
+    let relation_alias = quote_identifier(relation_alias);
     let field_name = bindings.push(PostgresBindValue::Text(
         field.path.field().as_str().to_owned(),
     ));
@@ -407,13 +573,17 @@ fn field_sql(field: &PlannedField, bindings: &mut Bindings) -> FieldSql {
         IndexValueType::Uuid => format!("({scalar_text})::uuid"),
         IndexValueType::Timestamp => format!("({scalar_text})::timestamptz"),
     };
+    let null_predicate = format!(
+        "{raw} IS NULL OR {type_text} IS NULL OR {type_text} = 'null'"
+    );
     FieldSql {
         raw,
         scalar,
         list_values: format!(
             "jsonb_extract_path({relation_alias}.payload, {field_name}::text, 'value')"
         ),
-        null_predicate: format!("{type_text} IS NULL OR {type_text} = 'null'"),
+        type_text,
+        null_predicate,
     }
 }
 

--- a/scripts/verify/verify-index-many-link-filtering.mjs
+++ b/scripts/verify/verify-index-many-link-filtering.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-many-link-filtering] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const plannerPath = 'crates/rustok-index/src/application/planner.rs';
+const planner = requireMarkers(plannerPath, [
+  'pub traverses_many: bool',
+  'let mut many_paths = BTreeMap::from([(Vec::new(), false)]);',
+  'link.cardinality == LinkCardinality::Many',
+  'many_paths.insert(path.clone(), traverses_many);',
+  'pub(crate) fn outer_joins(&self)',
+  'rustok-index-query-plan-v3',
+]);
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
+const compiler = requireMarkers(compilerPath, [
+  'ManyLinkProjectionPending(FieldPath)',
+  'ManyLinkOrderingPending(FieldPath)',
+  'MissingJoinPlan(Vec<LinkName>)',
+  'ManyTraversalMismatch(Vec<LinkName>)',
+  'expected_traverses_many',
+  'if field.traverses_many',
+  'if order.field.traverses_many',
+]);
+
+const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
+const sql = requireMarkers(sqlPath, [
+  'for join in plan.outer_joins()',
+  'for (index, join) in plan.outer_joins().enumerate()',
+  'fn compile_many_exists(',
+  'let mut wrappers = Vec::with_capacity(field.path.links().len());',
+  'EXISTS ({wrapper}{expression})',
+  '.source_version = {source_alias_q}.source_version',
+  'AND NOT ({disqualifying})',
+  'sql.non_null_predicate()',
+  'compile_many_exists(plan, field, bindings',
+]);
+
+const outerJoinPosition = sql.indexOf('for (index, join) in plan.outer_joins().enumerate()');
+const filterPosition = sql.indexOf('fn compile_filter(');
+const manyPosition = sql.indexOf('fn compile_many_exists(');
+const countPosition = sql.indexOf('fn compile_exact_count(');
+if (
+  outerJoinPosition < 0 ||
+  filterPosition < 0 ||
+  manyPosition < 0 ||
+  countPosition < 0 ||
+  !(outerJoinPosition < filterPosition && filterPosition < manyPosition && manyPosition < countPosition)
+) {
+  fail('outer joins, filter dispatch, correlated many predicates, and count must keep deterministic layering');
+}
+
+for (const [relative, source] of [
+  [plannerPath, planner],
+  [compilerPath, compiler],
+  [sqlPath, sql],
+]) {
+  for (const forbidden of [
+    'rustok_product',
+    'rustok_content',
+    'rustok_flex',
+    'DatabaseConnection',
+    'Statement::from_sql',
+    '.query_all(',
+    '.query_one(',
+    '.execute(',
+    'SELECT *',
+  ]) {
+    if (source.includes(forbidden)) fail(`${relative} contains forbidden marker ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/planner_tests.rs', [
+  'many_traversal_propagates_through_descendant_joins_and_fields',
+  'assert!(plan.joins.iter().all(|join| join.traverses_many))',
+  'assert_eq!(plan.outer_joins().count(), 0)',
+]);
+requireMarkers('crates/rustok-index/src/application/postgres_compiler_tests.rs', [
+  'compiles_nested_many_link_filter_as_correlated_exists_without_outer_join',
+  'compiles_many_link_ne_and_is_null_with_reference_totality',
+  'rejects_many_link_projection_until_nested_aggregation_exists',
+  'rejects_tampered_many_traversal_metadata',
+  'assert!(!compiled.sql.contains("LEFT JOIN index_links AS \\"l1\\""))',
+  'assert!(!count.sql.contains("ORDER BY"))',
+  'assert!(!count.sql.contains("LIMIT"))',
+]);
+requireMarkers('crates/rustok-index/src/application/postgres_query_result.rs', [
+  'plan.outer_joins().map(|join| CompiledQueryColumn::EntityId',
+]);
+requireMarkers('crates/rustok-index/docs/m4-many-link-filtering.md', [
+  'nested correlated `EXISTS` chain',
+  'Independent atomic subqueries are intentional.',
+  '`Ne` is deliberately not compiled as `NOT EXISTS(Eq)`',
+  'ManyLinkProjectionPending',
+  'does not execute SQL',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  'M4 many-link `EXISTS` filtering: `complete`',
+  '- [x] Add explicit many-link `EXISTS` filtering.',
+  '- [ ] Add nested many-link projection aggregation.',
+  'ManyLinkProjectionPending',
+]);
+
+console.log('[verify-index-many-link-filtering] OK');

--- a/scripts/verify/verify-index-postgres-query-compiler.mjs
+++ b/scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -34,9 +34,12 @@ const compiler = requireMarkers(compilerPath, [
   'pub fn compile_postgres(&self)',
   'self.validate_compiler_contract(cursor)?;',
   'super::postgres_query_sql::compile_postgres_plan(self, cursor)',
-  'ManyLinkSemanticsPending',
+  'ManyLinkProjectionPending(FieldPath)',
+  'ManyLinkOrderingPending(FieldPath)',
+  'ManyTraversalMismatch(Vec<LinkName>)',
   'self.referenced_fields.get(&field.path) != Some(field)',
   'self.path_aliases.get(&Vec::new())',
+  'expected_traverses_many',
   'validate_alias(&self.root_alias)?;',
 ]);
 
@@ -50,9 +53,15 @@ const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
 const sql = requireMarkers(sqlPath, [
   'pub(super) fn compile_postgres_plan(',
   'let base = compile_base(plan, &mut bindings);',
+  'for join in plan.outer_joins()',
   'FilterExpr::And(children)',
   'FilterExpr::Contains(path, value)',
   'FilterExpr::IsNull(path, expected_null)',
+  'fn compile_many_exists(',
+  'EXISTS ({wrapper}{expression})',
+  'AND NOT ({disqualifying})',
+  'sql.non_null_predicate()',
+  '.source_version = {source_alias_q}.source_version',
   'COALESCE(',
   '::boolean',
   '::bigint',
@@ -90,6 +99,12 @@ if (
   fail('scope, filters, keyset, ordering, and pagination must retain deterministic emission order');
 }
 
+const manyExistsPosition = sql.indexOf('fn compile_many_exists(');
+const exactCountPosition = sql.indexOf('fn compile_exact_count(');
+if (manyExistsPosition < 0 || exactCountPosition < 0 || manyExistsPosition >= exactCountPosition) {
+  fail('many-link correlated predicate support must be shared by page and count compilation');
+}
+
 for (const [relative, source] of [[compilerPath, compiler], [sqlPath, sql]]) {
   for (const forbidden of [
     'rustok_product',
@@ -121,7 +136,10 @@ requireMarkers('crates/rustok-index/src/application/postgres_compiler_tests.rs',
   'compiles_typed_filters_order_exact_count_and_bounded_offset',
   'compiles_validated_lexicographic_keyset_with_entity_tie_breaker',
   'rejects_cursor_reuse_across_query_semantics_before_sql_compilation',
-  'rejects_many_link_semantics_before_sql_is_emitted',
+  'compiles_nested_many_link_filter_as_correlated_exists_without_outer_join',
+  'compiles_many_link_ne_and_is_null_with_reference_totality',
+  'rejects_many_link_projection_until_nested_aggregation_exists',
+  'rejects_tampered_many_traversal_metadata',
   'rejects_tampered_path_alias_mapping',
   'assert!(!compiled.sql.contains(&tenant_id.to_string()))',
   'assert!(!compiled.sql.contains("sales_channel"))',
@@ -137,19 +155,21 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
 requireMarkers('crates/rustok-index/docs/m4-postgres-query-compiler.md', [
   '## Supported query semantics',
   'Atomic predicates are compiled into total booleans.',
+  '## Many-link filter boundary',
+  'Many-link `Ne` is intentionally stricter than `NOT EXISTS(Eq)`',
   'Ascending order uses `NULLS LAST`; descending order uses `NULLS FIRST`',
   'rustok-index-cursor-query-v1',
   'QueryFingerprintMismatch',
   'CompiledPostgresCount',
-  'ManyLinkSemanticsPending',
+  'ManyLinkProjectionPending',
   'does not connect to PostgreSQL',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   'M4 controlled PostgreSQL query compilation: `complete`',
-  'M4 typed root/one-link query semantics: `complete`',
-  '- [x] Compile plans through SeaQuery or controlled SQL.',
-  '- [x] Keep offset pagination bounded and compatibility-only.',
-  'Many-cardinality paths remain fail-closed with `ManyLinkSemanticsPending`',
+  'M4 many-link `EXISTS` filtering: `complete`',
+  '- [x] Add explicit many-link `EXISTS` filtering.',
+  '- [ ] Add nested many-link projection aggregation.',
+  'ManyLinkProjectionPending',
 ]);
 
 console.log('[verify-index-postgres-query-compiler] OK');

--- a/scripts/verify/verify-index-query-planner.mjs
+++ b/scripts/verify/verify-index-query-planner.mjs
@@ -26,27 +26,34 @@ const planner = requireMarkers(plannerPath, [
   'pub value_type: IndexValueType',
   'pub cardinality: FieldCardinality',
   'pub nullable: bool',
+  'pub traverses_many: bool',
   'pub referenced_fields: BTreeMap<FieldPath, PlannedField>',
   'pub fn plan_query(&self, query: &IndexQuery)',
   'self.validate_query(query)?;',
   'collect_link_prefixes(query)',
   'collect::<BTreeSet<_>>()',
   'BTreeMap::from([(Vec::new(), ROOT_ALIAS.to_owned())])',
+  'let mut many_paths = BTreeMap::from([(Vec::new(), false)]);',
+  'link.cardinality == LinkCardinality::Many',
+  'many_paths.insert(path.clone(), traverses_many);',
+  'pub(crate) fn outer_joins(&self)',
   'format!("t{}", index + 1)',
   'postcard::to_stdvec(self)?',
-  'rustok-index-query-plan-v2',
+  'rustok-index-query-plan-v3',
 ]);
 
 const validation = planner.indexOf('self.validate_query(query)?;');
 const aliasing = planner.indexOf('collect_link_prefixes(query)');
+const manyPlanning = planner.indexOf('let mut many_paths = BTreeMap::from([(Vec::new(), false)]);');
 const fieldContracts = planner.indexOf('let referenced_paths = query');
 if (
   validation < 0 ||
   aliasing < 0 ||
+  manyPlanning < 0 ||
   fieldContracts < 0 ||
-  !(validation < aliasing && aliasing < fieldContracts)
+  !(validation < aliasing && aliasing < manyPlanning && manyPlanning < fieldContracts)
 ) {
-  fail('query validation and alias planning must precede typed field-contract capture');
+  fail('query validation, aliases, and many-path propagation must precede field contracts');
 }
 
 for (const forbidden of [
@@ -64,10 +71,13 @@ for (const forbidden of [
 
 requireMarkers('crates/rustok-index/src/application/planner_tests.rs', [
   'aliases_do_not_depend_on_reference_encounter_order',
+  'many_traversal_propagates_through_descendant_joins_and_fields',
   'validation_precedes_plan_construction',
   'fingerprint_changes_with_order_semantics',
   'assert_eq!(first.referenced_fields, second.referenced_fields)',
   'assert_eq!(first.order_by[0].field.value_type, IndexValueType::Uuid)',
+  'assert!(plan.joins.iter().all(|join| join.traverses_many))',
+  'assert_eq!(plan.outer_joins().count(), 0)',
 ]);
 
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
@@ -79,15 +89,17 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
 
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
   'M4 typed referenced-field contracts: `source_complete_execution_pending`',
-  'rustok-index-query-plan-v2',
-  'M4 root/one-link filter/order/count/keyset/offset semantics: `source_complete_execution_pending`',
-  'Many-cardinality link paths remain fail-closed.',
+  'rustok-index-query-plan-v3',
+  'M4 many-link `EXISTS` filtering: `source_complete_execution_pending`',
+  'Many-cardinality projection remains fail-closed with',
   'Not run by the implementation agent',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '### M4 - Query engine v1',
   '- [x] Compile plans through SeaQuery or controlled SQL.',
+  '- [x] Add explicit many-link `EXISTS` filtering.',
+  '- [ ] Add nested many-link projection aggregation.',
   'Partition cutover remains forbidden until one retained real',
 ]);
 

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -23,7 +23,6 @@ const decoder = requireMarkers(decoderPath, [
   'pub enum CompiledPostgresCell',
   'pub struct CompiledPostgresRow',
   'pub struct CompiledPostgresPageQuery',
-  'The wrapper deliberately has no serde implementation',
   'pub struct IndexQueryPage',
   'pub enum PostgresQueryPageBuildError',
   'pub enum PostgresQueryDecodeError',
@@ -35,10 +34,11 @@ const decoder = requireMarkers(decoderPath, [
   'PlanFingerprintMismatch',
   'rows.len() > requested_page_size as usize',
   'CursorCodec::encode_for_query(&cursor, query, self)?',
-  'root_entity_id.flatten()',
-  'if missing_relation {',
+  'let root_entity_id = root_entity_id.ok_or_else',
+  'if missing_relation && !matches!(value, IndexValue::Null)',
   'fn join_is_projected(',
   'if join_is_projected(plan, &join.path)',
+  'plan.outer_joins().map(|join| CompiledQueryColumn::EntityId',
   'ExactCountContractMismatch',
   'InvalidTaggedValue',
 ]);
@@ -83,7 +83,8 @@ for (const forbidden of [
 }
 
 requireMarkers('crates/rustok-index/src/application/postgres_compiler.rs', [
-  'ManyLinkSemanticsPending',
+  'ManyLinkProjectionPending(FieldPath)',
+  'ManyLinkOrderingPending(FieldPath)',
 ]);
 requireMarkers('crates/rustok-index/src/application/postgres_query_result_tests.rs', [
   'page_compilation_adds_exactly_one_lookahead_row',
@@ -105,12 +106,14 @@ requireMarkers('crates/rustok-index/docs/m4-query-result-decoder.md', [
   'compiled column contract',
   'query-scoped continuation cursor',
   'does not execute SQL',
-  'Many-link semantics remain fail-closed',
+  'Many-link filtering is supported without changing the decoder result shape.',
+  'ManyLinkProjectionPending',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   'M4 deterministic PostgreSQL result decoding: `complete`',
   '- [x] Add deterministic root/one-link result decoding and cursor construction.',
-  '- [ ] Add explicit many-link `EXISTS` filtering and nested projection aggregation.',
+  '- [x] Add explicit many-link `EXISTS` filtering.',
+  '- [ ] Add nested many-link projection aggregation.',
 ]);
 
 console.log('[verify-index-query-result-decoder] OK');


### PR DESCRIPTION
## Summary

- propagate `traverses_many` through executable join and field plans and bump the plan fingerprint domain to `rustok-index-query-plan-v3`
- keep many-traversing joins out of the main rowset and compiled identity-column contract
- compile every atomic many-link predicate as an independent nested correlated `EXISTS` chain
- preserve complete source identity, source version, link name, and exact target schema fences at every hop
- implement reference-compatible any-match semantics for equality, membership, ranges, and containment
- implement many-link `IsNull` as absence/presence of reachable non-null values
- implement many-link `Ne` as non-empty reachable values with no null or equal value, rather than naive `NOT EXISTS(Eq)`
- reuse correlated predicates in exact-count compilation without outer-row multiplication, ordering, cursor, limit, or offset leakage
- retain typed fail-closed gates for many-link projection and ordering
- align the compiled-row decoder with non-many outer columns, reject duplicate output aliases, and fix the pre-existing root identity `Option` mismatch
- update focused source scenarios, static guards, M4 notes, `CRATE_API`, and the canonical implementation plan

## Recheck findings

The test-only reference engine flattens every explicit path to terminal values. Positive operators use any-match semantics, while `Ne` requires a non-empty value set whose every value is non-null and different. `IsNull` is true for an empty path or an all-null value set. The compiler now mirrors those semantics explicitly.

A many-link filter cannot be represented by an ordinary join without duplicating root rows and corrupting negative predicates, exact count, keyset/offset pagination, and one-row lookahead. This PR confines every many traversal to correlated subqueries and leaves only root/one-link joins in the outer result set.

Static patch review found a pre-existing decoder compile defect: root identity state was already a single `Option<Uuid>` but was still passed through `.flatten()`. The decoder now resolves that value directly and also rejects duplicate compiled output aliases and non-null values paired with an absent optional relation.

The branch is one commit behind current `main`. That commit changes only Product service/transport/evidence files and has no overlap with the sixteen files changed here. The canonical M3 `baseline/shadow ordinary-VACUUM` marker was also explicitly preserved during plan actualization.

## Boundary

This PR does not aggregate many-link projections, define aggregate many-link ordering, execute or prepare SQL, adapt SeaORM bind/row values, publish `IndexQueryPort`, verify persisted schema/index readiness, authorize callers, claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence, change migrations, or begin production partition lifecycle work.

One fresh admitted real PostgreSQL partition packet remains an independent owner action and continues to block production partition lifecycle design.

## Validation

Not run by the implementation agent, per maintainer instruction.

Suggested commands:

```bash
cargo test -p rustok-index planner_tests -- --nocapture
cargo test -p rustok-index postgres_compiler_tests -- --nocapture
cargo test -p rustok-index postgres_query_result_tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-query-planner.mjs
node scripts/verify/verify-index-postgres-query-compiler.mjs
node scripts/verify/verify-index-query-result-decoder.mjs
node scripts/verify/verify-index-many-link-filtering.mjs
cargo xtask module validate index
```
