### PR TITLE
feat(commerce): scope order read runtime into GraphQL

### DIFF
--- a/crates/rustok-commerce/docs/graphql-order-read-shim.md
+++ b/crates/rustok-commerce/docs/graphql-order-read-shim.md
@@ -1,6 +1,6 @@
 # Commerce GraphQL order read compatibility shim
 
-Status: source-ready, unvalidated.
+Status: host-runtime-scoped, unvalidated.
 
 The legacy Commerce safe-query source is still included from
 `src/graphql/query.rs`, but its `rustok_order` path is now resolved through a
@@ -8,14 +8,17 @@ module-local compatibility facade. Complete order detail and filtered-list reads
 use `OrderReadPort` with typed requests, explicit locale fallback, a two-second
 read deadline, stable owner errors, and the existing response shapes.
 
-The compatibility facade currently composes `CommerceOrderReadRuntime::in_process`
-from the resolver-provided database and transactional event bus. This removes the
-concrete owner-service implementation from complete detail/list execution while
-preserving embedded-schema behavior.
+Mounted GraphQL execution now scopes the host-selected `CommerceOrderReadRuntime`
+from `CommerceGraphqlRuntimeData` into the included safe-query source. The
+compatibility facade consumes that scoped runtime. Directly embedded schemas that
+do not install the mounted extension retain an explicit in-process fallback from
+the resolver-provided database and transactional event bus.
+
+This removes concrete owner-service implementation from complete detail/list
+execution while preserving embedded-schema behavior.
 
 The following work remains open and is not promoted by this source change:
 
-- scope the host-selected `CommerceOrderReadRuntime` through the safe-query resolver;
 - propagate authenticated actor and request channel into the order read context;
 - move REST storefront detail/ownership reads in their own atomic change;
 - publish wider owner contracts before moving return and order-change reads;

