### PR TITLE
feat(index): retain PostgreSQL query equivalence capture

### DIFF
--- a/crates/rustok-index/docs/m4-postgres-reference-equivalence.md
+++ b/crates/rustok-index/docs/m4-postgres-reference-equivalence.md
@@ -1,22 +1,26 @@
-# M4 PostgreSQL/reference equivalence fixture
+# M4 PostgreSQL/reference equivalence fixture and capture
 
 Date: 2026-07-29
 
-Status: `source_complete_owner_execution_pending`
+Status: `fixture_and_capture_source_complete_owner_execution_pending`
 
-This slice adds an owner-run PostgreSQL regression fixture for the M4 structured query
-engine. It compares the production PostgreSQL query path with an independent in-memory
-reference materialization built from the same validated `IndexRecord` contracts. It does
-not claim that the fixture was executed or that live equivalence evidence has been
-retained.
+This slice provides both the owner-run PostgreSQL regression fixture for the M4
+structured query engine and a separate retained capture command. The fixture compares
+the production PostgreSQL query path with an independent in-memory reference
+materialization built from the same validated `IndexRecord` contracts. The capture
+command binds one successful fixture execution to an exact clean Git commit,
+PostgreSQL identity, scenario contract, and retained stdout/stderr bytes.
 
-## Execution boundary
+Neither source path was executed by the implementation agent. Live equivalence evidence
+remains an explicit repository-owner action.
+
+## Fixture execution boundary
 
 The test runs only when `RUSTOK_INDEX_TEST_DATABASE_URL`, or the repository-wide
 `DATABASE_URL` fallback, contains a PostgreSQL URL. Without one, it prints an explicit
 skip message and succeeds without connecting to a database.
 
-Each run:
+Each fixture run:
 
 1. creates a uniquely named PostgreSQL schema;
 2. sets a single-connection search path to that schema;
@@ -66,12 +70,54 @@ child value, a blocked child, an empty relation, ordered relation targets, and t
 one-link targets. This makes null totality, independent atomic `EXISTS` branches,
 relation ordering, duplicate-free count, and nested alignment observable.
 
+## Retained capture command
+
+`index-query-equivalence-capture` lives under `ops/benches`; it is not linked into Index
+production runtime. It requires explicit `INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1` and
+refuses to publish unless all of the following are true:
+
+- the configured workspace is a Git checkout with an exact 40-character lowercase
+  `INDEX_QUERY_EQUIVALENCE_COMMIT` at `HEAD`;
+- the worktree is clean before and after the cargo subprocess;
+- PostgreSQL reports version 16, a numeric `system_identifier`, and a non-empty database
+  name;
+- the exact `postgres_query_port_matches_reference_fixture` cargo test exits successfully;
+- output names the required fixture, reports one passed test, and does not contain the
+  fixture's skip marker;
+- stdout and stderr are each at most 2 MiB;
+- PostgreSQL identity is unchanged after the fixture exits.
+
+The capture retains a descriptor-last no-clobber bundle:
+
+- `stdout.log` — exact cargo/test stdout;
+- `stderr.log` — exact cargo/test stderr;
+- `equivalence.json` — contract version, completion time, repository/commit/run key,
+  runner identity, PostgreSQL identity, exact command, fixed scenario names and scenario
+  digest, exit code, byte counts, and SHA-256 hashes of both logs.
+
+The output root must not already exist. Files are created with create-new semantics and
+the descriptor is published last, so a bundle without `equivalence.json` is incomplete
+and must not be admitted. The descriptor does not retain the PostgreSQL URL, credentials,
+or arbitrary environment values.
+
+## Required environment
+
+- `INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1` — explicit execution and publication opt-in;
+- `RUSTOK_INDEX_TEST_DATABASE_URL` or `DATABASE_URL` — PostgreSQL connection used by the
+  capture identity query and fixture;
+- `INDEX_QUERY_EQUIVALENCE_COMMIT` — exact clean checkout commit;
+- `INDEX_QUERY_EQUIVALENCE_RUN_KEY` — stable 1–128 byte ASCII run identity;
+- optional `INDEX_QUERY_EQUIVALENCE_OUTPUT_ROOT` — fresh bundle path, defaulting to
+  `target/index-query-equivalence/<run-key>`;
+- optional `INDEX_QUERY_EQUIVALENCE_REPOSITORY`, workspace root, cargo executable, and job
+  metadata overrides.
+
 ## Non-claims
 
-This slice does not:
+This source does not:
 
-- run the PostgreSQL fixture;
-- retain database identity, timing, EXPLAIN, or result-digest evidence;
+- claim that PostgreSQL/reference equivalence has been executed;
+- admit or archive a retained bundle;
 - add many-link aggregate ordering;
 - compose the query port into server/storefront/admin/search consumers;
 - authorize callers;
@@ -79,8 +125,9 @@ This slice does not:
   behavior;
 - authorize production partition lifecycle work.
 
-The plan/SQL snapshots are source complete. This fixture makes the live equivalence test
-source complete, while owner execution and retained live evidence remain open.
+The plan/SQL snapshots, fixture, and capture command are source complete. The combined M4
+roadmap item remains open until the repository owner runs the capture, reviews the
+retained bundle, and records admission/provenance.
 
 ## Owner validation
 
