### PR TITLE
feat(index): execute compiled queries through PostgreSQL port

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -45,9 +45,11 @@ scheduler modules remain deleted.
 - `IndexProjectedValue`, `IndexRelationIdentity`, `IndexNestedRelationItem`,
   `IndexNestedRelationProjection`, `IndexQueryItem`, `IndexQueryPage`
 - `PostgresQueryPageBuildError`, `PostgresQueryDecodeError`
+- `IndexQueryPort`, `IndexQueryExecutionError`, `PersistedSchemaReadinessFailure`
 
 ### Infrastructure
 
+- `PostgresIndexQueryPort`
 - `PostgresMutationStore`
 - `MutationDelivery`
 - `MutationApplyOutcome`
@@ -117,11 +119,14 @@ M4 provides validated typed executable plans, controlled PostgreSQL SQL and bind
 DTOs for root/one-link projection, filtering, ordering, counting and pagination,
 correlated many-link filtering, deterministic nested many-link projection aggregates,
 query-scoped cursor continuation, one-row page lookahead, strict scalar/nested result
-decoding, exact-count decoding, `has_more`, and next-cursor construction. It still
-does not execute statements, adapt SeaORM rows directly, order through many links,
-publish `IndexQueryPort`, or claim PostgreSQL/reference-engine equivalence.
-Multi-source catalog composition, batch ingestion, rebuild, query-port, partition
-cutover, and operator APIs remain later work.
+decoding, exact-count decoding, `has_more`, and next-cursor construction.
+`PostgresIndexQueryPort` now performs PostgreSQL-only execution with exact persisted
+schema readiness, one read-only repeatable-read page/count snapshot, exhaustive
+SeaORM bind conversion, and compiler-metadata-driven row mapping. It does not order
+through many links, authorize callers, compose into server/storefront/admin/search,
+or claim live PostgreSQL/reference-engine equivalence. Multi-source catalog
+composition, batch ingestion, rebuild, consumer cutover, partition cutover, and
+operator APIs remain later work.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`,
 `DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
@@ -142,7 +147,7 @@ APIs.
 - Writing `index_schemas` directly from a source module instead of calling
   `PostgresSchemaRegistrationStore`.
 - Treating in-memory `SchemaRegistry` registration as persisted tenant schema
-  readiness for `PostgresMutationStore`.
+  readiness for mutation or query execution.
 - Reactivating a retired schema or silently replacing a contract under the same
   schema version.
 - Treating Index as a ranking/full-text search engine.
@@ -153,8 +158,13 @@ APIs.
   ordered fields/directions, order arity, and order-value types.
 - Executing a page query through raw `compile_postgres_query` instead of the
   one-row-lookahead `compile_postgres_page_query` handoff.
+- Executing compiler SQL outside `PostgresIndexQueryPort` or bypassing its exact
+  tenant-scoped persisted schema preflight.
+- Executing page and exact-count statements in separate snapshots.
 - Decoding rows without rechecking the plan fingerprint and exact scalar/nested
   column contracts.
+- Reading arbitrary driver columns instead of compiler-declared UUID/JSONB/bigint
+  aliases.
 - Compiling a many-link filter as an ordinary outer join; it must remain a correlated
   predicate so child multiplicity cannot duplicate root rows or counts.
 - Flattening many-link projection into outer rows or independent value arrays; one
@@ -181,12 +191,16 @@ APIs.
 - `IndexSchema`, `IndexRecord`, `IndexMutation`, and `IndexQuery` are the current
   input contracts.
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
+- `IndexQueryPort::execute_query` is the transport-neutral owner boundary for one
+  structured query and typed page result.
 - `SchemaRegistry::compile_postgres_page_query` is the page-execution compiler
   handoff; it preserves SQL and increases only the validated limit bind by one.
 - `CompiledPostgresQuery::many_relations` binds every aggregate output alias to its
   exact `PlannedManyProjection` metadata.
 - `CompiledPostgresRow` is the narrow adapter handoff for compiler-owned UUID,
   tagged JSON, nested aggregate JSON, SQL-null, and exact-count cells.
+- `PostgresIndexQueryPort` binds one PostgreSQL connection to one immutable
+  `Arc<SchemaRegistry>` and never accepts arbitrary SQL or result metadata.
 - `PostgresSchemaRegistrationStore::register(tenant_id, schema)` binds one non-nil
   tenant to one validated exact schema contract and calculated fingerprint.
 - `SchemaApplicationLeaseRequest` binds one tenant, exact schema reference,
@@ -302,7 +316,7 @@ APIs.
 - Copy, constraints, indexes, replay/dual-write, cutover, rollback, durable global
   ownership, and PostgreSQL evidence remain mandatory future work.
 
-### Query Planning, Compilation, and Result Decoding
+### Query Planning, Compilation, Result Decoding, and Execution
 
 - `SchemaRegistry::plan_query` validates first and captures deterministic aliases,
   joins, typed referenced fields, propagated `traverses_many`, scalar projection,
@@ -331,8 +345,16 @@ APIs.
 - The lookahead row is removed. Cursor pages produce `has_more` and a scoped next
   cursor from the last retained entity/order tuple; offset pages produce
   `has_more` without a cursor.
