### PR TITLE
feat(commerce): propagate GraphQL order read context

### DIFF
--- a/crates/rustok-commerce/docs/graphql-order-read-shim.md
+++ b/crates/rustok-commerce/docs/graphql-order-read-shim.md
@@ -1,6 +1,6 @@
 # Commerce GraphQL order read compatibility shim
 
-Status: host-runtime-scoped, unvalidated.
+Status: request-context-scoped, unvalidated.
 
 The legacy Commerce safe-query source is still included from
 `src/graphql/query.rs`, but its `rustok_order` path is now resolved through a
@@ -8,18 +8,19 @@ module-local compatibility facade. Complete order detail and filtered-list reads
 use `OrderReadPort` with typed requests, explicit locale fallback, a two-second
 read deadline, stable owner errors, and the existing response shapes.
 
-Mounted GraphQL execution now scopes the host-selected `CommerceOrderReadRuntime`
-from `CommerceGraphqlRuntimeData` into the included safe-query source. The
-compatibility facade consumes that scoped runtime. Directly embedded schemas that
-do not install the mounted extension retain an explicit in-process fallback from
-the resolver-provided database and transactional event bus.
+Mounted GraphQL execution scopes the host-selected `CommerceOrderReadRuntime`
+from `CommerceGraphqlRuntimeData` into the included safe-query source. The same
+resolver scope derives the order actor only from validated `AuthContext` request
+data and carries the host-resolved `RequestContext.channel_slug` into
+`PortContext`. Unauthenticated mounted reads use a stable service actor.
 
-This removes concrete owner-service implementation from complete detail/list
-execution while preserving embedded-schema behavior.
+Directly embedded schemas that do not install the mounted extension retain an
+explicit in-process runtime fallback and a service-actor/no-channel context
+fallback. This preserves embedded-schema behavior without inventing user or
+channel attribution.
 
 The following work remains open and is not promoted by this source change:
 
-- propagate authenticated actor and request channel into the order read context;
 - move REST storefront detail/ownership reads in their own atomic change;
 - publish wider owner contracts before moving return and order-change reads;
 - execute compile, mounted parity, deadline/failure, restart, and remote-adapter evidence.

