### PR TITLE
feat(commerce): cut admin post-order reads to owner port

### DIFF
--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -2,6 +2,7 @@ pub mod changes;
 pub mod fulfillments;
 pub mod orders;
 pub mod payments;
+pub mod post_order_reads;
 pub mod products;
 pub mod returns;
 pub mod shipping;
@@ -196,11 +197,11 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
         .route(
             "/order-changes",
-            axum::routing::get(changes::list_order_changes),
+            axum::routing::get(post_order_reads::list_order_changes),
         )
         .route(
             "/order-changes/{id}",
-            axum::routing::get(changes::show_order_change),
+            axum::routing::get(post_order_reads::show_order_change),
         )
         .route(
             "/order-changes/{id}/apply",
@@ -210,10 +211,13 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
             "/order-changes/{id}/cancel",
             axum::routing::post(changes::cancel_order_change),
         )
-        .route("/returns", axum::routing::get(returns::list_order_returns))
+        .route(
+            "/returns",
+            axum::routing::get(post_order_reads::list_order_returns),
+        )
         .route(
             "/returns/{id}",
-            axum::routing::get(returns::show_order_return),
+            axum::routing::get(post_order_reads::show_order_return),
         )
         .route(
             "/returns/{id}/complete",

--- a/crates/rustok-commerce/src/controllers/admin/post_order_reads.rs
+++ b/crates/rustok-commerce/src/controllers/admin/post_order_reads.rs
@@ -1,0 +1,357 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_order::{
+    ListOrderChangeProjectionsRequest, ListOrderReturnProjectionsRequest, OrderChangeResponse,
+    OrderReturnResponse, ReadOrderChangeProjectionRequest, ReadOrderReturnProjectionRequest,
+};
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+use super::{
+    super::{
+        CommerceHttpRuntime,
+        common::{PaginatedResponse, PaginationMeta, ensure_permissions},
+    },
+    ListOrderChangesParams, ListOrderReturnsParams,
+};
+
+const ADMIN_POST_ORDER_OWNER: &str = "rustok_order.admin_post_order_reads";
+const ADMIN_POST_ORDER_BOUNDARY: &str = "commerce_admin_post_order_http";
+
+fn admin_post_order_read_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    resource_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = resource_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-post-order:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_admin_post_order_port_error(
+    error: PortError,
+    port_context: &PortContext,
+    owner_operation: &'static str,
+    consumer_operation: &'static str,
+    actor_id: Uuid,
+    return_id: Option<Uuid>,
+    change_id: Option<Uuid>,
+    order_id: Option<Uuid>,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    tracing::error!(
+        error = ?error,
+        owner = ADMIN_POST_ORDER_OWNER,
+        owner_operation,
+        consumer_operation,
+        correlation_id = %port_context.correlation_id,
+        tenant_id = %port_context.tenant_id,
+        actor_id = %actor_id,
+        return_id = ?return_id,
+        change_id = ?change_id,
+        order_id = ?order_id,
+        actor = ?port_context.actor,
+        channel = ?port_context.channel,
+        locale = %port_context.locale,
+        deadline_ms = ?port_context.deadline_ms,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_POST_ORDER_BOUNDARY,
+        "commerce admin post-order owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/returns",
+    tag = "admin",
+    params(ListOrderReturnsParams),
+    responses(
+        (status = 200, description = "Returns", body = PaginatedResponse<OrderReturnResponse>),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 503, description = "Order storage unavailable")
+    )
+)]
+pub async fn list_order_returns(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    auth: AuthContext,
+    Query(params): Query<ListOrderReturnsParams>,
+) -> HttpResult<Json<PaginatedResponse<OrderReturnResponse>>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
+    let pagination = params.pagination.unwrap_or_default();
+    let order_id = params.order_id;
+    let context = admin_post_order_read_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        order_id,
+        "list_order_returns",
+    );
+    let page = runtime
+        .order_read_port()
+        .list_order_return_projections(
+            context.clone(),
+            ListOrderReturnProjectionsRequest {
+                page: pagination.page,
+                per_page: pagination.limit(),
+                order_id,
+                status: params.status,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                error,
+                &context,
+                "list_order_return_projections",
+                "list_order_returns",
+                auth.user_id,
+                None,
+                None,
+                order_id,
+            )
+        })?;
+
+    Ok(Json(PaginatedResponse {
+        data: page.items,
+        meta: PaginationMeta::new(pagination.page, pagination.limit(), page.total),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/returns/{id}",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Return ID")),
+    responses(
+        (status = 200, description = "Return details", body = OrderReturnResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Return not found"),
+        (status = 503, description = "Order storage unavailable")
+    )
+)]
+pub async fn show_order_return(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    auth: AuthContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<OrderReturnResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
+    let context = admin_post_order_read_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "show_order_return",
+    );
+    let item = runtime
+        .order_read_port()
+        .read_order_return_projection(
+            context.clone(),
+            ReadOrderReturnProjectionRequest { return_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                error,
+                &context,
+                "read_order_return_projection",
+                "show_order_return",
+                auth.user_id,
+                Some(id),
+                None,
+                None,
+            )
+        })?;
+    Ok(Json(item))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/order-changes",
+    tag = "admin",
+    params(ListOrderChangesParams),
+    responses(
+        (status = 200, description = "Order changes", body = PaginatedResponse<OrderChangeResponse>),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 503, description = "Order storage unavailable")
+    )
+)]
+pub async fn list_order_changes(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    auth: AuthContext,
+    Query(params): Query<ListOrderChangesParams>,
+) -> HttpResult<Json<PaginatedResponse<OrderChangeResponse>>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
+    let pagination = params.pagination.unwrap_or_default();
+    let order_id = params.order_id;
+    let context = admin_post_order_read_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        order_id,
+        "list_order_changes",
+    );
+    let page = runtime
+        .order_read_port()
+        .list_order_change_projections(
+            context.clone(),
+            ListOrderChangeProjectionsRequest {
+                page: pagination.page,
+                per_page: pagination.limit(),
+                order_id,
+                status: params.status,
+                change_type: params.change_type,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                error,
+                &context,
+                "list_order_change_projections",
+                "list_order_changes",
+                auth.user_id,
+                None,
+                None,
+                order_id,
+            )
+        })?;
+
+    Ok(Json(PaginatedResponse {
+        data: page.items,
+        meta: PaginationMeta::new(pagination.page, pagination.limit(), page.total),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/order-changes/{id}",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order change ID")),
+    responses(
+        (status = 200, description = "Order change details", body = OrderChangeResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order change not found"),
+        (status = 503, description = "Order storage unavailable")
+    )
+)]
+pub async fn show_order_change(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    auth: AuthContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<OrderChangeResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
+    let context = admin_post_order_read_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "show_order_change",
+    );
+    let item = runtime
+        .order_read_port()
+        .read_order_change_projection(
+            context.clone(),
+            ReadOrderChangeProjectionRequest { change_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                error,
+                &context,
+                "read_order_change_projection",
+                "show_order_change",
+                auth.user_id,
+                None,
+                Some(id),
+                None,
+            )
+        })?;
+    Ok(Json(item))
+}

