### PR TITLE
feat(index): admit PostgreSQL query equivalence bundles

### DIFF
--- a/crates/rustok-index/docs/m4-postgres-reference-equivalence.md
+++ b/crates/rustok-index/docs/m4-postgres-reference-equivalence.md
@@ -1,26 +1,29 @@
-# M4 PostgreSQL/reference equivalence fixture and capture
+# M4 PostgreSQL/reference equivalence fixture, capture, and admission
 
 Date: 2026-07-29
 
-Status: `fixture_and_capture_source_complete_owner_execution_pending`
+Status: `fixture_capture_and_admission_source_complete_owner_execution_pending`
 
-This slice provides both the owner-run PostgreSQL regression fixture for the M4
-structured query engine and a separate retained capture command. The fixture compares
-the production PostgreSQL query path with an independent in-memory reference
-materialization built from the same validated `IndexRecord` contracts. The capture
-command binds one successful fixture execution to an exact clean Git commit,
-PostgreSQL identity, scenario contract, and retained stdout/stderr bytes.
+This M4 evidence chain now has three bounded source components:
 
-Neither source path was executed by the implementation agent. Live equivalence evidence
-remains an explicit repository-owner action.
+1. an owner-run PostgreSQL regression fixture that compares the production query path
+   with an independent in-memory reference materialization;
+2. a retained capture command that binds one successful fixture run to an exact clean
+   Git commit, PostgreSQL identity, scenario contract, and exact stdout/stderr bytes;
+3. a read-only admission command that reviews the immutable three-file bundle and emits
+   a separate no-clobber receipt.
+
+None of these commands were executed by the implementation agent. Live equivalence
+execution and admission remain explicit repository-owner actions.
 
 ## Fixture execution boundary
 
-The test runs only when `RUSTOK_INDEX_TEST_DATABASE_URL`, or the repository-wide
-`DATABASE_URL` fallback, contains a PostgreSQL URL. Without one, it prints an explicit
-skip message and succeeds without connecting to a database.
+The fixture runs only when `RUSTOK_INDEX_TEST_DATABASE_URL`, or the repository-wide
+`DATABASE_URL` fallback, contains a PostgreSQL URL. Without one it prints an explicit
+skip marker and succeeds without connecting to PostgreSQL. The retained capture rejects
+that skipped-success path.
 
-Each fixture run:
+Each real fixture run:
 
 1. creates a uniquely named PostgreSQL schema;
 2. sets a single-connection search path to that schema;
@@ -30,7 +33,8 @@ Each fixture run:
 5. persists schemas through `PostgresSchemaRegistrationStore`;
 6. writes records and relation ordinals through `PostgresMutationStore`;
 7. executes structured queries through `PostgresIndexQueryPort`;
-8. drops the isolated schema after successful comparison.
+8. compares the complete `IndexQueryPage` with an independent reference page;
+9. drops the isolated schema after successful comparison.
 
 The fixture does not write `index_schemas`, `index_entities`, or `index_links` directly,
 and it does not introduce Testcontainers or a second database stack.
@@ -51,24 +55,9 @@ query it independently evaluates:
 - grouped many-link projection items with complete identity chains and aligned values;
 - deterministic next-cursor construction.
 
-The assertion compares the complete `IndexQueryPage`, not only root IDs or row counts.
-
-## Retained scenarios
-
-The source fixture covers:
-
-- root filtering, descending typed ordering, exact count, first-page lookahead, and a
-  second scoped-cursor page;
-- one-link filtering and projection;
-- many-link `Gte`, `Contains`, and reference-compatible `Ne` combined with nested
-  projection aggregation;
-- many-link `IsNull` over empty and mixed reachable values;
-- bounded offset ordering and lookahead.
-
-The records intentionally include a many-link path with both a non-null and a tagged-null
-child value, a blocked child, an empty relation, ordered relation targets, and two
-one-link targets. This makes null totality, independent atomic `EXISTS` branches,
-relation ordering, duplicate-free count, and nested alignment observable.
+The source scenarios cover descending root ordering and cursor continuation, one-link
+filtering/projection, many-link `Gte`/`Contains`/`Ne`/`IsNull`, nested relation alignment,
+and bounded offset lookahead.
 
 ## Retained capture command
 
@@ -76,58 +65,90 @@ relation ordering, duplicate-free count, and nested alignment observable.
 production runtime. It requires explicit `INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1` and
 refuses to publish unless all of the following are true:
 
-- the configured workspace is a Git checkout with an exact 40-character lowercase
-  `INDEX_QUERY_EQUIVALENCE_COMMIT` at `HEAD`;
-- the worktree is clean before and after the cargo subprocess;
+- the workspace is a clean Git checkout at the exact configured 40-character lowercase
+  commit before and after the subprocess;
 - PostgreSQL reports version 16, a numeric `system_identifier`, and a non-empty database
-  name;
-- the exact `postgres_query_port_matches_reference_fixture` cargo test exits successfully;
+  name before and after execution;
+- exactly `postgres_query_port_matches_reference_fixture` exits successfully through one
+  test thread;
 - output names the required fixture, reports one passed test, and does not contain the
-  fixture's skip marker;
-- stdout and stderr are each at most 2 MiB;
-- PostgreSQL identity is unchanged after the fixture exits.
+  fixture skip marker;
+- stdout and stderr are each at most 2 MiB.
 
-The capture retains a descriptor-last no-clobber bundle:
+The capture publishes a fresh descriptor-last no-clobber bundle:
 
 - `stdout.log` — exact cargo/test stdout;
 - `stderr.log` — exact cargo/test stderr;
 - `equivalence.json` — contract version, completion time, repository/commit/run key,
-  runner identity, PostgreSQL identity, exact command, fixed scenario names and scenario
+  capture runner identity, PostgreSQL identity, exact command, fixed scenario names and
   digest, exit code, byte counts, and SHA-256 hashes of both logs.
 
-The output root must not already exist. Files are created with create-new semantics and
-the descriptor is published last, so a bundle without `equivalence.json` is incomplete
-and must not be admitted. The descriptor does not retain the PostgreSQL URL, credentials,
-or arbitrary environment values.
+The output root must not already exist. Files use create-new semantics and the descriptor
+is published last. The descriptor does not retain the PostgreSQL URL, credentials,
+workspace path, or arbitrary environment values.
+
+## Read-only admission command
+
+`index-query-equivalence-admission` also lives under `ops/benches` and requires explicit
+`INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION=1`. It does not connect to PostgreSQL and does
+not execute Cargo or the fixture. Instead it requires expected repository, commit, and
+run key values supplied independently by the reviewer.
+
+Admission fails closed unless:
+
+- the bundle root is an existing regular non-symlink directory;
+- its exact inventory is `equivalence.json`, `stderr.log`, and `stdout.log`, with no
+  aliases, subdirectories, symlinks, or extra files;
+- the capture descriptor has no unknown fields and matches the capture v1 contract;
+- repository, clean commit, run key, PostgreSQL 16 identity, runner identity, exact test
+  command, six scenario names, and scenario digest all match the admitted contract;
+- descriptor byte counts and SHA-256 hashes match the retained log bytes;
+- retained UTF-8 output proves one successful fixture and contains no skip marker;
+- inventory and all three files remain byte-identical across the full review.
+
+The receipt parent must already exist and must be a regular non-symlink directory. The
+receipt must be outside the immutable bundle and is created with no-clobber semantics.
+It records `admitted: true` and `production_lifecycle_authorized: false`, source and
+PostgreSQL identity, execution contract, exact inventory and artifact hashes, capture
+runner provenance, and reviewer runner provenance.
+
+A successful receipt admits only that exact equivalence bundle. It does not authorize
+production partition lifecycle changes, consumer cutover, or any other deployment.
 
 ## Required environment
 
