### PR TITLE
feat(forum): publish transactional projection invalidations

### DIFF
--- a/crates/rustok-forum/contracts/forum-projection-invalidation.json
+++ b/crates/rustok-forum/contracts/forum-projection-invalidation.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BK",
+  "upstream_task": "FORUM-20BJ",
+  "scope": "Publish durable owner-transactional invalidations for every canonical Forum mutation that can change exact public category or topic Search projections",
+  "root_event": "rustok_events::DomainEvent::ReindexRequested",
+  "event_type": "search.reindex_requested",
+  "outbox_transaction_api": "crates/rustok-outbox/src/transactional.rs",
+  "outbox_storage_api": "crates/rustok-outbox/src/transport.rs",
+  "forum_invalidation_owner": "crates/rustok-forum/src/services/projection_invalidation.rs",
+  "search_consumer": "crates/rustok-search/src/ingestion.rs",
+  "upstream_contract": "crates/rustok-forum/contracts/forum-search-projection.json",
+  "owner_note": "crates/rustok-forum/docs/forum-20bk-projection-invalidation.md",
+  "source_verifier": "scripts/verify/verify-forum-projection-invalidation.mjs",
+  "targets": {
+    "forum_scope": {
+      "target_type": "forum",
+      "target_id": null,
+      "reason": "Category copy, hierarchy, lifecycle and inherited category policy can change category documents and any descendant topic visibility or subtitle."
+    },
+    "category": {
+      "target_type": "forum_category",
+      "target_id": "category_id",
+      "reason": "Topic and approved-reply count changes update only the owning category document."
+    },
+    "topic": {
+      "target_type": "forum_topic",
+      "target_id": "topic_id",
+      "reason": "Topic-local copy, tags, channels, lock, solution and topic-local audience changes update one topic's locale documents."
+    }
+  },
+  "outbox_boundary": {
+    "owner_transaction_required": true,
+    "domain_event_validation_preserved": true,
+    "registered_envelope_schema_validation_preserved": true,
+    "canonical_sys_events_outbox_reused": true,
+    "new_root_domain_event_added": false,
+    "new_event_schema_added": false,
+    "sql_trigger_event_envelope_copy_added": false,
+    "second_database_connection_required": false,
+    "dispatch_reliability": "at_least_once",
+    "duplicate_invalidations_allowed": true,
+    "consumer_operations_are_idempotent": true
+  },
+  "forum_scope_invalidation": {
+    "category_create": true,
+    "category_content_or_translation_update": true,
+    "category_move": true,
+    "category_sibling_reorder": true,
+    "category_archive_or_restore_subtree": true,
+    "category_delete_archives_subtree": true,
+    "category_visibility_policy_replace": true,
+    "category_richer_audience_policy_replace": true,
+    "category_topic_creation_policy_changes_projection": false,
+    "category_reply_creation_policy_changes_projection": false,
+    "category_moderation_policy_changes_projection": false
+  },
+  "category_target_invalidation": {
+    "topic_create_updates_topic_count": true,
+    "topic_delete_updates_topic_and_reply_counts": true,
+    "approved_reply_create_updates_reply_count": true,
+    "approved_reply_delete_updates_reply_count": true,
+    "reply_moderation_public_state_transition_updates_reply_count": true,
+    "pending_or_rejected_reply_without_public_count_change_emits_category_target": false
+  },
+  "topic_target_invalidation": {
+    "topic_content_translation_metadata_tags_or_channel_update": true,
+    "topic_delete_removes_stale_document_even_when_already_archived": true,
+    "topic_lock_or_unlock": true,
+    "topic_solution_mark_or_clear": true,
+    "topic_local_audience_policy_replace": true,
+    "topic_create_already_refreshed_by_existing_lifecycle_event": true,
+    "topic_status_already_refreshed_by_existing_lifecycle_event": true,
+    "topic_pin_already_refreshed_by_existing_lifecycle_event": true,
+    "reply_lifecycle_already_refreshes_topic_document": true
+  },
+  "owner_sealing": {
+    "public_category_owner_routes_content_placement_and_lifecycle_writes": true,
+    "public_category_audience_alias_routes_policy_replacement": true,
+    "public_topic_audience_alias_routes_policy_replacement": true,
+    "public_moderation_facade_seals_private_transactional_owner": true,
+    "legacy_moderation_constructor_exported": false,
+    "raw_category_mutation_service_exported": false,
+    "raw_topic_mutation_service_exported": false,
+    "read_composers_may_use_private_read_implementations": true
+  },
+  "compatibility": {
+    "existing_reindex_target_strings_changed": false,
+    "search_ingestion_contract_changed": false,
+    "forum_rest_routes_changed": false,
+    "forum_graphql_fields_changed": false,
+    "forum_public_response_dto_changed": false,
+    "workspace_dependency_changed": false,
+    "cargo_lock_changed": false,
+    "migration_added": false,
+    "legacy_graphql_snapshot_changed": false
+  },
+  "documentation": {
+    "owner_note_added": true,
+    "contract_added": true,
+    "upstream_contract_updated": true,
+    "crate_api_updated": false,
+    "canonical_plan_updated": false,
+    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-20/FORUM-23 ledgers through FORUM-20BK with conflict-safe repository-local edits after maintainer validation."
+  },
+  "remaining_scope": [
+    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
+    "decide whether approved public replies become separate Search documents under FORUM-23",
+    "add visibility-scoped category and all-read commands",
+    "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
+    "capture maintainer-executed PostgreSQL and SQLite outbox projection cleanup and query runtime evidence",
+    "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
+  ],
+  "downstream_task": "FORUM-20BL",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-outbox transactional -- --nocapture",
+      "cargo test -p rustok-forum projection_invalidation -- --nocapture",
+      "cargo test -p rustok-forum category_audience_policy_sqlite -- --nocapture",
+      "cargo test -p rustok-forum topic_audience_policy_sqlite -- --nocapture",
+      "cargo test -p rustok-search forum_projector -- --nocapture",
+      "node scripts/verify/verify-forum-search-projection.mjs",
+      "node scripts/verify/verify-forum-projection-invalidation.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/contracts/forum-projection-invalidation.json
+++ b/crates/rustok-forum/contracts/forum-projection-invalidation.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "task": "FORUM-20BK",
   "upstream_task": "FORUM-20BJ",
-  "scope": "Publish durable owner-transactional invalidations for every canonical Forum mutation that can change exact public category or topic Search projections",
+  "scope": "Publish durable owner-transactional invalidations on the supported PostgreSQL Forum Search runtime for every canonical Forum mutation that can change exact public category or topic projections",
   "root_event": "rustok_events::DomainEvent::ReindexRequested",
   "event_type": "search.reindex_requested",
   "outbox_transaction_api": "crates/rustok-outbox/src/transactional.rs",
@@ -30,9 +30,12 @@
     }
   },
   "outbox_boundary": {
-    "owner_transaction_required": true,
+    "owner_transaction_required_on_postgresql": true,
+    "postgresql_direct_owner_invalidations_persisted": true,
+    "non_postgresql_direct_owner_invalidations_validation_only": true,
+    "non_postgresql_forum_search_projector_supported": false,
     "domain_event_validation_preserved": true,
-    "registered_envelope_schema_validation_preserved": true,
+    "registered_envelope_schema_validation_preserved_for_persisted_events": true,
     "canonical_sys_events_outbox_reused": true,
     "new_root_domain_event_added": false,
     "new_event_schema_added": false,
@@ -93,6 +96,7 @@
     "workspace_dependency_changed": false,
     "cargo_lock_changed": false,
     "migration_added": false,
+    "sqlite_forum_domain_fixtures_require_outbox_migration": false,
     "legacy_graphql_snapshot_changed": false
   },
   "documentation": {
@@ -108,7 +112,7 @@
     "decide whether approved public replies become separate Search documents under FORUM-23",
     "add visibility-scoped category and all-read commands",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
-    "capture maintainer-executed PostgreSQL and SQLite outbox projection cleanup and query runtime evidence",
+    "capture maintainer-executed PostgreSQL outbox projection cleanup and query runtime evidence plus SQLite validation-only domain evidence",
     "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
   ],
   "downstream_task": "FORUM-20BL",

--- a/crates/rustok-forum/contracts/forum-search-projection.json
+++ b/crates/rustok-forum/contracts/forum-search-projection.json
@@ -19,6 +19,7 @@
   "owner_note": "crates/rustok-forum/docs/forum-20bj-search-projection.md",
   "source_verifier": "scripts/verify/verify-forum-search-projection.mjs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-public-discovery-seo.json",
+  "invalidation_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json",
   "source_boundary": {
     "neutral_capability_has_no_forum_dependency": true,
     "neutral_capability_has_no_search_storage_or_query_logic": true,
@@ -64,11 +65,15 @@
     "explicit_forum_scope_reindex_supported": true,
     "explicit_forum_category_reindex_supported": true,
     "explicit_forum_topic_reindex_supported": true,
-    "automatic_category_policy_change_reindex_added": false,
-    "automatic_topic_policy_change_reindex_added": false,
-    "automatic_topic_content_translation_tag_solution_change_reindex_added": false,
-    "automatic_category_content_translation_tree_change_reindex_added": false,
-    "reply_documents_projected": false
+    "automatic_category_policy_change_reindex_added": true,
+    "automatic_topic_policy_change_reindex_added": true,
+    "automatic_topic_content_translation_tag_solution_change_reindex_added": true,
+    "automatic_category_content_translation_tree_change_reindex_added": true,
+    "automatic_category_and_reply_count_reindex_added": true,
+    "owner_transactional_outbox_delivery_added": true,
+    "root_reindex_event_schema_changed": false,
+    "reply_documents_projected": false,
+    "completion_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json"
   },
   "compatibility": {
     "existing_search_product_content_blog_projection_changed": false,
@@ -92,26 +97,26 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API, the Search owner plan and the canonical FORUM-20/FORUM-23 ledgers through FORUM-20BJ with conflict-safe repository-local edits after maintainer validation."
+    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-20/FORUM-23 ledgers through FORUM-20BK with conflict-safe repository-local edits after maintainer validation."
   },
   "remaining_scope": [
-    "publish owner-transactional projection invalidation events for category and topic content translations visibility policies tags solution state and tree or route changes",
-    "route those events to bounded category topic or tenant projection reauthorization with durable ordering",
     "decide whether approved public replies become separate Search documents under FORUM-23",
     "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
     "add visibility-scoped category and all-read commands",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
-    "capture maintainer-executed PostgreSQL projection event cleanup and query runtime evidence"
+    "capture maintainer-executed PostgreSQL and SQLite projection event cleanup and query runtime evidence",
+    "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
   ],
-  "downstream_task": "FORUM-20BK",
+  "downstream_task": "FORUM-20BL",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
       "cargo test -p rustok-core search_projection -- --nocapture",
+      "cargo test -p rustok-outbox transactional -- --nocapture",
       "cargo test -p rustok-search forum_projector -- --nocapture",
-      "cargo test -p rustok-forum search_projection -- --nocapture",
-      "node scripts/verify/verify-forum-public-discovery-seo.mjs",
+      "cargo test -p rustok-forum projection_invalidation -- --nocapture",
       "node scripts/verify/verify-forum-search-projection.mjs",
+      "node scripts/verify/verify-forum-projection-invalidation.mjs",
       "node scripts/verify/verify-search-canonical-url-contract.mjs",
       "cargo xtask module validate forum"
     ]

--- a/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
+++ b/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
@@ -1,9 +1,10 @@
 # FORUM-20BK — owner-transactional Search projection invalidation
 
 `FORUM-20BK` closes the canonical mutation-to-Search gap left by the initial
-Forum projection consumer. Forum owner transactions now insert durable
-`search.reindex_requested` events for every canonical mutation that can change
-an exact public category or topic document.
+Forum projection consumer. On the supported PostgreSQL Search runtime, Forum
+owner transactions now insert durable `search.reindex_requested` events for
+every canonical mutation that can change an exact public category or topic
+document.
 
 ## Existing event contract
 
@@ -25,6 +26,13 @@ entry point. It preserves both `DomainEvent::validate()` and registered envelope
 schema validation, then writes to the canonical `sys_events` outbox through the
 owner transaction. Domain services therefore do not create a second database
 connection and do not reproduce the event envelope in SQL.
+
+The Search-owned Forum projector is PostgreSQL-only. Direct invalidation helpers
+therefore persist to the outbox on PostgreSQL and perform event validation only
+on SQLite or another unsupported projector backend. This keeps standalone Forum
+SQLite domain fixtures independent from an unused Search/outbox schema rather
+than silently creating runtime tables. Existing owner paths that already carry
+a configured event bus keep their established transport behavior.
 
 ## Invalidation scopes
 
@@ -90,22 +98,24 @@ keeping read-only internal composers free to use private read implementations.
 
 ## Delivery and idempotency
 
