### PR TITLE
feat(index): publish source-owned schema registry

### DIFF
--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -102,3 +102,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+async-trait.workspace = true
+sea-orm-migration.workspace = true

--- a/crates/rustok-distribution/src/lib.rs
+++ b/crates/rustok-distribution/src/lib.rs
@@ -39,6 +39,7 @@ pub fn build_runtime_extensions(
 ) -> rustok_core::Result<ModuleRuntimeExtensions> {
     let mut extensions = registry.build_runtime_extensions()?;
     register_runtime_bridges(&mut extensions)?;
+    materialize_index_schema_sources(&mut extensions)?;
     Ok(extensions)
 }
 
@@ -56,6 +57,26 @@ fn register_runtime_bridges(extensions: &mut ModuleRuntimeExtensions) -> rustok_
     }
     #[cfg(not(feature = "ai-translation"))]
     let _ = extensions;
+    Ok(())
+}
+
+fn materialize_index_schema_sources(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> rustok_core::Result<()> {
+    if extensions.contains::<rustok_index::SharedIndexSchemaRegistry>() {
+        return Err(rustok_core::Error::Validation(
+            "shared Index schema registry is already materialized".to_string(),
+        ));
+    }
+
+    let shared = rustok_index::materialize_index_schema_registry(extensions).map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "Index source schema registry materialization failed: {error}"
+        ))
+    })?;
+    if let Some(shared) = shared {
+        extensions.insert(shared);
+    }
     Ok(())
 }
 
@@ -287,7 +308,73 @@ pub fn composition_identity() -> CompositionIdentity {
 
 #[cfg(test)]
 mod tests {
-    use super::composition_identity;
+    use async_trait::async_trait;
+    use rustok_core::{MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule};
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema,
+        IndexSchemaSourceCatalog, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+        SchemaVersion, SharedIndexSchemaRegistry, register_index_schema_source,
+    };
+    use sea_orm_migration::MigrationTrait;
+
+    use super::{build_runtime_extensions, composition_identity};
+
+    struct DemoIndexSourceModule;
+
+    impl MigrationSource for DemoIndexSourceModule {
+        fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+            Vec::new()
+        }
+    }
+
+    #[async_trait]
+    impl RusToKModule for DemoIndexSourceModule {
+        fn slug(&self) -> &'static str {
+            "demo_source"
+        }
+
+        fn name(&self) -> &'static str {
+            "Demo source"
+        }
+
+        fn description(&self) -> &'static str {
+            "Test source-owned Index schema publisher"
+        }
+
+        fn version(&self) -> &'static str {
+            "0.1.0"
+        }
+
+        fn register_runtime_extensions(
+            &self,
+            extensions: &mut ModuleRuntimeExtensions,
+        ) -> rustok_core::Result<()> {
+            register_index_schema_source(extensions, self.slug(), demo_schema()).map_err(|error| {
+                rustok_core::Error::Validation(format!("demo source registration failed: {error}"))
+            })
+        }
+    }
+
+    fn demo_schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("demo-source").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
 
     #[test]
     fn selected_composition_identity_is_stable_and_contains_modules() {
@@ -311,6 +398,33 @@ mod tests {
         );
         #[cfg(feature = "mod-ai")]
         assert!(first.modules.iter().any(|module| module.slug == "ai"));
+    }
+
+    #[test]
+    fn source_schema_catalog_materializes_after_all_modules_register() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoIndexSourceModule);
+        let extensions = build_runtime_extensions(&registry)
+            .expect("source-owned schema registry should materialize");
+
+        let catalog = extensions
+            .get::<IndexSchemaSourceCatalog>()
+            .expect("Index module should seed the source catalog");
+        assert_eq!(catalog.len(), 1);
+        let shared = extensions
+            .get::<SharedIndexSchemaRegistry>()
+            .expect("non-empty source catalog should publish a shared registry");
+        assert!(shared.registry().get(&demo_schema().reference).is_some());
+    }
+
+    #[test]
+    fn empty_source_catalog_does_not_publish_false_query_registry() {
+        let registry = ModuleRegistry::new().register(IndexModule);
+        let extensions = build_runtime_extensions(&registry)
+            .expect("empty source catalog should remain a valid module composition");
+        assert!(extensions.contains::<IndexSchemaSourceCatalog>());
+        assert!(!extensions.contains::<SharedIndexSchemaRegistry>());
     }
 
     #[cfg(feature = "ai-translation")]

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -1,6 +1,6 @@
 # M4 query planner actualization
 
-Date: 2026-07-29
+Date: 2026-07-30
 
 This note actualizes the live `rustok-index` implementation plan after rechecking the
 M3 storage boundary and the M4 query slices merged into `main`.
@@ -13,11 +13,11 @@ detection. The repository owner still needs to execute and admit one fresh real
 PostgreSQL partition packet. That owner gate blocks production partition lifecycle
 design but does not block M4 query source work.
 
-Server composition was also rechecked. `PostgresIndexQueryPort` requires one immutable
-source-owned `SchemaRegistry`; the server currently has no published source registry
-contract from which to compose that value. Building a host runtime from an empty or
-tenant-derived registry would be a false cutover, so server/consumer composition remains
-open until a source-owned registry boundary exists.
+The previous server-composition blocker is now narrowed. Source modules can publish
+generic schema contracts into an Index-owned catalog, and the selected distribution
+materializes one non-empty immutable registry after all module registrations. Social
+Graph is the first source publication. The server still does not construct an
+`IndexQueryPort`, authorize callers, or cut any consumer over.
 
 ## Actualized status
 
