### PR TITLE
fix(auth): restore OAuth CLI bootstrap after translation cutover

### DIFF
--- a/crates/rustok-auth/cli/Cargo.toml
+++ b/crates/rustok-auth/cli/Cargo.toml
@@ -15,3 +15,6 @@ rustok-tenant.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/rustok-auth/cli/src/lib.rs
+++ b/crates/rustok-auth/cli/src/lib.rs
@@ -9,8 +9,13 @@ use rustok_cli_core::{
 };
 use rustok_runtime::{RuntimeComposition, db_clone};
 use rustok_tenant::{TenantReadPort, TenantService};
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait,
+};
 use uuid::Uuid;
+
+const DEVELOPMENT_APP_LOCALE: &str = "en";
+const DEVELOPMENT_APP_DESCRIPTION: &str = "Created via rustok-cli oauth create-app";
 
 pub struct AuthCommandProvider {
     runtime: RuntimeComposition,
@@ -99,6 +104,7 @@ async fn create_development_app(
     name: String,
     slug: String,
 ) -> CliCoreResult<CreatedOAuthApp> {
+    let app_id = Uuid::new_v4();
     let client_id = Uuid::new_v4();
     let client_secret = format!(
         "sk_live_{}{}",
@@ -107,61 +113,62 @@ async fn create_development_app(
     );
     let client_secret_hash = hash_password(&client_secret).map_err(command_failed)?;
     let backend = db.get_database_backend();
-    let placeholders = match backend {
-        DbBackend::Sqlite => (
-            "?1", "?2", "?3", "?4", "?5", "?6", "?7", "?8", "?9", "?10", "?11", "?12", "?13",
-            "?14", "?15",
-        ),
-        _ => (
-            "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9", "$10", "$11", "$12", "$13",
-            "$14", "$15",
-        ),
+    let transaction = db.begin().await.map_err(command_failed)?;
+
+    let app_sql = match backend {
+        DbBackend::Postgres => "INSERT INTO oauth_apps (id, tenant_id, slug, app_type, client_id, client_secret_hash, redirect_uris, scopes, grant_types, granted_permissions, auto_created, is_active, metadata) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+        DbBackend::MySql => "INSERT INTO oauth_apps (id, tenant_id, slug, app_type, client_id, client_secret_hash, redirect_uris, scopes, grant_types, granted_permissions, auto_created, is_active, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        DbBackend::Sqlite => "INSERT INTO oauth_apps (id, tenant_id, slug, app_type, client_id, client_secret_hash, redirect_uris, scopes, grant_types, granted_permissions, auto_created, is_active, metadata) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
     };
-    let sql = format!(
-        "INSERT INTO oauth_apps (id, tenant_id, name, slug, description, app_type, client_id, client_secret_hash, redirect_uris, scopes, grant_types, granted_permissions, auto_created, is_active, metadata) VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})",
-        placeholders.0,
-        placeholders.1,
-        placeholders.2,
-        placeholders.3,
-        placeholders.4,
-        placeholders.5,
-        placeholders.6,
-        placeholders.7,
-        placeholders.8,
-        placeholders.9,
-        placeholders.10,
-        placeholders.11,
-        placeholders.12,
-        placeholders.13,
-        placeholders.14,
-    );
-    db.execute(Statement::from_sql_and_values(
-        backend,
-        sql,
-        vec![
-            Uuid::new_v4().into(),
-            tenant_id.into(),
-            name.clone().into(),
-            slug.into(),
-            Some("Created via rustok-cli oauth create-app".to_string()).into(),
-            "third_party".into(),
-            client_id.into(),
-            client_secret_hash.into(),
-            serde_json::json!([
-                "http://localhost:3000/api/auth/callback",
-                "http://localhost:1420"
-            ])
-            .into(),
-            serde_json::json!(["openid", "profile", "email", "offline_access"]).into(),
-            serde_json::json!(["authorization_code", "refresh_token"]).into(),
-            serde_json::json!([]).into(),
-            false.into(),
-            true.into(),
-            serde_json::json!({}).into(),
-        ],
-    ))
-    .await
-    .map_err(command_failed)?;
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            app_sql,
+            vec![
+                app_id.into(),
+                tenant_id.into(),
+                slug.into(),
+                "third_party".into(),
+                client_id.into(),
+                client_secret_hash.into(),
+                serde_json::json!([
+                    "http://localhost:3000/api/auth/callback",
+                    "http://localhost:1420"
+                ])
+                .into(),
+                serde_json::json!(["openid", "profile", "email", "offline_access"]).into(),
+                serde_json::json!(["authorization_code", "refresh_token"]).into(),
+                serde_json::json!([]).into(),
+                false.into(),
+                true.into(),
+                serde_json::json!({}).into(),
+            ],
+        ))
+        .await
+        .map_err(command_failed)?;
+
+    let translation_sql = match backend {
+        DbBackend::Postgres => "INSERT INTO oauth_app_translations (id, tenant_id, app_id, locale, name, description) VALUES ($1, $2, $3, $4, $5, $6)",
+        DbBackend::MySql => "INSERT INTO oauth_app_translations (id, tenant_id, app_id, locale, name, description) VALUES (?, ?, ?, ?, ?, ?)",
+        DbBackend::Sqlite => "INSERT INTO oauth_app_translations (id, tenant_id, app_id, locale, name, description) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    };
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            translation_sql,
+            vec![
+                Uuid::new_v4().into(),
+                tenant_id.into(),
+                app_id.into(),
+                DEVELOPMENT_APP_LOCALE.into(),
+                name.clone().into(),
+                Some(DEVELOPMENT_APP_DESCRIPTION.to_string()).into(),
+            ],
+        ))
+        .await
+        .map_err(command_failed)?;
+
+    transaction.commit().await.map_err(command_failed)?;
     Ok(CreatedOAuthApp {
         name,
         client_id,
@@ -180,8 +187,13 @@ async fn resolve_tenant_id(
     }
     TenantService::new(db.clone())
         .read_default_active_tenant(
-            PortContext::new("platform", PortActor::system(), "en", "oauth-create-app")
-                .with_deadline(Duration::from_secs(5)),
+            PortContext::new(
+                "platform",
+                PortActor::system(),
+                DEVELOPMENT_APP_LOCALE,
+                "oauth-create-app",
+            )
+            .with_deadline(Duration::from_secs(5)),
         )
         .await
         .map(|tenant| tenant.id)
@@ -195,12 +207,14 @@ fn options(args: &serde_json::Value) -> CliCoreResult<&serde_json::Map<String, s
             message: "oauth create-app expects normalized command options".to_string(),
         })
 }
+
 fn option<'a>(
     options: &'a serde_json::Map<String, serde_json::Value>,
     key: &str,
 ) -> Option<&'a str> {
     options.get(key).and_then(serde_json::Value::as_str)
 }