-The canonical outbox is at-least-once. A command may legitimately produce both
-an existing lifecycle event and one `ReindexRequested` event, and dispatcher
-retries can redeliver either. Search target refresh and Forum scope replacement
-are idempotent: they derive current exact owner state rather than applying a
-projection delta.
+The canonical PostgreSQL outbox is at-least-once. A command may legitimately
+produce both an existing lifecycle event and one `ReindexRequested` event, and
+dispatcher retries can redeliver either. Search target refresh and Forum scope
+replacement are idempotent: they derive current exact owner state rather than
+applying a projection delta.
 
-An owner write and its invalidation either commit together or roll back
-together. A later Search failure leaves the outbox event retryable. The broader
-multi-source full Search rebuild is still not one transaction across all source
-modules; that limitation remains downstream.
+On PostgreSQL, an owner write and its invalidation either commit together or
+roll back together. A later Search failure leaves the outbox event retryable.
+The broader multi-source full Search rebuild is still not one transaction across
+all source modules; that limitation remains downstream.
 
 ## Compatibility and remaining work
 
 No route, GraphQL field, public DTO, workspace dependency, lockfile or migration
 changes are introduced. Forum remains usable without an active Search listener;
-its outbox events simply have no matching consumer when Search is absent.
+its PostgreSQL outbox events simply have no matching consumer when Search is
+absent. SQLite Forum domain fixtures do not require an outbox migration because
+there is no supported SQLite Forum Search projector.
 
 Forum categories and topics are not currently registered as translation-control
 plane targets. If that integration is added later, its owner transaction must

--- a/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
+++ b/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
@@ -1,0 +1,119 @@
+# FORUM-20BK — owner-transactional Search projection invalidation
+
+`FORUM-20BK` closes the canonical mutation-to-Search gap left by the initial
+Forum projection consumer. Forum owner transactions now insert durable
+`search.reindex_requested` events for every canonical mutation that can change
+an exact public category or topic document.
+
+## Existing event contract
+
+The slice reuses the registered root event:
+
+```text
+DomainEvent::ReindexRequested { target_type, target_id }
+```
+
+No new root event variant, event schema or migration is added. The existing
+Search ingestion handler from `FORUM-20BJ` already maps:
+
+- `forum` with no ID to a complete Forum projection rebuild;
+- `forum_category` with an ID to one category refresh;
+- `forum_topic` with an ID to one topic refresh.
+
+`TransactionalEventBus::publish_root_in_tx` is the new transaction-only outbox
+entry point. It preserves both `DomainEvent::validate()` and registered envelope
+schema validation, then writes to the canonical `sys_events` outbox through the
+owner transaction. Domain services therefore do not create a second database
+connection and do not reproduce the event envelope in SQL.
+
+## Invalidation scopes
+
+### Full Forum scope
+
+A category affects more than its own document. Category copy is used as the
+subtitle of topic results, and hierarchy, lifecycle, base visibility and richer
+audience layers can change inherited visibility for an entire subtree.
+Therefore these canonical writes publish `target_type = "forum"`:
+
+- category create and category content or locale update;
+- category move and sibling reorder;
+- category subtree archive, delete-as-archive and restore;
+- base category visibility replacement;
+- richer inherited category audience replacement.
+
+Lifecycle no-ops do not publish an event because no projection state changed.
+Posting, reply-create and moderation authorization policies are not discovery
+policies and do not invalidate Search documents.
+
+### Category target
+
+Category documents include topic and approved-reply counters. These canonical
+writes publish `target_type = "forum_category"` with the owning category ID:
+
+- topic create;
+- topic delete;
+- approved reply create or delete;
+- moderation transitions into or out of approved reply state.
+
+A reply transition that does not change public counters does not publish a
+category invalidation. Existing reply/topic lifecycle events still refresh the
+topic document itself.
+
+### Topic target
+
+Topic-local projected state publishes `target_type = "forum_topic"` with the
+topic ID:
+
+- content, locale, metadata, tags or route-channel update;
+- delete, including an already-archived topic where no new status event exists;
+- lock or unlock;
+- solution mark or clear;
+- topic-local audience replacement.
+
+Existing topic create, status and pin events already refresh the topic. Duplicate
+refreshes are acceptable when an owner command also changes another projection
+scope.
+
+## Public owner sealing
+
+The raw category and topic mutation implementations remain crate-private.
+Category content, placement and lifecycle writes are routed through private
+same-module transactional owner wrappers. Public category and topic audience
+service names now alias wrappers that delegate reads but own policy replacement.
+
+Moderation is exposed through a public facade. Its transactional owner and the
+legacy delegate are private, so callers cannot construct a bypass around reply
+counter, lock or solution invalidation.
+
+This owner composition preserves REST, GraphQL and native call signatures while
+keeping read-only internal composers free to use private read implementations.
+
+## Delivery and idempotency
+
+The canonical outbox is at-least-once. A command may legitimately produce both
+an existing lifecycle event and one `ReindexRequested` event, and dispatcher
+retries can redeliver either. Search target refresh and Forum scope replacement
+are idempotent: they derive current exact owner state rather than applying a
+projection delta.
+
+An owner write and its invalidation either commit together or roll back
+together. A later Search failure leaves the outbox event retryable. The broader
+multi-source full Search rebuild is still not one transaction across all source
+modules; that limitation remains downstream.
+
+## Compatibility and remaining work
+
+No route, GraphQL field, public DTO, workspace dependency, lockfile or migration
+changes are introduced. Forum remains usable without an active Search listener;
+its outbox events simply have no matching consumer when Search is absent.
+
+Forum categories and topics are not currently registered as translation-control
+plane targets. If that integration is added later, its owner transaction must
+publish the same category or topic invalidation rather than writing translations
+behind these canonical owners.
+
+`implementation-plan.md`, `CRATE_API.md` and the Search owner plan remain
+conflict-sensitive synchronization debt. Tests, Cargo commands, formatting,
+verifiers, workflows and CI were not run by the implementation agent. Suggested
+maintainer commands are recorded in
+`contracts/forum-projection-invalidation.json`.

--- a/crates/rustok-forum/src/services/category_audience_owner.rs
+++ b/crates/rustok-forum/src/services/category_audience_owner.rs
@@ -1,0 +1,76 @@
+use std::ops::Deref;
+
+/// Transactional owner facade for category audience policy replacement.
+///
+/// Read operations continue through the established service. Replacement is
+/// repeated here inside the same module so private normalized storage helpers
+/// remain the single persistence implementation and the full Forum projection
+/// invalidation shares the owner transaction.
+pub struct ForumCategoryAudiencePolicyOwnerService {
+    inner: ForumCategoryAudiencePolicyService,
+    db: DatabaseConnection,
+}
+
+impl ForumCategoryAudiencePolicyOwnerService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: ForumCategoryAudiencePolicyService::new(db.clone()),
+            db,
+        }
+    }
+
+    pub async fn set(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: SetForumCategoryAudiencePolicyInput,
+    ) -> ForumResult<ForumCategoryAudiencePolicy> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        let constraints = input.constraints.normalize()?;
+
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+        load_category_ancestor_ids(&txn, tenant_id, category_id).await?;
+
+        forum_category_audience_policy::Entity::delete_many()
+            .filter(forum_category_audience_policy::Column::TenantId.eq(tenant_id))
+            .filter(forum_category_audience_policy::Column::CategoryId.eq(category_id))
+            .exec(&txn)
+            .await?;
+
+        if !constraints_are_empty(&constraints) {
+            forum_category_audience_policy::ActiveModel {
+                tenant_id: Set(tenant_id),
+                category_id: Set(category_id),
+                minimum_trust_level: Set(constraints.minimum_trust_level.map(i16::from)),
+                updated_at: Set(Utc::now().into()),
+            }
+            .insert(&txn)
+            .await?;
+
+            insert_roles(&txn, tenant_id, category_id, &constraints).await?;
+            insert_channels(&txn, tenant_id, category_id, &constraints).await?;
+            insert_groups(&txn, tenant_id, category_id, &constraints).await?;
+            insert_users(&txn, tenant_id, category_id, &constraints).await?;
+        }
+
+        let result = load_category_audience_policy(&txn, tenant_id, category_id).await?;
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(result)
+    }
+}
+
+impl Deref for ForumCategoryAudiencePolicyOwnerService {
+    type Target = ForumCategoryAudiencePolicyService;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/crates/rustok-forum/src/services/category_audience_owner.rs
+++ b/crates/rustok-forum/src/services/category_audience_owner.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 /// Transactional owner facade for category audience policy replacement.
 ///
 /// Read operations continue through the established service. Replacement is
@@ -17,6 +15,15 @@ impl ForumCategoryAudiencePolicyOwnerService {
             inner: ForumCategoryAudiencePolicyService::new(db.clone()),
             db,
         }
+    }
+
+    pub async fn get(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<ForumCategoryAudiencePolicy> {
+        self.inner.get(tenant_id, category_id, security).await
     }
 
     pub async fn set(
@@ -64,13 +71,5 @@ impl ForumCategoryAudiencePolicyOwnerService {
         .await?;
         txn.commit().await?;
         Ok(result)
-    }
-}
-
-impl Deref for ForumCategoryAudiencePolicyOwnerService {
-    type Target = ForumCategoryAudiencePolicyService;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }

--- a/crates/rustok-forum/src/services/category_command_owner.rs
+++ b/crates/rustok-forum/src/services/category_command_owner.rs
@@ -1,0 +1,151 @@
+/// Transactional category placement owner with full Forum projection invalidation.
+pub(super) struct CategoryCommandProjectionOwnerService {
+    db: DatabaseConnection,
+}
+
+impl CategoryCommandProjectionOwnerService {
+    pub(super) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub(super) async fn move_category(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: MoveCategoryInput,
+    ) -> ForumResult<MoveCategoryResponse> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+
+        let categories = load_categories_in_tx(&txn, tenant_id).await?;
+        let models = categories
+            .iter()
+            .cloned()
+            .map(|category| (category.id, category))
+            .collect::<HashMap<_, _>>();
+        let category = models
+            .get(&category_id)
+            .cloned()
+            .ok_or(ForumError::CategoryNotFound(category_id))?;
+        ensure_parent_exists(&models, input.parent_id)?;
+
+        let mut parent_by_id = models
+            .values()
+            .map(|category| (category.id, category.parent_id))
+            .collect::<HashMap<_, _>>();
+        validate_parent_map(&parent_by_id)?;
+        parent_by_id.insert(category_id, input.parent_id);
+        validate_parent_map(&parent_by_id)?;
+
+        let source_parent_id = category.parent_id;
+        let target_index = input.position as usize;
+        let updated = if source_parent_id == input.parent_id {
+            let mut siblings = sibling_ids(&categories, source_parent_id, Some(category_id));
+            if target_index > siblings.len() {
+                return Err(ForumError::Validation(format!(
+                    "Category position {} exceeds sibling count {}",
+                    input.position,
+                    siblings.len()
+                )));
+            }
+            siblings.insert(target_index, category_id);
+            persist_sibling_order(&txn, &models, source_parent_id, &siblings).await?
+        } else {
+            let source_siblings = sibling_ids(&categories, source_parent_id, Some(category_id));
+            let mut target_siblings = sibling_ids(&categories, input.parent_id, None);
+            if target_index > target_siblings.len() {
+                return Err(ForumError::Validation(format!(
+                    "Category position {} exceeds destination sibling count {}",
+                    input.position,
+                    target_siblings.len()
+                )));
+            }
+            target_siblings.insert(target_index, category_id);
+
+            let mut updated =
+                persist_sibling_order(&txn, &models, source_parent_id, &source_siblings).await?;
+            updated.extend(
+                persist_sibling_order(&txn, &models, input.parent_id, &target_siblings).await?,
+            );
+            updated
+        };
+
+        let moved = updated
+            .iter()
+            .find(|placement| placement.id == category_id)
+            .cloned()
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Moved category was not persisted in sibling order".to_string(),
+                )
+            })?;
+
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(MoveCategoryResponse { moved, updated })
+    }
+
+    pub(super) async fn reorder_siblings(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        input: ReorderCategorySiblingsInput,
+    ) -> ForumResult<ReorderCategorySiblingsResponse> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        if input.ordered_category_ids.len() > MAX_FORUM_CATEGORY_TREE_NODES as usize {
+            return Err(ForumError::Validation(format!(
+                "Category sibling order exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES}"
+            )));
+        }
+
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+        let categories = load_categories_in_tx(&txn, tenant_id).await?;
+        let models = categories
+            .iter()
+            .cloned()
+            .map(|category| (category.id, category))
+            .collect::<HashMap<_, _>>();
+        ensure_parent_exists(&models, input.parent_id)?;
+        let parent_by_id = models
+            .values()
+            .map(|category| (category.id, category.parent_id))
+            .collect::<HashMap<_, _>>();
+        validate_parent_map(&parent_by_id)?;
+
+        let current = sibling_ids(&categories, input.parent_id, None);
+        let requested = input.ordered_category_ids;
+        let requested_set = requested.iter().copied().collect::<HashSet<_>>();
+        let current_set = current.iter().copied().collect::<HashSet<_>>();
+        if requested_set.len() != requested.len() {
+            return Err(ForumError::Validation(
+                "Category sibling order contains duplicate category ids".to_string(),
+            ));
+        }
+        if requested_set != current_set || requested.len() != current.len() {
+            return Err(ForumError::Validation(
+                "Category sibling order must contain every direct child exactly once".to_string(),
+            ));
+        }
+
+        let siblings = persist_sibling_order(&txn, &models, input.parent_id, &requested).await?;
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(ReorderCategorySiblingsResponse {
+            parent_id: input.parent_id,
+            siblings,
+        })
+    }
+}

