### PR TITLE
feat(commerce): cut storefront order reads to owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # RusToK ecommerce implementation plan
 
-Last reviewed: 2026-07-28
+Last reviewed: 2026-07-29
 
 ## Source of truth
 
@@ -199,8 +199,16 @@ These are source-contract defects, not verification-only tasks.
   explicit unvalidated source evidence.
 - [x] Host-compose `CommerceOrderReadRuntime`, require it in Commerce HTTP and GraphQL
   schema data, and cut admin REST order list/detail to the owner port while preserving
-  public envelopes and payment/fulfillment detail aggregation. GraphQL resolvers and
-  storefront order reads remain open.
+  public envelopes and payment/fulfillment detail aggregation.
+- [x] Cut mounted GraphQL order list/detail to the host-selected runtime with validated
+  actor, resolved channel, locale fallback, deadline, and embedded-schema fallback.
+- [x] Cut storefront HTTP order detail and shared ownership reads to the host-selected
+  runtime while preserving customer resolution, locale fallback, public envelopes,
+  and the concrete return/change/payment operations after ownership validation.
+- [ ] Publish wider typed owner ports for storefront return and order-change reads;
+  their current concrete services remain after typed order ownership validation.
+- [ ] Retain compile, mounted parity, deadline/failure, restart, and remote-adapter
+  evidence for the complete order projection cutover before status promotion.
 - [ ] Correct Product's declared dependency contract or extract its direct
   inventory/pricing persistence operations behind owner ports; the current manifest
   declares only Taxonomy while production code uses Inventory and Pricing persistence.
@@ -558,6 +566,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-marketplace-listing-event-contract.mjs`
 - [ ] `node scripts/verify/verify-marketplace-listing-provenance-cutover.mjs`
 - [ ] `node scripts/verify/verify-order-read-port.mjs`
+- [ ] `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - [ ] `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - [ ] `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
@@ -595,8 +604,8 @@ Source inspection is not execution evidence.
 - [x] Extend the public-error guard to pricing and `PaymentCollectionPort`, including
   correlation, tenant, operation, stable code, and raw-cause bans.
 - [x] Add static source guards for host-selected order read runtime composition and
-  admin REST order list/detail cutover without changing mutation or detail-aggregation
-  ownership.
+  admin REST, mounted GraphQL, and storefront HTTP detail/list/ownership cutover without
+  changing mutation, payment, fulfillment, return, or order-change ownership.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, and order-read
   static guards against a repository checkout and retain their output.
 
@@ -607,7 +616,7 @@ Source inspection is not execution evidence.
 - [ ] `cargo check -p rustok-order --all-features`
 - [ ] `cargo check -p rustok-server --features mod-commerce`
 - [ ] Targeted `OrderReadPort` detail/list, locale fallback, context, typed-error,
-  host-composition, and admin REST transport tests.
+  host-composition, admin REST, mounted GraphQL, and storefront HTTP transport tests.
 - [ ] `cargo test -p rustok-order --test order_checkout_identity`
 - [ ] `cargo test -p rustok-order --test checkout_order_identity_port`
 - [ ] `cargo test -p rustok-order --test checkout_completion_port`
@@ -693,19 +702,24 @@ Source inspection is not execution evidence.
     recovery/settlement/compensation, typed fulfillment recovery, and cart
     atomic/finalization/compensation all use staged or canonical typed paths.
     Compatibility source removal and execution evidence remain separate open tasks.
-12. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
-13. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
-14. [x] Mount authenticated request-scoped listing native composition.
-15. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
-16. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
+12. [x] Cut complete order projection consumers over to `CommerceOrderReadRuntime`:
+    admin REST list/detail, mounted GraphQL list/detail with request context, and
+    storefront HTTP detail/shared ownership now use the typed owner port.
+13. [ ] Publish wider owner read ports for storefront returns and order changes without
+    moving mutations or payment policy.
+14. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
+15. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
+16. [x] Mount authenticated request-scoped listing native composition.
+17. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
+18. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
     reconciliation surfaces.
-17. [ ] Run static verifiers and fix remaining source drift.
-18. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
-19. [ ] Apply clean/upgraded migrations and targeted regression tests.
-20. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
+19. [ ] Run static verifiers and fix remaining source drift.
+20. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
+21. [ ] Apply clean/upgraded migrations and targeted regression tests.
+22. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
     transfer, and mounted transport scenarios.
-21. [ ] Execute production-like payment and payout provider evidence.
-22. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
+23. [ ] Execute production-like payment and payout provider evidence.
+24. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
 
 ## Completed source waves retained for history
 
@@ -746,9 +760,10 @@ Source inspection is not execution evidence.
 - [x] Harden pricing and payment collection owner-port errors with stable public
   messages plus correlation-aware internal logging.
 - [x] Publish `OrderReadPort` for complete order detail/list projections.