-- `INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1` — explicit execution and publication opt-in;
-- `RUSTOK_INDEX_TEST_DATABASE_URL` or `DATABASE_URL` — PostgreSQL connection used by the
-  capture identity query and fixture;
-- `INDEX_QUERY_EQUIVALENCE_COMMIT` — exact clean checkout commit;
-- `INDEX_QUERY_EQUIVALENCE_RUN_KEY` — stable 1–128 byte ASCII run identity;
-- optional `INDEX_QUERY_EQUIVALENCE_OUTPUT_ROOT` — fresh bundle path, defaulting to
-  `target/index-query-equivalence/<run-key>`;
-- optional `INDEX_QUERY_EQUIVALENCE_REPOSITORY`, workspace root, cargo executable, and job
-  metadata overrides.
+Capture:
+
+- `INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1`;
+- `RUSTOK_INDEX_TEST_DATABASE_URL` or `DATABASE_URL`;
+- `INDEX_QUERY_EQUIVALENCE_COMMIT`;
+- `INDEX_QUERY_EQUIVALENCE_RUN_KEY`;
+- optional output root, repository, workspace, cargo executable, and job metadata.
+
+Admission:
+
+- `INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION=1`;
+- `INDEX_QUERY_EQUIVALENCE_BUNDLE`;
+- `INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT`;
+- `INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY`;
+- optional expected repository, receipt output path, and reviewer job metadata.
 
 ## Non-claims
 
 This source does not:
 
-- claim that PostgreSQL/reference equivalence has been executed;
-- admit or archive a retained bundle;
+- claim that PostgreSQL/reference equivalence has been executed or admitted;
+- modify or archive the immutable capture bundle;
 - add many-link aggregate ordering;
 - compose the query port into server/storefront/admin/search consumers;
-- authorize callers;
+- publish a source-owned schema-registry composition contract;
 - change production planner, compiler, decoder, query-port, migration, or mutation
   behavior;
 - authorize production partition lifecycle work.
 
-The plan/SQL snapshots, fixture, and capture command are source complete. The combined M4
-roadmap item remains open until the repository owner runs the capture, reviews the
-retained bundle, and records admission/provenance.
+The plan/SQL snapshots, fixture, capture, and admission review are source complete. The
+combined M4 roadmap item remains open until the repository owner runs the capture,
+reviews it through admission, and retains the resulting bundle and receipt.
 
 ## Owner validation
 
@@ -145,10 +166,19 @@ INDEX_QUERY_EQUIVALENCE_COMMIT=<40-char-head-commit> \
 INDEX_QUERY_EQUIVALENCE_RUN_KEY=<stable-run-key> \
   cargo run -p rustok-benchmarks --bin index-query-equivalence-capture
 
+INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION=1 \
+INDEX_QUERY_EQUIVALENCE_BUNDLE=<fresh-capture-root> \
+INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT=<40-char-head-commit> \
+INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY=<stable-run-key> \
+INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT=<existing-parent>/equivalence-admission.json \
+  cargo run -p rustok-benchmarks --bin index-query-equivalence-admission
+
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs
+node scripts/verify/verify-index-query-equivalence-admission.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
+cargo check -p rustok-benchmarks --bin index-query-equivalence-admission
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -13,6 +13,12 @@ detection. The repository owner still needs to execute and admit one fresh real
 PostgreSQL partition packet. That owner gate blocks production partition lifecycle
 design but does not block M4 query source work.
 
+Server composition was also rechecked. `PostgresIndexQueryPort` requires one immutable
+source-owned `SchemaRegistry`; the server currently has no published source registry
+contract from which to compose that value. Building a host runtime from an empty or
+tenant-derived registry would be a false cutover, so server/consumer composition remains
+open until a source-owned registry boundary exists.
+
 ## Actualized status
 
 - M3 real retained PostgreSQL packet execution: `open_owner_action`.
@@ -27,6 +33,7 @@ design but does not block M4 query source work.
 - M4 retained plan/SQL snapshots: `source_complete_owner_execution_pending`.
 - M4 PostgreSQL/reference fixture source: `source_complete_owner_execution_pending`.
 - M4 retained PostgreSQL/reference capture source: `source_complete_owner_execution_pending`.
+- M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -110,28 +117,32 @@ one-link filtering/projection, many-link `Gte`/`Contains`/`Ne`/`IsNull`, and nes
 identity/value alignment. The fixture is env-gated and has not been run by the
 implementation agent.
 
-## Retained equivalence capture
+## Retained equivalence capture and admission
 
-`index-query-equivalence-capture` is an owner-operated `ops/benches` binary. It requires
-an explicit opt-in, exact clean checkout commit, stable run key, and PostgreSQL 16. It
-runs only the merged fixture, rejects skipped-test success, rechecks source and database
-identity after execution, and publishes a fresh descriptor-last bundle containing exact
-stdout/stderr plus hashes and provenance. The PostgreSQL URL and credentials are not
-serialized.
+`index-query-equivalence-capture` requires explicit opt-in, an exact clean checkout
+commit, stable run key, and PostgreSQL 16. It runs only the merged fixture, rejects
+skipped-test success, rechecks source and database identity, and publishes a fresh
+three-file descriptor-last bundle containing exact stdout/stderr plus hashes and
+provenance. The PostgreSQL URL and credentials are not serialized.
 
-The capture command is source complete but has not been run. Its bundle is not admitted
-merely because the command exits successfully; the repository owner still reviews the
-three-file inventory, descriptor, commit, database identity, and log hashes.
+`index-query-equivalence-admission` performs no Cargo or database execution. It reads the
+immutable bundle, requires independent expected source identity, rejects unknown
+descriptor fields, aliases, symlinks, extras, hash drift, command/scenario drift,
+skipped output, and mid-review byte changes, then creates one no-clobber receipt outside
+the bundle. The receipt records `production_lifecycle_authorized: false`.
+
+Both tools are source complete but have not been run. A capture exit alone does not admit
+the bundle; an admission receipt alone does not authorize deployment or partition work.
 
 ## Remaining bounded M4 work
 
-The canonical checklist remains open until the owner runs the fixture through the
-capture command and retains live PostgreSQL/reference evidence. Additional boundaries
+The canonical checklist remains open until the owner runs the fixture through capture,
+admits the retained bundle, and preserves both bundle and receipt. Additional boundaries
 remain:
 
 - aggregate ordering semantics for paths traversing `many`;