--- a/crates/rustok-forum/src/services/category_lifecycle_owner.rs
+++ b/crates/rustok-forum/src/services/category_lifecycle_owner.rs
@@ -1,0 +1,145 @@
+/// Transactional category lifecycle owner with inherited projection invalidation.
+pub(super) struct CategoryLifecycleProjectionOwnerService {
+    db: DatabaseConnection,
+}
+
+impl CategoryLifecycleProjectionOwnerService {
+    pub(super) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub(super) async fn archive_subtree(
+        &self,
+        tenant_id: Uuid,
+        root_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<CategorySubtreeLifecycleResponse> {
+        self.set_subtree_archived(tenant_id, root_id, security, true, Action::Manage)
+            .await
+    }
+
+    pub(super) async fn archive_subtree_for_delete(
+        &self,
+        tenant_id: Uuid,
+        root_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<CategorySubtreeLifecycleResponse> {
+        self.set_subtree_archived(tenant_id, root_id, security, true, Action::Delete)
+            .await
+    }
+
+    pub(super) async fn restore_subtree(
+        &self,
+        tenant_id: Uuid,
+        root_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<CategorySubtreeLifecycleResponse> {
+        self.set_subtree_archived(tenant_id, root_id, security, false, Action::Manage)
+            .await
+    }
+
+    async fn set_subtree_archived(
+        &self,
+        tenant_id: Uuid,
+        root_id: Uuid,
+        security: SecurityContext,
+        archived: bool,
+        required_action: Action,
+    ) -> ForumResult<CategorySubtreeLifecycleResponse> {
+        enforce_scope(&security, Resource::ForumCategories, required_action)?;
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+
+        let categories = load_categories_in_tx(&txn, tenant_id).await?;
+        let models = categories
+            .iter()
+            .cloned()
+            .map(|category| (category.id, category))
+            .collect::<HashMap<_, _>>();
+        let root = models
+            .get(&root_id)
+            .cloned()
+            .ok_or(ForumError::CategoryNotFound(root_id))?;
+        validate_parent_map(&models)?;
+
+        let lifecycle_rows = forum_category_lifecycle::Entity::find()
+            .filter(forum_category_lifecycle::Column::TenantId.eq(tenant_id))
+            .all(&txn)
+            .await?;
+        let lifecycle_by_category = lifecycle_rows
+            .into_iter()
+            .map(|lifecycle| (lifecycle.category_id, lifecycle))
+            .collect::<HashMap<_, _>>();
+
+        let affected_category_ids = collect_subtree_ids(&categories, root_id)?;
+        if !archived {
+            ensure_restore_ancestors_are_active(&models, &lifecycle_by_category, &root)?;
+        }
+
+        let now = Utc::now();
+        let mut update_ids = affected_category_ids.clone();
+        if archived {
+            update_ids.reverse();
+        }
+
+        let mut changed = HashSet::new();
+        for category_id in update_ids {
+            let is_archived = lifecycle_by_category.contains_key(&category_id);
+            if is_archived == archived {
+                continue;
+            }
+
+            if archived {
+                forum_category_lifecycle::ActiveModel {
+                    category_id: Set(category_id),
+                    tenant_id: Set(tenant_id),
+                    archived_at: Set(now.into()),
+                    updated_at: Set(now.into()),
+                }
+                .insert(&txn)
+                .await?;
+            } else {
+                forum_category_lifecycle::Entity::delete_many()
+                    .filter(forum_category_lifecycle::Column::TenantId.eq(tenant_id))
+                    .filter(forum_category_lifecycle::Column::CategoryId.eq(category_id))
+                    .exec(&txn)
+                    .await?;
+            }
+            changed.insert(category_id);
+        }
+
+        if !changed.is_empty() {
+            super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+                &txn,
+                tenant_id,
+                security.user_id,
+            )
+            .await?;
+        }
+        txn.commit().await?;
+
+        let changed_category_ids = affected_category_ids
+            .iter()
+            .copied()
+            .filter(|category_id| changed.contains(category_id))
+            .collect::<Vec<_>>();
+        let archived_at = if archived {
+            lifecycle_by_category
+                .get(&root_id)
+                .map(|lifecycle| lifecycle.archived_at.to_rfc3339())
+                .or_else(|| Some(now.to_rfc3339()))
+        } else {
+            None
+        };
+
+        Ok(CategorySubtreeLifecycleResponse {
+            root_id,
+            archived,
+            archived_at,
+            affected_count: affected_category_ids.len() as u32,
+            changed_count: changed_category_ids.len() as u32,
+            affected_category_ids,
+            changed_category_ids,
+        })
+    }
+}

--- a/crates/rustok-forum/src/services/category_owner.rs
+++ b/crates/rustok-forum/src/services/category_owner.rs
@@ -23,9 +23,9 @@ use super::{category, category_command, category_lifecycle, category_policy, cat
 /// kept crate-private so callers cannot bypass placement, lifecycle or policy
 /// commands through `Deref`.
 pub struct CategoryService {
-    inner: category::CategoryService,
-    commands: category_command::CategoryCommandService,
-    lifecycle: category_lifecycle::CategoryLifecycleService,
+    inner: category::CategoryProjectionOwnerService,
+    commands: category_command::CategoryCommandProjectionOwnerService,
+    lifecycle: category_lifecycle::CategoryLifecycleProjectionOwnerService,
     policy: category_policy::CategoryTopicPolicyService,
     tree: category_tree::CategoryTreeService,
     visibility: ForumCategoryVisibilityPolicyService,
@@ -34,9 +34,9 @@ pub struct CategoryService {
 impl CategoryService {
     pub fn new(db: DatabaseConnection) -> Self {
         Self {
-            inner: category::CategoryService::new(db.clone()),
-            commands: category_command::CategoryCommandService::new(db.clone()),
-            lifecycle: category_lifecycle::CategoryLifecycleService::new(db.clone()),
+            inner: category::CategoryProjectionOwnerService::new(db.clone()),
+            commands: category_command::CategoryCommandProjectionOwnerService::new(db.clone()),
+            lifecycle: category_lifecycle::CategoryLifecycleProjectionOwnerService::new(db.clone()),
             policy: category_policy::CategoryTopicPolicyService::new(db.clone()),
             tree: category_tree::CategoryTreeService::new(db.clone()),
             visibility: ForumCategoryVisibilityPolicyService::new(db),

--- a/crates/rustok-forum/src/services/category_projection_owner.rs
+++ b/crates/rustok-forum/src/services/category_projection_owner.rs
@@ -1,0 +1,228 @@
+use std::ops::Deref;
+
+/// Transactional owner facade for category content mutations.
+///
+/// Read methods remain delegated to the established category service. Create,
+/// update and compatibility delete reuse the same private validators and tree
+/// helpers from this module while adding a full Forum projection invalidation
+/// before commit because category copy and ancestry affect topic documents.
+pub(super) struct CategoryProjectionOwnerService {
+    inner: CategoryService,
+    db: DatabaseConnection,
+}
+
+impl CategoryProjectionOwnerService {
+    pub(super) fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: CategoryService::new(db.clone()),
+            db,
+        }
+    }
+
+    #[instrument(skip(self, security, input))]
+    pub(super) async fn create(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        input: CreateCategoryInput,
+    ) -> ForumResult<CategoryResponse> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Create)?;
+        validate_category_name(&input.name)?;
+        let locale = normalize_locale(&input.locale)?;
+        let slug = normalize_required_slug(&input.slug)?;
+        let requested_position = input.position.unwrap_or(0);
+        if requested_position < 0 {
+            return Err(ForumError::Validation(
+                "Category position cannot be negative".to_string(),
+            ));
+        }
+
+        let now = Utc::now();
+        let id = Uuid::new_v4();
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+
+        if let Some(parent_id) = input.parent_id {
+            CategoryService::find_category_in_tx(&txn, tenant_id, parent_id).await?;
+        }
+
+        shift_siblings_for_insert_in_tx(&txn, tenant_id, input.parent_id, requested_position, now)
+            .await?;
+
+        forum_category::ActiveModel {
+            id: Set(id),
+            tenant_id: Set(tenant_id),
+            parent_id: Set(input.parent_id),
+            position: Set(requested_position),
+            icon: Set(input.icon),
+            color: Set(input.color),
+            moderated: Set(input.moderated),
+            topic_count: Set(0),
+            reply_count: Set(0),
+            created_at: Set(now.into()),
+            updated_at: Set(now.into()),
+        }
+        .insert(&txn)
+        .await?;
+
+        forum_category_translation::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            category_id: Set(id),
+            tenant_id: Set(tenant_id),
+            locale: Set(locale.clone()),
+            name: Set(input.name),
+            slug: Set(slug),
+            description: Set(input.description),
+        }
+        .insert(&txn)
+        .await?;
+
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        self.inner.get(tenant_id, security, id, &locale).await
+    }
+
+    #[instrument(skip(self, security, input))]
+    pub(super) async fn update(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        input: UpdateCategoryInput,
+    ) -> ForumResult<CategoryResponse> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Update)?;
+        let locale = normalize_locale(&input.locale)?;
+        let txn = self.db.begin().await?;
+        let category = forum_category::Entity::find_by_id(category_id)
+            .filter(forum_category::Column::TenantId.eq(tenant_id))
+            .one(&txn)
+            .await?
+            .ok_or(ForumError::CategoryNotFound(category_id))?;
+
+        let mut active: forum_category::ActiveModel = category.into();
+        active.updated_at = Set(Utc::now().into());
+        if let Some(position) = input.position {
+            active.position = Set(position);
+        }
+        if input.icon.is_some() {
+            active.icon = Set(input.icon);
+        }
+        if input.color.is_some() {
+            active.color = Set(input.color);
+        }
+        if let Some(moderated) = input.moderated {
+            active.moderated = Set(moderated);
+        }
+        active.update(&txn).await?;
+
+        let existing_translation = forum_category_translation::Entity::find()
+            .filter(forum_category_translation::Column::TenantId.eq(tenant_id))
+            .filter(forum_category_translation::Column::CategoryId.eq(category_id))
+            .filter(forum_category_translation::Column::Locale.eq(&locale))
+            .one(&txn)
+            .await?;
+
+        match existing_translation {
+            Some(existing_translation) => {
+                let mut active: forum_category_translation::ActiveModel =
+                    existing_translation.into();
+                if let Some(name) = input.name {
+                    validate_category_name(&name)?;
+                    active.name = Set(name.clone());
+                    if input.slug.is_none() {
+                        active.slug = Set(normalize_slug(&name));
+                    }
+                }
+                if let Some(slug) = input.slug.as_deref() {
+                    active.slug = Set(normalize_required_slug(slug)?);
+                }
+                if input.description.is_some() {
+                    active.description = Set(input.description);
+                }
+                active.update(&txn).await?;
+            }
+            None => {
+                let name = input.name.ok_or_else(|| {
+                    ForumError::Validation("Category name is required".to_string())
+                })?;
+                validate_category_name(&name)?;
+                let slug = input
+                    .slug
+                    .as_deref()
+                    .map(normalize_required_slug)
+                    .transpose()?
+                    .unwrap_or_else(|| normalize_slug(&name));
+
+                forum_category_translation::ActiveModel {
+                    id: Set(Uuid::new_v4()),
+                    category_id: Set(category_id),
+                    tenant_id: Set(tenant_id),
+                    locale: Set(locale.clone()),
+                    name: Set(name),
+                    slug: Set(slug),
+                    description: Set(input.description),
+                }
+                .insert(&txn)
+                .await?;
+            }
+        }
+
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        self.inner
+            .get(tenant_id, security, category_id, &locale)
+            .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub(super) async fn delete(
+        &self,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Delete)?;
+        let txn = self.db.begin().await?;
+        let category = forum_category::Entity::find_by_id(category_id)
+            .filter(forum_category::Column::TenantId.eq(tenant_id))
+            .one(&txn)
+            .await?
+            .ok_or(ForumError::CategoryNotFound(category_id))?;
+
+        forum_category_translation::Entity::delete_many()
+            .filter(forum_category_translation::Column::TenantId.eq(tenant_id))
+            .filter(forum_category_translation::Column::CategoryId.eq(category_id))
+            .exec(&txn)
+            .await?;
+        forum_category::Entity::delete_by_id(category.id)
+            .exec(&txn)
+            .await?;
+
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+}
+
+impl Deref for CategoryProjectionOwnerService {
+    type Target = CategoryService;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/crates/rustok-forum/src/services/category_visibility.rs
+++ b/crates/rustok-forum/src/services/category_visibility.rs
@@ -17,6 +17,7 @@ use rustok_core::SecurityContext;
 use crate::dto::{MAX_FORUM_CATEGORY_TREE_DEPTH, MAX_FORUM_CATEGORY_TREE_NODES};
 use crate::entities::{forum_category, forum_category_policy};
 use crate::error::{ForumError, ForumResult};
+use crate::services::projection_invalidation::publish_forum_projection_scope_direct_in_tx;
 use crate::services::rbac::enforce_scope;
 use crate::visibility::ForumCategoryVisibility;
 
@@ -120,6 +121,12 @@ impl ForumCategoryVisibilityPolicyService {
         let result = CategoryVisibilitySnapshot::load(&txn, tenant_id)
             .await?
             .policy(category_id)?;
+        publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+        )
+        .await?;
         txn.commit().await?;
         Ok(result)
     }
@@ -264,15 +271,15 @@ impl CategoryVisibilitySnapshot {
                     "Forum category visibility tree contains a hierarchy cycle".to_string(),
                 ));
             }