-- Many-link ordering, SQL execution, SeaORM row adaptation, and live equivalence
-  evidence remain separate future boundaries.
+- `PostgresIndexQueryPort` requires PostgreSQL, verifies every root/source/target
+  schema against the query tenant's exact active persisted fingerprint and JSON
+  contract, and performs preflight/page/count/decode in one read-only repeatable-read
+  transaction.
+- `PostgresBindValue` conversion is exhaustive for boolean, integer, decimal, text,
+  UUID, UTC timestamp, and JSONB.
+- The row adapter reads only compiler-declared identity, scalar, order, nested, and
+  count aliases and delegates semantic validation to the strict decoder.
+- Many-link ordering, server/consumer composition, and live equivalence evidence
+  remain separate future boundaries.
 
 ### Cursor Contract
 
@@ -378,6 +400,10 @@ APIs.
   `PostgresQueryDecodeError` rejects plan/scalar/many/count mismatches, malformed
   cells, invalid tagged values, invalid nested JSON, identity/value arity drift,
   nil/duplicate nested identities, unexpected nulls, and oversized result batches.
+- `IndexQueryExecutionError` separates plan/build/decode failures, unsupported
+  backends, missing/inactive/drifted persisted schemas, missing counts, invalid driver
+  column types, contract preparation, and storage operations. Storage diagnostic
+  details are retained in fields while top-level display remains operation-level.
 - `MutationStorageError` separates validation, delivery identity conflict,
   in-progress/rejected replay, stored-version corruption, backend limits, and
   database failure. Its public display is generic; transport adapters must still
@@ -390,5 +416,5 @@ APIs.
 - `PartitionAdmissionError` separates invalid policy, invalid evidence, metric
   overflow, and unsupported hash modulus. Typed admission reasons explain every
   rejected evidence gate without exposing storage internals.
-- Later milestones add source catalog, retry, cancellation, rebuild, and query-port
-  execution errors.
+- Later milestones add source catalog, retry, cancellation, rebuild, transport, and
+  consumer composition errors.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -19,6 +19,7 @@ a rewrite goal.
 - Validate and plan cross-module queries.
 - Compile projection, filtering, sorting, count, and pagination to Index storage
   queries.
+- Execute compiled queries through an Index-owned PostgreSQL port.
 - Publish stable query, source, rebuild, and operator contracts.
 - Keep product-facing relevance and ranking in `rustok-search`.
 
@@ -37,7 +38,7 @@ a rewrite goal.
 
 ## Rewrite status
 
-- Current milestone: `M3 - PostgreSQL storage engine`
+- Current milestone: `M4 - Query engine v1`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: complete
@@ -53,18 +54,28 @@ a rewrite goal.
 - M3 partition evidence capture and packet assembly: complete
 - M3 retained packet owner orchestration: complete
 - M3 retained bundle review and archive verification: complete
+- M4 deterministic query planning and controlled SQL compilation: complete
+- M4 root/one and many-link query result semantics: complete
+- M4 PostgreSQL query port and row adapter: source complete
 - Real retained PostgreSQL packet execution: open
+- Query-port server/consumer composition and live equivalence evidence: open
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
 configuration, scheduler, errors, and server composition have been deleted. M3
 registers the canonical production schema, publishes an Index-owned transactional
 mutation adapter, owns durable schema-application leases, manages deterministic
 schema-derived secondary indexes, and rejects partition rollout until measured
-shadow evidence passes an explicit policy. Owner-operated tooling now captures and
+shadow evidence passes an explicit policy. Owner-operated tooling captures and
 validates the nine-file retained bundle, renders a read-only review, emits an
 admitted-only archive manifest outside the bundle, and verifies the saved manifest
-against an exact recursive filesystem snapshot. Query execution and production
-partition cutover remain absent.
+against an exact recursive filesystem snapshot.
+
+M4 now provides deterministic typed planning, controlled PostgreSQL compilation,
+correlated many-link filtering, nested many-link projection aggregation, strict
+result decoding, lookahead pagination, exact count, scoped cursors, and an
+Index-owned PostgreSQL execution port. Server/storefront/admin/search composition,
+many-link aggregate ordering policy, live PostgreSQL/reference equivalence, and
+production partition cutover remain open.
 
 The module-owned migration source creates:
 
@@ -130,6 +141,16 @@ metadata drift, inventory drift, or byte drift. Public manifest and receipt sche
 remain stable, and every successful receipt keeps
 `production_lifecycle_authorized: false`.
 
+`IndexQueryPort` is the transport-neutral query execution boundary.
+`PostgresIndexQueryPort` owns a PostgreSQL connection and immutable
+`Arc<SchemaRegistry>`. Each call compiles through the registry, starts one read-only
+repeatable-read transaction, verifies every root/source/target schema against the
+query tenant's exact active `index_schemas` fingerprint and JSON contract, executes
+the page and optional exact-count statements in the same snapshot, maps only
+compiler-declared UUID/JSONB/bigint aliases, and delegates semantic validation and
+cursor construction to `decode_postgres_query_page`. Authentication and transport
+policy remain caller responsibilities.
+
 ## Current entry points
 
 - `IndexModule`