@@ -91,8 +138,17 @@ Suggested commands:
 ```bash
 RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
   cargo test -p rustok-index postgres_query_port_matches_reference_fixture -- --nocapture
+
+INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1 \
+RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
+INDEX_QUERY_EQUIVALENCE_COMMIT=<40-char-head-commit> \
+INDEX_QUERY_EQUIVALENCE_RUN_KEY=<stable-run-key> \
+  cargo run -p rustok-benchmarks --bin index-query-equivalence-capture
+
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
+node scripts/verify/verify-index-query-equivalence-capture.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
+cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -26,6 +26,7 @@ design but does not block M4 query source work.
 - M4 PostgreSQL query port and strict row adapter: `source_complete_execution_pending`.
 - M4 retained plan/SQL snapshots: `source_complete_owner_execution_pending`.
 - M4 PostgreSQL/reference fixture source: `source_complete_owner_execution_pending`.
+- M4 retained PostgreSQL/reference capture source: `source_complete_owner_execution_pending`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -109,14 +110,28 @@ one-link filtering/projection, many-link `Gte`/`Contains`/`Ne`/`IsNull`, and nes
 identity/value alignment. The fixture is env-gated and has not been run by the
 implementation agent.
 
+## Retained equivalence capture
+
+`index-query-equivalence-capture` is an owner-operated `ops/benches` binary. It requires
+an explicit opt-in, exact clean checkout commit, stable run key, and PostgreSQL 16. It
+runs only the merged fixture, rejects skipped-test success, rechecks source and database
+identity after execution, and publishes a fresh descriptor-last bundle containing exact
+stdout/stderr plus hashes and provenance. The PostgreSQL URL and credentials are not
+serialized.
+
+The capture command is source complete but has not been run. Its bundle is not admitted
+merely because the command exits successfully; the repository owner still reviews the
+three-file inventory, descriptor, commit, database identity, and log hashes.
+
 ## Remaining bounded M4 work
 
-The canonical checklist remains open until the owner runs the fixture and retains live
-PostgreSQL/reference evidence. Additional boundaries remain:
+The canonical checklist remains open until the owner runs the fixture through the
+capture command and retains live PostgreSQL/reference evidence. Additional boundaries
+remain:
 
 - aggregate ordering semantics for paths traversing `many`;
 - server/storefront/admin/search query-port composition and consumer cutover;
-- retained live equivalence evidence with database identity and result provenance.
+- owner review and admission of one retained live equivalence bundle.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.
@@ -135,7 +150,13 @@ cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index query_snapshot_tests -- --nocapture
 RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
   cargo test -p rustok-index postgres_query_port_matches_reference_fixture -- --nocapture
+INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1 \
+RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
+INDEX_QUERY_EQUIVALENCE_COMMIT=<40-char-head-commit> \
+INDEX_QUERY_EQUIVALENCE_RUN_KEY=<stable-run-key> \
+  cargo run -p rustok-benchmarks --bin index-query-equivalence-capture
 cargo check -p rustok-index --all-targets
+cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
 node scripts/verify/verify-index-query-contract.mjs
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -143,5 +164,6 @@ node scripts/verify/verify-index-query-result-decoder.mjs
 node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-query-snapshots.mjs
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
+node scripts/verify/verify-index-query-equivalence-capture.mjs
 cargo xtask module validate index
 ```

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -27,6 +27,7 @@ rust_decimal = "1.42"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+hex = { workspace = true }
 futures = "0.3"
 
 [[bin]]

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -65,6 +65,10 @@ path = "src/bin/index_partition_cutover_evidence.rs"
 name = "index-partition-capture-finalize"
 path = "src/bin/index_partition_capture_finalize.rs"
 
+[[bin]]
+name = "index-query-equivalence-capture"
+path = "src/bin/index_query_equivalence_capture.rs"
+
 [[bench]]
 name = "tenant_cache"
 harness = false