-- [x] Host-compose `CommerceOrderReadRuntime` and cut admin REST order list/detail to the
-  owner port while preserving public envelopes and unchanged mutation/detail aggregation
-  ownership; GraphQL/storefront reads and execution evidence remain open.
+- [x] Host-compose `CommerceOrderReadRuntime` and cut admin REST, mounted GraphQL, and
+  storefront HTTP complete detail/list/ownership projection reads to the owner port
+  while preserving context, public envelopes, and unchanged mutation/payment/
+  fulfillment/return/order-change ownership; execution evidence remains open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -3,11 +3,12 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::{PortContext, PortErrorKind};
-use rustok_api::{PortError, RequestContext, TenantContext};
+use rustok_api::{
+    PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext,
+};
 use rustok_customer::dto::CustomerResponse;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
-use rustok_order::{OrderService, error::OrderError};
+use rustok_order::{OrderService, ReadOrderProjectionRequest, error::OrderError};
 use rustok_payment::{PaymentService, error::PaymentError};
 use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use uuid::Uuid;
@@ -27,6 +28,8 @@ use crate::dto::{
 const STOREFRONT_ORDER_CUSTOMER_OWNER: &str = "rustok_customer";
 const STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";
 const STOREFRONT_ORDER_CUSTOMER_BOUNDARY: &str = "commerce_storefront_order_http";
+const STOREFRONT_ORDER_OWNER: &str = "rustok_order.storefront_orders";
+const STOREFRONT_ORDER_OWNER_OPERATION: &str = "read_order_projection";
 const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
 const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
 
@@ -132,6 +135,98 @@ fn map_storefront_customer_port_error(
         }
     }
     public
+}
+
+fn storefront_order_read_port_context(
+    tenant_id: Uuid,
+    auth: &rustok_api::AuthContext,
+    request_context: &RequestContext,
+    order_id: Uuid,
+    operation: &'static str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-storefront-order:{operation}:{order_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_storefront_order_port_error(
+    error: PortError,
+    context: &PortContext,
+    operation: &'static str,
+    actor_id: Uuid,
+    customer_id: Uuid,
+    order_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_store_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_store_order_not_found",
+            "Order resource was not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_store_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_store_order_access_denied",
+            "Order does not belong to the current customer",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_order_unavailable",
+            "Order service is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_order_failed",
+            "Order operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = STOREFRONT_ORDER_OWNER,
+        owner_operation = STOREFRONT_ORDER_OWNER_OPERATION,
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        actor_id = %actor_id,
+        customer_id = %customer_id,
+        order_id = %order_id,
+        actor = ?context.actor,
+        channel = ?context.channel,
+        locale = %context.locale,
+        deadline_ms = ?context.deadline_ms,
+        internal_code = %error.code,
+        internal_message = %error.message,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = STOREFRONT_ORDER_CUSTOMER_BOUNDARY,
+        "storefront order owner read failed"
+    );
+    HttpError::new(status, code, message)
 }
 
 fn map_storefront_order_error(
@@ -326,9 +421,45 @@ async fn current_storefront_customer_id(
     }
 }
 
+async fn read_storefront_order_projection(
+    runtime: &CommerceHttpRuntime,
+    tenant_id: Uuid,
+    tenant_default_locale: &str,
+    request_context: &RequestContext,
+    auth: &rustok_api::AuthContext,
+    customer_id: Uuid,
+    order_id: Uuid,
+    operation: &'static str,
+) -> HttpResult<OrderResponse> {
+    let read_context =
+        storefront_order_read_port_context(tenant_id, auth, request_context, order_id, operation);
+    runtime
+        .order_read_port()
+        .read_order_projection(
+            read_context.clone(),
+            ReadOrderProjectionRequest {
+                order_id,
+                tenant_default_locale: Some(tenant_default_locale.to_string()),
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_storefront_order_port_error(
+                error,
+                &read_context,
+                operation,
+                auth.user_id,
+                customer_id,
+                order_id,
+            )
+        })
+}
+
 async fn ensure_customer_owns_order(
     runtime: &CommerceHttpRuntime,
     tenant_id: Uuid,
+    tenant_default_locale: &str,
+    request_context: &RequestContext,
     auth: &rustok_api::AuthContext,
     order_id: Uuid,
     operation: &'static str,
@@ -341,10 +472,17 @@ async fn ensure_customer_owns_order(
                 "Customer account required",
             )
         })?;
