### PR TITLE
feat(index): aggregate nested many-link projections

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -35,12 +35,15 @@ scheduler modules remain deleted.
 - `SchemaRegistryError`, `LinkPathStep`
 - `RecordValidationError`, `QueryValidationError`
 - `IndexCursor`, `CursorCodec`, `CursorCodecError`, `CursorValidationError`
-- `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedOrder`
+- `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedManyProjection`,
+  `PlannedOrder`
 - `QueryPlanFingerprint`, `QueryPlanError`
-- `PostgresBindValue`, `CompiledQueryColumn`, `CompiledPostgresCount`
+- `PostgresBindValue`, `CompiledQueryColumn`, `CompiledManyRelationColumn`,
+  `CompiledPostgresCount`
 - `CompiledPostgresQuery`, `PostgresQueryBuildError`, `PostgresQueryCompileError`
 - `CompiledPostgresCell`, `CompiledPostgresRow`, `CompiledPostgresPageQuery`
-- `IndexProjectedValue`, `IndexRelationIdentity`, `IndexQueryItem`, `IndexQueryPage`
+- `IndexProjectedValue`, `IndexRelationIdentity`, `IndexNestedRelationItem`,
+  `IndexNestedRelationProjection`, `IndexQueryItem`, `IndexQueryPage`
 - `PostgresQueryPageBuildError`, `PostgresQueryDecodeError`
 
 ### Infrastructure
@@ -112,13 +115,13 @@ cutover, or rollback.
 
 M4 provides validated typed executable plans, controlled PostgreSQL SQL and bind
 DTOs for root/one-link projection, filtering, ordering, counting and pagination,
-correlated many-link filtering, query-scoped cursor continuation, one-row page
-lookahead, strict compiled-column/result decoding, exact-count decoding, `has_more`,
-and next-cursor construction. It still does not execute statements, adapt SeaORM
-rows directly, aggregate many-link projections, publish `IndexQueryPort`, or claim
-PostgreSQL/reference-engine equivalence. Multi-source catalog composition, batch
-ingestion, rebuild, query-port, partition cutover, and operator APIs remain later
-work.
+correlated many-link filtering, deterministic nested many-link projection aggregates,
+query-scoped cursor continuation, one-row page lookahead, strict scalar/nested result
+decoding, exact-count decoding, `has_more`, and next-cursor construction. It still
+does not execute statements, adapt SeaORM rows directly, order through many links,
+publish `IndexQueryPort`, or claim PostgreSQL/reference-engine equivalence.
+Multi-source catalog composition, batch ingestion, rebuild, query-port, partition
+cutover, and operator APIs remain later work.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -150,11 +153,13 @@ APIs.
   ordered fields/directions, order arity, and order-value types.
 - Executing a page query through raw `compile_postgres_query` instead of the
   one-row-lookahead `compile_postgres_page_query` handoff.
-- Decoding rows without rechecking the plan fingerprint and exact compiled column
-  contract.
+- Decoding rows without rechecking the plan fingerprint and exact scalar/nested
+  column contracts.
 - Compiling a many-link filter as an ordinary outer join; it must remain a correlated
   predicate so child multiplicity cannot duplicate root rows or counts.
-- Sorting or projecting through a `many` link without an explicit aggregate policy.
+- Flattening many-link projection into outer rows or independent value arrays; one
+  aggregate item must retain its full identity chain and aligned selected values.
+- Sorting through a `many` link without an explicit aggregate ordering policy.
 - Completing or heartbeating schema/index work without exact worker and attempt
   fencing.
 - Building expression indexes against `payload ->> field`; stored `IndexValue`
@@ -178,8 +183,10 @@ APIs.
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
 - `SchemaRegistry::compile_postgres_page_query` is the page-execution compiler
   handoff; it preserves SQL and increases only the validated limit bind by one.
+- `CompiledPostgresQuery::many_relations` binds every aggregate output alias to its
+  exact `PlannedManyProjection` metadata.
 - `CompiledPostgresRow` is the narrow adapter handoff for compiler-owned UUID,
-  tagged JSON, SQL-null, and exact-count cells.
+  tagged JSON, nested aggregate JSON, SQL-null, and exact-count cells.
 - `PostgresSchemaRegistrationStore::register(tenant_id, schema)` binds one non-nil
   tenant to one validated exact schema contract and calculated fingerprint.
 - `SchemaApplicationLeaseRequest` binds one tenant, exact schema reference,
@@ -213,7 +220,9 @@ APIs.
 - Selected, filtered, and ordered fields are resolved through typed link paths.
 - Query complexity, path depth, page size, and offset depth are bounded.
 - Filtering through `many` paths uses correlated existential semantics.
-- Sorting through a `many` link is rejected until aggregation is explicit.
+- Projection through `many` paths returns deterministic nested items with complete
+  relation identity chains and aligned tagged values.
+- Sorting through a `many` link is rejected until aggregate ordering is explicit.
 - Source versions and tombstones prevent stale mutation overwrite.
 - Generic engine types remain source-domain agnostic.
 
@@ -296,25 +305,34 @@ APIs.
 ### Query Planning, Compilation, and Result Decoding
 
 - `SchemaRegistry::plan_query` validates first and captures deterministic aliases,
-  joins, typed referenced fields, propagated `traverses_many`, projection, filters,
-  ordering, pagination, and a v3 plan fingerprint.
+  joins, typed referenced fields, propagated `traverses_many`, scalar projection,
+  grouped `PlannedManyProjection` metadata, filters, ordering, pagination, and a v4
+  plan fingerprint.
+- Many projection groups preserve first terminal-path appearance and requested field
+  order; each group records every relation-prefix identity path.
 - `compile_postgres_query` emits controlled SQL plus ordered bind DTOs for root and
-  one-link projection/ordering plus all validated filters; caller values and contract
-  names remain binds.
+  one-link projection/ordering, nested many projection aggregates, and all validated
+  filters; caller values and contract names remain binds.
 - Every many-traversing atomic filter emits an independent nested correlated `EXISTS`
   chain. No many join enters the outer rowset or identity-column contract.
+- Every selected many path emits one correlated JSONB aggregate ordered by stored link
+  ordinal, target entity identity, and locale at every hop. Empty reachability emits
+  an empty array rather than a null relation.
+- Aggregate items carry parallel identity/value arrays whose exact arity and metadata
+  are fixed by the compiled plan; the public decoder reconstructs typed nested items.
 - Many-link `Ne` requires at least one stored reachable value and no reachable null or
   equal value; `IsNull` tests the absence of any reachable non-null value.
 - `compile_postgres_page_query` changes only the validated main-statement page-limit
   bind from `N` to `N + 1`; offset and exact-count binds are preserved.
 - `decode_postgres_query_page` re-plans the query, compares the plan fingerprint and
-  complete unique column metadata, validates every tagged field value, and rejects
-  more than `N + 1` rows.
+  complete unique scalar/many metadata, validates every tagged field value, nested
+  identity/value arity, nil or duplicate identity chains, and rejects more than
+  `N + 1` rows.
 - The lookahead row is removed. Cursor pages produce `has_more` and a scoped next
   cursor from the last retained entity/order tuple; offset pages produce
   `has_more` without a cursor.
-- Many-link projection/order, SQL execution, SeaORM row adaptation, and live
-  equivalence evidence remain separate future boundaries.
+- Many-link ordering, SQL execution, SeaORM row adaptation, and live equivalence
+  evidence remain separate future boundaries.
 
 ### Cursor Contract
 
@@ -354,11 +372,12 @@ APIs.
   scope/schema/query-fingerprint/type mismatches.
 - `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError`
   separate validation/planning failures from unsupported or corrupted compiler
-  contracts. Many-link projection, ordering, missing join plans, and inconsistent
-  traversal metadata are distinct typed compiler failures.
+  contracts. Many-link ordering, missing join plans, inconsistent traversal metadata,
+  and inconsistent nested projection plans are distinct typed compiler failures.
 - `PostgresQueryPageBuildError` rejects missing or mismatched pagination binds;