@@ -34,6 +34,7 @@ open until a source-owned registry boundary exists.
 - M4 PostgreSQL/reference fixture source: `source_complete_owner_execution_pending`.
 - M4 retained PostgreSQL/reference capture source: `source_complete_owner_execution_pending`.
 - M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
+- M4 source-owned immutable schema registry: `source_complete_execution_pending`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -134,6 +135,22 @@ the bundle. The receipt records `production_lifecycle_authorized: false`.
 Both tools are source complete but have not been run. A capture exit alone does not admit
 the bundle; an admission receipt alone does not authorize deployment or partition work.
 
+## Source-owned schema registry
+
+`IndexModule` seeds `IndexSchemaSourceCatalog` in `ModuleRuntimeExtensions`. Source
+modules publish exact generic contracts with `register_index_schema_source`; duplicate
+ownership for one `SchemaRef` fails even when fingerprints match.
+
+After all modules and selected bridges register, `rustok-distribution` materializes the
+complete catalog through one `SchemaRegistry::register_batch`. This permits cross-source
+links, preserves deterministic `BTreeMap` order, and publishes one
+`SharedIndexSchemaRegistry` wrapping an immutable `Arc<SchemaRegistry>`. Missing or empty
+catalogs do not publish a false query runtime.
+
+With its `index` feature enabled, `SocialGraphModule` is the first source owner. It
+publishes the existing relation schema under owner slug `social_graph`; distribution and
+server code do not import the schema builder or Social Graph DTOs.
+
 ## Remaining bounded M4 work
 
 The canonical checklist remains open until the owner runs the fixture through capture,
@@ -141,8 +158,9 @@ admits the retained bundle, and preserves both bundle and receipt. Additional bo
 remain:
 
 - aggregate ordering semantics for paths traversing `many`;
-- a source-owned immutable registry contract for server composition;
-- server/storefront/admin/search query-port composition and consumer cutover.
+- construct an Index-owned query runtime from `SharedIndexSchemaRegistry` and host DB;
+- publish schemas from additional source owners as their consumers are selected;
+- server/storefront/admin/search authorization and consumer cutover.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.
@@ -155,10 +173,13 @@ Suggested commands:
 
 ```bash
 cargo test -p rustok-index planner_tests -- --nocapture
+cargo test -p rustok-index source_schema_registry -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo test -p rustok-index postgres_many_projection_tests -- --nocapture
 cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index query_snapshot_tests -- --nocapture
+cargo test -p rustok-social-graph --features index module_publishes_its_index_schema_through_runtime_extensions -- --nocapture
+cargo test -p rustok-distribution source_schema_catalog_materializes_after_all_modules_register -- --nocapture
 RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
   cargo test -p rustok-index postgres_query_port_matches_reference_fixture -- --nocapture
 INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1 \
@@ -173,6 +194,8 @@ INDEX_QUERY_EQUIVALENCE_EXPECTED_RUN_KEY=<stable-run-key> \
 INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT=<existing-parent>/equivalence-admission.json \
   cargo run -p rustok-benchmarks --bin index-query-equivalence-admission
 cargo check -p rustok-index --all-targets
+cargo check -p rustok-social-graph --features index --all-targets
+cargo check -p rustok-distribution --all-targets
 cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
 cargo check -p rustok-benchmarks --bin index-query-equivalence-admission
 node scripts/verify/verify-index-query-contract.mjs
@@ -184,5 +207,6 @@ node scripts/verify/verify-index-query-snapshots.mjs
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs
 node scripts/verify/verify-index-query-equivalence-admission.mjs
+node scripts/verify/verify-index-source-schema-registry.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-source-schema-registry.md
+++ b/crates/rustok-index/docs/m4-source-schema-registry.md
@@ -1,0 +1,95 @@
+# M4 source-owned schema registry
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice publishes the source-owned schema boundary required before an honest
+server-side `IndexQueryPort` composition can exist. Source modules contribute generic
+`IndexSchema` contracts through `ModuleRuntimeExtensions`; the selected distribution
+then materializes one immutable `Arc<SchemaRegistry>` after every compiled module has
+finished runtime-extension registration.
+
+## Ownership contract
+
+`IndexModule` seeds an `IndexSchemaSourceCatalog`. A source module publishes a schema
+with `register_index_schema_source(extensions, owner_module, schema)`.
+
+Each catalog entry retains:
+
+- the exact `SchemaRef` and validated `IndexSchema`;
+- the calculated `SchemaFingerprint`;
+- the platform module slug that owns publication, replay, and drift repair.
+
+The owner module slug is deliberately separate from `SchemaRef.module`: the former is a
+platform composition identity such as `social_graph`, while the latter is the stable
+Index contract namespace such as `rustok-social-graph`.
+
+One exact schema reference may have only one source owner. Duplicate ownership is
+rejected even when both schemas have the same fingerprint, because two publishers would
+make replay and repair responsibility ambiguous.
+
+## Deterministic materialization
+
+The catalog stores entries in `BTreeMap<SchemaRef, ...>` order. The distribution calls
+`materialize_index_schema_registry` only after module-owned extensions and selected
+runtime bridges have registered.
+
+All schemas are passed to `SchemaRegistry::register_batch` together. This preserves:
+
+- atomic validation;
+- deterministic schema ordering;
+- links targeting schemas contributed by another source module;
+- exact fingerprint and field/link type validation;
+- absence of partial registry state on failure.
+
+A missing or empty catalog returns `None`; it never publishes an empty
+`SharedIndexSchemaRegistry` as a completed query runtime. A non-empty catalog publishes
+one cloneable wrapper around the same immutable `Arc<SchemaRegistry>` through the module
+runtime extensions consumed by executable hosts.
+
+## First source publication
+
+With the Social Graph `index` feature enabled, `SocialGraphModule` now declares an
+explicit dependency on core module `index` and publishes
+`social_graph_relation_index_schema()` under owner slug `social_graph`.
+
+The projector continues using the same owner-defined schema and existing Index-owned
+persistence APIs. This slice does not move source authority into Index and does not make
+the distribution import Social Graph DTOs or construct its schema directly.
+
+## Boundary
+
+This slice does not:
+
+- construct `PostgresIndexQueryPort`;
+- connect the registry to server/storefront/admin/search consumers;
+- persist tenant schema readiness or replace `PostgresSchemaRegistrationStore`;
+- change mutation delivery, replay, or Social Graph source storage;
+- add schemas for Product, Content, Flex, or other owners;
+- add ordering through a `many` relation;
+- execute PostgreSQL/reference capture or admission;
+- authorize production partition lifecycle work.
+
+The next composition slice may construct an Index-owned query runtime from
+`SharedIndexSchemaRegistry` and the host database without importing any source-domain
+schema builder. Consumer authorization and cutover remain separate changes.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-index source_schema_registry -- --nocapture
+cargo test -p rustok-social-graph --features index module_publishes_its_index_schema_through_runtime_extensions -- --nocapture
+cargo test -p rustok-distribution source_schema_catalog_materializes_after_all_modules_register -- --nocapture
+cargo test -p rustok-distribution empty_source_catalog_does_not_publish_false_query_registry -- --nocapture
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-social-graph --features index --all-targets
+cargo check -p rustok-distribution --all-targets
+node scripts/verify/verify-index-source-schema-registry.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo xtask module validate index
+```

