### PR TITLE
docs(commerce): sync mounted order read cutover

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # RusToK ecommerce implementation plan
 
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-30
 
 ## Source of truth
 
@@ -210,8 +210,12 @@ These are source-contract defects, not verification-only tasks.
 - [x] Cut GraphQL return/order-change detail and list reads to the scoped host-selected
   runtime with validated actor, resolved channel/effective locale context, typed
   not-found compatibility errors, and no concrete owner service storage.
-- [ ] Audit and cut admin post-order reads separately without moving mutations or
-  payment/fulfillment policy.
+- [x] Cut mounted admin return/order-change detail and list reads to the host-selected
+  runtime while preserving `ORDERS_READ`, filters, clamped pagination, totals, public
+  envelopes, actor/channel/effective-locale/deadline context, and unchanged mutation,
+  payment, and fulfillment ownership.
+- [ ] Execute compile and mounted parity for the four admin post-order GET routes, then
+  remove their unmounted compatibility handlers.
 - [ ] Retain compile, mounted parity, deadline/failure, restart, and remote-adapter
   evidence for order and post-order projections before status promotion.
 - [ ] Correct Product's declared dependency contract or extract its direct
@@ -574,6 +578,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-graphql-order-read-shim.mjs`
 - [ ] `node scripts/verify/verify-commerce-storefront-order-read-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-storefront-post-order-read-cutover.mjs`
+- [ ] `node scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
 - [ ] `node scripts/verify/verify-commerce-order-identity-boundary.mjs`
 - [ ] `node --test scripts/verify/verify-commerce-order-identity-boundary.test.mjs`
@@ -611,9 +616,10 @@ Source inspection is not execution evidence.
 - [x] Extend the public-error guard to pricing and `PaymentCollectionPort`, including
   correlation, tenant, operation, stable code, and raw-cause bans.
 - [x] Add static source guards for host-selected complete order and post-order read
-  runtime composition plus admin REST complete order, mounted GraphQL complete/post-order,
-  and storefront order/return/change cutovers without changing mutation, payment, or
-  fulfillment ownership.
+  runtime composition plus admin REST complete/post-order, mounted GraphQL
+  complete/post-order, and storefront order/return/change cutovers without changing
+  mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
+  handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, and order-read
   static guards against a repository checkout and retain their output.
 
@@ -717,21 +723,24 @@ Source inspection is not execution evidence.
     storefront return/order-change lists to the host-selected runtime.
 14. [x] Cut GraphQL return/order-change detail/list reads to the scoped runtime with
     validated actor/channel/effective-locale context and compatible error shapes.
-15. [ ] Audit and cut admin post-order reads without moving mutations or payment/
-    fulfillment policy.
-16. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
-17. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
-18. [x] Mount authenticated request-scoped listing native composition.
-19. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
-20. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
+15. [x] Cut mounted admin return/order-change detail/list reads to the host-selected
+    runtime while preserving `ORDERS_READ`, filters, clamped pagination, totals,
+    public envelopes, request context, and existing mutation/payment/fulfillment ownership.
+16. [ ] Run compile and mounted parity for the four admin post-order GET routes, then
+    remove the unmounted compatibility handlers.
+17. [ ] Run checkout admission, duplicate request, kill-point, restart, and contention evidence.
+18. [ ] Run checkpoint and order identity clean/upgraded/down/reapply and contention evidence on all supported databases.
+19. [x] Mount authenticated request-scoped listing native composition.
+20. [x] Publish listing GraphQL roots and replace the declared-unmounted adapter.
+21. [ ] Add payout provider journal, webhook inbox, multi-order settlement orchestration, and
     reconciliation surfaces.
-21. [ ] Run static verifiers and fix remaining source drift.
-22. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
-23. [ ] Apply clean/upgraded migrations and targeted regression tests.
-24. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
+22. [ ] Run static verifiers and fix remaining source drift.
+23. [ ] Compile remaining commerce/order/payment/Marketplace packages and server features.
+24. [ ] Apply clean/upgraded migrations and targeted regression tests.
+25. [ ] Run contention, restart, kill-point, tenant, locale, provenance, outbox, ledger
     transfer, and mounted transport scenarios.
-25. [ ] Execute production-like payment and payout provider evidence.
-26. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
+26. [ ] Execute production-like payment and payout provider evidence.
+27. [ ] Reassess FBA/FFA promotion strictly from retained evidence.
 
 ## Completed source waves retained for history
 
@@ -773,9 +782,9 @@ Source inspection is not execution evidence.
   messages plus correlation-aware internal logging.
 - [x] Publish and host-compose `OrderReadPort`, cut complete order projections across
   admin REST, mounted GraphQL, and storefront HTTP, extend the boundary to
-  return/order-change projections, and cut storefront plus GraphQL post-order reads
-  while preserving mutations, refunds, admin post-order compatibility paths, and
-  unvalidated status.
+  return/order-change projections, and cut storefront, GraphQL, and mounted admin
+  post-order reads while preserving mutations, refunds, unmounted admin compatibility
+  GET source, and unvalidated status.
 
 ## Change rules
 


### PR DESCRIPTION
## Summary
- mark mounted admin return/order-change reads complete in the ecommerce source-of-truth plan
- preserve the compile/runtime evidence gate and add removal of the four unmounted compatibility handlers as a separate open task
- register the new admin post-order read verifier
- synchronize immediate execution order and completed source-wave history
- keep FBA/FFA statuses unchanged

## Source checkpoint
- implementation: PR #2476 / `60e8342c3d1110e3521df29df7064aa2be53e728`
- owner evidence status: `mounted_consumer_cutover_unvalidated`
- validation remains open

## Verification
Documentation-only synchronization. No tests, Cargo commands, formatting, verifiers, workflow checks, or CI are claimed.