--- a/crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ::rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
+use ::rustok_api::{PortContext, PortError, PortErrorKind};
 use ::rustok_order::{
     ListOrderChangesInput, ListOrderProjectionsRequest, ListOrderReturnsInput, ListOrdersInput,
     OrderChangeResponse, OrderReadPort, OrderResponse, OrderReturnResponse,
@@ -149,13 +149,19 @@ fn graphql_order_read_context(
     operation: &'static str,
     resource_id: Uuid,
 ) -> PortContext {
-    PortContext::new(
+    let call_context =
+        crate::graphql_runtime::order_read_call_context_for_current_graphql_scope();
+    let context = PortContext::new(
         tenant_id.to_string(),
-        PortActor::service("rustok-commerce.graphql-order-query"),
+        call_context.actor(),
         locale,
         format!("commerce-graphql-order:{operation}:{resource_id}"),
     )
-    .with_deadline(std::time::Duration::from_secs(2))
+    .with_deadline(std::time::Duration::from_secs(2));
+    match call_context.channel() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
 }
 
 fn map_order_read_port_error(

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -4,6 +4,7 @@ use async_graphql::extensions::{
     Extension, ExtensionContext, ExtensionFactory, NextResolve, ResolveInfo,
 };
 use async_graphql::{Context, ServerResult, Value};
+use rustok_api::{AuthContext, PortActor, RequestContext};
 use rustok_fulfillment::providers::FulfillmentProviderRegistry;
 use rustok_fulfillment::{
     FulfillmentReadPort, ShippingOptionAdminReadPort, ShippingOptionReadPort,
@@ -104,18 +105,60 @@ impl CommerceOrderReadRuntime {
     }
 }
 
+/// Request-owned identity and channel facts used to build order read `PortContext` values.
+///
+/// Mounted GraphQL requests derive the actor only from validated `AuthContext` data. An absent
+/// principal uses a stable service actor. The channel is the host-resolved request channel slug;
+/// caller-supplied identity headers are never consulted here.
+#[derive(Clone)]
+pub(crate) struct CommerceOrderReadCallContext {
+    actor: PortActor,
+    channel: Option<String>,
+}
+
+impl CommerceOrderReadCallContext {
+    fn from_extension_context(ctx: &ExtensionContext<'_>) -> Self {
+        let actor = ctx
+            .data_opt::<AuthContext>()
+            .map(|auth| PortActor::user(auth.user_id.to_string()))
+            .unwrap_or_else(|| PortActor::service("rustok-commerce.graphql-order-query"));
+        let channel = ctx
+            .data_opt::<RequestContext>()
+            .and_then(|request| request.channel_slug.clone());
+        Self { actor, channel }
+    }
+
+    pub(crate) fn actor(&self) -> PortActor {
+        self.actor.clone()
+    }
+
+    pub(crate) fn channel(&self) -> Option<&str> {
+        self.channel.as_deref()
+    }
+}
+
+impl Default for CommerceOrderReadCallContext {
+    fn default() -> Self {
+        Self {
+            actor: PortActor::service("rustok-commerce.graphql-order-query"),
+            channel: None,
+        }
+    }
+}
+
 tokio::task_local! {
     static CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME: CommerceShippingOptionReadRuntime;
     static CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME: CommerceFulfillmentLifecycleReadRuntime;
     static CURRENT_COMMERCE_ORDER_READ_RUNTIME: CommerceOrderReadRuntime;
+    static CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT: CommerceOrderReadCallContext;
     static CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME: ProductCatalogReadRuntime;
 }
 
 /// Resolver-scoped bridge from schema runtime data to private compatibility facades.
 ///
 /// The mounted extension carries shipping-option, fulfillment-lifecycle, order, and Product catalog
-/// owner ports so every included Commerce resolver uses host-selected adapters for the current async
-/// task.
+/// owner ports plus validated order actor/channel facts so every included Commerce resolver uses
+/// host-selected adapters and request-owned context for the current async task.
 #[derive(Default)]
 pub struct CommerceShippingOptionReadScope;
 
@@ -138,16 +181,20 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
         let Some(runtime_data) = ctx.data_opt::<CommerceGraphqlRuntimeData>() else {
             return next.run(ctx, info).await;
         };
+        let order_call_context = CommerceOrderReadCallContext::from_extension_context(ctx);
         CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME
             .scope(
                 runtime_data.shipping_option_read_runtime(),
                 CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME.scope(
                     runtime_data.fulfillment_lifecycle_read_runtime(),
-                    CURRENT_COMMERCE_ORDER_READ_RUNTIME.scope(
-                        runtime_data.order_read_runtime(),
-                        CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME.scope(
-                            runtime_data.product_catalog_read_runtime(),
-                            next.run(ctx, info),
+                    CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT.scope(
+                        order_call_context,
+                        CURRENT_COMMERCE_ORDER_READ_RUNTIME.scope(
+                            runtime_data.order_read_runtime(),
+                            CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME.scope(
+                                runtime_data.product_catalog_read_runtime(),
+                                next.run(ctx, info),
+                            ),
                         ),
                     ),
                 ),
@@ -179,6 +226,12 @@ pub(crate) fn order_read_runtime_for_current_graphql_scope(
     CURRENT_COMMERCE_ORDER_READ_RUNTIME
         .try_with(Clone::clone)
         .unwrap_or_else(|_| CommerceOrderReadRuntime::in_process(db, event_bus))
+}
+
+pub(crate) fn order_read_call_context_for_current_graphql_scope() -> CommerceOrderReadCallContext {
+    CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT
+        .try_with(Clone::clone)
+        .unwrap_or_default()
 }
 
 pub(crate) fn product_catalog_read_runtime_for_current_graphql_scope(

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-29",
-  "status": "graphql_host_runtime_scoped_unvalidated",
-  "source_base_revision": "c1b7459651bbdaba6bf29a78ae47f15dbb02050d",
+  "status": "graphql_request_context_scoped_unvalidated",
+  "source_base_revision": "aaa613ae4eea8358aba755fbda56b09c4d0f1373",
   "scope": "order detail and filtered list projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
@@ -43,7 +43,10 @@
     "locale_retained": true,
     "correlation_retained": true,
     "deadline_required": true,
-    "admin_deadline_seconds": 2
+    "admin_deadline_seconds": 2,
+    "graphql_actor_source": "validated_auth_context_or_service_actor",
+    "graphql_channel_source": "resolved_request_context_channel_slug",
+    "graphql_embedded_context_fallback": "service_actor_without_channel"
   },
   "runtime_composition": {
     "type": "CommerceOrderReadRuntime",
@@ -53,7 +56,8 @@
     "commerce_http_required": true,
     "commerce_graphql_schema_data_required": true,
     "graphql_resolver_scope_published": true,
-    "graphql_embedded_fallback_retained": true
+    "graphql_embedded_fallback_retained": true,
+    "graphql_request_context_scope_published": true
   },
   "errors": {
     "type": "PortError",
@@ -72,7 +76,7 @@
     "commerce_admin_rest_list_detail": "order_read_port",
     "commerce_admin_rest_cutover_completed": true,
     "commerce_storefront_detail_and_ownership": "concrete_order_service",
-    "commerce_graphql_order_list_detail": "order_read_port_host_runtime",
+    "commerce_graphql_order_list_detail": "order_read_port_host_runtime_with_request_context",
     "commerce_graphql_order_list_detail_cutover_completed": true,
     "runtime_composition_published": true,
     "all_consumer_cutover_completed": false,
@@ -84,7 +88,7 @@
     "admin_detail_fulfillment_lookup": "concrete_fulfillment_service"
   },
   "decision": {
-    "next_slice": "propagate authenticated actor and request channel into GraphQL order PortContext, then cut storefront detail and ownership reads separately",
+    "next_slice": "cut storefront detail and ownership reads to the host-composed order read port without changing mutations or payment and fulfillment ownership",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -59,8 +59,9 @@ port through the default server, `HostRuntimeContext`, Commerce HTTP, and Commer
 GraphQL schema data. Mounted admin REST list/detail reads use the port with locale,
 channel, deadline, filters, ordering, pagination total, public error envelopes,
 and payment/fulfillment detail aggregation preserved. Mounted GraphQL detail/list
-reads consume the same host-selected runtime through resolver scope. GraphQL
-actor/channel propagation and storefront order reads remain open and unvalidated.
+reads consume the same host-selected runtime through resolver scope and carry an
+authenticated user actor plus host-resolved channel when present. Storefront HTTP
+order reads remain open and unvalidated.
 
 ## FFA/FBA boundary
 
@@ -169,8 +170,9 @@ actor/channel propagation and storefront order reads remain open and unvalidated
   public envelopes.
 - [x] Cut GraphQL order list/detail over to the host-selected runtime through the
   mounted resolver scope while retaining an embedded-schema in-process fallback.
-- [ ] Propagate authenticated actor and request channel into GraphQL order reads.
-- [ ] Cut storefront order detail/ownership reads over in a separate atomic change.
+- [x] Propagate authenticated actor and request channel into GraphQL order reads;
+  unauthenticated or embedded reads retain explicit service/no-channel fallback.
+- [ ] Cut storefront HTTP order detail/ownership reads over in a separate atomic change.
 - [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence before status promotion.
 
@@ -226,8 +228,8 @@ actor/channel propagation and storefront order reads remain open and unvalidated
    fallback behavior supports a justified status promotion.
 
 7. **Finish mounted order projection read cutover.** Admin REST and mounted
-   GraphQL list/detail now use the host-selected `CommerceOrderReadRuntime`;
-   propagate GraphQL actor/channel context next, then cut storefront reads
+   GraphQL list/detail now use the host-selected `CommerceOrderReadRuntime` with
+   authenticated actor and resolved channel context; cut storefront HTTP reads
    separately without changing order mutations or payment/fulfillment detail
    ownership.
    **Depends on:** the published runtime and current public transport envelope
@@ -246,6 +248,7 @@ actor/channel propagation and storefront order reads remain open and unvalidated
 
 - `npm run verify:ecommerce:fba`
 - `node scripts/verify/verify-order-read-port.mjs`
+- `node scripts/verify/verify-commerce-graphql-order-read-shim.mjs`
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,6 +1,6 @@
 # Order read port
 
-Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over, unvalidated.
+Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over with request context, unvalidated.
 
 ## Scope
 
@@ -15,8 +15,8 @@ needed by mounted Commerce REST and GraphQL query consumers. It is separate from
   order-owner commands and services.
 
 The owner boundary and host-selected runtime are now published. Mounted admin REST
-and GraphQL order list/detail reads use the port. Storefront order reads remain an
-explicit later cutover.
+and GraphQL order list/detail reads use the port. Storefront HTTP order reads remain
+an explicit later cutover.
 
 ## Operations
 
@@ -70,14 +70,22 @@ The default application host:
 3. caches the runtime in `ServerRuntimeContext`;
 4. attaches the same value to `HostRuntimeContext`.
 
-`CommerceHttpRuntime` now requires this value. Commerce GraphQL schema-data
-composition also requires it. The mounted resolver extension scopes the same value
-into the safe-query compatibility facade. Directly embedded schemas retain an
-explicit in-process fallback rather than receiving an unrelated global runtime.
+`CommerceHttpRuntime` requires this value. Commerce GraphQL schema-data composition
+also requires it. The mounted resolver extension scopes the same runtime into the
+safe-query compatibility facade.
+
+The resolver extension separately scopes request-owned order context:
+
+- authenticated actors come only from validated `AuthContext` data;
+- unauthenticated reads use the stable `rustok-commerce.graphql-order-query`
+  service actor;
+- the channel is the host-resolved `RequestContext.channel_slug`;
+- directly embedded schemas without the mounted extension use the service actor
+  and no channel rather than inventing attribution.
 
 ## Admin REST cutover
 
-`GET /admin/orders` now calls `list_order_projections` and preserves:
+`GET /admin/orders` calls `list_order_projections` and preserves:
 
 - `orders:list` authorization;
 - page and per-page values;
@@ -86,7 +94,7 @@ explicit in-process fallback rather than receiving an unrelated global runtime.
 - descending owner ordering and owner pagination total;
 - the existing `PaginatedResponse<OrderResponse>` envelope.
 
-`GET /admin/orders/{id}` now calls `read_order_projection` and preserves:
+`GET /admin/orders/{id}` calls `read_order_projection` and preserves:
 
 - `orders:read` authorization;
 - requested locale and tenant-default fallback;
@@ -119,7 +127,7 @@ This source wave deliberately leaves these paths unchanged:
   `OrderService`;
 - admin order detail payment lookup still constructs `PaymentService`;
 - admin order detail fulfillment lookup still constructs `FulfillmentService`;
-- storefront order detail and ownership checks still construct `OrderService`;
+- storefront HTTP order detail and ownership checks still construct `OrderService`;
 - return and order-change paths still require wider owner contracts.
 
 Keeping payment/fulfillment aggregation and mutations out of this cutover avoids
@@ -136,11 +144,10 @@ or owner-invariant details.
 
 ## Remaining source work
 
-1. propagate authenticated actor and request channel into GraphQL order read context;
-2. cut storefront order detail and ownership checks in a separate atomic change;
-3. publish wider owner contracts before moving return/order-change reads or order
+1. cut storefront HTTP order detail and ownership checks in a separate atomic change;
+2. publish wider owner contracts before moving return/order-change reads or order
    mutations;
-4. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
+3. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
    evidence before any status promotion.
 
 ## Evidence
@@ -149,15 +156,17 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `graphql_host_runtime_scoped_unvalidated`. Host composition, admin
-REST, and mounted GraphQL source cutover are recorded as complete. Storefront
-consumer cutover, compile evidence, mounted parity, deadline/failure execution,
-restart, and remote-adapter evidence remain false or open.
+Its status is `graphql_request_context_scoped_unvalidated`. Host composition,
+admin REST, and mounted GraphQL source cutover with actor/channel context are
+recorded as complete. Storefront HTTP consumer cutover, compile evidence, mounted
+parity, deadline/failure execution, restart, and remote-adapter evidence remain
+false or open.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-order-read-port.mjs
+node scripts/verify/verify-commerce-graphql-order-read-shim.mjs
 node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
 cargo check -p rustok-order --lib
 cargo check -p rustok-commerce --lib

--- a/scripts/verify/verify-commerce-graphql-order-read-shim.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-read-shim.mjs
@@ -31,10 +31,19 @@ for (const [value, text, label] of [
   [source, 'use self::rustok_order_shim as rustok_order;', 'safe-query order alias'],
   [shim, 'pub(crate) mod dto {', 'order DTO passthrough'],
   [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_RUNTIME:', 'order task-local runtime'],
+  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT:', 'order request task-local context'],
+  [graphqlRuntime, 'ctx.data_opt::<AuthContext>()', 'validated GraphQL actor source'],
+  [graphqlRuntime, 'PortActor::user(auth.user_id.to_string())', 'authenticated user actor'],
+  [graphqlRuntime, 'ctx.data_opt::<RequestContext>()', 'resolved GraphQL request context source'],
+  [graphqlRuntime, 'request.channel_slug.clone()', 'resolved request channel slug'],
   [graphqlRuntime, 'runtime_data.order_read_runtime()', 'host-selected order runtime scope'],
   [graphqlRuntime, 'pub(crate) fn order_read_runtime_for_current_graphql_scope(', 'order runtime scope accessor'],
+  [graphqlRuntime, 'pub(crate) fn order_read_call_context_for_current_graphql_scope()', 'order request context accessor'],
   [shim, 'order_reads: Arc<dyn OrderReadPort>', 'typed owner read dependency'],
   [shim, 'order_read_runtime_for_current_graphql_scope(', 'scoped runtime lookup'],
+  [shim, 'order_read_call_context_for_current_graphql_scope()', 'scoped call context lookup'],
+  [shim, 'call_context.actor()', 'PortContext actor propagation'],
+  [shim, 'context.with_channel(channel)', 'PortContext channel propagation'],
   [shim, '.read_order_projection(', 'detail owner port call'],
   [shim, '.list_order_projections(', 'list owner port call'],
   [shim, 'ReadOrderProjectionRequest {', 'detail typed request'],
@@ -46,12 +55,15 @@ for (const [value, text, label] of [
   [shim, '.get_return(tenant_id, return_id)', 'unchanged return delegate'],
   [shim, '.list_returns(tenant_id, input)', 'unchanged return list delegate'],
   [query, 'use rustok_order::OrderService;', 'legacy included source import'],
-  [note, 'Status: host-runtime-scoped, unvalidated.', 'checkpoint status'],
-  [note, 'Directly embedded schemas', 'embedded compatibility fallback'],
+  [note, 'Status: request-context-scoped, unvalidated.', 'checkpoint status'],
+  [note, 'validated `AuthContext`', 'authenticated actor note'],
+  [note, '`RequestContext.channel_slug`', 'resolved channel note'],
+  [note, 'service-actor/no-channel context', 'embedded context fallback'],
 ]) requireText(value, text, label);
 
 for (const [text, label] of [
   ['CommerceOrderReadRuntime::in_process(', 'shim-local runtime construction'],
+  ['PortActor::service(', 'shim-local actor construction'],
   ['.get_order_with_locale_fallback(tenant_id, order_id', 'concrete detail delegation'],
   ['.list_orders_with_locale_fallback(tenant_id, input', 'concrete list delegation'],
 ]) forbidText(shim, text, label);
@@ -63,5 +75,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL safe-query order detail/list reads use the host-selected typed owner runtime; embedded schemas retain an explicit in-process fallback',
+  '✔ Commerce GraphQL safe-query order detail/list reads use the host-selected typed owner runtime with validated actor and resolved request channel context; embedded schemas retain explicit service/no-channel fallbacks',
 );

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -84,9 +84,18 @@ for (const [source, value, label] of [
   [graphqlRuntime, 'order_read_runtime: CommerceOrderReadRuntime,', 'GraphQL runtime data field'],
   [graphqlRuntime, '.shared_get::<CommerceOrderReadRuntime>()', 'GraphQL host runtime requirement'],
   [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_RUNTIME:', 'GraphQL order task-local runtime'],
+  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT:', 'GraphQL order call context'],
+  [graphqlRuntime, 'ctx.data_opt::<AuthContext>()', 'GraphQL validated actor source'],
+  [graphqlRuntime, 'PortActor::user(auth.user_id.to_string())', 'GraphQL user actor'],
+  [graphqlRuntime, 'ctx.data_opt::<RequestContext>()', 'GraphQL resolved request source'],
+  [graphqlRuntime, 'request.channel_slug.clone()', 'GraphQL channel slug source'],
   [graphqlRuntime, 'runtime_data.order_read_runtime()', 'GraphQL scoped host runtime'],
   [graphqlRuntime, 'pub(crate) fn order_read_runtime_for_current_graphql_scope(', 'GraphQL runtime accessor'],
+  [graphqlRuntime, 'pub(crate) fn order_read_call_context_for_current_graphql_scope()', 'GraphQL call context accessor'],
   [graphqlOrderShim, 'order_read_runtime_for_current_graphql_scope(', 'GraphQL shim scoped runtime lookup'],
+  [graphqlOrderShim, 'order_read_call_context_for_current_graphql_scope()', 'GraphQL shim call context lookup'],
+  [graphqlOrderShim, 'call_context.actor()', 'GraphQL actor propagation'],
+  [graphqlOrderShim, 'context.with_channel(channel)', 'GraphQL channel propagation'],
   [graphqlRuntime, 'commerce GraphQL requires CommerceOrderReadRuntime in host composition', 'GraphQL fail-closed message'],
   [httpRuntime, 'order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,', 'HTTP runtime field'],
   [httpRuntime, 'fn order_read_port(&self)', 'HTTP port getter'],
@@ -112,7 +121,7 @@ for (const [source, value, label] of [
   [storefrontFixtures, 'CommerceOrderReadRuntime::in_process(', 'storefront fixture runtime'],
   [fulfillmentFailureContract, 'CommerceOrderReadRuntime::in_process(', 'manual host fixture runtime'],
   [fulfillmentFailureContract, '.with_shared_value(event_bus.clone())', 'manual host fixture shared event bus'],
-  [note, 'Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over, unvalidated.', 'owner note status'],
+  [note, 'Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over with request context, unvalidated.', 'owner note status'],
   [orderPlan, 'CommerceOrderReadRuntime', 'order plan runtime checkpoint'],
   [commercePlan, 'CommerceOrderReadRuntime', 'commerce plan runtime checkpoint'],
 ]) requireText(source, value, label);
@@ -153,7 +162,7 @@ for (const [value, label] of [
   ['.cancel_order(', 'cancel mutation remains owner service'],
 ]) requireText(adminOrders, value, label);
 
-if (evidence.status !== 'graphql_host_runtime_scoped_unvalidated') {
+if (evidence.status !== 'graphql_request_context_scoped_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.owner?.port !== 'OrderReadPort') {
@@ -175,16 +184,22 @@ for (const key of [
   'host_runtime_attachment',
   'commerce_http_required',
   'commerce_graphql_schema_data_required',
+  'graphql_resolver_scope_published',
+  'graphql_embedded_fallback_retained',
+  'graphql_request_context_scope_published',
 ]) {
   if (evidence.runtime_composition?.[key] !== true) {
     failures.push(`evidence runtime_composition.${key} must be true`);
   }
 }
-if (evidence.runtime_composition?.graphql_resolver_scope_published !== true) {
-  failures.push('GraphQL resolver scope must be published');
+if (evidence.context?.graphql_actor_source !== 'validated_auth_context_or_service_actor') {
+  failures.push('GraphQL actor source must remain validated AuthContext or service actor');
 }
-if (evidence.runtime_composition?.graphql_embedded_fallback_retained !== true) {
-  failures.push('GraphQL embedded fallback must remain explicit');
+if (evidence.context?.graphql_channel_source !== 'resolved_request_context_channel_slug') {
+  failures.push('GraphQL channel source must remain the resolved request channel slug');
+}
+if (evidence.context?.graphql_embedded_context_fallback !== 'service_actor_without_channel') {
+  failures.push('GraphQL embedded context fallback must not invent actor or channel attribution');
 }
 if (evidence.errors?.owner_message_control_flow !== false) {
   failures.push('evidence must forbid owner-message control flow');
@@ -198,8 +213,8 @@ if (evidence.consumer_inventory?.commerce_admin_rest_list_detail !== 'order_read
 if (evidence.consumer_inventory?.commerce_admin_rest_cutover_completed !== true) {
   failures.push('admin REST source cutover must be complete');
 }
-if (evidence.consumer_inventory?.commerce_graphql_order_list_detail !== 'order_read_port_host_runtime') {
-  failures.push('GraphQL list/detail must use the host-selected order read runtime');
+if (evidence.consumer_inventory?.commerce_graphql_order_list_detail !== 'order_read_port_host_runtime_with_request_context') {
+  failures.push('GraphQL list/detail must use the host-selected runtime with request context');
 }
 if (evidence.consumer_inventory?.commerce_graphql_order_list_detail_cutover_completed !== true) {
   failures.push('GraphQL list/detail source cutover must be complete');
@@ -237,5 +252,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Order read runtime is host-composed and admin REST plus mounted GraphQL list/detail use the typed owner port while storefront and runtime evidence remain pending',
+  '✔ Order read runtime is host-composed and admin REST plus mounted GraphQL list/detail use typed owner ports with validated actor and resolved channel context while storefront and runtime evidence remain pending',
 );


### PR DESCRIPTION
## Summary
- derive mounted GraphQL order actors only from validated `AuthContext`
- carry the host-resolved `RequestContext.channel_slug` into order read `PortContext`
- retain stable service-actor/no-channel fallbacks for unauthenticated and directly embedded schemas
- update the safe-query facade, owner evidence, owner plan/documentation, and static source guards

## Recheck
- confirmed PR #2457 scopes the host-selected `CommerceOrderReadRuntime` but still builds order `PortContext` with an unconditional service actor and no channel
- confirmed the HTTP GraphQL host installs validated `AuthContext` and resolved `RequestContext` into request data
- confirmed the PR contains eight expected files and is mergeable without conflicts; one unrelated Index commit landed on `main` after branch creation

## Remaining work
- cut storefront HTTP order detail and ownership reads to the host-composed order port
- publish wider owner contracts before moving return/order-change reads
- execute compile, mounted parity, deadline/failure, restart, and remote-adapter evidence

## Plan note
The focused Commerce note, order owner plan, evidence, and source guards are synchronized. The large ecommerce master plan still contains its prior GraphQL wording because the connected Contents API rejected the full-file replacement; no completion claim relies on that stale line.

## Verification
Not run per maintainer instruction. Tests, Cargo commands, formatting, verifiers, workflow checks, and CI are not claimed as implementation evidence.