-            if self.overrides.get(&current_id) == Some(&ForumCategoryVisibility::Authenticated) {
+            if let Some(visibility) = self.overrides.get(&current_id).copied() {
                 return Ok(ResolvedVisibility {
-                    effective_visibility: ForumCategoryVisibility::Authenticated,
+                    effective_visibility: visibility,
                     effective_from_category_id: Some(current_id),
                 });
             }
             current = self.parents.get(&current_id).copied().ok_or_else(|| {
                 ForumError::Validation(format!(
-                    "Forum category visibility tree references missing or foreign category {current_id}"
+                    "Forum category visibility tree references missing category {current_id}"
                 ))
             })?;
             depth += 1;
@@ -285,6 +292,7 @@ impl CategoryVisibilitySnapshot {
     }
 }
 
+#[derive(Clone, Copy)]
 struct ResolvedVisibility {
     effective_visibility: ForumCategoryVisibility,
     effective_from_category_id: Option<Uuid>,

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -5,7 +5,10 @@ mod category {
     include!("category.rs");
     include!("category_visibility_list.rs");
 }
-mod category_audience;
+mod category_audience {
+    include!("category_audience.rs");
+    include!("category_audience_owner.rs");
+}
 mod category_audience_read {
     include!("category_audience_read.rs");
     include!("category_audience_read_inline.rs");
@@ -76,6 +79,7 @@ mod topic {
 }
 mod topic_audience {
     include!("topic_audience.rs");
+    include!("topic_audience_owner.rs");
 }
 mod topic_audience_visibility;
 mod topic_audience_list;
@@ -96,7 +100,8 @@ pub mod widget_contract;
 
 pub use category_audience::{
     ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
-    ForumCategoryAudiencePolicyService, SetForumCategoryAudiencePolicyInput,
+    ForumCategoryAudiencePolicyOwnerService as ForumCategoryAudiencePolicyService,
+    SetForumCategoryAudiencePolicyInput,
 };
 pub use category_audience_read::{
     ForumCategoryAudiencePage, ForumCategoryAudienceReadService,
@@ -172,7 +177,8 @@ pub use storefront_read_state::{
 };
 pub use subscription::SubscriptionService;
 pub use topic_audience::{
-    ForumTopicAudiencePolicy, ForumTopicAudiencePolicyService, SetForumTopicAudiencePolicyInput,
+    ForumTopicAudiencePolicy, ForumTopicAudiencePolicyOwnerService as ForumTopicAudiencePolicyService,
+    SetForumTopicAudiencePolicyInput,
 };
 pub use topic_audience_visibility::{
     ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService,

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -40,6 +40,7 @@ mod posting_policy_create_window_facts;
 mod posting_policy_evaluator;
 mod posting_policy_facts;
 mod posting_policy_reading_facts;
+mod projection_invalidation;
 mod public_discovery;
 mod quote_command;
 mod rbac;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -3,6 +3,7 @@
 mod bounded_compat;
 mod category {
     include!("category.rs");
+    include!("category_projection_owner.rs");
     include!("category_visibility_list.rs");
 }
 mod category_audience {
@@ -15,8 +16,14 @@ mod category_audience_read {
 }
 mod category_audience_visibility;
 #[allow(clippy::collapsible_if)]
-mod category_command;
-mod category_lifecycle;
+mod category_command {
+    include!("category_command.rs");
+    include!("category_command_owner.rs");
+}
+mod category_lifecycle {
+    include!("category_lifecycle.rs");
+    include!("category_lifecycle_owner.rs");
+}
 mod category_moderation_audience;
 mod category_owner;
 mod category_policy;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -44,6 +44,8 @@ mod mention_relation_tests {
 }
 #[path = "moderation.rs"]
 mod moderation_legacy;
+#[doc(hidden)]
+pub use moderation_legacy::ModerationService as __ModerationServiceLegacyTarget;
 mod moderation_owner;
 pub mod moderation {
     pub use super::moderation_owner::ModerationService;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -44,11 +44,10 @@ mod mention_relation_tests {
 }
 #[path = "moderation.rs"]
 mod moderation_legacy;
-#[doc(hidden)]
-pub use moderation_legacy::ModerationService as __ModerationServiceLegacyTarget;
 mod moderation_owner;
+mod moderation_public_owner;
 pub mod moderation {
-    pub use super::moderation_owner::ModerationService;
+    pub use super::moderation_public_owner::ModerationService;
 }
 mod moderation_audience_authorization;
 mod posting_policy;
@@ -186,7 +185,8 @@ pub use storefront_read_state::{
 };
 pub use subscription::SubscriptionService;
 pub use topic_audience::{
-    ForumTopicAudiencePolicy, ForumTopicAudiencePolicyOwnerService as ForumTopicAudiencePolicyService,
+    ForumTopicAudiencePolicy,
+    ForumTopicAudiencePolicyOwnerService as ForumTopicAudiencePolicyService,
     SetForumTopicAudiencePolicyInput,
 };
 pub use topic_audience_visibility::{

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -32,7 +32,12 @@ mod mention_relation_tests {
     include!("mention_relation_tests.rs");
     include!("relation_quote_input_tests.rs");
 }
-pub mod moderation;
+#[path = "moderation.rs"]
+mod moderation_legacy;
+mod moderation_owner;
+pub mod moderation {
+    pub use super::moderation_owner::ModerationService;
+}
 mod moderation_audience_authorization;
 mod posting_policy;
 mod posting_policy_approved_facts;

--- a/crates/rustok-forum/src/services/moderation_owner.rs
+++ b/crates/rustok-forum/src/services/moderation_owner.rs
@@ -1,0 +1,571 @@
+use std::ops::Deref;
+
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    TransactionTrait,
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use rustok_api::PortContext;
+use rustok_core::SecurityContext;
+use rustok_events::DomainEvent;
+use rustok_outbox::TransactionalEventBus;
+
+use crate::audience::SharedForumAudienceFactsPort;
+use crate::entities::forum_solution;
+use crate::error::{ForumError, ForumResult};
+use crate::services::moderation_audience_authorization::ForumModerationAudienceAuthorizationService;
+use crate::services::projection_invalidation::{
+    publish_forum_category_projection_in_tx, publish_forum_topic_projection_in_tx,
+};
+use crate::services::user_stats::UserStatsService;
+use crate::services::{CategoryService, ReplyService, TopicService};
+use crate::state_machine::ReplyStatus;
+
+/// Compatibility owner wrapper around the established moderation service.
+///
+/// Existing moderation operations remain delegated through `Deref`. The
+/// projection-affecting operations that previously lacked root events are
+/// implemented here so their `ReindexRequested` invalidation is inserted into
+/// the same owner transaction.
+pub struct ModerationService {
+    inner: super::moderation_legacy::ModerationService,
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+    audience: ForumModerationAudienceAuthorizationService,
+}
+
+impl ModerationService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        let audience =
+            ForumModerationAudienceAuthorizationService::without_facts_provider(db.clone());
+        Self {
+            inner: super::moderation_legacy::ModerationService::new(
+                db.clone(),
+                event_bus.clone(),
+            ),
+            db,
+            event_bus,
+            audience,
+        }
+    }
+
+    pub fn with_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        facts: SharedForumAudienceFactsPort,
+    ) -> Self {
+        let audience = ForumModerationAudienceAuthorizationService::new(db.clone(), Some(facts.clone()));
+        Self {
+            inner: super::moderation_legacy::ModerationService::with_audience_facts(
+                db.clone(),
+                event_bus.clone(),
+                facts,
+            ),
+            db,
+            event_bus,
+            audience,
+        }
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn approve_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            None,
+            ReplyStatus::Approved,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn approve_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            Some(context),
+            ReplyStatus::Approved,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn reject_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            None,
+            ReplyStatus::Rejected,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn reject_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            Some(context),
+            ReplyStatus::Rejected,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn hide_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            None,
+            ReplyStatus::Hidden,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn hide_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.moderate_reply_status(
+            tenant_id,
+            reply_id,
+            topic_id,
+            security,
+            Some(context),
+            ReplyStatus::Hidden,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn lock_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.set_topic_locked(tenant_id, topic_id, security, None, true)
+            .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn lock_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.set_topic_locked(tenant_id, topic_id, security, Some(context), true)
+            .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn unlock_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.set_topic_locked(tenant_id, topic_id, security, None, false)
+            .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn unlock_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.set_topic_locked(tenant_id, topic_id, security, Some(context), false)
+            .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn mark_solution(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        reply_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.mark_solution_with_optional_audience_context(
+            tenant_id, topic_id, reply_id, security, None,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn mark_solution_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        reply_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.mark_solution_with_optional_audience_context(
+            tenant_id,
+            topic_id,
+            reply_id,
+            security,
+            Some(context),
+        )
+        .await
+    }
+
+    #[instrument(skip(self, security))]
+    pub async fn clear_solution(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.clear_solution_with_optional_audience_context(tenant_id, topic_id, security, None)
+            .await
+    }
+
+    #[instrument(skip(self, security, context))]
+    pub async fn clear_solution_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.clear_solution_with_optional_audience_context(
+            tenant_id,
+            topic_id,
+            security,
+            Some(context),
+        )
+        .await
+    }
+
+    async fn moderate_reply_status(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: Option<PortContext>,
+        target: ReplyStatus,
+    ) -> ForumResult<()> {
+        self.audience
+            .require_reply(tenant_id, reply_id, topic_id, &security, context)
+            .await?;
+        self.update_reply_status(tenant_id, reply_id, topic_id, security, target)
+            .await
+    }
+
+    async fn set_topic_locked(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: Option<PortContext>,
+        locked: bool,
+    ) -> ForumResult<()> {
+        self.audience
+            .require_topic(tenant_id, topic_id, &security, context)
+            .await?;
+        let txn = self.db.begin().await?;
+        TopicService::set_locked_in_tx(&txn, tenant_id, topic_id, locked).await?;
+        publish_forum_topic_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn mark_solution_with_optional_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        reply_id: Uuid,
+        security: SecurityContext,
+        context: Option<PortContext>,
+    ) -> ForumResult<()> {
+        let topic_service = TopicService::new(self.db.clone(), self.event_bus.clone());
+        let reply_service = ReplyService::new(self.db.clone(), self.event_bus.clone());
+        let topic = topic_service.find_topic(tenant_id, topic_id).await?;
+        if !is_exact_topic_author(&security, topic.author_id) {
+            self.audience
+                .require_topic(tenant_id, topic_id, &security, context)
+                .await?;
+        }
+        let reply = reply_service.find_reply(tenant_id, reply_id).await?;
+        if reply.topic_id != topic_id {
+            return Err(ForumError::Validation(
+                "Reply belongs to another topic".to_string(),
+            ));
+        }
+        if reply.status != ReplyStatus::Approved {
+            return Err(ForumError::Validation(
+                "Only approved replies can be marked as solutions".to_string(),
+            ));
+        }
+
+        let txn = self.db.begin().await?;
+        let previous_solution_reply_id = forum_solution::Entity::find()
+            .filter(forum_solution::Column::TenantId.eq(tenant_id))
+            .filter(forum_solution::Column::TopicId.eq(topic_id))
+            .one(&txn)
+            .await?
+            .map(|solution| solution.reply_id);
+        let previous_solution_author_id =
+            if let Some(previous_reply_id) = previous_solution_reply_id {
+                ReplyService::find_reply_in_tx(&txn, tenant_id, previous_reply_id)
+                    .await?
+                    .author_id
+            } else {
+                None
+            };
+        forum_solution::Entity::delete_many()
+            .filter(forum_solution::Column::TenantId.eq(tenant_id))
+            .filter(forum_solution::Column::TopicId.eq(topic_id))
+            .exec(&txn)
+            .await?;
+        forum_solution::ActiveModel {
+            topic_id: Set(topic_id),
+            tenant_id: Set(tenant_id),
+            reply_id: Set(reply_id),
+            marked_by_user_id: Set(security.user_id),
+            marked_at: Set(Utc::now().into()),
+        }
+        .insert(&txn)
+        .await?;
+        if previous_solution_reply_id != Some(reply_id) {
+            UserStatsService::adjust_solution_count_in_tx(
+                &txn,
+                tenant_id,
+                previous_solution_author_id,
+                -1,
+            )
+            .await?;
+            UserStatsService::adjust_solution_count_in_tx(&txn, tenant_id, reply.author_id, 1)
+                .await?;
+        }
+        publish_forum_topic_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn clear_solution_with_optional_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: Option<PortContext>,
+    ) -> ForumResult<()> {
+        let topic_service = TopicService::new(self.db.clone(), self.event_bus.clone());
+        let topic = topic_service.find_topic(tenant_id, topic_id).await?;
+        if !is_exact_topic_author(&security, topic.author_id) {
+            self.audience
+                .require_topic(tenant_id, topic_id, &security, context)
+                .await?;
+        }
+
+        let txn = self.db.begin().await?;
+        let solution_author_id = if let Some(solution) = forum_solution::Entity::find()
+            .filter(forum_solution::Column::TenantId.eq(tenant_id))
+            .filter(forum_solution::Column::TopicId.eq(topic_id))
+            .one(&txn)
+            .await?
+        {
+            ReplyService::find_reply_in_tx(&txn, tenant_id, solution.reply_id)
+                .await?
+                .author_id
+        } else {
+            None
+        };
+        forum_solution::Entity::delete_many()
+            .filter(forum_solution::Column::TenantId.eq(tenant_id))
+            .filter(forum_solution::Column::TopicId.eq(topic_id))
+            .exec(&txn)
+            .await?;
+        UserStatsService::adjust_solution_count_in_tx(&txn, tenant_id, solution_author_id, -1)
+            .await?;
+        publish_forum_topic_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn update_reply_status(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        target: ReplyStatus,
+    ) -> ForumResult<()> {
+        let txn = self.db.begin().await?;
+        let reply = ReplyService::find_reply_in_tx(&txn, tenant_id, reply_id).await?;
+        if reply.topic_id != topic_id {
+            return Err(ForumError::Validation(
+                "Reply belongs to another topic".to_string(),
+            ));
+        }
+        let current = reply.status;
+        current.validate_transition(&target)?;
+
+        let became_public = current != ReplyStatus::Approved && target == ReplyStatus::Approved;
+        let stopped_being_public =
+            current == ReplyStatus::Approved && target != ReplyStatus::Approved;
+        let old_status = current.to_string();
+        let new_status = target.to_string();
+
+        ReplyService::set_status_in_tx(&txn, tenant_id, reply_id, target).await?;
+
+        let changed_category_id = if became_public || stopped_being_public {
+            let public_delta = if became_public { 1 } else { -1 };
+            let topic =
+                TopicService::adjust_reply_count_in_tx(&txn, tenant_id, topic_id, public_delta)
+                    .await?;
+            CategoryService::adjust_counters_in_tx(
+                &txn,
+                tenant_id,
+                topic.category_id,
+                0,
+                public_delta,
+            )
+            .await?;
+            UserStatsService::adjust_reply_count_in_tx(
+                &txn,
+                tenant_id,
+                reply.author_id,
+                public_delta,
+            )
+            .await?;
+            Some(topic.category_id)
+        } else {
+            None
+        };
+
+        self.event_bus
+            .publish_in_tx(
+                &txn,
+                tenant_id,
+                security.user_id,
+                DomainEvent::ForumReplyStatusChanged {
+                    reply_id,
+                    topic_id,
+                    old_status,
+                    new_status,
+                    moderator_id: security.user_id,
+                },
+            )
+            .await?;
+
+        if became_public {
+            self.event_bus
+                .publish_in_tx(
+                    &txn,
+                    tenant_id,
+                    reply.author_id,
+                    DomainEvent::ForumTopicReplied {
+                        topic_id,
+                        reply_id,
+                        author_id: reply.author_id,
+                    },
+                )
+                .await?;
+        }
+        if let Some(category_id) = changed_category_id {
+            publish_forum_category_projection_in_tx(
+                &self.event_bus,
+                &txn,
+                tenant_id,
+                security.user_id,
+                category_id,
+            )
+            .await?;
+        }
+
+        txn.commit().await?;
+        Ok(())
+    }
+}
+
+impl Deref for ModerationService {
+    type Target = super::moderation_legacy::ModerationService;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+fn is_exact_topic_author(security: &SecurityContext, topic_author_id: Option<Uuid>) -> bool {
+    topic_author_id.is_some() && security.user_id == topic_author_id
+}

--- a/crates/rustok-forum/src/services/moderation_public_owner.rs
+++ b/crates/rustok-forum/src/services/moderation_public_owner.rs
@@ -1,0 +1,309 @@
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use rustok_api::PortContext;
+use rustok_core::SecurityContext;
+use rustok_outbox::TransactionalEventBus;
+
+use crate::audience::SharedForumAudienceFactsPort;
+use crate::error::ForumResult;
+
+/// Public moderation facade that keeps legacy and transactional owner types
+/// private while preserving the established method surface.
+pub struct ModerationService {
+    inner: super::moderation_owner::ModerationService,
+}
+
+impl ModerationService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            inner: super::moderation_owner::ModerationService::new(db, event_bus),
+        }
+    }
+
+    pub fn with_audience_facts(
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+        facts: SharedForumAudienceFactsPort,
+    ) -> Self {
+        Self {
+            inner: super::moderation_owner::ModerationService::with_audience_facts(
+                db, event_bus, facts,
+            ),
+        }
+    }
+
+    pub async fn approve_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .approve_reply(tenant_id, reply_id, topic_id, security)
+            .await
+    }
+
+    pub async fn approve_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .approve_reply_with_audience_context(
+                tenant_id, reply_id, topic_id, security, context,
+            )
+            .await
+    }
+
+    pub async fn reject_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .reject_reply(tenant_id, reply_id, topic_id, security)
+            .await
+    }
+
+    pub async fn reject_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .reject_reply_with_audience_context(
+                tenant_id, reply_id, topic_id, security, context,
+            )
+            .await
+    }
+
+    pub async fn hide_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .hide_reply(tenant_id, reply_id, topic_id, security)
+            .await
+    }
+
+    pub async fn hide_reply_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .hide_reply_with_audience_context(tenant_id, reply_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn pin_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.pin_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn pin_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .pin_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn unpin_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.unpin_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn unpin_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .unpin_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn lock_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.lock_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn lock_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .lock_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn unlock_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.unlock_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn unlock_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .unlock_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn close_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.close_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn close_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .close_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn reopen_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.reopen_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn reopen_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .reopen_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn archive_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.archive_topic(tenant_id, topic_id, security).await
+    }
+
+    pub async fn archive_topic_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .archive_topic_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+
+    pub async fn mark_solution(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        reply_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .mark_solution(tenant_id, topic_id, reply_id, security)
+            .await
+    }
+
+    pub async fn mark_solution_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        reply_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .mark_solution_with_audience_context(
+                tenant_id, topic_id, reply_id, security, context,
+            )
+            .await
+    }
+
+    pub async fn clear_solution(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<()> {
+        self.inner.clear_solution(tenant_id, topic_id, security).await
+    }
+
+    pub async fn clear_solution_with_audience_context(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+    ) -> ForumResult<()> {
+        self.inner
+            .clear_solution_with_audience_context(tenant_id, topic_id, security, context)
+            .await
+    }
+}

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,9 +1,9 @@
-use rustok_events::DomainEvent;
+use rustok_events::{DomainEvent, ValidateEvent};
 use rustok_outbox::TransactionalEventBus;