@@ -145,6 +166,9 @@ remain stable, and every successful receipt keeps
   `PartitionShadowPlan`, and `evaluate_partition_admission`
 - `SchemaRegistry`, `IndexSchema`, `IndexRecord`, and `IndexMutation`
 - `IndexQuery`, `IndexQueryScope`, `FilterExpr`, and typed `FieldPath`
+- `ExecutableQueryPlan`, `CompiledPostgresQuery`, and `CompiledPostgresPageQuery`
+- `IndexQueryPort`, `PostgresIndexQueryPort`, `IndexQueryExecutionError`, and
+  `IndexQueryPage`
 - `CursorCodec`, `IndexCursor`, and query-scope cursor validation
 
 ## Implemented invariants
@@ -173,7 +197,13 @@ remain stable, and every successful receipt keeps
   limits, deterministic tenant-hash shadow names, and no destructive cutover SQL;
 - exact-byte retained review and admitted archive verification bound to stable file
   and directory identities, metadata fingerprints, and recursive inventory without
-  production lifecycle authorization.
+  production lifecycle authorization;
+- deterministic typed plans, controlled ordered binds, duplicate-free many-link
+  `EXISTS` filtering, row-preserving nested many-link JSONB aggregation, strict
+  decoded column contracts, exact count, lookahead, and scoped cursor construction;
+- PostgreSQL-only query execution with exact persisted schema preflight, one
+  read-only repeatable-read page/count snapshot, exhaustive bind conversion, and
+  compiler-metadata-driven row mapping.
 
 ## M2 benchmark
 
@@ -192,6 +222,8 @@ DDL remains benchmark-only and must not be copied into production migrations.
 
 - [Module documentation](./docs/README.md)
 - [Live implementation plan](./docs/implementation-plan.md)