+
 fn validate_identity(value: &str, flag: &str) -> CliCoreResult<()> {
     if value.trim().is_empty() {
         Err(CliCoreError::InvalidInput {
@@ -210,8 +224,84 @@ fn validate_identity(value: &str, flag: &str) -> CliCoreResult<()> {
         Ok(())
     }
 }
+
 fn command_failed(error: impl std::fmt::Display) -> CliCoreError {
     CliCoreError::CommandFailed {
         message: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEVELOPMENT_APP_LOCALE, create_development_app};
+    use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn development_app_uses_current_translation_schema() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("SQLite database");
+        db.execute_unprepared(
+            r#"CREATE TABLE oauth_apps (
+                id TEXT PRIMARY KEY NOT NULL,
+                tenant_id TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                app_type TEXT NOT NULL,
+                client_id TEXT NOT NULL,
+                client_secret_hash TEXT NULL,
+                redirect_uris TEXT NOT NULL,
+                scopes TEXT NOT NULL,
+                grant_types TEXT NOT NULL,
+                granted_permissions TEXT NOT NULL,
+                auto_created INTEGER NOT NULL,
+                is_active INTEGER NOT NULL,
+                metadata TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE oauth_app_translations (
+                id TEXT PRIMARY KEY NOT NULL,
+                tenant_id TEXT NOT NULL,
+                app_id TEXT NOT NULL,
+                locale TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (tenant_id, app_id, locale)
+            );"#,
+        )
+        .await
+        .expect("current OAuth schema");
+
+        let tenant_id = Uuid::new_v4();
+        let created = create_development_app(
+            &db,
+            tenant_id,
+            "Development App".to_string(),
+            "dev-app".to_string(),
+        )
+        .await
+        .expect("development app");
+
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT a.slug, t.locale, t.name FROM oauth_apps a JOIN oauth_app_translations t ON t.tenant_id = a.tenant_id AND t.app_id = a.id WHERE a.tenant_id = ?1 AND a.client_id = ?2",
+                vec![tenant_id.into(), created.client_id.into()],
+            ))
+            .await
+            .expect("OAuth app query")
+            .expect("OAuth app row");
+        assert_eq!(row.try_get::<String>("", "slug").expect("slug"), "dev-app");
+        assert_eq!(
+            row.try_get::<String>("", "locale").expect("locale"),
+            DEVELOPMENT_APP_LOCALE
+        );
+        assert_eq!(
+            row.try_get::<String>("", "name").expect("name"),
+            "Development App"
+        );
     }
 }