-use sea_orm::DatabaseTransaction;
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseTransaction};
 use uuid::Uuid;
 
-use crate::error::ForumResult;
+use crate::error::{ForumError, ForumResult};
 
 pub(crate) const FORUM_PROJECTION_SCOPE: &str = "forum";
 pub(crate) const FORUM_CATEGORY_PROJECTION_TARGET: &str = "forum_category";
@@ -116,16 +116,23 @@ async fn write_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    TransactionalEventBus::publish_root_in_tx(
-        txn,
-        tenant_id,
-        actor_id,
-        DomainEvent::ReindexRequested {
-            target_type: target_type.to_string(),
-            target_id,
-        },
-    )
-    .await?;
+    let event = DomainEvent::ReindexRequested {
+        target_type: target_type.to_string(),
+        target_id,
+    };
+
+    // The Search-owned Forum projector is PostgreSQL-only. SQLite and any
+    // other non-PostgreSQL backend are domain-test/unsupported projection
+    // environments, so keep root validation without requiring an outbox table
+    // that has no matching Search consumer.
+    if txn.get_database_backend() != DatabaseBackend::Postgres {
+        event.validate().map_err(|error| {
+            ForumError::Validation(format!("Forum projection invalidation failed: {error}"))
+        })?;
+        return Ok(());
+    }
+
+    TransactionalEventBus::publish_root_in_tx(txn, tenant_id, actor_id, event).await?;
     Ok(())
 }
 

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,0 +1,85 @@
+use rustok_events::DomainEvent;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseTransaction;
+use uuid::Uuid;
+
+use crate::error::ForumResult;
+
+pub(crate) const FORUM_PROJECTION_SCOPE: &str = "forum";
+pub(crate) const FORUM_CATEGORY_PROJECTION_TARGET: &str = "forum_category";
+pub(crate) const FORUM_TOPIC_PROJECTION_TARGET: &str = "forum_topic";
+
+pub(crate) async fn publish_forum_projection_scope_in_tx(
+    event_bus: &TransactionalEventBus,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+) -> ForumResult<()> {
+    publish_projection_invalidation_in_tx(
+        event_bus,
+        txn,
+        tenant_id,
+        actor_id,
+        FORUM_PROJECTION_SCOPE,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn publish_forum_category_projection_in_tx(
+    event_bus: &TransactionalEventBus,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    category_id: Uuid,
+) -> ForumResult<()> {
+    publish_projection_invalidation_in_tx(
+        event_bus,
+        txn,
+        tenant_id,
+        actor_id,
+        FORUM_CATEGORY_PROJECTION_TARGET,
+        Some(category_id),
+    )
+    .await
+}
+
+pub(crate) async fn publish_forum_topic_projection_in_tx(
+    event_bus: &TransactionalEventBus,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    topic_id: Uuid,
+) -> ForumResult<()> {
+    publish_projection_invalidation_in_tx(
+        event_bus,
+        txn,
+        tenant_id,
+        actor_id,
+        FORUM_TOPIC_PROJECTION_TARGET,
+        Some(topic_id),
+    )
+    .await
+}
+
+async fn publish_projection_invalidation_in_tx(
+    event_bus: &TransactionalEventBus,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    target_type: &'static str,
+    target_id: Option<Uuid>,
+) -> ForumResult<()> {
+    event_bus
+        .publish_in_tx(
+            txn,
+            tenant_id,
+            actor_id,
+            DomainEvent::ReindexRequested {
+                target_type: target_type.to_string(),
+                target_id,
+            },
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,5 +1,5 @@
-use rustok_events::{DomainEvent, EventEnvelope};
-use rustok_outbox::{OutboxTransport, TransactionalEventBus};
+use rustok_events::DomainEvent;
+use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseTransaction;
 use uuid::Uuid;
 
@@ -116,15 +116,16 @@ async fn write_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    let envelope = EventEnvelope::new(
+    TransactionalEventBus::publish_root_in_tx(
+        txn,
         tenant_id,
         actor_id,
         DomainEvent::ReindexRequested {
             target_type: target_type.to_string(),
             target_id,
         },
-    );
-    OutboxTransport::write_envelope_in_tx(txn, envelope).await?;
+    )
+    .await?;
     Ok(())
 }
 

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use rustok_events::DomainEvent;
-use rustok_outbox::TransactionalEventBus;
-use sea_orm::DatabaseTransaction;
+use rustok_outbox::{OutboxTransport, TransactionalEventBus};
+use sea_orm::{DatabaseConnection, DatabaseTransaction};
 use uuid::Uuid;
 
 use crate::error::ForumResult;
@@ -8,6 +10,42 @@ use crate::error::ForumResult;
 pub(crate) const FORUM_PROJECTION_SCOPE: &str = "forum";
 pub(crate) const FORUM_CATEGORY_PROJECTION_TARGET: &str = "forum_category";
 pub(crate) const FORUM_TOPIC_PROJECTION_TARGET: &str = "forum_topic";
+
+pub(crate) async fn publish_forum_projection_scope_using_db_in_tx(
+    db: &DatabaseConnection,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+) -> ForumResult<()> {
+    publish_forum_projection_scope_in_tx(&event_bus(db), txn, tenant_id, actor_id).await
+}
+
+pub(crate) async fn publish_forum_category_projection_using_db_in_tx(
+    db: &DatabaseConnection,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    category_id: Uuid,
+) -> ForumResult<()> {
+    publish_forum_category_projection_in_tx(
+        &event_bus(db),
+        txn,
+        tenant_id,
+        actor_id,
+        category_id,
+    )
+    .await
+}
+
+pub(crate) async fn publish_forum_topic_projection_using_db_in_tx(
+    db: &DatabaseConnection,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    topic_id: Uuid,
+) -> ForumResult<()> {
+    publish_forum_topic_projection_in_tx(&event_bus(db), txn, tenant_id, actor_id, topic_id).await
+}
 
 pub(crate) async fn publish_forum_projection_scope_in_tx(
     event_bus: &TransactionalEventBus,
@@ -82,4 +120,8 @@ async fn publish_projection_invalidation_in_tx(
         )
         .await?;
     Ok(())
+}
+
+fn event_bus(db: &DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())))
 }

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
-use rustok_events::DomainEvent;
+use rustok_events::{DomainEvent, EventEnvelope};
 use rustok_outbox::{OutboxTransport, TransactionalEventBus};