+- [M4 PostgreSQL query port contract](./docs/m4-postgres-query-port.md)
+- [M4 many-link projection contract](./docs/m4-many-link-projection.md)
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)
 - [M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)
 - [M3 retained partition capture runbook](./docs/partition-full-capture.md)

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (nested many-link projection added; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (PostgreSQL query port source added; M3 retained packet owner gate remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -57,6 +57,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 deterministic PostgreSQL result decoding: `complete`
 - M4 many-link `EXISTS` filtering: `complete`
 - M4 nested many-link projection aggregation: `complete`
+- M4 PostgreSQL query port and strict row adapter: `source_complete`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -65,9 +66,10 @@ pull requests record checks and PostgreSQL runs that were not executed.
   root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
   compilation, correlated many-link filtering, deterministic nested many-link
   projection aggregation, one-row page lookahead, tagged row decoding, exact-count
-  decoding, and scoped next-cursor construction are implemented; one retained admitted
-  packet, SQL execution composition, PostgreSQL/reference equivalence, and production
-  partition lifecycle remain open
+  decoding, scoped next-cursor construction, persisted-schema query preflight,
+  PostgreSQL page/count execution, and compiler-driven row adaptation are implemented;
+  one retained admitted packet, server/consumer query-port composition,
+  PostgreSQL/reference equivalence, and production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -75,10 +77,11 @@ lifecycle management, measured partition admission that emits shadow bootstrap
 plans only, an M4 typed structural query planner with deterministic relation aliases,
 a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
 exact count, keyset and bounded offset plus duplicate-free correlated many-link
-filtering and nested many-link projection aggregates, and a strict compiled-row decoder
+filtering and nested many-link projection aggregates, a strict compiled-row decoder
 with aligned nested identities/values, lookahead pagination, and scoped cursor
-construction. Owner-operated evidence tools live under `ops/benches`; they do not
-become runtime storage code.
+construction, and `PostgresIndexQueryPort` for exact-schema-preflighted execution in
+one read-only repeatable-read page/count snapshot. Owner-operated evidence tools live
+under `ops/benches`; they do not become runtime storage code.
 
 ## Ownership
 
@@ -112,12 +115,14 @@ crates/rustok-index/src/
     postgres_compiler.rs
     postgres_query_sql.rs
     postgres_query_result.rs
+    query_port.rs
   migrations/
   infrastructure/postgres/
     mutation_store.rs
     schema_lease.rs
     secondary_index.rs
     partition_admission.rs
+    query_port.rs
   api/
 
 ops/benches/src/index_storage/
@@ -204,7 +209,7 @@ unpartitioned until separate shadow evidence is retained and admitted.
 - [x] Add owner-operated PostgreSQL baseline/shadow snapshot capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow query evidence capture.
 - [x] Add owner-operated PostgreSQL baseline/shadow mutation and WAL evidence capture.
-- [x] Add owner-operated PostgreSQL baseline/shadow ordinary-VACUUM maintenance evidence capture.
+- [x] Add owner-operated PostgreSQL ordinary-VACUUM maintenance evidence capture.
 - [x] Add owner-operated PostgreSQL cutover/rollback rehearsal evidence capture.
 - [x] Add owner-operated full retained packet orchestration and capture finalization.
 - [x] Add read-only retained bundle review with recalculated assembly and admission.
@@ -313,6 +318,7 @@ relations.
 - [x] Add deterministic root/one-link result decoding and cursor construction.
 - [x] Add explicit many-link `EXISTS` filtering.
 - [x] Add nested many-link projection aggregation.
+- [x] Add PostgreSQL `IndexQueryPort` execution and strict SeaORM row adaptation.
 - [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
 
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
@@ -352,10 +358,19 @@ any-match semantics; `IsNull` checks for the absence of a reachable non-null val
 `Ne` requires at least one stored reachable value and rejects any null or equal value.
 This matches the test-only reference engine's flattened path-value semantics.
 
-Many-link ordering remains rejected until an aggregate ordering policy exists. SQL
-execution, direct SeaORM row adaptation, persisted-schema readiness, query-port
-composition, consumer cutover, plan/SQL snapshots, and PostgreSQL/reference-engine
-equivalence remain open.
+`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
+query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
+PostgreSQL connection. It derives every root/source/target schema used by the plan,
+requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
+and schema JSON, executes the page and optional exact count in one read-only
+repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
+maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
+calling the strict decoder. Authentication and transport policy remain caller-owned.
+
+Many-link ordering remains rejected until an aggregate ordering policy exists.
+Server/storefront/admin/search composition, source schema/mutation publication,
+consumer cutover, plan/SQL snapshots, live PostgreSQL execution evidence, and
+PostgreSQL/reference-engine equivalence remain open.
 
 ### M5 - Incremental ingestion
 
@@ -489,9 +504,12 @@ node scripts/verify/verify-index-many-link-filtering.mjs
   compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
   count decoding, relation identity reconstruction, scoped next-cursor creation,
   correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
-  and deterministic nested many-link projection aggregation with aligned identity/value
-  decoding. Direct SQL execution/row adaptation, plan/SQL snapshots, and
-  PostgreSQL/reference equivalence remain open.
+  deterministic nested many-link projection aggregation with aligned identity/value
+  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
+  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
+  compiler-metadata-driven row adaptation. Server/consumer composition, plan/SQL
+  snapshots, live PostgreSQL execution, and PostgreSQL/reference equivalence remain
+  open.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition
   lifecycle work begins.

--- a/crates/rustok-index/docs/m4-postgres-query-port.md
+++ b/crates/rustok-index/docs/m4-postgres-query-port.md
@@ -1,0 +1,113 @@
+# M4 PostgreSQL query port
+
+This slice connects the existing typed M4 plan/compiler/result contracts to a
+production PostgreSQL execution boundary. It adds source code only. No database,
+Cargo, verifier, test, benchmark, or evidence command was executed for this change.
+
+## Application port
+
+`IndexQueryPort` is the transport-neutral owner boundary for executing an
+`IndexQuery` and returning an `IndexQueryPage`.
+
+The query already carries its tenant and locale scope. The port does not invent,
+replace, or widen that scope. Authentication, caller authorization, rate limits, and
+transport error mapping remain responsibilities of the server or another consuming
+adapter.
+
+`IndexQueryExecutionError` keeps validation/planning, page compilation, result
+decoding, backend, persisted-schema readiness, row mapping, and storage failures
+separate. Storage details are retained as typed diagnostic fields while the public
+error text remains operation-level.
+
+## PostgreSQL composition
+
+`PostgresIndexQueryPort` owns:
+
+- one `DatabaseConnection`;
+- one immutable `Arc<SchemaRegistry>`;
+- compiler and decoder access only through public Index application contracts.
+
+The adapter rejects every backend except PostgreSQL. SQLite remains available only
+for the existing storage contract tests and is not an Index query execution backend.
+
+## Snapshot contract
+
+One call performs the following work in one transaction:
+
+1. begin a database transaction;
+2. configure `REPEATABLE READ, READ ONLY` before any read;
+3. verify persisted schema readiness;
+4. execute the compiled page statement;
+5. execute the optional exact-count statement;
+6. map only compiler-declared columns;
+7. call `SchemaRegistry::decode_postgres_query_page`;
+8. commit on success or roll back on failure.
+
+The page and exact count therefore observe one PostgreSQL snapshot. Concurrent
+mutations cannot make the count describe a different committed state from the page.
+The existing one-row lookahead and cursor construction remain owned by the result
+decoder.
+
+## Persisted schema readiness
+
+Before executing compiled SQL, the adapter derives every distinct schema reference
+used by the plan: the root schema plus all join source and target schemas.
+
+For the query tenant, each exact `index_schemas` row must:
+
+- exist;
+- have status `active`;
+- match the in-memory registered schema fingerprint;
+- match the exact serialized schema contract.
+
+Missing, inactive, fingerprint-drifted, or contract-drifted schemas fail closed before
+the page statement executes. The check and query share the same repeatable-read
+snapshot.
+
+`index_entities` already references the complete tenant/module/entity/version/
+fingerprint key in `index_schemas`, so a row cannot point at an unrelated schema
+fingerprint while the database constraints are intact.
+
+## Bind execution
+
+`PostgresBindValue` is converted exhaustively to SeaORM values:
+
+- boolean;
+- signed integer;
+- decimal;
+- text;
+- UUID;
+- UTC timestamp;
+- JSONB.
+
+The adapter executes the exact compiler SQL and ordered bind list. It does not parse,
+append, interpolate, or rewrite caller values, schema identifiers, filters, ordering,
+or pagination.
+
+## Row adapter
+
+The page mapper reads only aliases declared by `CompiledPostgresQuery`:
+
+- identity columns as nullable PostgreSQL UUIDs;
+- projected and hidden order columns as nullable JSONB;
+- nested many-relation aggregates as nullable JSONB.
+
+The optional count mapper reads only `__exact_count` as a non-null PostgreSQL bigint.
+All values are converted into `CompiledPostgresRow`; semantic validation remains in
+the existing strict decoder. Missing aliases, incompatible database types, malformed
+tagged values, invalid nested relation payloads, count mismatches, and cursor contract
+mismatches fail closed through typed errors.
+
+## Remaining boundaries
+
+This slice does not:
+
+- wire the port into `rustok-server`, storefront, admin, or `rustok-search`;
+- add a transport or authorization adapter;
+- add source-module schemas, mutations, rebuild sources, or consumer cutover;
+- define ordering through a many-cardinality link;
+- change migrations, partition lifecycle, or query SQL semantics;
+- claim formatting, compilation, tests, static verifier results, live PostgreSQL
+  execution, or PostgreSQL/reference-engine equivalence.
+
+Those remain separate source and later owner-operated verification steps.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -3,6 +3,7 @@ mod planner;
 mod postgres_compiler;
 mod postgres_query_result;
 mod postgres_query_sql;
+mod query_port;
 mod registry;
 mod validation;
 
@@ -30,6 +31,9 @@ pub use postgres_query_result::{
     IndexNestedRelationItem, IndexNestedRelationProjection, IndexProjectedValue, IndexQueryItem,
     IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError,
     PostgresQueryPageBuildError,
+};
+pub use query_port::{
+    IndexQueryExecutionError, IndexQueryPort, PersistedSchemaReadinessFailure,
 };
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,

--- a/crates/rustok-index/src/application/query_port.rs
+++ b/crates/rustok-index/src/application/query_port.rs
@@ -1,0 +1,109 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::domain::{IndexQuery, SchemaRef};
+
+use super::{
+    IndexQueryPage, PostgresQueryDecodeError, PostgresQueryPageBuildError, QueryPlanError,
+};
+
+/// Persisted schema state that prevents a compiled query from executing safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistedSchemaReadinessFailure {
+    Missing,
+    Inactive,
+    FingerprintMismatch,
+    ContractMismatch,
+}
+
+impl fmt::Display for PersistedSchemaReadinessFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Missing => "missing",
+            Self::Inactive => "inactive",
+            Self::FingerprintMismatch => "fingerprint mismatch",
+            Self::ContractMismatch => "contract mismatch",
+        })
+    }
+}
+
+/// Transport-neutral failure contract for executing one validated Index query.
+#[derive(Debug, Error)]
+pub enum IndexQueryExecutionError {
+    #[error(transparent)]
+    Plan(#[from] QueryPlanError),
+    #[error(transparent)]
+    Build(#[from] PostgresQueryPageBuildError),
+    #[error(transparent)]
+    Decode(#[from] PostgresQueryDecodeError),
+    #[error("Index query execution requires a PostgreSQL connection")]
+    UnsupportedBackend,
+    #[error("persisted Index schema is not query-ready: {reference} ({reason})")]
+    SchemaNotReady {
+        reference: SchemaRef,
+        reason: PersistedSchemaReadinessFailure,
+    },
+    #[error("Index query exact-count statement returned no row")]
+    MissingExactCountRow,
+    #[error("Index query result column {alias} could not be decoded as {expected}")]
+    InvalidRowColumn {
+        alias: String,
+        expected: &'static str,
+        details: String,
+    },
+    #[error("Index query contract preparation failed for {reference}")]
+    ContractPreparation {
+        reference: SchemaRef,
+        details: String,
+    },
+    #[error("Index query storage operation failed during {operation}")]
+    Storage {
+        operation: &'static str,
+        details: String,
+    },
+}
+
+impl IndexQueryExecutionError {
+    pub(crate) fn storage(operation: &'static str, error: impl fmt::Display) -> Self {
+        Self::Storage {
+            operation,
+            details: error.to_string(),
+        }
+    }
+
+    pub(crate) fn invalid_row_column(
+        alias: impl Into<String>,
+        expected: &'static str,
+        error: impl fmt::Display,
+    ) -> Self {
+        Self::InvalidRowColumn {
+            alias: alias.into(),
+            expected,
+            details: error.to_string(),
+        }
+    }
+
+    pub(crate) fn contract_preparation(
+        reference: SchemaRef,
+        error: impl fmt::Display,
+    ) -> Self {
+        Self::ContractPreparation {
+            reference,
+            details: error.to_string(),
+        }
+    }
+}
+
+/// Owner boundary for executing structured, tenant-scoped Index queries.
+///
+/// The query already carries tenant and locale scope. Authentication and transport
+/// policy remain caller responsibilities; implementations must not widen that scope.
+#[async_trait]
+pub trait IndexQueryPort: Send + Sync {
+    async fn execute_query(
+        &self,
+        query: IndexQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError>;
+}

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,5 +1,6 @@
 mod mutation_store;
 mod partition_admission;
+mod query_port;
 mod schema_lease;
 mod schema_registration;
 mod secondary_index;
@@ -24,6 +25,7 @@ pub use partition_admission::{
     PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
 };
+pub use query_port::PostgresIndexQueryPort;
 pub use schema_lease::{
     PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,
     SchemaLeaseAcquireOutcome, SchemaLeaseError,

--- a/crates/rustok-index/src/infrastructure/postgres/query_port.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_port.rs
@@ -1,0 +1,328 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use async_trait::async_trait;
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use crate::{
+    application::{
+        CompiledPostgresCell, CompiledPostgresCount, CompiledPostgresPageQuery,
+        CompiledPostgresQuery, CompiledPostgresRow, CompiledQueryColumn,
+        IndexQueryExecutionError, IndexQueryPage, IndexQueryPort,
+        PersistedSchemaReadinessFailure, PostgresBindValue, SchemaRegistry,
+    },
+    domain::{IndexQuery, SchemaRef},
+};
+
+const EXACT_COUNT_ALIAS: &str = "__exact_count";
+const READ_ONLY_SNAPSHOT_SQL: &str =
+    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY";
+const SELECT_SCHEMA_READINESS_SQL: &str =
+    "SELECT schema_fingerprint, schema_json, status FROM index_schemas WHERE tenant_id = $1 AND module_name = $2 AND entity_name = $3 AND schema_version = $4";
+
+#[derive(Debug)]
+struct RequiredSchemaContract {
+    reference: SchemaRef,
+    fingerprint: String,
+    schema_json: JsonValue,
+}
+
+/// PostgreSQL execution adapter for the transport-neutral [`IndexQueryPort`].
+///
+/// The adapter compiles through the owned immutable registry, verifies every schema
+/// touched by the plan against tenant-scoped persisted registration, and executes the
+/// page plus optional exact count inside one read-only repeatable-read snapshot.
+#[derive(Clone)]
+pub struct PostgresIndexQueryPort {
+    db: DatabaseConnection,
+    registry: Arc<SchemaRegistry>,
+}
+
+impl PostgresIndexQueryPort {
+    pub fn new(db: DatabaseConnection, registry: Arc<SchemaRegistry>) -> Self {
+        Self { db, registry }
+    }
+
+    pub fn connection(&self) -> &DatabaseConnection {
+        &self.db
+    }
+
+    pub fn registry(&self) -> &SchemaRegistry {
+        &self.registry
+    }
+
+    async fn execute_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        query: &IndexQuery,
+        page_query: &CompiledPostgresPageQuery,
+        required_schemas: &[RequiredSchemaContract],
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        transaction
+            .execute_unprepared(READ_ONLY_SNAPSHOT_SQL)
+            .await
+            .map_err(|error| {
+                IndexQueryExecutionError::storage("configure read-only snapshot", error)
+            })?;
+
+        verify_persisted_schemas(transaction, query, required_schemas).await?;
+
+        let compiled = page_query.compiled();
+        let page_rows = transaction
+            .query_all(compiled_statement(compiled))
+            .await
+            .map_err(|error| IndexQueryExecutionError::storage("execute page statement", error))?
+            .into_iter()
+            .map(|row| map_page_row(row, compiled))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let exact_count_row = match compiled.exact_count.as_ref() {
+            Some(count) => Some(execute_exact_count(transaction, count).await?),
+            None => None,
+        };
+
+        self.registry
+            .decode_postgres_query_page(query, page_query, page_rows, exact_count_row)
+            .map_err(IndexQueryExecutionError::from)
+    }
+}
+
+#[async_trait]
+impl IndexQueryPort for PostgresIndexQueryPort {
+    async fn execute_query(
+        &self,
+        query: IndexQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(IndexQueryExecutionError::UnsupportedBackend);
+        }
+
+        let required_schemas = required_schema_contracts(&self.registry, &query)?;
+        let page_query = self.registry.compile_postgres_page_query(&query)?;
+        let transaction = self
+            .db
+            .begin()
+            .await
+            .map_err(|error| IndexQueryExecutionError::storage("begin query snapshot", error))?;
+        let result = self
+            .execute_in_transaction(&transaction, &query, &page_query, &required_schemas)
+            .await;
+
+        match result {
+            Ok(page) => {
+                transaction.commit().await.map_err(|error| {
+                    IndexQueryExecutionError::storage("commit query snapshot", error)
+                })?;
+                Ok(page)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(|rollback_error| {
+                    IndexQueryExecutionError::storage("rollback query snapshot", rollback_error)
+                })?;
+                Err(error)
+            }
+        }
+    }
+}
+
+fn required_schema_contracts(
+    registry: &SchemaRegistry,
+    query: &IndexQuery,
+) -> Result<Vec<RequiredSchemaContract>, IndexQueryExecutionError> {
+    let plan = registry.plan_query(query)?;
+    let mut references = BTreeSet::new();
+    references.insert(plan.root_schema.clone());
+    for join in &plan.joins {
+        references.insert(join.source_schema.clone());
+        references.insert(join.target_schema.clone());
+    }
+
+    references
+        .into_iter()
+        .map(|reference| {
+            let registered = registry.get(&reference).ok_or_else(|| {
+                IndexQueryExecutionError::SchemaNotReady {
+                    reference: reference.clone(),
+                    reason: PersistedSchemaReadinessFailure::Missing,
+                }
+            })?;
+            let schema_json = serde_json::to_value(&registered.schema).map_err(|error| {
+                IndexQueryExecutionError::contract_preparation(reference.clone(), error)
+            })?;
+            Ok(RequiredSchemaContract {
+                reference,
+                fingerprint: registered.fingerprint.to_string(),
+                schema_json,
+            })
+        })
+        .collect()
+}
+
+async fn verify_persisted_schemas(
+    transaction: &DatabaseTransaction,
+    query: &IndexQuery,
+    required_schemas: &[RequiredSchemaContract],
+) -> Result<(), IndexQueryExecutionError> {
+    for required in required_schemas {
+        let row = transaction
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                SELECT_SCHEMA_READINESS_SQL,
+                vec![
+                    query.scope.tenant_id.into(),
+                    required.reference.module.as_str().to_owned().into(),
+                    required.reference.entity.as_str().to_owned().into(),
+                    i64::from(required.reference.version.get()).into(),
+                ],
+            ))
+            .await
+            .map_err(|error| {
+                IndexQueryExecutionError::storage("load persisted schema readiness", error)
+            })?
+            .ok_or_else(|| IndexQueryExecutionError::SchemaNotReady {
+                reference: required.reference.clone(),
+                reason: PersistedSchemaReadinessFailure::Missing,
+            })?;
+
+        let fingerprint: String = row.try_get("", "schema_fingerprint").map_err(|error| {
+            IndexQueryExecutionError::storage("decode persisted schema fingerprint", error)
+        })?;
+        let schema_json: JsonValue = row.try_get("", "schema_json").map_err(|error| {
+            IndexQueryExecutionError::storage("decode persisted schema contract", error)
+        })?;
+        let status: String = row.try_get("", "status").map_err(|error| {
+            IndexQueryExecutionError::storage("decode persisted schema status", error)
+        })?;
+
+        if status != "active" {
+            return Err(IndexQueryExecutionError::SchemaNotReady {
+                reference: required.reference.clone(),
+                reason: PersistedSchemaReadinessFailure::Inactive,
+            });
+        }
+        if fingerprint != required.fingerprint {
+            return Err(IndexQueryExecutionError::SchemaNotReady {
+                reference: required.reference.clone(),
+                reason: PersistedSchemaReadinessFailure::FingerprintMismatch,
+            });
+        }
+        if schema_json != required.schema_json {
+            return Err(IndexQueryExecutionError::SchemaNotReady {
+                reference: required.reference.clone(),
+                reason: PersistedSchemaReadinessFailure::ContractMismatch,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn compiled_statement(compiled: &CompiledPostgresQuery) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        compiled.sql.clone(),
+        compiled
+            .binds
+            .iter()
+            .cloned()
+            .map(postgres_bind_value)
+            .collect(),
+    )
+}
+
+fn count_statement(compiled: &CompiledPostgresCount) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        compiled.sql.clone(),
+        compiled
+            .binds
+            .iter()
+            .cloned()
+            .map(postgres_bind_value)
+            .collect(),
+    )
+}
+
+fn postgres_bind_value(value: PostgresBindValue) -> SqlValue {
+    match value {
+        PostgresBindValue::Boolean(value) => value.into(),
+        PostgresBindValue::Integer(value) => value.into(),
+        PostgresBindValue::Decimal(value) => value.into(),
+        PostgresBindValue::Text(value) => value.into(),
+        PostgresBindValue::Uuid(value) => value.into(),
+        PostgresBindValue::Timestamp(value) => value.into(),
+        PostgresBindValue::Json(value) => SqlValue::Json(Some(Box::new(value))),
+    }
+}
+
+fn map_page_row(
+    row: QueryResult,
+    compiled: &CompiledPostgresQuery,
+) -> Result<CompiledPostgresRow, IndexQueryExecutionError> {
+    let mut values = Vec::with_capacity(compiled.columns.len() + compiled.many_relations.len());
+    for column in &compiled.columns {
+        match column {
+            CompiledQueryColumn::EntityId { output_alias, .. } => {
+                values.push((output_alias.clone(), optional_uuid_cell(&row, output_alias)?));
+            }
+            CompiledQueryColumn::Field { output_alias, .. }
+            | CompiledQueryColumn::OrderValue { output_alias, .. } => {
+                values.push((output_alias.clone(), optional_json_cell(&row, output_alias)?));
+            }
+        }
+    }
+    for column in &compiled.many_relations {
+        values.push((
+            column.output_alias.clone(),
+            optional_json_cell(&row, &column.output_alias)?,
+        ));
+    }
+    Ok(CompiledPostgresRow::from_values(values))
+}
+
+fn optional_uuid_cell(
+    row: &QueryResult,
+    alias: &str,
+) -> Result<CompiledPostgresCell, IndexQueryExecutionError> {
+    let value: Option<Uuid> = row.try_get("", alias).map_err(|error| {
+        IndexQueryExecutionError::invalid_row_column(alias, "a UUID or SQL null", error)
+    })?;
+    Ok(value.map_or(CompiledPostgresCell::Null, CompiledPostgresCell::Uuid))
+}
+
+fn optional_json_cell(
+    row: &QueryResult,
+    alias: &str,
+) -> Result<CompiledPostgresCell, IndexQueryExecutionError> {
+    let value: Option<JsonValue> = row.try_get("", alias).map_err(|error| {
+        IndexQueryExecutionError::invalid_row_column(alias, "JSONB or SQL null", error)
+    })?;
+    Ok(value.map_or(CompiledPostgresCell::Null, CompiledPostgresCell::Json))
+}
+
+async fn execute_exact_count(
+    transaction: &DatabaseTransaction,
+    count: &CompiledPostgresCount,
+) -> Result<CompiledPostgresRow, IndexQueryExecutionError> {
+    let row = transaction
+        .query_one(count_statement(count))
+        .await
+        .map_err(|error| {
+            IndexQueryExecutionError::storage("execute exact-count statement", error)
+        })?
+        .ok_or(IndexQueryExecutionError::MissingExactCountRow)?;
+    let value: i64 = row.try_get("", EXACT_COUNT_ALIAS).map_err(|error| {
+        IndexQueryExecutionError::invalid_row_column(
+            EXACT_COUNT_ALIAS,
+            "a non-null PostgreSQL bigint",
+            error,
+        )
+    })?;
+    Ok(CompiledPostgresRow::from_values([(
+        EXACT_COUNT_ALIAS.to_owned(),
+        CompiledPostgresCell::Integer(value),
+    )]))
+}

--- a/crates/rustok-index/src/infrastructure/postgres/query_port.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_port.rs
@@ -20,7 +20,7 @@ use crate::{
 
 const EXACT_COUNT_ALIAS: &str = "__exact_count";
 const READ_ONLY_SNAPSHOT_SQL: &str =
-    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY";
+    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY";
 const SELECT_SCHEMA_READINESS_SQL: &str =
     "SELECT schema_fingerprint, schema_json, status FROM index_schemas WHERE tenant_id = $1 AND module_name = $2 AND entity_name = $3 AND schema_version = $4";
 
@@ -229,7 +229,7 @@ fn compiled_statement(compiled: &CompiledPostgresQuery) -> Statement {
             .iter()
             .cloned()
             .map(postgres_bind_value)
-            .collect(),
+            .collect::<Vec<_>>(),
     )
 }
 
@@ -242,7 +242,7 @@ fn count_statement(compiled: &CompiledPostgresCount) -> Statement {
             .iter()
             .cloned()
             .map(postgres_bind_value)
-            .collect(),
+            .collect::<Vec<_>>(),
     )
 }
 

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -4,7 +4,8 @@
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, durable schema-application leases, schema-derived
-//! secondary-index lifecycle, and a fail-closed measured partition-admission contract.
+//! secondary-index lifecycle, fail-closed measured partition admission, and the
+//! PostgreSQL execution adapter for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{MigrationDependencyDescriptor, MigrationSource, ModuleKind, RusToKModule};
@@ -23,12 +24,12 @@ pub use infrastructure::postgres::{
     PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
     PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
     PartitionShadowPlan, PartitionStrategy, PersistedSchemaRegistrationOutcome,
-    PostgresMutationStore, PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore,
-    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
-    SchemaLeaseAcquireOutcome, SchemaLeaseError, SchemaRegistrationError,
-    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
-    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
-    SecondaryIndexRequest, SecondaryIndexSpec,
+    PostgresIndexQueryPort, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
+    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
+    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
+    SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };
 
 pub struct IndexModule;


### PR DESCRIPTION
## Summary

- add the transport-neutral `IndexQueryPort` and typed `IndexQueryExecutionError` application contracts
- add `PostgresIndexQueryPort` over one immutable `Arc<SchemaRegistry>` and one PostgreSQL connection
- verify every root/source/target schema against the query tenant's exact active persisted fingerprint and schema JSON before query execution
- execute the page statement and optional exact-count statement in one read-only repeatable-read transaction
- convert every compiler-owned bind type exhaustively into SeaORM values
- map only compiler-declared UUID, JSONB, nested aggregate, hidden order, and bigint aliases into the existing strict decoder handoff
- publish the new port through the crate API and advance the M4 implementation documentation

## Remaining boundaries

- server, storefront, admin, and search composition
- source schema/mutation publication and first consumer cutover
- many-link aggregate ordering policy
- plan/SQL snapshots, live PostgreSQL execution, and PostgreSQL/reference-engine equivalence

## Validation

Not run per maintainer instruction: no tests, Cargo commands, builds, verifiers, database execution, benchmarks, or evidence capture. Static source and contract review only.

No test, fixture, verifier, migration, dependency, or workspace manifest files are changed. Existing Index verifier scripts are intentionally left for the later coordinated testing phase; some already retain pre-#2450 M4 markers.