-    let order = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .get_order(tenant_id, order_id)
-        .await
-        .map_err(|error| map_storefront_order_error(error, operation, tenant_id, order_id))?;
+    let order = read_storefront_order_projection(
+        runtime,
+        tenant_id,
+        tenant_default_locale,
+        request_context,
+        auth,
+        customer_id,
+        order_id,
+        operation,
+    )
+    .await?;
 
     if order.customer_id != Some(customer_id) {
         return Err(HttpError::unauthorized(
@@ -418,16 +556,17 @@ pub async fn get_order(
                 "Customer account required",
             )
         })?;
-    let service = OrderService::new(runtime.db_clone(), runtime.event_bus());
-    let order = service
-        .get_order_with_locale_fallback(
-            tenant.id,
-            id,
-            request_context.locale.as_str(),
-            Some(tenant.default_locale.as_str()),
-        )
-        .await
-        .map_err(|error| map_storefront_order_error(error, "get_order", tenant.id, id))?;
+    let order = read_storefront_order_projection(
+        &runtime,
+        tenant.id,
+        tenant.default_locale.as_str(),
+        &request_context,
+        &auth,
+        customer_id,
+        id,
+        "get_order",
+    )
+    .await?;
 
     if order.customer_id != Some(customer_id) {
         return Err(HttpError::unauthorized(
@@ -462,8 +601,16 @@ pub async fn create_order_return(
 ) -> HttpResult<(StatusCode, Json<OrderReturnResponse>)> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "create_order_return_access")
-        .await?;
+    ensure_customer_owns_order(
+        &runtime,
+        tenant.id,
+        tenant.default_locale.as_str(),
+        &request_context,
+        &auth,
+        id,
+        "create_order_return_access",
+    )
+    .await?;
 
     let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .create_return(tenant.id, id, input)
@@ -499,7 +646,16 @@ pub async fn list_order_returns(
 ) -> HttpResult<Json<PaginatedResponse<OrderReturnResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_returns_access").await?;
+    ensure_customer_owns_order(
+        &runtime,
+        tenant.id,
+        tenant.default_locale.as_str(),
+        &request_context,
+        &auth,
+        id,
+        "list_order_returns_access",
+    )
+    .await?;
 
     let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_returns(
@@ -546,9 +702,16 @@ pub async fn list_order_refunds(
 ) -> HttpResult<Json<PaginatedResponse<RefundResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    let customer_id =
-        ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_refunds_access")
-            .await?;
+    let customer_id = ensure_customer_owns_order(
+        &runtime,
+        tenant.id,
+        tenant.default_locale.as_str(),
+        &request_context,
+        &auth,
+        id,
+        "list_order_refunds_access",
+    )
+    .await?;
 
     let payment_service = PaymentService::new(runtime.db_clone());
     let (items, total) = payment_service
@@ -610,7 +773,16 @@ pub async fn list_order_changes(
 ) -> HttpResult<Json<PaginatedResponse<OrderChangeResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_changes_access").await?;
+    ensure_customer_owns_order(
+        &runtime,
+        tenant.id,
+        tenant.default_locale.as_str(),
+        &request_context,
+        &auth,
+        id,
+        "list_order_changes_access",
+    )
+    .await?;
 
     let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
         .list_order_changes(

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-29",
-  "status": "graphql_request_context_scoped_unvalidated",
-  "source_base_revision": "aaa613ae4eea8358aba755fbda56b09c4d0f1373",
+  "status": "storefront_http_cutover_unvalidated",
+  "source_base_revision": "f4ff7627c93b18e7fefd8070f8bac99da7eed78b",
   "scope": "order detail and filtered list projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
@@ -46,7 +46,10 @@
     "admin_deadline_seconds": 2,
     "graphql_actor_source": "validated_auth_context_or_service_actor",
     "graphql_channel_source": "resolved_request_context_channel_slug",
-    "graphql_embedded_context_fallback": "service_actor_without_channel"
+    "graphql_embedded_context_fallback": "service_actor_without_channel",
+    "storefront_actor_source": "validated_auth_context_user",
+    "storefront_channel_source": "resolved_request_context_channel_slug",
+    "storefront_deadline_seconds": 2
   },
   "runtime_composition": {
     "type": "CommerceOrderReadRuntime",
@@ -70,25 +73,30 @@
     "core_kind": "InvariantViolation",
     "database_retryable": true,
     "core_retryable": false,
-    "admin_public_envelopes_preserved": true
+    "admin_public_envelopes_preserved": true,
+    "storefront_public_envelopes_preserved": true
   },
   "consumer_inventory": {
     "commerce_admin_rest_list_detail": "order_read_port",
     "commerce_admin_rest_cutover_completed": true,
-    "commerce_storefront_detail_and_ownership": "concrete_order_service",
+    "commerce_storefront_detail_and_ownership": "order_read_port_host_runtime",
+    "commerce_storefront_detail_and_ownership_cutover_completed": true,
     "commerce_graphql_order_list_detail": "order_read_port_host_runtime_with_request_context",
     "commerce_graphql_order_list_detail_cutover_completed": true,
     "runtime_composition_published": true,
-    "all_consumer_cutover_completed": false,
-    "cutover_required": true
+    "all_consumer_cutover_completed": true,
+    "cutover_required": false
   },
   "unchanged_scope": {
     "admin_order_mutations": "concrete_order_service",
     "admin_detail_payment_lookup": "concrete_payment_service",
-    "admin_detail_fulfillment_lookup": "concrete_fulfillment_service"
+    "admin_detail_fulfillment_lookup": "concrete_fulfillment_service",
+    "storefront_return_mutations_and_reads": "concrete_order_service",
+    "storefront_order_change_reads": "concrete_order_service",
+    "storefront_refund_reads": "concrete_payment_service"
   },
   "decision": {
-    "next_slice": "cut storefront detail and ownership reads to the host-composed order read port without changing mutations or payment and fulfillment ownership",
+    "next_slice": "publish wider owner read contracts for returns and order changes separately; execute compile, mounted parity, deadline, restart, and remote-adapter evidence before status promotion",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -54,14 +54,14 @@ and old JSON indexes must be removed after all completion/result consumers use
 typed identity exclusively.
 
 Complete order detail and filtered-list projection reads are published through
-`OrderReadPort`. `CommerceOrderReadRuntime` now carries one host-selected owner
-port through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
-GraphQL schema data. Mounted admin REST list/detail reads use the port with locale,
-channel, deadline, filters, ordering, pagination total, public error envelopes,
-and payment/fulfillment detail aggregation preserved. Mounted GraphQL detail/list
-reads consume the same host-selected runtime through resolver scope and carry an
-authenticated user actor plus host-resolved channel when present. Storefront HTTP
-order reads remain open and unvalidated.
+`OrderReadPort`. `CommerceOrderReadRuntime` carries one host-selected owner port
+through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
+GraphQL schema data. Mounted admin REST list/detail, mounted GraphQL list/detail,
+and storefront HTTP detail/ownership reads use the same port with locale fallback,
+authenticated actor, resolved channel, deadline, public error policy, filters,
+ordering, pagination total, and ownership behavior preserved. All current complete
+order projection consumers are cut over in source; runtime evidence remains
+unvalidated.
 
 ## FFA/FBA boundary
 
@@ -87,6 +87,7 @@ order reads remain open and unvalidated.
 - `scripts/verify/verify-order-admin-boundary.mjs`,
   `scripts/verify/verify-order-storefront-boundary.mjs`,
   `scripts/verify/verify-order-read-port.mjs`,
+  `scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`,
   `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`,
   `scripts/verify/verify-commerce-storefront-transport-handoff.mjs`,
   `scripts/verify/verify-commerce-order-identity-boundary.mjs`,
@@ -97,8 +98,8 @@ order reads remain open and unvalidated.
   UI, transport, projection, identity, staged-consumer, lifecycle, compensation,
   and payment settlement split.
 - No status promotion is allowed from source inspection. Clean/upgraded
-  migrations, compile/tests, contention, restart, remaining mounted consumers,
-  and remote-profile evidence remain missing.
+  migrations, compile/tests, contention, restart, and remote-profile evidence
+  remain missing.
 
 ## Checkout identity, completion, compensation, and settlement workstream
 
@@ -160,7 +161,7 @@ order reads remain open and unvalidated.
 - [x] Map every current `OrderError` variant to stable `PortError` policy without
   owner-message control flow.
 - [x] Export the canonical `in_process_order_read_port` factory.
-- [x] Retain source evidence and a focused guard without claiming runtime parity.
+- [x] Retain source evidence and focused guards without claiming runtime parity.
 - [x] Publish and host-compose `CommerceOrderReadRuntime` while preserving an
   externally installed runtime.
 - [x] Require the host-selected runtime in Commerce HTTP and GraphQL schema-data
@@ -172,7 +173,10 @@ order reads remain open and unvalidated.
   mounted resolver scope while retaining an embedded-schema in-process fallback.
 - [x] Propagate authenticated actor and request channel into GraphQL order reads;
   unauthenticated or embedded reads retain explicit service/no-channel fallback.
-- [ ] Cut storefront HTTP order detail/ownership reads over in a separate atomic change.
+- [x] Cut storefront HTTP order detail and shared ownership reads over to the
+  host-selected runtime while preserving customer resolution, locale fallback,
+  public envelopes, and the concrete return/change/payment operations that follow
+  ownership validation.
 - [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence before status promotion.
 
@@ -227,18 +231,23 @@ order reads remain open and unvalidated.
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Finish mounted order projection read cutover.** Admin REST and mounted
-   GraphQL list/detail now use the host-selected `CommerceOrderReadRuntime` with
-   authenticated actor and resolved channel context; cut storefront HTTP reads
-   separately without changing order mutations or payment/fulfillment detail
-   ownership.
-   **Depends on:** the published runtime and current public transport envelope
-   inventory.
-   **Done when:** every mounted detail/list/ownership projection read no longer
-   constructs `OrderService`, retains locale/filter/pagination/authorization
-   behavior, and has bounded parity evidence.
+7. **Prove mounted order projection read parity.** Admin REST, mounted GraphQL,
+   and storefront HTTP detail/list/ownership reads now use the host-selected
+   `CommerceOrderReadRuntime` without concrete `OrderService` projection reads.
+   **Depends on:** compiled order/commerce/server crates and mounted local plus
+   remote adapter profiles.
+   **Done when:** locale/filter/pagination/authorization/ownership behavior,
+   deadlines, stable failure policy, restart, and remote adapter parity are
+   retained as execution evidence.
 
-8. **Keep order and commerce documentation synchronized.** Update local docs,
+8. **Publish wider post-order read boundaries.** Return and order-change reads
+   still use concrete owner services after typed order ownership validation.
+   **Depends on:** explicit owner projection contracts that preserve current DTOs,
+   filters, totals, lifecycle policy, and safe error mapping.
+   **Done when:** mounted consumers no longer construct foreign owner services for
+   return/order-change reads without moving mutations or payment policy.
+
+9. **Keep order and commerce documentation synchronized.** Update local docs,
    manifests, registries, central status, and the umbrella commerce plan whenever
    order lifecycle, checkout snapshots, identity ownership, or projection read
    ownership changes.
@@ -249,6 +258,7 @@ order reads remain open and unvalidated.
 - `npm run verify:ecommerce:fba`
 - `node scripts/verify/verify-order-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-order-read-shim.mjs`
+- `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
@@ -269,7 +279,7 @@ order reads remain open and unvalidated.
 - `cargo test -p rustok-order --test checkout_order_identity_port`
 - `cargo test -p rustok-order --test checkout_completion_port`
 - Targeted order read-port detail/list, locale fallback, context, error-policy,
-  host-composition, and admin transport tests.
+  host-composition, admin, GraphQL, and storefront transport tests.
 - Targeted staged checkout completion/adoption/replay, unknown lifecycle,
   compensation, and payment settlement tests.
 - Clean/upgraded/down/reapply identity migrations on SQLite/PostgreSQL/MySQL.

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,6 +1,6 @@
 # Order read port
 
-Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over with request context, unvalidated.
+Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.
 
 ## Scope
 
@@ -14,9 +14,10 @@ needed by mounted Commerce REST and GraphQL query consumers. It is separate from
 - order lifecycle, return, and order-change mutations, which remain on existing
   order-owner commands and services.
 
-The owner boundary and host-selected runtime are now published. Mounted admin REST
-and GraphQL order list/detail reads use the port. Storefront HTTP order reads remain
-an explicit later cutover.
+The owner boundary and host-selected runtime are now published. Mounted admin REST,
+GraphQL order list/detail, and storefront HTTP order detail/ownership reads use the
+port. Current complete detail/list/ownership projection consumers are cut over in
+source; runtime evidence remains unvalidated.
 
 ## Operations
 
@@ -119,6 +120,28 @@ The mapper logs stable internal code, retryability, owner operation, correlation
 actor/channel/locale/deadline context, and route identities without copying owner
 messages into public envelopes.
 
+## Storefront HTTP cutover
+
+`GET /store/orders/{id}` and the shared customer-ownership check now call
+`read_order_projection` through `CommerceHttpRuntime.order_read_port()`.
+
+The cutover preserves:
+
+- authenticated customer resolution before order access;
+- complete `OrderResponse` detail and tenant-default locale fallback;
+- exact customer-id ownership comparison;
+- the existing customer-required and access-denied public envelopes;
+- the existing order validation, not-found, conflict, unavailable, and fail-closed
+  public codes;
+- a two-second read deadline, authenticated user actor, request locale, optional
+  host-resolved channel, and resource-scoped correlation id.
+
+The ownership helper protects storefront return creation/listing, refund listing,
+and order-change listing without constructing `OrderService` for the ownership
+projection. The subsequent return mutation/list, refund list, and order-change list
+remain on their existing concrete owner services until wider typed contracts are
+published.
+
 ## Unchanged behavior
 
 This source wave deliberately leaves these paths unchanged:
@@ -127,11 +150,14 @@ This source wave deliberately leaves these paths unchanged:
   `OrderService`;
 - admin order detail payment lookup still constructs `PaymentService`;
 - admin order detail fulfillment lookup still constructs `FulfillmentService`;
-- storefront HTTP order detail and ownership checks still construct `OrderService`;
+- storefront return creation/listing and order-change listing still construct
+  `OrderService` after typed ownership validation;
+- storefront refund listing still constructs `PaymentService` after typed ownership
+  validation;
 - return and order-change paths still require wider owner contracts.
 
 Keeping payment/fulfillment aggregation and mutations out of this cutover avoids
-claiming ownership changes beyond the two order projection reads.
+claiming ownership changes beyond complete order projection reads.
 
 ## Context and diagnostics
 
@@ -144,10 +170,9 @@ or owner-invariant details.
 
 ## Remaining source work
 
-1. cut storefront HTTP order detail and ownership checks in a separate atomic change;
-2. publish wider owner contracts before moving return/order-change reads or order
+1. publish wider owner contracts before moving return/order-change reads or order
    mutations;
-3. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
+2. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
    evidence before any status promotion.
 
 ## Evidence
@@ -156,17 +181,18 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `graphql_request_context_scoped_unvalidated`. Host composition,
-admin REST, and mounted GraphQL source cutover with actor/channel context are
-recorded as complete. Storefront HTTP consumer cutover, compile evidence, mounted
-parity, deadline/failure execution, restart, and remote-adapter evidence remain
-false or open.
+Its status is `storefront_http_cutover_unvalidated`. Host composition, admin REST,
+mounted GraphQL with actor/channel context, and storefront HTTP detail/ownership
+source cutover are recorded as complete. Compile evidence, mounted parity,
+deadline/failure execution, restart, and remote-adapter evidence remain false or
+open.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-order-read-port.mjs
 node scripts/verify/verify-commerce-graphql-order-read-shim.mjs
+node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
 node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
 cargo check -p rustok-order --lib
 cargo check -p rustok-commerce --lib

--- a/scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const runtime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const storefrontOrders = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const evidence = JSON.parse(
+  read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
+);
+const note = read('crates/rustok-order/docs/order-read-port.md');
+const orderPlan = read('crates/rustok-order/docs/implementation-plan.md');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+for (const [source, value, label] of [
+  [runtime, 'fn order_read_port(&self)', 'HTTP runtime owner port accessor'],
+  [storefrontOrders, 'fn storefront_order_read_port_context(', 'storefront read context'],
+  [storefrontOrders, 'PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
+  [storefrontOrders, 'request_context.locale.as_str()', 'request locale'],
+  [storefrontOrders, 'request_context.channel_slug.as_deref()', 'resolved channel'],
+  [storefrontOrders, '.with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
+  [storefrontOrders, 'async fn read_storefront_order_projection(', 'shared read helper'],
+  [storefrontOrders, 'runtime\n        .order_read_port()', 'host-selected owner port'],
+  [storefrontOrders, '.read_order_projection(', 'typed owner detail call'],
+  [storefrontOrders, 'ReadOrderProjectionRequest {', 'typed detail request'],
+  [storefrontOrders, 'tenant_default_locale: Some(tenant_default_locale.to_string())', 'locale fallback'],
+  [storefrontOrders, 'fn map_storefront_order_port_error(', 'safe PortError mapper'],
+  [storefrontOrders, 'internal_code = %error.code', 'stable internal diagnostics'],
+  [storefrontOrders, 'if order.customer_id != Some(customer_id)', 'ownership comparison'],
+  [note, 'Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.', 'owner note status'],
+  [orderPlan, 'storefront HTTP', 'order plan storefront checkpoint'],
+]) requireText(source, value, label);
+
+const ownershipHelper = between(
+  storefrontOrders,
+  'async fn ensure_customer_owns_order(',
+  '/// Get current storefront customer',
+  'storefront ownership helper',
+);
+const getOrderRoute = between(
+  storefrontOrders,
+  'pub async fn get_order(',
+  '/// Create a return request',
+  'storefront get-order route',
+);
+for (const [source, label] of [
+  [ownershipHelper, 'storefront ownership helper'],
+  [getOrderRoute, 'storefront get-order route'],
+]) {
+  requireText(source, 'read_storefront_order_projection(', `${label} shared owner read`);
+  forbidText(source, 'OrderService::new', `${label} concrete owner construction`);
+  forbidText(source, '.get_order(', `${label} concrete detail call`);
+  forbidText(source, '.get_order_with_locale_fallback(', `${label} concrete locale detail call`);
+}
+
+for (const [value, label] of [
+  ['.create_return(tenant.id, id, input)', 'return mutation remains owner service'],
+  ['.list_returns(', 'return list remains owner service'],
+  ['.list_order_changes(', 'order-change list remains owner service'],
+  ['PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
+]) requireText(storefrontOrders, value, label);
+
+if (evidence.status !== 'storefront_http_cutover_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership !==
+    'order_read_port_host_runtime') {
+  failures.push('storefront detail/ownership must use the host-selected order read port');
+}
+if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership_cutover_completed !== true) {
+  failures.push('storefront detail/ownership source cutover must be complete');
+}
+if (evidence.consumer_inventory?.all_consumer_cutover_completed !== true) {
+  failures.push('complete order projection consumer cutover must be recorded');
+}
+if (evidence.consumer_inventory?.cutover_required !== false) {
+  failures.push('complete order projection consumer cutover must no longer be pending');
+}
+if (evidence.context?.storefront_actor_source !== 'validated_auth_context_user') {
+  failures.push('storefront actor source mismatch');
+}
+if (evidence.context?.storefront_channel_source !== 'resolved_request_context_channel_slug') {
+  failures.push('storefront channel source mismatch');
+}
+if (evidence.errors?.storefront_public_envelopes_preserved !== true) {
+  failures.push('storefront public envelopes must be preserved');
+}
+if (evidence.decision?.status_promotion !== false) {
+  failures.push('source cutover must not promote status');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront order read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront order detail and shared ownership reads use the host-selected typed owner port while return/change/payment operations remain unchanged',
+);

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -18,6 +18,7 @@ const graphqlOrderShim = read(
 );
 const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
 const adminOrders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const storefrontOrders = read('crates/rustok-commerce/src/controllers/store/orders.rs');
 const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
 const adminFixtures = read('crates/rustok-commerce/src/controllers/admin/tests/mod.rs');
 const storefrontFixtures = read('crates/rustok-commerce/src/controllers/store/tests/mod.rs');
@@ -117,11 +118,19 @@ for (const [source, value, label] of [
   [adminOrders, 'page.total,', 'admin owner total'],
   [adminOrders, 'find_latest_collection_by_order(tenant.id, id)', 'unchanged payment aggregation'],
   [adminOrders, 'find_by_order(tenant.id, id)', 'unchanged fulfillment aggregation'],
+  [storefrontOrders, 'fn storefront_order_read_port_context(', 'storefront PortContext builder'],
+  [storefrontOrders, 'PortActor::user(auth.user_id.to_string())', 'storefront actor propagation'],
+  [storefrontOrders, 'request_context.channel_slug.as_deref()', 'storefront channel propagation'],
+  [storefrontOrders, 'async fn read_storefront_order_projection(', 'storefront shared read helper'],
+  [storefrontOrders, 'runtime\n        .order_read_port()', 'storefront host-selected port'],
+  [storefrontOrders, '.read_order_projection(', 'storefront detail port call'],
+  [storefrontOrders, 'tenant_default_locale: Some(tenant_default_locale.to_string())', 'storefront locale fallback'],
+  [storefrontOrders, 'fn map_storefront_order_port_error(', 'storefront PortError mapper'],
   [adminFixtures, 'CommerceOrderReadRuntime::in_process(', 'admin fixture runtime'],
   [storefrontFixtures, 'CommerceOrderReadRuntime::in_process(', 'storefront fixture runtime'],
   [fulfillmentFailureContract, 'CommerceOrderReadRuntime::in_process(', 'manual host fixture runtime'],
   [fulfillmentFailureContract, '.with_shared_value(event_bus.clone())', 'manual host fixture shared event bus'],
-  [note, 'Status: owner port and host runtime published; admin REST and mounted GraphQL list/detail cut over with request context, unvalidated.', 'owner note status'],
+  [note, 'Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.', 'owner note status'],
   [orderPlan, 'CommerceOrderReadRuntime', 'order plan runtime checkpoint'],
   [commercePlan, 'CommerceOrderReadRuntime', 'commerce plan runtime checkpoint'],
 ]) requireText(source, value, label);
@@ -155,14 +164,42 @@ for (const [route, label] of [
   requireText(route, 'runtime\n        .order_read_port()', `${label} injected owner port`);
 }
 
+const storefrontOwnership = between(
+  storefrontOrders,
+  'async fn ensure_customer_owns_order(',
+  '/// Get current storefront customer',
+  'storefront ownership helper',
+);
+const storefrontDetail = between(
+  storefrontOrders,
+  'pub async fn get_order(',
+  '/// Create a return request',
+  'storefront detail route',
+);
+for (const [route, label] of [
+  [storefrontOwnership, 'storefront ownership helper'],
+  [storefrontDetail, 'storefront detail route'],
+]) {
+  forbidText(route, 'OrderService::new', `${label} concrete owner construction`);
+  forbidText(route, '.get_order(', `${label} concrete detail call`);
+  forbidText(route, '.get_order_with_locale_fallback(', `${label} concrete locale detail call`);
+  requireText(route, 'read_storefront_order_projection(', `${label} shared owner read`);
+}
+
 for (const [value, label] of [
   ['.mark_paid(', 'mark-paid mutation remains owner service'],
   ['.ship_order(', 'ship mutation remains owner service'],
   ['.deliver_order(', 'deliver mutation remains owner service'],
   ['.cancel_order(', 'cancel mutation remains owner service'],
 ]) requireText(adminOrders, value, label);
+for (const [value, label] of [
+  ['.create_return(tenant.id, id, input)', 'storefront return mutation remains owner service'],
+  ['.list_returns(', 'storefront return list remains owner service'],
+  ['.list_order_changes(', 'storefront order-change list remains owner service'],
+  ['PaymentService::new(runtime.db_clone())', 'storefront refund list remains payment service'],
+]) requireText(storefrontOrders, value, label);
 
-if (evidence.status !== 'graphql_request_context_scoped_unvalidated') {
+if (evidence.status !== 'storefront_http_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.owner?.port !== 'OrderReadPort') {
@@ -201,11 +238,20 @@ if (evidence.context?.graphql_channel_source !== 'resolved_request_context_chann
 if (evidence.context?.graphql_embedded_context_fallback !== 'service_actor_without_channel') {
   failures.push('GraphQL embedded context fallback must not invent actor or channel attribution');
 }
+if (evidence.context?.storefront_actor_source !== 'validated_auth_context_user') {
+  failures.push('storefront actor source must remain validated AuthContext user');
+}
+if (evidence.context?.storefront_channel_source !== 'resolved_request_context_channel_slug') {
+  failures.push('storefront channel source must remain the resolved request channel slug');
+}
 if (evidence.errors?.owner_message_control_flow !== false) {
   failures.push('evidence must forbid owner-message control flow');
 }
 if (evidence.errors?.all_current_order_error_variants_mapped !== true) {
   failures.push('evidence must record complete current OrderError mapping');
+}
+if (evidence.errors?.storefront_public_envelopes_preserved !== true) {
+  failures.push('storefront public envelopes must be preserved');
 }
 if (evidence.consumer_inventory?.commerce_admin_rest_list_detail !== 'order_read_port') {
   failures.push('admin REST list/detail must be recorded on order_read_port');
@@ -219,14 +265,20 @@ if (evidence.consumer_inventory?.commerce_graphql_order_list_detail !== 'order_r
 if (evidence.consumer_inventory?.commerce_graphql_order_list_detail_cutover_completed !== true) {
   failures.push('GraphQL list/detail source cutover must be complete');
 }
+if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership !== 'order_read_port_host_runtime') {
+  failures.push('storefront detail/ownership must use the host-selected runtime');
+}
+if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership_cutover_completed !== true) {
+  failures.push('storefront detail/ownership source cutover must be complete');
+}
 if (evidence.consumer_inventory?.runtime_composition_published !== true) {
   failures.push('runtime composition must be published');
 }
-if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
-  failures.push('all-consumer cutover must remain incomplete');
+if (evidence.consumer_inventory?.all_consumer_cutover_completed !== true) {
+  failures.push('complete order projection consumer cutover must be recorded');
 }
-if (evidence.consumer_inventory?.cutover_required !== true) {
-  failures.push('evidence must retain pending storefront cutover');
+if (evidence.consumer_inventory?.cutover_required !== false) {
+  failures.push('complete order projection consumer cutover must no longer be pending');
 }
 if (evidence.decision?.status_promotion !== false) {
   failures.push('source cutover must not promote status');
@@ -252,5 +304,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Order read runtime is host-composed and admin REST plus mounted GraphQL list/detail use typed owner ports with validated actor and resolved channel context while storefront and runtime evidence remain pending',
+  '✔ Order read runtime is host-composed and admin REST, mounted GraphQL, and storefront detail/ownership use typed owner ports while runtime evidence remains pending',
 );


### PR DESCRIPTION
## Summary
- route storefront `GET /store/orders/{id}` through the host-composed `OrderReadPort`
- route the shared customer-ownership check used by returns, refunds, and order changes through the same typed owner projection
- preserve validated user actor, resolved request channel, locale fallback, two-second deadline, customer ownership policy, and existing public HTTP envelopes
- leave return mutation/listing, order-change listing, and payment refund listing on their current concrete owner services
- synchronize the ecommerce master plan, order owner plan/documentation, source evidence, and static guards

## Recheck
- confirmed storefront order detail still constructed `OrderService` for locale-aware detail
- confirmed the shared ownership helper constructed `OrderService` and gates return, refund, and order-change endpoints
- confirmed `CommerceHttpRuntime` already exposes the host-selected `OrderReadPort`
- rebased the final one-commit branch onto current `main`; it is not behind and contains exactly seven target files

## Remaining work
- publish wider typed owner read contracts for storefront returns and order changes without moving mutations or payment policy
- execute compile, mounted parity, deadline/failure, restart, and remote-adapter evidence before status promotion

## Verification
Not run per maintainer instruction. Tests, Cargo commands, formatting, verifiers, workflow checks, and CI are not claimed as implementation evidence.