### PR TITLE
feat(order): publish storefront post-order reads

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -194,9 +194,9 @@ These are source-contract defects, not verification-only tasks.
   compiled/migration evidence only when the validation policy allows it.
 - [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,
   Payment, and Fulfillment concrete services behind host-composed owner ports.
-- [x] Publish the order-owned `OrderReadPort` for complete detail/list projections with
-  locale fallback, canonical read context/deadline policy, stable typed errors, and
-  explicit unvalidated source evidence.
+- [x] Publish the order-owned `OrderReadPort` for complete order, return, and
+  order-change detail/list projections with canonical read context/deadline policy,
+  stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
 - [x] Host-compose `CommerceOrderReadRuntime`, require it in Commerce HTTP and GraphQL
   schema data, and cut admin REST order list/detail to the owner port while preserving
   public envelopes and payment/fulfillment detail aggregation.
@@ -204,11 +204,15 @@ These are source-contract defects, not verification-only tasks.
   actor, resolved channel, locale fallback, deadline, and embedded-schema fallback.
 - [x] Cut storefront HTTP order detail and shared ownership reads to the host-selected
   runtime while preserving customer resolution, locale fallback, public envelopes,
-  and the concrete return/change/payment operations after ownership validation.
-- [ ] Publish wider typed owner ports for storefront return and order-change reads;
-  their current concrete services remain after typed order ownership validation.
+  and the concrete operations after ownership validation.
+- [x] Cut storefront return and order-change list reads to the same host-selected
+  runtime while preserving filters, ordering, complete DTOs, totals, and envelopes.
+- [ ] Cut GraphQL return/order-change detail and list reads to the scoped host-selected
+  runtime without moving mutations.
+- [ ] Audit and cut admin post-order reads separately without moving mutations or
+  payment/fulfillment policy.
 - [ ] Retain compile, mounted parity, deadline/failure, restart, and remote-adapter
-  evidence for the complete order projection cutover before status promotion.
+  evidence for order and post-order projections before status promotion.
 - [ ] Correct Product's declared dependency contract or extract its direct
   inventory/pricing persistence operations behind owner ports; the current manifest
   declares only Taxonomy while production code uses Inventory and Pricing persistence.
@@ -567,6 +571,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-marketplace-listing-provenance-cutover.mjs`
 - [ ] `node scripts/verify/verify-order-read-port.mjs`
 - [ ] `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
+- [ ] `node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - [ ] `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - [ ] `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
@@ -603,9 +608,9 @@ Source inspection is not execution evidence.
   staged completion paths.
 - [x] Extend the public-error guard to pricing and `PaymentCollectionPort`, including
   correlation, tenant, operation, stable code, and raw-cause bans.
-- [x] Add static source guards for host-selected order read runtime composition and
-  admin REST, mounted GraphQL, and storefront HTTP detail/list/ownership cutover without
-  changing mutation, payment, fulfillment, return, or order-change ownership.
+- [x] Add static source guards for host-selected complete order and post-order read
+  runtime composition plus admin REST, mounted GraphQL complete order, and storefront
+  order/return/change cutovers without changing mutation, payment, or fulfillment ownership.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, and order-read
   static guards against a repository checkout and retain their output.
 
@@ -615,7 +620,7 @@ Source inspection is not execution evidence.
 - [ ] `cargo test -p rustok-commerce --test checkout_marketplace_economics_checkpoint`
 - [ ] `cargo check -p rustok-order --all-features`
 - [ ] `cargo check -p rustok-server --features mod-commerce`
-- [ ] Targeted `OrderReadPort` detail/list, locale fallback, context, typed-error,
+- [ ] Targeted `OrderReadPort` six-operation, locale fallback, context, typed-error,
   host-composition, admin REST, mounted GraphQL, and storefront HTTP transport tests.
 - [ ] `cargo test -p rustok-order --test order_checkout_identity`
 - [ ] `cargo test -p rustok-order --test checkout_order_identity_port`
@@ -704,22 +709,24 @@ Source inspection is not execution evidence.
     Compatibility source removal and execution evidence remain separate open tasks.
 12. [x] Cut complete order projection consumers over to `CommerceOrderReadRuntime`:
     admin REST list/detail, mounted GraphQL list/detail with request context, and
-    storefront HTTP detail/shared ownership now use the typed owner port.
-13. [ ] Publish wider owner read ports for storefront returns and order changes without
-    moving mutations or payment policy.
-14. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
-15. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
-16. [x] Mount authenticated request-scoped listing native composition.
-17. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
-18. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
+    storefront HTTP detail/shared ownership use the typed owner port.
+13. [x] Publish return/order-change detail/list operations on `OrderReadPort` and cut
+    storefront return/order-change lists to the host-selected runtime.
+14. [ ] Cut GraphQL return/order-change detail/list reads to the scoped runtime, then
+    audit admin post-order reads separately.
+15. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
+16. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
+17. [x] Mount authenticated request-scoped listing native composition.
+18. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
+19. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
     reconciliation surfaces.
-19. [ ] Run static verifiers and fix remaining source drift.
-20. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
-21. [ ] Apply clean/upgraded migrations and targeted regression tests.
-22. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
+20. [ ] Run static verifiers and fix remaining source drift.
+21. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
+22. [ ] Apply clean/upgraded migrations and targeted regression tests.
+23. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
     transfer, and mounted transport scenarios.
-23. [ ] Execute production-like payment and payout provider evidence.
-24. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
+24. [ ] Execute production-like payment and payout provider evidence.
+25. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
 
 ## Completed source waves retained for history
 
@@ -759,11 +766,10 @@ Source inspection is not execution evidence.
   one staged recovery runtime with explicit idempotency and host provider composition.
 - [x] Harden pricing and payment collection owner-port errors with stable public
   messages plus correlation-aware internal logging.
-- [x] Publish `OrderReadPort` for complete order detail/list projections.
-- [x] Host-compose `CommerceOrderReadRuntime` and cut admin REST, mounted GraphQL, and
-  storefront HTTP complete detail/list/ownership projection reads to the owner port
-  while preserving context, public envelopes, and unchanged mutation/payment/
-  fulfillment/return/order-change ownership; execution evidence remains open.
+- [x] Publish and host-compose `OrderReadPort`, cut complete order projections across
+  admin REST, mounted GraphQL, and storefront HTTP, then extend the same boundary to
+  return/order-change detail/list and cut storefront post-order lists while preserving
+  mutations, refunds, GraphQL/admin post-order compatibility paths, and unvalidated status.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -8,7 +8,10 @@ use rustok_api::{
 };
 use rustok_customer::dto::CustomerResponse;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
-use rustok_order::{OrderService, ReadOrderProjectionRequest, error::OrderError};
+use rustok_order::{
+    ListOrderChangeProjectionsRequest, ListOrderReturnProjectionsRequest, OrderService,
+    ReadOrderProjectionRequest, error::OrderError,
+};
 use rustok_payment::{PaymentService, error::PaymentError};
 use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use uuid::Uuid;
@@ -21,15 +24,17 @@ use super::{
     StoreOrderChangesParams, StoreOrderRefundsParams, StoreOrderReturnsParams,
 };
 use crate::dto::{
-    CreateOrderReturnInput, ListOrderChangesInput, ListOrderReturnsInput, ListRefundsInput,
-    OrderChangeResponse, OrderResponse, OrderReturnResponse, RefundResponse,
+    CreateOrderReturnInput, ListRefundsInput, OrderChangeResponse, OrderResponse,
+    OrderReturnResponse, RefundResponse,
 };
 
 const STOREFRONT_ORDER_CUSTOMER_OWNER: &str = "rustok_customer";
 const STOREFRONT_ORDER_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";
 const STOREFRONT_ORDER_CUSTOMER_BOUNDARY: &str = "commerce_storefront_order_http";
 const STOREFRONT_ORDER_OWNER: &str = "rustok_order.storefront_orders";
-const STOREFRONT_ORDER_OWNER_OPERATION: &str = "read_order_projection";
+const STOREFRONT_ORDER_DETAIL_OPERATION: &str = "read_order_projection";
+const STOREFRONT_ORDER_RETURN_LIST_OPERATION: &str = "list_order_return_projections";
+const STOREFRONT_ORDER_CHANGE_LIST_OPERATION: &str = "list_order_change_projections";
 const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
 const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
 
@@ -160,7 +165,8 @@ fn storefront_order_read_port_context(
 fn map_storefront_order_port_error(
     error: PortError,
     context: &PortContext,
-    operation: &'static str,
+    owner_operation: &'static str,
+    consumer_operation: &'static str,
     actor_id: Uuid,
     customer_id: Uuid,
     order_id: Uuid,
@@ -206,8 +212,8 @@ fn map_storefront_order_port_error(
     tracing::error!(
         error = ?error,
         owner = STOREFRONT_ORDER_OWNER,
-        owner_operation = STOREFRONT_ORDER_OWNER_OPERATION,
-        operation,
+        owner_operation,
+        consumer_operation,
         correlation_id = %context.correlation_id,
         tenant_id = %context.tenant_id,
         actor_id = %actor_id,
@@ -447,6 +453,7 @@ async fn read_storefront_order_projection(
             map_storefront_order_port_error(
                 error,
                 &read_context,
+                STOREFRONT_ORDER_DETAIL_OPERATION,
                 operation,
                 auth.user_id,
                 customer_id,
@@ -646,7 +653,7 @@ pub async fn list_order_returns(
 ) -> HttpResult<Json<PaginatedResponse<OrderReturnResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(
+    let customer_id = ensure_customer_owns_order(
         &runtime,
         tenant.id,
         tenant.default_locale.as_str(),
@@ -657,10 +664,18 @@ pub async fn list_order_returns(
     )
     .await?;
 
-    let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .list_returns(
-            tenant.id,
-            ListOrderReturnsInput {
+    let read_context = storefront_order_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        id,
+        "list_order_returns",
+    );
+    let page = runtime
+        .order_read_port()
+        .list_order_return_projections(
+            read_context.clone(),
+            ListOrderReturnProjectionsRequest {
                 page: params.pagination.page,
                 per_page: params.pagination.per_page,
                 order_id: Some(id),
@@ -668,11 +683,21 @@ pub async fn list_order_returns(
             },
         )
         .await
-        .map_err(|error| map_storefront_order_error(error, "list_order_returns", tenant.id, id))?;
+        .map_err(|error| {
+            map_storefront_order_port_error(
+                error,
+                &read_context,
+                STOREFRONT_ORDER_RETURN_LIST_OPERATION,
+                "list_order_returns",
+                auth.user_id,
+                customer_id,
+                id,
+            )
+        })?;
 
     Ok(Json(PaginatedResponse {
-        data: items,
-        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), total),
+        data: page.items,
+        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total),
     }))
 }
 
@@ -773,7 +798,7 @@ pub async fn list_order_changes(
 ) -> HttpResult<Json<PaginatedResponse<OrderChangeResponse>>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(
+    let customer_id = ensure_customer_owns_order(
         &runtime,
         tenant.id,
         tenant.default_locale.as_str(),
@@ -784,10 +809,18 @@ pub async fn list_order_changes(
     )
     .await?;
 
-    let (items, total) = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .list_order_changes(
-            tenant.id,
-            ListOrderChangesInput {
+    let read_context = storefront_order_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        id,
+        "list_order_changes",
+    );
+    let page = runtime
+        .order_read_port()
+        .list_order_change_projections(
+            read_context.clone(),
+            ListOrderChangeProjectionsRequest {
                 page: params.pagination.page,
                 per_page: params.pagination.per_page,
                 order_id: Some(id),
@@ -796,10 +829,20 @@ pub async fn list_order_changes(
             },
         )
         .await
-        .map_err(|error| map_storefront_order_error(error, "list_order_changes", tenant.id, id))?;
+        .map_err(|error| {
+            map_storefront_order_port_error(
+                error,
+                &read_context,
+                STOREFRONT_ORDER_CHANGE_LIST_OPERATION,
+                "list_order_changes",
+                auth.user_id,
+                customer_id,
+                id,
+            )
+        })?;
 
     Ok(Json(PaginatedResponse {
-        data: items,
-        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), total),
+        data: page.items,
+        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total),
     }))
 }

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "generated_at": "2026-07-29",
-  "status": "storefront_http_cutover_unvalidated",
-  "source_base_revision": "f4ff7627c93b18e7fefd8070f8bac99da7eed78b",
-  "scope": "order detail and filtered list projections for mounted Commerce query consumers",
+  "status": "storefront_post_order_reads_cutover_unvalidated",
+  "source_base_revision": "f0a6799a536b369dbffc3ab5f48946fb3825302b",
+  "scope": "complete order, return, and order-change projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
     "port": "OrderReadPort",
@@ -33,6 +33,43 @@
       "ordering": "created_at_desc",
       "locale_source": "PortContext.locale",
       "tenant_default_locale_fallback": true
+    },
+    {
+      "name": "read_order_return_projection",
+      "request": "ReadOrderReturnProjectionRequest",
+      "result": "OrderReturnResponse",
+      "optional_not_found": false
+    },
+    {
+      "name": "list_order_return_projections",
+      "request": "ListOrderReturnProjectionsRequest",
+      "result": "OrderReturnProjectionPage",
+      "filters": [
+        "page",
+        "per_page",
+        "order_id",
+        "status"
+      ],
+      "ordering": "created_at_desc"
+    },
+    {
+      "name": "read_order_change_projection",
+      "request": "ReadOrderChangeProjectionRequest",
+      "result": "OrderChangeResponse",
+      "optional_not_found": false
+    },
+    {
+      "name": "list_order_change_projections",
+      "request": "ListOrderChangeProjectionsRequest",
+      "result": "OrderChangeProjectionPage",
+      "filters": [
+        "page",
+        "per_page",
+        "order_id",
+        "status",
+        "change_type"
+      ],
+      "ordering": "created_at_desc"
     }
   ],
   "context": {
@@ -81,22 +118,31 @@
     "commerce_admin_rest_cutover_completed": true,
     "commerce_storefront_detail_and_ownership": "order_read_port_host_runtime",
     "commerce_storefront_detail_and_ownership_cutover_completed": true,
+    "commerce_storefront_return_list": "order_read_port_host_runtime",
+    "commerce_storefront_return_list_cutover_completed": true,
+    "commerce_storefront_order_change_list": "order_read_port_host_runtime",
+    "commerce_storefront_order_change_list_cutover_completed": true,
     "commerce_graphql_order_list_detail": "order_read_port_host_runtime_with_request_context",
     "commerce_graphql_order_list_detail_cutover_completed": true,
+    "commerce_graphql_return_and_order_change_reads": "concrete_order_service",
+    "commerce_admin_return_and_order_change_reads": "concrete_order_service",
+    "complete_order_projection_consumer_cutover_completed": true,
+    "post_order_consumer_cutover_completed": false,
     "runtime_composition_published": true,
-    "all_consumer_cutover_completed": true,
-    "cutover_required": false
+    "all_consumer_cutover_completed": false,
+    "cutover_required": true
   },
   "unchanged_scope": {
     "admin_order_mutations": "concrete_order_service",
     "admin_detail_payment_lookup": "concrete_payment_service",
     "admin_detail_fulfillment_lookup": "concrete_fulfillment_service",
-    "storefront_return_mutations_and_reads": "concrete_order_service",
-    "storefront_order_change_reads": "concrete_order_service",
-    "storefront_refund_reads": "concrete_payment_service"
+    "storefront_return_mutation": "concrete_order_service",
+    "storefront_refund_reads": "concrete_payment_service",
+    "graphql_return_and_order_change_reads": "concrete_order_service",
+    "admin_return_and_order_change_reads": "concrete_order_service"
   },
   "decision": {
-    "next_slice": "publish wider owner read contracts for returns and order changes separately; execute compile, mounted parity, deadline, restart, and remote-adapter evidence before status promotion",
+    "next_slice": "cut GraphQL post-order reads to the host-selected OrderReadPort, then audit admin post-order reads separately; execute compile and mounted parity evidence before status promotion",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -53,15 +53,15 @@ shipping, or hash facts rather than fabricating attribution. The metadata bridge
 and old JSON indexes must be removed after all completion/result consumers use
 typed identity exclusively.
 
-Complete order detail and filtered-list projection reads are published through
+Complete order, return, and order-change projection reads are published through
 `OrderReadPort`. `CommerceOrderReadRuntime` carries one host-selected owner port
 through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
-GraphQL schema data. Mounted admin REST list/detail, mounted GraphQL list/detail,
-and storefront HTTP detail/ownership reads use the same port with locale fallback,
-authenticated actor, resolved channel, deadline, public error policy, filters,
-ordering, pagination total, and ownership behavior preserved. All current complete
-order projection consumers are cut over in source; runtime evidence remains
-unvalidated.
+GraphQL schema data. Mounted admin REST and GraphQL complete-order list/detail,
+storefront HTTP order detail/ownership, and storefront return/order-change lists
+use the same port with authenticated actor, resolved channel, deadline, public
+error policy, filters, ordering, pagination total, locale fallback where applicable,
+and ownership behavior preserved. GraphQL and admin post-order reads plus runtime
+evidence remain open and unvalidated.
 
 ## FFA/FBA boundary
 
@@ -88,6 +88,7 @@ unvalidated.
   `scripts/verify/verify-order-storefront-boundary.mjs`,
   `scripts/verify/verify-order-read-port.mjs`,
   `scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`,
+  `scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`,
   `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`,
   `scripts/verify/verify-commerce-storefront-transport-handoff.mjs`,
   `scripts/verify/verify-commerce-order-identity-boundary.mjs`,
@@ -150,17 +151,19 @@ unvalidated.
 
 ## Order projection read source checklist
 
-- [x] Publish one owner `OrderReadPort` for complete detail and filtered list
-  projections.
-- [x] Preserve `OrderResponse`, descending creation ordering, status/customer
-  filters, page/per-page handling, and owner pagination total.
-- [x] Use `PortContext.locale` as requested locale and retain an explicit optional
-  tenant-default fallback locale in typed requests.
+- [x] Publish one owner `OrderReadPort` for complete order detail/list plus
+  return and order-change detail/list projections.
+- [x] Preserve `OrderResponse`, `OrderReturnResponse`, and `OrderChangeResponse`;
+  page/per-page handling, owner totals, descending ordering, complete return items,
+  and current status/customer/order/type filters.
+- [x] Use `PortContext.locale` and explicit tenant-default fallback only for the
+  currently localized complete-order projection requests.
 - [x] Require `PortCallPolicy::read()` and parse tenant identity from
-  `PortContext`.
+  `PortContext` for all six operations.
 - [x] Map every current `OrderError` variant to stable `PortError` policy without
   owner-message control flow.
-- [x] Export the canonical `in_process_order_read_port` factory.
+- [x] Export the canonical `in_process_order_read_port` factory and all typed
+  request/page contracts.
 - [x] Retain source evidence and focused guards without claiming runtime parity.
 - [x] Publish and host-compose `CommerceOrderReadRuntime` while preserving an
   externally installed runtime.
@@ -175,8 +178,13 @@ unvalidated.
   unauthenticated or embedded reads retain explicit service/no-channel fallback.
 - [x] Cut storefront HTTP order detail and shared ownership reads over to the
   host-selected runtime while preserving customer resolution, locale fallback,
-  public envelopes, and the concrete return/change/payment operations that follow
-  ownership validation.
+  public envelopes, and the concrete operations that follow ownership validation.
+- [x] Cut storefront return and order-change list reads over to the host-selected
+  runtime while preserving filters, ordering, complete DTOs, totals, and envelopes.
+- [ ] Cut GraphQL return/order-change detail and list reads over to the scoped
+  host-selected runtime without changing mutations.
+- [ ] Audit and cut admin post-order reads separately without moving mutations or
+  payment/fulfillment policy.
 - [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence before status promotion.
 
@@ -231,21 +239,23 @@ unvalidated.
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Prove mounted order projection read parity.** Admin REST, mounted GraphQL,
-   and storefront HTTP detail/list/ownership reads now use the host-selected
-   `CommerceOrderReadRuntime` without concrete `OrderService` projection reads.
+7. **Prove mounted order projection read parity.** Admin REST and mounted GraphQL
+   complete order reads plus storefront order/return/change reads now use the
+   host-selected `CommerceOrderReadRuntime` without concrete `OrderService`
+   projection reads on those paths.
    **Depends on:** compiled order/commerce/server crates and mounted local plus
    remote adapter profiles.
    **Done when:** locale/filter/pagination/authorization/ownership behavior,
    deadlines, stable failure policy, restart, and remote adapter parity are
    retained as execution evidence.
 
-8. **Publish wider post-order read boundaries.** Return and order-change reads
-   still use concrete owner services after typed order ownership validation.
-   **Depends on:** explicit owner projection contracts that preserve current DTOs,
-   filters, totals, lifecycle policy, and safe error mapping.
-   **Done when:** mounted consumers no longer construct foreign owner services for
-   return/order-change reads without moving mutations or payment policy.
+8. **Finish post-order consumer cutover.** GraphQL and admin return/order-change
+   reads still use concrete owner services even though all six typed operations
+   are published.
+   **Depends on:** the host-selected runtime and current transport envelope
+   inventory.
+   **Done when:** mounted GraphQL and admin post-order reads no longer construct
+   foreign owner services, while mutations and payment policy remain unchanged.
 
 9. **Keep order and commerce documentation synchronized.** Update local docs,
    manifests, registries, central status, and the umbrella commerce plan whenever
@@ -259,6 +269,7 @@ unvalidated.
 - `node scripts/verify/verify-order-read-port.mjs`
 - `node scripts/verify/verify-commerce-graphql-order-read-shim.mjs`
 - `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
+- `node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
@@ -278,7 +289,7 @@ unvalidated.
 - `cargo test -p rustok-order --test order_checkout_identity`
 - `cargo test -p rustok-order --test checkout_order_identity_port`
 - `cargo test -p rustok-order --test checkout_completion_port`
-- Targeted order read-port detail/list, locale fallback, context, error-policy,
+- Targeted order read-port six-operation, locale fallback, context, error-policy,
   host-composition, admin, GraphQL, and storefront transport tests.
 - Targeted staged checkout completion/adoption/replay, unknown lifecycle,
   compensation, and payment settlement tests.

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,11 +1,12 @@
 # Order read port
 
-Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.
+Status: owner port and host runtime published; complete order projections plus storefront return/change lists cut over, unvalidated.
 
 ## Scope
 
-`OrderReadPort` is the order-owned boundary for complete order projection reads
-needed by mounted Commerce REST and GraphQL query consumers. It is separate from:
+`OrderReadPort` is the order-owned boundary for complete order, return, and
+order-change projection reads needed by mounted Commerce REST and GraphQL query
+consumers. It is separate from:
 
 - `CheckoutCompletionPort`, which owns checkout create/place/replay;
 - `CheckoutOrderIdentityPort`, which owns checkout/order identity;
@@ -14,23 +15,30 @@ needed by mounted Commerce REST and GraphQL query consumers. It is separate from
 - order lifecycle, return, and order-change mutations, which remain on existing
   order-owner commands and services.
 
-The owner boundary and host-selected runtime are now published. Mounted admin REST,
-GraphQL order list/detail, and storefront HTTP order detail/ownership reads use the
-port. Current complete detail/list/ownership projection consumers are cut over in
-source; runtime evidence remains unvalidated.
+The owner boundary and host-selected runtime are published. Mounted admin REST and
+GraphQL complete order list/detail, storefront HTTP order detail/ownership, and
+storefront return/order-change lists use the port. GraphQL and admin post-order
+reads remain open; runtime evidence remains unvalidated.
 
 ## Operations
 
-The owner publishes two read-only operations:
+The owner publishes six read-only operations:
 
 - `read_order_projection` returns one complete `OrderResponse` by order id;
 - `list_order_projections` preserves page, per-page, status, customer filtering,
-  descending creation ordering, and the owner pagination total through
-  `OrderProjectionPage`.
+  descending creation ordering, and owner pagination total;
+- `read_order_return_projection` returns one `OrderReturnResponse` by return id;
+- `list_order_return_projections` preserves page, per-page, order-id/status filters,
+  descending creation ordering, return items, and owner pagination total;
+- `read_order_change_projection` returns one `OrderChangeResponse` by change id;
+- `list_order_change_projections` preserves page, per-page, order-id/status/type
+  filters, descending creation ordering, and owner pagination total.
 
-Both operations use `PortContext.locale` as the requested locale and accept an
-optional tenant-default fallback locale in the typed request. The existing owner
-DTO is returned unchanged; Commerce does not define a partial order projection.
+Complete order operations use `PortContext.locale` as requested locale and accept
+an optional tenant-default fallback locale. Return and order-change DTOs are not
+localized in the current owner model, so their typed requests do not invent locale
+fields. All operations preserve existing owner DTOs rather than defining partial
+Commerce projections.
 
 ## In-process adapter
 
@@ -45,9 +53,9 @@ Every operation:
 
 1. requires `PortCallPolicy::read()`;
 2. parses tenant identity from `PortContext`;
-3. delegates to the existing locale-aware owner service operation;
+3. delegates to the existing owner service operation;
 4. maps every current `OrderError` variant to stable `PortError` policy;
-5. preserves complete owner projections and list totals.
+5. preserves complete owner projections, filters, ordering, and list totals.
 
 The adapter does not inspect owner error messages for control flow. Validation
 maps to `Validation`; missing order/return/change maps to `NotFound`; invalid
@@ -84,96 +92,68 @@ The resolver extension separately scopes request-owned order context:
 - directly embedded schemas without the mounted extension use the service actor
   and no channel rather than inventing attribution.
 
-## Admin REST cutover
+## Complete order consumer cutover
 
-`GET /admin/orders` calls `list_order_projections` and preserves:
+Admin REST order list/detail, mounted GraphQL order list/detail, storefront order
+detail, and the shared storefront customer-ownership check use the host-selected
+port. Existing authorization, locale fallback, filters, pagination, detail
+aggregation, public envelopes, authenticated actor, resolved channel, correlation,
+and two-second deadline behavior are preserved.
 
-- `orders:list` authorization;
-- page and per-page values;
-- status and customer filters;
-- requested locale and tenant-default fallback;
-- descending owner ordering and owner pagination total;
-- the existing `PaginatedResponse<OrderResponse>` envelope.
+## Storefront post-order read cutover
 
-`GET /admin/orders/{id}` calls `read_order_projection` and preserves:
+`GET /store/orders/{id}/returns` calls `list_order_return_projections` after the
+shared typed ownership check. It preserves:
 
-- `orders:read` authorization;
-- requested locale and tenant-default fallback;
-- the complete `OrderResponse` projection;
-- the existing `AdminOrderDetailResponse` envelope;
-- the existing payment-collection and fulfillment aggregation lookups.
+- customer resolution and exact order ownership validation;
+- page/per-page values and owner total;
+- the order-id and optional status filters;
+- descending owner ordering and complete return items;
+- the existing `PaginatedResponse<OrderReturnResponse>` envelope.
 
-Both handlers create a two-second read `PortContext` with tenant identity,
-authenticated user actor, request locale, optional request channel, and a
-resource-scoped correlation id.
+`GET /store/orders/{id}/changes` calls `list_order_change_projections` after the
+same ownership check. It preserves:
 
-`PortErrorKind` is mapped back to the established admin HTTP policy:
+- page/per-page values and owner total;
+- order-id, optional status, and optional change-type filters;
+- descending owner ordering;
+- the existing `PaginatedResponse<OrderChangeResponse>` envelope.
 
-- validation -> `400 commerce_admin_order_invalid`;
-- not found -> `404 commerce_admin_not_found`;
-- conflict -> `409 commerce_admin_order_state_conflict`;
-- forbidden -> `401 commerce_permission_denied`;
-- unavailable/timeout -> `503 commerce_admin_order_storage_unavailable`;
-- invariant violation -> `500 commerce_admin_order_failed`.
-
-The mapper logs stable internal code, retryability, owner operation, correlation,
-actor/channel/locale/deadline context, and route identities without copying owner
-messages into public envelopes.
-
-## Storefront HTTP cutover
-
-`GET /store/orders/{id}` and the shared customer-ownership check now call
-`read_order_projection` through `CommerceHttpRuntime.order_read_port()`.
-
-The cutover preserves:
-
-- authenticated customer resolution before order access;
-- complete `OrderResponse` detail and tenant-default locale fallback;
-- exact customer-id ownership comparison;
-- the existing customer-required and access-denied public envelopes;
-- the existing order validation, not-found, conflict, unavailable, and fail-closed
-  public codes;
-- a two-second read deadline, authenticated user actor, request locale, optional
-  host-resolved channel, and resource-scoped correlation id.
-
-The ownership helper protects storefront return creation/listing, refund listing,
-and order-change listing without constructing `OrderService` for the ownership
-projection. The subsequent return mutation/list, refund list, and order-change list
-remain on their existing concrete owner services until wider typed contracts are
-published.
+Both handlers use the same validated user actor, resolved channel, request locale,
+resource-scoped correlation id, two-second deadline, and stable storefront public
+error policy as complete order reads.
 
 ## Unchanged behavior
 
 This source wave deliberately leaves these paths unchanged:
 
-- admin order mark-paid, ship, deliver, and cancel mutations still construct
-  `OrderService`;
-- admin order detail payment lookup still constructs `PaymentService`;
-- admin order detail fulfillment lookup still constructs `FulfillmentService`;
-- storefront return creation/listing and order-change listing still construct
-  `OrderService` after typed ownership validation;
+- storefront return creation still constructs `OrderService` after typed ownership
+  validation;
 - storefront refund listing still constructs `PaymentService` after typed ownership
   validation;
-- return and order-change paths still require wider owner contracts.
+- GraphQL return/order-change detail and list reads still use the compatibility
+  facade's concrete `OrderService` path;
+- admin return/order-change reads and all order/return/change mutations remain on
+  their current owner services;
+- admin order detail payment and fulfillment aggregation remain unchanged.
 
-Keeping payment/fulfillment aggregation and mutations out of this cutover avoids
-claiming ownership changes beyond complete order projection reads.
+No mutation, payment, or fulfillment policy moved into the read port.
 
 ## Context and diagnostics
 
 The owner boundary retains operation, correlation id, tenant, actor, channel
 length, requested/fallback locale lengths, causation/trace presence, deadline,
-order/customer/filter facts, stable owner code, error kind, and retryability.
-Only database and core failures retain the typed internal cause in technical
-logs. Public `PortError.message` values are stable and do not contain raw storage
-or owner-invariant details.
+order/return/change/customer/filter facts, stable owner code, error kind, and
+retryability. Only database and core failures retain the typed internal cause in
+technical logs. Public `PortError.message` values are stable and do not contain raw
+storage or owner-invariant details.
 
 ## Remaining source work
 
-1. publish wider owner contracts before moving return/order-change reads or order
-   mutations;
-2. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
-   evidence before any status promotion.
+1. cut GraphQL return/order-change detail and list reads to the host-selected port;
+2. audit and cut admin post-order reads separately without moving mutations;
+3. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
+   evidence before status promotion.
 
 ## Evidence
 
@@ -181,11 +161,11 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `storefront_http_cutover_unvalidated`. Host composition, admin REST,
-mounted GraphQL with actor/channel context, and storefront HTTP detail/ownership
-source cutover are recorded as complete. Compile evidence, mounted parity,
-deadline/failure execution, restart, and remote-adapter evidence remain false or
-open.
+Its status is `storefront_post_order_reads_cutover_unvalidated`. Six owner read
+operations, host composition, complete order consumers, and storefront post-order
+list consumers are recorded as source complete. GraphQL/admin post-order consumer
+cutover, compile evidence, mounted parity, deadline/failure execution, restart, and
+remote-adapter evidence remain false or open.
 
 ## Intended checks
 
@@ -193,6 +173,7 @@ open.
 node scripts/verify/verify-order-read-port.mjs
 node scripts/verify/verify-commerce-graphql-order-read-shim.mjs
 node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
+node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
 node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
 cargo check -p rustok-order --lib
 cargo check -p rustok-commerce --lib

--- a/crates/rustok-order/src/lib.rs
+++ b/crates/rustok-order/src/lib.rs
@@ -58,8 +58,10 @@ pub use checkout_payment_settlement::{
 pub use dto::*;
 pub use entities::*;
 pub use order_read::{
-    InProcessOrderReadPort, ListOrderProjectionsRequest, OrderProjectionPage, OrderReadPort,
-    ReadOrderProjectionRequest, in_process_order_read_port,
+    InProcessOrderReadPort, ListOrderChangeProjectionsRequest, ListOrderProjectionsRequest,
+    ListOrderReturnProjectionsRequest, OrderChangeProjectionPage, OrderProjectionPage,
+    OrderReadPort, OrderReturnProjectionPage, ReadOrderChangeProjectionRequest,
+    ReadOrderProjectionRequest, ReadOrderReturnProjectionRequest, in_process_order_read_port,
 };
 pub use ports::*;
 pub use status::*;

--- a/crates/rustok-order/src/order_read.rs
+++ b/crates/rustok-order/src/order_read.rs
@@ -6,9 +6,12 @@ use rustok_outbox::TransactionalEventBus;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{ListOrdersInput, OrderError, OrderResponse, OrderService};
+use crate::{
+    ListOrderChangesInput, ListOrderReturnsInput, ListOrdersInput, OrderChangeResponse, OrderError,
+    OrderResponse, OrderReturnResponse, OrderService,
+};
 
-/// Transport-neutral order-owner boundary for complete order projection reads.
+/// Transport-neutral order-owner boundary for complete order and post-order projection reads.
 #[async_trait]
 pub trait OrderReadPort: Send + Sync {
     async fn read_order_projection(
@@ -22,6 +25,30 @@ pub trait OrderReadPort: Send + Sync {
         context: PortContext,
         request: ListOrderProjectionsRequest,
     ) -> Result<OrderProjectionPage, PortError>;
+
+    async fn read_order_return_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderReturnProjectionRequest,
+    ) -> Result<OrderReturnResponse, PortError>;
+
+    async fn list_order_return_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderReturnProjectionsRequest,
+    ) -> Result<OrderReturnProjectionPage, PortError>;
+
+    async fn read_order_change_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderChangeProjectionRequest,
+    ) -> Result<OrderChangeResponse, PortError>;
+
+    async fn list_order_change_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderChangeProjectionsRequest,
+    ) -> Result<OrderChangeProjectionPage, PortError>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -42,6 +69,45 @@ pub struct ListOrderProjectionsRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderProjectionPage {
     pub items: Vec<OrderResponse>,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadOrderReturnProjectionRequest {
+    pub return_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListOrderReturnProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub order_id: Option<Uuid>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderReturnProjectionPage {
+    pub items: Vec<OrderReturnResponse>,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadOrderChangeProjectionRequest {
+    pub change_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListOrderChangeProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub order_id: Option<Uuid>,
+    pub status: Option<String>,
+    pub change_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderChangeProjectionPage {
+    pub items: Vec<OrderChangeResponse>,
     pub total: u64,
 }
 
@@ -98,6 +164,9 @@ impl OrderReadPort for InProcessOrderReadPort {
                     Some(request.order_id),
                     None,
                     None,
+                    None,
+                    None,
+                    None,
                     fallback_locale_length,
                     error,
                 )
@@ -135,14 +204,157 @@ impl OrderReadPort for InProcessOrderReadPort {
                     &context,
                     OPERATION,
                     None,
+                    None,
+                    None,
                     customer_id,
                     status_length,
+                    None,
                     fallback_locale_length,
                     error,
                 )
             })?;
 
         Ok(OrderProjectionPage { items, total })
+    }
+
+    async fn read_order_return_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderReturnProjectionRequest,
+    ) -> Result<OrderReturnResponse, PortError> {
+        const OPERATION: &str = "read_order_return_projection";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+
+        self.inner
+            .get_return(tenant_id, request.return_id)
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    None,
+                    Some(request.return_id),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    error,
+                )
+            })
+    }
+
+    async fn list_order_return_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderReturnProjectionsRequest,
+    ) -> Result<OrderReturnProjectionPage, PortError> {
+        const OPERATION: &str = "list_order_return_projections";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        let order_id = request.order_id;
+        let status_length = request.status.as_deref().map(str::len);
+
+        let (items, total) = self
+            .inner
+            .list_returns(
+                tenant_id,
+                ListOrderReturnsInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    order_id,
+                    status: request.status,
+                },
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    order_id,
+                    None,
+                    None,
+                    None,
+                    status_length,
+                    None,
+                    None,
+                    error,
+                )
+            })?;
+
+        Ok(OrderReturnProjectionPage { items, total })
+    }
+
+    async fn read_order_change_projection(
+        &self,
+        context: PortContext,
+        request: ReadOrderChangeProjectionRequest,
+    ) -> Result<OrderChangeResponse, PortError> {
+        const OPERATION: &str = "read_order_change_projection";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+
+        self.inner
+            .get_order_change(tenant_id, request.change_id)
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    None,
+                    None,
+                    Some(request.change_id),
+                    None,
+                    None,
+                    None,
+                    None,
+                    error,
+                )
+            })
+    }
+
+    async fn list_order_change_projections(
+        &self,
+        context: PortContext,
+        request: ListOrderChangeProjectionsRequest,
+    ) -> Result<OrderChangeProjectionPage, PortError> {
+        const OPERATION: &str = "list_order_change_projections";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        let order_id = request.order_id;
+        let status_length = request.status.as_deref().map(str::len);
+        let change_type_length = request.change_type.as_deref().map(str::len);
+
+        let (items, total) = self
+            .inner
+            .list_order_changes(
+                tenant_id,
+                ListOrderChangesInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    order_id,
+                    status: request.status,
+                    change_type: request.change_type,
+                },
+            )
+            .await
+            .map_err(|error| {
+                map_owner_error(
+                    &context,
+                    OPERATION,
+                    order_id,
+                    None,
+                    None,
+                    None,
+                    status_length,
+                    change_type_length,
+                    None,
+                    error,
+                )
+            })?;
+
+        Ok(OrderChangeProjectionPage { items, total })
     }
 }
 
@@ -176,8 +388,11 @@ fn map_owner_error(
     context: &PortContext,
     operation: &'static str,
     order_id: Option<Uuid>,
+    return_id: Option<Uuid>,
+    change_id: Option<Uuid>,
     customer_id: Option<Uuid>,
     status_length: Option<usize>,
+    change_type_length: Option<usize>,
     fallback_locale_length: Option<usize>,
     error: OrderError,
 ) -> PortError {
@@ -248,8 +463,11 @@ fn map_owner_error(
             traceparent_present = context.traceparent.is_some(),
             deadline_ms = ?context.deadline_ms,
             order_id = ?order_id,
+            return_id = ?return_id,
+            change_id = ?change_id,
             customer_id = ?customer_id,
             status_length = ?status_length,
+            change_type_length = ?change_type_length,
             error_kind,
             code,
             retryable,
@@ -270,8 +488,11 @@ fn map_owner_error(
             traceparent_present = context.traceparent.is_some(),
             deadline_ms = ?context.deadline_ms,
             order_id = ?order_id,
+            return_id = ?return_id,
+            change_id = ?change_id,
             customer_id = ?customer_id,
             status_length = ?status_length,
+            change_type_length = ?change_type_length,
             error_kind,
             code,
             retryable,

--- a/scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
@@ -50,7 +50,7 @@ for (const [source, value, label] of [
   [storefrontOrders, 'fn map_storefront_order_port_error(', 'safe PortError mapper'],
   [storefrontOrders, 'internal_code = %error.code', 'stable internal diagnostics'],
   [storefrontOrders, 'if order.customer_id != Some(customer_id)', 'ownership comparison'],
-  [note, 'Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.', 'owner note status'],
+  [note, 'Status: owner port and host runtime published; complete order projections plus storefront return/change lists cut over, unvalidated.', 'owner note status'],
   [orderPlan, 'storefront HTTP', 'order plan storefront checkpoint'],
 ]) requireText(source, value, label);
 
@@ -78,12 +78,10 @@ for (const [source, label] of [
 
 for (const [value, label] of [
   ['.create_return(tenant.id, id, input)', 'return mutation remains owner service'],
-  ['.list_returns(', 'return list remains owner service'],
-  ['.list_order_changes(', 'order-change list remains owner service'],
   ['PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
 ]) requireText(storefrontOrders, value, label);
 
-if (evidence.status !== 'storefront_http_cutover_unvalidated') {
+if (evidence.status !== 'storefront_post_order_reads_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership !==
@@ -93,11 +91,14 @@ if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership !==
 if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership_cutover_completed !== true) {
   failures.push('storefront detail/ownership source cutover must be complete');
 }
-if (evidence.consumer_inventory?.all_consumer_cutover_completed !== true) {
-  failures.push('complete order projection consumer cutover must be recorded');
+if (evidence.consumer_inventory?.complete_order_projection_consumer_cutover_completed !== true) {
+  failures.push('complete order projection consumer cutover must remain complete');
 }
-if (evidence.consumer_inventory?.cutover_required !== false) {
-  failures.push('complete order projection consumer cutover must no longer be pending');
+if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
+  failures.push('post-order GraphQL/admin consumers must remain open');
+}
+if (evidence.consumer_inventory?.cutover_required !== true) {
+  failures.push('post-order consumer cutover must remain pending');
 }
 if (evidence.context?.storefront_actor_source !== 'validated_auth_context_user') {
   failures.push('storefront actor source mismatch');
@@ -132,5 +133,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Storefront order detail and shared ownership reads use the host-selected typed owner port while return/change/payment operations remain unchanged',
+  '✔ Storefront order detail and shared ownership reads use the host-selected typed owner port while mutations and payment policy remain unchanged',
 );

--- a/scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const owner = read('crates/rustok-order/src/order_read.rs');
+const exports = read('crates/rustok-order/src/lib.rs');
+const storefront = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const evidence = JSON.parse(
+  read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
+);
+const note = read('crates/rustok-order/docs/order-read-port.md');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+for (const [source, value, label] of [
+  [owner, 'async fn read_order_return_projection(', 'return detail operation'],
+  [owner, 'async fn list_order_return_projections(', 'return list operation'],
+  [owner, 'async fn read_order_change_projection(', 'change detail operation'],
+  [owner, 'async fn list_order_change_projections(', 'change list operation'],
+  [owner, 'pub struct ReadOrderReturnProjectionRequest {', 'return detail request'],
+  [owner, 'pub struct ListOrderReturnProjectionsRequest {', 'return list request'],
+  [owner, 'pub struct OrderReturnProjectionPage {', 'return page'],
+  [owner, 'pub struct ReadOrderChangeProjectionRequest {', 'change detail request'],
+  [owner, 'pub struct ListOrderChangeProjectionsRequest {', 'change list request'],
+  [owner, 'pub struct OrderChangeProjectionPage {', 'change page'],
+  [owner, '.get_return(tenant_id, request.return_id)', 'owner return detail delegation'],
+  [owner, '.list_returns(', 'owner return list delegation'],
+  [owner, '.get_order_change(tenant_id, request.change_id)', 'owner change detail delegation'],
+  [owner, '.list_order_changes(', 'owner change list delegation'],
+  [exports, 'ListOrderReturnProjectionsRequest', 'return request export'],
+  [exports, 'ListOrderChangeProjectionsRequest', 'change request export'],
+  [storefront, '.list_order_return_projections(', 'storefront return port call'],
+  [storefront, 'ListOrderReturnProjectionsRequest {', 'storefront return request'],
+  [storefront, '.list_order_change_projections(', 'storefront change port call'],
+  [storefront, 'ListOrderChangeProjectionsRequest {', 'storefront change request'],
+  [storefront, 'data: page.items,', 'typed page items'],
+  [storefront, 'page.total', 'typed page total'],
+  [note, 'complete order projections plus storefront return/change lists cut over', 'owner note status'],
+]) requireText(source, value, label);
+
+const returnRoute = between(
+  storefront,
+  'pub async fn list_order_returns(',
+  '/// List refunds',
+  'storefront return list route',
+);
+const changeRoute = between(
+  storefront,
+  'pub async fn list_order_changes(',
+  '\n}',
+  'storefront change list route',
+);
+for (const [route, label, call] of [
+  [returnRoute, 'storefront return list route', '.list_order_return_projections('],
+  [changeRoute, 'storefront change list route', '.list_order_change_projections('],
+]) {
+  requireText(route, call, `${label} typed owner port`);
+  forbidText(route, 'OrderService::new', `${label} concrete owner construction`);
+  forbidText(route, '.list_returns(', `${label} concrete return list`);
+  forbidText(route, '.list_order_changes(', `${label} concrete change list`);
+}
+
+for (const [value, label] of [
+  ['.create_return(tenant.id, id, input)', 'return mutation remains owner service'],
+  ['PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
+]) requireText(storefront, value, label);
+
+if (evidence.status !== 'storefront_post_order_reads_cutover_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (evidence.operations?.map((operation) => operation.name).join(',') !==
+    'read_order_projection,list_order_projections,read_order_return_projection,list_order_return_projections,read_order_change_projection,list_order_change_projections') {
+  failures.push('owner operation inventory mismatch');
+}
+if (evidence.consumer_inventory?.commerce_storefront_return_list !==
+    'order_read_port_host_runtime') {
+  failures.push('storefront return list must use the host-selected owner port');
+}
+if (evidence.consumer_inventory?.commerce_storefront_order_change_list !==
+    'order_read_port_host_runtime') {
+  failures.push('storefront order-change list must use the host-selected owner port');
+}
+if (evidence.consumer_inventory?.post_order_consumer_cutover_completed !== false) {
+  failures.push('GraphQL/admin post-order consumer cutover must remain incomplete');
+}
+if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
+  failures.push('all consumer cutover must remain incomplete');
+}
+if (evidence.consumer_inventory?.cutover_required !== true) {
+  failures.push('remaining post-order cutover must stay open');
+}
+if (evidence.decision?.status_promotion !== false) {
+  failures.push('source cutover must not promote status');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront post-order read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Storefront return and order-change lists use typed owner projections while return mutation, refunds, GraphQL, and admin post-order reads remain unchanged',
+);

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -20,11 +20,6 @@ const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
 const adminOrders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
 const storefrontOrders = read('crates/rustok-commerce/src/controllers/store/orders.rs');
 const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
-const adminFixtures = read('crates/rustok-commerce/src/controllers/admin/tests/mod.rs');
-const storefrontFixtures = read('crates/rustok-commerce/src/controllers/store/tests/mod.rs');
-const fulfillmentFailureContract = read(
-  'crates/rustok-commerce/tests/fulfillment_read_port_failure_contract.rs',
-);
 const evidence = JSON.parse(
   read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
 );
@@ -51,88 +46,60 @@ const between = (source, start, end, label) => {
 
 for (const [source, value, label] of [
   [owner, 'pub trait OrderReadPort: Send + Sync {', 'owner read trait'],
-  [owner, 'async fn read_order_projection(', 'detail operation'],
-  [owner, 'async fn list_order_projections(', 'list operation'],
-  [owner, 'pub struct ReadOrderProjectionRequest {', 'detail request'],
-  [owner, 'pub struct ListOrderProjectionsRequest {', 'list request'],
-  [owner, 'pub struct OrderProjectionPage {', 'page projection'],
+  [owner, 'async fn read_order_projection(', 'order detail operation'],
+  [owner, 'async fn list_order_projections(', 'order list operation'],
+  [owner, 'async fn read_order_return_projection(', 'return detail operation'],
+  [owner, 'async fn list_order_return_projections(', 'return list operation'],
+  [owner, 'async fn read_order_change_projection(', 'change detail operation'],
+  [owner, 'async fn list_order_change_projections(', 'change list operation'],
+  [owner, 'pub struct ReadOrderProjectionRequest {', 'order detail request'],
+  [owner, 'pub struct ListOrderProjectionsRequest {', 'order list request'],
+  [owner, 'pub struct ReadOrderReturnProjectionRequest {', 'return detail request'],
+  [owner, 'pub struct ListOrderReturnProjectionsRequest {', 'return list request'],
+  [owner, 'pub struct ReadOrderChangeProjectionRequest {', 'change detail request'],
+  [owner, 'pub struct ListOrderChangeProjectionsRequest {', 'change list request'],
+  [owner, 'pub struct OrderProjectionPage {', 'order page'],
+  [owner, 'pub struct OrderReturnProjectionPage {', 'return page'],
+  [owner, 'pub struct OrderChangeProjectionPage {', 'change page'],
   [owner, 'pub struct InProcessOrderReadPort {', 'in-process adapter'],
   [owner, 'pub fn in_process_order_read_port(', 'root factory'],
   [owner, 'context.require_policy(PortCallPolicy::read())?', 'read policy'],
   [owner, 'Uuid::parse_str(&context.tenant_id)', 'tenant parsing'],
-  [owner, '.get_order_with_locale_fallback(', 'owner detail delegation'],
-  [owner, '.list_orders_with_locale_fallback(', 'owner list delegation'],
-  [owner, 'context.locale.as_str()', 'requested locale propagation'],
-  [owner, 'request.tenant_default_locale.as_deref()', 'fallback locale propagation'],
+  [owner, '.get_order_with_locale_fallback(', 'order detail delegation'],
+  [owner, '.list_orders_with_locale_fallback(', 'order list delegation'],
+  [owner, '.get_return(tenant_id, request.return_id)', 'return detail delegation'],
+  [owner, '.list_returns(', 'return list delegation'],
+  [owner, '.get_order_change(tenant_id, request.change_id)', 'change detail delegation'],
+  [owner, '.list_order_changes(', 'change list delegation'],
   [owner, 'OrderError::Validation(_)', 'validation mapping'],
   [owner, 'OrderError::OrderNotFound(_)', 'order not-found mapping'],
   [owner, 'OrderError::OrderReturnNotFound(_)', 'return not-found mapping'],
   [owner, 'OrderError::OrderChangeNotFound(_)', 'change not-found mapping'],
-  [owner, 'OrderError::InvalidTransition { .. }', 'transition mapping'],
   [owner, 'OrderError::Database(_)', 'database mapping'],
   [owner, 'OrderError::Core(_)', 'core mapping'],
-  [owner, 'PortErrorKind::InvariantViolation', 'core fail-closed kind'],
   [owner, 'PortError::new(kind, code, message, retryable)', 'stable port error'],
-  [owner, 'boundary = "order_read_port"', 'owner diagnostic boundary'],
-  [exports, 'mod order_read;', 'private owner module'],
-  [exports, 'OrderReadPort,', 'root trait export'],
-  [exports, 'InProcessOrderReadPort,', 'root adapter export'],
-  [exports, 'in_process_order_read_port,', 'root factory export'],
+  [exports, 'ListOrderReturnProjectionsRequest', 'return contract export'],
+  [exports, 'ListOrderChangeProjectionsRequest', 'change contract export'],
   [graphqlRuntime, 'pub struct CommerceOrderReadRuntime {', 'Commerce order runtime'],
   [graphqlRuntime, 'order_reads: Arc<dyn OrderReadPort>', 'runtime owner port'],
-  [graphqlRuntime, 'in_process_order_read_port(db, event_bus)', 'runtime in-process factory'],
-  [graphqlRuntime, 'pub fn order_read_port(&self)', 'runtime port getter'],
-  [graphqlRuntime, 'order_read_runtime: CommerceOrderReadRuntime,', 'GraphQL runtime data field'],
-  [graphqlRuntime, '.shared_get::<CommerceOrderReadRuntime>()', 'GraphQL host runtime requirement'],
-  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_RUNTIME:', 'GraphQL order task-local runtime'],
-  [graphqlRuntime, 'static CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT:', 'GraphQL order call context'],
-  [graphqlRuntime, 'ctx.data_opt::<AuthContext>()', 'GraphQL validated actor source'],
-  [graphqlRuntime, 'PortActor::user(auth.user_id.to_string())', 'GraphQL user actor'],
-  [graphqlRuntime, 'ctx.data_opt::<RequestContext>()', 'GraphQL resolved request source'],
-  [graphqlRuntime, 'request.channel_slug.clone()', 'GraphQL channel slug source'],
-  [graphqlRuntime, 'runtime_data.order_read_runtime()', 'GraphQL scoped host runtime'],
-  [graphqlRuntime, 'pub(crate) fn order_read_runtime_for_current_graphql_scope(', 'GraphQL runtime accessor'],
-  [graphqlRuntime, 'pub(crate) fn order_read_call_context_for_current_graphql_scope()', 'GraphQL call context accessor'],
-  [graphqlOrderShim, 'order_read_runtime_for_current_graphql_scope(', 'GraphQL shim scoped runtime lookup'],
-  [graphqlOrderShim, 'order_read_call_context_for_current_graphql_scope()', 'GraphQL shim call context lookup'],
-  [graphqlOrderShim, 'call_context.actor()', 'GraphQL actor propagation'],
-  [graphqlOrderShim, 'context.with_channel(channel)', 'GraphQL channel propagation'],
-  [graphqlRuntime, 'commerce GraphQL requires CommerceOrderReadRuntime in host composition', 'GraphQL fail-closed message'],
-  [httpRuntime, 'order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,', 'HTTP runtime field'],
+  [graphqlRuntime, 'runtime_data.order_read_runtime()', 'GraphQL scoped runtime'],
+  [graphqlRuntime, 'ctx.data_opt::<AuthContext>()', 'GraphQL actor source'],
+  [graphqlRuntime, 'ctx.data_opt::<RequestContext>()', 'GraphQL request source'],
+  [graphqlOrderShim, 'order_read_runtime_for_current_graphql_scope(', 'GraphQL runtime lookup'],
   [httpRuntime, 'fn order_read_port(&self)', 'HTTP port getter'],
-  [httpRuntime, '.shared_get::<crate::graphql_runtime::CommerceOrderReadRuntime>()', 'HTTP host requirement'],
-  [httpRuntime, 'Commerce HTTP routes require CommerceOrderReadRuntime in HostRuntimeContext', 'HTTP fail-closed message'],
-  [serverRuntime, '.shared_get::<rustok_commerce::graphql_runtime::CommerceOrderReadRuntime>()', 'server runtime reuse'],
-  [serverRuntime, 'CommerceOrderReadRuntime::in_process(', 'server in-process composition'],
-  [serverRuntime, 'server.shared_insert(runtime.clone());', 'server runtime cache'],
-  [serverRuntime, 'host.with_shared_value(runtime)', 'host runtime attachment'],
-  [adminOrders, 'fn admin_order_read_port_context(', 'admin PortContext builder'],
-  [adminOrders, 'PortActor::user(auth.user_id.to_string())', 'admin actor propagation'],
-  [adminOrders, '.with_deadline(std::time::Duration::from_secs(2))', 'admin deadline'],
-  [adminOrders, 'request_context.channel_slug.as_deref()', 'admin channel propagation'],
-  [adminOrders, 'fn map_admin_order_port_error(', 'admin PortError mapper'],
+  [serverRuntime, 'CommerceOrderReadRuntime::in_process(', 'server composition'],
   [adminOrders, '.list_order_projections(', 'admin list port call'],
   [adminOrders, '.read_order_projection(', 'admin detail port call'],
-  [adminOrders, 'tenant_default_locale: Some(tenant.default_locale.clone())', 'admin locale fallback'],
-  [adminOrders, 'data: page.items,', 'admin list envelope'],
-  [adminOrders, 'page.total,', 'admin owner total'],
-  [adminOrders, 'find_latest_collection_by_order(tenant.id, id)', 'unchanged payment aggregation'],
-  [adminOrders, 'find_by_order(tenant.id, id)', 'unchanged fulfillment aggregation'],
-  [storefrontOrders, 'fn storefront_order_read_port_context(', 'storefront PortContext builder'],
-  [storefrontOrders, 'PortActor::user(auth.user_id.to_string())', 'storefront actor propagation'],
-  [storefrontOrders, 'request_context.channel_slug.as_deref()', 'storefront channel propagation'],
-  [storefrontOrders, 'async fn read_storefront_order_projection(', 'storefront shared read helper'],
-  [storefrontOrders, 'runtime\n        .order_read_port()', 'storefront host-selected port'],
   [storefrontOrders, '.read_order_projection(', 'storefront detail port call'],
-  [storefrontOrders, 'tenant_default_locale: Some(tenant_default_locale.to_string())', 'storefront locale fallback'],
-  [storefrontOrders, 'fn map_storefront_order_port_error(', 'storefront PortError mapper'],
-  [adminFixtures, 'CommerceOrderReadRuntime::in_process(', 'admin fixture runtime'],
-  [storefrontFixtures, 'CommerceOrderReadRuntime::in_process(', 'storefront fixture runtime'],
-  [fulfillmentFailureContract, 'CommerceOrderReadRuntime::in_process(', 'manual host fixture runtime'],
-  [fulfillmentFailureContract, '.with_shared_value(event_bus.clone())', 'manual host fixture shared event bus'],
-  [note, 'Status: owner port and host runtime published; admin REST, mounted GraphQL, and storefront HTTP detail/ownership cut over, unvalidated.', 'owner note status'],
-  [orderPlan, 'CommerceOrderReadRuntime', 'order plan runtime checkpoint'],
-  [commercePlan, 'CommerceOrderReadRuntime', 'commerce plan runtime checkpoint'],
+  [storefrontOrders, '.list_order_return_projections(', 'storefront return port call'],
+  [storefrontOrders, '.list_order_change_projections(', 'storefront change port call'],
+  [storefrontOrders, 'ListOrderReturnProjectionsRequest {', 'storefront return request'],
+  [storefrontOrders, 'ListOrderChangeProjectionsRequest {', 'storefront change request'],
+  [storefrontOrders, 'data: page.items,', 'storefront typed page items'],
+  [storefrontOrders, 'page.total', 'storefront typed page total'],
+  [note, 'complete order projections plus storefront return/change lists cut over', 'owner note status'],
+  [orderPlan, 'OrderReadPort', 'order plan checkpoint'],
+  [commercePlan, 'OrderReadPort', 'commerce plan checkpoint'],
 ]) requireText(source, value, label);
 
 for (const [value, label] of [
@@ -142,28 +109,18 @@ for (const [value, label] of [
   ['PortError::new(kind, code, error', 'raw owner error publication'],
 ]) forbidText(owner, value, label);
 
-const listRoute = between(
+const adminList = between(
   adminOrders,
   'pub async fn list_orders(',
   '#[utoipa::path(\n    get,\n    path = "/admin/orders/{id}"',
   'admin list route',
 );
-const showRoute = between(
+const adminDetail = between(
   adminOrders,
   'pub async fn show_order(',
   'fn map_order_detail_payment_error(',
   'admin detail route',
 );
-for (const [route, label] of [
-  [listRoute, 'admin list route'],
-  [showRoute, 'admin detail route'],
-]) {
-  forbidText(route, 'OrderService::new', `${label} concrete owner construction`);
-  forbidText(route, '.list_orders_with_locale_fallback(', `${label} concrete list call`);
-  forbidText(route, '.get_order_with_locale_fallback(', `${label} concrete detail call`);
-  requireText(route, 'runtime\n        .order_read_port()', `${label} injected owner port`);
-}
-
 const storefrontOwnership = between(
   storefrontOrders,
   'async fn ensure_customer_owns_order(',
@@ -176,44 +133,57 @@ const storefrontDetail = between(
   '/// Create a return request',
   'storefront detail route',
 );
+const storefrontReturns = between(
+  storefrontOrders,
+  'pub async fn list_order_returns(',
+  '/// List refunds',
+  'storefront return list route',
+);
+const storefrontChanges = storefrontOrders.slice(
+  storefrontOrders.indexOf('pub async fn list_order_changes('),
+);
+
 for (const [route, label] of [
+  [adminList, 'admin list route'],
+  [adminDetail, 'admin detail route'],
   [storefrontOwnership, 'storefront ownership helper'],
   [storefrontDetail, 'storefront detail route'],
+  [storefrontReturns, 'storefront return list route'],
+  [storefrontChanges, 'storefront change list route'],
 ]) {
-  forbidText(route, 'OrderService::new', `${label} concrete owner construction`);
-  forbidText(route, '.get_order(', `${label} concrete detail call`);
-  forbidText(route, '.get_order_with_locale_fallback(', `${label} concrete locale detail call`);
-  requireText(route, 'read_storefront_order_projection(', `${label} shared owner read`);
+  forbidText(route, '.get_order_with_locale_fallback(', `${label} concrete order detail`);
 }
+for (const [route, value, label] of [
+  [storefrontReturns, 'OrderService::new', 'storefront return concrete service'],
+  [storefrontReturns, '.list_returns(', 'storefront concrete return list'],
+  [storefrontChanges, 'OrderService::new', 'storefront change concrete service'],
+  [storefrontChanges, '.list_order_changes(', 'storefront concrete change list'],
+]) forbidText(route, value, label);
 
-for (const [value, label] of [
-  ['.mark_paid(', 'mark-paid mutation remains owner service'],
-  ['.ship_order(', 'ship mutation remains owner service'],
-  ['.deliver_order(', 'deliver mutation remains owner service'],
-  ['.cancel_order(', 'cancel mutation remains owner service'],
-]) requireText(adminOrders, value, label);
-for (const [value, label] of [
-  ['.create_return(tenant.id, id, input)', 'storefront return mutation remains owner service'],
-  ['.list_returns(', 'storefront return list remains owner service'],
-  ['.list_order_changes(', 'storefront order-change list remains owner service'],
-  ['PaymentService::new(runtime.db_clone())', 'storefront refund list remains payment service'],
-]) requireText(storefrontOrders, value, label);
+for (const [source, value, label] of [
+  [adminOrders, '.mark_paid(', 'mark-paid mutation remains owner service'],
+  [adminOrders, '.ship_order(', 'ship mutation remains owner service'],
+  [adminOrders, '.deliver_order(', 'deliver mutation remains owner service'],
+  [adminOrders, '.cancel_order(', 'cancel mutation remains owner service'],
+  [storefrontOrders, '.create_return(tenant.id, id, input)', 'return mutation remains owner service'],
+  [storefrontOrders, 'PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
+  [graphqlOrderShim, '.get_return(tenant_id, return_id)', 'GraphQL return detail remains concrete'],
+  [graphqlOrderShim, '.list_returns(tenant_id, input)', 'GraphQL return list remains concrete'],
+  [graphqlOrderShim, '.get_order_change(tenant_id, change_id)', 'GraphQL change detail remains concrete'],
+  [graphqlOrderShim, '.list_order_changes(tenant_id, input)', 'GraphQL change list remains concrete'],
+]) requireText(source, value, label);
 
-if (evidence.status !== 'storefront_http_cutover_unvalidated') {
+const operationNames = evidence.operations?.map((operation) => operation.name).join(',');
+if (evidence.status !== 'storefront_post_order_reads_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
-if (evidence.owner?.port !== 'OrderReadPort') {
-  failures.push('evidence owner port must be OrderReadPort');
+if (operationNames !==
+    'read_order_projection,list_order_projections,read_order_return_projection,list_order_return_projections,read_order_change_projection,list_order_change_projections') {
+  failures.push(`evidence operation inventory mismatch: ${operationNames}`);
 }
-if (evidence.owner?.adapter !== 'InProcessOrderReadPort') {
-  failures.push('evidence adapter must be InProcessOrderReadPort');
-}
-if (evidence.operations?.map((operation) => operation.name).join(',') !==
-    'read_order_projection,list_order_projections') {
-  failures.push('evidence operation inventory mismatch');
-}
-if (evidence.runtime_composition?.type !== 'CommerceOrderReadRuntime') {
-  failures.push('evidence runtime type must be CommerceOrderReadRuntime');
+if (evidence.owner?.port !== 'OrderReadPort' ||
+    evidence.owner?.adapter !== 'InProcessOrderReadPort') {
+  failures.push('evidence owner boundary mismatch');
 }
 for (const key of [
   'server_runtime_reuse',
@@ -229,56 +199,25 @@ for (const key of [
     failures.push(`evidence runtime_composition.${key} must be true`);
   }
 }
-if (evidence.context?.graphql_actor_source !== 'validated_auth_context_or_service_actor') {
-  failures.push('GraphQL actor source must remain validated AuthContext or service actor');
+for (const [key, expected] of [
+  ['commerce_admin_rest_cutover_completed', true],
+  ['commerce_storefront_detail_and_ownership_cutover_completed', true],
+  ['commerce_storefront_return_list_cutover_completed', true],
+  ['commerce_storefront_order_change_list_cutover_completed', true],
+  ['commerce_graphql_order_list_detail_cutover_completed', true],
+  ['complete_order_projection_consumer_cutover_completed', true],
+  ['post_order_consumer_cutover_completed', false],
+  ['all_consumer_cutover_completed', false],
+  ['cutover_required', true],
+]) {
+  if (evidence.consumer_inventory?.[key] !== expected) {
+    failures.push(`evidence consumer_inventory.${key} must be ${expected}`);
+  }
 }
-if (evidence.context?.graphql_channel_source !== 'resolved_request_context_channel_slug') {
-  failures.push('GraphQL channel source must remain the resolved request channel slug');
-}
-if (evidence.context?.graphql_embedded_context_fallback !== 'service_actor_without_channel') {
-  failures.push('GraphQL embedded context fallback must not invent actor or channel attribution');
-}
-if (evidence.context?.storefront_actor_source !== 'validated_auth_context_user') {
-  failures.push('storefront actor source must remain validated AuthContext user');
-}
-if (evidence.context?.storefront_channel_source !== 'resolved_request_context_channel_slug') {
-  failures.push('storefront channel source must remain the resolved request channel slug');
-}
-if (evidence.errors?.owner_message_control_flow !== false) {
-  failures.push('evidence must forbid owner-message control flow');
-}
-if (evidence.errors?.all_current_order_error_variants_mapped !== true) {
-  failures.push('evidence must record complete current OrderError mapping');
-}
-if (evidence.errors?.storefront_public_envelopes_preserved !== true) {
-  failures.push('storefront public envelopes must be preserved');
-}
-if (evidence.consumer_inventory?.commerce_admin_rest_list_detail !== 'order_read_port') {
-  failures.push('admin REST list/detail must be recorded on order_read_port');
-}
-if (evidence.consumer_inventory?.commerce_admin_rest_cutover_completed !== true) {
-  failures.push('admin REST source cutover must be complete');
-}
-if (evidence.consumer_inventory?.commerce_graphql_order_list_detail !== 'order_read_port_host_runtime_with_request_context') {
-  failures.push('GraphQL list/detail must use the host-selected runtime with request context');
-}
-if (evidence.consumer_inventory?.commerce_graphql_order_list_detail_cutover_completed !== true) {
-  failures.push('GraphQL list/detail source cutover must be complete');
-}
-if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership !== 'order_read_port_host_runtime') {
-  failures.push('storefront detail/ownership must use the host-selected runtime');
-}
-if (evidence.consumer_inventory?.commerce_storefront_detail_and_ownership_cutover_completed !== true) {
-  failures.push('storefront detail/ownership source cutover must be complete');
-}
-if (evidence.consumer_inventory?.runtime_composition_published !== true) {
-  failures.push('runtime composition must be published');
-}
-if (evidence.consumer_inventory?.all_consumer_cutover_completed !== true) {
-  failures.push('complete order projection consumer cutover must be recorded');
-}
-if (evidence.consumer_inventory?.cutover_required !== false) {
-  failures.push('complete order projection consumer cutover must no longer be pending');
+if (evidence.errors?.owner_message_control_flow !== false ||
+    evidence.errors?.all_current_order_error_variants_mapped !== true ||
+    evidence.errors?.storefront_public_envelopes_preserved !== true) {
+  failures.push('evidence error policy mismatch');
 }
 if (evidence.decision?.status_promotion !== false) {
   failures.push('source cutover must not promote status');
@@ -304,5 +243,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Order read runtime is host-composed and admin REST, mounted GraphQL, and storefront detail/ownership use typed owner ports while runtime evidence remains pending',
+  '✔ OrderReadPort publishes six typed projections; storefront order, return, and change reads are cut over while GraphQL/admin post-order reads and runtime evidence remain open',
 );


### PR DESCRIPTION
## Summary
- extend `OrderReadPort` with typed detail/list projections for returns and order changes
- preserve existing owner DTOs, filters, descending ordering, and pagination totals
- cut storefront return and order-change lists to the host-selected `CommerceOrderReadRuntime`
- preserve customer ownership, validated actor, resolved channel, two-second deadline, and existing public envelopes
- leave return mutation, refund payment reads, GraphQL post-order reads, and admin post-order reads unchanged
- synchronize ecommerce/order plans, source evidence, documentation, and focused static guards

## Recheck
- confirmed the order owner already exposes pure return/order-change detail and list reads
- confirmed the repository has one current `OrderReadPort` implementation, updated in this change
- confirmed storefront list handlers constructed `OrderService` only after typed order ownership validation
- rebased the final branch onto current `main`; it contains one commit, ten target files, and is not behind

## Remaining work
- cut GraphQL return/order-change detail and list reads to the scoped host-selected runtime
- audit and cut admin post-order reads separately without moving mutations or payment/fulfillment policy
- execute compile, mounted parity, deadline/failure, restart, and remote-adapter evidence before status promotion

## Verification
Not run per maintainer instruction. Tests, Cargo commands, formatting, verifiers, workflow checks, and CI are not claimed as implementation evidence.