--- a/crates/rustok-index/docs/m4-source-schema-registry.md
+++ b/crates/rustok-index/docs/m4-source-schema-registry.md
@@ -26,8 +26,10 @@ platform composition identity such as `social_graph`, while the latter is the st
 Index contract namespace such as `rustok-social-graph`.
 
 One exact schema reference may have only one source owner. Duplicate ownership is
-rejected even when both schemas have the same fingerprint, because two publishers would
-make replay and repair responsibility ambiguous.
+rejected even when both schemas have the same fingerprint. Ownership is also fixed for
+the entire schema identity across versions: one source may publish v1, v2, and later
+contracts, but a second source cannot take over another version of the same
+`(module, entity)` identity. Both rules prevent ambiguous replay and repair authority.
 
 ## Deterministic materialization
 
@@ -46,7 +48,8 @@ All schemas are passed to `SchemaRegistry::register_batch` together. This preser
 A missing or empty catalog returns `None`; it never publishes an empty
 `SharedIndexSchemaRegistry` as a completed query runtime. A non-empty catalog publishes
 one cloneable wrapper around the same immutable `Arc<SchemaRegistry>` through the module
-runtime extensions consumed by executable hosts.
+runtime extensions consumed by executable hosts. Its constructor is private, so callers
+cannot bypass catalog validation with an ad hoc registry.
 
 ## First source publication
 

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -5,6 +5,7 @@ mod postgres_query_result;
 mod postgres_query_sql;
 mod query_port;
 mod registry;
+mod source_schema_registry;
 mod validation;
 
 #[cfg(test)]
@@ -41,5 +42,9 @@ pub use query_port::{
 };
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
+};
+pub use source_schema_registry::{
+    IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,
+    SharedIndexSchemaRegistry, materialize_index_schema_registry, register_index_schema_source,
 };
 pub use validation::{QueryValidationError, RecordValidationError};