-  `PostgresQueryDecodeError` rejects plan/column/count mismatches, malformed cells,
-  invalid tagged values, unexpected nulls, and oversized result batches.
+  `PostgresQueryDecodeError` rejects plan/scalar/many/count mismatches, malformed
+  cells, invalid tagged values, invalid nested JSON, identity/value arity drift,
+  nil/duplicate nested identities, unexpected nulls, and oversized result batches.
 - `MutationStorageError` separates validation, delivery identity conflict,
   in-progress/rejected replay, stored-version corruption, backend limits, and
   database failure. Its public display is generic; transport adapters must still

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (many-link EXISTS filtering added; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (nested many-link projection added; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -56,16 +56,18 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 typed root/one-link query semantics: `complete`
 - M4 deterministic PostgreSQL result decoding: `complete`
 - M4 many-link `EXISTS` filtering: `complete`
+- M4 nested many-link projection aggregation: `complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
   admitted archive manifest generation, saved-manifest verification, recursive
   filesystem integrity checks, typed executable query planning, controlled projection,
   root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
-  compilation, correlated many-link filtering, one-row page lookahead, tagged row
-  decoding, exact-count decoding, and scoped next-cursor construction are implemented;
-  one retained admitted packet, many-link projection, SQL execution composition,
-  PostgreSQL/reference equivalence, and production partition lifecycle remain open
+  compilation, correlated many-link filtering, deterministic nested many-link
+  projection aggregation, one-row page lookahead, tagged row decoding, exact-count
+  decoding, and scoped next-cursor construction are implemented; one retained admitted
+  packet, SQL execution composition, PostgreSQL/reference equivalence, and production
+  partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -73,9 +75,10 @@ lifecycle management, measured partition admission that emits shadow bootstrap
 plans only, an M4 typed structural query planner with deterministic relation aliases,
 a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
 exact count, keyset and bounded offset plus duplicate-free correlated many-link
-filtering, and a strict compiled-row decoder with lookahead pagination and scoped
-cursor construction. Owner-operated evidence tools live under `ops/benches`; they do
-not become runtime storage code.
+filtering and nested many-link projection aggregates, and a strict compiled-row decoder
+with aligned nested identities/values, lookahead pagination, and scoped cursor
+construction. Owner-operated evidence tools live under `ops/benches`; they do not
+become runtime storage code.
 
 ## Ownership
 
@@ -309,14 +312,15 @@ relations.
 - [x] Keep offset pagination bounded and compatibility-only.
 - [x] Add deterministic root/one-link result decoding and cursor construction.
 - [x] Add explicit many-link `EXISTS` filtering.
-- [ ] Add nested many-link projection aggregation.
+- [x] Add nested many-link projection aggregation.
 - [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
 
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
 prefixes, and captures every referenced field with type, cardinality, nullability,
-path, alias, and propagated many-link traversal state. The typed plan fingerprint
-uses the versioned `rustok-index-query-plan-v3` domain.
+path, alias, and propagated many-link traversal state. It groups selected many fields
+by terminal relation path while preserving first path appearance and field order. The
+typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
 
 The controlled compiler emits ordered typed binds, deterministic identity/projection/
 order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
@@ -326,13 +330,20 @@ separate exact-count statement without pagination leakage. Opaque continuation t
 must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
 schema fingerprint, order arity, and order-value types before SQL emission.
 
+Each selected many path compiles as one correlated JSONB aggregate outside the outer
+rowset. Aggregate items preserve the complete linked entity identity chain and aligned
+tagged field values, are ordered by stored link ordinal plus target identity/locale at
+each hop, and produce an empty array when no reachable row exists. Many aggregates do
+not alter root pagination, lookahead, or exact-count cardinality.
+
 The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
 the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
-fingerprint, deterministic compiled column contract, page size, row count, tagged
-`IndexValue` type/cardinality/nullability, relation identities, and optional count.
-It removes the lookahead row, reports `has_more`, preserves selection order, and emits
-a query-scoped cursor from the last retained root identity plus hidden order values.
-Offset pages use the same lookahead rule but do not synthesize a cursor.
+fingerprint, deterministic scalar and many-relation column contracts, page size, row
+count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
+identity/value arity, duplicate/nil nested identities, and optional count. It removes
+the lookahead row, reports `has_more`, preserves flat and nested selection order, and
+emits a query-scoped cursor from the last retained root identity plus hidden order
+values. Offset pages use the same lookahead rule but do not synthesize a cursor.
 
 Many-link filtering compiles every atomic predicate through an independent nested
 correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
@@ -341,11 +352,10 @@ any-match semantics; `IsNull` checks for the absence of a reachable non-null val
 `Ne` requires at least one stored reachable value and rejects any null or equal value.
 This matches the test-only reference engine's flattened path-value semantics.
 
-Many-link projection remains fail-closed with `ManyLinkProjectionPending` until a
-nested aggregation result shape is explicit. Many-link ordering remains rejected until
-an aggregate policy exists. SQL execution, direct SeaORM row adaptation,
-persisted-schema readiness, query-port composition, consumer cutover, plan/SQL
-snapshots, and PostgreSQL/reference-engine equivalence remain open.
+Many-link ordering remains rejected until an aggregate ordering policy exists. SQL
+execution, direct SeaORM row adaptation, persisted-schema readiness, query-port
+composition, consumer cutover, plan/SQL snapshots, and PostgreSQL/reference-engine
+equivalence remain open.
 
 ### M5 - Incremental ingestion
 
@@ -477,9 +487,10 @@ node scripts/verify/verify-index-many-link-filtering.mjs
   M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
   exact count, validated lexicographic keyset continuation, bounded offset
   compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
-  count decoding, relation identity reconstruction, scoped next-cursor creation, and
-  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination.
-  Many-link projection, direct SQL execution/row adaptation, plan/SQL snapshots, and
+  count decoding, relation identity reconstruction, scoped next-cursor creation,
+  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
+  and deterministic nested many-link projection aggregation with aligned identity/value
+  decoding. Direct SQL execution/row adaptation, plan/SQL snapshots, and
   PostgreSQL/reference equivalence remain open.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition

--- a/crates/rustok-index/docs/m4-many-link-projection.md
+++ b/crates/rustok-index/docs/m4-many-link-projection.md
@@ -1,0 +1,109 @@
+# M4 nested many-link projection aggregation
+
+This slice adds deterministic typed projection through explicit relation paths that
+cross one or more `many` links. It extends the controlled planner, PostgreSQL compiler,
+and compiled-row decoder only. It does not execute SQL, adapt database-driver rows,
+or add aggregate ordering semantics.
+
+## Planned result shape
+
+`ExecutableQueryPlan` now carries `many_projections`. Every
+`PlannedManyProjection` groups selected fields that share the same terminal link path.
+Groups are ordered by the first selected field for that path, and fields inside a group
+preserve query selection order. Interleaved selections across different many paths are
+therefore deterministic without requiring callers to reorder the query.
+
+Each group records every relation-path prefix in `identity_paths`. A projected path
+`variants.prices.amount`, for example, retains both `variants` and
+`variants.prices` identities for every terminal row. The plan fingerprint domain is
+`rustok-index-query-plan-v4` because this nested result shape is part of the executable
+contract.
+
+Before SQL emission the compiler derives the groups again from the selected fields and
+requires exact equality with the plan. Missing joins, empty groups, inconsistent path
+prefixes, altered field order, or incorrect many-traversal metadata fail closed.
+
+## Root rowset boundary
+
+Many projection paths never become joins in the outer page rowset. The main statement
+still contains exactly one row per root entity and retains the existing root/one-link
+identity, ordering, keyset, bounded-offset, lookahead, and exact-count semantics.
+
+Each many projection is one correlated scalar JSONB subquery. The subquery starts at
+the root identity, traverses the complete explicit link path through `index_links` and
+live `index_entities`, and returns one JSON array. An empty or missing relation returns
+an empty array rather than SQL `NULL`.
+
+## Deterministic row aggregation
+
+Every terminal relation row is encoded internally as two aligned arrays:
+
+- `entity_ids` contains one UUID for every relation-path prefix;
+- `values` contains one tagged `IndexValue` for every selected field in the group.
+
+Missing stored fields are encoded as the tagged `IndexValue::Null` shape. Existing
+list-cardinality fields remain tagged lists inside the row; they are not flattened and
+do not lose their per-entity boundary.
+
+The aggregate is ordered at every relation step by:
+
+1. persisted link ordinal ascending;
+2. target entity UUID ascending;
+3. target locale key ascending.
+
+This ordering preserves source-declared relation order while adding stable identity
+tie-breakers. Duplicate target identities are already rejected by Index record
+validation, and the result decoder also rejects a repeated complete identity chain.
+
+## Public decoded result
+
+Root and one-link projected values remain in `IndexQueryItem::fields`, with their
+existing `IndexRelationIdentity` entries in `IndexQueryItem::relations`.
+Many-traversing values are returned separately in
+`IndexQueryItem::nested_relations`:
+
+- `IndexNestedRelationProjection::path` identifies the terminal relation path;
+- each `IndexNestedRelationItem` contains the complete ordered relation identity chain;
+- the item's fields preserve their absolute `FieldPath`, source cardinality,
+  nullability, type, and query selection order.
+
+Keeping row identities and field values together avoids the false alignment produced
+by independent per-field arrays. Consumers can distinguish two variants that carry
+different combinations of projected attributes, and deeper many/one paths retain their
+ancestry.
+
+## Decoder boundary
+
+`CompiledQueryColumn::ManyRelation` carries the exact planned group. The decoder
+re-plans the query and requires exact fingerprint and column equality before reading a
+row. It then validates:
+
+- JSON array shape;
+- identity and field arity;
+- non-nil UUID identities;
+- unique complete identity chains;
+- tagged `IndexValue` decoding;
+- source field type, cardinality, and nullability.
+
+Malformed or partially aligned aggregate data never becomes a public query result.
+
+## Remaining fail-closed semantics
+
+Ordering through a many link remains rejected with `ManyLinkOrderingPending` until an
+explicit aggregate ordering policy is selected. The existing correlated `EXISTS`
+filtering contract is unchanged; every atomic filter remains independent and does not
+reuse projection aggregates.
+
+This slice does not:
+
+- prepare or execute PostgreSQL statements;
+- map `PostgresBindValue` into SeaORM/sqlx parameters;
+- adapt SeaORM `QueryResult` values into `CompiledPostgresRow`;
+- publish or compose `IndexQueryPort`;
+- authorize callers;
+- read source-module tables;
+- claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence;
+- change migrations, ingestion, rebuild, or partition lifecycle state.
+
+Formatting, compilation, tests, static verifiers, and live PostgreSQL equivalence are
+reserved for the later owner-operated verification phase.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -17,9 +17,12 @@ separate application handoff; neither slice publishes an `IndexQueryPort`.
 - nullability;
 - whether the path traverses at least one many-cardinality link.
 
-`PlannedJoin` carries the same propagated `traverses_many` boundary. The plan
-fingerprint domain is `rustok-index-query-plan-v3`, so plans without canonical
-many-traversal metadata cannot be confused with current compiler input.
+`PlannedJoin` carries the same propagated `traverses_many` boundary. Projected fields
+that traverse many are grouped into `PlannedManyProjection` values by terminal link
+path. Each group preserves first-path occurrence, selected field order, and every
+relation identity prefix. The plan fingerprint domain is
+`rustok-index-query-plan-v4`, so older or altered nested-result plans cannot be
+confused with current compiler input.
 
 ## Supported query semantics
 
@@ -27,6 +30,7 @@ many-traversal metadata cannot be confused with current compiler input.
 and validates any continuation cursor, and then compiles:
 
 - root projection and projection through explicit one-cardinality links;
+- row-aligned nested projection through paths crossing one or more many links;
 - `And`, `Or`, `Not`, `Eq`, `Ne`, `In`, range, `Contains`, and `IsNull` filters;
 - filtering through paths that cross one or more many-cardinality links;
 - typed PostgreSQL casts for boolean, integer, decimal, string, UUID, and
@@ -37,7 +41,7 @@ and validates any continuation cursor, and then compiles:
 - bounded cursor limits;
 - bounded compatibility offset pagination;
 - an optional separate exact-count statement over the same scope and filters,
-  without cursor, limit, or offset leakage.
+  without cursor, limit, offset, or projection leakage.
 
 The main page statement selects hidden tagged JSONB order values when explicit
 ordering is present. `decode_postgres_query_page` uses those values to construct
@@ -47,12 +51,12 @@ projection.
 ## Predicate and ordering contract
 
 Scalar fields are extracted from the tagged JSONB storage value and cast to the
-registered field type. Field names and scalar/list values remain bind
-parameters. Strings use `COLLATE "C"`; timestamps use `timestamptz`.
+registered field type. Field names and scalar/list values remain bind parameters.
+Strings use `COLLATE "C"`; timestamps use `timestamptz`.
 
 Atomic predicates are compiled into total booleans. Missing linked rows, absent
-fields, and tagged null values do not leak SQL `NULL` into `Not`, `And`, or
-`Or` semantics:
+fields, and tagged null values do not leak SQL `NULL` into `Not`, `And`, or `Or`
+semantics:
 
 - equality, membership, range, and containment use `COALESCE(..., FALSE)`;
 - root/one-link `Ne` is true only for an existing non-null scalar that differs;
@@ -60,17 +64,16 @@ fields, and tagged null values do not leak SQL `NULL` into `Not`, `And`, or
   null.
 
 Ascending order uses `NULLS LAST`; descending order uses `NULLS FIRST`, followed
-by the invariant ascending `entity_id` tie-breaker. PostgreSQL/reference-engine
-equivalence remains a later evidence slice rather than a claim of this source
-change.
+by the invariant ascending `entity_id` tie-breaker. Ordering through a many link
+remains rejected because no aggregate order policy exists.
 
 ## Many-link filter boundary
 
-Many-traversing joins are excluded from the main `FROM` clause and compiled identity
-columns. Every atomic filter on such a field emits an independent nested correlated
-`EXISTS` chain over `index_links` and live `index_entities` targets. Complete source
-identity, source version, link name, and exact target schema identity are checked at
-each hop.
+Many-traversing joins are excluded from the main `FROM` clause and compiled outer
+identity columns. Every atomic filter on such a field emits an independent nested
+correlated `EXISTS` chain over `index_links` and live `index_entities` targets.
+Complete source identity, source version, link name, and exact target schema identity
+are checked at each hop.
 
 Independent atomic subqueries preserve reference semantics when separate children
 satisfy separate logical branches. Positive operators use any-match behavior.
@@ -82,6 +85,28 @@ equal to the requested value.
 
 Because no many join enters the outer rowset, root keyset/offset pagination,
 one-row lookahead, and `COUNT(*)` remain duplicate free.
+
+## Nested many-link projection boundary
+
+Each `PlannedManyProjection` compiles into one correlated scalar JSONB aggregate.
+The subquery traverses the complete explicit relation path but never joins that path
+into the outer root rowset. Empty relations return `[]`.
+
+Every aggregate item stores aligned arrays for:
+
+- the UUID at every relation-path prefix;
+- the tagged `IndexValue` for every selected field sharing the terminal path.
+
+Stored list fields remain one tagged list value inside their owning relation item;
+they are not flattened across entities. Missing stored fields become tagged nulls and
+are revalidated against source nullability by the decoder.
+
+Aggregate rows use deterministic ordering at each link step: persisted ordinal,
+target UUID, then target locale key. The decoder reconstructs
+`IndexNestedRelationProjection` / `IndexNestedRelationItem`, preserving complete
+ancestry and field alignment. It rejects malformed JSON, arity drift, nil identities,
+duplicate identity chains, invalid tagged values, and source type/cardinality/
+nullability mismatches.
 
 ## Cursor boundary
 
@@ -103,54 +128,53 @@ and ordered field/direction semantics. A continuation query must use
 - every non-null cursor order value against the registered field type.
 
 Changing a filter, ordered field, or order direction therefore produces
-`QueryFingerprintMismatch` before keyset SQL is emitted.
+`QueryFingerprintMismatch` before keyset SQL is emitted. Projection changes alter the
+v4 executable plan and compiled-column contract without invalidating a cursor whose
+filter/order scope is otherwise unchanged.
 
 ## Bind and SQL boundary
 
-Tenant UUID, schema identities, locale, link metadata, field names, filter
-values, cursor values, limit, and offset are bind values. Only fixed
-`index_entities`/`index_links` table and column names plus compiler-owned `tN`,
-`lN`, and `mx_*` aliases appear in SQL.
+Tenant UUID, schema identities, locale, link metadata, field names, filter values,
+cursor values, limit, and offset are bind values. Only fixed
+`index_entities`/`index_links` table and column names plus compiler-owned `tN`, `lN`,
+`mx_*`, and `mpN_*` aliases appear in SQL.
 
-The compiler contract, SQL emission, and page/result handoff live in separate
-modules:
+The compiler contract, SQL emission, and page/result handoff live in separate modules:
 
-- `application/postgres_compiler.rs` owns public SQL/bind types, scoped cursor
-  entry points, and plan invariant checks;
+- `application/planner.rs` owns propagated many metadata and nested projection groups;
+- `application/postgres_compiler.rs` owns public SQL/bind types, scoped cursor entry
+  points, compiled column metadata, and plan invariant checks;
 - `application/postgres_query_sql.rs` owns controlled SQL, correlated many-link
-  predicates, and deterministic bind emission;
+  predicates/aggregates, and deterministic bind emission;
 - `application/postgres_query_result.rs` owns one-row lookahead wrapping, strict
-  compiled-column decoding, exact count, `has_more`, and scoped next cursors.
+  compiled-column and nested-payload decoding, exact count, `has_more`, and scoped
+  next cursors.
 
 ## Page and result handoff
 
-`SchemaRegistry::compile_postgres_page_query` calls the validated compiler and
-changes only the main page-limit bind from `N` to `N + 1`. The SQL string,
-filters, ordering, keyset predicate, offset, plan fingerprint, and optional count
-statement remain unchanged.
+`SchemaRegistry::compile_postgres_page_query` calls the validated compiler and changes
+only the main page-limit bind from `N` to `N + 1`. The SQL string, filters, projection,
+ordering, keyset predicate, offset, plan fingerprint, and optional count statement
+remain unchanged.
 
-A later database adapter executes the compiled statements and maps driver values
-into `CompiledPostgresRow`. `decode_postgres_query_page` then rechecks the plan
-fingerprint and complete `CompiledQueryColumn` contract, validates tagged
-`IndexValue` type/cardinality/nullability, removes the lookahead row, and returns
-`IndexQueryPage`. Many-filter paths do not add hidden relation columns because they
-are confined to correlated subqueries.
+A later database adapter executes the compiled statements and maps driver values into
+`CompiledPostgresRow`. `decode_postgres_query_page` then rechecks the v4 plan
+fingerprint and complete `CompiledQueryColumn` contract, validates flat and nested
+tagged values, removes the lookahead row, and returns `IndexQueryPage`.
 
 ## Exact count
 
 `include_exact_count` produces `CompiledPostgresCount` as a separate controlled
 statement with its own ordered bind list. The count applies tenant/schema/locale,
-live-row, non-many outer joins, and all filters, but deliberately excludes keyset,
-ordering, limit, and offset. Many filters remain correlated subqueries, so child
-multiplicity cannot inflate the count.
+live-row, non-many outer joins, and all filters, but deliberately excludes projection,
+keyset, ordering, limit, and offset. Many filters remain correlated subqueries, so
+child multiplicity cannot inflate the count.
 
-## Fail-closed pending semantics
+## Remaining fail-closed semantics
 
-Projection through a many-cardinality path remains rejected with
-`ManyLinkProjectionPending` until a nested aggregation result shape is explicit.
-Many-link ordering remains rejected until an aggregate ordering policy exists.
-Compiler validation recalculates propagated many metadata and rejects missing or
-inconsistent join/field contracts before SQL emission.
+Many-link ordering remains rejected until an explicit aggregate policy exists.
+Compiler validation recalculates propagated many metadata and nested projection groups,
+and rejects missing or inconsistent join/field/result contracts before SQL emission.
 
 ## Non-claims
 
@@ -161,10 +185,10 @@ This source chain does not:
 - decode directly from SeaORM `QueryResult`;
 - authorize callers;
 - verify persisted schema readiness;
-- support many-link projection or aggregate ordering;
+- support aggregate ordering through many links;
 - claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence;
 - read source-module tables;
 - change migrations or production partition lifecycle state.
 
-The repository owner runs formatting, compilation, tests, static verifiers, and
-later PostgreSQL/reference-engine equivalence evidence.
+Formatting, compilation, tests, static verifiers, and later PostgreSQL/reference-engine
+equivalence evidence are reserved for the owner-operated verification phase.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -17,16 +17,17 @@ mod reference;
 
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};
 pub use planner::{
-    ExecutableQueryPlan, PlannedField, PlannedJoin, PlannedOrder, QueryPlanError,
-    QueryPlanFingerprint,
+    ExecutableQueryPlan, PlannedField, PlannedJoin, PlannedManyProjection, PlannedOrder,
+    QueryPlanError, QueryPlanFingerprint,
 };
 pub use postgres_compiler::{
     CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue,
     PostgresQueryBuildError, PostgresQueryCompileError,
 };
 pub use postgres_query_result::{
-    CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow, IndexProjectedValue,
-    IndexQueryItem, IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError,
+    CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,
+    IndexNestedRelationItem, IndexNestedRelationProjection, IndexProjectedValue, IndexQueryItem,
+    IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError,
     PostgresQueryPageBuildError,
 };
 pub use registry::{

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -21,8 +21,9 @@ pub use planner::{
     QueryPlanError, QueryPlanFingerprint,
 };
 pub use postgres_compiler::{
-    CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue,
-    PostgresQueryBuildError, PostgresQueryCompileError,
+    CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
+    CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError,
+    PostgresQueryCompileError,
 };
 pub use postgres_query_result::{
     CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -66,6 +66,15 @@ pub struct PlannedOrder {
     pub direction: OrderDirection,
 }
 
+/// One deterministic nested result group for projected fields sharing a terminal
+/// relation path that crosses at least one many-cardinality link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannedManyProjection {
+    pub path: Vec<LinkName>,
+    pub identity_paths: Vec<Vec<LinkName>>,
+    pub fields: Vec<PlannedField>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutableQueryPlan {
     pub scope: IndexQueryScope,
@@ -75,6 +84,7 @@ pub struct ExecutableQueryPlan {
     pub joins: Vec<PlannedJoin>,
     pub referenced_fields: BTreeMap<FieldPath, PlannedField>,
     pub projection: Vec<PlannedField>,
+    pub many_projections: Vec<PlannedManyProjection>,
     pub filter: Option<FilterExpr>,
     pub order_by: Vec<PlannedOrder>,
     pub pagination: Pagination,
@@ -100,10 +110,14 @@ impl ExecutableQueryPlan {
         self.joins.iter().filter(|join| !join.traverses_many)
     }
 
+    pub(crate) fn outer_projection(&self) -> impl Iterator<Item = &PlannedField> {
+        self.projection.iter().filter(|field| !field.traverses_many)
+    }
+
     pub fn fingerprint(&self) -> Result<QueryPlanFingerprint, postcard::Error> {
         let bytes = postcard::to_stdvec(self)?;
         let mut hasher = Sha256::new();
-        hasher.update(b"rustok-index-query-plan-v3");
+        hasher.update(b"rustok-index-query-plan-v4");
         hasher.update((bytes.len() as u64).to_be_bytes());
         hasher.update(bytes);
         Ok(QueryPlanFingerprint(hasher.finalize().into()))
@@ -227,6 +241,7 @@ impl SchemaRegistry {
             .iter()
             .map(|path| planned_field(&referenced_fields, path))
             .collect::<Result<Vec<_>, _>>()?;
+        let many_projections = plan_many_projections(&projection);
         let order_by = query
             .order_by
             .iter()
@@ -246,6 +261,7 @@ impl SchemaRegistry {
             joins,
             referenced_fields,
             projection,
+            many_projections,
             filter: query.filter.clone(),
             order_by,
             pagination: query.pagination.clone(),
@@ -262,6 +278,31 @@ fn planned_field(
         .get(path)
         .cloned()
         .ok_or_else(|| QueryPlanError::ValidatedAliasMissing(path.clone()))
+}
+
+fn plan_many_projections(projection: &[PlannedField]) -> Vec<PlannedManyProjection> {
+    let mut group_indexes = BTreeMap::<Vec<LinkName>, usize>::new();
+    let mut groups = Vec::<PlannedManyProjection>::new();
+
+    for field in projection.iter().filter(|field| field.traverses_many) {
+        let path = field.path.links().to_vec();
+        if let Some(index) = group_indexes.get(&path).copied() {
+            groups[index].fields.push(field.clone());
+            continue;
+        }
+
+        let identity_paths = (1..=path.len())
+            .map(|depth| path[..depth].to_vec())
+            .collect();
+        group_indexes.insert(path.clone(), groups.len());
+        groups.push(PlannedManyProjection {
+            path,
+            identity_paths,
+            fields: vec![field.clone()],
+        });
+    }
+
+    groups
 }
 
 fn collect_link_prefixes(query: &IndexQuery) -> Vec<Vec<LinkName>> {

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -241,7 +241,7 @@ impl SchemaRegistry {
             .iter()
             .map(|path| planned_field(&referenced_fields, path))
             .collect::<Result<Vec<_>, _>>()?;
-        let many_projections = plan_many_projections(&projection);
+        let many_projections = derive_many_projections(&projection);
         let order_by = query
             .order_by
             .iter()
@@ -280,7 +280,9 @@ fn planned_field(
         .ok_or_else(|| QueryPlanError::ValidatedAliasMissing(path.clone()))
 }
 
-fn plan_many_projections(projection: &[PlannedField]) -> Vec<PlannedManyProjection> {
+pub(crate) fn derive_many_projections(
+    projection: &[PlannedField],
+) -> Vec<PlannedManyProjection> {
     let mut group_indexes = BTreeMap::<Vec<LinkName>, usize>::new();
     let mut groups = Vec::<PlannedManyProjection>::new();
 

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -9,7 +11,7 @@ use crate::domain::{FieldPath, IndexQuery, LinkCardinality, LinkName, Pagination
 
 use super::{
     CursorCodec, CursorValidationError, ExecutableQueryPlan, IndexCursor, PlannedField,
-    QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
+    PlannedManyProjection, QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +36,10 @@ pub enum CompiledQueryColumn {
     Field {
         output_alias: String,
         field: PlannedField,
+    },
+    ManyRelation {
+        output_alias: String,
+        projection: PlannedManyProjection,
     },
     OrderValue {
         output_alias: String,
@@ -72,14 +78,14 @@ pub enum PostgresQueryCompileError {
     CursorContextRequired,
     #[error("decoded cursor context does not match query pagination")]
     CursorContextMismatch,
-    #[error("many-cardinality projection requires nested aggregation planning: {0:?}")]
-    ManyLinkProjectionPending(FieldPath),
     #[error("many-cardinality ordering requires an explicit aggregate policy: {0:?}")]
     ManyLinkOrderingPending(FieldPath),
     #[error("query plan has no join contract for path {0:?}")]
     MissingJoinPlan(Vec<LinkName>),
     #[error("query plan many-link traversal metadata is inconsistent for path {0:?}")]
     ManyTraversalMismatch(Vec<LinkName>),
+    #[error("query plan nested many-projection metadata is inconsistent")]
+    ManyProjectionPlanMismatch,
     #[error("query plan relation aliases do not match the path-alias map")]
     AliasMappingMismatch,
     #[error("query plan has no typed field contract for {0:?}")]
@@ -215,12 +221,8 @@ impl ExecutableQueryPlan {
                     field.path.clone(),
                 ));
             }
-            if field.traverses_many {
-                return Err(PostgresQueryCompileError::ManyLinkProjectionPending(
-                    field.path.clone(),
-                ));
-            }
         }
+        validate_many_projection_contract(self)?;
         for order in &self.order_by {
             if self.referenced_fields.get(&order.field.path) != Some(&order.field) {
                 return Err(PostgresQueryCompileError::MissingFieldPlan(
@@ -271,6 +273,50 @@ impl ExecutableQueryPlan {
             _ => Err(PostgresQueryCompileError::CursorContextMismatch),
         }
     }
+}
+
+fn validate_many_projection_contract(
+    plan: &ExecutableQueryPlan,
+) -> Result<(), PostgresQueryCompileError> {
+    let expected_fields = plan
+        .projection
+        .iter()
+        .filter(|field| field.traverses_many)
+        .collect::<Vec<_>>();
+    let actual_fields = plan
+        .many_projections
+        .iter()
+        .flat_map(|projection| projection.fields.iter())
+        .collect::<Vec<_>>();
+    if actual_fields != expected_fields {
+        return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
+    }
+
+    let mut paths = BTreeSet::new();
+    for projection in &plan.many_projections {
+        if projection.path.is_empty()
+            || projection.fields.is_empty()
+            || !paths.insert(projection.path.clone())
+        {
+            return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
+        }
+        let expected_identity_paths = (1..=projection.path.len())
+            .map(|depth| projection.path[..depth].to_vec())
+            .collect::<Vec<_>>();
+        if projection.identity_paths != expected_identity_paths
+            || projection.fields.iter().any(|field| {
+                !field.traverses_many || field.path.links() != projection.path.as_slice()
+            })
+        {
+            return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
+        }
+        for path in &projection.identity_paths {
+            if plan.join_for_path(path).is_none() {
+                return Err(PostgresQueryCompileError::MissingJoinPlan(path.clone()));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_alias(alias: &str) -> Result<(), PostgresQueryCompileError> {

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -12,6 +10,7 @@ use crate::domain::{FieldPath, IndexQuery, LinkCardinality, LinkName, Pagination
 use super::{
     CursorCodec, CursorValidationError, ExecutableQueryPlan, IndexCursor, PlannedField,
     PlannedManyProjection, QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
+    planner::derive_many_projections,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -278,36 +277,12 @@ impl ExecutableQueryPlan {
 fn validate_many_projection_contract(
     plan: &ExecutableQueryPlan,
 ) -> Result<(), PostgresQueryCompileError> {
-    let expected_fields = plan
-        .projection
-        .iter()
-        .filter(|field| field.traverses_many)
-        .collect::<Vec<_>>();
-    let actual_fields = plan
-        .many_projections
-        .iter()
-        .flat_map(|projection| projection.fields.iter())
-        .collect::<Vec<_>>();
-    if actual_fields != expected_fields {
+    if plan.many_projections != derive_many_projections(&plan.projection) {
         return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
     }
 
-    let mut paths = BTreeSet::new();
     for projection in &plan.many_projections {
-        if projection.path.is_empty()
-            || projection.fields.is_empty()
-            || !paths.insert(projection.path.clone())
-        {
-            return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
-        }
-        let expected_identity_paths = (1..=projection.path.len())
-            .map(|depth| projection.path[..depth].to_vec())
-            .collect::<Vec<_>>();
-        if projection.identity_paths != expected_identity_paths
-            || projection.fields.iter().any(|field| {
-                !field.traverses_many || field.path.links() != projection.path.as_slice()
-            })
-        {
+        if projection.path.is_empty() || projection.fields.is_empty() {
             return Err(PostgresQueryCompileError::ManyProjectionPlanMismatch);
         }
         for path in &projection.identity_paths {

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -36,14 +36,16 @@ pub enum CompiledQueryColumn {
         output_alias: String,
         field: PlannedField,
     },
-    ManyRelation {
-        output_alias: String,
-        projection: PlannedManyProjection,
-    },
     OrderValue {
         output_alias: String,
         field: PlannedField,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledManyRelationColumn {
+    pub output_alias: String,
+    pub projection: PlannedManyProjection,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +59,7 @@ pub struct CompiledPostgresQuery {
     pub sql: String,
     pub binds: Vec<PostgresBindValue>,
     pub columns: Vec<CompiledQueryColumn>,
+    pub many_relations: Vec<CompiledManyRelationColumn>,
     pub exact_count: Option<CompiledPostgresCount>,
     pub plan_fingerprint: QueryPlanFingerprint,
 }

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -10,10 +10,10 @@ use crate::domain::{
 };
 
 use super::{
-    CompiledPostgresQuery, CompiledQueryColumn, CursorCodec, CursorValidationError,
-    ExecutableQueryPlan, IndexCursor, PlannedField, PlannedManyProjection, PostgresBindValue,
-    PostgresQueryBuildError, QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
-    SchemaRegistryError,
+    CompiledManyRelationColumn, CompiledPostgresQuery, CompiledQueryColumn, CursorCodec,
+    CursorValidationError, ExecutableQueryPlan, IndexCursor, PlannedField,
+    PlannedManyProjection, PostgresBindValue, PostgresQueryBuildError, QueryPlanError,
+    QueryPlanFingerprint, SchemaRegistry, SchemaRegistryError,
 };
 
 const EXACT_COUNT_ALIAS: &str = "__exact_count";
@@ -245,9 +245,16 @@ impl SchemaRegistry {
             .columns
             .iter()
             .map(column_output_alias)
+            .chain(
+                compiled
+                    .many_relations
+                    .iter()
+                    .map(|column| column.output_alias.as_str()),
+            )
             .collect::<BTreeSet<_>>();
-        if unique_aliases.len() != compiled.columns.len()
+        if unique_aliases.len() != compiled.columns.len() + compiled.many_relations.len()
             || compiled.columns != expected_columns(&plan)
+            || compiled.many_relations != expected_many_relations(&plan)
         {
             return Err(PostgresQueryDecodeError::ColumnContractMismatch);
         }
@@ -374,15 +381,6 @@ fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
             }),
     );
     columns.extend(
-        plan.many_projections
-            .iter()
-            .enumerate()
-            .map(|(index, projection)| CompiledQueryColumn::ManyRelation {
-                output_alias: format!("__many_{index}"),
-                projection: projection.clone(),
-            }),
-    );
-    columns.extend(
         plan.order_by
             .iter()
             .enumerate()
@@ -394,11 +392,21 @@ fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
     columns
 }
 
+fn expected_many_relations(plan: &ExecutableQueryPlan) -> Vec<CompiledManyRelationColumn> {
+    plan.many_projections
+        .iter()
+        .enumerate()
+        .map(|(index, projection)| CompiledManyRelationColumn {
+            output_alias: format!("__many_{index}"),
+            projection: projection.clone(),
+        })
+        .collect()
+}
+
 fn column_output_alias(column: &CompiledQueryColumn) -> &str {
     match column {
         CompiledQueryColumn::EntityId { output_alias, .. }
         | CompiledQueryColumn::Field { output_alias, .. }
-        | CompiledQueryColumn::ManyRelation { output_alias, .. }
         | CompiledQueryColumn::OrderValue { output_alias, .. } => output_alias,
     }
 }
@@ -460,7 +468,6 @@ fn decode_row(
         PostgresQueryDecodeError::MissingColumn(identity_alias(&plan.root_alias))
     })?;
     let mut fields = Vec::with_capacity(plan.outer_projection().count());
-    let mut nested_relations = Vec::with_capacity(plan.many_projections.len());
     let mut order_values = Vec::with_capacity(plan.order_by.len());
 
     for column in &compiled.columns {
@@ -472,14 +479,6 @@ fn decode_row(
                 path: field.path.clone(),
                 value: decode_field(row, output_alias, field, &identities)?,
             }),
-            CompiledQueryColumn::ManyRelation {
-                output_alias,
-                projection,
-            } => nested_relations.push(decode_nested_relation(
-                row,
-                output_alias,
-                projection,
-            )?),
             CompiledQueryColumn::OrderValue {
                 output_alias,
                 field,
@@ -487,6 +486,13 @@ fn decode_row(
             CompiledQueryColumn::EntityId { .. } => {}
         }
     }
+    let nested_relations = compiled
+        .many_relations
+        .iter()
+        .map(|column| {
+            decode_nested_relation(row, &column.output_alias, &column.projection)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(DecodedRow {
         item: IndexQueryItem {

--- a/crates/rustok-index/src/application/postgres_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_query_result.rs
@@ -11,8 +11,9 @@ use crate::domain::{
 
 use super::{
     CompiledPostgresQuery, CompiledQueryColumn, CursorCodec, CursorValidationError,
-    ExecutableQueryPlan, IndexCursor, PlannedField, PostgresBindValue, PostgresQueryBuildError,
-    QueryPlanError, QueryPlanFingerprint, SchemaRegistry, SchemaRegistryError,
+    ExecutableQueryPlan, IndexCursor, PlannedField, PlannedManyProjection, PostgresBindValue,
+    PostgresQueryBuildError, QueryPlanError, QueryPlanFingerprint, SchemaRegistry,
+    SchemaRegistryError,
 };
 
 const EXACT_COUNT_ALIAS: &str = "__exact_count";
@@ -93,11 +94,28 @@ pub struct IndexRelationIdentity {
     pub entity_id: Option<Uuid>,
 }
 
+/// One row reached through a projection path that crosses a many-cardinality link.
+/// Field values remain aligned with the complete relation identity chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexNestedRelationItem {
+    pub relations: Vec<IndexRelationIdentity>,
+    pub fields: Vec<IndexProjectedValue>,
+}
+
+/// Deterministic nested projection for all requested fields sharing one terminal
+/// many-traversing relation path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexNestedRelationProjection {
+    pub path: Vec<LinkName>,
+    pub items: Vec<IndexNestedRelationItem>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexQueryItem {
     pub entity_id: Uuid,
     pub relations: Vec<IndexRelationIdentity>,
     pub fields: Vec<IndexProjectedValue>,
+    pub nested_relations: Vec<IndexNestedRelationProjection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,6 +180,28 @@ pub enum PostgresQueryDecodeError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("compiled row column {alias} contains invalid nested relation JSON")]
+    InvalidNestedRelation {
+        alias: String,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("nested relation column {alias} has identity arity {actual}; expected {expected}")]
+    NestedIdentityArity {
+        alias: String,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("nested relation column {alias} has field arity {actual}; expected {expected}")]
+    NestedFieldArity {
+        alias: String,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("nested relation column {alias} contains a nil entity identity")]
+    NilNestedIdentity { alias: String },
+    #[error("nested relation column {alias} contains a duplicate identity chain")]
+    DuplicateNestedIdentity { alias: String },
     #[error("exact-count value is negative: {0}")]
     NegativeExactCount(i64),
 }
@@ -327,9 +367,19 @@ fn expected_columns(plan: &ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
         plan.projection
             .iter()
             .enumerate()
+            .filter(|(_, field)| !field.traverses_many)
             .map(|(index, field)| CompiledQueryColumn::Field {
                 output_alias: format!("f{index}"),
                 field: field.clone(),
+            }),
+    );
+    columns.extend(
+        plan.many_projections
+            .iter()
+            .enumerate()
+            .map(|(index, projection)| CompiledQueryColumn::ManyRelation {
+                output_alias: format!("__many_{index}"),
+                projection: projection.clone(),
             }),
     );
     columns.extend(
@@ -348,6 +398,7 @@ fn column_output_alias(column: &CompiledQueryColumn) -> &str {
     match column {
         CompiledQueryColumn::EntityId { output_alias, .. }
         | CompiledQueryColumn::Field { output_alias, .. }
+        | CompiledQueryColumn::ManyRelation { output_alias, .. }
         | CompiledQueryColumn::OrderValue { output_alias, .. } => output_alias,
     }
 }
@@ -359,7 +410,7 @@ fn identity_alias(relation_alias: &str) -> String {
 fn join_is_projected(plan: &ExecutableQueryPlan, join_path: &[LinkName]) -> bool {
     plan.projection
         .iter()
-        .any(|field| field.path.links().starts_with(join_path))
+        .any(|field| !field.traverses_many && field.path.links().starts_with(join_path))
 }
 
 struct DecodedRow {
@@ -408,7 +459,8 @@ fn decode_row(
     let root_entity_id = root_entity_id.ok_or_else(|| {
         PostgresQueryDecodeError::MissingColumn(identity_alias(&plan.root_alias))
     })?;
-    let mut fields = Vec::with_capacity(plan.projection.len());
+    let mut fields = Vec::with_capacity(plan.outer_projection().count());
+    let mut nested_relations = Vec::with_capacity(plan.many_projections.len());
     let mut order_values = Vec::with_capacity(plan.order_by.len());
 
     for column in &compiled.columns {
@@ -420,6 +472,14 @@ fn decode_row(
                 path: field.path.clone(),
                 value: decode_field(row, output_alias, field, &identities)?,
             }),
+            CompiledQueryColumn::ManyRelation {
+                output_alias,
+                projection,
+            } => nested_relations.push(decode_nested_relation(
+                row,
+                output_alias,
+                projection,
+            )?),
             CompiledQueryColumn::OrderValue {
                 output_alias,
                 field,
@@ -433,6 +493,7 @@ fn decode_row(
             entity_id: root_entity_id,
             relations,
             fields,
+            nested_relations,
         },
         order_values,
     })
@@ -467,12 +528,7 @@ fn decode_field(
         .is_some_and(Option::is_none);
     let value = match required_cell(row, output_alias)? {
         CompiledPostgresCell::Null => IndexValue::Null,
-        CompiledPostgresCell::Json(value) => serde_json::from_value(value.clone()).map_err(
-            |source| PostgresQueryDecodeError::InvalidTaggedValue {
-                alias: output_alias.to_owned(),
-                source,
-            },
-        )?,
+        CompiledPostgresCell::Json(value) => decode_tagged_value(value, output_alias)?,
         _ => {
             return Err(PostgresQueryDecodeError::UnexpectedCellType {
                 alias: output_alias.to_owned(),
@@ -481,6 +537,114 @@ fn decode_field(
         }
     };
 
+    validate_projected_value(field, &value, missing_relation)?;
+    Ok(value)
+}
+
+#[derive(Debug, Deserialize)]
+struct CompiledNestedRelationItem {
+    entity_ids: Vec<Uuid>,
+    values: Vec<JsonValue>,
+}
+
+fn decode_nested_relation(
+    row: &CompiledPostgresRow,
+    output_alias: &str,
+    projection: &PlannedManyProjection,
+) -> Result<IndexNestedRelationProjection, PostgresQueryDecodeError> {
+    let payload = match required_cell(row, output_alias)? {
+        CompiledPostgresCell::Json(value) => value.clone(),
+        _ => {
+            return Err(PostgresQueryDecodeError::UnexpectedCellType {
+                alias: output_alias.to_owned(),
+                expected: "a nested relation JSON array",
+            });
+        }
+    };
+    let wire_items = serde_json::from_value::<Vec<CompiledNestedRelationItem>>(payload).map_err(
+        |source| PostgresQueryDecodeError::InvalidNestedRelation {
+            alias: output_alias.to_owned(),
+            source,
+        },
+    )?;
+    let mut identity_chains = BTreeSet::new();
+    let mut items = Vec::with_capacity(wire_items.len());
+
+    for wire in wire_items {
+        if wire.entity_ids.len() != projection.identity_paths.len() {
+            return Err(PostgresQueryDecodeError::NestedIdentityArity {
+                alias: output_alias.to_owned(),
+                expected: projection.identity_paths.len(),
+                actual: wire.entity_ids.len(),
+            });
+        }
+        if wire.values.len() != projection.fields.len() {
+            return Err(PostgresQueryDecodeError::NestedFieldArity {
+                alias: output_alias.to_owned(),
+                expected: projection.fields.len(),
+                actual: wire.values.len(),
+            });
+        }
+        if wire.entity_ids.iter().any(Uuid::is_nil) {
+            return Err(PostgresQueryDecodeError::NilNestedIdentity {
+                alias: output_alias.to_owned(),
+            });
+        }
+        if !identity_chains.insert(wire.entity_ids.clone()) {
+            return Err(PostgresQueryDecodeError::DuplicateNestedIdentity {
+                alias: output_alias.to_owned(),
+            });
+        }
+
+        let relations = projection
+            .identity_paths
+            .iter()
+            .cloned()
+            .zip(wire.entity_ids.into_iter())
+            .map(|(path, entity_id)| IndexRelationIdentity {
+                path,
+                entity_id: Some(entity_id),
+            })
+            .collect();
+        let fields = projection
+            .fields
+            .iter()
+            .zip(wire.values.iter())
+            .map(|(field, value)| {
+                let decoded = decode_tagged_value(value, output_alias)?;
+                validate_projected_value(field, &decoded, false)?;
+                Ok(IndexProjectedValue {
+                    path: field.path.clone(),
+                    value: decoded,
+                })
+            })
+            .collect::<Result<Vec<_>, PostgresQueryDecodeError>>()?;
+        items.push(IndexNestedRelationItem { relations, fields });
+    }
+
+    Ok(IndexNestedRelationProjection {
+        path: projection.path.clone(),
+        items,
+    })
+}
+
+fn decode_tagged_value(
+    value: &JsonValue,
+    output_alias: &str,
+) -> Result<IndexValue, PostgresQueryDecodeError> {
+    serde_json::from_value(value.clone()).map_err(|source| {
+        PostgresQueryDecodeError::InvalidTaggedValue {
+            alias: output_alias.to_owned(),
+            source,
+        }
+    })
+}
+
+fn validate_projected_value(
+    field: &PlannedField,
+    value: &IndexValue,
+    missing_relation: bool,
+) -> Result<(), PostgresQueryDecodeError> {
     if missing_relation && !matches!(value, IndexValue::Null) {
         return Err(PostgresQueryDecodeError::InvalidFieldValue {
             path: field.path.clone(),
@@ -491,12 +655,12 @@ fn decode_field(
             path: field.path.clone(),
         });
     }
-    if !valid_field_value(field, &value, missing_relation) {
+    if !valid_field_value(field, value, missing_relation) {
         return Err(PostgresQueryDecodeError::InvalidFieldValue {
             path: field.path.clone(),
         });
     }
-    Ok(value)
+    Ok(())
 }
 
 fn valid_field_value(field: &PlannedField, value: &IndexValue, missing_relation: bool) -> bool {

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -6,8 +6,8 @@ use super::{
     cursor::IndexCursor,
     planner::{ExecutableQueryPlan, PlannedField, PlannedManyProjection},
     postgres_compiler::{
-        CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue,
-        PostgresQueryCompileError, quote_identifier,
+        CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
+        CompiledQueryColumn, PostgresBindValue, PostgresQueryCompileError, quote_identifier,
     },
 };
 
@@ -19,6 +19,7 @@ pub(super) fn compile_postgres_plan(
     let base = compile_base(plan, &mut bindings);
     let mut select = Vec::new();
     let mut columns = Vec::new();
+    let mut many_relations = Vec::new();
     push_identity_column(
         &mut select,
         &mut columns,
@@ -58,7 +59,7 @@ pub(super) fn compile_postgres_plan(
             "{aggregate} AS {}",
             quote_identifier(&output_alias),
         ));
-        columns.push(CompiledQueryColumn::ManyRelation {
+        many_relations.push(CompiledManyRelationColumn {
             output_alias,
             projection: projection.clone(),
         });
@@ -104,6 +105,7 @@ pub(super) fn compile_postgres_plan(
         sql,
         binds: bindings.values,
         columns,
+        many_relations,
         exact_count,
         plan_fingerprint: plan.fingerprint()?,
     })

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -4,7 +4,7 @@ use crate::domain::{
 
 use super::{
     cursor::IndexCursor,
-    planner::{ExecutableQueryPlan, PlannedField},
+    planner::{ExecutableQueryPlan, PlannedField, PlannedManyProjection},
     postgres_compiler::{
         CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, PostgresBindValue,
         PostgresQueryCompileError, quote_identifier,
@@ -35,6 +35,9 @@ pub(super) fn compile_postgres_plan(
     }
 
     for (index, field) in plan.projection.iter().enumerate() {
+        if field.traverses_many {
+            continue;
+        }
         let field_sql = field_sql(field, &mut bindings);
         let output_alias = format!("f{index}");
         select.push(format!(
@@ -45,6 +48,19 @@ pub(super) fn compile_postgres_plan(
         columns.push(CompiledQueryColumn::Field {
             output_alias,
             field: field.clone(),
+        });
+    }
+
+    for (index, projection) in plan.many_projections.iter().enumerate() {
+        let output_alias = format!("__many_{index}");
+        let aggregate = compile_many_projection(plan, projection, index, &mut bindings)?;
+        select.push(format!(
+            "{aggregate} AS {}",
+            quote_identifier(&output_alias),
+        ));
+        columns.push(CompiledQueryColumn::ManyRelation {
+            output_alias,
+            projection: projection.clone(),
         });
     }
 
@@ -145,6 +161,90 @@ fn compile_base(plan: &ExecutableQueryPlan, bindings: &mut Bindings) -> Compiled
             "{root_alias}.tenant_id = {tenant} AND {root_alias}.module_name = {module} AND {root_alias}.entity_name = {entity} AND {root_alias}.schema_version = {version} AND {root_alias}.locale_key = {locale} AND {root_alias}.is_deleted = FALSE"
         )],
     }
+}
+
+fn compile_many_projection(
+    plan: &ExecutableQueryPlan,
+    projection: &PlannedManyProjection,
+    projection_index: usize,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let mut source_alias = plan.root_alias.clone();
+    let mut from_sql = String::new();
+    let mut predicates = Vec::new();
+    let mut identity_values = Vec::with_capacity(projection.identity_paths.len());
+    let mut order_terms = Vec::with_capacity(projection.identity_paths.len() * 3);
+    let mut terminal_alias = None;
+
+    for (index, path) in projection.identity_paths.iter().enumerate() {
+        let join = plan
+            .join_for_path(path)
+            .ok_or_else(|| PostgresQueryCompileError::MissingJoinPlan(path.clone()))?;
+        let link_alias_name = format!("mp{projection_index}_l{}", index + 1);
+        let target_alias_name = format!("mp{projection_index}_t{}", index + 1);
+        let source_alias_q = quote_identifier(&source_alias);
+        let link_alias = quote_identifier(&link_alias_name);
+        let target_alias = quote_identifier(&target_alias_name);
+        let link_name = bindings.push(PostgresBindValue::Text(join.link.as_str().to_owned()));
+        let target_module = bindings.push(PostgresBindValue::Text(
+            join.target_schema.module.as_str().to_owned(),
+        ));
+        let target_entity = bindings.push(PostgresBindValue::Text(
+            join.target_schema.entity.as_str().to_owned(),
+        ));
+        let target_version = bindings.push(PostgresBindValue::Integer(i64::from(
+            join.target_schema.version.get(),
+        )));
+        let source_predicate = format!(
+            "{link_alias}.tenant_id = {source_alias_q}.tenant_id AND {link_alias}.source_module = {source_alias_q}.module_name AND {link_alias}.source_entity = {source_alias_q}.entity_name AND {link_alias}.source_schema_version = {source_alias_q}.schema_version AND {link_alias}.source_entity_id = {source_alias_q}.entity_id AND {link_alias}.source_locale_key = {source_alias_q}.locale_key AND {link_alias}.source_version = {source_alias_q}.source_version AND {link_alias}.link_name = {link_name} AND {link_alias}.target_module = {target_module} AND {link_alias}.target_entity = {target_entity} AND {link_alias}.target_schema_version = {target_version}"
+        );
+        let target_predicate = format!(
+            "{target_alias}.tenant_id = {link_alias}.tenant_id AND {target_alias}.module_name = {link_alias}.target_module AND {target_alias}.entity_name = {link_alias}.target_entity AND {target_alias}.schema_version = {link_alias}.target_schema_version AND {target_alias}.entity_id = {link_alias}.target_entity_id AND {target_alias}.locale_key = {link_alias}.target_locale_key AND {target_alias}.is_deleted = FALSE"
+        );
+
+        if index == 0 {
+            from_sql.push_str(&format!(
+                "FROM index_links AS {link_alias} JOIN index_entities AS {target_alias} ON {target_predicate}",
+            ));
+            predicates.push(source_predicate);
+        } else {
+            from_sql.push_str(&format!(
+                " JOIN index_links AS {link_alias} ON {source_predicate} JOIN index_entities AS {target_alias} ON {target_predicate}",
+            ));
+        }
+
+        identity_values.push(format!("{target_alias}.entity_id"));
+        order_terms.push(format!("{link_alias}.ordinal ASC"));
+        order_terms.push(format!("{target_alias}.entity_id ASC"));
+        order_terms.push(format!("{target_alias}.locale_key ASC"));
+        source_alias = target_alias_name.clone();
+        terminal_alias = Some(target_alias_name);
+    }
+
+    let terminal_alias = terminal_alias.ok_or(
+        PostgresQueryCompileError::ManyProjectionPlanMismatch,
+    )?;
+    let field_values = projection
+        .fields
+        .iter()
+        .map(|field| {
+            let sql = field_sql_for_alias(field, &terminal_alias, bindings);
+            format!(
+                "COALESCE({}, jsonb_build_object('type', 'null'))",
+                sql.raw
+            )
+        })
+        .collect::<Vec<_>>();
+    let item = format!(
+        "jsonb_build_object('entity_ids', jsonb_build_array({}), 'values', jsonb_build_array({}))",
+        identity_values.join(", "),
+        field_values.join(", "),
+    );
+    Ok(format!(
+        "COALESCE((SELECT jsonb_agg({item} ORDER BY {}) {from_sql} WHERE {}), '[]'::jsonb)",
+        order_terms.join(", "),
+        predicates.join(" AND "),
+    ))
 }
 
 fn compile_filter(


### PR DESCRIPTION
## Summary

- group selected many-traversing fields into deterministic `PlannedManyProjection` contracts and bump the executable-plan fingerprint to v4
- compile each many projection as a correlated, row-preserving JSONB aggregate outside the root rowset
- preserve complete linked identity chains and aligned tagged field values in typed nested query results
- fail closed on scalar/many metadata drift, malformed nested JSON, arity mismatches, nil identities, duplicates, and invalid field contracts
- keep many-link ordering, SQL execution/row adaptation, snapshots, and PostgreSQL/reference equivalence open
- update the M4 compiler contract, public crate API, and implementation roadmap

## Validation

Not run per maintainer instruction: no tests, Cargo commands, builds, verifiers, or execution/evidence capture. Static source and contract review only.

No test, fixture, verifier, migration, or dependency files are changed.