--- a/ops/benches/src/bin/index_query_equivalence_capture.rs
+++ b/ops/benches/src/bin/index_query_equivalence_capture.rs
@@ -1,0 +1,16 @@
+use rustok_benchmarks::index_storage::{
+    QueryEquivalenceCaptureConfig, capture_query_equivalence,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = QueryEquivalenceCaptureConfig::from_env()?;
+    let capture = capture_query_equivalence(&config).await?;
+    println!(
+        "index query equivalence capture complete: commit={} run_key={} output={}",
+        capture.commit,
+        capture.run_key,
+        capture.output_root.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -10,6 +10,7 @@ mod partition_maintenance;
 mod partition_mutation;
 mod partition_query;
 mod partition_snapshot;
+mod query_equivalence_capture;
 mod report_provenance;
 mod runner;
 mod sql;
@@ -41,6 +42,9 @@ pub use partition_query::{
 pub use partition_snapshot::{
     BaselineSnapshot, PartitionSnapshotCapture, PartitionSnapshotConfig, RelationEvidence,
     ShadowRelationEvidence, ShadowSnapshot, TenantPredicateAudit, capture_partition_snapshot,
+};
+pub use query_equivalence_capture::{
+    QueryEquivalenceCapture, QueryEquivalenceCaptureConfig, capture_query_equivalence,
 };
 pub use report_provenance::write_provenance_bound_report;
 pub use runner::{BenchmarkReport, run, write_report};

--- a/ops/benches/src/index_storage/query_equivalence_capture.rs
+++ b/ops/benches/src/index_storage/query_equivalence_capture.rs
@@ -1,6 +1,5 @@
 use std::{
     env,
-    ffi::OsStr,
     fs::{self, OpenOptions},
     io::Write as _,
     path::{Path, PathBuf},
@@ -81,7 +80,10 @@ impl QueryEquivalenceCaptureConfig {
         );
 
         let commit = env::var(COMMIT_ENV).context(format!("{COMMIT_ENV} is required"))?;
-        ensure!(is_lower_hex_commit(&commit), "{COMMIT_ENV} must be a 40-character lowercase Git commit");
+        ensure!(
+            is_lower_hex_commit(&commit),
+            "{COMMIT_ENV} must be a 40-character lowercase Git commit"
+        );
         let run_key = env::var(RUN_KEY_ENV).context(format!("{RUN_KEY_ENV} is required"))?;
         validate_run_key(&run_key)?;
         let repository = env::var(REPOSITORY_ENV).unwrap_or_else(|_| "RusTokRs/RusTok".to_owned());
@@ -106,7 +108,10 @@ impl QueryEquivalenceCaptureConfig {
             "query equivalence output root must have a final path component"
         );
         let cargo_program = env::var(CARGO_ENV).unwrap_or_else(|_| "cargo".to_owned());
-        ensure!(!cargo_program.trim().is_empty(), "{CARGO_ENV} must not be empty");
+        ensure!(
+            !cargo_program.trim().is_empty(),
+            "{CARGO_ENV} must not be empty"
+        );
 
         Ok(Self {
             database_url,
@@ -200,6 +205,7 @@ pub async fn capture_query_equivalence(
         output.stderr.len() <= MAX_LOG_BYTES,
         "query equivalence stderr exceeds the {MAX_LOG_BYTES}-byte retained limit"
     );
+    verify_source_identity(config)?;
 
     let database_after = read_database_identity(&db).await?;
     ensure!(
@@ -210,7 +216,7 @@ pub async fn capture_query_equivalence(
     let execution = QueryEquivalenceExecution {
         package: TEST_PACKAGE,
         test_filter: TEST_FILTER,
-        command: equivalence_command(),
+        command: equivalence_command(config),
         scenarios: &SCENARIOS,
         scenario_contract_sha256: sha256_json(&SCENARIOS)?,
         exit_code: output.status.code().unwrap_or(-1),
@@ -247,11 +253,11 @@ pub async fn capture_query_equivalence(
         execution,
     };
 
-    publish_bundle(config, &descriptor, &output)?;
+    let output_root = publish_bundle(config, &descriptor, &output)?;
     Ok(QueryEquivalenceCapture {
         commit: config.commit.clone(),
         run_key: config.run_key.clone(),
-        output_root: config.output_root.clone(),
+        output_root,
     })
 }
 
@@ -340,9 +346,9 @@ fn validate_test_output(output: &Output) -> Result<()> {
     Ok(())
 }
 
-fn equivalence_command() -> Vec<String> {
+fn equivalence_command(config: &QueryEquivalenceCaptureConfig) -> Vec<String> {
     vec![
-        "cargo".to_owned(),
+        config.cargo_program.clone(),
         "test".to_owned(),
         "-p".to_owned(),
         TEST_PACKAGE.to_owned(),
@@ -403,7 +409,7 @@ fn publish_bundle(
     config: &QueryEquivalenceCaptureConfig,
     descriptor: &QueryEquivalenceDescriptor,
     output: &Output,
-) -> Result<()> {
+) -> Result<PathBuf> {
     ensure_output_absent(&config.output_root)?;
     let parent = config
         .output_root
@@ -435,7 +441,7 @@ fn publish_bundle(
     fs::create_dir(&staged_root)
         .with_context(|| format!("failed to create staged query equivalence root {staged_root:?}"))?;
 
-    let result: Result<()> = (|| {
+    let result: Result<PathBuf> = (|| {
         write_new_file(&staged_root.join(STDOUT_FILE), &output.stdout)?;
         write_new_file(&staged_root.join(STDERR_FILE), &output.stderr)?;
         let mut descriptor_bytes = serde_json::to_vec_pretty(descriptor)?;
@@ -446,7 +452,7 @@ fn publish_bundle(
                 "failed to publish query equivalence bundle from {staged_root:?} to {final_root:?}"
             )
         })?;
-        Ok(())
+        Ok(final_root.clone())
     })();
     if staged_root.exists() {
         let _ = fs::remove_dir_all(&staged_root);
@@ -486,7 +492,10 @@ fn validate_run_key(value: &str) -> Result<()> {
         }),
         "{RUN_KEY_ENV} may contain only ASCII letters, digits, dash, underscore, and dot"
     );
-    ensure!(value != "." && value != "..", "{RUN_KEY_ENV} must not be dot traversal");
+    ensure!(
+        value != "." && value != "..",
+        "{RUN_KEY_ENV} must not be dot traversal"
+    );
     Ok(())
 }
 
@@ -518,8 +527,4 @@ fn tail(value: &str, max_chars: usize) -> String {
         .nth(max_chars)
         .map_or(0, |(index, _)| index);
     value[start..].to_owned()
-}
-
-fn _os_str_is_non_empty(value: &OsStr) -> bool {
-    !value.is_empty()
 }

--- a/ops/benches/src/index_storage/query_equivalence_capture.rs
+++ b/ops/benches/src/index_storage/query_equivalence_capture.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     env,
     fs::{self, OpenOptions},
     io::Write as _,
@@ -432,30 +433,26 @@ fn publish_bundle(
         .context("query equivalence output root must have a filename")?;
     let final_root = canonical_parent.join(output_name);
     ensure_output_absent(&final_root)?;
-    let staged_root = canonical_parent.join(format!(
-        ".{}.tmp-{}",
-        output_name.to_string_lossy(),
-        std::process::id()
-    ));
-    ensure_output_absent(&staged_root)?;
-    fs::create_dir(&staged_root)
-        .with_context(|| format!("failed to create staged query equivalence root {staged_root:?}"))?;
+    fs::create_dir(&final_root).with_context(|| {
+        format!("failed to reserve fresh query equivalence output root {final_root:?}")
+    })?;
 
     let result: Result<PathBuf> = (|| {
-        write_new_file(&staged_root.join(STDOUT_FILE), &output.stdout)?;
-        write_new_file(&staged_root.join(STDERR_FILE), &output.stderr)?;
+        write_new_file(&final_root.join(STDOUT_FILE), &output.stdout)?;
+        write_new_file(&final_root.join(STDERR_FILE), &output.stderr)?;
+        ensure_exact_files(&final_root, &[STDERR_FILE, STDOUT_FILE])?;
+
         let mut descriptor_bytes = serde_json::to_vec_pretty(descriptor)?;
         descriptor_bytes.push(b'\n');
-        write_new_file(&staged_root.join(DESCRIPTOR_FILE), &descriptor_bytes)?;
-        fs::rename(&staged_root, &final_root).with_context(|| {
-            format!(
-                "failed to publish query equivalence bundle from {staged_root:?} to {final_root:?}"
-            )
-        })?;
+        write_new_file(&final_root.join(DESCRIPTOR_FILE), &descriptor_bytes)?;
+        ensure_exact_files(
+            &final_root,
+            &[DESCRIPTOR_FILE, STDERR_FILE, STDOUT_FILE],
+        )?;
         Ok(final_root.clone())
     })();
-    if staged_root.exists() {
-        let _ = fs::remove_dir_all(&staged_root);
+    if result.is_err() && final_root.exists() {
+        let _ = fs::remove_dir_all(&final_root);
     }
     result
 }
@@ -470,6 +467,31 @@ fn write_new_file(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("failed to write retained query equivalence artifact {path:?}"))?;
     file.sync_all()
         .with_context(|| format!("failed to sync retained query equivalence artifact {path:?}"))?;
+    Ok(())
+}
+
+fn ensure_exact_files(root: &Path, expected: &[&str]) -> Result<()> {
+    let expected = expected.iter().map(|value| (*value).to_owned()).collect::<BTreeSet<_>>();
+    let mut actual = BTreeSet::new();
+    for entry in fs::read_dir(root)
+        .with_context(|| format!("failed to inspect query equivalence bundle {root:?}"))?
+    {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        ensure!(
+            file_type.is_file() && !file_type.is_symlink(),
+            "query equivalence bundle entries must be regular non-symlink files"
+        );
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("query equivalence bundle filename must be UTF-8"))?;
+        actual.insert(name);
+    }
+    ensure!(
+        actual == expected,
+        "query equivalence bundle inventory mismatch: expected {expected:?}, got {actual:?}"
+    );
     Ok(())
 }
 

--- a/ops/benches/src/index_storage/query_equivalence_capture.rs
+++ b/ops/benches/src/index_storage/query_equivalence_capture.rs
@@ -1,0 +1,525 @@
+use std::{
+    env,
+    ffi::OsStr,
+    fs::{self, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use anyhow::{Context, Result, ensure};
+use chrono::{DateTime, Utc};
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::connect_benchmark_database;
+
+const CAPTURE_CONTRACT: &str = "index_query_equivalence_capture_v1";
+const CAPTURE_OPT_IN: &str = "INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE";
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const OUTPUT_ENV: &str = "INDEX_QUERY_EQUIVALENCE_OUTPUT_ROOT";
+const COMMIT_ENV: &str = "INDEX_QUERY_EQUIVALENCE_COMMIT";
+const RUN_KEY_ENV: &str = "INDEX_QUERY_EQUIVALENCE_RUN_KEY";
+const REPOSITORY_ENV: &str = "INDEX_QUERY_EQUIVALENCE_REPOSITORY";
+const WORKSPACE_ENV: &str = "INDEX_QUERY_EQUIVALENCE_WORKSPACE_ROOT";
+const CARGO_ENV: &str = "INDEX_QUERY_EQUIVALENCE_CARGO";
+const STDOUT_FILE: &str = "stdout.log";
+const STDERR_FILE: &str = "stderr.log";
+const DESCRIPTOR_FILE: &str = "equivalence.json";
+const MAX_LOG_BYTES: usize = 2 * 1024 * 1024;
+const TEST_FILTER: &str = "postgres_query_port_matches_reference_fixture";
+const TEST_PACKAGE: &str = "rustok-index";
+const SCENARIOS: [&str; 6] = [
+    "root_filter_desc_keyset_first_page",
+    "root_filter_desc_keyset_continuation",
+    "one_link_projection_and_filter",
+    "many_link_filter_and_nested_projection",
+    "many_link_is_null_totality",
+    "bounded_offset_ordering",
+];
+
+#[derive(Debug, Clone)]
+pub struct QueryEquivalenceCaptureConfig {
+    pub database_url: String,
+    pub workspace_root: PathBuf,
+    pub output_root: PathBuf,
+    pub repository: String,
+    pub commit: String,
+    pub run_key: String,
+    pub cargo_program: String,
+}
+
+impl QueryEquivalenceCaptureConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(CAPTURE_OPT_IN).as_deref(), Ok("1")),
+            "{CAPTURE_OPT_IN}=1 is required because this command executes PostgreSQL equivalence tests and publishes retained evidence"
+        );
+        let database_url = env::var(DATABASE_ENV)
+            .or_else(|_| env::var("DATABASE_URL"))
+            .with_context(|| format!("{DATABASE_ENV} or DATABASE_URL is required"))?;
+        ensure!(
+            database_url.starts_with("postgres://")
+                || database_url.starts_with("postgresql://"),
+            "query equivalence capture requires a PostgreSQL URL"
+        );
+
+        let workspace_root = env::var(WORKSPACE_ENV)
+            .map(PathBuf::from)
+            .unwrap_or(env::current_dir().context("failed to resolve current workspace directory")?);
+        let workspace_root = workspace_root
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize workspace root {workspace_root:?}"))?;
+        ensure!(
+            workspace_root.join("Cargo.toml").is_file(),
+            "query equivalence workspace root must contain Cargo.toml"
+        );
+        ensure!(
+            workspace_root.join(".git").exists(),
+            "query equivalence workspace root must be a Git checkout"
+        );
+
+        let commit = env::var(COMMIT_ENV).context(format!("{COMMIT_ENV} is required"))?;
+        ensure!(is_lower_hex_commit(&commit), "{COMMIT_ENV} must be a 40-character lowercase Git commit");
+        let run_key = env::var(RUN_KEY_ENV).context(format!("{RUN_KEY_ENV} is required"))?;
+        validate_run_key(&run_key)?;
+        let repository = env::var(REPOSITORY_ENV).unwrap_or_else(|_| "RusTokRs/RusTok".to_owned());
+        ensure!(
+            repository.split('/').count() == 2
+                && repository
+                    .split('/')
+                    .all(|part| !part.is_empty() && part.len() <= 100),
+            "{REPOSITORY_ENV} must use owner/repository form"
+        );
+
+        let output_root = env::var(OUTPUT_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("target/index-query-equivalence").join(&run_key));
+        let output_root = if output_root.is_absolute() {
+            output_root
+        } else {
+            workspace_root.join(output_root)
+        };
+        ensure!(
+            output_root.file_name().is_some(),
+            "query equivalence output root must have a final path component"
+        );
+        let cargo_program = env::var(CARGO_ENV).unwrap_or_else(|_| "cargo".to_owned());
+        ensure!(!cargo_program.trim().is_empty(), "{CARGO_ENV} must not be empty");
+
+        Ok(Self {
+            database_url,
+            workspace_root,
+            output_root,
+            repository,
+            commit,
+            run_key,
+            cargo_program,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct QueryEquivalenceDatabaseIdentity {
+    version: String,
+    server_version_num: String,
+    system_identifier: String,
+    database_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryEquivalenceSourceIdentity {
+    repository: String,
+    commit: String,
+    run_key: String,
+    clean_worktree: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryEquivalenceRunnerIdentity {
+    job: String,
+    runner_os: String,
+    runner_arch: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryEquivalenceExecution {
+    package: &'static str,
+    test_filter: &'static str,
+    command: Vec<String>,
+    scenarios: &'static [&'static str],
+    scenario_contract_sha256: String,
+    exit_code: i32,
+    skipped: bool,
+    stdout: QueryEquivalenceArtifact,
+    stderr: QueryEquivalenceArtifact,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryEquivalenceArtifact {
+    path: &'static str,
+    bytes: usize,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryEquivalenceDescriptor {
+    contract: &'static str,
+    completed_at: DateTime<Utc>,
+    source: QueryEquivalenceSourceIdentity,
+    runner: QueryEquivalenceRunnerIdentity,
+    database: QueryEquivalenceDatabaseIdentity,
+    execution: QueryEquivalenceExecution,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryEquivalenceCapture {
+    pub commit: String,
+    pub run_key: String,
+    pub output_root: PathBuf,
+}
+
+pub async fn capture_query_equivalence(
+    config: &QueryEquivalenceCaptureConfig,
+) -> Result<QueryEquivalenceCapture> {
+    ensure_output_absent(&config.output_root)?;
+    verify_source_identity(config)?;
+
+    let db = connect_benchmark_database(&config.database_url).await?;
+    let database_before = read_database_identity(&db).await?;
+    validate_database_identity(&database_before)?;
+
+    let output = run_equivalence_test(config)?;
+    validate_test_output(&output)?;
+    ensure!(
+        output.stdout.len() <= MAX_LOG_BYTES,
+        "query equivalence stdout exceeds the {MAX_LOG_BYTES}-byte retained limit"
+    );
+    ensure!(
+        output.stderr.len() <= MAX_LOG_BYTES,
+        "query equivalence stderr exceeds the {MAX_LOG_BYTES}-byte retained limit"
+    );
+
+    let database_after = read_database_identity(&db).await?;
+    ensure!(
+        database_after == database_before,
+        "PostgreSQL identity changed during query equivalence capture"
+    );
+
+    let execution = QueryEquivalenceExecution {
+        package: TEST_PACKAGE,
+        test_filter: TEST_FILTER,
+        command: equivalence_command(),
+        scenarios: &SCENARIOS,
+        scenario_contract_sha256: sha256_json(&SCENARIOS)?,
+        exit_code: output.status.code().unwrap_or(-1),
+        skipped: false,
+        stdout: QueryEquivalenceArtifact {
+            path: STDOUT_FILE,
+            bytes: output.stdout.len(),
+            sha256: sha256_bytes(&output.stdout),
+        },
+        stderr: QueryEquivalenceArtifact {
+            path: STDERR_FILE,
+            bytes: output.stderr.len(),
+            sha256: sha256_bytes(&output.stderr),
+        },
+    };
+    let descriptor = QueryEquivalenceDescriptor {
+        contract: CAPTURE_CONTRACT,
+        completed_at: Utc::now(),
+        source: QueryEquivalenceSourceIdentity {
+            repository: config.repository.clone(),
+            commit: config.commit.clone(),
+            run_key: config.run_key.clone(),
+            clean_worktree: true,
+        },
+        runner: QueryEquivalenceRunnerIdentity {
+            job: first_non_empty_env(
+                &["INDEX_QUERY_EQUIVALENCE_JOB", "GITHUB_JOB"],
+                "index-query-equivalence",
+            ),
+            runner_os: first_non_empty_env(&["RUNNER_OS"], env::consts::OS),
+            runner_arch: first_non_empty_env(&["RUNNER_ARCH"], env::consts::ARCH),
+        },
+        database: database_before,
+        execution,
+    };
+
+    publish_bundle(config, &descriptor, &output)?;
+    Ok(QueryEquivalenceCapture {
+        commit: config.commit.clone(),
+        run_key: config.run_key.clone(),
+        output_root: config.output_root.clone(),
+    })
+}
+
+fn verify_source_identity(config: &QueryEquivalenceCaptureConfig) -> Result<()> {
+    let head = git_output(&config.workspace_root, ["rev-parse", "HEAD"])?;
+    ensure!(
+        head.trim() == config.commit,
+        "query equivalence commit mismatch: configured {}, checkout {}",
+        config.commit,
+        head.trim()
+    );
+    let status = git_output(
+        &config.workspace_root,
+        ["status", "--porcelain=v1", "--untracked-files=all"],
+    )?;
+    ensure!(
+        status.trim().is_empty(),
+        "query equivalence capture requires a clean worktree"
+    );
+    Ok(())
+}
+
+fn git_output<const N: usize>(workspace_root: &Path, args: [&str; N]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(args)
+        .output()
+        .context("failed to start git for query equivalence source verification")?;
+    ensure!(
+        output.status.success(),
+        "git source verification failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    String::from_utf8(output.stdout).context("git source verification output was not UTF-8")
+}
+
+fn run_equivalence_test(config: &QueryEquivalenceCaptureConfig) -> Result<Output> {
+    Command::new(&config.cargo_program)
+        .current_dir(&config.workspace_root)
+        .args([
+            "test",
+            "-p",
+            TEST_PACKAGE,
+            TEST_FILTER,
+            "--",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(DATABASE_ENV, &config.database_url)
+        .env("CARGO_TERM_COLOR", "never")
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to execute query equivalence test through {}",
+                config.cargo_program
+            )
+        })
+}
+
+fn validate_test_output(output: &Output) -> Result<()> {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    ensure!(
+        output.status.success(),
+        "PostgreSQL/reference equivalence test failed with status {:?}: {}",
+        output.status.code(),
+        tail(&combined, 4_000)
+    );
+    ensure!(
+        combined.contains(TEST_FILTER),
+        "query equivalence test output does not name the required fixture"
+    );
+    ensure!(
+        !combined.contains("skipping rustok-index PostgreSQL/reference equivalence"),
+        "query equivalence test reported success by skipping PostgreSQL execution"
+    );
+    ensure!(
+        combined.contains("test result: ok.") && combined.contains("1 passed; 0 failed"),
+        "query equivalence test output does not prove one successful fixture: {}",
+        tail(&combined, 4_000)
+    );
+    Ok(())
+}
+
+fn equivalence_command() -> Vec<String> {
+    vec![
+        "cargo".to_owned(),
+        "test".to_owned(),
+        "-p".to_owned(),
+        TEST_PACKAGE.to_owned(),
+        TEST_FILTER.to_owned(),
+        "--".to_owned(),
+        "--nocapture".to_owned(),
+        "--test-threads=1".to_owned(),
+    ]
+}
+
+async fn read_database_identity(
+    db: &sea_orm::DatabaseConnection,
+) -> Result<QueryEquivalenceDatabaseIdentity> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            concat!(
+                "SELECT version() AS version,",
+                " current_setting('server_version_num') AS server_version_num,",
+                " control.system_identifier::text AS system_identifier,",
+                " current_database() AS database_name",
+                " FROM pg_control_system() AS control"
+            )
+            .to_owned(),
+        ))
+        .await?
+        .context("query equivalence database identity query returned no row")?;
+    Ok(QueryEquivalenceDatabaseIdentity {
+        version: row.try_get("", "version")?,
+        server_version_num: row.try_get("", "server_version_num")?,
+        system_identifier: row.try_get("", "system_identifier")?,
+        database_name: row.try_get("", "database_name")?,
+    })
+}
+
+fn validate_database_identity(identity: &QueryEquivalenceDatabaseIdentity) -> Result<()> {
+    ensure!(
+        identity.server_version_num.starts_with("16"),
+        "query equivalence capture requires PostgreSQL 16, got {}",
+        identity.server_version_num
+    );
+    ensure!(
+        !identity.system_identifier.is_empty()
+            && identity
+                .system_identifier
+                .bytes()
+                .all(|byte| byte.is_ascii_digit()),
+        "PostgreSQL system identifier must contain only digits"
+    );
+    ensure!(
+        !identity.database_name.is_empty(),
+        "PostgreSQL database name must not be empty"
+    );
+    Ok(())
+}
+
+fn publish_bundle(
+    config: &QueryEquivalenceCaptureConfig,
+    descriptor: &QueryEquivalenceDescriptor,
+    output: &Output,
+) -> Result<()> {
+    ensure_output_absent(&config.output_root)?;
+    let parent = config
+        .output_root
+        .parent()
+        .context("query equivalence output root must have a parent")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create query equivalence output parent {parent:?}"))?;
+    let parent_metadata = fs::symlink_metadata(parent)
+        .with_context(|| format!("failed to inspect query equivalence output parent {parent:?}"))?;
+    ensure!(
+        parent_metadata.is_dir() && !parent_metadata.file_type().is_symlink(),
+        "query equivalence output parent must be a regular non-symlink directory"
+    );
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize query equivalence output parent {parent:?}"))?;
+    let output_name = config
+        .output_root
+        .file_name()
+        .context("query equivalence output root must have a filename")?;
+    let final_root = canonical_parent.join(output_name);
+    ensure_output_absent(&final_root)?;
+    let staged_root = canonical_parent.join(format!(
+        ".{}.tmp-{}",
+        output_name.to_string_lossy(),
+        std::process::id()
+    ));
+    ensure_output_absent(&staged_root)?;
+    fs::create_dir(&staged_root)
+        .with_context(|| format!("failed to create staged query equivalence root {staged_root:?}"))?;
+
+    let result: Result<()> = (|| {
+        write_new_file(&staged_root.join(STDOUT_FILE), &output.stdout)?;
+        write_new_file(&staged_root.join(STDERR_FILE), &output.stderr)?;
+        let mut descriptor_bytes = serde_json::to_vec_pretty(descriptor)?;
+        descriptor_bytes.push(b'\n');
+        write_new_file(&staged_root.join(DESCRIPTOR_FILE), &descriptor_bytes)?;
+        fs::rename(&staged_root, &final_root).with_context(|| {
+            format!(
+                "failed to publish query equivalence bundle from {staged_root:?} to {final_root:?}"
+            )
+        })?;
+        Ok(())
+    })();
+    if staged_root.exists() {
+        let _ = fs::remove_dir_all(&staged_root);
+    }
+    result
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("failed to create retained query equivalence artifact {path:?}"))?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to write retained query equivalence artifact {path:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync retained query equivalence artifact {path:?}"))?;
+    Ok(())
+}
+
+fn ensure_output_absent(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => anyhow::bail!("query equivalence output already exists: {path:?}"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to inspect output path {path:?}")),
+    }
+}
+
+fn validate_run_key(value: &str) -> Result<()> {
+    ensure!(
+        !value.is_empty() && value.len() <= 128,
+        "{RUN_KEY_ENV} must contain between 1 and 128 bytes"
+    );
+    ensure!(
+        value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+        }),
+        "{RUN_KEY_ENV} may contain only ASCII letters, digits, dash, underscore, and dot"
+    );
+    ensure!(value != "." && value != "..", "{RUN_KEY_ENV} must not be dot traversal");
+    Ok(())
+}
+
+fn is_lower_hex_commit(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn sha256_json(value: &impl Serialize) -> Result<String> {
+    Ok(sha256_bytes(&serde_json::to_vec(value)?))
+}
+
+fn first_non_empty_env(keys: &[&str], fallback: &str) -> String {
+    keys.iter()
+        .find_map(|key| env::var(key).ok().filter(|value| !value.trim().is_empty()))
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn tail(value: &str, max_chars: usize) -> String {
+    let start = value
+        .char_indices()
+        .rev()
+        .nth(max_chars)
+        .map_or(0, |(index, _)| index);
+    value[start..].to_owned()
+}
+
+fn _os_str_is_non_empty(value: &OsStr) -> bool {
+    !value.is_empty()
+}

--- a/scripts/verify/verify-index-postgres-reference-equivalence.mjs
+++ b/scripts/verify/verify-index-postgres-reference-equivalence.mjs
@@ -76,7 +76,7 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-postgres-reference-equivalence.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', [
-  'Status: `source_complete_owner_execution_pending`',
+  'Status: `fixture_and_capture_source_complete_owner_execution_pending`',
   'compares the complete `IndexQueryPage`',
   'does not introduce Testcontainers or a second database stack',
   'Not run by the implementation agent',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -12,6 +12,7 @@ const scripts = [
   'verify-index-many-link-filtering.mjs',
   'verify-index-query-snapshots.mjs',
   'verify-index-postgres-reference-equivalence.mjs',
+  'verify-index-query-equivalence-capture.mjs',
 ];
 
 for (const script of scripts) {

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -39,8 +39,12 @@ const capture = requireMarkers(capturePath, [
   'stderr.log',
   'equivalence.json',
   'create_new(true)',
+  'fs::create_dir(&final_root)',
+  'ensure_exact_files(&final_root, &[STDERR_FILE, STDOUT_FILE])',
+  '&[DESCRIPTOR_FILE, STDERR_FILE, STDOUT_FILE]',
   'output.stdout.len() <= MAX_LOG_BYTES',
   'database_after == database_before',
+  'verify_source_identity(config)?;',
 ]);
 for (const forbidden of [
   'Command::new("sh")',
@@ -48,12 +52,22 @@ for (const forbidden of [
   'INSERT INTO index_schemas',
   'INSERT INTO index_entities',
   'INSERT INTO index_links',
-  'database_url:',
   'serde_json::to_value(&config)',
   'fs::write(',
   'File::create(',
 ]) {
   if (capture.includes(forbidden)) fail(`${capturePath} contains forbidden marker ${forbidden}`);
+}
+const descriptorStart = capture.indexOf('struct QueryEquivalenceDescriptor');
+const descriptorEnd = capture.indexOf('pub struct QueryEquivalenceCapture');
+if (descriptorStart < 0 || descriptorEnd <= descriptorStart) {
+  fail(`${capturePath} has no inspectable descriptor contract`);
+}
+const descriptorContract = capture.slice(descriptorStart, descriptorEnd);
+for (const forbidden of ['database_url', 'workspace_root', 'cargo_program']) {
+  if (descriptorContract.includes(forbidden)) {
+    fail(`${capturePath} serializes forbidden descriptor field ${forbidden}`);
+  }
 }
 
 requireMarkers('ops/benches/src/bin/index_query_equivalence_capture.rs', [
@@ -66,6 +80,7 @@ requireMarkers('ops/benches/src/index_storage/mod.rs', [
   'QueryEquivalenceCapture, QueryEquivalenceCaptureConfig, capture_query_equivalence',
 ]);
 requireMarkers('ops/benches/Cargo.toml', [
+  'hex = { workspace = true }',
   'name = "index-query-equivalence-capture"',
   'path = "src/bin/index_query_equivalence_capture.rs"',
 ]);

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -59,7 +59,7 @@ for (const forbidden of [
   if (capture.includes(forbidden)) fail(`${capturePath} contains forbidden marker ${forbidden}`);
 }
 const descriptorStart = capture.indexOf('struct QueryEquivalenceDescriptor');
-const descriptorEnd = capture.indexOf('pub struct QueryEquivalenceCapture');
+const descriptorEnd = capture.indexOf('pub struct QueryEquivalenceCapture {');
 if (descriptorStart < 0 || descriptorEnd <= descriptorStart) {
   fail(`${capturePath} has no inspectable descriptor contract`);
 }

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-query-equivalence-capture] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const capturePath = 'ops/benches/src/index_storage/query_equivalence_capture.rs';
+const capture = requireMarkers(capturePath, [
+  'index_query_equivalence_capture_v1',
+  'INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE',
+  'RUSTOK_INDEX_TEST_DATABASE_URL',
+  'INDEX_QUERY_EQUIVALENCE_OUTPUT_ROOT',
+  'INDEX_QUERY_EQUIVALENCE_COMMIT',
+  'INDEX_QUERY_EQUIVALENCE_RUN_KEY',
+  'git_output(&config.workspace_root, ["rev-parse", "HEAD"])',
+  'status", "--porcelain=v1", "--untracked-files=all',
+  'postgres_query_port_matches_reference_fixture',
+  '--test-threads=1',
+  'skipping rustok-index PostgreSQL/reference equivalence',
+  '1 passed; 0 failed',
+  'pg_control_system()',
+  'system_identifier',
+  'scenario_contract_sha256',
+  'stdout.log',
+  'stderr.log',
+  'equivalence.json',
+  'create_new(true)',
+  'output.stdout.len() <= MAX_LOG_BYTES',
+  'database_after == database_before',
+]);
+for (const forbidden of [
+  'Command::new("sh")',
+  'Command::new("bash")',
+  'INSERT INTO index_schemas',
+  'INSERT INTO index_entities',
+  'INSERT INTO index_links',
+  'database_url:',
+  'serde_json::to_value(&config)',
+  'fs::write(',
+  'File::create(',
+]) {
+  if (capture.includes(forbidden)) fail(`${capturePath} contains forbidden marker ${forbidden}`);
+}
+
+requireMarkers('ops/benches/src/bin/index_query_equivalence_capture.rs', [
+  'QueryEquivalenceCaptureConfig::from_env()',
+  'capture_query_equivalence(&config).await?',
+  'index query equivalence capture complete',
+]);
+requireMarkers('ops/benches/src/index_storage/mod.rs', [
+  'mod query_equivalence_capture;',
+  'QueryEquivalenceCapture, QueryEquivalenceCaptureConfig, capture_query_equivalence',
+]);
+requireMarkers('ops/benches/Cargo.toml', [
+  'name = "index-query-equivalence-capture"',
+  'path = "src/bin/index_query_equivalence_capture.rs"',
+]);
+requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', [
+  'Status: `fixture_and_capture_source_complete_owner_execution_pending`',
+  '`index-query-equivalence-capture`',
+  'descriptor-last no-clobber bundle',
+  'does not retain the PostgreSQL URL',
+  'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+]);
+
+console.log('[verify-index-query-equivalence-capture] OK');


### PR DESCRIPTION
## Summary

- add an owner-operated `index-query-equivalence-capture` binary under `ops/benches`
- require explicit capture opt-in, an exact 40-character Git commit, a clean worktree, and a stable run key
- bind a successful run to PostgreSQL 16 version, system identifier, and database identity before and after execution
- execute only `postgres_query_port_matches_reference_fixture` with one test thread
- reject fixture skips, failed/missing test output, oversized logs, source drift, and database identity drift
- retain the exact stdout/stderr bytes with byte counts and SHA-256 hashes
- retain a fixed six-scenario contract and its digest
- publish a fresh descriptor-last no-clobber three-file bundle: `stdout.log`, `stderr.log`, and `equivalence.json`
- reserve the output root atomically, require exact regular-file inventory, and remove incomplete bundles on failure
- keep PostgreSQL URL, credentials, workspace path, and arbitrary environment values out of the descriptor
- add a static capture guard and include it in the unified M4 query contract
- actualize M4 fixture/capture documentation while keeping live execution and admission explicitly owner-pending

## Recheck findings

The merged PostgreSQL/reference fixture is source complete, but its env-gated success can currently be produced by a skip when no database URL is present and no retained database/source provenance is emitted. This PR adds the bounded evidence-capture layer without changing the fixture or production Index behavior.

The branch started at `3210a4386f2eadabcff6efc28ab34f5f11519311`. Main later advanced to `aaa613ae4eea8358aba755fbda56b09c4d0f1373` through Commerce/Order files only; those changes do not overlap this PR.

## Boundary

This PR does not execute PostgreSQL equivalence, admit or archive a bundle, add many-link aggregate ordering, compose `IndexQueryPort` into consumers, or change production planner/compiler/decoder/query-port/migration/mutation behavior.

The combined M4 checklist remains open until the repository owner runs the capture and reviews the retained commit, PostgreSQL identity, exact inventory, descriptor, and log hashes.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, PostgreSQL execution, builds, or Node verifiers were run.

Suggested commands:

```bash
cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
node scripts/verify/verify-index-query-equivalence-capture.mjs
node scripts/verify/verify-index-query-contract.mjs

INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1 \
RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
INDEX_QUERY_EQUIVALENCE_COMMIT=<40-char-head-commit> \
INDEX_QUERY_EQUIVALENCE_RUN_KEY=<stable-run-key> \
  cargo run -p rustok-benchmarks --bin index-query-equivalence-capture

cargo xtask module validate index
```