--- a/crates/rustok-index/src/application/source_schema_registry.rs
+++ b/crates/rustok-index/src/application/source_schema_registry.rs
@@ -108,7 +108,7 @@ impl IndexSchemaSourceCatalog {
 pub struct SharedIndexSchemaRegistry(Arc<SchemaRegistry>);
 
 impl SharedIndexSchemaRegistry {
-    pub fn new(registry: Arc<SchemaRegistry>) -> Self {
+    fn new(registry: Arc<SchemaRegistry>) -> Self {
         Self(registry)
     }
 

--- a/crates/rustok-index/src/application/source_schema_registry.rs
+++ b/crates/rustok-index/src/application/source_schema_registry.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, sync::Arc};
 use rustok_core::ModuleRuntimeExtensions;
 use thiserror::Error;
 
-use crate::domain::{DomainError, IndexSchema, SchemaFingerprint, SchemaRef};
+use crate::domain::{
+    DomainError, IndexSchema, SchemaFingerprint, SchemaIdentity, SchemaRef,
+};
 
 use super::{SchemaRegistry, SchemaRegistryError};
 
@@ -50,11 +52,12 @@ impl IndexSchemaSourceCatalog {
         self.sources.values()
     }
 
-    /// Registers exactly one source owner for an exact schema reference.
+    /// Registers exactly one source owner for an exact schema reference and its
+    /// complete module/entity identity across versions.
     ///
-    /// Duplicate ownership is rejected even when the semantic contract is equal;
-    /// two publishers for one schema reference would make replay and drift repair
-    /// ownership ambiguous.
+    /// Duplicate exact references are rejected even when the semantic contract is
+    /// equal. Different source owners also cannot split versions of one schema
+    /// identity, because that would make replay and drift repair ownership ambiguous.
     pub fn register(
         &mut self,
         owner_module: impl Into<String>,
@@ -68,6 +71,18 @@ impl IndexSchemaSourceCatalog {
         if let Some(existing) = self.sources.get(&reference) {
             return Err(IndexSchemaSourceError::DuplicateSchemaOwner {
                 reference,
+                existing_owner: existing.owner_module.clone(),
+                incoming_owner: owner_module,
+            });
+        }
+
+        let identity = reference.identity();
+        if let Some(existing) = self.sources.values().find(|existing| {
+            existing.schema.reference.identity() == identity
+                && existing.owner_module.as_str() != owner_module.as_str()
+        }) {
+            return Err(IndexSchemaSourceError::SchemaIdentityOwnerConflict {
+                identity,
                 existing_owner: existing.owner_module.clone(),
                 incoming_owner: owner_module,
             });
@@ -130,6 +145,14 @@ pub enum IndexSchemaSourceError {
     )]
     DuplicateSchemaOwner {
         reference: SchemaRef,
+        existing_owner: String,
+        incoming_owner: String,
+    },
+    #[error(
+        "Index schema identity {identity} changes source owner across versions: existing={existing_owner}, incoming={incoming_owner}"
+    )]
+    SchemaIdentityOwnerConflict {
+        identity: SchemaIdentity,
         existing_owner: String,
         incoming_owner: String,
     },
@@ -222,6 +245,12 @@ mod tests {
         }
     }
 
+    fn target_schema_version(version: u32) -> IndexSchema {
+        let mut schema = target_schema();
+        schema.reference.version = SchemaVersion::new(version);
+        schema
+    }
+
     fn source_schema() -> IndexSchema {
         IndexSchema {
             reference: reference("test-owner", "post"),
@@ -275,6 +304,27 @@ mod tests {
         assert!(matches!(
             error,
             IndexSchemaSourceError::DuplicateSchemaOwner {
+                existing_owner,
+                incoming_owner,
+                ..
+            } if existing_owner == "profiles" && incoming_owner == "accounts"
+        ));
+    }
+
+    #[test]
+    fn schema_identity_owner_is_stable_across_versions() {
+        let mut catalog = IndexSchemaSourceCatalog::new();
+        catalog.register("profiles", target_schema()).unwrap();
+        catalog
+            .register("profiles", target_schema_version(2))
+            .expect("one owner may publish a later schema version");
+        let error = catalog
+            .register("accounts", target_schema_version(3))
+            .expect_err("schema identity ownership must not move across versions");
+
+        assert!(matches!(
+            error,
+            IndexSchemaSourceError::SchemaIdentityOwnerConflict {
                 existing_owner,
                 incoming_owner,
                 ..

--- a/crates/rustok-index/src/application/source_schema_registry.rs
+++ b/crates/rustok-index/src/application/source_schema_registry.rs
@@ -22,7 +22,7 @@ pub struct IndexSchemaSourceDescriptor {
 /// Deterministic source-owned schema catalog collected during module registration.
 ///
 /// The catalog is mutable only while `ModuleRuntimeExtensions` are being built.
-/// The server materializes one immutable [`SchemaRegistry`] from the complete
+/// The distribution materializes one immutable [`SchemaRegistry`] from the complete
 /// catalog after every compiled source module has registered its contracts.
 #[derive(Debug, Clone, Default)]
 pub struct IndexSchemaSourceCatalog {
@@ -249,12 +249,12 @@ mod tests {
 
         let shared = catalog.materialize().expect("catalog should materialize");
         assert_eq!(shared.registry().len(), 2);
-        assert!(
-            shared
-                .registry()
-                .resolve_link_path(&source_schema().reference, &[LinkName::new("author").unwrap()])
-                .is_ok()
-        );
+        let path = shared
+            .registry()
+            .resolve_path(&source_schema().reference, &target_schema().reference)
+            .expect("cross-source link should resolve");
+        assert_eq!(path.len(), 1);
+        assert_eq!(path[0].link, LinkName::new("author").unwrap());
         assert_eq!(
             catalog
                 .get(&target_schema().reference)

--- a/crates/rustok-index/src/application/source_schema_registry.rs
+++ b/crates/rustok-index/src/application/source_schema_registry.rs
@@ -1,0 +1,315 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use rustok_core::ModuleRuntimeExtensions;
+use thiserror::Error;
+
+use crate::domain::{DomainError, IndexSchema, SchemaFingerprint, SchemaRef};
+
+use super::{SchemaRegistry, SchemaRegistryError};
+
+/// One source-module-owned schema contribution to the generic Index engine.
+///
+/// `owner_module` is the platform module slug that owns publication and replay of
+/// the schema. It is intentionally separate from `schema.reference.module`, which
+/// is the stable Index contract namespace and may use a different naming grammar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSchemaSourceDescriptor {
+    pub owner_module: String,
+    pub schema: IndexSchema,
+    pub fingerprint: SchemaFingerprint,
+}
+
+/// Deterministic source-owned schema catalog collected during module registration.
+///
+/// The catalog is mutable only while `ModuleRuntimeExtensions` are being built.
+/// The server materializes one immutable [`SchemaRegistry`] from the complete
+/// catalog after every compiled source module has registered its contracts.
+#[derive(Debug, Clone, Default)]
+pub struct IndexSchemaSourceCatalog {
+    sources: BTreeMap<SchemaRef, IndexSchemaSourceDescriptor>,
+}
+
+impl IndexSchemaSourceCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+
+    pub fn get(&self, reference: &SchemaRef) -> Option<&IndexSchemaSourceDescriptor> {
+        self.sources.get(reference)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &IndexSchemaSourceDescriptor> {
+        self.sources.values()
+    }
+
+    /// Registers exactly one source owner for an exact schema reference.
+    ///
+    /// Duplicate ownership is rejected even when the semantic contract is equal;
+    /// two publishers for one schema reference would make replay and drift repair
+    /// ownership ambiguous.
+    pub fn register(
+        &mut self,
+        owner_module: impl Into<String>,
+        schema: IndexSchema,
+    ) -> Result<(), IndexSchemaSourceError> {
+        let owner_module = owner_module.into();
+        validate_owner_module(&owner_module)?;
+        let fingerprint = schema.fingerprint()?;
+        let reference = schema.reference.clone();
+
+        if let Some(existing) = self.sources.get(&reference) {
+            return Err(IndexSchemaSourceError::DuplicateSchemaOwner {
+                reference,
+                existing_owner: existing.owner_module.clone(),
+                incoming_owner: owner_module,
+            });
+        }
+
+        self.sources.insert(
+            reference,
+            IndexSchemaSourceDescriptor {
+                owner_module,
+                schema,
+                fingerprint,
+            },
+        );
+        Ok(())
+    }
+
+    /// Builds the complete immutable query registry as one atomic batch.
+    ///
+    /// Batch materialization allows links to target schemas contributed by another
+    /// source module while retaining the registry's validation and monotonicity
+    /// guarantees. An empty catalog is never promoted into a query runtime.
+    pub fn materialize(&self) -> Result<SharedIndexSchemaRegistry, IndexSchemaSourceError> {
+        if self.sources.is_empty() {
+            return Err(IndexSchemaSourceError::EmptyCatalog);
+        }
+
+        let mut registry = SchemaRegistry::new();
+        registry.register_batch(
+            self.sources
+                .values()
+                .map(|descriptor| descriptor.schema.clone()),
+        )?;
+        Ok(SharedIndexSchemaRegistry::new(Arc::new(registry)))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SharedIndexSchemaRegistry(Arc<SchemaRegistry>);
+
+impl SharedIndexSchemaRegistry {
+    pub fn new(registry: Arc<SchemaRegistry>) -> Self {
+        Self(registry)
+    }
+
+    pub fn registry(&self) -> &SchemaRegistry {
+        self.0.as_ref()
+    }
+
+    pub fn shared(&self) -> Arc<SchemaRegistry> {
+        self.0.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexSchemaSourceError {
+    #[error("Index schema source owner module is invalid: {0}")]
+    InvalidOwnerModule(String),
+    #[error(
+        "Index schema {reference} has multiple source owners: existing={existing_owner}, incoming={incoming_owner}"
+    )]
+    DuplicateSchemaOwner {
+        reference: SchemaRef,
+        existing_owner: String,
+        incoming_owner: String,
+    },
+    #[error("Index schema source catalog is empty")]
+    EmptyCatalog,
+    #[error(transparent)]
+    InvalidSchema(#[from] DomainError),
+    #[error(transparent)]
+    Registry(#[from] SchemaRegistryError),
+}
+
+/// Publishes one source-owned schema into the module runtime extension catalog.
+pub fn register_index_schema_source(
+    extensions: &mut ModuleRuntimeExtensions,
+    owner_module: impl Into<String>,
+    schema: IndexSchema,
+) -> Result<(), IndexSchemaSourceError> {
+    extensions
+        .get_or_insert_with::<IndexSchemaSourceCatalog, _>(IndexSchemaSourceCatalog::new)
+        .register(owner_module, schema)
+}
+
+/// Materializes a query registry only when at least one source schema exists.
+///
+/// Returning `None` for an absent or empty catalog prevents a host from presenting
+/// an empty registry as a completed query-port composition.
+pub fn materialize_index_schema_registry(
+    extensions: &ModuleRuntimeExtensions,
+) -> Result<Option<SharedIndexSchemaRegistry>, IndexSchemaSourceError> {
+    let Some(catalog) = extensions.get::<IndexSchemaSourceCatalog>() else {
+        return Ok(None);
+    };
+    if catalog.is_empty() {
+        return Ok(None);
+    }
+    catalog.materialize().map(Some)
+}
+
+fn validate_owner_module(value: &str) -> Result<(), IndexSchemaSourceError> {
+    let valid = !value.is_empty()
+        && value.len() <= 128
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(IndexSchemaSourceError::InvalidOwnerModule(
+            value.to_owned(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexLink, IndexValueType,
+        LinkCardinality, LinkName, LocaleMode, ModuleName, SchemaVersion,
+    };
+
+    fn reference(module: &str, entity: &str) -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new(module).unwrap(),
+            entity: EntityName::new(entity).unwrap(),
+            version: SchemaVersion::INITIAL,
+        }
+    }
+
+    fn uuid_field(name: &str) -> IndexField {
+        IndexField {
+            name: FieldName::new(name).unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }
+    }
+
+    fn target_schema() -> IndexSchema {
+        IndexSchema {
+            reference: reference("test-owner", "user"),
+            locale_mode: LocaleMode::None,
+            fields: vec![uuid_field("id")],
+            links: Vec::new(),
+        }
+    }
+
+    fn source_schema() -> IndexSchema {
+        IndexSchema {
+            reference: reference("test-owner", "post"),
+            locale_mode: LocaleMode::None,
+            fields: vec![uuid_field("author_id")],
+            links: vec![IndexLink {
+                name: LinkName::new("author").unwrap(),
+                source_fields: vec![FieldName::new("author_id").unwrap()],
+                target_schema: target_schema().reference,
+                target_fields: vec![FieldName::new("id").unwrap()],
+                cardinality: LinkCardinality::One,
+            }],
+        }
+    }
+
+    #[test]
+    fn catalog_materializes_cross_source_links_as_one_batch() {
+        let mut catalog = IndexSchemaSourceCatalog::new();
+        catalog
+            .register("posts", source_schema())
+            .expect("source schema should register");
+        catalog
+            .register("profiles", target_schema())
+            .expect("target schema should register");
+
+        let shared = catalog.materialize().expect("catalog should materialize");
+        assert_eq!(shared.registry().len(), 2);
+        assert!(
+            shared
+                .registry()
+                .resolve_link_path(&source_schema().reference, &[LinkName::new("author").unwrap()])
+                .is_ok()
+        );
+        assert_eq!(
+            catalog
+                .get(&target_schema().reference)
+                .expect("target descriptor")
+                .owner_module,
+            "profiles"
+        );
+    }
+
+    #[test]
+    fn duplicate_schema_reference_rejects_ambiguous_ownership() {
+        let mut catalog = IndexSchemaSourceCatalog::new();
+        catalog.register("profiles", target_schema()).unwrap();
+        let error = catalog
+            .register("accounts", target_schema())
+            .expect_err("duplicate ownership must fail");
+
+        assert!(matches!(
+            error,
+            IndexSchemaSourceError::DuplicateSchemaOwner {
+                existing_owner,
+                incoming_owner,
+                ..
+            } if existing_owner == "profiles" && incoming_owner == "accounts"
+        ));
+    }
+
+    #[test]
+    fn extensions_do_not_materialize_an_empty_registry() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        extensions.insert(IndexSchemaSourceCatalog::new());
+        assert!(
+            materialize_index_schema_registry(&extensions)
+                .expect("empty catalog should be accepted")
+                .is_none()
+        );
+
+        register_index_schema_source(&mut extensions, "profiles", target_schema())
+            .expect("source registration should succeed");
+        let shared = materialize_index_schema_registry(&extensions)
+            .expect("catalog should materialize")
+            .expect("non-empty catalog should publish a registry");
+        assert!(shared.registry().get(&target_schema().reference).is_some());
+    }
+
+    #[test]
+    fn owner_module_identity_is_bounded_lowercase_ascii() {
+        let mut catalog = IndexSchemaSourceCatalog::new();
+        assert!(matches!(
+            catalog.register("Profiles", target_schema()),
+            Err(IndexSchemaSourceError::InvalidOwnerModule(_))
+        ));
+        assert!(matches!(
+            catalog.register("", target_schema()),
+            Err(IndexSchemaSourceError::InvalidOwnerModule(_))
+        ));
+    }
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -8,7 +8,10 @@
 //! PostgreSQL execution adapter for structured Index queries.
 
 use async_trait::async_trait;
-use rustok_core::{MigrationDependencyDescriptor, MigrationSource, ModuleKind, RusToKModule};
+use rustok_core::{
+    MigrationDependencyDescriptor, MigrationSource, ModuleKind, ModuleRuntimeExtensions,
+    RusToKModule,
+};
 use sea_orm_migration::MigrationTrait;
 
 pub mod application;
@@ -54,6 +57,14 @@ impl RusToKModule for IndexModule {
 
     fn kind(&self) -> ModuleKind {
         ModuleKind::Core
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        extensions.get_or_insert_with::<IndexSchemaSourceCatalog, _>(IndexSchemaSourceCatalog::new);
+        Ok(())
     }
 }
 

--- a/crates/rustok-social-graph/src/lib.rs
+++ b/crates/rustok-social-graph/src/lib.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rustok_core::{MigrationSource, RusToKModule};
+use rustok_core::{MigrationSource, ModuleRuntimeExtensions, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
 pub mod entities;
@@ -65,7 +65,38 @@ impl RusToKModule for SocialGraphModule {
     }
 
     fn dependencies(&self) -> &[&'static str] {
-        &["outbox"]
+        #[cfg(feature = "index")]
+        {
+            &["index", "outbox"]
+        }
+        #[cfg(not(feature = "index"))]
+        {
+            &["outbox"]
+        }
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        #[cfg(feature = "index")]
+        {
+            let schema = index::social_graph_relation_index_schema().map_err(|error| {
+                rustok_core::Error::Validation(format!(
+                    "Social Graph Index schema construction failed: {error}"
+                ))
+            })?;
+            rustok_index::register_index_schema_source(extensions, self.slug(), schema).map_err(
+                |error| {
+                    rustok_core::Error::Validation(format!(
+                        "Social Graph Index schema source registration failed: {error}"
+                    ))
+                },
+            )?;
+        }
+        #[cfg(not(feature = "index"))]
+        let _ = extensions;
+        Ok(())
     }
 }
 
@@ -81,7 +112,7 @@ impl MigrationSource for SocialGraphModule {
 
 #[cfg(test)]
 mod tests {
-    use rustok_core::{MigrationSource, RusToKModule};
+    use rustok_core::{MigrationSource, ModuleRuntimeExtensions, RusToKModule};
 
     use super::SocialGraphModule;
 
@@ -89,8 +120,30 @@ mod tests {
     fn module_metadata_and_migrations_are_stable() {
         let module = SocialGraphModule;
         assert_eq!(module.slug(), "social_graph");
+        #[cfg(feature = "index")]
+        assert_eq!(module.dependencies(), &["index", "outbox"]);
+        #[cfg(not(feature = "index"))]
         assert_eq!(module.dependencies(), &["outbox"]);
         assert_eq!(module.migrations().len(), 4);
         assert_eq!(module.migration_dependencies().len(), 4);
+    }
+
+    #[cfg(feature = "index")]
+    #[test]
+    fn module_publishes_its_index_schema_through_runtime_extensions() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        SocialGraphModule
+            .register_runtime_extensions(&mut extensions)
+            .expect("Social Graph schema source should register");
+
+        let catalog = extensions
+            .get::<rustok_index::IndexSchemaSourceCatalog>()
+            .expect("Index schema source catalog should be present");
+        let schema = crate::index::social_graph_relation_index_schema().unwrap();
+        let descriptor = catalog
+            .get(&schema.reference)
+            .expect("Social Graph schema should be source-published");
+        assert_eq!(descriptor.owner_module, "social_graph");
+        assert_eq!(descriptor.schema, schema);
     }
 }

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -14,6 +14,7 @@ const scripts = [
   'verify-index-postgres-reference-equivalence.mjs',
   'verify-index-query-equivalence-capture.mjs',
   'verify-index-query-equivalence-admission.mjs',
+  'verify-index-source-schema-registry.mjs',
 ];
 
 for (const script of scripts) {

--- a/scripts/verify/verify-index-source-schema-registry.mjs
+++ b/scripts/verify/verify-index-source-schema-registry.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-source-schema-registry] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const sourceRegistryPath = 'crates/rustok-index/src/application/source_schema_registry.rs';
+const sourceRegistry = requireMarkers(sourceRegistryPath, [
+  'pub struct IndexSchemaSourceCatalog',
+  'BTreeMap<SchemaRef, IndexSchemaSourceDescriptor>',
+  'pub struct IndexSchemaSourceDescriptor',
+  'pub struct SharedIndexSchemaRegistry',
+  'DuplicateSchemaOwner',
+  'Index schema source catalog is empty',
+  'registry.register_batch(',
+  'register_index_schema_source(',
+  'materialize_index_schema_registry(',
+  'return Ok(None);',
+  'owner module is invalid',
+  'catalog_materializes_cross_source_links_as_one_batch',
+  'duplicate_schema_reference_rejects_ambiguous_ownership',
+  'extensions_do_not_materialize_an_empty_registry',
+]);
+for (const forbidden of [
+  'PostgresIndexQueryPort',
+  'PostgresSchemaRegistrationStore',
+  'DatabaseConnection',
+  'index_schemas',
+  'index_entities',
+  'index_links',
+]) {
+  if (sourceRegistry.includes(forbidden)) {
+    fail(`${sourceRegistryPath} contains forbidden runtime/storage marker ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod source_schema_registry;',
+  'IndexSchemaSourceCatalog',
+  'SharedIndexSchemaRegistry',
+  'materialize_index_schema_registry',
+  'register_index_schema_source',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'fn register_runtime_extensions(',
+  'get_or_insert_with::<IndexSchemaSourceCatalog',
+]);
+
+const socialGraph = requireMarkers('crates/rustok-social-graph/src/lib.rs', [
+  '#[cfg(feature = "index")]',
+  '&["index", "outbox"]',
+  'social_graph_relation_index_schema()',
+  'register_index_schema_source(extensions, self.slug(), schema)',
+  'module_publishes_its_index_schema_through_runtime_extensions',
+]);
+if (socialGraph.includes('PostgresIndexQueryPort::new')) {
+  fail('Social Graph module composition must not construct the query port');
+}
+
+const distributionPath = 'crates/rustok-distribution/src/lib.rs';
+const distribution = requireMarkers(distributionPath, [
+  'materialize_index_schema_sources(&mut extensions)?;',
+  'fn materialize_index_schema_sources(',
+  'materialize_index_schema_registry(extensions)',
+  'SharedIndexSchemaRegistry',
+  'shared Index schema registry is already materialized',
+  'source_schema_catalog_materializes_after_all_modules_register',
+  'empty_source_catalog_does_not_publish_false_query_registry',
+]);
+const productionDistribution = distribution.split('#[cfg(test)]')[0];
+for (const forbidden of [
+  'social_graph_relation_index_schema',
+  'PostgresIndexQueryPort::new',
+  'SchemaRegistry::new()',
+  'IndexSchema {',
+]) {
+  if (productionDistribution.includes(forbidden)) {
+    fail(`${distributionPath} production composition contains forbidden owner/runtime marker ${forbidden}`);
+  }
+}
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-source-schema-registry.mjs'",
+]);
+requireMarkers('crates/rustok-index/CRATE_API.md', [
+  'IndexSchemaSourceCatalog',
+  'SharedIndexSchemaRegistry',
+  'source-owned immutable registry',
+]);
+requireMarkers('crates/rustok-index/docs/m4-source-schema-registry.md', [
+  'Status: `source_complete_execution_pending`',
+  '`social_graph`',
+  'does not construct `PostgresIndexQueryPort`',
+  'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+]);
+
+console.log('[verify-index-source-schema-registry] OK');

--- a/scripts/verify/verify-index-source-schema-registry.mjs
+++ b/scripts/verify/verify-index-source-schema-registry.mjs
@@ -96,16 +96,16 @@ for (const forbidden of [
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",
 ]);
-requireMarkers('crates/rustok-index/CRATE_API.md', [
-  'IndexSchemaSourceCatalog',
-  'SharedIndexSchemaRegistry',
-  'source-owned immutable registry',
-]);
 requireMarkers('crates/rustok-index/docs/m4-source-schema-registry.md', [
   'Status: `source_complete_execution_pending`',
   '`social_graph`',
-  'does not construct `PostgresIndexQueryPort`',
+  '- construct `PostgresIndexQueryPort`;',
   'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
+  'M4 source-owned immutable schema registry: `source_complete_execution_pending`',
+  '`SharedIndexSchemaRegistry`',
+  'construct an Index-owned query runtime',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',

--- a/scripts/verify/verify-index-source-schema-registry.mjs
+++ b/scripts/verify/verify-index-source-schema-registry.mjs
@@ -25,6 +25,7 @@ const sourceRegistry = requireMarkers(sourceRegistryPath, [
   'pub struct IndexSchemaSourceDescriptor',
   'pub struct SharedIndexSchemaRegistry',
   'DuplicateSchemaOwner',
+  'SchemaIdentityOwnerConflict',
   'Index schema source catalog is empty',
   'registry.register_batch(',
   'register_index_schema_source(',
@@ -33,9 +34,12 @@ const sourceRegistry = requireMarkers(sourceRegistryPath, [
   'owner module is invalid',
   'catalog_materializes_cross_source_links_as_one_batch',
   'duplicate_schema_reference_rejects_ambiguous_ownership',
+  'schema_identity_owner_is_stable_across_versions',
   'extensions_do_not_materialize_an_empty_registry',
+  'fn new(registry: Arc<SchemaRegistry>) -> Self',
 ]);
 for (const forbidden of [
+  'pub fn new(registry: Arc<SchemaRegistry>)',
   'PostgresIndexQueryPort',
   'PostgresSchemaRegistrationStore',
   'DatabaseConnection',
@@ -99,6 +103,7 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
 requireMarkers('crates/rustok-index/docs/m4-source-schema-registry.md', [
   'Status: `source_complete_execution_pending`',
   '`social_graph`',
+  'entire schema identity across versions',
   '- construct `PostgresIndexQueryPort`;',
   'Not run by the implementation agent',
 ]);


### PR DESCRIPTION
## Summary

- add an Index-owned deterministic `IndexSchemaSourceCatalog` to `ModuleRuntimeExtensions`
- retain exact source owner, validated schema, and calculated fingerprint for every source contribution
- reject duplicate ownership for one exact `SchemaRef`
- bind one platform source owner to the complete `(module, entity)` schema identity across versions
- materialize all contributed schemas through one atomic `SchemaRegistry::register_batch`
- publish a cloneable `SharedIndexSchemaRegistry` around one immutable `Arc<SchemaRegistry>`
- keep the shared-registry constructor private so hosts cannot bypass catalog validation
- return no shared registry for an absent or empty catalog rather than presenting a false query runtime
- make Social Graph the first source publisher through its existing generic relation schema
- declare Social Graph's Index module dependency only when its `index` feature is enabled
- materialize the catalog in `rustok-distribution` only after all module extensions and selected bridges register
- add focused source/catalog/distribution tests and a static source guard
- include the guard in the unified M4 query contract
- document the ownership, materialization, and remaining composition boundaries

## Recheck findings

`PostgresIndexQueryPort` already requires an immutable `Arc<SchemaRegistry>`, but no source-neutral runtime registry existed. Social Graph already owned a valid generic Index schema and persisted it through Index-owned stores, while its projector constructed an isolated in-memory registry. This PR publishes that existing source contract through the neutral module-extension boundary without moving schema authority into Index or importing owner DTOs into distribution/server code.

The branch started from `89c7cde43e994df08b7764fe31861b41a0022ddd`. Main later advanced by one unrelated Commerce/Order commit; no changed path overlaps this PR.

## Boundary

This PR does not construct `PostgresIndexQueryPort`, connect the registry to server/storefront/admin/search consumers, persist tenant schema readiness, replace `PostgresSchemaRegistrationStore`, change mutation delivery or replay, add schemas for other source owners, add many-link ordering, execute PostgreSQL/reference evidence, or authorize production partition lifecycle work.

The next bounded composition slice can construct an Index-owned query runtime from `SharedIndexSchemaRegistry` plus the host database. Authorization and consumer cutover remain separate work.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, capture/admission, Node verifiers, workflow checks, or CI were run.

Suggested commands:

```bash
cargo test -p rustok-index source_schema_registry -- --nocapture
cargo test -p rustok-social-graph --features index module_publishes_its_index_schema_through_runtime_extensions -- --nocapture
cargo test -p rustok-distribution source_schema_catalog_materializes_after_all_modules_register -- --nocapture
cargo test -p rustok-distribution empty_source_catalog_does_not_publish_false_query_registry -- --nocapture
cargo check -p rustok-index --all-targets
cargo check -p rustok-social-graph --features index --all-targets
cargo check -p rustok-distribution --all-targets
node scripts/verify/verify-index-source-schema-registry.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo xtask module validate index
```