### PR TITLE
fix(search): preserve external scopes during tenant rebuild

### DIFF
--- a/crates/rustok-forum/contracts/forum-projection-invalidation.json
+++ b/crates/rustok-forum/contracts/forum-projection-invalidation.json
@@ -13,6 +13,7 @@
   "owner_note": "crates/rustok-forum/docs/forum-20bk-projection-invalidation.md",
   "source_verifier": "scripts/verify/verify-forum-projection-invalidation.mjs",
   "visibility_scoped_bulk_read_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json",
+  "rebuild_scope_preservation_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json",
   "targets": {
     "forum_scope": {
       "target_type": "forum",
@@ -90,8 +91,11 @@
   },
   "downstream_handoff": {
     "visibility_scoped_category_and_all_read_commands_completed": true,
-    "completion_task": "FORUM-20BL",
-    "completion_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json"
+    "visibility_completion_task": "FORUM-20BL",
+    "visibility_completion_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json",
+    "full_rebuild_external_scope_preservation_completed": true,
+    "completion_task": "FORUM-20BM",
+    "completion_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json"
   },
   "compatibility": {
     "existing_reindex_target_strings_changed": false,
@@ -111,24 +115,25 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-20BL with conflict-safe repository-local edits after maintainer validation."
+    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-20BM with conflict-safe repository-local edits after maintainer validation."
   },
   "remaining_scope": [
-    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
     "decide whether approved public replies become separate Search documents under FORUM-23",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
-    "capture maintainer-executed PostgreSQL outbox projection cleanup and query runtime evidence plus SQLite validation-only domain evidence",
-    "capture maintainer-executed exact-visible bulk read and PostgreSQL cursor concurrency query-plan evidence",
+    "capture maintainer-executed PostgreSQL full-rebuild failure preservation and projection cleanup evidence",
+    "capture maintainer-executed Search query runtime plus SQLite exact-visible bulk-read evidence",
     "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
   ],
-  "downstream_task": "FORUM-20BM",
+  "downstream_task": "FORUM-20BN",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
       "cargo test -p rustok-outbox transactional -- --nocapture",
       "cargo test -p rustok-forum projection_invalidation -- --nocapture",
       "cargo test -p rustok-forum --test topic_visibility_bulk_read_state_sqlite -- --nocapture",
+      "cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture",
       "cargo test -p rustok-search forum_projector -- --nocapture",
+      "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
       "node scripts/verify/verify-forum-projection-invalidation.mjs",
       "node scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs",
       "cargo xtask module validate forum"

--- a/crates/rustok-forum/contracts/forum-search-projection.json
+++ b/crates/rustok-forum/contracts/forum-search-projection.json
@@ -21,6 +21,7 @@
   "upstream_contract": "crates/rustok-forum/contracts/forum-public-discovery-seo.json",
   "invalidation_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json",
   "visibility_scoped_bulk_read_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json",
+  "rebuild_scope_preservation_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json",
   "source_boundary": {
     "neutral_capability_has_no_forum_dependency": true,
     "neutral_capability_has_no_search_storage_or_query_logic": true,
@@ -45,7 +46,10 @@
     "explicit_forum_rebuild_replaces_scope_after_successful_scan": true,
     "explicit_forum_rebuild_source_failure_keeps_previous_scope": true,
     "full_search_rebuild_includes_forum_after_core_and_blog": true,
-    "full_search_rebuild_source_failure_keeps_previous_forum_scope": false,
+    "full_search_rebuild_source_failure_keeps_previous_forum_scope": true,
+    "direct_search_rebuild_deletes_external_scopes": false,
+    "global_cross_source_atomicity_added": false,
+    "earlier_successful_scope_may_commit_before_later_failure": true,
     "target_refresh_deletes_and_reinserts_in_one_transaction": true,
     "denied_closed_missing_or_deleted_target_removes_stale_documents": true,
     "foreign_or_non_public_source_document_rejected": true,
@@ -78,8 +82,11 @@
   },
   "downstream_handoff": {
     "visibility_scoped_category_and_all_read_commands_completed": true,
-    "completion_task": "FORUM-20BL",
-    "completion_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json"
+    "visibility_completion_task": "FORUM-20BL",
+    "visibility_completion_contract": "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json",
+    "full_rebuild_external_scope_preservation_completed": true,
+    "completion_task": "FORUM-20BM",
+    "completion_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json"
   },
   "compatibility": {
     "existing_search_product_content_blog_projection_changed": false,
@@ -103,24 +110,26 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-20BL with conflict-safe repository-local edits after maintainer validation."
+    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-20BM with conflict-safe repository-local edits after maintainer validation."
   },
   "remaining_scope": [
     "decide whether approved public replies become separate Search documents under FORUM-23",
-    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
-    "capture maintainer-executed PostgreSQL and SQLite projection event cleanup query runtime and exact-visible bulk-read evidence",
+    "capture maintainer-executed PostgreSQL full-rebuild failure preservation and projection cleanup evidence",
+    "capture maintainer-executed Search query runtime plus SQLite exact-visible bulk-read evidence",
     "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
   ],
-  "downstream_task": "FORUM-20BM",
+  "downstream_task": "FORUM-20BN",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
       "cargo test -p rustok-core search_projection -- --nocapture",
       "cargo test -p rustok-outbox transactional -- --nocapture",
+      "cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture",
       "cargo test -p rustok-search forum_projector -- --nocapture",
       "cargo test -p rustok-forum projection_invalidation -- --nocapture",
       "cargo test -p rustok-forum --test topic_visibility_bulk_read_state_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
       "node scripts/verify/verify-forum-search-projection.mjs",
       "node scripts/verify/verify-forum-projection-invalidation.mjs",
       "node scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs",

--- a/crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json
+++ b/crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BM",
+  "upstream_task": "FORUM-20BL",
+  "scope": "Preserve the previous committed value of each external Search projection scope during sequential tenant rebuilds by preventing the direct Search projector from deleting Blog, Forum or future provider-owned documents",
+  "active_search_projector": "crates/rustok-search/src/projector.rs",
+  "private_legacy_projector": "crates/rustok-search/src/projector_legacy.rs",
+  "search_module_wiring": "crates/rustok-search/src/lib.rs",
+  "search_ingestion": "crates/rustok-search/src/ingestion.rs",
+  "blog_projector": "crates/rustok-search/src/blog_projector.rs",
+  "forum_projector": "crates/rustok-search/src/forum_projector.rs",
+  "source_contract_test": "crates/rustok-search/tests/search_scope_preservation_contract.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20bm-search-rebuild-scope-preservation.md",
+  "source_verifier": "scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
+  "upstream_contracts": [
+    "crates/rustok-forum/contracts/forum-search-projection.json",
+    "crates/rustok-forum/contracts/forum-projection-invalidation.json",
+    "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json"
+  ],
+  "ownership_boundary": {
+    "public_search_projector_is_scope_preserving_facade": true,
+    "legacy_projector_module_is_private": true,
+    "legacy_projector_reexported": false,
+    "active_tenant_rebuild_calls_legacy_all_tenant_delete": false,
+    "active_direct_scopes": [
+      "node",
+      "product"
+    ],
+    "core_rebuild_deletes_blog_scope": false,
+    "core_rebuild_deletes_forum_scope": false,
+    "core_rebuild_deletes_unknown_future_external_scope": false,
+    "search_document_storage_owner_changed": false
+  },
+  "replacement_boundary": {
+    "full_ingestion_order": [
+      "search_core",
+      "blog",
+      "forum_if_registered"
+    ],
+    "global_cross_source_transaction_added": false,
+    "global_cross_source_atomicity_claimed": false,
+    "content_scope_replacement_transactional": true,
+    "product_scope_replacement_transactional": true,
+    "blog_scope_replacement_transactional": true,
+    "forum_scope_replacement_uses_temporary_stage": true,
+    "forum_scope_replacement_transactional": true,
+    "failed_blog_rebuild_keeps_previous_blog_scope": true,
+    "failed_forum_rebuild_keeps_previous_forum_scope": true,
+    "later_source_failure_cannot_remove_untouched_external_scope": true,
+    "earlier_successful_scope_may_commit_before_later_failure": true,
+    "retry_reexecutes_current_owner_state": true
+  },
+  "bootstrap_boundary": {
+    "bootstrap_presence_query_counts_only_node_and_product": true,
+    "external_only_documents_suppress_core_bootstrap": false,
+    "blog_documents_count_as_core_bootstrap": false,
+    "forum_documents_count_as_core_bootstrap": false
+  },
+  "compatibility": {
+    "search_projector_public_type_changed": false,
+    "search_projector_public_method_names_changed": false,
+    "search_ingestion_event_contract_changed": false,
+    "search_query_contract_changed": false,
+    "forum_projection_source_contract_changed": false,
+    "forum_rest_routes_changed": false,
+    "forum_graphql_fields_changed": false,
+    "public_response_dto_changed": false,
+    "workspace_dependency_changed": false,
+    "cargo_lock_changed": false,
+    "migration_added": false,
+    "ffa_status_changed": false,
+    "fba_status_changed": false,
+    "legacy_graphql_snapshot_changed": false
+  },
+  "documentation": {
+    "owner_note_added": true,
+    "contract_added": true,
+    "upstream_contracts_updated": true,
+    "source_verifier_added": true,
+    "crate_api_updated": false,
+    "search_plan_updated": false,
+    "canonical_forum_plan_updated": false,
+    "synchronization_debt": "Advance Search CRATE_API/local plan and the canonical FORUM-20/FORUM-23 ledger through FORUM-20BM with conflict-safe repository-local edits after maintainer validation."
+  },
+  "remaining_scope": [
+    "decide whether approved public replies become separate Search documents under FORUM-23",
+    "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
+    "capture maintainer-executed PostgreSQL full-rebuild failure preservation and Forum projection cleanup evidence",
+    "capture maintainer-executed Search query runtime plus SQLite exact-visible bulk-read evidence",
+    "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
+  ],
+  "downstream_task": "FORUM-20BN",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture",
+      "cargo test -p rustok-search --test blog_projection_postgres_test -- --nocapture",
+      "cargo test -p rustok-search forum_projector -- --nocapture",
+      "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
+      "node scripts/verify/verify-forum-search-projection.mjs",
+      "node scripts/verify/verify-forum-projection-invalidation.mjs",
+      "node scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json
+++ b/crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json
@@ -16,6 +16,7 @@
   "owner_note": "crates/rustok-forum/docs/forum-20bl-visibility-scoped-bulk-read.md",
   "source_verifier": "scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs",
   "upstream_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json",
+  "rebuild_scope_preservation_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json",
   "owner_boundary": {
     "authenticated_human_user_required": true,
     "forum_topics_read_scope_required": true,
@@ -77,6 +78,11 @@
     "request_dto_accepts_tenant_or_user_identity": false,
     "storefront_ui_controls_added": false
   },
+  "downstream_handoff": {
+    "full_rebuild_external_scope_preservation_completed": true,
+    "completion_task": "FORUM-20BM",
+    "completion_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json"
+  },
   "compatibility": {
     "legacy_br1_trusted_owner_methods_removed": false,
     "legacy_br1_used_by_public_bulk_transports": false,
@@ -100,17 +106,16 @@
     "crate_api_updated": false,
     "canonical_plan_updated": false,
     "central_readiness_status_updated": false,
-    "synchronization_debt": "Advance the canonical FORUM-16/FORUM-20 ledger and CRATE_API through FORUM-20BL with conflict-safe repository-local edits after maintainer validation; no FFA/FBA readiness status changes in this transport-only slice."
+    "synchronization_debt": "Advance the canonical FORUM-16/FORUM-20/FORUM-23 ledger, Search plan and CRATE_API through FORUM-20BM with conflict-safe repository-local edits after maintainer validation; no FFA/FBA readiness status changes."
   },
   "remaining_scope": [
-    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
     "decide whether approved public replies become separate Search documents under FORUM-23",
     "remove the uncompiled legacy GraphQL query snapshot after verifier migration",
     "capture maintainer-executed SQLite exact-visible bulk read and PostgreSQL cursor concurrency query-plan evidence",
-    "capture maintainer-executed PostgreSQL outbox projection cleanup and Search query runtime evidence",
+    "capture maintainer-executed PostgreSQL full-rebuild failure preservation projection cleanup and Search query runtime evidence",
     "add an explicit Forum translation target invalidation adapter if Forum categories or topics are later registered with the translation control plane"
   ],
-  "downstream_task": "FORUM-20BM",
+  "downstream_task": "FORUM-20BN",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
@@ -119,6 +124,8 @@
       "cargo test -p rustok-forum --test read_state_transport_contract -- --nocapture",
       "cargo test -p rustok-forum --test storefront_read_state_contract -- --nocapture",
       "cargo test -p rustok-forum topic_read_transport -- --nocapture",
+      "cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture",
+      "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
       "node scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs",
       "npm run verify:forum:storefront-boundary",
       "cargo xtask module validate forum"

--- a/crates/rustok-forum/docs/forum-20bm-search-rebuild-scope-preservation.md
+++ b/crates/rustok-forum/docs/forum-20bm-search-rebuild-scope-preservation.md
@@ -1,0 +1,83 @@
+# FORUM-20BM Search rebuild scope preservation
+
+`FORUM-20BM` closes the destructive failure mode that remained after Forum
+Search projection composition: a full tenant rebuild used to commit a direct
+Search projector transaction that deleted every `search_documents` row for the
+tenant before Blog and Forum rebuilt their own scopes. A later Blog or Forum
+failure could therefore leave that source empty even though its previous
+projection had been valid.
+
+The canonical Forum roadmap remains
+[`implementation-plan.md`](./implementation-plan.md). This note records the
+stable owner boundary delivered by this slice; it is not a second roadmap.
+
+## Active projector boundary
+
+`crates/rustok-search/src/projector.rs` is now the public `SearchProjector`
+facade. It owns only the direct `node` and `product` rebuild sequence and delegates
+targeted operations to the previous implementation.
+
+The previous implementation is retained byte-for-byte as
+`projector_legacy.rs`, declared as a private crate module. The active facade does
+not call its destructive `rebuild_tenant` method. It calls only the existing
+transactional `rebuild_content_scope` and `rebuild_product_scope` methods.
+Keeping the previous implementation private avoids a large conflict-prone source
+rewrite while preserving every public `SearchProjector` type and method name.
+
+The bootstrap presence query is also scoped to `node` and `product`. Existing
+Blog or Forum documents no longer suppress bootstrap of the direct Search
+scopes.
+
+## Sequential replacement semantics
+
+The ingestion order remains:
+
+1. direct Search `node` scope;
+2. direct Search `product` scope;
+3. Blog scope;
+4. Forum scope when the Forum projection source is registered.
+
+This is source-scoped preservation, not a new cross-source transaction.
+
+- content and product retain their existing per-scope transactions;
+- Blog continues to delete and repopulate only its scope in one transaction;
+- Forum continues to scan into its temporary stage and replace only its scope in
+  one transaction;
+- the active core projector never deletes Blog, Forum, or an unknown future
+  external projection scope.
+
+If Blog fails, its transaction rolls back and its previous Blog documents remain.
+If Forum fails, its staging transaction rolls back and its previous Forum
+documents remain. A source that completed successfully before a later source
+failed may already expose its newer projection. Global all-source atomicity is
+therefore still not claimed.
+
+This model is retry-safe because every source rebuild derives current owner state
+and replaces only its own idempotent storage scope.
+
+## Compatibility
+
+No Search query, event, Forum source, REST, GraphQL, response DTO, migration,
+workspace dependency, or `Cargo.lock` contract changes in this slice. The public
+`rustok_search::SearchProjector` path and method names remain unchanged.
+
+The legacy all-tenant implementation is deliberately private and quarantined for
+delegation of targeted/per-scope methods. It is not exported and is not reachable
+from Search ingestion.
+
+## Verification and remaining evidence
+
+Source contract coverage lives in:
+
+- `crates/rustok-search/tests/search_scope_preservation_contract.rs`;
+- `scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs`;
+- `crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json`.
+
+The implementation agent did not run tests, Cargo commands, formatting,
+verifiers, workflows, or CI. Maintainer-executed PostgreSQL evidence should still
+exercise a full rebuild where a later Forum source fails and confirm that the
+previous Forum rows remain queryable.
+
+Large Search/Forum plan and `CRATE_API.md` files remain conflict-sensitive
+repository-local synchronization debt. The machine contract records the exact
+handoff to `FORUM-20BN`.

--- a/crates/rustok-search/src/lib.rs
+++ b/crates/rustok-search/src/lib.rs
@@ -20,6 +20,8 @@ pub mod pg_engine;
 pub mod ports;
 pub mod presets;
 pub mod projection_source;
+#[path = "projector_legacy.rs"]
+mod projector_legacy;
 pub mod projector;
 pub mod ranking;
 pub mod search_settings;

--- a/crates/rustok-search/src/lib.rs
+++ b/crates/rustok-search/src/lib.rs
@@ -20,6 +20,7 @@ pub mod pg_engine;
 pub mod ports;
 pub mod presets;
 pub mod projection_source;
+#[allow(dead_code)]
 #[path = "projector_legacy.rs"]
 mod projector_legacy;
 pub mod projector;

--- a/crates/rustok-search/src/projector.rs
+++ b/crates/rustok-search/src/projector.rs
@@ -1,6 +1,3 @@
-#[path = "projector_legacy.rs"]
-mod legacy;
-
 use std::time::Instant;
 
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
@@ -8,6 +5,8 @@ use uuid::Uuid;
 
 use rustok_core::{Error, Result};
 use rustok_telemetry::metrics;
+
+use crate::projector_legacy;
 
 const CORE_SCOPE_COUNT_SQL: &str = r#"
 SELECT COUNT(*) AS total
@@ -26,13 +25,13 @@ WHERE tenant_id = $1
 #[derive(Clone)]
 pub struct SearchProjector {
     db: DatabaseConnection,
-    legacy: legacy::SearchProjector,
+    legacy: projector_legacy::SearchProjector,
 }
 
 impl SearchProjector {
     pub fn new(db: DatabaseConnection) -> Self {
         Self {
-            legacy: legacy::SearchProjector::new(db.clone()),
+            legacy: projector_legacy::SearchProjector::new(db.clone()),
             db,
         }
     }

--- a/crates/rustok-search/src/projector.rs
+++ b/crates/rustok-search/src/projector.rs
@@ -1,141 +1,91 @@
-use sea_orm::{
-    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
-    TransactionTrait,
-};
-use std::time::{Duration, Instant};
+#[path = "projector_legacy.rs"]
+mod legacy;
+
+use std::time::Instant;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
 use uuid::Uuid;
 
 use rustok_core::{Error, Result};
 use rustok_telemetry::metrics;
 
+const CORE_SCOPE_COUNT_SQL: &str = r#"
+SELECT COUNT(*) AS total
+FROM search_documents
+WHERE tenant_id = $1
+  AND entity_type IN ('node', 'product')
+"#;
+
+/// Search-owned projector facade.
+///
+/// Tenant rebuilds replace only the direct `node` and `product` scopes owned by
+/// this projector. External Blog, Forum and future registered projection scopes
+/// remain untouched until their own projectors complete an atomic replacement.
+/// This prevents an early core rebuild commit from deleting the previous value
+/// of a later source when that source subsequently fails.
 #[derive(Clone)]
 pub struct SearchProjector {
     db: DatabaseConnection,
+    legacy: legacy::SearchProjector,
 }
 
 impl SearchProjector {
     pub fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+        Self {
+            legacy: legacy::SearchProjector::new(db.clone()),
+            db,
+        }
     }
 
+    /// Bootstraps the scopes owned by this projector even when an external source
+    /// has already populated the shared Search document store.
     pub async fn ensure_bootstrap(&self, tenant_id: Uuid) -> Result<()> {
         self.ensure_postgres()?;
-
-        let stmt = Statement::from_sql_and_values(
+        let statement = Statement::from_sql_and_values(
             DbBackend::Postgres,
-            "SELECT COUNT(*) AS total FROM search_documents WHERE tenant_id = $1",
+            CORE_SCOPE_COUNT_SQL,
             vec![tenant_id.into()],
         );
-
         let total = self
             .db
-            .query_one(stmt)
+            .query_one(statement)
             .await
             .map_err(Error::Database)?
             .and_then(|row| row.try_get::<i64>("", "total").ok())
             .unwrap_or(0);
-
         if total == 0 {
             self.rebuild_tenant(tenant_id).await?;
         }
-
         Ok(())
     }
 
+    /// Replaces the direct Search-owned scopes without deleting documents owned
+    /// by later Blog, Forum or future projection-source stages.
+    ///
+    /// Content and product replacements keep their existing per-scope database
+    /// transactions. A later scope failure therefore leaves every external scope
+    /// at its previous committed value and leaves the failed scope rolled back.
     pub async fn rebuild_tenant(&self, tenant_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
         let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
         let result = async {
-            self.delete_tenant_documents_in(&tx, tenant_id).await?;
-            self.upsert_content_documents_in(&tx, tenant_id, None, None, None)
-                .await?;
-            self.upsert_product_documents_in(&tx, tenant_id, None)
-                .await?;
-            self.commit_transaction(tx).await
+            self.legacy.rebuild_content_scope(tenant_id).await?;
+            self.legacy.rebuild_product_scope(tenant_id).await
         }
         .await;
-        record_projector_operation(
-            "rebuild_tenant",
-            "tenant",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
+        record_scope_preserving_rebuild(tenant_id, &result, started_at);
         result
     }
 
     pub async fn rebuild_content_scope(&self, tenant_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_documents_in(
-                &tx,
-                "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node'",
-                vec![tenant_id.into()],
-            )
-            .await?;
-            self.upsert_content_documents_in(&tx, tenant_id, None, None, None)
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "rebuild_content_scope",
-            "node",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy.rebuild_content_scope(tenant_id).await
     }
 
     pub async fn rebuild_product_scope(&self, tenant_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_documents_in(
-                &tx,
-                "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'product'",
-                vec![tenant_id.into()],
-            )
-            .await?;
-            self.upsert_product_documents_in(&tx, tenant_id, None)
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "rebuild_product_scope",
-            "product",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy.rebuild_product_scope(tenant_id).await
     }
 
     pub async fn upsert_node(&self, tenant_id: Uuid, node_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_node_in(&tx, tenant_id, node_id).await?;
-            self.upsert_content_documents_in(&tx, tenant_id, Some(node_id), None, None)
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "upsert_node",
-            "node",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy.upsert_node(tenant_id, node_id).await
     }
 
     pub async fn upsert_node_locale(
@@ -144,29 +94,13 @@ impl SearchProjector {
         node_id: Uuid,
         locale: &str,
     ) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_node_locale_in(&tx, tenant_id, node_id, locale)
-                .await?;
-            self.upsert_content_documents_in(&tx, tenant_id, Some(node_id), Some(locale), None)
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "upsert_node_locale",
-            "node",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy
+            .upsert_node_locale(tenant_id, node_id, locale)
+            .await
     }
 
     pub async fn delete_node(&self, tenant_id: Uuid, node_id: Uuid) -> Result<()> {
-        self.delete_node_in(&self.db, tenant_id, node_id).await
+        self.legacy.delete_node(tenant_id, node_id).await
     }
 
     pub async fn delete_node_locale(
@@ -175,70 +109,21 @@ impl SearchProjector {
         node_id: Uuid,
         locale: &str,
     ) -> Result<()> {
-        self.delete_node_locale_in(&self.db, tenant_id, node_id, locale)
+        self.legacy
+            .delete_node_locale(tenant_id, node_id, locale)
             .await
     }
 
     pub async fn reindex_category(&self, tenant_id: Uuid, category_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_documents_in(
-                &tx,
-                r#"
-                DELETE FROM search_documents
-                WHERE tenant_id = $1
-                  AND entity_type = 'node'
-                  AND document_id IN (
-                      SELECT id FROM nodes
-                      WHERE tenant_id = $1
-                        AND category_id = $2
-                        AND deleted_at IS NULL
-                  )
-                "#,
-                vec![tenant_id.into(), category_id.into()],
-            )
-            .await?;
-            self.upsert_content_documents_in(&tx, tenant_id, None, None, Some(category_id))
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "reindex_category",
-            "node",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy.reindex_category(tenant_id, category_id).await
     }
 
     pub async fn upsert_product(&self, tenant_id: Uuid, product_id: Uuid) -> Result<()> {
-        self.ensure_postgres()?;
-        let started_at = Instant::now();
-        let tx = self.begin_transaction().await?;
-        let result = async {
-            self.delete_product_in(&tx, tenant_id, product_id).await?;
-            self.upsert_product_documents_in(&tx, tenant_id, Some(product_id))
-                .await?;
-            self.commit_transaction(tx).await
-        }
-        .await;
-        record_projector_operation(
-            "upsert_product",
-            "product",
-            tenant_id,
-            &result,
-            started_at.elapsed(),
-        );
-        result
+        self.legacy.upsert_product(tenant_id, product_id).await
     }
 
     pub async fn delete_product(&self, tenant_id: Uuid, product_id: Uuid) -> Result<()> {
-        self.delete_product_in(&self.db, tenant_id, product_id)
-            .await
+        self.legacy.delete_product(tenant_id, product_id).await
     }
 
     fn ensure_postgres(&self) -> Result<()> {
@@ -247,429 +132,42 @@ impl SearchProjector {
                 "SearchProjector requires PostgreSQL backend".to_string(),
             ));
         }
-
-        Ok(())
-    }
-
-    async fn begin_transaction(&self) -> Result<DatabaseTransaction> {
-        self.db.begin().await.map_err(Error::Database)
-    }
-
-    async fn commit_transaction(&self, tx: DatabaseTransaction) -> Result<()> {
-        tx.commit().await.map_err(Error::Database)
-    }
-
-    async fn delete_tenant_documents_in<C>(&self, conn: &C, tenant_id: Uuid) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        self.delete_documents_in(
-            conn,
-            "DELETE FROM search_documents WHERE tenant_id = $1",
-            vec![tenant_id.into()],
-        )
-        .await
-    }
-
-    async fn delete_node_in<C>(&self, conn: &C, tenant_id: Uuid, node_id: Uuid) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        self.delete_documents_in(
-            conn,
-            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node' AND document_id = $2",
-            vec![tenant_id.into(), node_id.into()],
-        )
-        .await
-    }
-
-    async fn delete_node_locale_in<C>(
-        &self,
-        conn: &C,
-        tenant_id: Uuid,
-        node_id: Uuid,
-        locale: &str,
-    ) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        self.delete_documents_in(
-            conn,
-            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node' AND document_id = $2 AND locale = $3",
-            vec![tenant_id.into(), node_id.into(), locale.to_string().into()],
-        )
-        .await
-    }
-
-    async fn delete_product_in<C>(&self, conn: &C, tenant_id: Uuid, product_id: Uuid) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        self.delete_documents_in(
-            conn,
-            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'product' AND document_id = $2",
-            vec![tenant_id.into(), product_id.into()],
-        )
-        .await
-    }
-
-    async fn delete_documents_in<C>(
-        &self,
-        conn: &C,
-        sql: &str,
-        values: Vec<sea_orm::Value>,
-    ) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
-        conn.execute(stmt).await.map_err(Error::Database)?;
-        Ok(())
-    }
-
-    async fn upsert_content_documents_in<C>(
-        &self,
-        conn: &C,
-        tenant_id: Uuid,
-        node_id: Option<Uuid>,
-        locale: Option<&str>,
-        category_id: Option<Uuid>,
-    ) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        let mut values = vec![tenant_id.into()];
-        let mut param = 2;
-        let mut where_clause = String::from("WHERE n.tenant_id = $1 AND n.deleted_at IS NULL");
-
-        if let Some(node_id) = node_id {
-            where_clause.push_str(&format!(" AND n.id = ${param}"));
-            values.push(node_id.into());
-            param += 1;
-        }
-
-        if let Some(locale) = locale {
-            where_clause.push_str(&format!(" AND nt.locale = ${param}"));
-            values.push(locale.to_string().into());
-            param += 1;
-        }
-
-        if let Some(category_id) = category_id {
-            where_clause.push_str(&format!(" AND n.category_id = ${param}"));
-            values.push(category_id.into());
-        }
-
-        let sql = format!(
-            r#"
-            INSERT INTO search_documents (
-                document_key,
-                tenant_id,
-                document_id,
-                source_module,
-                entity_type,
-                locale,
-                status,
-                is_public,
-                title,
-                subtitle,
-                slug,
-                handle,
-                body,
-                keywords_text,
-                facets,
-                payload,
-                published_at,
-                created_at,
-                updated_at,
-                indexed_at
-            )
-            SELECT
-                CONCAT('node:', n.id::text, ':', nt.locale) AS document_key,
-                n.tenant_id,
-                n.id AS document_id,
-                COALESCE(NULLIF(n.kind::text, ''), 'content') AS source_module,
-                'node'::text AS entity_type,
-                nt.locale,
-                n.status::text AS status,
-                (LOWER(n.status::text) = 'published') AS is_public,
-                COALESCE(nt.title, '') AS title,
-                ct.name AS subtitle,
-                nt.slug,
-                NULL::text AS handle,
-                CONCAT_WS(E'\n\n', COALESCE(nt.excerpt, ''), COALESCE(b.body, '')) AS body,
-                CONCAT_WS(
-                    ' ',
-                    COALESCE(ct.name, ''),
-                    COALESCE(u.name, ''),
-                    COALESCE(tags.tag_names, '')
-                ) AS keywords_text,
-                jsonb_build_object(
-                    'has_category', (ct.slug IS NOT NULL),
-                    'has_tags', (COALESCE(tags.tag_count, 0) > 0)
-                ) AS facets,
-                jsonb_build_object(
-                    'slug', nt.slug,
-                    'excerpt', nt.excerpt,
-                    'category_id', n.category_id,
-                    'category_name', ct.name,
-                    'category_slug', ct.slug,
-                    'author_name', u.name,
-                    'tags', COALESCE(tags.tag_list, '[]'::jsonb),
-                    'published_at', n.published_at
-                ) AS payload,
-                n.published_at,
-                n.created_at,
-                n.updated_at,
-                NOW()
-            FROM nodes n
-            JOIN node_translations nt
-                ON nt.node_id = n.id
-            LEFT JOIN bodies b
-                ON b.node_id = n.id AND b.locale = nt.locale
-            LEFT JOIN category_translations ct
-                ON ct.category_id = n.category_id AND ct.locale = nt.locale
-            LEFT JOIN users u
-                ON u.id = n.author_id
-            LEFT JOIN LATERAL (
-                SELECT
-                    COUNT(*)::bigint AS tag_count,
-                    string_agg(tag.tag_name, ' ') AS tag_names,
-                    COALESCE(
-                        jsonb_agg(
-                            jsonb_build_object(
-                                'id',
-                                LOWER(
-                                    SUBSTRING(md5(tag.slug) FROM 1 FOR 8) || '-' ||
-                                    SUBSTRING(md5(tag.slug) FROM 9 FOR 4) || '-' ||
-                                    SUBSTRING(md5(tag.slug) FROM 13 FOR 4) || '-' ||
-                                    SUBSTRING(md5(tag.slug) FROM 17 FOR 4) || '-' ||
-                                    SUBSTRING(md5(tag.slug) FROM 21 FOR 12)
-                                ),
-                                'name', tag.tag_name,
-                                'slug', tag.slug
-                            )
-                            ORDER BY tag.tag_name
-                        ) FILTER (WHERE tag.slug <> ''),
-                        '[]'::jsonb
-                    ) AS tag_list
-                FROM (
-                    SELECT DISTINCT
-                        BTRIM(tag_value) AS tag_name,
-                        LOWER(
-                            BTRIM(
-                                REGEXP_REPLACE(
-                                    BTRIM(tag_value),
-                                    '[^[:alnum:]]+',
-                                    '-',
-                                    'g'
-                                ),
-                                '-'
-                            )
-                        ) AS slug
-                    FROM jsonb_array_elements_text(
-                        CASE
-                            WHEN jsonb_typeof(n.metadata -> 'tags') = 'array' THEN n.metadata -> 'tags'
-                            ELSE '[]'::jsonb
-                        END
-                    ) AS tag_values(tag_value)
-                    WHERE BTRIM(tag_value) <> ''
-                ) tag
-                WHERE tag.slug <> ''
-            ) tags ON TRUE
-            {where_clause}
-            ON CONFLICT (document_key) DO UPDATE SET
-                status = EXCLUDED.status,
-                is_public = EXCLUDED.is_public,
-                title = EXCLUDED.title,
-                subtitle = EXCLUDED.subtitle,
-                slug = EXCLUDED.slug,
-                handle = EXCLUDED.handle,
-                body = EXCLUDED.body,
-                keywords_text = EXCLUDED.keywords_text,
-                facets = EXCLUDED.facets,
-                payload = EXCLUDED.payload,
-                published_at = EXCLUDED.published_at,
-                updated_at = EXCLUDED.updated_at,
-                indexed_at = NOW()
-            "#
-        );
-
-        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
-        conn.execute(stmt).await.map_err(Error::Database)?;
-        Ok(())
-    }
-
-    async fn upsert_product_documents_in<C>(
-        &self,
-        conn: &C,
-        tenant_id: Uuid,
-        product_id: Option<Uuid>,
-    ) -> Result<()>
-    where
-        C: ConnectionTrait,
-    {
-        let mut values = vec![tenant_id.into()];
-        let mut where_clause = String::from("WHERE p.tenant_id = $1");
-
-        if let Some(product_id) = product_id {
-            where_clause.push_str(" AND p.id = $2");
-            values.push(product_id.into());
-        }
-
-        let sql = format!(
-            r#"
-            INSERT INTO search_documents (
-                document_key,
-                tenant_id,
-                document_id,
-                source_module,
-                entity_type,
-                locale,
-                status,
-                is_public,
-                title,
-                subtitle,
-                slug,
-                handle,
-                body,
-                keywords_text,
-                facets,
-                payload,
-                published_at,
-                created_at,
-                updated_at,
-                indexed_at
-            )
-            SELECT
-                CONCAT('product:', p.id::text, ':', pt.locale) AS document_key,
-                p.tenant_id,
-                p.id AS document_id,
-                'commerce'::text AS source_module,
-                'product'::text AS entity_type,
-                pt.locale,
-                p.status::text AS status,
-                (LOWER(p.status::text) = 'active') AS is_public,
-                COALESCE(pt.title, '') AS title,
-                p.vendor AS subtitle,
-                NULL::text AS slug,
-                pt.handle,
-                COALESCE(pt.description, '') AS body,
-                CONCAT_WS(
-                    ' ',
-                    COALESCE(p.vendor, ''),
-                    COALESCE(pt.meta_title, ''),
-                    COALESCE(pt.meta_description, '')
-                ) AS keywords_text,
-                jsonb_build_object(
-                    'in_stock', COALESCE(agg.in_stock, false),
-                    'has_price', (agg.price_min IS NOT NULL OR agg.price_max IS NOT NULL)
-                ) AS facets,
-                jsonb_build_object(
-                    'handle', pt.handle,
-                    'description', pt.description,
-                    'vendor', p.vendor,
-                    'price_min', agg.price_min,
-                    'price_max', agg.price_max,
-                    'in_stock', COALESCE(agg.in_stock, false),
-                    'variant_count', COALESCE(agg.variant_count, 0),
-                    'published_at', p.published_at
-                ) AS payload,
-                p.published_at,
-                p.created_at,
-                p.updated_at,
-                NOW()
-            FROM products p
-            JOIN product_translations pt
-                ON pt.product_id = p.id
-            LEFT JOIN LATERAL (
-                SELECT
-                    COUNT(pv.id)::bigint AS variant_count,
-                    COALESCE(SUM(inv.available_quantity), 0) > 0 AS in_stock,
-                    MIN(price_agg.min_amount)::bigint AS price_min,
-                    MAX(price_agg.max_amount)::bigint AS price_max
-                FROM product_variants pv
-                LEFT JOIN LATERAL (
-                    SELECT COALESCE(SUM(il.stocked_quantity - il.reserved_quantity), 0) AS available_quantity
-                    FROM inventory_items ii
-                    LEFT JOIN inventory_levels il ON il.inventory_item_id = ii.id
-                    WHERE ii.variant_id = pv.id
-                ) inv ON TRUE
-                LEFT JOIN LATERAL (
-                    SELECT
-                        MIN(pr.amount) AS min_amount,
-                        MAX(pr.amount) AS max_amount
-                    FROM prices pr
-                    WHERE pr.variant_id = pv.id
-                ) price_agg ON TRUE
-                WHERE pv.product_id = p.id
-                  AND pv.tenant_id = p.tenant_id
-            ) agg ON TRUE
-            {where_clause}
-            ON CONFLICT (document_key) DO UPDATE SET
-                status = EXCLUDED.status,
-                is_public = EXCLUDED.is_public,
-                title = EXCLUDED.title,
-                subtitle = EXCLUDED.subtitle,
-                slug = EXCLUDED.slug,
-                handle = EXCLUDED.handle,
-                body = EXCLUDED.body,
-                keywords_text = EXCLUDED.keywords_text,
-                facets = EXCLUDED.facets,
-                payload = EXCLUDED.payload,
-                published_at = EXCLUDED.published_at,
-                updated_at = EXCLUDED.updated_at,
-                indexed_at = NOW()
-            "#
-        );
-
-        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
-        conn.execute(stmt).await.map_err(Error::Database)?;
         Ok(())
     }
 }
 