--- a/crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs
@@ -35,7 +35,7 @@ pub(crate) struct OrderService {
 
 impl OrderService {
     pub(crate) fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
-        let order_reads = crate::graphql_runtime::CommerceOrderReadRuntime::in_process(
+        let order_reads = crate::graphql_runtime::order_read_runtime_for_current_graphql_scope(
             db.clone(),
             event_bus.clone(),
         )

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -79,9 +79,9 @@ impl CommerceFulfillmentLifecycleReadRuntime {
 
 /// Host-selected complete order projection read port.
 ///
-/// HTTP admin routes consume this runtime in the current source wave. GraphQL schema data carries
-/// the same host-selected value so later resolver cutover cannot silently construct a different
-/// owner adapter.
+/// HTTP admin routes and mounted GraphQL resolvers consume this runtime. GraphQL schema data carries
+/// the host-selected value through the resolver scope so compatibility facades cannot silently
+/// construct a different owner adapter.
 #[derive(Clone)]
 pub struct CommerceOrderReadRuntime {
     order_reads: Arc<dyn OrderReadPort>,
@@ -107,13 +107,15 @@ impl CommerceOrderReadRuntime {
 tokio::task_local! {
     static CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME: CommerceShippingOptionReadRuntime;
     static CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME: CommerceFulfillmentLifecycleReadRuntime;
+    static CURRENT_COMMERCE_ORDER_READ_RUNTIME: CommerceOrderReadRuntime;
     static CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME: ProductCatalogReadRuntime;
 }
 
 /// Resolver-scoped bridge from schema runtime data to private compatibility facades.
 ///
-/// The mounted extension carries shipping-option, fulfillment-lifecycle, and Product catalog owner
-/// ports so every included Commerce resolver uses host-selected adapters for the current async task.
+/// The mounted extension carries shipping-option, fulfillment-lifecycle, order, and Product catalog
+/// owner ports so every included Commerce resolver uses host-selected adapters for the current async
+/// task.
 #[derive(Default)]
 pub struct CommerceShippingOptionReadScope;
 
@@ -141,9 +143,12 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
                 runtime_data.shipping_option_read_runtime(),
                 CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME.scope(
                     runtime_data.fulfillment_lifecycle_read_runtime(),
-                    CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME.scope(
-                        runtime_data.product_catalog_read_runtime(),
-                        next.run(ctx, info),
+                    CURRENT_COMMERCE_ORDER_READ_RUNTIME.scope(
+                        runtime_data.order_read_runtime(),
+                        CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME.scope(
+                            runtime_data.product_catalog_read_runtime(),
+                            next.run(ctx, info),
+                        ),
                     ),
                 ),
             )
@@ -165,6 +170,15 @@ pub(crate) fn fulfillment_lifecycle_read_runtime_for_current_graphql_scope(
     CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME
         .try_with(Clone::clone)
         .unwrap_or_else(|_| CommerceFulfillmentLifecycleReadRuntime::in_process(db))
+}
+
+pub(crate) fn order_read_runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+    event_bus: rustok_outbox::TransactionalEventBus,
+) -> CommerceOrderReadRuntime {
+    CURRENT_COMMERCE_ORDER_READ_RUNTIME
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| CommerceOrderReadRuntime::in_process(db, event_bus))
 }
 
 pub(crate) fn product_catalog_read_runtime_for_current_graphql_scope(

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-28",
-  "status": "admin_rest_cutover_unvalidated",
-  "source_base_revision": "4ec8abcff51f30d3c949cf49705f8e0d402dff9f",
+  "generated_at": "2026-07-29",
+  "status": "graphql_host_runtime_scoped_unvalidated",
+  "source_base_revision": "c1b7459651bbdaba6bf29a78ae47f15dbb02050d",
   "scope": "order detail and filtered list projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
@@ -52,7 +52,8 @@
     "host_runtime_attachment": true,
     "commerce_http_required": true,
     "commerce_graphql_schema_data_required": true,
-    "graphql_resolver_scope_published": false
+    "graphql_resolver_scope_published": true,
+    "graphql_embedded_fallback_retained": true
   },
   "errors": {
     "type": "PortError",
@@ -71,7 +72,8 @@
     "commerce_admin_rest_list_detail": "order_read_port",
     "commerce_admin_rest_cutover_completed": true,
     "commerce_storefront_detail_and_ownership": "concrete_order_service",
-    "commerce_graphql_order_list_detail": "concrete_order_service",
+    "commerce_graphql_order_list_detail": "order_read_port_host_runtime",
+    "commerce_graphql_order_list_detail_cutover_completed": true,
     "runtime_composition_published": true,
     "all_consumer_cutover_completed": false,
     "cutover_required": true
@@ -82,7 +84,7 @@
     "admin_detail_fulfillment_lookup": "concrete_fulfillment_service"
   },
   "decision": {
-    "next_slice": "cut mounted GraphQL order list/detail to the host-selected CommerceOrderReadRuntime, then cut storefront detail and ownership reads separately",
+    "next_slice": "propagate authenticated actor and request channel into GraphQL order PortContext, then cut storefront detail and ownership reads separately",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Implementation plan for `rustok-order`
 
-Last reviewed: 2026-07-28
+Last reviewed: 2026-07-29
 
 ## Current state
 
@@ -58,8 +58,9 @@ Complete order detail and filtered-list projection reads are published through
 port through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
 GraphQL schema data. Mounted admin REST list/detail reads use the port with locale,
 channel, deadline, filters, ordering, pagination total, public error envelopes,
-and payment/fulfillment detail aggregation preserved. GraphQL resolvers and
-storefront order reads remain open and unvalidated.
+and payment/fulfillment detail aggregation preserved. Mounted GraphQL detail/list
+reads consume the same host-selected runtime through resolver scope. GraphQL
+actor/channel propagation and storefront order reads remain open and unvalidated.
 
 ## FFA/FBA boundary
 
@@ -166,7 +167,9 @@ storefront order reads remain open and unvalidated.
 - [x] Cut admin REST order list/detail over to the owner port while preserving
   locale, channel, deadline, filters, pagination total, detail aggregation, and
   public envelopes.
-- [ ] Cut GraphQL order list/detail over to the host-selected runtime.
+- [x] Cut GraphQL order list/detail over to the host-selected runtime through the
+  mounted resolver scope while retaining an embedded-schema in-process fallback.
+- [ ] Propagate authenticated actor and request channel into GraphQL order reads.
 - [ ] Cut storefront order detail/ownership reads over in a separate atomic change.
 - [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence before status promotion.
@@ -222,9 +225,10 @@ storefront order reads remain open and unvalidated.
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Finish mounted order projection read cutover.** Admin REST list/detail now use
-   the host-selected `CommerceOrderReadRuntime`; cut GraphQL next and storefront
-   reads separately without changing order mutations or payment/fulfillment detail
+7. **Finish mounted order projection read cutover.** Admin REST and mounted
+   GraphQL list/detail now use the host-selected `CommerceOrderReadRuntime`;
+   propagate GraphQL actor/channel context next, then cut storefront reads
+   separately without changing order mutations or payment/fulfillment detail
    ownership.
    **Depends on:** the published runtime and current public transport envelope
    inventory.

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,6 +1,6 @@
 # Order read port
 
-Status: owner port and host runtime published; admin REST list/detail cut over, unvalidated.
+Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over, unvalidated.
 
 ## Scope
 
@@ -15,8 +15,8 @@ needed by mounted Commerce REST and GraphQL query consumers. It is separate from
   order-owner commands and services.
 
 The owner boundary and host-selected runtime are now published. Mounted admin REST
-order list/detail reads use the port. GraphQL and storefront order reads remain
-explicit later cutovers.
+and GraphQL order list/detail reads use the port. Storefront order reads remain an
+explicit later cutover.
 
 ## Operations
 
@@ -71,9 +71,9 @@ The default application host:
 4. attaches the same value to `HostRuntimeContext`.
 
 `CommerceHttpRuntime` now requires this value. Commerce GraphQL schema-data
-composition also requires it, preventing a later resolver cutover from silently
-constructing a different adapter. This wave does not add a GraphQL resolver scope
-or change any GraphQL order resolver.
+composition also requires it. The mounted resolver extension scopes the same value
+into the safe-query compatibility facade. Directly embedded schemas retain an
+explicit in-process fallback rather than receiving an unrelated global runtime.
 
 ## Admin REST cutover
 
@@ -120,7 +120,6 @@ This source wave deliberately leaves these paths unchanged:
 - admin order detail payment lookup still constructs `PaymentService`;
 - admin order detail fulfillment lookup still constructs `FulfillmentService`;
 - storefront order detail and ownership checks still construct `OrderService`;
-- GraphQL order detail and list still construct their current concrete service;
 - return and order-change paths still require wider owner contracts.
 
 Keeping payment/fulfillment aggregation and mutations out of this cutover avoids
@@ -137,7 +136,7 @@ or owner-invariant details.
 
 ## Remaining source work
 
-1. cut mounted GraphQL order detail/list reads to the host-selected runtime;
+1. propagate authenticated actor and request channel into GraphQL order read context;
 2. cut storefront order detail and ownership checks in a separate atomic change;
 3. publish wider owner contracts before moving return/order-change reads or order
    mutations;
@@ -150,10 +149,10 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `admin_rest_cutover_unvalidated`. Host composition and admin REST
-source cutover are recorded as complete. GraphQL/storefront consumer cutover,
-compile evidence, mounted parity, deadline/failure execution, restart, and
-remote-adapter evidence remain false or open.
+Its status is `graphql_host_runtime_scoped_unvalidated`. Host composition, admin
+REST, and mounted GraphQL source cutover are recorded as complete. Storefront
+consumer cutover, compile evidence, mounted parity, deadline/failure execution,
+restart, and remote-adapter evidence remain false or open.
 
 ## Intended checks
 

--- a/scripts/verify/verify-commerce-graphql-order-read-shim.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-read-shim.mjs
@@ -10,6 +10,7 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
 const source = read('crates/rustok-commerce/src/graphql/safe_query/source.rs');
 const shim = read(
   'crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs',
@@ -29,8 +30,11 @@ for (const [value, text, label] of [
   [source, 'mod rustok_order_shim;', 'safe-query order shim module'],
   [source, 'use self::rustok_order_shim as rustok_order;', 'safe-query order alias'],
   [shim, 'pub(crate) mod dto {', 'order DTO passthrough'],
+  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_RUNTIME:', 'order task-local runtime'],
+  [graphqlRuntime, 'runtime_data.order_read_runtime()', 'host-selected order runtime scope'],
+  [graphqlRuntime, 'pub(crate) fn order_read_runtime_for_current_graphql_scope(', 'order runtime scope accessor'],
   [shim, 'order_reads: Arc<dyn OrderReadPort>', 'typed owner read dependency'],
-  [shim, 'CommerceOrderReadRuntime::in_process(', 'explicit compatibility runtime'],
+  [shim, 'order_read_runtime_for_current_graphql_scope(', 'scoped runtime lookup'],
   [shim, '.read_order_projection(', 'detail owner port call'],
   [shim, '.list_order_projections(', 'list owner port call'],
   [shim, 'ReadOrderProjectionRequest {', 'detail typed request'],
@@ -42,11 +46,12 @@ for (const [value, text, label] of [
   [shim, '.get_return(tenant_id, return_id)', 'unchanged return delegate'],
   [shim, '.list_returns(tenant_id, input)', 'unchanged return list delegate'],
   [query, 'use rustok_order::OrderService;', 'legacy included source import'],
-  [note, 'Status: source-ready, unvalidated.', 'checkpoint status'],
-  [note, 'scope the host-selected `CommerceOrderReadRuntime`', 'remaining runtime handoff'],
+  [note, 'Status: host-runtime-scoped, unvalidated.', 'checkpoint status'],
+  [note, 'Directly embedded schemas', 'embedded compatibility fallback'],
 ]) requireText(value, text, label);
 
 for (const [text, label] of [
+  ['CommerceOrderReadRuntime::in_process(', 'shim-local runtime construction'],
   ['.get_order_with_locale_fallback(tenant_id, order_id', 'concrete detail delegation'],
   ['.list_orders_with_locale_fallback(tenant_id, input', 'concrete list delegation'],
 ]) forbidText(shim, text, label);
@@ -58,5 +63,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL safe-query order detail/list reads use the typed owner port through an explicit in-process compatibility facade; host-selected runtime scoping remains open',
+  '✔ Commerce GraphQL safe-query order detail/list reads use the host-selected typed owner runtime; embedded schemas retain an explicit in-process fallback',
 );

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -13,6 +13,9 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 const owner = read('crates/rustok-order/src/order_read.rs');
 const exports = read('crates/rustok-order/src/lib.rs');
 const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const graphqlOrderShim = read(
+  'crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs',
+);
 const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
 const adminOrders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
 const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
@@ -80,6 +83,10 @@ for (const [source, value, label] of [
   [graphqlRuntime, 'pub fn order_read_port(&self)', 'runtime port getter'],
   [graphqlRuntime, 'order_read_runtime: CommerceOrderReadRuntime,', 'GraphQL runtime data field'],
   [graphqlRuntime, '.shared_get::<CommerceOrderReadRuntime>()', 'GraphQL host runtime requirement'],
+  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_RUNTIME:', 'GraphQL order task-local runtime'],
+  [graphqlRuntime, 'runtime_data.order_read_runtime()', 'GraphQL scoped host runtime'],
+  [graphqlRuntime, 'pub(crate) fn order_read_runtime_for_current_graphql_scope(', 'GraphQL runtime accessor'],
+  [graphqlOrderShim, 'order_read_runtime_for_current_graphql_scope(', 'GraphQL shim scoped runtime lookup'],
   [graphqlRuntime, 'commerce GraphQL requires CommerceOrderReadRuntime in host composition', 'GraphQL fail-closed message'],
   [httpRuntime, 'order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,', 'HTTP runtime field'],
   [httpRuntime, 'fn order_read_port(&self)', 'HTTP port getter'],
@@ -105,7 +112,7 @@ for (const [source, value, label] of [
   [storefrontFixtures, 'CommerceOrderReadRuntime::in_process(', 'storefront fixture runtime'],
   [fulfillmentFailureContract, 'CommerceOrderReadRuntime::in_process(', 'manual host fixture runtime'],
   [fulfillmentFailureContract, '.with_shared_value(event_bus.clone())', 'manual host fixture shared event bus'],
-  [note, 'Status: owner port and host runtime published; admin REST list/detail cut over, unvalidated.', 'owner note status'],
+  [note, 'Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over, unvalidated.', 'owner note status'],
   [orderPlan, 'CommerceOrderReadRuntime', 'order plan runtime checkpoint'],
   [commercePlan, 'CommerceOrderReadRuntime', 'commerce plan runtime checkpoint'],
 ]) requireText(source, value, label);
@@ -146,7 +153,7 @@ for (const [value, label] of [
   ['.cancel_order(', 'cancel mutation remains owner service'],
 ]) requireText(adminOrders, value, label);
 
-if (evidence.status !== 'admin_rest_cutover_unvalidated') {
+if (evidence.status !== 'graphql_host_runtime_scoped_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.owner?.port !== 'OrderReadPort') {
@@ -173,8 +180,11 @@ for (const key of [
     failures.push(`evidence runtime_composition.${key} must be true`);
   }
 }
-if (evidence.runtime_composition?.graphql_resolver_scope_published !== false) {
-  failures.push('GraphQL resolver scope must remain unpublished in this wave');
+if (evidence.runtime_composition?.graphql_resolver_scope_published !== true) {
+  failures.push('GraphQL resolver scope must be published');
+}
+if (evidence.runtime_composition?.graphql_embedded_fallback_retained !== true) {
+  failures.push('GraphQL embedded fallback must remain explicit');
 }
 if (evidence.errors?.owner_message_control_flow !== false) {
   failures.push('evidence must forbid owner-message control flow');
@@ -188,6 +198,12 @@ if (evidence.consumer_inventory?.commerce_admin_rest_list_detail !== 'order_read
 if (evidence.consumer_inventory?.commerce_admin_rest_cutover_completed !== true) {
   failures.push('admin REST source cutover must be complete');
 }
+if (evidence.consumer_inventory?.commerce_graphql_order_list_detail !== 'order_read_port_host_runtime') {
+  failures.push('GraphQL list/detail must use the host-selected order read runtime');
+}
+if (evidence.consumer_inventory?.commerce_graphql_order_list_detail_cutover_completed !== true) {
+  failures.push('GraphQL list/detail source cutover must be complete');
+}
 if (evidence.consumer_inventory?.runtime_composition_published !== true) {
   failures.push('runtime composition must be published');
 }
@@ -195,7 +211,7 @@ if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
   failures.push('all-consumer cutover must remain incomplete');
 }
 if (evidence.consumer_inventory?.cutover_required !== true) {
-  failures.push('evidence must retain pending GraphQL/storefront cutover');
+  failures.push('evidence must retain pending storefront cutover');
 }
 if (evidence.decision?.status_promotion !== false) {
   failures.push('source cutover must not promote status');
@@ -221,5 +237,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Order read runtime is host-composed and admin REST list/detail use the typed owner port while GraphQL/storefront cutover and runtime evidence remain pending',
+  '✔ Order read runtime is host-composed and admin REST plus mounted GraphQL list/detail use the typed owner port while storefront and runtime evidence remain pending',
 );


### PR DESCRIPTION
## Summary
- add `CommerceOrderReadRuntime` to the mounted GraphQL task-local resolver scope
- make the safe-query order facade reuse the host-selected runtime instead of constructing its own runtime
- retain the explicit in-process fallback for directly embedded schemas
- update order read source evidence, owner documentation, implementation plan, and static guards

## Recheck
- confirmed PR #2454 routed GraphQL detail/list through `OrderReadPort` but still composed a local runtime in the shim
- confirmed `CommerceGraphqlRuntimeData` already required the host-selected runtime
- confirmed the mounted extension scoped shipping, fulfillment, and Product runtimes but omitted Order
- rebased the final branch onto current `main`; it is not behind

## Remaining work
- propagate authenticated actor and request channel into GraphQL order `PortContext`
- cut storefront detail/ownership reads separately
- execute compile, mounted parity, deadline/failure, restart, and remote-adapter evidence

## Verification
Not run per maintainer instruction. Tests, Cargo commands, formatting, verifiers, workflow checks, and CI are not claimed as implementation evidence.