-use sea_orm::{DatabaseConnection, DatabaseTransaction};
+use sea_orm::DatabaseTransaction;
 use uuid::Uuid;
 
 use crate::error::ForumResult;
@@ -11,40 +9,51 @@ pub(crate) const FORUM_PROJECTION_SCOPE: &str = "forum";
 pub(crate) const FORUM_CATEGORY_PROJECTION_TARGET: &str = "forum_category";
 pub(crate) const FORUM_TOPIC_PROJECTION_TARGET: &str = "forum_topic";
 
-pub(crate) async fn publish_forum_projection_scope_using_db_in_tx(
-    db: &DatabaseConnection,
+pub(crate) async fn publish_forum_projection_scope_direct_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     actor_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    publish_forum_projection_scope_in_tx(&event_bus(db), txn, tenant_id, actor_id).await
+    write_projection_invalidation_in_tx(
+        txn,
+        tenant_id,
+        actor_id,
+        FORUM_PROJECTION_SCOPE,
+        None,
+    )
+    .await
 }
 
-pub(crate) async fn publish_forum_category_projection_using_db_in_tx(
-    db: &DatabaseConnection,
+pub(crate) async fn publish_forum_category_projection_direct_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     actor_id: Option<Uuid>,
     category_id: Uuid,
 ) -> ForumResult<()> {
-    publish_forum_category_projection_in_tx(
-        &event_bus(db),
+    write_projection_invalidation_in_tx(
         txn,
         tenant_id,
         actor_id,
-        category_id,
+        FORUM_CATEGORY_PROJECTION_TARGET,
+        Some(category_id),
     )
     .await
 }
 
-pub(crate) async fn publish_forum_topic_projection_using_db_in_tx(
-    db: &DatabaseConnection,
+pub(crate) async fn publish_forum_topic_projection_direct_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     actor_id: Option<Uuid>,
     topic_id: Uuid,
 ) -> ForumResult<()> {
-    publish_forum_topic_projection_in_tx(&event_bus(db), txn, tenant_id, actor_id, topic_id).await
+    write_projection_invalidation_in_tx(
+        txn,
+        tenant_id,
+        actor_id,
+        FORUM_TOPIC_PROJECTION_TARGET,
+        Some(topic_id),
+    )
+    .await
 }
 
 pub(crate) async fn publish_forum_projection_scope_in_tx(
@@ -100,6 +109,25 @@ pub(crate) async fn publish_forum_topic_projection_in_tx(
     .await
 }
 
+async fn write_projection_invalidation_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    target_type: &'static str,
+    target_id: Option<Uuid>,
+) -> ForumResult<()> {
+    let envelope = EventEnvelope::new(
+        tenant_id,
+        actor_id,
+        DomainEvent::ReindexRequested {
+            target_type: target_type.to_string(),
+            target_id,
+        },
+    );
+    OutboxTransport::write_envelope_in_tx(txn, envelope).await?;
+    Ok(())
+}
+
 async fn publish_projection_invalidation_in_tx(
     event_bus: &TransactionalEventBus,
     txn: &DatabaseTransaction,
@@ -120,8 +148,4 @@ async fn publish_projection_invalidation_in_tx(
         )
         .await?;
     Ok(())
-}
-
-fn event_bus(db: &DatabaseConnection) -> TransactionalEventBus {
-    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())))
 }

--- a/crates/rustok-forum/src/services/reply_owner.rs
+++ b/crates/rustok-forum/src/services/reply_owner.rs
@@ -22,6 +22,7 @@ use crate::state_machine::{ReplyStatus, TopicStatus};
 
 use super::category::CategoryService;
 use super::mention_relation::MentionRelationService;
+use super::projection_invalidation::publish_forum_category_projection_in_tx;
 use super::rbac::{enforce_owned_scope, enforce_scope};
 use super::reply;
 use super::topic_owner::TopicService;
@@ -168,6 +169,14 @@ impl ReplyService {
                     },
                 )
                 .await?;
+            publish_forum_category_projection_in_tx(
+                &self.event_bus,
+                &txn,
+                tenant_id,
+                security.user_id,
+                topic.category_id,
+            )
+            .await?;
         }
 
         txn.commit().await?;
@@ -252,6 +261,16 @@ impl ReplyService {
                 },
             )
             .await?;
+        if reply.status == ReplyStatus::Approved {
+            publish_forum_category_projection_in_tx(
+                &self.event_bus,
+                &txn,
+                tenant_id,
+                security.user_id,
+                topic.category_id,
+            )
+            .await?;
+        }
 
         txn.commit().await?;
         Ok(())

--- a/crates/rustok-forum/src/services/topic_audience_owner.rs
+++ b/crates/rustok-forum/src/services/topic_audience_owner.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 /// Transactional owner facade for topic-local audience replacement.
 ///
 /// The original service remains the read delegate. This facade uses the same
@@ -16,6 +14,15 @@ impl ForumTopicAudiencePolicyOwnerService {
             inner: ForumTopicAudiencePolicyService::new(db.clone()),
             db,
         }
+    }
+
+    pub async fn get(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+    ) -> ForumResult<ForumTopicAudiencePolicy> {
+        self.inner.get(tenant_id, topic_id, security).await
     }
 
     pub async fn set(
@@ -66,13 +73,5 @@ impl ForumTopicAudiencePolicyOwnerService {
         .await?;
         txn.commit().await?;
         Ok(result)
-    }
-}
-
-impl Deref for ForumTopicAudiencePolicyOwnerService {
-    type Target = ForumTopicAudiencePolicyService;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }

--- a/crates/rustok-forum/src/services/topic_audience_owner.rs
+++ b/crates/rustok-forum/src/services/topic_audience_owner.rs
@@ -1,0 +1,78 @@
+use std::ops::Deref;
+
+/// Transactional owner facade for topic-local audience replacement.
+///
+/// The original service remains the read delegate. This facade uses the same
+/// private normalized persistence helpers and writes a topic projection
+/// invalidation before the policy transaction commits.
+pub struct ForumTopicAudiencePolicyOwnerService {
+    inner: ForumTopicAudiencePolicyService,
+    db: DatabaseConnection,
+}
+
+impl ForumTopicAudiencePolicyOwnerService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: ForumTopicAudiencePolicyService::new(db.clone()),
+            db,
+        }
+    }
+
+    pub async fn set(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+        security: SecurityContext,
+        input: SetForumTopicAudiencePolicyInput,
+    ) -> ForumResult<ForumTopicAudiencePolicy> {
+        enforce_scope(&security, Resource::ForumTopics, Action::Manage)?;
+        let constraints = input.constraints.normalize()?;
+
+        let txn = self.db.begin().await?;
+        lock_category_tree_in_tx(&txn, tenant_id).await?;
+        lock_topic_audience_in_tx(&txn, tenant_id, topic_id).await?;
+        let topic = find_topic(&txn, tenant_id, topic_id).await?;
+        load_category_audience_policy(&txn, tenant_id, topic.category_id).await?;
+
+        forum_topic_audience_policy::Entity::delete_many()
+            .filter(forum_topic_audience_policy::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic_audience_policy::Column::TopicId.eq(topic_id))
+            .exec(&txn)
+            .await?;
+
+        if !constraints_are_empty(&constraints) {
+            forum_topic_audience_policy::ActiveModel {
+                tenant_id: Set(tenant_id),
+                topic_id: Set(topic_id),
+                minimum_trust_level: Set(constraints.minimum_trust_level.map(i16::from)),
+                updated_at: Set(Utc::now().into()),
+            }
+            .insert(&txn)
+            .await?;
+
+            insert_roles(&txn, tenant_id, topic_id, &constraints).await?;
+            insert_channels(&txn, tenant_id, topic_id, &constraints).await?;
+            insert_groups(&txn, tenant_id, topic_id, &constraints).await?;
+            insert_users(&txn, tenant_id, topic_id, &constraints).await?;
+        }
+
+        let result = load_policy_for_topic(&txn, tenant_id, &topic).await?;
+        super::projection_invalidation::publish_forum_topic_projection_direct_in_tx(
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
+        txn.commit().await?;
+        Ok(result)
+    }
+}
+
+impl Deref for ForumTopicAudiencePolicyOwnerService {
+    type Target = ForumTopicAudiencePolicyService;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/crates/rustok-forum/src/services/topic_inline.rs
+++ b/crates/rustok-forum/src/services/topic_inline.rs
@@ -114,6 +114,14 @@ impl TopicService {
                 },
             )
             .await?;
+        super::projection_invalidation::publish_forum_category_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            input.category_id,
+        )
+        .await?;
 
         txn.commit().await?;
         self.get(tenant_id, security, topic_id, &locale).await
@@ -272,6 +280,14 @@ impl TopicService {
                 .await?;
         }
 
+        super::projection_invalidation::publish_forum_topic_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
         txn.commit().await?;
         self.get(tenant_id, security, topic_id, &locale).await
     }

--- a/crates/rustok-forum/src/services/topic_owner.rs
+++ b/crates/rustok-forum/src/services/topic_owner.rs
@@ -19,6 +19,9 @@ use crate::error::{ForumError, ForumResult};
 use crate::state_machine::{ReplyStatus, TopicStatus};
 
 use super::category::CategoryService;
+use super::projection_invalidation::{
+    publish_forum_category_projection_in_tx, publish_forum_topic_projection_in_tx,
+};
 use super::rbac::enforce_owned_scope;
 use super::topic;
 use super::user_stats::UserStatsService;
@@ -157,6 +160,22 @@ impl TopicService {
                 )
                 .await?;
         }
+        publish_forum_topic_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic_id,
+        )
+        .await?;
+        publish_forum_category_projection_in_tx(
+            &self.event_bus,
+            &txn,
+            tenant_id,
+            security.user_id,
+            topic.category_id,
+        )
+        .await?;
 
         txn.commit().await?;
         Ok(())