--- a/crates/rustok-auth/docs/implementation-plan.md
+++ b/crates/rustok-auth/docs/implementation-plan.md
@@ -27,16 +27,16 @@ does not create a package-local locale fallback.
 
 ## Open results
 
-1. **Move OAuth application display content to the multilingual database
-   contract.** `oauth_apps.name` and `oauth_apps.description` are currently
-   inline user-facing strings. Introduce an auth-owned translation table with a
-   canonical default locale, tenant-composite integrity, and parity across REST,
-   GraphQL, native admin transport, and both admin hosts. Do not add a JSON or
-   transport-only translation fallback.
-   **Depends on:** the database multilingual contract and an atomic transport/UI
-   cutover.
-   **Done when:** storage, reads, writes, fallback behavior, migration evidence,
-   and all auth-owned transports use the same translation contract.
+1. **Remove implicit OAuth grant expansion for manifest-created applications.**
+   `oauth_apps::Model::supports_grant_type` currently treats an auto-created
+   application that declares only `authorization_code` as also supporting
+   `refresh_token`. This is a compatibility execution path that expands the
+   persisted grant policy instead of enforcing it literally.
+   **Depends on:** updating any manifest producer that genuinely requires
+   refresh rotation to declare `refresh_token` explicitly.
+   **Done when:** grant checks use exact persisted membership, all required
+   producers declare their complete grant set, and regression tests reject an
+   undeclared refresh grant for both manual and auto-created applications.
 
 2. **Capture runtime parity evidence for user and OAuth mutations.** Exercise
    the browser/admin path and the owner-owned GraphQL/native paths for the same
@@ -65,7 +65,9 @@ does not create a package-local locale fallback.
 5. **Keep OAuth bootstrap in the auth-owned CLI adapter.**
    `rustok-cli oauth create-app` creates the development application through
    `rustok-auth/cli`, an explicit database handle, and the tenant-owned default
-   tenant read. The server does not register a task for this operation.
+   tenant read. Base application identity and localized display copy must be
+   persisted in one transaction against the current translation-table schema.
+   The server does not register a task for this operation.
 
 6. **Keep session maintenance in the auth-owned CLI adapter.**
    `rustok-cli auth sessions-cleanup` removes expired auth sessions without the
@@ -92,6 +94,7 @@ does not create a package-local locale fallback.
 - `npm run verify:ai:fba-baseline`
 - `cargo xtask module validate auth`
 - `cargo xtask module test auth`
+- `cargo test -p rustok-auth-cli development_app_uses_current_translation_schema`
 - `cargo check -p rustok-auth-admin`
 - Targeted auth/RBAC server tests when runtime wiring changes.
 