-- server/storefront/admin/search query-port composition and consumer cutover;
-- owner review and admission of one retained live equivalence bundle.
+- a source-owned immutable registry contract for server composition;
+- server/storefront/admin/search query-port composition and consumer cutover.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.
@@ -155,8 +166,15 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
 INDEX_QUERY_EQUIVALENCE_COMMIT=<40-char-head-commit> \
 INDEX_QUERY_EQUIVALENCE_RUN_KEY=<stable-run-key> \
   cargo run -p rustok-benchmarks --bin index-query-equivalence-capture
+INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION=1 \
+INDEX_QUERY_EQUIVALENCE_BUNDLE=<fresh-capture-root> \
+INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT=<40-char-head-commit> \
+INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY=<stable-run-key> \
+INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT=<existing-parent>/equivalence-admission.json \
+  cargo run -p rustok-benchmarks --bin index-query-equivalence-admission
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
+cargo check -p rustok-benchmarks --bin index-query-equivalence-admission
 node scripts/verify/verify-index-query-contract.mjs
 node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -165,5 +183,6 @@ node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-query-snapshots.mjs
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs
+node scripts/verify/verify-index-query-equivalence-admission.mjs
 cargo xtask module validate index
 ```

--- a/ops/benches/Cargo.toml
+++ b/ops/benches/Cargo.toml
@@ -70,6 +70,10 @@ path = "src/bin/index_partition_capture_finalize.rs"
 name = "index-query-equivalence-capture"
 path = "src/bin/index_query_equivalence_capture.rs"
 
+[[bin]]
+name = "index-query-equivalence-admission"
+path = "src/bin/index_query_equivalence_admission.rs"
+
 [[bench]]
 name = "tenant_cache"
 harness = false

--- a/ops/benches/src/bin/index_query_equivalence_admission.rs
+++ b/ops/benches/src/bin/index_query_equivalence_admission.rs
@@ -1,0 +1,15 @@
+use rustok_benchmarks::index_storage::{
+    QueryEquivalenceAdmissionConfig, admit_query_equivalence_bundle,
+};
+
+fn main() -> anyhow::Result<()> {
+    let config = QueryEquivalenceAdmissionConfig::from_env()?;
+    let admission = admit_query_equivalence_bundle(&config)?;
+    println!(
+        "index query equivalence admission complete: commit={} run_key={} output={}",
+        admission.commit,
+        admission.run_key,
+        admission.output_path.display(),
+    );
+    Ok(())
+}

--- a/ops/benches/src/index_storage/mod.rs
+++ b/ops/benches/src/index_storage/mod.rs
@@ -10,6 +10,7 @@ mod partition_maintenance;
 mod partition_mutation;
 mod partition_query;
 mod partition_snapshot;
+mod query_equivalence_admission;
 mod query_equivalence_capture;
 mod report_provenance;
 mod runner;
@@ -42,6 +43,9 @@ pub use partition_query::{
 pub use partition_snapshot::{
     BaselineSnapshot, PartitionSnapshotCapture, PartitionSnapshotConfig, RelationEvidence,
     ShadowRelationEvidence, ShadowSnapshot, TenantPredicateAudit, capture_partition_snapshot,
+};
+pub use query_equivalence_admission::{
+    QueryEquivalenceAdmission, QueryEquivalenceAdmissionConfig, admit_query_equivalence_bundle,
 };
 pub use query_equivalence_capture::{
     QueryEquivalenceCapture, QueryEquivalenceCaptureConfig, capture_query_equivalence,

--- a/ops/benches/src/index_storage/query_equivalence_admission.rs
+++ b/ops/benches/src/index_storage/query_equivalence_admission.rs
@@ -1,0 +1,602 @@
+use std::{
+    collections::BTreeSet,
+    env,
+    fs::{self, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const CAPTURE_CONTRACT: &str = "index_query_equivalence_capture_v1";
+const ADMISSION_CONTRACT: &str = "index_query_equivalence_admission_v1";
+const ADMISSION_OPT_IN: &str = "INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION";
+const BUNDLE_ENV: &str = "INDEX_QUERY_EQUIVALENCE_BUNDLE";
+const OUTPUT_ENV: &str = "INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT";
+const REPOSITORY_ENV: &str = "INDEX_QUERY_EQUIVALENCE_EXPECTED_REPOSITORY";
+const COMMIT_ENV: &str = "INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT";
+const RUN_KEY_ENV: &str = "INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY";
+const DESCRIPTOR_FILE: &str = "equivalence.json";
+const STDOUT_FILE: &str = "stdout.log";
+const STDERR_FILE: &str = "stderr.log";
+const MAX_DESCRIPTOR_BYTES: usize = 256 * 1024;
+const MAX_LOG_BYTES: usize = 2 * 1024 * 1024;
+const TEST_PACKAGE: &str = "rustok-index";
+const TEST_FILTER: &str = "postgres_query_port_matches_reference_fixture";
+const SKIP_MARKER: &str = "skipping rustok-index PostgreSQL/reference equivalence";
+const EXPECTED_COMMAND_ARGS: [&str; 7] = [
+    "test",
+    "-p",
+    TEST_PACKAGE,
+    TEST_FILTER,
+    "--",
+    "--nocapture",
+    "--test-threads=1",
+];
+const SCENARIOS: [&str; 6] = [
+    "root_filter_desc_keyset_first_page",
+    "root_filter_desc_keyset_continuation",
+    "one_link_projection_and_filter",
+    "many_link_filter_and_nested_projection",
+    "many_link_is_null_totality",
+    "bounded_offset_ordering",
+];
+const INVENTORY: [&str; 3] = [DESCRIPTOR_FILE, STDERR_FILE, STDOUT_FILE];
+
+#[derive(Debug, Clone)]
+pub struct QueryEquivalenceAdmissionConfig {
+    pub bundle_root: PathBuf,
+    pub output_path: PathBuf,
+    pub expected_repository: String,
+    pub expected_commit: String,
+    pub expected_run_key: String,
+}
+
+impl QueryEquivalenceAdmissionConfig {
+    pub fn from_env() -> Result<Self> {
+        ensure!(
+            matches!(env::var(ADMISSION_OPT_IN).as_deref(), Ok("1")),
+            "{ADMISSION_OPT_IN}=1 is required because this command emits an equivalence admission receipt"
+        );
+        let bundle_root = env::var(BUNDLE_ENV)
+            .map(PathBuf::from)
+            .context(format!("{BUNDLE_ENV} is required"))?;
+        let bundle_root = absolute_path(bundle_root)?;
+        let expected_repository = env::var(REPOSITORY_ENV)
+            .unwrap_or_else(|_| "RusTokRs/RusTok".to_owned());
+        validate_repository(&expected_repository)?;
+        let expected_commit = env::var(COMMIT_ENV)
+            .context(format!("{COMMIT_ENV} is required"))?;
+        ensure!(
+            is_lower_hex_commit(&expected_commit),
+            "{COMMIT_ENV} must be a 40-character lowercase Git commit"
+        );
+        let expected_run_key = env::var(RUN_KEY_ENV)
+            .context(format!("{RUN_KEY_ENV} is required"))?;
+        validate_run_key(&expected_run_key)?;
+        let output_path = env::var(OUTPUT_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                bundle_root
+                    .parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .join(format!("{}-admission.json", expected_run_key))
+            });
+        let output_path = absolute_path(output_path)?;
+
+        Ok(Self {
+            bundle_root,
+            output_path,
+            expected_repository,
+            expected_commit,
+            expected_run_key,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CaptureSourceIdentity {
+    repository: String,
+    commit: String,
+    run_key: String,
+    clean_worktree: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CaptureRunnerIdentity {
+    job: String,
+    runner_os: String,
+    runner_arch: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CaptureDatabaseIdentity {
+    version: String,
+    server_version_num: String,
+    system_identifier: String,
+    database_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CaptureArtifact {
+    path: String,
+    bytes: usize,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CaptureExecution {
+    package: String,
+    test_filter: String,
+    command: Vec<String>,
+    scenarios: Vec<String>,
+    scenario_contract_sha256: String,
+    exit_code: i32,
+    skipped: bool,
+    stdout: CaptureArtifact,
+    stderr: CaptureArtifact,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CaptureDescriptor {
+    contract: String,
+    completed_at: DateTime<Utc>,
+    source: CaptureSourceIdentity,
+    runner: CaptureRunnerIdentity,
+    database: CaptureDatabaseIdentity,
+    execution: CaptureExecution,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AdmissionArtifact {
+    path: String,
+    bytes: usize,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AdmissionBundle {
+    inventory: Vec<String>,
+    descriptor: AdmissionArtifact,
+    stdout: AdmissionArtifact,
+    stderr: AdmissionArtifact,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AdmissionExecution {
+    package: String,
+    test_filter: String,
+    command: Vec<String>,
+    scenarios: Vec<String>,
+    scenario_contract_sha256: String,
+    exit_code: i32,
+    skipped: bool,
+    captured_at: DateTime<Utc>,
+    capture_job: String,
+    capture_runner_os: String,
+    capture_runner_arch: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AdmissionReviewer {
+    job: String,
+    runner_os: String,
+    runner_arch: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AdmissionReceipt {
+    contract: &'static str,
+    reviewed_at: DateTime<Utc>,
+    admitted: bool,
+    production_lifecycle_authorized: bool,
+    source: CaptureSourceIdentity,
+    database: CaptureDatabaseIdentity,
+    execution: AdmissionExecution,
+    bundle: AdmissionBundle,
+    reviewer: AdmissionReviewer,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryEquivalenceAdmission {
+    pub commit: String,
+    pub run_key: String,
+    pub output_path: PathBuf,
+}
+
+pub fn admit_query_equivalence_bundle(
+    config: &QueryEquivalenceAdmissionConfig,
+) -> Result<QueryEquivalenceAdmission> {
+    let canonical_bundle = validate_bundle_root(&config.bundle_root)?;
+    let output_path = resolve_output_path(&config.output_path)?;
+    ensure!(
+        !output_path.starts_with(&canonical_bundle),
+        "query equivalence admission receipt must be outside the immutable bundle"
+    );
+    ensure_output_absent(&output_path)?;
+
+    let inventory_before = read_inventory(&canonical_bundle)?;
+    ensure!(
+        inventory_before == expected_inventory(),
+        "query equivalence bundle inventory mismatch: expected {:?}, got {:?}",
+        expected_inventory(),
+        inventory_before
+    );
+
+    let descriptor_bytes = read_stable_regular_file(
+        &canonical_bundle.join(DESCRIPTOR_FILE),
+        MAX_DESCRIPTOR_BYTES,
+        "equivalence descriptor",
+    )?;
+    let stdout = read_stable_regular_file(
+        &canonical_bundle.join(STDOUT_FILE),
+        MAX_LOG_BYTES,
+        "equivalence stdout",
+    )?;
+    let stderr = read_stable_regular_file(
+        &canonical_bundle.join(STDERR_FILE),
+        MAX_LOG_BYTES,
+        "equivalence stderr",
+    )?;
+    let descriptor: CaptureDescriptor = serde_json::from_slice(&descriptor_bytes)
+        .context("failed to decode retained query equivalence descriptor")?;
+
+    validate_descriptor(config, &descriptor, &stdout, &stderr)?;
+
+    let inventory_after = read_inventory(&canonical_bundle)?;
+    ensure!(
+        inventory_after == inventory_before,
+        "query equivalence bundle inventory drifted during admission review"
+    );
+    ensure!(
+        read_stable_regular_file(
+            &canonical_bundle.join(DESCRIPTOR_FILE),
+            MAX_DESCRIPTOR_BYTES,
+            "equivalence descriptor reread",
+        )? == descriptor_bytes,
+        "query equivalence descriptor changed during admission review"
+    );
+    ensure!(
+        read_stable_regular_file(
+            &canonical_bundle.join(STDOUT_FILE),
+            MAX_LOG_BYTES,
+            "equivalence stdout reread",
+        )? == stdout,
+        "query equivalence stdout changed during admission review"
+    );
+    ensure!(
+        read_stable_regular_file(
+            &canonical_bundle.join(STDERR_FILE),
+            MAX_LOG_BYTES,
+            "equivalence stderr reread",
+        )? == stderr,
+        "query equivalence stderr changed during admission review"
+    );
+
+    let receipt = AdmissionReceipt {
+        contract: ADMISSION_CONTRACT,
+        reviewed_at: Utc::now(),
+        admitted: true,
+        production_lifecycle_authorized: false,
+        source: descriptor.source.clone(),
+        database: descriptor.database.clone(),
+        execution: AdmissionExecution {
+            package: descriptor.execution.package.clone(),
+            test_filter: descriptor.execution.test_filter.clone(),
+            command: descriptor.execution.command.clone(),
+            scenarios: descriptor.execution.scenarios.clone(),
+            scenario_contract_sha256: descriptor.execution.scenario_contract_sha256.clone(),
+            exit_code: descriptor.execution.exit_code,
+            skipped: descriptor.execution.skipped,
+            captured_at: descriptor.completed_at,
+            capture_job: descriptor.runner.job,
+            capture_runner_os: descriptor.runner.runner_os,
+            capture_runner_arch: descriptor.runner.runner_arch,
+        },
+        bundle: AdmissionBundle {
+            inventory: INVENTORY.iter().map(|value| (*value).to_owned()).collect(),
+            descriptor: artifact(DESCRIPTOR_FILE, &descriptor_bytes),
+            stdout: artifact(STDOUT_FILE, &stdout),
+            stderr: artifact(STDERR_FILE, &stderr),
+        },
+        reviewer: AdmissionReviewer {
+            job: first_non_empty_env(
+                &["INDEX_QUERY_EQUIVALENCE_ADMISSION_JOB", "GITHUB_JOB"],
+                "index-query-equivalence-admission",
+            ),
+            runner_os: first_non_empty_env(&["RUNNER_OS"], env::consts::OS),
+            runner_arch: first_non_empty_env(&["RUNNER_ARCH"], env::consts::ARCH),
+        },
+    };
+    publish_receipt(&output_path, &receipt)?;
+
+    Ok(QueryEquivalenceAdmission {
+        commit: descriptor.source.commit,
+        run_key: descriptor.source.run_key,
+        output_path,
+    })
+}
+
+fn validate_descriptor(
+    config: &QueryEquivalenceAdmissionConfig,
+    descriptor: &CaptureDescriptor,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<()> {
+    ensure!(
+        descriptor.contract == CAPTURE_CONTRACT,
+        "unexpected query equivalence capture contract: {}",
+        descriptor.contract
+    );
+    ensure!(
+        descriptor.source.repository == config.expected_repository,
+        "query equivalence repository mismatch"
+    );
+    ensure!(
+        descriptor.source.commit == config.expected_commit,
+        "query equivalence commit mismatch"
+    );
+    ensure!(
+        descriptor.source.run_key == config.expected_run_key,
+        "query equivalence run key mismatch"
+    );
+    ensure!(
+        descriptor.source.clean_worktree,
+        "query equivalence capture was not bound to a clean worktree"
+    );
+    ensure!(
+        is_lower_hex_commit(&descriptor.source.commit),
+        "captured query equivalence commit is not canonical lowercase hex"
+    );
+    validate_database(&descriptor.database)?;
+    ensure!(
+        !descriptor.runner.job.trim().is_empty()
+            && !descriptor.runner.runner_os.trim().is_empty()
+            && !descriptor.runner.runner_arch.trim().is_empty(),
+        "query equivalence capture runner identity is incomplete"
+    );
+
+    let execution = &descriptor.execution;
+    ensure!(execution.package == TEST_PACKAGE, "unexpected test package");
+    ensure!(execution.test_filter == TEST_FILTER, "unexpected test filter");
+    ensure!(execution.exit_code == 0, "captured fixture did not exit successfully");
+    ensure!(!execution.skipped, "captured fixture is marked skipped");
+    ensure!(
+        execution.command.len() == EXPECTED_COMMAND_ARGS.len() + 1
+            && !execution.command[0].trim().is_empty()
+            && execution.command[1..]
+                == EXPECTED_COMMAND_ARGS.map(str::to_owned),
+        "captured equivalence command does not match the admitted command contract"
+    );
+    let expected_scenarios = SCENARIOS.map(str::to_owned);
+    ensure!(
+        execution.scenarios == expected_scenarios,
+        "captured equivalence scenarios do not match the admitted scenario contract"
+    );
+    ensure!(
+        execution.scenario_contract_sha256 == sha256_json(&SCENARIOS)?,
+        "captured equivalence scenario digest mismatch"
+    );
+    validate_artifact_descriptor(&execution.stdout, STDOUT_FILE, stdout)?;
+    validate_artifact_descriptor(&execution.stderr, STDERR_FILE, stderr)?;
+
+    let stdout_text = std::str::from_utf8(stdout)
+        .context("retained query equivalence stdout is not UTF-8")?;
+    let stderr_text = std::str::from_utf8(stderr)
+        .context("retained query equivalence stderr is not UTF-8")?;
+    let combined = format!("{stdout_text}\n{stderr_text}");
+    ensure!(
+        combined.contains(TEST_FILTER),
+        "retained output does not name the required equivalence fixture"
+    );
+    ensure!(
+        combined.contains("test result: ok.") && combined.contains("1 passed; 0 failed"),
+        "retained output does not prove exactly one successful equivalence fixture"
+    );
+    ensure!(
+        !combined.contains(SKIP_MARKER),
+        "retained output proves the PostgreSQL equivalence fixture was skipped"
+    );
+    Ok(())
+}
+
+fn validate_artifact_descriptor(
+    descriptor: &CaptureArtifact,
+    expected_path: &str,
+    bytes: &[u8],
+) -> Result<()> {
+    ensure!(descriptor.path == expected_path, "retained artifact path mismatch");
+    ensure!(descriptor.bytes == bytes.len(), "retained artifact byte count mismatch");
+    ensure!(
+        descriptor.sha256 == sha256_bytes(bytes),
+        "retained artifact SHA-256 mismatch"
+    );
+    Ok(())
+}
+
+fn validate_database(identity: &CaptureDatabaseIdentity) -> Result<()> {
+    ensure!(
+        identity.server_version_num.starts_with("16"),
+        "query equivalence admission requires PostgreSQL 16"
+    );
+    ensure!(!identity.version.trim().is_empty(), "PostgreSQL version is empty");
+    ensure!(
+        !identity.system_identifier.is_empty()
+            && identity.system_identifier.bytes().all(|byte| byte.is_ascii_digit()),
+        "PostgreSQL system identifier must contain only digits"
+    );
+    ensure!(
+        !identity.database_name.trim().is_empty(),
+        "PostgreSQL database name is empty"
+    );
+    Ok(())
+}
+
+fn validate_bundle_root(path: &Path) -> Result<PathBuf> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("query equivalence bundle does not exist: {path:?}"))?;
+    ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "query equivalence bundle must be a regular non-symlink directory"
+    );
+    path.canonicalize()
+        .with_context(|| format!("failed to canonicalize query equivalence bundle {path:?}"))
+}
+
+fn read_inventory(root: &Path) -> Result<BTreeSet<String>> {
+    let mut inventory = BTreeSet::new();
+    for entry in fs::read_dir(root)
+        .with_context(|| format!("failed to list query equivalence bundle {root:?}"))?
+    {
+        let entry = entry?;
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("query equivalence bundle contains a non-UTF-8 name"))?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        ensure!(
+            metadata.is_file() && !metadata.file_type().is_symlink(),
+            "query equivalence bundle entry must be a regular non-symlink file: {name}"
+        );
+        ensure!(inventory.insert(name.clone()), "duplicate bundle entry: {name}");
+    }
+    Ok(inventory)
+}
+
+fn expected_inventory() -> BTreeSet<String> {
+    INVENTORY.iter().map(|value| (*value).to_owned()).collect()
+}
+
+fn read_stable_regular_file(path: &Path, max_bytes: usize, label: &str) -> Result<Vec<u8>> {
+    let before = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {label} {path:?}"))?;
+    ensure!(
+        before.is_file() && !before.file_type().is_symlink(),
+        "{label} must be a regular non-symlink file"
+    );
+    ensure!(before.len() <= max_bytes as u64, "{label} exceeds retained size limit");
+    let first = fs::read(path).with_context(|| format!("failed to read {label} {path:?}"))?;
+    let second = fs::read(path).with_context(|| format!("failed to reread {label} {path:?}"))?;
+    let after = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to re-inspect {label} {path:?}"))?;
+    ensure!(
+        before.len() == after.len() && first == second,
+        "{label} changed while it was being reviewed"
+    );
+    Ok(first)
+}
+
+fn resolve_output_path(path: &Path) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create admission receipt parent {parent:?}"))?;
+    let metadata = fs::symlink_metadata(parent)
+        .with_context(|| format!("failed to inspect admission receipt parent {parent:?}"))?;
+    ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "admission receipt parent must be a regular non-symlink directory"
+    );
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize admission receipt parent {parent:?}"))?;
+    let filename = path
+        .file_name()
+        .context("admission receipt path must have a filename")?;
+    Ok(canonical_parent.join(filename))
+}
+
+fn publish_receipt(path: &Path, receipt: &AdmissionReceipt) -> Result<()> {
+    ensure_output_absent(path)?;
+    let mut bytes = serde_json::to_vec_pretty(receipt)?;
+    bytes.push(b'\n');
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("failed to create query equivalence admission receipt {path:?}"))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("failed to write query equivalence admission receipt {path:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync query equivalence admission receipt {path:?}"))?;
+    Ok(())
+}
+
+fn ensure_output_absent(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => anyhow::bail!("query equivalence admission output already exists: {path:?}"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to inspect admission output path {path:?}")),
+    }
+}
+
+fn artifact(path: &str, bytes: &[u8]) -> AdmissionArtifact {
+    AdmissionArtifact {
+        path: path.to_owned(),
+        bytes: bytes.len(),
+        sha256: sha256_bytes(bytes),
+    }
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn sha256_json(value: &impl Serialize) -> Result<String> {
+    Ok(sha256_bytes(&serde_json::to_vec(value)?))
+}
+
+fn absolute_path(path: PathBuf) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(env::current_dir()
+            .context("failed to resolve current directory")?
+            .join(path))
+    }
+}
+
+fn validate_repository(value: &str) -> Result<()> {
+    ensure!(
+        value.split('/').count() == 2
+            && value
+                .split('/')
+                .all(|part| !part.is_empty() && part.len() <= 100),
+        "{REPOSITORY_ENV} must use owner/repository form"
+    );
+    Ok(())
+}
+
+fn validate_run_key(value: &str) -> Result<()> {
+    ensure!(
+        !value.is_empty() && value.len() <= 128,
+        "{RUN_KEY_ENV} must contain between 1 and 128 bytes"
+    );
+    ensure!(
+        value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+        }),
+        "{RUN_KEY_ENV} may contain only ASCII letters, digits, dash, underscore, and dot"
+    );
+    ensure!(value != "." && value != "..", "{RUN_KEY_ENV} must not be dot traversal");
+    Ok(())
+}
+
+fn is_lower_hex_commit(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn first_non_empty_env(keys: &[&str], fallback: &str) -> String {
+    keys.iter()
+        .find_map(|key| env::var(key).ok().filter(|value| !value.trim().is_empty()))
+        .unwrap_or_else(|| fallback.to_owned())
+}

--- a/ops/benches/src/index_storage/query_equivalence_admission.rs
+++ b/ops/benches/src/index_storage/query_equivalence_admission.rs
@@ -65,17 +65,17 @@ impl QueryEquivalenceAdmissionConfig {
             .map(PathBuf::from)
             .context(format!("{BUNDLE_ENV} is required"))?;
         let bundle_root = absolute_path(bundle_root)?;
-        let expected_repository = env::var(REPOSITORY_ENV)
-            .unwrap_or_else(|_| "RusTokRs/RusTok".to_owned());
+        let expected_repository =
+            env::var(REPOSITORY_ENV).unwrap_or_else(|_| "RusTokRs/RusTok".to_owned());
         validate_repository(&expected_repository)?;
-        let expected_commit = env::var(COMMIT_ENV)
-            .context(format!("{COMMIT_ENV} is required"))?;
+        let expected_commit =
+            env::var(COMMIT_ENV).context(format!("{COMMIT_ENV} is required"))?;
         ensure!(
             is_lower_hex_commit(&expected_commit),
             "{COMMIT_ENV} must be a 40-character lowercase Git commit"
         );
-        let expected_run_key = env::var(RUN_KEY_ENV)
-            .context(format!("{RUN_KEY_ENV} is required"))?;
+        let expected_run_key =
+            env::var(RUN_KEY_ENV).context(format!("{RUN_KEY_ENV} is required"))?;
         validate_run_key(&expected_run_key)?;
         let output_path = env::var(OUTPUT_ENV)
             .map(PathBuf::from)
@@ -98,6 +98,7 @@ impl QueryEquivalenceAdmissionConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureSourceIdentity {
     repository: String,
     commit: String,
@@ -106,6 +107,7 @@ struct CaptureSourceIdentity {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureRunnerIdentity {
     job: String,
     runner_os: String,
@@ -113,6 +115,7 @@ struct CaptureRunnerIdentity {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureDatabaseIdentity {
     version: String,
     server_version_num: String,
@@ -121,6 +124,7 @@ struct CaptureDatabaseIdentity {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureArtifact {
     path: String,
     bytes: usize,
@@ -128,6 +132,7 @@ struct CaptureArtifact {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureExecution {
     package: String,
     test_filter: String,
@@ -141,6 +146,7 @@ struct CaptureExecution {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CaptureDescriptor {
     contract: String,
     completed_at: DateTime<Utc>,
@@ -211,11 +217,7 @@ pub fn admit_query_equivalence_bundle(
     config: &QueryEquivalenceAdmissionConfig,
 ) -> Result<QueryEquivalenceAdmission> {
     let canonical_bundle = validate_bundle_root(&config.bundle_root)?;
-    let output_path = resolve_output_path(&config.output_path)?;
-    ensure!(
-        !output_path.starts_with(&canonical_bundle),
-        "query equivalence admission receipt must be outside the immutable bundle"
-    );
+    let output_path = resolve_output_path(&config.output_path, &canonical_bundle)?;
     ensure_output_absent(&output_path)?;
 
     let inventory_before = read_inventory(&canonical_bundle)?;
@@ -292,9 +294,9 @@ pub fn admit_query_equivalence_bundle(
             exit_code: descriptor.execution.exit_code,
             skipped: descriptor.execution.skipped,
             captured_at: descriptor.completed_at,
-            capture_job: descriptor.runner.job,
-            capture_runner_os: descriptor.runner.runner_os,
-            capture_runner_arch: descriptor.runner.runner_arch,
+            capture_job: descriptor.runner.job.clone(),
+            capture_runner_os: descriptor.runner.runner_os.clone(),
+            capture_runner_arch: descriptor.runner.runner_arch.clone(),
         },
         bundle: AdmissionBundle {
             inventory: INVENTORY.iter().map(|value| (*value).to_owned()).collect(),
@@ -314,8 +316,8 @@ pub fn admit_query_equivalence_bundle(
     publish_receipt(&output_path, &receipt)?;
 
     Ok(QueryEquivalenceAdmission {
-        commit: descriptor.source.commit,
-        run_key: descriptor.source.run_key,
+        commit: descriptor.source.commit.clone(),
+        run_key: descriptor.source.run_key.clone(),
         output_path,
     })
 }
@@ -362,18 +364,26 @@ fn validate_descriptor(
     let execution = &descriptor.execution;
     ensure!(execution.package == TEST_PACKAGE, "unexpected test package");
     ensure!(execution.test_filter == TEST_FILTER, "unexpected test filter");
-    ensure!(execution.exit_code == 0, "captured fixture did not exit successfully");
+    ensure!(
+        execution.exit_code == 0,
+        "captured fixture did not exit successfully"
+    );
     ensure!(!execution.skipped, "captured fixture is marked skipped");
     ensure!(
         execution.command.len() == EXPECTED_COMMAND_ARGS.len() + 1
             && !execution.command[0].trim().is_empty()
             && execution.command[1..]
-                == EXPECTED_COMMAND_ARGS.map(str::to_owned),
+                .iter()
+                .map(String::as_str)
+                .eq(EXPECTED_COMMAND_ARGS),
         "captured equivalence command does not match the admitted command contract"
     );
-    let expected_scenarios = SCENARIOS.map(str::to_owned);
     ensure!(
-        execution.scenarios == expected_scenarios,
+        execution
+            .scenarios
+            .iter()
+            .map(String::as_str)
+            .eq(SCENARIOS),
         "captured equivalence scenarios do not match the admitted scenario contract"
     );
     ensure!(
@@ -383,10 +393,10 @@ fn validate_descriptor(
     validate_artifact_descriptor(&execution.stdout, STDOUT_FILE, stdout)?;
     validate_artifact_descriptor(&execution.stderr, STDERR_FILE, stderr)?;
 
-    let stdout_text = std::str::from_utf8(stdout)
-        .context("retained query equivalence stdout is not UTF-8")?;
-    let stderr_text = std::str::from_utf8(stderr)
-        .context("retained query equivalence stderr is not UTF-8")?;
+    let stdout_text =
+        std::str::from_utf8(stdout).context("retained query equivalence stdout is not UTF-8")?;
+    let stderr_text =
+        std::str::from_utf8(stderr).context("retained query equivalence stderr is not UTF-8")?;
     let combined = format!("{stdout_text}\n{stderr_text}");
     ensure!(
         combined.contains(TEST_FILTER),
@@ -408,8 +418,14 @@ fn validate_artifact_descriptor(
     expected_path: &str,
     bytes: &[u8],
 ) -> Result<()> {
-    ensure!(descriptor.path == expected_path, "retained artifact path mismatch");
-    ensure!(descriptor.bytes == bytes.len(), "retained artifact byte count mismatch");
+    ensure!(
+        descriptor.path == expected_path,
+        "retained artifact path mismatch"
+    );
+    ensure!(
+        descriptor.bytes == bytes.len(),
+        "retained artifact byte count mismatch"
+    );
     ensure!(
         descriptor.sha256 == sha256_bytes(bytes),
         "retained artifact SHA-256 mismatch"
@@ -422,10 +438,16 @@ fn validate_database(identity: &CaptureDatabaseIdentity) -> Result<()> {
         identity.server_version_num.starts_with("16"),
         "query equivalence admission requires PostgreSQL 16"
     );
-    ensure!(!identity.version.trim().is_empty(), "PostgreSQL version is empty");
+    ensure!(
+        !identity.version.trim().is_empty(),
+        "PostgreSQL version is empty"
+    );
     ensure!(
         !identity.system_identifier.is_empty()
-            && identity.system_identifier.bytes().all(|byte| byte.is_ascii_digit()),
+            && identity
+                .system_identifier
+                .bytes()
+                .all(|byte| byte.is_ascii_digit()),
         "PostgreSQL system identifier must contain only digits"
     );
     ensure!(
@@ -461,13 +483,19 @@ fn read_inventory(root: &Path) -> Result<BTreeSet<String>> {
             metadata.is_file() && !metadata.file_type().is_symlink(),
             "query equivalence bundle entry must be a regular non-symlink file: {name}"
         );
-        ensure!(inventory.insert(name.clone()), "duplicate bundle entry: {name}");
+        ensure!(
+            inventory.insert(name.clone()),
+            "duplicate bundle entry: {name}"
+        );
     }
     Ok(inventory)
 }
 
 fn expected_inventory() -> BTreeSet<String> {
-    INVENTORY.iter().map(|value| (*value).to_owned()).collect()
+    INVENTORY
+        .iter()
+        .map(|value| (*value).to_owned())
+        .collect()
 }
 
 fn read_stable_regular_file(path: &Path, max_bytes: usize, label: &str) -> Result<Vec<u8>> {
@@ -477,27 +505,32 @@ fn read_stable_regular_file(path: &Path, max_bytes: usize, label: &str) -> Resul
         before.is_file() && !before.file_type().is_symlink(),
         "{label} must be a regular non-symlink file"
     );
-    ensure!(before.len() <= max_bytes as u64, "{label} exceeds retained size limit");
+    ensure!(
+        before.len() <= max_bytes as u64,
+        "{label} exceeds retained size limit"
+    );
     let first = fs::read(path).with_context(|| format!("failed to read {label} {path:?}"))?;
     let second = fs::read(path).with_context(|| format!("failed to reread {label} {path:?}"))?;
     let after = fs::symlink_metadata(path)
         .with_context(|| format!("failed to re-inspect {label} {path:?}"))?;
     ensure!(
-        before.len() == after.len() && first == second,
+        after.is_file()
+            && !after.file_type().is_symlink()
+            && before.len() == after.len()
+            && first == second,
         "{label} changed while it was being reviewed"
     );
     Ok(first)
 }
 
-fn resolve_output_path(path: &Path) -> Result<PathBuf> {
+fn resolve_output_path(path: &Path, forbidden_root: &Path) -> Result<PathBuf> {
     let parent = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create admission receipt parent {parent:?}"))?;
-    let metadata = fs::symlink_metadata(parent)
-        .with_context(|| format!("failed to inspect admission receipt parent {parent:?}"))?;
+    let metadata = fs::symlink_metadata(parent).with_context(|| {
+        format!("query equivalence admission receipt parent must already exist: {parent:?}")
+    })?;
     ensure!(
         metadata.is_dir() && !metadata.file_type().is_symlink(),
         "admission receipt parent must be a regular non-symlink directory"
@@ -508,7 +541,12 @@ fn resolve_output_path(path: &Path) -> Result<PathBuf> {
     let filename = path
         .file_name()
         .context("admission receipt path must have a filename")?;
-    Ok(canonical_parent.join(filename))
+    let output_path = canonical_parent.join(filename);
+    ensure!(
+        !output_path.starts_with(forbidden_root),
+        "query equivalence admission receipt must be outside the immutable bundle"
+    );
+    Ok(output_path)
 }
 
 fn publish_receipt(path: &Path, receipt: &AdmissionReceipt) -> Result<()> {
@@ -519,7 +557,9 @@ fn publish_receipt(path: &Path, receipt: &AdmissionReceipt) -> Result<()> {
         .write(true)
         .create_new(true)
         .open(path)
-        .with_context(|| format!("failed to create query equivalence admission receipt {path:?}"))?;
+        .with_context(|| {
+            format!("failed to create query equivalence admission receipt {path:?}")
+        })?;
     file.write_all(&bytes)
         .with_context(|| format!("failed to write query equivalence admission receipt {path:?}"))?;
     file.sync_all()
@@ -584,7 +624,10 @@ fn validate_run_key(value: &str) -> Result<()> {
         }),
         "{RUN_KEY_ENV} may contain only ASCII letters, digits, dash, underscore, and dot"
     );
-    ensure!(value != "." && value != "..", "{RUN_KEY_ENV} must not be dot traversal");
+    ensure!(
+        value != "." && value != "..",
+        "{RUN_KEY_ENV} must not be dot traversal"
+    );
     Ok(())
 }
 
@@ -597,6 +640,10 @@ fn is_lower_hex_commit(value: &str) -> bool {
 
 fn first_non_empty_env(keys: &[&str], fallback: &str) -> String {
     keys.iter()
-        .find_map(|key| env::var(key).ok().filter(|value| !value.trim().is_empty()))
+        .find_map(|key| {
+            env::var(key)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
         .unwrap_or_else(|| fallback.to_owned())
 }

--- a/scripts/verify/verify-index-postgres-reference-equivalence.mjs
+++ b/scripts/verify/verify-index-postgres-reference-equivalence.mjs
@@ -76,7 +76,7 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-postgres-reference-equivalence.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', [
-  'Status: `fixture_and_capture_source_complete_owner_execution_pending`',
+  'Status: `fixture_capture_and_admission_source_complete_owner_execution_pending`',
   'compares the complete `IndexQueryPage`',
   'does not introduce Testcontainers or a second database stack',
   'Not run by the implementation agent',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -13,6 +13,7 @@ const scripts = [
   'verify-index-query-snapshots.mjs',
   'verify-index-postgres-reference-equivalence.mjs',
   'verify-index-query-equivalence-capture.mjs',
+  'verify-index-query-equivalence-admission.mjs',
 ];
 
 for (const script of scripts) {

--- a/scripts/verify/verify-index-query-equivalence-admission.mjs
+++ b/scripts/verify/verify-index-query-equivalence-admission.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-query-equivalence-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const admissionPath = 'ops/benches/src/index_storage/query_equivalence_admission.rs';
+const admission = requireMarkers(admissionPath, [
+  'index_query_equivalence_admission_v1',
+  'index_query_equivalence_capture_v1',
+  'INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION',
+  'INDEX_QUERY_EQUIVALENCE_BUNDLE',
+  'INDEX_QUERY_EQUIVALENCE_EXPECTED_REPOSITORY',
+  'INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT',
+  'INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY',
+  '#[serde(deny_unknown_fields)]',
+  'const INVENTORY: [&str; 3] = [DESCRIPTOR_FILE, STDERR_FILE, STDOUT_FILE];',
+  'postgres_query_port_matches_reference_fixture',
+  '--test-threads=1',
+  'scenario_contract_sha256 == sha256_json(&SCENARIOS)?',
+  'descriptor.sha256 == sha256_bytes(bytes)',
+  'combined.contains("test result: ok.")',
+  'combined.contains("1 passed; 0 failed")',
+  '!combined.contains(SKIP_MARKER)',
+  'inventory_after == inventory_before',
+  'query equivalence descriptor changed during admission review',
+  'query equivalence stdout changed during admission review',
+  'query equivalence stderr changed during admission review',
+  'production_lifecycle_authorized: false',
+  'query equivalence admission receipt must be outside the immutable bundle',
+  'query equivalence admission receipt parent must already exist',
+  '.create_new(true)',
+  'file.sync_all()',
+]);
+
+for (const forbidden of [
+  'DATABASE_URL',
+  'database_url',
+  'Command::new(',
+  'INSERT INTO index_schemas',
+  'INSERT INTO index_entities',
+  'INSERT INTO index_links',
+  'fs::write(',
+  'File::create(',
+  'remove_dir_all',
+  'remove_file',
+]) {
+  if (admission.includes(forbidden)) {
+    fail(`${admissionPath} contains forbidden marker ${forbidden}`);
+  }
+}
+
+requireMarkers('ops/benches/src/bin/index_query_equivalence_admission.rs', [
+  'QueryEquivalenceAdmissionConfig::from_env()',
+  'admit_query_equivalence_bundle(&config)?',
+  'index query equivalence admission complete',
+]);
+requireMarkers('ops/benches/src/index_storage/mod.rs', [
+  'mod query_equivalence_admission;',
+  'QueryEquivalenceAdmission, QueryEquivalenceAdmissionConfig, admit_query_equivalence_bundle',
+]);
+requireMarkers('ops/benches/Cargo.toml', [
+  'name = "index-query-equivalence-admission"',
+  'path = "src/bin/index_query_equivalence_admission.rs"',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-query-equivalence-admission.mjs'",
+]);
+requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', [
+  'Status: `fixture_capture_and_admission_source_complete_owner_execution_pending`',
+  '`index-query-equivalence-admission`',
+  '`production_lifecycle_authorized: false`',
+  'receipt parent must already exist',
+  'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+]);
+
+console.log('[verify-index-query-equivalence-admission] OK');

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -85,7 +85,7 @@ requireMarkers('ops/benches/Cargo.toml', [
   'path = "src/bin/index_query_equivalence_capture.rs"',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', [
-  'Status: `fixture_and_capture_source_complete_owner_execution_pending`',
+  'Status: `fixture_capture_and_admission_source_complete_owner_execution_pending`',
   '`index-query-equivalence-capture`',
   'descriptor-last no-clobber bundle',
   'does not retain the PostgreSQL URL',


### PR DESCRIPTION
## Summary

- add an owner-operated `index-query-equivalence-admission` binary under `ops/benches`
- review the immutable three-file capture bundle without executing Cargo or connecting to PostgreSQL
- require explicit admission opt-in plus independently supplied expected repository, commit, and run key
- require the bundle root and every entry to be regular non-symlink filesystem objects
- accept only the exact `equivalence.json`, `stderr.log`, and `stdout.log` inventory
- decode the capture v1 descriptor with unknown fields denied
- verify clean source identity, PostgreSQL 16 identity, capture runner identity, exact fixture command, six fixed scenarios, and the scenario digest
- recompute retained byte counts and SHA-256 hashes from the actual logs
- require UTF-8 output proving exactly one successful fixture and reject the fixture skip marker
- reread inventory and all three files before publication to reject mid-review drift
- emit a separate no-clobber admission receipt outside the immutable bundle
- keep the receipt explicitly scoped with `production_lifecycle_authorized: false`
- add a focused static guard and include it in the unified M4 query contract
- document the source-registry blocker that prevents honest server composition today

## Recheck findings

`PostgresIndexQueryPort` requires an immutable source-owned `SchemaRegistry`, while the server currently publishes no source registry contract. Composing a host runtime from an empty or tenant-derived registry would be a false cutover, so server/consumer composition remains open.

Many-link aggregate ordering also requires a coordinated planner/compiler/cursor/reference/snapshot semantic change. Without owner test execution, this PR does not introduce that wider behavior. It instead completes the bounded evidence review path for the already merged PostgreSQL/reference fixture and capture.

The branch started at `f4ff7627c93b18e7fefd8070f8bac99da7eed78b`. Main subsequently advanced through Auth/Forum/Blog changes only; no changed path overlaps this PR.

## Boundary

This PR does not execute or admit a real bundle, connect to PostgreSQL, run Cargo, modify the immutable bundle, authorize production partition lifecycle, add many-link ordering, publish a source schema registry, compose `IndexQueryPort` into consumers, or change production Index planner/compiler/decoder/query-port/migration/mutation behavior.

The combined M4 checklist remains open until the repository owner executes capture, runs admission, and retains both the exact bundle and receipt.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, capture/admission commands, or Node verifiers were run.

Suggested commands:

```bash
cargo check -p rustok-benchmarks --bin index-query-equivalence-admission
node scripts/verify/verify-index-query-equivalence-admission.mjs
node scripts/verify/verify-index-query-contract.mjs

INDEX_QUERY_EQUIVALENCE_ALLOW_ADMISSION=1 \
INDEX_QUERY_EQUIVALENCE_BUNDLE=<fresh-capture-root> \
INDEX_QUERY_EQUIVALENCE_EXPECTED_COMMIT=<40-char-head-commit> \
INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY=<stable-run-key> \
INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT=<existing-parent>/equivalence-admission.json \
  cargo run -p rustok-benchmarks --bin index-query-equivalence-admission

cargo xtask module validate index
```