@@ -250,7 +269,7 @@ async fn redact_topic_content_in_tx(
         format!(
             "UPDATE forum_topic_translations \
              SET title = '[deleted]', slug = NULL, body = '[deleted]', \
-                 body_format = 'markdown', updated_at = CURRENT_TIMESTAMP \
+                  body_format = 'markdown', updated_at = CURRENT_TIMESTAMP \
              WHERE tenant_id = '{tenant_id}' AND topic_id = '{topic_id}'"
         ),
         format!(

--- a/crates/rustok-outbox/src/transactional.rs
+++ b/crates/rustok-outbox/src/transactional.rs
@@ -18,6 +18,29 @@ impl TransactionalEventBus {
         Self { transport }
     }
 
+    /// Publishes a validated registered root event through an owner transaction
+    /// without requiring a separately configured transport handle.
+    ///
+    /// This is intended for domain helpers that receive only the active
+    /// transaction. It preserves both `DomainEvent::validate()` and registered
+    /// envelope/schema validation before inserting into the canonical outbox.
+    pub async fn publish_root_in_tx<C>(
+        txn: &C,
+        tenant_id: Uuid,
+        actor_id: Option<Uuid>,
+        event: DomainEvent,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        validate_event(&event)?;
+        OutboxTransport::write_envelope_in_tx(
+            txn,
+            EventEnvelope::new(tenant_id, actor_id, event),
+        )
+        .await
+    }
+
     pub async fn publish_in_tx<C>(
         &self,
         txn: &C,

--- a/crates/rustok-outbox/src/transport.rs
+++ b/crates/rustok-outbox/src/transport.rs
@@ -25,9 +25,9 @@ impl OutboxTransport {
 
     /// Writes one validated root event through an owner-supplied transaction.
     ///
-    /// This crate-private boundary is used by the validated transactional bus;
-    /// external domain code must publish through `TransactionalEventBus` so
-    /// `DomainEvent::validate()` cannot be bypassed.
+    /// This static boundary is used by the validated transactional bus. Keeping
+    /// it crate-private avoids adding a second public raw-envelope entry point;
+    /// the existing instance compatibility API remains unchanged.
     pub(crate) async fn write_envelope_in_tx<C>(
         txn: &C,
         envelope: EventEnvelope,

--- a/crates/rustok-outbox/src/transport.rs
+++ b/crates/rustok-outbox/src/transport.rs
@@ -23,7 +23,13 @@ impl OutboxTransport {
         Self { db }
     }
 
-    pub async fn write_to_outbox<C>(&self, txn: &C, envelope: EventEnvelope) -> Result<()>
+    /// Writes one validated root event through an owner-supplied transaction.
+    ///
+    /// This static boundary is intended for domain helpers that already own a
+    /// transaction and must not manufacture a second database handle merely to
+    /// use the outbox. The same envelope/schema validation as normal transport
+    /// publishing remains mandatory.
+    pub async fn write_envelope_in_tx<C>(txn: &C, envelope: EventEnvelope) -> Result<()>
     where
         C: ConnectionTrait,
     {
@@ -33,8 +39,8 @@ impl OutboxTransport {
         Ok(())
     }
 
-    pub async fn write_contract_to_outbox<C>(
-        &self,
+    /// Writes one validated sealed contract event through an owner transaction.
+    pub async fn write_contract_envelope_in_tx<C>(
         txn: &C,
         envelope: ContractEventEnvelope,
     ) -> Result<()>
@@ -45,6 +51,24 @@ impl OutboxTransport {
             .exec_without_returning(txn)
             .await?;
         Ok(())
+    }
+
+    pub async fn write_to_outbox<C>(&self, txn: &C, envelope: EventEnvelope) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        Self::write_envelope_in_tx(txn, envelope).await
+    }
+
+    pub async fn write_contract_to_outbox<C>(
+        &self,
+        txn: &C,
+        envelope: ContractEventEnvelope,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        Self::write_contract_envelope_in_tx(txn, envelope).await
     }
 
     fn model_from_envelope(envelope: EventEnvelope) -> Result<entity::ActiveModel> {

--- a/crates/rustok-outbox/src/transport.rs
+++ b/crates/rustok-outbox/src/transport.rs
@@ -25,11 +25,13 @@ impl OutboxTransport {
 
     /// Writes one validated root event through an owner-supplied transaction.
     ///
-    /// This static boundary is intended for domain helpers that already own a
-    /// transaction and must not manufacture a second database handle merely to
-    /// use the outbox. The same envelope/schema validation as normal transport
-    /// publishing remains mandatory.
-    pub async fn write_envelope_in_tx<C>(txn: &C, envelope: EventEnvelope) -> Result<()>
+    /// This crate-private boundary is used by the validated transactional bus;
+    /// external domain code must publish through `TransactionalEventBus` so
+    /// `DomainEvent::validate()` cannot be bypassed.
+    pub(crate) async fn write_envelope_in_tx<C>(
+        txn: &C,
+        envelope: EventEnvelope,
+    ) -> Result<()>
     where
         C: ConnectionTrait,
     {
@@ -40,7 +42,7 @@ impl OutboxTransport {
     }
 
     /// Writes one validated sealed contract event through an owner transaction.
-    pub async fn write_contract_envelope_in_tx<C>(
+    pub(crate) async fn write_contract_envelope_in_tx<C>(
         txn: &C,
         envelope: ContractEventEnvelope,
     ) -> Result<()>

--- a/crates/rustok-outbox/src/transport.rs
+++ b/crates/rustok-outbox/src/transport.rs
@@ -26,7 +26,8 @@ impl OutboxTransport {
     /// Writes one validated root event through an owner-supplied transaction.
     ///
     /// This static boundary is used by the validated transactional bus. Keeping
-    /// it crate-private avoids adding a second public raw-envelope entry point;
+    /// it crate-private avoids adding a second public raw-envelope entry point.
+    /// New external domain code must publish through `TransactionalEventBus`;
     /// the existing instance compatibility API remains unchanged.
     pub(crate) async fn write_envelope_in_tx<C>(
         txn: &C,

--- a/scripts/verify/verify-forum-projection-invalidation.mjs
+++ b/scripts/verify/verify-forum-projection-invalidation.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const outboxBusPath = "crates/rustok-outbox/src/transactional.rs";
+const outboxTransportPath = "crates/rustok-outbox/src/transport.rs";
+const helperPath = "crates/rustok-forum/src/services/projection_invalidation.rs";
+const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
+const categoryProjectionPath = "crates/rustok-forum/src/services/category_projection_owner.rs";
+const categoryCommandPath = "crates/rustok-forum/src/services/category_command_owner.rs";
+const categoryLifecyclePath = "crates/rustok-forum/src/services/category_lifecycle_owner.rs";
+const categoryVisibilityPath = "crates/rustok-forum/src/services/category_visibility.rs";
+const categoryAudiencePath = "crates/rustok-forum/src/services/category_audience_owner.rs";
+const topicAudiencePath = "crates/rustok-forum/src/services/topic_audience_owner.rs";
+const topicInlinePath = "crates/rustok-forum/src/services/topic_inline.rs";
+const topicOwnerPath = "crates/rustok-forum/src/services/topic_owner.rs";
+const replyOwnerPath = "crates/rustok-forum/src/services/reply_owner.rs";
+const moderationOwnerPath = "crates/rustok-forum/src/services/moderation_owner.rs";
+const moderationPublicPath = "crates/rustok-forum/src/services/moderation_public_owner.rs";
+const searchContractPath = "crates/rustok-forum/contracts/forum-search-projection.json";
+const contractPath = "crates/rustok-forum/contracts/forum-projection-invalidation.json";
+const notePath = "crates/rustok-forum/docs/forum-20bk-projection-invalidation.md";
+
+const outboxBus = read(outboxBusPath);
+const outboxTransport = read(outboxTransportPath);
+const helper = read(helperPath);
+const servicesMod = read(servicesModPath);
+const categoryProjection = read(categoryProjectionPath);
+const categoryCommand = read(categoryCommandPath);
+const categoryLifecycle = read(categoryLifecyclePath);
+const categoryVisibility = read(categoryVisibilityPath);
+const categoryAudience = read(categoryAudiencePath);
+const topicAudience = read(topicAudiencePath);
+const topicInline = read(topicInlinePath);
+const topicOwner = read(topicOwnerPath);
+const replyOwner = read(replyOwnerPath);
+const moderationOwner = read(moderationOwnerPath);
+const moderationPublic = read(moderationPublicPath);
+const note = read(notePath);
+let searchContract = null;
+let contract = null;
+try {
+  searchContract = JSON.parse(read(searchContractPath));
+} catch (error) {
+  failures.push(`${searchContractPath}: invalid JSON: ${error.message}`);
+}
+try {
+  contract = JSON.parse(read(contractPath));
+} catch (error) {
+  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
+}
+
+for (const marker of [
+  "pub async fn publish_root_in_tx<C>",
+  "validate_event(&event)?",
+  "OutboxTransport::write_envelope_in_tx",
+  "EventEnvelope::new(tenant_id, actor_id, event)",
+]) {
+  requireMarker(outboxBus, marker, outboxBusPath);
+}
+for (const marker of [
+  "pub async fn write_envelope_in_tx<C>",
+  "Self::model_from_envelope(envelope)?",
+  "validate_registered_schema()",
+  "pub async fn write_contract_envelope_in_tx<C>",
+]) {
+  requireMarker(outboxTransport, marker, outboxTransportPath);
+}
+
+for (const marker of [
+  'FORUM_PROJECTION_SCOPE: &str = "forum"',
+  'FORUM_CATEGORY_PROJECTION_TARGET: &str = "forum_category"',
+  'FORUM_TOPIC_PROJECTION_TARGET: &str = "forum_topic"',
+  "TransactionalEventBus::publish_root_in_tx",
+  "DomainEvent::ReindexRequested",
+  "publish_forum_projection_scope_direct_in_tx",
+  "publish_forum_category_projection_in_tx",
+  "publish_forum_topic_projection_in_tx",
+]) {
+  requireMarker(helper, marker, helperPath);
+}
+for (const forbidden of [
+  "ForumProjectionInvalidated",
+  "INSERT INTO sys_events",
+  "EventEnvelope::new",
+]) {
+  rejectMarker(helper, forbidden, helperPath);
+}
+
+for (const [source, label, markers] of [
+  [categoryProjection, categoryProjectionPath, [
+    "pub(super) async fn create",
+    "pub(super) async fn update",
+    "publish_forum_projection_scope_direct_in_tx",
+  ]],
+  [categoryCommand, categoryCommandPath, [
+    "move_category",
+    "reorder_siblings",
+    "publish_forum_projection_scope_direct_in_tx",
+  ]],
+  [categoryLifecycle, categoryLifecyclePath, [
+    "archive_subtree_for_delete",
+    "restore_subtree",
+    "if !changed.is_empty()",
+    "publish_forum_projection_scope_direct_in_tx",
+  ]],
+  [categoryVisibility, categoryVisibilityPath, [
+    "SetForumCategoryVisibilityPolicyInput",
+    "publish_forum_projection_scope_direct_in_tx",
+  ]],
+  [categoryAudience, categoryAudiencePath, [
+    "ForumCategoryAudiencePolicyOwnerService",
+    "load_category_audience_policy",
+    "publish_forum_projection_scope_direct_in_tx",
+  ]],
+]) {
+  for (const marker of markers) requireMarker(source, marker, label);
+}
+
+for (const marker of [
+  "ForumTopicAudiencePolicyOwnerService",
+  "load_policy_for_topic",
+  "publish_forum_topic_projection_direct_in_tx",
+]) {
+  requireMarker(topicAudience, marker, topicAudiencePath);
+}
+for (const marker of [
+  "ForumTopicCreated",
+  "publish_forum_category_projection_in_tx",
+  "publish_forum_topic_projection_in_tx",
+]) {
+  requireMarker(topicInline, marker, topicInlinePath);
+}
+for (const marker of [
+  "publish_forum_topic_projection_in_tx",
+  "publish_forum_category_projection_in_tx",
+  "topic.status != TopicStatus::Archived",
+]) {
+  requireMarker(topicOwner, marker, topicOwnerPath);
+}
+for (const marker of [
+  "status == ReplyStatus::Approved",
+  "publish_forum_category_projection_in_tx",
+  "DomainEvent::ForumReplyStatusChanged",
+]) {
+  requireMarker(replyOwner, marker, replyOwnerPath);
+}
+for (const marker of [
+  "set_topic_locked",
+  "mark_solution_with_optional_audience_context",
+  "clear_solution_with_optional_audience_context",
+  "publish_forum_topic_projection_in_tx",
+  "changed_category_id",
+  "publish_forum_category_projection_in_tx",
+]) {
+  requireMarker(moderationOwner, marker, moderationOwnerPath);
+}
+
+for (const marker of [
+  "mod moderation_legacy;",
+  "mod moderation_owner;",
+  "mod moderation_public_owner;",
+  "pub use super::moderation_public_owner::ModerationService;",
+  "ForumCategoryAudiencePolicyOwnerService as ForumCategoryAudiencePolicyService",
+  "ForumTopicAudiencePolicyOwnerService as ForumTopicAudiencePolicyService",
+  'include!("category_projection_owner.rs")',
+  'include!("category_command_owner.rs")',
+  'include!("category_lifecycle_owner.rs")',
+]) {
+  requireMarker(servicesMod, marker, servicesModPath);
+}
+for (const forbidden of [
+  "__ModerationServiceLegacyTarget",
+  "pub use super::moderation_owner::ModerationService",
+]) {
+  rejectMarker(servicesMod, forbidden, servicesModPath);
+}
+for (const marker of [
+  "pub struct ModerationService",
+  "inner: super::moderation_owner::ModerationService",
+  "pub async fn pin_topic",
+  "pub async fn lock_topic",
+  "pub async fn mark_solution",
+]) {
+  requireMarker(moderationPublic, marker, moderationPublicPath);
+}
+rejectMarker(moderationPublic, "impl Deref", moderationPublicPath);
+
+for (const marker of [
+  "search.reindex_requested",
+  "owner transaction",
+  "at-least-once",
+  "full Forum projection",
+  "FORUM-20BL",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-20BK") failures.push(`${contractPath}: unexpected task`);
+  if (contract.upstream_task !== "FORUM-20BJ") {
+    failures.push(`${contractPath}: unexpected upstream task`);
+  }
+  if (contract.downstream_task !== "FORUM-20BL") {
+    failures.push(`${contractPath}: unexpected downstream task`);
+  }
+  if (contract.root_event !== "rustok_events::DomainEvent::ReindexRequested") {
+    failures.push(`${contractPath}: root event drift`);
+  }
+  for (const key of [
+    "owner_transaction_required",
+    "domain_event_validation_preserved",
+    "registered_envelope_schema_validation_preserved",
+    "canonical_sys_events_outbox_reused",
+    "duplicate_invalidations_allowed",
+    "consumer_operations_are_idempotent",
+  ]) {
+    if (contract.outbox_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: outbox boundary ${key} drift`);
+    }
+  }
+  for (const key of [
+    "new_root_domain_event_added",
+    "new_event_schema_added",
+    "sql_trigger_event_envelope_copy_added",
+    "second_database_connection_required",
+  ]) {
+    if (contract.outbox_boundary?.[key] !== false) {
+      failures.push(`${contractPath}: outbox boundary ${key} must remain false`);
+    }
+  }
+  for (const section of [
+    "forum_scope_invalidation",
+    "category_target_invalidation",
+    "topic_target_invalidation",
+    "owner_sealing",
+  ]) {
+    if (!contract[section]) failures.push(`${contractPath}: missing ${section}`);
+  }
+  for (const [key, expected] of Object.entries({
+    existing_reindex_target_strings_changed: false,
+    search_ingestion_contract_changed: false,
+    workspace_dependency_changed: false,
+    cargo_lock_changed: false,
+    migration_added: false,
+  })) {
+    if (contract.compatibility?.[key] !== expected) {
+      failures.push(`${contractPath}: compatibility ${key} drift`);
+    }
+  }
+}
+
+if (searchContract) {
+  if (searchContract.invalidation_contract !== contractPath) {
+    failures.push(`${searchContractPath}: invalidation contract handoff drift`);
+  }
+  if (searchContract.ingestion_boundary?.completion_contract !== contractPath) {
+    failures.push(`${searchContractPath}: completion contract drift`);
+  }
+  for (const key of [
+    "automatic_category_policy_change_reindex_added",
+    "automatic_topic_policy_change_reindex_added",
+    "automatic_topic_content_translation_tag_solution_change_reindex_added",
+    "automatic_category_content_translation_tree_change_reindex_added",
+    "automatic_category_and_reply_count_reindex_added",
+    "owner_transactional_outbox_delivery_added",
+  ]) {
+    if (searchContract.ingestion_boundary?.[key] !== true) {
+      failures.push(`${searchContractPath}: ${key} handoff drift`);
+    }
+  }
+  if (searchContract.downstream_task !== "FORUM-20BL") {
+    failures.push(`${searchContractPath}: downstream task drift`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("forum projection invalidation verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("forum projection invalidation ownership verified");

--- a/scripts/verify/verify-forum-projection-invalidation.mjs
+++ b/scripts/verify/verify-forum-projection-invalidation.mjs
@@ -96,6 +96,8 @@ for (const marker of [
   'FORUM_TOPIC_PROJECTION_TARGET: &str = "forum_topic"',
   "TransactionalEventBus::publish_root_in_tx",
   "DomainEvent::ReindexRequested",
+  "DatabaseBackend::Postgres",
+  "event.validate()",
   "publish_forum_projection_scope_direct_in_tx",
   "publish_forum_category_projection_in_tx",
   "publish_forum_topic_projection_in_tx",
@@ -212,8 +214,10 @@ rejectMarker(moderationPublic, "impl Deref", moderationPublicPath);
 for (const marker of [
   "search.reindex_requested",
   "owner transaction",
+  "PostgreSQL-only",
+  "validation only",
   "at-least-once",
-  "full Forum projection",
+  "Full Forum scope",
   "FORUM-20BL",
 ]) {
   requireMarker(note, marker, notePath);
@@ -231,9 +235,11 @@ if (contract) {
     failures.push(`${contractPath}: root event drift`);
   }
   for (const key of [
-    "owner_transaction_required",
+    "owner_transaction_required_on_postgresql",
+    "postgresql_direct_owner_invalidations_persisted",
+    "non_postgresql_direct_owner_invalidations_validation_only",
     "domain_event_validation_preserved",
-    "registered_envelope_schema_validation_preserved",
+    "registered_envelope_schema_validation_preserved_for_persisted_events",
     "canonical_sys_events_outbox_reused",
     "duplicate_invalidations_allowed",
     "consumer_operations_are_idempotent",
@@ -243,6 +249,7 @@ if (contract) {
     }
   }
   for (const key of [
+    "non_postgresql_forum_search_projector_supported",
     "new_root_domain_event_added",
     "new_event_schema_added",
     "sql_trigger_event_envelope_copy_added",
@@ -266,6 +273,7 @@ if (contract) {
     workspace_dependency_changed: false,
     cargo_lock_changed: false,
     migration_added: false,
+    sqlite_forum_domain_fixtures_require_outbox_migration: false,
   })) {
     if (contract.compatibility?.[key] !== expected) {
       failures.push(`${contractPath}: compatibility ${key} drift`);

--- a/scripts/verify/verify-forum-projection-invalidation.mjs
+++ b/scripts/verify/verify-forum-projection-invalidation.mjs
@@ -82,12 +82,19 @@ for (const marker of [
   requireMarker(outboxBus, marker, outboxBusPath);
 }
 for (const marker of [
-  "pub async fn write_envelope_in_tx<C>",
+  "pub(crate) async fn write_envelope_in_tx<C>",
   "Self::model_from_envelope(envelope)?",
   "validate_registered_schema()",
-  "pub async fn write_contract_envelope_in_tx<C>",
+  "pub(crate) async fn write_contract_envelope_in_tx<C>",
+  "external domain code must publish through `TransactionalEventBus`",
 ]) {
   requireMarker(outboxTransport, marker, outboxTransportPath);
+}
+for (const forbidden of [
+  "pub async fn write_envelope_in_tx<C>",
+  "pub async fn write_contract_envelope_in_tx<C>",
+]) {
+  rejectMarker(outboxTransport, forbidden, outboxTransportPath);
 }
 
 for (const marker of [

--- a/scripts/verify/verify-forum-search-projection.mjs
+++ b/scripts/verify/verify-forum-search-projection.mjs
@@ -33,6 +33,7 @@ const searchLibPath = "crates/rustok-search/src/lib.rs";
 const providerPath = "crates/rustok-forum/src/search_projection.rs";
 const forumLibPath = "crates/rustok-forum/src/lib.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-projection.json";
+const invalidationPath = "crates/rustok-forum/contracts/forum-projection-invalidation.json";
 const upstreamPath = "crates/rustok-forum/contracts/forum-public-discovery-seo.json";
 const notePath = "crates/rustok-forum/docs/forum-20bj-search-projection.md";
 
@@ -45,11 +46,17 @@ const provider = read(providerPath);
 const forumLib = read(forumLibPath);
 const note = read(notePath);
 let contract = null;
+let invalidation = null;
 let upstream = null;
 try {
   contract = JSON.parse(read(contractPath));
 } catch (error) {
   failures.push(`${contractPath}: invalid JSON: ${error.message}`);
+}
+try {
+  invalidation = JSON.parse(read(invalidationPath));
+} catch (error) {
+  failures.push(`${invalidationPath}: invalid JSON: ${error.message}`);
 }
 try {
   upstream = JSON.parse(read(upstreamPath));
@@ -175,8 +182,11 @@ if (contract) {
   if (contract.upstream_task !== "FORUM-20BI") {
     failures.push(`${contractPath}: unexpected upstream task`);
   }
-  if (contract.downstream_task !== "FORUM-20BK") {
+  if (contract.downstream_task !== "FORUM-20BL") {
     failures.push(`${contractPath}: unexpected downstream task`);
+  }
+  if (contract.invalidation_contract !== invalidationPath) {
+    failures.push(`${contractPath}: invalidation contract handoff drift`);
   }
   for (const key of [
     "neutral_capability_has_no_forum_dependency",
@@ -219,20 +229,22 @@ if (contract) {
     "explicit_forum_scope_reindex_supported",
     "explicit_forum_category_reindex_supported",
     "explicit_forum_topic_reindex_supported",
-  ]) {
-    if (!contract.ingestion_boundary?.[key]) {
-      failures.push(`${contractPath}: ingestion boundary must lock ${key}`);
-    }
-  }
-  for (const key of [
     "automatic_category_policy_change_reindex_added",
     "automatic_topic_policy_change_reindex_added",
     "automatic_topic_content_translation_tag_solution_change_reindex_added",
     "automatic_category_content_translation_tree_change_reindex_added",
+    "automatic_category_and_reply_count_reindex_added",
+    "owner_transactional_outbox_delivery_added",
   ]) {
-    if (contract.ingestion_boundary?.[key] !== false) {
-      failures.push(`${contractPath}: ${key} must remain explicit downstream scope`);
+    if (contract.ingestion_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: ingestion boundary ${key} drift`);
     }
+  }
+  if (contract.ingestion_boundary?.root_reindex_event_schema_changed !== false) {
+    failures.push(`${contractPath}: root reindex event schema must remain unchanged`);
+  }
+  if (contract.ingestion_boundary?.completion_contract !== invalidationPath) {
+    failures.push(`${contractPath}: completion contract drift`);
   }
   for (const [key, expected] of Object.entries({
     forum_to_search_workspace_dependency_added: false,
@@ -245,6 +257,21 @@ if (contract) {
     if (contract.compatibility?.[key] !== expected) {
       failures.push(`${contractPath}: compatibility ${key} drift`);
     }
+  }
+}
+
+if (invalidation) {
+  if (invalidation.task !== "FORUM-20BK") {
+    failures.push(`${invalidationPath}: unexpected task`);
+  }
+  if (invalidation.upstream_task !== "FORUM-20BJ") {
+    failures.push(`${invalidationPath}: unexpected upstream task`);
+  }
+  if (invalidation.downstream_task !== "FORUM-20BL") {
+    failures.push(`${invalidationPath}: unexpected downstream task`);
+  }
+  if (invalidation.upstream_contract !== contractPath) {
+    failures.push(`${invalidationPath}: upstream contract drift`);
   }
 }
 
@@ -262,7 +289,7 @@ if (upstream) {
     failures.push(`${upstreamPath}: workspace dependency handoff drift`);
   }
   if (upstream.downstream_task !== "FORUM-20BK") {
-    failures.push(`${upstreamPath}: downstream task drift`);
+    failures.push(`${upstreamPath}: historical downstream task drift`);
   }
 }
 


### PR DESCRIPTION
## Summary

- reuse the registered `DomainEvent::ReindexRequested` contract for canonical Forum Search projection invalidation; no new root event or schema
- add `TransactionalEventBus::publish_root_in_tx` so owner helpers with only an active transaction preserve both `DomainEvent::validate()` and registered envelope validation
- keep low-level static outbox writers crate-private; the validated transactional bus is the public root-event boundary
- publish full `forum` invalidations for category content/translations, hierarchy placement, subtree lifecycle, base visibility and inherited richer audience policy changes
- publish `forum_category` invalidations for topic and approved-reply count changes
- publish `forum_topic` invalidations for topic content/metadata/tags/channels, delete fallback, lock state, solution state and topic-local audience policy changes
- seal canonical category, audience and moderation write paths behind transactional owner facades while preserving existing public method signatures
- advance the FORUM-20BJ handoff and publish the FORUM-20BK contract, owner note and source verifier

## Runtime boundary

The Forum Search projector is PostgreSQL-only. Direct owner invalidations are written to the canonical `sys_events` outbox in the same PostgreSQL transaction as the domain mutation. SQLite and other unsupported projector backends perform event validation only, so standalone Forum SQLite fixtures do not require an unused outbox migration.

Owner paths that already carry a configured `TransactionalEventBus` retain their established transport behavior.

## Invalidation matrix

- `forum`, no ID: category create/update, locale copy, move/reorder, archive/delete-as-archive/restore, base visibility and inherited category audience changes
- `forum_category`, category ID: topic create/delete and approved-reply create/delete/moderation transitions that change category counters
- `forum_topic`, topic ID: topic update/delete fallback, lock/unlock, solution mark/clear and topic-local audience replacement

Existing topic create/status/pin and reply lifecycle events continue to refresh topic documents. Duplicate delivery is allowed under at-least-once dispatch because Search refreshes derive current exact owner state and are idempotent.

## Owner sealing

- public `CategoryService` routes content, placement and lifecycle writes through private same-module transactional owners
- public category/topic audience service names alias wrappers that delegate reads but own replacement transactions
- public moderation facade delegates to a private transactional owner; the legacy implementation and constructor are not exported
- private compatibility delegates remain implementation detail and are recorded as cleanup debt rather than alternative owners

## Compatibility

- no Search ingestion target change, migration, workspace dependency or `Cargo.lock` change
- no REST route, GraphQL field, native contract or public DTO change
- no requirement for SQLite Forum domain fixtures to install outbox migrations
- Forum remains usable without an active Search listener
- `implementation-plan.md`, `CRATE_API.md`, the Outbox owner API note and Search owner plan remain conflict-sensitive repository-local synchronization debt

## Remaining FORUM-20BL scope

- visibility-scoped category and all-read commands
- cross-source full Search rebuild atomicity or prior-scope preservation
- decision on approved public reply documents under FORUM-23
- removal of the uncompiled legacy GraphQL snapshot after verifier migration
- PostgreSQL runtime evidence and SQLite validation-only evidence
- a translation-control-plane invalidation adapter if Forum targets are registered later

## Validation

Not run by the implementation agent, per maintainer request: no tests, Cargo commands, formatting, verifiers, workflows or CI.

Suggested maintainer commands:

```text
cargo test -p rustok-outbox transactional -- --nocapture
cargo test -p rustok-forum projection_invalidation -- --nocapture
cargo test -p rustok-forum category_audience_policy_sqlite -- --nocapture
cargo test -p rustok-forum topic_audience_policy_sqlite -- --nocapture
cargo test -p rustok-search forum_projector -- --nocapture
node scripts/verify/verify-forum-search-projection.mjs
node scripts/verify/verify-forum-projection-invalidation.mjs
cargo xtask module validate forum
```