--- a/crates/rustok-order/contracts/evidence/order-read-port-source.json
+++ b/crates/rustok-order/contracts/evidence/order-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-29",
-  "status": "graphql_post_order_reads_cutover_unvalidated",
-  "source_base_revision": "246dde3e152a4f56f446d577e11108305a679fde",
+  "generated_at": "2026-07-30",
+  "status": "mounted_consumer_cutover_unvalidated",
+  "source_base_revision": "89c7cde43e994df08b7764fe31861b41a0022ddd",
   "scope": "complete order, return, and order-change projections for mounted Commerce query consumers",
   "owner": {
     "crate": "rustok-order",
@@ -80,6 +80,9 @@
     "locale_retained": true,
     "correlation_retained": true,
     "deadline_required": true,
+    "admin_actor_source": "validated_auth_context_user",
+    "admin_channel_source": "resolved_request_context_channel_slug",
+    "admin_locale_source": "resolved_request_context_locale",
     "admin_deadline_seconds": 2,
     "graphql_actor_source": "validated_auth_context_or_service_actor",
     "graphql_channel_source": "resolved_request_context_channel_slug",
@@ -118,6 +121,8 @@
   "consumer_inventory": {
     "commerce_admin_rest_list_detail": "order_read_port",
     "commerce_admin_rest_cutover_completed": true,
+    "commerce_admin_return_and_order_change_reads": "order_read_port_host_runtime_with_request_context",
+    "commerce_admin_return_and_order_change_reads_cutover_completed": true,
     "commerce_storefront_detail_and_ownership": "order_read_port_host_runtime",
     "commerce_storefront_detail_and_ownership_cutover_completed": true,
     "commerce_storefront_return_list": "order_read_port_host_runtime",
@@ -128,13 +133,14 @@
     "commerce_graphql_order_list_detail_cutover_completed": true,
     "commerce_graphql_return_and_order_change_reads": "order_read_port_host_runtime_with_request_context",
     "commerce_graphql_return_and_order_change_reads_cutover_completed": true,
-    "commerce_admin_return_and_order_change_reads": "concrete_order_service",
     "complete_order_projection_consumer_cutover_completed": true,
     "graphql_post_order_consumer_cutover_completed": true,
-    "post_order_consumer_cutover_completed": false,
+    "admin_post_order_consumer_cutover_completed": true,
+    "post_order_consumer_cutover_completed": true,
     "runtime_composition_published": true,
-    "all_consumer_cutover_completed": false,
-    "cutover_required": true
+    "all_mounted_consumer_cutover_completed": true,
+    "all_consumer_cutover_completed": true,
+    "cutover_required": false
   },
   "unchanged_scope": {
     "admin_order_mutations": "concrete_order_service",
@@ -142,10 +148,10 @@
     "admin_detail_fulfillment_lookup": "concrete_fulfillment_service",
     "storefront_return_mutation": "concrete_order_service",
     "storefront_refund_reads": "concrete_payment_service",
-    "admin_return_and_order_change_reads": "concrete_order_service"
+    "unmounted_admin_compatibility_handlers": "concrete_order_service_source_only_not_routed"
   },
   "decision": {
-    "next_slice": "audit and cut admin post-order reads to the host-selected OrderReadPort without moving mutations or payment and fulfillment policy; execute compile and mounted parity evidence before status promotion",
+    "next_slice": "execute compile, mounted parity, deadline and failure, restart, and remote-adapter evidence; remove unmounted compatibility GET handlers only after validation",
     "mutation_scope": "unchanged",
     "status_promotion": false
   },

--- a/crates/rustok-order/docs/implementation-plan.md
+++ b/crates/rustok-order/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Implementation plan for `rustok-order`
 
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-30
 
 ## Current state
 
@@ -56,12 +56,13 @@ typed identity exclusively.
 Complete order, return, and order-change projection reads are published through
 `OrderReadPort`. `CommerceOrderReadRuntime` carries one host-selected owner port
 through the default server, `HostRuntimeContext`, Commerce HTTP, and Commerce
-GraphQL schema data. Mounted GraphQL complete-order and post-order reads,
-storefront HTTP order detail/ownership and post-order lists, plus admin REST
-complete-order reads use the same port with authenticated actor, resolved channel,
-effective locale context, deadline, public error policy, filters, ordering,
-pagination total, locale fallback where applicable, and ownership behavior
-preserved. Admin post-order reads plus runtime evidence remain open and unvalidated.
+GraphQL schema data. Mounted GraphQL, storefront HTTP, and admin REST complete-order
+and post-order query consumers use the same port with authenticated actor, resolved
+channel, effective locale context, deadline, public error policy, filters,
+ordering, pagination total, locale fallback where applicable, and ownership
+behavior preserved. Runtime evidence remains open and unvalidated. The superseded
+admin post-order GET functions remain compiled but unmounted until maintainer
+compile and mounted-parity validation permits their removal.
 
 ## FFA/FBA boundary
 
@@ -90,6 +91,7 @@ preserved. Admin post-order reads plus runtime evidence remain open and unvalida
   `scripts/verify/verify-commerce-graphql-order-read-shim.mjs`,
   `scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`,
   `scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`,
+  `scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs`,
   `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`,
   `scripts/verify/verify-commerce-storefront-transport-handoff.mjs`,
   `scripts/verify/verify-commerce-order-identity-boundary.mjs`,
@@ -187,10 +189,14 @@ preserved. Admin post-order reads plus runtime evidence remain open and unvalida
 - [x] Cut GraphQL return/order-change detail and list reads over to the scoped
   host-selected runtime while preserving typed not-found error shapes and without
   changing mutations.
-- [ ] Audit and cut admin post-order reads separately without moving mutations or
-  payment/fulfillment policy.
-- [ ] Execute compile, mounted parity, deadline/failure, restart, and remote-adapter
-  evidence before status promotion.
+- [x] Cut mounted admin return/order-change detail and list reads over to the
+  host-selected runtime while preserving `ORDERS_READ`, filters, clamped
+  pagination, totals, public envelopes, actor/channel/locale/deadline context, and
+  all mutation/payment/fulfillment ownership.
+- [ ] Execute compile and mounted parity for the four admin post-order GET routes,
+  then remove their unmounted compatibility handlers.
+- [ ] Execute deadline/failure, restart, and remote-adapter evidence before status
+  promotion.
 
 ## Open results
 
@@ -243,23 +249,22 @@ preserved. Admin post-order reads plus runtime evidence remain open and unvalida
    **Done when:** the contract-test matrix has executable remote evidence and
    fallback behavior supports a justified status promotion.
 
-7. **Prove mounted order projection read parity.** Mounted GraphQL complete-order
-   and post-order reads, storefront order/return/change reads, and admin REST
-   complete-order reads now use the host-selected `CommerceOrderReadRuntime`
-   without concrete `OrderService` projection reads on those paths.
+7. **Prove mounted order projection read parity.** Mounted GraphQL, storefront,
+   and admin REST complete-order and post-order reads use the host-selected
+   `CommerceOrderReadRuntime` without concrete `OrderService` projection reads on
+   active routes.
    **Depends on:** compiled order/commerce/server crates and mounted local plus
    remote adapter profiles.
    **Done when:** locale/filter/pagination/authorization/ownership behavior,
    deadlines, stable failure policy, restart, and remote adapter parity are
    retained as execution evidence.
 
-8. **Finish admin post-order consumer cutover.** Admin return/order-change reads
-   still use concrete owner services even though all six typed operations are
-   published and GraphQL/storefront consumers are cut over.
-   **Depends on:** the host-selected runtime and current admin transport envelope
-   inventory.
-   **Done when:** mounted admin post-order reads no longer construct foreign owner
-   services, while mutations and payment/fulfillment policy remain unchanged.
+8. **Remove unmounted admin post-order compatibility handlers.** The active admin
+   GET routes are cut over, but the superseded functions in `admin/returns.rs` and
+   `admin/changes.rs` remain compiled as rollback-compatible source.
+   **Depends on:** successful compile plus mounted route parity evidence.
+   **Done when:** those four unmounted GET functions are deleted, OpenAPI remains
+   unchanged, and no admin mutation or orchestration route moves ownership.
 
 9. **Keep order and commerce documentation synchronized.** Update local docs,
    manifests, registries, central status, and the umbrella commerce plan whenever
@@ -274,6 +279,7 @@ preserved. Admin post-order reads plus runtime evidence remain open and unvalida
 - `node scripts/verify/verify-commerce-graphql-order-read-shim.mjs`
 - `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
 - `node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`
+- `node scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs`
 - `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`

--- a/crates/rustok-order/docs/order-read-port.md
+++ b/crates/rustok-order/docs/order-read-port.md
@@ -1,6 +1,6 @@
 # Order read port
 
-Status: owner port and host runtime published; storefront and GraphQL complete/post-order reads cut over, unvalidated.
+Status: owner port and host runtime published; all mounted complete/post-order reads cut over, unvalidated.
 
 ## Scope
 
@@ -15,11 +15,11 @@ consumers. It is separate from:
 - order lifecycle, return, and order-change mutations, which remain on existing
   order-owner commands and services.
 
-The owner boundary and host-selected runtime are published. Mounted admin REST
-complete-order reads, mounted GraphQL complete-order and post-order reads,
-storefront HTTP order detail/ownership, and storefront return/order-change lists
-use the port. Admin post-order reads remain open; runtime evidence remains
-unvalidated.
+The owner boundary and host-selected runtime are published. Mounted admin REST,
+mounted GraphQL, and storefront HTTP complete-order and post-order query consumers
+use the port. Runtime evidence remains unvalidated. The superseded admin GET
+functions remain as explicitly unmounted compatibility source until compile and
+mounted-parity validation permits their removal.
 
 ## Operations
 
@@ -121,7 +121,7 @@ error policy.
 
 ## GraphQL post-order read cutover
 
-The Commerce safe-query compatibility facade now calls all six typed operations.
+The Commerce safe-query compatibility facade calls all six typed operations.
 Return/order-change detail and list methods use the scoped host-selected runtime
 instead of constructing `OrderService`. Existing DTOs, filters, totals, and query
 method signatures are unchanged.
@@ -131,6 +131,27 @@ channel, effective locale, correlation id, and two-second deadline. Typed
 `NotFound` results map back to `OrderReturnNotFound` or
 `OrderChangeNotFound`, preserving the existing GraphQL error boundary.
 
+## Admin post-order read cutover
+
+The mounted admin router now directs these four GET endpoints to the dedicated
+`post_order_reads` module:
+
+- `GET /admin/returns` -> `list_order_return_projections`;
+- `GET /admin/returns/{id}` -> `read_order_return_projection`;
+- `GET /admin/order-changes` -> `list_order_change_projections`;
+- `GET /admin/order-changes/{id}` -> `read_order_change_projection`.
+
+The handlers preserve the existing `ORDERS_READ` authorization contract, request
+and response DTOs, optional filters, descending owner ordering, clamped pagination,
+owner totals, public HTTP codes/messages, validated user actor, resolved channel,
+effective request locale, resource-scoped correlation id, and two-second deadline.
+All POST routes remain mounted to their existing mutation/orchestration services.
+
+The old GET functions in `admin/returns.rs` and `admin/changes.rs` remain compiled
+but are no longer referenced by the mounted router. They are compatibility source,
+not active consumers, and should be removed only after maintainer-executed compile
+and mounted-parity validation.
+
 ## Unchanged behavior
 
 This source wave deliberately leaves these paths unchanged:
@@ -139,8 +160,8 @@ This source wave deliberately leaves these paths unchanged:
   validation;
 - storefront refund listing still constructs `PaymentService` after typed ownership
   validation;
-- admin return/order-change reads and all order/return/change mutations remain on
-  their current owner services;
+- admin order, return, and order-change mutations remain on their current owner or
+  orchestration services;
 - admin order detail payment and fulfillment aggregation remain unchanged.
 
 No mutation, payment, or fulfillment policy moved into the read port.
@@ -156,9 +177,10 @@ storage or owner-invariant details.
 
 ## Remaining source work
 
-1. audit and cut admin post-order reads separately without moving mutations;
-2. retain compile, mounted parity, deadline/failure, restart, and remote-adapter
-   evidence before status promotion.
+1. execute compile and mounted transport parity for all six operations;
+2. remove the unmounted admin compatibility GET handlers after that validation;
+3. retain deadline/failure, restart, and remote-adapter evidence before status
+   promotion.
 
 ## Evidence
 
@@ -166,11 +188,11 @@ Source evidence is retained at:
 
 `crates/rustok-order/contracts/evidence/order-read-port-source.json`
 
-Its status is `graphql_post_order_reads_cutover_unvalidated`. Six owner read
-operations, host composition, complete order consumers, storefront post-order
-lists, and mounted GraphQL post-order reads are recorded as source complete. Admin
-post-order consumer cutover, compile evidence, mounted parity, deadline/failure
-execution, restart, and remote-adapter evidence remain false or open.
+Its status is `mounted_consumer_cutover_unvalidated`. Six owner read operations,
+host composition, and all mounted admin REST, GraphQL, and storefront complete and
+post-order query consumers are recorded as source complete. Compile evidence,
+mounted parity, deadline/failure execution, restart, remote-adapter evidence, and
+compatibility-handler removal remain false or open.
 
 ## Intended checks
 
@@ -179,6 +201,7 @@ node scripts/verify/verify-order-read-port.mjs
 node scripts/verify/verify-commerce-graphql-order-read-shim.mjs
 node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs
 node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
+node scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs
 node scripts/verify/verify-commerce-admin-order-route-error-context.mjs
 cargo check -p rustok-order --lib
 cargo check -p rustok-commerce --lib

--- a/scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const router = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const reads = read('crates/rustok-commerce/src/controllers/admin/post_order_reads.rs');
+const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const changes = read('crates/rustok-commerce/src/controllers/admin/changes.rs');
+const evidence = JSON.parse(
+  read('crates/rustok-order/contracts/evidence/order-read-port-source.json'),
+);
+const note = read('crates/rustok-order/docs/order-read-port.md');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const count = (source, value) => source.split(value).length - 1;
+
+for (const [source, value, label] of [
+  [router, 'pub mod post_order_reads;', 'mounted admin read module'],
+  [router, 'axum::routing::get(post_order_reads::list_order_returns)', 'mounted return list'],
+  [router, 'axum::routing::get(post_order_reads::show_order_return)', 'mounted return detail'],
+  [router, 'axum::routing::get(post_order_reads::list_order_changes)', 'mounted change list'],
+  [router, 'axum::routing::get(post_order_reads::show_order_change)', 'mounted change detail'],
+  [router, 'axum::routing::post(returns::create_order_return)', 'return creation remains mounted mutation'],
+  [router, 'axum::routing::post(returns::create_order_return_decision)', 'return decision remains mounted orchestration'],
+  [router, 'axum::routing::post(returns::complete_order_return)', 'return completion remains mounted orchestration'],
+  [router, 'axum::routing::post(returns::cancel_order_return)', 'return cancel remains mounted mutation'],
+  [router, 'axum::routing::post(changes::create_order_change)', 'change creation remains mounted mutation'],
+  [router, 'axum::routing::post(changes::apply_order_change)', 'change apply remains mounted orchestration'],
+  [router, 'axum::routing::post(changes::cancel_order_change)', 'change cancel remains mounted mutation'],
+  [reads, 'ListOrderReturnProjectionsRequest {', 'typed return list request'],
+  [reads, 'ReadOrderReturnProjectionRequest { return_id: id }', 'typed return detail request'],
+  [reads, 'ListOrderChangeProjectionsRequest {', 'typed change list request'],
+  [reads, 'ReadOrderChangeProjectionRequest { change_id: id }', 'typed change detail request'],
+  [reads, '.list_order_return_projections(', 'return list owner port call'],
+  [reads, '.read_order_return_projection(', 'return detail owner port call'],
+  [reads, '.list_order_change_projections(', 'change list owner port call'],
+  [reads, '.read_order_change_projection(', 'change detail owner port call'],
+  [reads, 'PortActor::user(auth.user_id.to_string())', 'validated user actor'],
+  [reads, 'request_context.locale.as_str()', 'resolved request locale'],
+  [reads, 'request_context.channel_slug.as_deref()', 'resolved request channel'],
+  [reads, '.with_deadline(std::time::Duration::from_secs(2))', 'two-second deadline'],
+  [reads, '&[Permission::ORDERS_READ]', 'preserved orders-read permission'],
+  [reads, '"Permission denied: orders:read required"', 'preserved permission message'],
+  [reads, 'per_page: pagination.limit()', 'clamped owner page size'],
+  [reads, 'data: page.items,', 'typed page items'],
+  [reads, 'page.total', 'owner pagination total'],
+  [returns, '.create_return(tenant.id, id, input)', 'return mutation remains concrete owner command'],
+  [returns, '.complete_return(tenant.id, auth.user_id, id, command)', 'return completion remains orchestration'],
+  [returns, '.cancel_return(tenant.id, id, input)', 'return cancel remains concrete owner command'],
+  [changes, '.create_order_change(tenant.id, actor_id, id, input)', 'change creation remains concrete owner command'],
+  [changes, '.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)', 'change apply remains orchestration'],
+  [changes, '.cancel_order_change(tenant.id, id, input)', 'change cancel remains concrete owner command'],
+  [note, '## Admin post-order read cutover', 'focused admin cutover note'],
+  [note, 'all mounted complete/post-order reads cut over, unvalidated', 'focused status'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['OrderService::new', 'concrete owner construction'],
+  ['.list_returns(', 'concrete return list'],
+  ['.get_return(', 'concrete return detail'],
+  ['.list_order_changes(', 'concrete change list'],
+  ['.get_order_change(', 'concrete change detail'],
+  ['PermissionExtractor', 'changed granular permission extractor'],
+]) forbidText(reads, value, label);
+
+if (count(reads, '&[Permission::ORDERS_READ]') !== 4) {
+  failures.push('all four mounted handlers must preserve ORDERS_READ');
+}
+if (count(reads, 'per_page: pagination.limit()') !== 2) {
+  failures.push('both mounted list handlers must clamp page size');
+}
+
+if (evidence.status !== 'mounted_consumer_cutover_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of [
+  ['commerce_admin_return_and_order_change_reads_cutover_completed', true],
+  ['admin_post_order_consumer_cutover_completed', true],
+  ['post_order_consumer_cutover_completed', true],
+  ['all_mounted_consumer_cutover_completed', true],
+  ['all_consumer_cutover_completed', true],
+  ['cutover_required', false],
+]) {
+  if (evidence.consumer_inventory?.[key] !== expected) {
+    failures.push(`evidence consumer_inventory.${key} must be ${expected}`);
+  }
+}
+if (evidence.consumer_inventory?.commerce_admin_return_and_order_change_reads !==
+    'order_read_port_host_runtime_with_request_context') {
+  failures.push('mounted admin post-order reads must use the host-selected owner port');
+}
+if (evidence.unchanged_scope?.unmounted_admin_compatibility_handlers !==
+    'concrete_order_service_source_only_not_routed') {
+  failures.push('unmounted compatibility handlers must remain explicit source debt');
+}
+if (evidence.decision?.status_promotion !== false) {
+  failures.push('source cutover must not promote status');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce admin post-order read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Mounted admin return/order-change list and detail routes use typed owner projections with preserved ORDERS_READ, filters, pagination, actor/channel/locale/deadline context, while POST mutations remain unchanged',
+);

--- a/scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs
@@ -58,7 +58,7 @@ for (const [source, value, label] of [
   [storefront, 'ListOrderChangeProjectionsRequest {', 'storefront change request'],
   [storefront, 'data: page.items,', 'typed page items'],
   [storefront, 'page.total', 'typed page total'],
-  [note, 'storefront return/order-change lists use the port', 'owner note status'],
+  [note, '## Storefront post-order read cutover', 'owner note section'],
 ]) requireText(source, value, label);
 
 const returnRoute = between(
@@ -88,7 +88,7 @@ for (const [value, label] of [
   ['PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
 ]) requireText(storefront, value, label);
 
-if (evidence.status !== 'graphql_post_order_reads_cutover_unvalidated') {
+if (evidence.status !== 'mounted_consumer_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (evidence.operations?.map((operation) => operation.name).join(',') !==
@@ -103,17 +103,17 @@ if (evidence.consumer_inventory?.commerce_storefront_order_change_list !==
     'order_read_port_host_runtime') {
   failures.push('storefront order-change list must use the host-selected owner port');
 }
-if (evidence.consumer_inventory?.commerce_graphql_return_and_order_change_reads_cutover_completed !== true) {
-  failures.push('GraphQL post-order consumer cutover must be complete');
-}
-if (evidence.consumer_inventory?.post_order_consumer_cutover_completed !== false) {
-  failures.push('admin post-order consumer cutover must remain incomplete');
-}
-if (evidence.consumer_inventory?.all_consumer_cutover_completed !== false) {
-  failures.push('all consumer cutover must remain incomplete');
-}
-if (evidence.consumer_inventory?.cutover_required !== true) {
-  failures.push('remaining admin post-order cutover must stay open');
+for (const [key, expected] of [
+  ['commerce_graphql_return_and_order_change_reads_cutover_completed', true],
+  ['commerce_admin_return_and_order_change_reads_cutover_completed', true],
+  ['post_order_consumer_cutover_completed', true],
+  ['all_mounted_consumer_cutover_completed', true],
+  ['all_consumer_cutover_completed', true],
+  ['cutover_required', false],
+]) {
+  if (evidence.consumer_inventory?.[key] !== expected) {
+    failures.push(`evidence consumer_inventory.${key} must be ${expected}`);
+  }
 }
 if (evidence.decision?.status_promotion !== false) {
   failures.push('source cutover must not promote status');
@@ -139,5 +139,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Storefront return and order-change lists use typed owner projections while return mutation, refunds, and admin post-order reads remain unchanged',
+  '✔ Storefront return and order-change lists use typed owner projections while return mutation and refunds remain unchanged; all mounted post-order read consumers are cut over and execution evidence remains open',
 );

--- a/scripts/verify/verify-order-read-port.mjs
+++ b/scripts/verify/verify-order-read-port.mjs
@@ -17,7 +17,13 @@ const graphqlOrderShim = read(
   'crates/rustok-commerce/src/graphql/safe_query/source/rustok_order_shim.rs',
 );
 const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const adminRouter = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
 const adminOrders = read('crates/rustok-commerce/src/controllers/admin/orders.rs');
+const adminPostOrderReads = read(
+  'crates/rustok-commerce/src/controllers/admin/post_order_reads.rs',
+);
+const adminReturns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const adminChanges = read('crates/rustok-commerce/src/controllers/admin/changes.rs');
 const storefrontOrders = read('crates/rustok-commerce/src/controllers/store/orders.rs');
 const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
 const evidence = JSON.parse(
@@ -97,12 +103,23 @@ for (const [source, value, label] of [
   [graphqlOrderShim, 'OrderError::OrderChangeNotFound(id)', 'GraphQL change error compatibility'],
   [httpRuntime, 'fn order_read_port(&self)', 'HTTP port getter'],
   [serverRuntime, 'CommerceOrderReadRuntime::in_process(', 'server composition'],
-  [adminOrders, '.list_order_projections(', 'admin list port call'],
-  [adminOrders, '.read_order_projection(', 'admin detail port call'],
+  [adminOrders, '.list_order_projections(', 'admin order list port call'],
+  [adminOrders, '.read_order_projection(', 'admin order detail port call'],
+  [adminRouter, 'pub mod post_order_reads;', 'admin post-order read module'],
+  [adminRouter, 'axum::routing::get(post_order_reads::list_order_returns)', 'admin return list route'],
+  [adminRouter, 'axum::routing::get(post_order_reads::show_order_return)', 'admin return detail route'],
+  [adminRouter, 'axum::routing::get(post_order_reads::list_order_changes)', 'admin change list route'],
+  [adminRouter, 'axum::routing::get(post_order_reads::show_order_change)', 'admin change detail route'],
+  [adminPostOrderReads, '.list_order_return_projections(', 'admin return list port call'],
+  [adminPostOrderReads, '.read_order_return_projection(', 'admin return detail port call'],
+  [adminPostOrderReads, '.list_order_change_projections(', 'admin change list port call'],
+  [adminPostOrderReads, '.read_order_change_projection(', 'admin change detail port call'],
+  [adminPostOrderReads, '&[Permission::ORDERS_READ]', 'admin preserved read permission'],
+  [adminPostOrderReads, 'per_page: pagination.limit()', 'admin clamped page size'],
   [storefrontOrders, '.read_order_projection(', 'storefront detail port call'],
   [storefrontOrders, '.list_order_return_projections(', 'storefront return port call'],
   [storefrontOrders, '.list_order_change_projections(', 'storefront change port call'],
-  [note, 'GraphQL complete-order and post-order reads use the port', 'owner note status'],
+  [note, 'all mounted complete/post-order reads cut over, unvalidated', 'owner note status'],
   [orderPlan, 'GraphQL return/order-change detail and list reads', 'order plan checkpoint'],
   [commercePlan, 'GraphQL return/order-change detail and list reads', 'commerce plan checkpoint'],
 ]) requireText(source, value, label);
@@ -121,6 +138,14 @@ for (const [value, label] of [
   ['.get_order_change(tenant_id, change_id)', 'GraphQL concrete change detail'],
   ['.list_order_changes(tenant_id, input)', 'GraphQL concrete change list'],
 ]) forbidText(graphqlOrderShim, value, label);
+for (const [value, label] of [
+  ['OrderService::new', 'mounted admin concrete owner construction'],
+  ['.get_return(', 'mounted admin concrete return detail'],
+  ['.list_returns(', 'mounted admin concrete return list'],
+  ['.get_order_change(', 'mounted admin concrete change detail'],
+  ['.list_order_changes(', 'mounted admin concrete change list'],
+  ['PermissionExtractor', 'mounted admin changed permission contract'],
+]) forbidText(adminPostOrderReads, value, label);
 
 const adminList = between(
   adminOrders,
@@ -178,12 +203,16 @@ for (const [source, value, label] of [
   [adminOrders, '.ship_order(', 'ship mutation remains owner service'],
   [adminOrders, '.deliver_order(', 'deliver mutation remains owner service'],
   [adminOrders, '.cancel_order(', 'cancel mutation remains owner service'],
-  [storefrontOrders, '.create_return(tenant.id, id, input)', 'return mutation remains owner service'],
+  [adminReturns, '.create_return(tenant.id, id, input)', 'admin return mutation remains owner service'],
+  [adminReturns, '.cancel_return(tenant.id, id, input)', 'admin return cancel remains owner service'],
+  [adminChanges, '.create_order_change(tenant.id, actor_id, id, input)', 'admin change mutation remains owner service'],
+  [adminChanges, '.cancel_order_change(tenant.id, id, input)', 'admin change cancel remains owner service'],
+  [storefrontOrders, '.create_return(tenant.id, id, input)', 'storefront return mutation remains owner service'],
   [storefrontOrders, 'PaymentService::new(runtime.db_clone())', 'refund list remains payment service'],
 ]) requireText(source, value, label);
 
 const operationNames = evidence.operations?.map((operation) => operation.name).join(',');
-if (evidence.status !== 'graphql_post_order_reads_cutover_unvalidated') {
+if (evidence.status !== 'mounted_consumer_cutover_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 if (operationNames !==
@@ -210,6 +239,7 @@ for (const key of [
 }
 for (const [key, expected] of [
   ['commerce_admin_rest_cutover_completed', true],
+  ['commerce_admin_return_and_order_change_reads_cutover_completed', true],
   ['commerce_storefront_detail_and_ownership_cutover_completed', true],
   ['commerce_storefront_return_list_cutover_completed', true],
   ['commerce_storefront_order_change_list_cutover_completed', true],
@@ -217,9 +247,11 @@ for (const [key, expected] of [
   ['commerce_graphql_return_and_order_change_reads_cutover_completed', true],
   ['complete_order_projection_consumer_cutover_completed', true],
   ['graphql_post_order_consumer_cutover_completed', true],
-  ['post_order_consumer_cutover_completed', false],
-  ['all_consumer_cutover_completed', false],
-  ['cutover_required', true],
+  ['admin_post_order_consumer_cutover_completed', true],
+  ['post_order_consumer_cutover_completed', true],
+  ['all_mounted_consumer_cutover_completed', true],
+  ['all_consumer_cutover_completed', true],
+  ['cutover_required', false],
 ]) {
   if (evidence.consumer_inventory?.[key] !== expected) {
     failures.push(`evidence consumer_inventory.${key} must be ${expected}`);
@@ -229,11 +261,21 @@ if (evidence.context?.graphql_locale_source !==
     'explicit_order_locale_or_resolved_request_context_locale') {
   failures.push('GraphQL locale source mismatch');
 }
+if (evidence.context?.admin_actor_source !== 'validated_auth_context_user' ||
+    evidence.context?.admin_channel_source !== 'resolved_request_context_channel_slug' ||
+    evidence.context?.admin_locale_source !== 'resolved_request_context_locale') {
+  failures.push('admin request context source mismatch');
+}
 if (evidence.errors?.owner_message_control_flow !== false ||
     evidence.errors?.all_current_order_error_variants_mapped !== true ||
+    evidence.errors?.admin_public_envelopes_preserved !== true ||
     evidence.errors?.storefront_public_envelopes_preserved !== true ||
     evidence.errors?.graphql_order_error_shapes_preserved !== true) {
   failures.push('evidence error policy mismatch');
+}
+if (evidence.unchanged_scope?.unmounted_admin_compatibility_handlers !==
+    'concrete_order_service_source_only_not_routed') {
+  failures.push('unmounted compatibility source must remain explicit');
 }
 if (evidence.decision?.status_promotion !== false) {
   failures.push('source cutover must not promote status');
@@ -259,5 +301,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ OrderReadPort publishes six typed projections; storefront and GraphQL order/return/change reads are cut over while admin post-order reads and runtime evidence remain open',
+  '✔ OrderReadPort publishes six typed projections and all mounted admin, GraphQL, and storefront complete/post-order query consumers use the host-selected runtime; execution evidence and compatibility-source removal remain open',
 );


### PR DESCRIPTION
## Summary
- add a dedicated mounted admin read module for return and order-change list/detail projections
- route the four admin GET endpoints through the host-selected `OrderReadPort`
- preserve the existing `ORDERS_READ` authorization contract, permission message, DTOs, filters, clamped pagination, ordering, owner totals, and HTTP envelopes
- retain validated actor, resolved request channel/effective locale, resource correlation, and two-second deadline context
- leave all POST mutations plus payment and fulfillment policy on their existing services
- retain the superseded GET functions as explicitly unmounted compatibility source pending compile and mounted-parity evidence
- synchronize order owner evidence, focused documentation, plan, and static guards

## Recheck
- found that draft PR #2471 contained unrelated router and error-policy drift and changed the authorization contract; it is not used as the implementation source
- rebuilt this slice from current `main` with one commit and exactly eight target files
- confirmed the router diff is limited to one module declaration and four GET bindings
- confirmed all four mounted handlers preserve `Permission::ORDERS_READ` and `pagination.limit()`
- confirmed mutation routes remain mounted to `returns.rs` and `changes.rs`

## Remaining work
- execute compile and mounted route parity, then remove the four unmounted compatibility GET handlers
- execute deadline/failure, restart, and remote-adapter evidence before status promotion
- synchronize the umbrella ecommerce plan checkbox in a conflict-safe documentation slice

## Verification
Not run per maintainer instruction. Tests, Cargo commands, formatting, verifiers, workflow checks, and CI are not claimed as implementation evidence.