-fn record_projector_operation(
-    operation: &str,
-    entity: &str,
-    tenant_id: Uuid,
-    result: &Result<()>,
-    duration: Duration,
-) {
+fn record_scope_preserving_rebuild(tenant_id: Uuid, result: &Result<()>, started_at: Instant) {
     let status = if result.is_ok() { "success" } else { "error" };
-    metrics::record_search_indexing_operation(operation, entity, status, duration.as_secs_f64());
-
-    if let Err(error) = result {
-        metrics::record_module_error("search", classify_error(error), "error");
-        tracing::error!(
-            operation,
-            entity,
+    metrics::record_search_indexing_operation(
+        "rebuild_tenant_scoped",
+        "tenant",
+        status,
+        started_at.elapsed().as_secs_f64(),
+    );
+    match result {
+        Ok(()) => tracing::info!(
+            tenant_id = %tenant_id,
+            duration_ms = started_at.elapsed().as_millis() as u64,
+            "Search-owned tenant scopes rebuilt without deleting external projections"
+        ),
+        Err(error) => tracing::error!(
             tenant_id = %tenant_id,
             error = %error,
-            duration_ms = duration.as_millis() as u64,
-            "Search projector operation failed"
-        );
-    } else {
-        tracing::info!(
-            operation,
-            entity,
-            tenant_id = %tenant_id,
-            duration_ms = duration.as_millis() as u64,
-            "Search projector operation completed"
-        );
+            duration_ms = started_at.elapsed().as_millis() as u64,
+            "Search-owned tenant scope rebuild failed"
+        ),
     }
 }
 
-fn classify_error(error: &Error) -> &'static str {
-    match error {
-        Error::Database(_) => "database",
-        Error::Validation(_) => "validation",
-        Error::External(_) => "external",
-        Error::NotFound(_) => "not_found",
-        Error::Forbidden(_) => "forbidden",
-        Error::Auth(_) => "auth",
-        Error::Cache(_) => "cache",
-        Error::Serialization(_) => "serialization",
-        Error::Scripting(_) => "scripting",
-        Error::InvalidIdFormat(_) => "invalid_id",
+#[cfg(test)]
+mod tests {
+    use super::CORE_SCOPE_COUNT_SQL;
+
+    #[test]
+    fn bootstrap_count_is_limited_to_direct_search_scopes() {
+        assert!(CORE_SCOPE_COUNT_SQL.contains("entity_type IN ('node', 'product')"));
+        assert!(!CORE_SCOPE_COUNT_SQL.contains("blog_post"));
+        assert!(!CORE_SCOPE_COUNT_SQL.contains("forum_category"));
+        assert!(!CORE_SCOPE_COUNT_SQL.contains("forum_topic"));
     }
 }

--- a/crates/rustok-search/src/projector.rs
+++ b/crates/rustok-search/src/projector.rs
@@ -59,11 +59,12 @@ impl SearchProjector {
     }
 
     /// Replaces the direct Search-owned scopes without deleting documents owned
-    /// by later Blog, Forum or future projection-source stages.
+    /// by Blog, Forum or future projection-source stages.
     ///
-    /// Content and product replacements keep their existing per-scope database
-    /// transactions. A later scope failure therefore leaves every external scope
-    /// at its previous committed value and leaves the failed scope rolled back.
+    /// Content and product retain their existing per-scope transactions. The
+    /// ingestion orchestrator remains sequential rather than globally atomic:
+    /// scopes that completed before a later failure may advance, while the failed
+    /// external scope keeps its previous committed value.
     pub async fn rebuild_tenant(&self, tenant_id: Uuid) -> Result<()> {
         let started_at = Instant::now();
         let result = async {
@@ -138,7 +139,7 @@ impl SearchProjector {
 fn record_scope_preserving_rebuild(tenant_id: Uuid, result: &Result<()>, started_at: Instant) {
     let status = if result.is_ok() { "success" } else { "error" };
     metrics::record_search_indexing_operation(
-        "rebuild_tenant_scoped",
+        "rebuild_tenant",
         "tenant",
         status,
         started_at.elapsed().as_secs_f64(),

--- a/crates/rustok-search/src/projector_legacy.rs
+++ b/crates/rustok-search/src/projector_legacy.rs
@@ -1,0 +1,675 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+    TransactionTrait,
+};
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+use rustok_core::{Error, Result};
+use rustok_telemetry::metrics;
+
+#[derive(Clone)]
+pub struct SearchProjector {
+    db: DatabaseConnection,
+}
+
+impl SearchProjector {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn ensure_bootstrap(&self, tenant_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+
+        let stmt = Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*) AS total FROM search_documents WHERE tenant_id = $1",
+            vec![tenant_id.into()],
+        );
+
+        let total = self
+            .db
+            .query_one(stmt)
+            .await
+            .map_err(Error::Database)?
+            .and_then(|row| row.try_get::<i64>("", "total").ok())
+            .unwrap_or(0);
+
+        if total == 0 {
+            self.rebuild_tenant(tenant_id).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn rebuild_tenant(&self, tenant_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_tenant_documents_in(&tx, tenant_id).await?;
+            self.upsert_content_documents_in(&tx, tenant_id, None, None, None)
+                .await?;
+            self.upsert_product_documents_in(&tx, tenant_id, None)
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "rebuild_tenant",
+            "tenant",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn rebuild_content_scope(&self, tenant_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_documents_in(
+                &tx,
+                "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node'",
+                vec![tenant_id.into()],
+            )
+            .await?;
+            self.upsert_content_documents_in(&tx, tenant_id, None, None, None)
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "rebuild_content_scope",
+            "node",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn rebuild_product_scope(&self, tenant_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_documents_in(
+                &tx,
+                "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'product'",
+                vec![tenant_id.into()],
+            )
+            .await?;
+            self.upsert_product_documents_in(&tx, tenant_id, None)
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "rebuild_product_scope",
+            "product",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn upsert_node(&self, tenant_id: Uuid, node_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_node_in(&tx, tenant_id, node_id).await?;
+            self.upsert_content_documents_in(&tx, tenant_id, Some(node_id), None, None)
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "upsert_node",
+            "node",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn upsert_node_locale(
+        &self,
+        tenant_id: Uuid,
+        node_id: Uuid,
+        locale: &str,
+    ) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_node_locale_in(&tx, tenant_id, node_id, locale)
+                .await?;
+            self.upsert_content_documents_in(&tx, tenant_id, Some(node_id), Some(locale), None)
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "upsert_node_locale",
+            "node",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn delete_node(&self, tenant_id: Uuid, node_id: Uuid) -> Result<()> {
+        self.delete_node_in(&self.db, tenant_id, node_id).await
+    }
+
+    pub async fn delete_node_locale(
+        &self,
+        tenant_id: Uuid,
+        node_id: Uuid,
+        locale: &str,
+    ) -> Result<()> {
+        self.delete_node_locale_in(&self.db, tenant_id, node_id, locale)
+            .await
+    }
+
+    pub async fn reindex_category(&self, tenant_id: Uuid, category_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_documents_in(
+                &tx,
+                r#"
+                DELETE FROM search_documents
+                WHERE tenant_id = $1
+                  AND entity_type = 'node'
+                  AND document_id IN (
+                      SELECT id FROM nodes
+                      WHERE tenant_id = $1
+                        AND category_id = $2
+                        AND deleted_at IS NULL
+                  )
+                "#,
+                vec![tenant_id.into(), category_id.into()],
+            )
+            .await?;
+            self.upsert_content_documents_in(&tx, tenant_id, None, None, Some(category_id))
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "reindex_category",
+            "node",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn upsert_product(&self, tenant_id: Uuid, product_id: Uuid) -> Result<()> {
+        self.ensure_postgres()?;
+        let started_at = Instant::now();
+        let tx = self.begin_transaction().await?;
+        let result = async {
+            self.delete_product_in(&tx, tenant_id, product_id).await?;
+            self.upsert_product_documents_in(&tx, tenant_id, Some(product_id))
+                .await?;
+            self.commit_transaction(tx).await
+        }
+        .await;
+        record_projector_operation(
+            "upsert_product",
+            "product",
+            tenant_id,
+            &result,
+            started_at.elapsed(),
+        );
+        result
+    }
+
+    pub async fn delete_product(&self, tenant_id: Uuid, product_id: Uuid) -> Result<()> {
+        self.delete_product_in(&self.db, tenant_id, product_id)
+            .await
+    }
+
+    fn ensure_postgres(&self) -> Result<()> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(Error::External(
+                "SearchProjector requires PostgreSQL backend".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn begin_transaction(&self) -> Result<DatabaseTransaction> {
+        self.db.begin().await.map_err(Error::Database)
+    }
+
+    async fn commit_transaction(&self, tx: DatabaseTransaction) -> Result<()> {
+        tx.commit().await.map_err(Error::Database)
+    }
+
+    async fn delete_tenant_documents_in<C>(&self, conn: &C, tenant_id: Uuid) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        self.delete_documents_in(
+            conn,
+            "DELETE FROM search_documents WHERE tenant_id = $1",
+            vec![tenant_id.into()],
+        )
+        .await
+    }
+
+    async fn delete_node_in<C>(&self, conn: &C, tenant_id: Uuid, node_id: Uuid) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        self.delete_documents_in(
+            conn,
+            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node' AND document_id = $2",
+            vec![tenant_id.into(), node_id.into()],
+        )
+        .await
+    }
+
+    async fn delete_node_locale_in<C>(
+        &self,
+        conn: &C,
+        tenant_id: Uuid,
+        node_id: Uuid,
+        locale: &str,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        self.delete_documents_in(
+            conn,
+            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'node' AND document_id = $2 AND locale = $3",
+            vec![tenant_id.into(), node_id.into(), locale.to_string().into()],
+        )
+        .await
+    }
+
+    async fn delete_product_in<C>(&self, conn: &C, tenant_id: Uuid, product_id: Uuid) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        self.delete_documents_in(
+            conn,
+            "DELETE FROM search_documents WHERE tenant_id = $1 AND entity_type = 'product' AND document_id = $2",
+            vec![tenant_id.into(), product_id.into()],
+        )
+        .await
+    }
+
+    async fn delete_documents_in<C>(
+        &self,
+        conn: &C,
+        sql: &str,
+        values: Vec<sea_orm::Value>,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
+        conn.execute(stmt).await.map_err(Error::Database)?;
+        Ok(())
+    }
+
+    async fn upsert_content_documents_in<C>(
+        &self,
+        conn: &C,
+        tenant_id: Uuid,
+        node_id: Option<Uuid>,
+        locale: Option<&str>,
+        category_id: Option<Uuid>,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        let mut values = vec![tenant_id.into()];
+        let mut param = 2;
+        let mut where_clause = String::from("WHERE n.tenant_id = $1 AND n.deleted_at IS NULL");
+
+        if let Some(node_id) = node_id {
+            where_clause.push_str(&format!(" AND n.id = ${param}"));
+            values.push(node_id.into());
+            param += 1;
+        }
+
+        if let Some(locale) = locale {
+            where_clause.push_str(&format!(" AND nt.locale = ${param}"));
+            values.push(locale.to_string().into());
+            param += 1;
+        }
+
+        if let Some(category_id) = category_id {
+            where_clause.push_str(&format!(" AND n.category_id = ${param}"));
+            values.push(category_id.into());
+        }
+
+        let sql = format!(
+            r#"
+            INSERT INTO search_documents (
+                document_key,
+                tenant_id,
+                document_id,
+                source_module,
+                entity_type,
+                locale,
+                status,
+                is_public,
+                title,
+                subtitle,
+                slug,
+                handle,
+                body,
+                keywords_text,
+                facets,
+                payload,
+                published_at,
+                created_at,
+                updated_at,
+                indexed_at
+            )
+            SELECT
+                CONCAT('node:', n.id::text, ':', nt.locale) AS document_key,
+                n.tenant_id,
+                n.id AS document_id,
+                COALESCE(NULLIF(n.kind::text, ''), 'content') AS source_module,
+                'node'::text AS entity_type,
+                nt.locale,
+                n.status::text AS status,
+                (LOWER(n.status::text) = 'published') AS is_public,
+                COALESCE(nt.title, '') AS title,
+                ct.name AS subtitle,
+                nt.slug,
+                NULL::text AS handle,
+                CONCAT_WS(E'\n\n', COALESCE(nt.excerpt, ''), COALESCE(b.body, '')) AS body,
+                CONCAT_WS(
+                    ' ',
+                    COALESCE(ct.name, ''),
+                    COALESCE(u.name, ''),
+                    COALESCE(tags.tag_names, '')
+                ) AS keywords_text,
+                jsonb_build_object(
+                    'has_category', (ct.slug IS NOT NULL),
+                    'has_tags', (COALESCE(tags.tag_count, 0) > 0)
+                ) AS facets,
+                jsonb_build_object(
+                    'slug', nt.slug,
+                    'excerpt', nt.excerpt,
+                    'category_id', n.category_id,
+                    'category_name', ct.name,
+                    'category_slug', ct.slug,
+                    'author_name', u.name,
+                    'tags', COALESCE(tags.tag_list, '[]'::jsonb),
+                    'published_at', n.published_at
+                ) AS payload,
+                n.published_at,
+                n.created_at,
+                n.updated_at,
+                NOW()
+            FROM nodes n
+            JOIN node_translations nt
+                ON nt.node_id = n.id
+            LEFT JOIN bodies b
+                ON b.node_id = n.id AND b.locale = nt.locale
+            LEFT JOIN category_translations ct
+                ON ct.category_id = n.category_id AND ct.locale = nt.locale
+            LEFT JOIN users u
+                ON u.id = n.author_id
+            LEFT JOIN LATERAL (
+                SELECT
+                    COUNT(*)::bigint AS tag_count,
+                    string_agg(tag.tag_name, ' ') AS tag_names,
+                    COALESCE(
+                        jsonb_agg(
+                            jsonb_build_object(
+                                'id',
+                                LOWER(
+                                    SUBSTRING(md5(tag.slug) FROM 1 FOR 8) || '-' ||
+                                    SUBSTRING(md5(tag.slug) FROM 9 FOR 4) || '-' ||
+                                    SUBSTRING(md5(tag.slug) FROM 13 FOR 4) || '-' ||
+                                    SUBSTRING(md5(tag.slug) FROM 17 FOR 4) || '-' ||
+                                    SUBSTRING(md5(tag.slug) FROM 21 FOR 12)
+                                ),
+                                'name', tag.tag_name,
+                                'slug', tag.slug
+                            )
+                            ORDER BY tag.tag_name
+                        ) FILTER (WHERE tag.slug <> ''),
+                        '[]'::jsonb
+                    ) AS tag_list
+                FROM (
+                    SELECT DISTINCT
+                        BTRIM(tag_value) AS tag_name,
+                        LOWER(
+                            BTRIM(
+                                REGEXP_REPLACE(
+                                    BTRIM(tag_value),
+                                    '[^[:alnum:]]+',
+                                    '-',
+                                    'g'
+                                ),
+                                '-'
+                            )
+                        ) AS slug
+                    FROM jsonb_array_elements_text(
+                        CASE
+                            WHEN jsonb_typeof(n.metadata -> 'tags') = 'array' THEN n.metadata -> 'tags'
+                            ELSE '[]'::jsonb
+                        END
+                    ) AS tag_values(tag_value)
+                    WHERE BTRIM(tag_value) <> ''
+                ) tag
+                WHERE tag.slug <> ''
+            ) tags ON TRUE
+            {where_clause}
+            ON CONFLICT (document_key) DO UPDATE SET
+                status = EXCLUDED.status,
+                is_public = EXCLUDED.is_public,
+                title = EXCLUDED.title,
+                subtitle = EXCLUDED.subtitle,
+                slug = EXCLUDED.slug,
+                handle = EXCLUDED.handle,
+                body = EXCLUDED.body,
+                keywords_text = EXCLUDED.keywords_text,
+                facets = EXCLUDED.facets,
+                payload = EXCLUDED.payload,
+                published_at = EXCLUDED.published_at,
+                updated_at = EXCLUDED.updated_at,
+                indexed_at = NOW()
+            "#
+        );
+
+        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
+        conn.execute(stmt).await.map_err(Error::Database)?;
+        Ok(())
+    }
+
+    async fn upsert_product_documents_in<C>(
+        &self,
+        conn: &C,
+        tenant_id: Uuid,
+        product_id: Option<Uuid>,
+    ) -> Result<()>
+    where
+        C: ConnectionTrait,
+    {
+        let mut values = vec![tenant_id.into()];
+        let mut where_clause = String::from("WHERE p.tenant_id = $1");
+
+        if let Some(product_id) = product_id {
+            where_clause.push_str(" AND p.id = $2");
+            values.push(product_id.into());
+        }
+
+        let sql = format!(
+            r#"
+            INSERT INTO search_documents (
+                document_key,
+                tenant_id,
+                document_id,
+                source_module,
+                entity_type,
+                locale,
+                status,
+                is_public,
+                title,
+                subtitle,
+                slug,
+                handle,
+                body,
+                keywords_text,
+                facets,
+                payload,
+                published_at,
+                created_at,
+                updated_at,
+                indexed_at
+            )
+            SELECT
+                CONCAT('product:', p.id::text, ':', pt.locale) AS document_key,
+                p.tenant_id,
+                p.id AS document_id,
+                'commerce'::text AS source_module,
+                'product'::text AS entity_type,
+                pt.locale,
+                p.status::text AS status,
+                (LOWER(p.status::text) = 'active') AS is_public,
+                COALESCE(pt.title, '') AS title,
+                p.vendor AS subtitle,
+                NULL::text AS slug,
+                pt.handle,
+                COALESCE(pt.description, '') AS body,
+                CONCAT_WS(
+                    ' ',
+                    COALESCE(p.vendor, ''),
+                    COALESCE(pt.meta_title, ''),
+                    COALESCE(pt.meta_description, '')
+                ) AS keywords_text,
+                jsonb_build_object(
+                    'in_stock', COALESCE(agg.in_stock, false),
+                    'has_price', (agg.price_min IS NOT NULL OR agg.price_max IS NOT NULL)
+                ) AS facets,
+                jsonb_build_object(
+                    'handle', pt.handle,
+                    'description', pt.description,
+                    'vendor', p.vendor,
+                    'price_min', agg.price_min,
+                    'price_max', agg.price_max,
+                    'in_stock', COALESCE(agg.in_stock, false),
+                    'variant_count', COALESCE(agg.variant_count, 0),
+                    'published_at', p.published_at
+                ) AS payload,
+                p.published_at,
+                p.created_at,
+                p.updated_at,
+                NOW()
+            FROM products p
+            JOIN product_translations pt
+                ON pt.product_id = p.id
+            LEFT JOIN LATERAL (
+                SELECT
+                    COUNT(pv.id)::bigint AS variant_count,
+                    COALESCE(SUM(inv.available_quantity), 0) > 0 AS in_stock,
+                    MIN(price_agg.min_amount)::bigint AS price_min,
+                    MAX(price_agg.max_amount)::bigint AS price_max
+                FROM product_variants pv
+                LEFT JOIN LATERAL (
+                    SELECT COALESCE(SUM(il.stocked_quantity - il.reserved_quantity), 0) AS available_quantity
+                    FROM inventory_items ii
+                    LEFT JOIN inventory_levels il ON il.inventory_item_id = ii.id
+                    WHERE ii.variant_id = pv.id
+                ) inv ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT
+                        MIN(pr.amount) AS min_amount,
+                        MAX(pr.amount) AS max_amount
+                    FROM prices pr
+                    WHERE pr.variant_id = pv.id
+                ) price_agg ON TRUE
+                WHERE pv.product_id = p.id
+                  AND pv.tenant_id = p.tenant_id
+            ) agg ON TRUE
+            {where_clause}
+            ON CONFLICT (document_key) DO UPDATE SET
+                status = EXCLUDED.status,
+                is_public = EXCLUDED.is_public,
+                title = EXCLUDED.title,
+                subtitle = EXCLUDED.subtitle,
+                slug = EXCLUDED.slug,
+                handle = EXCLUDED.handle,
+                body = EXCLUDED.body,
+                keywords_text = EXCLUDED.keywords_text,
+                facets = EXCLUDED.facets,
+                payload = EXCLUDED.payload,
+                published_at = EXCLUDED.published_at,
+                updated_at = EXCLUDED.updated_at,
+                indexed_at = NOW()
+            "#
+        );
+
+        let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, values);
+        conn.execute(stmt).await.map_err(Error::Database)?;
+        Ok(())
+    }
+}
+
+fn record_projector_operation(
+    operation: &str,
+    entity: &str,
+    tenant_id: Uuid,
+    result: &Result<()>,
+    duration: Duration,
+) {
+    let status = if result.is_ok() { "success" } else { "error" };
+    metrics::record_search_indexing_operation(operation, entity, status, duration.as_secs_f64());
+
+    if let Err(error) = result {
+        metrics::record_module_error("search", classify_error(error), "error");
+        tracing::error!(
+            operation,
+            entity,
+            tenant_id = %tenant_id,
+            error = %error,
+            duration_ms = duration.as_millis() as u64,
+            "Search projector operation failed"
+        );
+    } else {
+        tracing::info!(
+            operation,
+            entity,
+            tenant_id = %tenant_id,
+            duration_ms = duration.as_millis() as u64,
+            "Search projector operation completed"
+        );
+    }
+}
+
+fn classify_error(error: &Error) -> &'static str {
+    match error {
+        Error::Database(_) => "database",
+        Error::Validation(_) => "validation",
+        Error::External(_) => "external",
+        Error::NotFound(_) => "not_found",
+        Error::Forbidden(_) => "forbidden",
+        Error::Auth(_) => "auth",
+        Error::Cache(_) => "cache",
+        Error::Serialization(_) => "serialization",
+        Error::Scripting(_) => "scripting",
+        Error::InvalidIdFormat(_) => "invalid_id",
+    }
+}

--- a/crates/rustok-search/tests/search_scope_preservation_contract.rs
+++ b/crates/rustok-search/tests/search_scope_preservation_contract.rs
@@ -36,7 +36,7 @@ fn full_ingestion_rebuild_keeps_source_order_and_atomic_external_replacements() 
         .find("self.blog_projector.rebuild_tenant")
         .expect("Blog scope should rebuild after core scopes");
     let forum = rebuild
-        .find("projector.rebuild_tenant")
+        .rfind("projector.rebuild_tenant")
         .expect("Forum scope should rebuild after Blog");
     assert!(core < blog && blog < forum);
 

--- a/crates/rustok-search/tests/search_scope_preservation_contract.rs
+++ b/crates/rustok-search/tests/search_scope_preservation_contract.rs
@@ -1,0 +1,76 @@
+const SEARCH_LIB: &str = include_str!("../src/lib.rs");
+const ACTIVE_PROJECTOR: &str = include_str!("../src/projector.rs");
+const LEGACY_PROJECTOR: &str = include_str!("../src/projector_legacy.rs");
+const INGESTION: &str = include_str!("../src/ingestion.rs");
+const BLOG_PROJECTOR: &str = include_str!("../src/blog_projector.rs");
+const FORUM_PROJECTOR: &str = include_str!("../src/forum_projector.rs");
+
+#[test]
+fn active_tenant_rebuild_never_calls_the_destructive_legacy_tenant_rebuild() {
+    assert!(SEARCH_LIB.contains("mod projector_legacy;"));
+    assert!(!SEARCH_LIB.contains("pub mod projector_legacy;"));
+    assert!(ACTIVE_PROJECTOR.contains("self.legacy.rebuild_content_scope(tenant_id).await?"));
+    assert!(ACTIVE_PROJECTOR.contains("self.legacy.rebuild_product_scope(tenant_id).await"));
+    assert!(!ACTIVE_PROJECTOR.contains("self.legacy.rebuild_tenant"));
+    assert!(!ACTIVE_PROJECTOR.contains(
+        "DELETE FROM search_documents WHERE tenant_id = $1\""
+    ));
+    assert!(LEGACY_PROJECTOR.contains(
+        "DELETE FROM search_documents WHERE tenant_id = $1\""
+    ));
+}
+
+#[test]
+fn full_ingestion_rebuild_keeps_source_order_and_atomic_external_replacements() {
+    let rebuild = INGESTION
+        .split("async fn rebuild_tenant")
+        .nth(1)
+        .expect("Search ingestion tenant rebuild should remain explicit")
+        .split("async fn handle_reindex_request")
+        .next()
+        .expect("Search ingestion tenant rebuild should have a bounded body");
+    let core = rebuild
+        .find("self.projector.rebuild_tenant")
+        .expect("core Search scopes should rebuild first");
+    let blog = rebuild
+        .find("self.blog_projector.rebuild_tenant")
+        .expect("Blog scope should rebuild after core scopes");
+    let forum = rebuild
+        .find("projector.rebuild_tenant")
+        .expect("Forum scope should rebuild after Blog");
+    assert!(core < blog && blog < forum);
+
+    for marker in [
+        "let tx = self.begin_transaction().await?",
+        "self.delete_tenant_documents_in(&tx, tenant_id).await?",
+        "self.commit_transaction(tx).await",
+    ] {
+        assert!(BLOG_PROJECTOR.contains(marker), "missing Blog atomic marker {marker}");
+    }
+    for marker in [
+        "let tx = self.db.begin().await.map_err(Error::Database)?",
+        "self.create_stage(&tx).await?",
+        "delete_forum_scope(&tx, tenant_id).await?",
+        "tx.commit().await.map_err(Error::Database)",
+    ] {
+        assert!(FORUM_PROJECTOR.contains(marker), "missing Forum atomic marker {marker}");
+    }
+}
+
+#[test]
+fn bootstrap_presence_check_ignores_external_only_documents() {
+    assert!(ACTIVE_PROJECTOR.contains("entity_type IN ('node', 'product')"));
+    for external_entity in ["blog_post", "forum_category", "forum_topic"] {
+        assert!(
+            !ACTIVE_PROJECTOR
+                .split("const CORE_SCOPE_COUNT_SQL")
+                .nth(1)
+                .expect("core count SQL should exist")
+                .split("\"#;")
+                .next()
+                .expect("core count SQL should terminate")
+                .contains(external_entity),
+            "bootstrap count must ignore {external_entity}"
+        );
+    }
+}

--- a/scripts/verify/verify-forum-projection-invalidation.mjs
+++ b/scripts/verify/verify-forum-projection-invalidation.mjs
@@ -43,6 +43,7 @@ const moderationPublicPath = "crates/rustok-forum/src/services/moderation_public
 const searchContractPath = "crates/rustok-forum/contracts/forum-search-projection.json";
 const contractPath = "crates/rustok-forum/contracts/forum-projection-invalidation.json";
 const visibilityBulkPath = "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json";
+const rebuildPath = "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json";
 const notePath = "crates/rustok-forum/docs/forum-20bk-projection-invalidation.md";
 
 const outboxBus = read(outboxBusPath);
@@ -64,20 +65,18 @@ const note = read(notePath);
 let searchContract = null;
 let contract = null;
 let visibilityBulk = null;
-try {
-  searchContract = JSON.parse(read(searchContractPath));
-} catch (error) {
-  failures.push(`${searchContractPath}: invalid JSON: ${error.message}`);
-}
-try {
-  contract = JSON.parse(read(contractPath));
-} catch (error) {
-  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
-}
-try {
-  visibilityBulk = JSON.parse(read(visibilityBulkPath));
-} catch (error) {
-  failures.push(`${visibilityBulkPath}: invalid JSON: ${error.message}`);
+let rebuild = null;
+for (const [label, source, assign] of [
+  [searchContractPath, read(searchContractPath), (value) => { searchContract = value; }],
+  [contractPath, read(contractPath), (value) => { contract = value; }],
+  [visibilityBulkPath, read(visibilityBulkPath), (value) => { visibilityBulk = value; }],
+  [rebuildPath, read(rebuildPath), (value) => { rebuild = value; }],
+]) {
+  try {
+    assign(JSON.parse(source));
+  } catch (error) {
+    failures.push(`${label}: invalid JSON: ${error.message}`);
+  }
 }
 
 for (const marker of [
@@ -242,7 +241,7 @@ if (contract) {
   if (contract.upstream_task !== "FORUM-20BJ") {
     failures.push(`${contractPath}: unexpected upstream task`);
   }
-  if (contract.downstream_task !== "FORUM-20BM") {
+  if (contract.downstream_task !== "FORUM-20BN") {
     failures.push(`${contractPath}: unexpected downstream task`);
   }
   if (contract.root_event !== "rustok_events::DomainEvent::ReindexRequested") {
@@ -251,14 +250,28 @@ if (contract) {
   if (contract.visibility_scoped_bulk_read_contract !== visibilityBulkPath) {
     failures.push(`${contractPath}: visible bulk read contract handoff drift`);
   }
-  if (contract.downstream_handoff?.completion_contract !== visibilityBulkPath) {
-    failures.push(`${contractPath}: downstream completion contract drift`);
+  if (contract.rebuild_scope_preservation_contract !== rebuildPath) {
+    failures.push(`${contractPath}: rebuild preservation contract handoff drift`);
+  }
+  if (contract.downstream_handoff?.visibility_completion_contract !== visibilityBulkPath) {
+    failures.push(`${contractPath}: visible bulk completion contract drift`);
+  }
+  if (contract.downstream_handoff?.completion_contract !== rebuildPath) {
+    failures.push(`${contractPath}: rebuild preservation completion contract drift`);
   }
   if (contract.downstream_handoff?.visibility_scoped_category_and_all_read_commands_completed !== true) {
     failures.push(`${contractPath}: visible bulk read completion not recorded`);
   }
-  if (contract.remaining_scope?.includes("add visibility-scoped category and all-read commands")) {
-    failures.push(`${contractPath}: completed visible bulk scope remains listed`);
+  if (contract.downstream_handoff?.full_rebuild_external_scope_preservation_completed !== true) {
+    failures.push(`${contractPath}: rebuild preservation completion not recorded`);
+  }
+  for (const completed of [
+    "add visibility-scoped category and all-read commands",
+    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
+  ]) {
+    if (contract.remaining_scope?.includes(completed)) {
+      failures.push(`${contractPath}: completed scope remains listed: ${completed}`);
+    }
   }
   for (const key of [
     "owner_transaction_required_on_postgresql",
@@ -314,11 +327,17 @@ if (searchContract) {
   if (searchContract.visibility_scoped_bulk_read_contract !== visibilityBulkPath) {
     failures.push(`${searchContractPath}: visible bulk read handoff drift`);
   }
-  if (searchContract.ingestion_boundary?.completion_contract !== contractPath) {
-    failures.push(`${searchContractPath}: completion contract drift`);
+  if (searchContract.rebuild_scope_preservation_contract !== rebuildPath) {
+    failures.push(`${searchContractPath}: rebuild preservation handoff drift`);
   }
-  if (searchContract.downstream_handoff?.completion_contract !== visibilityBulkPath) {
+  if (searchContract.ingestion_boundary?.completion_contract !== contractPath) {
+    failures.push(`${searchContractPath}: invalidation completion contract drift`);
+  }
+  if (searchContract.downstream_handoff?.visibility_completion_contract !== visibilityBulkPath) {
     failures.push(`${searchContractPath}: downstream visible bulk completion drift`);
+  }
+  if (searchContract.downstream_handoff?.completion_contract !== rebuildPath) {
+    failures.push(`${searchContractPath}: downstream rebuild preservation completion drift`);
   }
   for (const key of [
     "automatic_category_policy_change_reindex_added",
@@ -332,7 +351,16 @@ if (searchContract) {
       failures.push(`${searchContractPath}: ${key} handoff drift`);
     }
   }
-  if (searchContract.downstream_task !== "FORUM-20BM") {
+  if (searchContract.persistence_boundary?.full_search_rebuild_source_failure_keeps_previous_forum_scope !== true) {
+    failures.push(`${searchContractPath}: failed full rebuild must preserve previous Forum scope`);
+  }
+  if (searchContract.persistence_boundary?.direct_search_rebuild_deletes_external_scopes !== false) {
+    failures.push(`${searchContractPath}: direct Search rebuild must not delete external scopes`);
+  }
+  if (searchContract.persistence_boundary?.global_cross_source_atomicity_added !== false) {
+    failures.push(`${searchContractPath}: global atomicity must remain explicitly unclaimed`);
+  }
+  if (searchContract.downstream_task !== "FORUM-20BN") {
     failures.push(`${searchContractPath}: downstream task drift`);
   }
 }
@@ -344,8 +372,27 @@ if (visibilityBulk) {
   if (visibilityBulk.upstream_task !== "FORUM-20BK") {
     failures.push(`${visibilityBulkPath}: unexpected upstream task`);
   }
-  if (visibilityBulk.downstream_task !== "FORUM-20BM") {
+  if (visibilityBulk.downstream_task !== "FORUM-20BN") {
     failures.push(`${visibilityBulkPath}: downstream task drift`);
+  }
+  if (visibilityBulk.rebuild_scope_preservation_contract !== rebuildPath) {
+    failures.push(`${visibilityBulkPath}: rebuild preservation handoff drift`);
+  }
+}
+
+if (rebuild) {
+  if (rebuild.task !== "FORUM-20BM") failures.push(`${rebuildPath}: unexpected task`);
+  if (rebuild.upstream_task !== "FORUM-20BL") {
+    failures.push(`${rebuildPath}: unexpected upstream task`);
+  }
+  if (rebuild.downstream_task !== "FORUM-20BN") {
+    failures.push(`${rebuildPath}: downstream task drift`);
+  }
+  if (rebuild.replacement_boundary?.failed_forum_rebuild_keeps_previous_forum_scope !== true) {
+    failures.push(`${rebuildPath}: failed Forum rebuild must preserve previous scope`);
+  }
+  if (rebuild.replacement_boundary?.global_cross_source_atomicity_claimed !== false) {
+    failures.push(`${rebuildPath}: global atomicity must remain explicitly unclaimed`);
   }
 }
 

--- a/scripts/verify/verify-forum-search-projection.mjs
+++ b/scripts/verify/verify-forum-search-projection.mjs
@@ -35,6 +35,7 @@ const forumLibPath = "crates/rustok-forum/src/lib.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-projection.json";
 const invalidationPath = "crates/rustok-forum/contracts/forum-projection-invalidation.json";
 const visibilityBulkPath = "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json";
+const rebuildPreservationPath = "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json";
 const upstreamPath = "crates/rustok-forum/contracts/forum-public-discovery-seo.json";
 const notePath = "crates/rustok-forum/docs/forum-20bj-search-projection.md";
 
@@ -49,26 +50,20 @@ const note = read(notePath);
 let contract = null;
 let invalidation = null;
 let visibilityBulk = null;
+let rebuildPreservation = null;
 let upstream = null;
-try {
-  contract = JSON.parse(read(contractPath));
-} catch (error) {
-  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
-}
-try {
-  invalidation = JSON.parse(read(invalidationPath));
-} catch (error) {
-  failures.push(`${invalidationPath}: invalid JSON: ${error.message}`);
-}
-try {
-  visibilityBulk = JSON.parse(read(visibilityBulkPath));
-} catch (error) {
-  failures.push(`${visibilityBulkPath}: invalid JSON: ${error.message}`);
-}
-try {
-  upstream = JSON.parse(read(upstreamPath));
-} catch (error) {
-  failures.push(`${upstreamPath}: invalid JSON: ${error.message}`);
+for (const [label, source, assign] of [
+  [contractPath, read(contractPath), (value) => { contract = value; }],
+  [invalidationPath, read(invalidationPath), (value) => { invalidation = value; }],
+  [visibilityBulkPath, read(visibilityBulkPath), (value) => { visibilityBulk = value; }],
+  [rebuildPreservationPath, read(rebuildPreservationPath), (value) => { rebuildPreservation = value; }],
+  [upstreamPath, read(upstreamPath), (value) => { upstream = value; }],
+]) {
+  try {
+    assign(JSON.parse(source));
+  } catch (error) {
+    failures.push(`${label}: invalid JSON: ${error.message}`);
+  }
 }
 
 for (const marker of [
@@ -189,7 +184,7 @@ if (contract) {
   if (contract.upstream_task !== "FORUM-20BI") {
     failures.push(`${contractPath}: unexpected upstream task`);
   }
-  if (contract.downstream_task !== "FORUM-20BM") {
+  if (contract.downstream_task !== "FORUM-20BN") {
     failures.push(`${contractPath}: unexpected downstream task`);
   }
   if (contract.invalidation_contract !== invalidationPath) {
@@ -197,6 +192,9 @@ if (contract) {
   }
   if (contract.visibility_scoped_bulk_read_contract !== visibilityBulkPath) {
     failures.push(`${contractPath}: visible bulk read contract handoff drift`);
+  }
+  if (contract.rebuild_scope_preservation_contract !== rebuildPreservationPath) {
+    failures.push(`${contractPath}: rebuild preservation contract handoff drift`);
   }
   for (const key of [
     "neutral_capability_has_no_forum_dependency",
@@ -218,15 +216,22 @@ if (contract) {
     "explicit_forum_rebuild_uses_postgresql_temporary_stage",
     "explicit_forum_rebuild_replaces_scope_after_successful_scan",
     "explicit_forum_rebuild_source_failure_keeps_previous_scope",
+    "full_search_rebuild_source_failure_keeps_previous_forum_scope",
+    "earlier_successful_scope_may_commit_before_later_failure",
     "target_refresh_deletes_and_reinserts_in_one_transaction",
     "denied_closed_missing_or_deleted_target_removes_stale_documents",
   ]) {
-    if (!contract.persistence_boundary?.[key]) {
+    if (contract.persistence_boundary?.[key] !== true) {
       failures.push(`${contractPath}: persistence boundary must lock ${key}`);
     }
   }
-  if (contract.persistence_boundary?.full_search_rebuild_source_failure_keeps_previous_forum_scope !== false) {
-    failures.push(`${contractPath}: cross-source rebuild limitation must remain explicit`);
+  for (const key of [
+    "direct_search_rebuild_deletes_external_scopes",
+    "global_cross_source_atomicity_added",
+  ]) {
+    if (contract.persistence_boundary?.[key] !== false) {
+      failures.push(`${contractPath}: persistence boundary ${key} must remain false`);
+    }
   }
   for (const key of [
     "forum_topic_created_refreshes_topic",
@@ -254,13 +259,21 @@ if (contract) {
     failures.push(`${contractPath}: root reindex event schema must remain unchanged`);
   }
   if (contract.ingestion_boundary?.completion_contract !== invalidationPath) {
-    failures.push(`${contractPath}: completion contract drift`);
+    failures.push(`${contractPath}: invalidation completion contract drift`);
   }
-  if (contract.downstream_handoff?.completion_contract !== visibilityBulkPath) {
+  if (contract.downstream_handoff?.visibility_completion_contract !== visibilityBulkPath) {
     failures.push(`${contractPath}: downstream visible bulk completion drift`);
   }
-  if (contract.remaining_scope?.includes("add visibility-scoped category and all-read commands")) {
-    failures.push(`${contractPath}: completed visible bulk scope remains listed`);
+  if (contract.downstream_handoff?.completion_contract !== rebuildPreservationPath) {
+    failures.push(`${contractPath}: downstream rebuild preservation completion drift`);
+  }
+  for (const completed of [
+    "add visibility-scoped category and all-read commands",
+    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
+  ]) {
+    if (contract.remaining_scope?.includes(completed)) {
+      failures.push(`${contractPath}: completed scope remains listed: ${completed}`);
+    }
   }
   for (const [key, expected] of Object.entries({
     forum_to_search_workspace_dependency_added: false,
@@ -283,7 +296,7 @@ if (invalidation) {
   if (invalidation.upstream_task !== "FORUM-20BJ") {
     failures.push(`${invalidationPath}: unexpected upstream task`);
   }
-  if (invalidation.downstream_task !== "FORUM-20BM") {
+  if (invalidation.downstream_task !== "FORUM-20BN") {
     failures.push(`${invalidationPath}: unexpected downstream task`);
   }
   if (invalidation.upstream_contract !== contractPath) {
@@ -291,6 +304,9 @@ if (invalidation) {
   }
   if (invalidation.visibility_scoped_bulk_read_contract !== visibilityBulkPath) {
     failures.push(`${invalidationPath}: visible bulk read handoff drift`);
+  }
+  if (invalidation.rebuild_scope_preservation_contract !== rebuildPreservationPath) {
+    failures.push(`${invalidationPath}: rebuild preservation handoff drift`);
   }
 }
 
@@ -300,6 +316,24 @@ if (visibilityBulk) {
   }
   if (visibilityBulk.upstream_task !== "FORUM-20BK") {
     failures.push(`${visibilityBulkPath}: unexpected upstream task`);
+  }
+  if (visibilityBulk.downstream_task !== "FORUM-20BN") {
+    failures.push(`${visibilityBulkPath}: downstream task drift`);
+  }
+  if (visibilityBulk.rebuild_scope_preservation_contract !== rebuildPreservationPath) {
+    failures.push(`${visibilityBulkPath}: rebuild preservation handoff drift`);
+  }
+}
+
+if (rebuildPreservation) {
+  if (rebuildPreservation.task !== "FORUM-20BM") {
+    failures.push(`${rebuildPreservationPath}: unexpected task`);
+  }
+  if (rebuildPreservation.upstream_task !== "FORUM-20BL") {
+    failures.push(`${rebuildPreservationPath}: unexpected upstream task`);
+  }
+  if (rebuildPreservation.downstream_task !== "FORUM-20BN") {
+    failures.push(`${rebuildPreservationPath}: unexpected downstream task`);
   }
 }
 

--- a/scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs
+++ b/scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const activePath = "crates/rustok-search/src/projector.rs";
+const legacyPath = "crates/rustok-search/src/projector_legacy.rs";
+const libPath = "crates/rustok-search/src/lib.rs";
+const ingestionPath = "crates/rustok-search/src/ingestion.rs";
+const blogPath = "crates/rustok-search/src/blog_projector.rs";
+const forumPath = "crates/rustok-search/src/forum_projector.rs";
+const rustTestPath = "crates/rustok-search/tests/search_scope_preservation_contract.rs";
+const contractPath = "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json";
+const searchContractPath = "crates/rustok-forum/contracts/forum-search-projection.json";
+const invalidationPath = "crates/rustok-forum/contracts/forum-projection-invalidation.json";
+const visibilityPath = "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json";
+const notePath = "crates/rustok-forum/docs/forum-20bm-search-rebuild-scope-preservation.md";
+
+const active = read(activePath);
+const legacy = read(legacyPath);
+const lib = read(libPath);
+const ingestion = read(ingestionPath);
+const blog = read(blogPath);
+const forum = read(forumPath);
+const rustTest = read(rustTestPath);
+const note = read(notePath);
+
+let contract = null;
+let searchContract = null;
+let invalidation = null;
+let visibility = null;
+for (const [label, source, assign] of [
+  [contractPath, read(contractPath), (value) => { contract = value; }],
+  [searchContractPath, read(searchContractPath), (value) => { searchContract = value; }],
+  [invalidationPath, read(invalidationPath), (value) => { invalidation = value; }],
+  [visibilityPath, read(visibilityPath), (value) => { visibility = value; }],
+]) {
+  try {
+    assign(JSON.parse(source));
+  } catch (error) {
+    failures.push(`${label}: invalid JSON: ${error.message}`);
+  }
+}
+
+for (const marker of [
+  "use crate::projector_legacy;",
+  "const CORE_SCOPE_COUNT_SQL",
+  "entity_type IN ('node', 'product')",
+  "self.legacy.rebuild_content_scope(tenant_id).await?",
+  "self.legacy.rebuild_product_scope(tenant_id).await",
+  '"rebuild_tenant"',
+]) {
+  requireMarker(active, marker, activePath);
+}
+for (const forbidden of [
+  "self.legacy.rebuild_tenant",
+  '"DELETE FROM search_documents WHERE tenant_id = $1"',
+  "blog_post",
+  "forum_category",
+  "forum_topic",
+]) {
+  rejectMarker(
+    forbidden === "blog_post" || forbidden.startsWith("forum_")
+      ? active.split("const CORE_SCOPE_COUNT_SQL")[1]?.split('"#;')[0] ?? ""
+      : active,
+    forbidden,
+    activePath,
+  );
+}
+
+for (const marker of [
+  "pub struct SearchProjector",
+  "pub async fn rebuild_tenant",
+  '"DELETE FROM search_documents WHERE tenant_id = $1"',
+]) {
+  requireMarker(legacy, marker, legacyPath);
+}
+for (const marker of [
+  "#[allow(dead_code)]",
+  '#[path = "projector_legacy.rs"]',
+  "mod projector_legacy;",
+  "pub mod projector;",
+  "pub use projector::SearchProjector;",
+]) {
+  requireMarker(lib, marker, libPath);
+}
+rejectMarker(lib, "pub mod projector_legacy;", libPath);
+rejectMarker(lib, "pub use projector_legacy", libPath);
+
+const rebuild = ingestion
+  .split("async fn rebuild_tenant")[1]
+  ?.split("async fn handle_reindex_request")[0] ?? "";
+const coreIndex = rebuild.indexOf("self.projector.rebuild_tenant");
+const blogIndex = rebuild.indexOf("self.blog_projector.rebuild_tenant");
+const forumIndex = rebuild.lastIndexOf("projector.rebuild_tenant");
+if (!(coreIndex >= 0 && blogIndex > coreIndex && forumIndex > blogIndex)) {
+  failures.push(`${ingestionPath}: full rebuild order must remain core -> Blog -> Forum`);
+}
+
+for (const marker of [
+  "let tx = self.begin_transaction().await?",
+  "self.delete_tenant_documents_in(&tx, tenant_id).await?",
+  "self.commit_transaction(tx).await",
+]) {
+  requireMarker(blog, marker, blogPath);
+}
+for (const marker of [
+  "let tx = self.db.begin().await.map_err(Error::Database)?",
+  "self.create_stage(&tx).await?",
+  "delete_forum_scope(&tx, tenant_id).await?",
+  "tx.commit().await.map_err(Error::Database)",
+]) {
+  requireMarker(forum, marker, forumPath);
+}
+for (const marker of [
+  "active_tenant_rebuild_never_calls_the_destructive_legacy_tenant_rebuild",
+  "full_ingestion_rebuild_keeps_source_order_and_atomic_external_replacements",
+  "bootstrap_presence_check_ignores_external_only_documents",
+  ".rfind(\"projector.rebuild_tenant\")",
+]) {
+  requireMarker(rustTest, marker, rustTestPath);
+}
+for (const marker of [
+  "FORUM-20BM",
+  "source-scoped preservation",
+  "not a new cross-source transaction",
+  "previous Forum documents remain",
+  "Global all-source atomicity",
+  "FORUM-20BN",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-20BM") failures.push(`${contractPath}: unexpected task`);
+  if (contract.upstream_task !== "FORUM-20BL") {
+    failures.push(`${contractPath}: unexpected upstream task`);
+  }
+  if (contract.downstream_task !== "FORUM-20BN") {
+    failures.push(`${contractPath}: unexpected downstream task`);
+  }
+  for (const key of [
+    "public_search_projector_is_scope_preserving_facade",
+    "legacy_projector_module_is_private",
+  ]) {
+    if (contract.ownership_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: ownership boundary ${key} drift`);
+    }
+  }
+  for (const key of [
+    "legacy_projector_reexported",
+    "active_tenant_rebuild_calls_legacy_all_tenant_delete",
+    "core_rebuild_deletes_blog_scope",
+    "core_rebuild_deletes_forum_scope",
+    "core_rebuild_deletes_unknown_future_external_scope",
+  ]) {
+    if (contract.ownership_boundary?.[key] !== false) {
+      failures.push(`${contractPath}: ownership boundary ${key} must remain false`);
+    }
+  }
+  for (const key of [
+    "content_scope_replacement_transactional",
+    "product_scope_replacement_transactional",
+    "blog_scope_replacement_transactional",
+    "forum_scope_replacement_uses_temporary_stage",
+    "forum_scope_replacement_transactional",
+    "failed_blog_rebuild_keeps_previous_blog_scope",
+    "failed_forum_rebuild_keeps_previous_forum_scope",
+    "later_source_failure_cannot_remove_untouched_external_scope",
+    "earlier_successful_scope_may_commit_before_later_failure",
+  ]) {
+    if (contract.replacement_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: replacement boundary ${key} drift`);
+    }
+  }
+  for (const key of [
+    "global_cross_source_transaction_added",
+    "global_cross_source_atomicity_claimed",
+  ]) {
+    if (contract.replacement_boundary?.[key] !== false) {
+      failures.push(`${contractPath}: replacement boundary ${key} must remain false`);
+    }
+  }
+  if (contract.bootstrap_boundary?.external_only_documents_suppress_core_bootstrap !== false) {
+    failures.push(`${contractPath}: external-only documents must not suppress core bootstrap`);
+  }
+}
+
+for (const [label, upstream] of [
+  [searchContractPath, searchContract],
+  [invalidationPath, invalidation],
+  [visibilityPath, visibility],
+]) {
+  if (!upstream) continue;
+  if (upstream.rebuild_scope_preservation_contract !== contractPath) {
+    failures.push(`${label}: rebuild preservation contract handoff drift`);
+  }
+  if (upstream.downstream_task !== "FORUM-20BN") {
+    failures.push(`${label}: downstream task must advance to FORUM-20BN`);
+  }
+}
+if (searchContract) {
+  if (searchContract.persistence_boundary?.full_search_rebuild_source_failure_keeps_previous_forum_scope !== true) {
+    failures.push(`${searchContractPath}: previous Forum scope must survive full rebuild source failure`);
+  }
+  if (searchContract.persistence_boundary?.direct_search_rebuild_deletes_external_scopes !== false) {
+    failures.push(`${searchContractPath}: direct Search rebuild must not delete external scopes`);
+  }
+  if (searchContract.persistence_boundary?.global_cross_source_atomicity_added !== false) {
+    failures.push(`${searchContractPath}: global atomicity must remain explicitly unclaimed`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("forum Search rebuild scope preservation verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("forum Search rebuild scope preservation verified");

--- a/scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs
+++ b/scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs
@@ -77,17 +77,13 @@ for (const marker of [
 for (const forbidden of [
   "self.legacy.rebuild_tenant",
   '"DELETE FROM search_documents WHERE tenant_id = $1"',
-  "blog_post",
-  "forum_category",
-  "forum_topic",
 ]) {
-  rejectMarker(
-    forbidden === "blog_post" || forbidden.startsWith("forum_")
-      ? active.split("const CORE_SCOPE_COUNT_SQL")[1]?.split('"#;')[0] ?? ""
-      : active,
-    forbidden,
-    activePath,
-  );
+  rejectMarker(active, forbidden, activePath);
+}
+const coreCountSection = active.split("const CORE_SCOPE_COUNT_SQL")[1] ?? "";
+const coreCountSql = coreCountSection.split('"#;')[0] ?? "";
+for (const forbidden of ["blog_post", "forum_category", "forum_topic"]) {
+  rejectMarker(coreCountSql, forbidden, activePath);
 }
 
 for (const marker of [
@@ -109,9 +105,8 @@ for (const marker of [
 rejectMarker(lib, "pub mod projector_legacy;", libPath);
 rejectMarker(lib, "pub use projector_legacy", libPath);
 
-const rebuild = ingestion
-  .split("async fn rebuild_tenant")[1]
-  ?.split("async fn handle_reindex_request")[0] ?? "";
+const rebuildSection = ingestion.split("async fn rebuild_tenant")[1] ?? "";
+const rebuild = rebuildSection.split("async fn handle_reindex_request")[0] ?? "";
 const coreIndex = rebuild.indexOf("self.projector.rebuild_tenant");
 const blogIndex = rebuild.indexOf("self.blog_projector.rebuild_tenant");
 const forumIndex = rebuild.lastIndexOf("projector.rebuild_tenant");

--- a/scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs
+++ b/scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs
@@ -51,6 +51,8 @@ const contractPath =
   "crates/rustok-forum/contracts/forum-visibility-scoped-bulk-read.json";
 const upstreamPath =
   "crates/rustok-forum/contracts/forum-projection-invalidation.json";
+const rebuildPath =
+  "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json";
 const notePath =
   "crates/rustok-forum/docs/forum-20bl-visibility-scoped-bulk-read.md";
 
@@ -73,15 +75,17 @@ const note = read(notePath);
 
 let contract = null;
 let upstream = null;
-try {
-  contract = JSON.parse(read(contractPath));
-} catch (error) {
-  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
-}
-try {
-  upstream = JSON.parse(read(upstreamPath));
-} catch (error) {
-  failures.push(`${upstreamPath}: invalid JSON: ${error.message}`);
+let rebuild = null;
+for (const [label, source, assign] of [
+  [contractPath, read(contractPath), (value) => { contract = value; }],
+  [upstreamPath, read(upstreamPath), (value) => { upstream = value; }],
+  [rebuildPath, read(rebuildPath), (value) => { rebuild = value; }],
+]) {
+  try {
+    assign(JSON.parse(source));
+  } catch (error) {
+    failures.push(`${label}: invalid JSON: ${error.message}`);
+  }
 }
 
 for (const marker of [
@@ -138,7 +142,6 @@ for (const marker of [
 ]) {
   requireMarker(context, marker, contextPath);
 }
-
 for (const marker of [
   "ForumVisibilityScopedReadStateService",
   "ForumTopicReadTransport::Rest",
@@ -149,10 +152,7 @@ for (const marker of [
 ]) {
   requireMarker(rest, marker, restPath);
 }
-for (const forbidden of [
-  ".mark_category_read(\n",
-  ".mark_all_read(\n",
-]) {
+for (const forbidden of [".mark_category_read(\n", ".mark_all_read(\n"]) {
   rejectMarker(rest, forbidden, restPath);
 }
 
@@ -165,10 +165,7 @@ for (const marker of [
 ]) {
   requireMarker(graphql, marker, graphqlPath);
 }
-for (const forbidden of [
-  ".mark_category_read(\n",
-  ".mark_all_read(\n",
-]) {
+for (const forbidden of [".mark_category_read(\n", ".mark_all_read(\n"]) {
   rejectMarker(graphql, forbidden, graphqlPath);
 }
 requireMarker(runtime, "visibility_scoped_read_state_service", runtimePath);
@@ -225,7 +222,11 @@ for (const marker of [
 ]) {
   requireMarker(sqliteTest, marker, sqliteTestPath);
 }
-requireMarker(transportTest, "category_and_all_read_transports_use_exact_visibility_owner", transportTestPath);
+requireMarker(
+  transportTest,
+  "category_and_all_read_transports_use_exact_visibility_owner",
+  transportTestPath,
+);
 for (const marker of [
   "markForumStorefrontCategoryRead",
   "markAllForumStorefrontTopicsRead",
@@ -249,8 +250,17 @@ if (contract) {
   if (contract.upstream_task !== "FORUM-20BK") {
     failures.push(`${contractPath}: unexpected upstream task`);
   }
-  if (contract.downstream_task !== "FORUM-20BM") {
+  if (contract.downstream_task !== "FORUM-20BN") {
     failures.push(`${contractPath}: unexpected downstream task`);
+  }
+  if (contract.rebuild_scope_preservation_contract !== rebuildPath) {
+    failures.push(`${contractPath}: rebuild preservation handoff drift`);
+  }
+  if (contract.downstream_handoff?.completion_contract !== rebuildPath) {
+    failures.push(`${contractPath}: downstream completion contract drift`);
+  }
+  if (contract.downstream_handoff?.full_rebuild_external_scope_preservation_completed !== true) {
+    failures.push(`${contractPath}: rebuild preservation completion not recorded`);
   }
   for (const key of [
     "category_root_uses_exact_category_audience_owner",
@@ -311,17 +321,41 @@ if (contract) {
       failures.push(`${contractPath}: compatibility ${key} drift`);
     }
   }
+  if (contract.remaining_scope?.includes(
+    "make full multi-source Search rebuild replacement atomic or preserve each prior external scope when a later source fails",
+  )) {
+    failures.push(`${contractPath}: completed rebuild preservation remains listed`);
+  }
 }
 
 if (upstream) {
   if (upstream.visibility_scoped_bulk_read_contract !== contractPath) {
-    failures.push(`${upstreamPath}: completion contract handoff drift`);
+    failures.push(`${upstreamPath}: visible bulk contract handoff drift`);
   }
-  if (upstream.downstream_task !== "FORUM-20BM") {
+  if (upstream.rebuild_scope_preservation_contract !== rebuildPath) {
+    failures.push(`${upstreamPath}: rebuild preservation handoff drift`);
+  }
+  if (upstream.downstream_task !== "FORUM-20BN") {
     failures.push(`${upstreamPath}: downstream task drift`);
   }
   if (upstream.remaining_scope?.includes("add visibility-scoped category and all-read commands")) {
     failures.push(`${upstreamPath}: completed bulk read scope remains listed`);
+  }
+}
+
+if (rebuild) {
+  if (rebuild.task !== "FORUM-20BM") failures.push(`${rebuildPath}: unexpected task`);
+  if (rebuild.upstream_task !== "FORUM-20BL") {
+    failures.push(`${rebuildPath}: unexpected upstream task`);
+  }
+  if (rebuild.downstream_task !== "FORUM-20BN") {
+    failures.push(`${rebuildPath}: downstream task drift`);
+  }
+  if (rebuild.replacement_boundary?.failed_forum_rebuild_keeps_previous_forum_scope !== true) {
+    failures.push(`${rebuildPath}: failed Forum rebuild must preserve previous scope`);
+  }
+  if (rebuild.replacement_boundary?.global_cross_source_atomicity_claimed !== false) {
+    failures.push(`${rebuildPath}: global atomicity must remain explicitly unclaimed`);
   }
 }
 


### PR DESCRIPTION
## Summary

- add a scope-preserving public `SearchProjector` facade for `FORUM-20BM`
- rebuild only the direct Search-owned `node` and `product` scopes during full tenant rebuilds
- stop the active runtime from calling the legacy all-tenant delete before Blog and Forum stages run
- keep Blog and Forum on their existing transactional scope replacements, including the Forum temporary stage
- preserve the previous committed Blog or Forum scope when that source rebuild fails
- scope bootstrap detection to `node` and `product`, so external-only documents do not suppress direct Search bootstrap
- retain every existing public `SearchProjector` type path and method name
- quarantine the previous projector implementation as a private, non-reexported delegate for targeted and per-scope operations
- add source contract coverage, a FORUM-20BM machine contract, owner note and verifier
- advance FORUM-20BJ/BK/BL handoffs to FORUM-20BN

## Failure semantics

The full Search rebuild remains sequential:

1. direct Search `node` scope
2. direct Search `product` scope
3. Blog scope
4. Forum scope when registered

This PR does **not** add a global cross-source transaction. A source that completed before a later failure may expose its newer projection. The corrected guarantee is source-scoped preservation:

- core rebuild no longer deletes Blog, Forum or future external rows
- Blog failure rolls back the Blog replacement and keeps the previous Blog scope
- Forum failure rolls back its staged replacement and keeps the previous Forum scope
- retries re-read current owner state and replace only the relevant scope

## Projector compatibility facade

The prior `projector.rs` implementation is retained byte-for-byte as private `projector_legacy.rs`. The public `projector.rs` facade delegates targeted operations and the existing transactional content/product scope replacements, but never calls legacy `rebuild_tenant`.

This avoids a conflict-prone rewrite of the large projector source while keeping `rustok_search::SearchProjector` and all public methods unchanged. The legacy module is private and not reexported.

## Compatibility

- Search event ingestion and query contracts unchanged
- Forum projection source and exact visibility contracts unchanged
- no REST, GraphQL or public response DTO change
- no migration, workspace dependency or `Cargo.lock` change
- no FFA/FBA readiness promotion
- no legacy GraphQL snapshot change
- Search/Forum implementation plans and `CRATE_API.md` remain conflict-sensitive repository-local synchronization debt recorded in the machine contract

## Remaining FORUM-20BN scope

- decide whether approved public replies become separate Search documents under FORUM-23
- remove the uncompiled legacy GraphQL query snapshot after verifier migration
- capture PostgreSQL full-rebuild failure-preservation and Forum projection-cleanup runtime evidence
- capture Search query runtime and SQLite exact-visible bulk-read evidence
- add a Translation control-plane invalidation adapter if Forum targets are registered later

## Validation

Not run by the implementation agent, per maintainer request: no tests, Cargo commands, formatting, verifiers, workflows or CI.

Suggested maintainer commands:

```text
cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture
cargo test -p rustok-search --test blog_projection_postgres_test -- --nocapture
cargo test -p rustok-search forum_projector -- --nocapture
node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs
node scripts/verify/verify-forum-search-projection.mjs
node scripts/verify/verify-forum-projection-invalidation.mjs
node scripts/verify/verify-forum-visibility-scoped-bulk-read.mjs
cargo xtask module validate forum
```