@@ -107,12 +110,12 @@ does not create a package-local locale fallback.
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
-- Status: `in_progress`
-- Last verified at (UTC): `2026-07-20`
-- Scope inspected: `auth ownership; HS256/RS256 JWT configuration and issuer/audience validation; credential-bound password reset; sessions; OAuth apps, code exchange, refresh rotation, consent, scopes and revocation; tenant-composite migrations and queries; RBAC durable-generation invalidation; multilingual database contract; REST/GraphQL/native/server composition`
-- Findings: `P0=0, P1=4, P2=1, P3=2`
-- Fixed in this pass: `added fail-closed tenant-composite OAuth and invite database integrity plus tenant-qualified consent queries; deleted the unbound replayable password-reset path; made RS256 configuration parse and prove its key pair at startup; replaced middleware-shadowed legacy OAuth token handlers with one direct transactional service and deleted superseded issuance methods; made app/consent token revocation atomic`
-- Remaining risks or blockers: `P2 OAuth app name/description still require the planned translation-table cutover; PostgreSQL forward/down migration smoke remains part of the closing migration gate; browser/runtime mutation parity evidence remains an existing promotion requirement; default-feature targeted server test hit environmental LLVM OOM while linking rustok-admin, and the lightweight owner-owned OAuth test target is now explicit P3 verification debt`
-- Evidence: `auth boundary, AI FBA, and runtime-context guards pass; module validate auth passes; rustok-auth unit/migration/JWT suite 34/34 passes; default-feature server attempt reached rustok-admin then failed with rustc-LLVM out of memory; one-job no-default-features retry is active in target/codex-auth-cycle/server-min.*.log`
-- Next action: `finish the one-job minimal server test, run the canonical auth module test, then hand off to core/cache`
-- Resume command: `Get-Content target/codex-auth-cycle/server-min.err.log -Tail 80; Get-Content target/codex-auth-cycle/server-min.out.log -Tail 40`
+- Status: `blocked`
+- Last verified at (UTC): `2026-07-29`
+- Scope inspected: `auth ownership; JWT and credential lifecycle; OAuth app, authorization-code and refresh-token paths; tenant-qualified admin mutations; translation-table migration and runtime localization; auth-owned CLI bootstrap adapter; implicit grant expansion`
+- Findings: `P0=0, P1=6, P2=0, P3=2`
+- Fixed in this pass: `preserved the four previously repaired P1 defects; fixed the post-migration rustok-auth-cli OAuth bootstrap failure by deleting raw writes to removed oauth_apps.name/description columns and persisting the base row plus en translation in one transaction; added a SQLite regression against the current translation-table schema`
+- Remaining risks or blockers: `P1 implicit refresh_token authority remains for auto-created applications whose persisted grant_types omit it; targeted Rust execution is unavailable in the current connector-only environment because local git clone failed DNS resolution and no workflow run exists for the branch yet; PostgreSQL forward/down migration smoke and browser/runtime mutation parity evidence remain required; lightweight owner-owned OAuth code/refresh regression target remains P3 verification debt`
+- Evidence: `source inspection confirms tenant-qualified OAuth client, consent and admin lookups; authorization-code and refresh-token replacements use transactional compare-and-set; oauth_app_translations uses VARCHAR(32), tenant-composite FK and unique tenant/app/locale identity; branch agent/verify-core-auth-cycle-001 commits e4a7fb44902af0dd64e60516444958d440d21535 and 435e5f3a3b02311ca62eaeda5e1d1daef9f97b59 contain the CLI fix and regression; local clone failure was Could not resolve host: github.com and is classified as an environment limitation`
+- Next action: `run the targeted rustok-auth-cli regression and canonical auth module checks; remove implicit refresh grant expansion with explicit producer updates; rerun PostgreSQL migration smoke; then revisit this blocked item during closing gates`
+- Resume command: `cargo test -p rustok-auth-cli development_app_uses_current_translation_schema && cargo xtask module validate auth && cargo xtask module test auth`


### PR DESCRIPTION
Superseded by fresh-base PR #2463, which was squash-merged into `main` as `ccfac7a4333bfb5cd31f8708a5fde1c8601dba80`.