### PR TITLE
test(product): guard lifecycle owner collaboration

### DIFF
--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "product_lifecycle_collaboration_contained_unvalidated",
+  "source_base_revision": "c4cd6e281e6a40122843617e0471edc8f589f931",
+  "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
+  "module_topology": {
+    "product_dependencies": [
+      "taxonomy"
+    ],
+    "inventory_dependencies": [
+      "product"
+    ],
+    "pricing_dependencies": [
+      "product"
+    ],
+    "ordinary_reverse_dependencies_forbidden": true,
+    "reason": "Declaring Inventory or Pricing as ordinary Product dependencies would create a module dependency cycle",
+    "default_enabled_bundle": [
+      "product",
+      "pricing",
+      "inventory"
+    ],
+    "standalone_product_write_activation_proven": false
+  },
+  "inventory_collaboration": {
+    "owner_crate": "rustok-inventory",
+    "contract": "BootstrapService",
+    "input": "InitialInventory",
+    "operations": [
+      "ensure_default_location_in_tx",
+      "create_initial_records_in_tx",
+      "load_available_quantities",
+      "delete_records_for_variants_in_tx"
+    ],
+    "same_transaction_connection": true,
+    "transport_contract_published": false
+  },
+  "pricing_collaboration": {
+    "owner_crate": "rustok-pricing-persistence",
+    "contract": "BootstrapService",
+    "input": "InitialPrice",
+    "operations": [
+      "create_initial_prices_in_tx",
+      "load_prices_for_variants",
+      "delete_prices_for_variants_in_tx"
+    ],
+    "same_transaction_connection": true,
+    "transport_contract_published": false
+  },
+  "product_boundary": {
+    "foreign_owner_entities_imported": false,
+    "foreign_owner_tables_queried_directly": false,
+    "owner_bootstrap_services_only": true,
+    "product_variant_persistence_owned_by_product": true,
+    "initial_inventory_persistence_owned_by_inventory": true,
+    "initial_price_persistence_owned_by_pricing": true
+  },
+  "decision": {
+    "containment_complete": true,
+    "dependency_contract_resolved": false,
+    "next_slice": "Choose and implement a control-plane co-requisite contract or host-injected transaction participant ports; prove Product write behavior when optional modules are selected outside the default ecommerce bundle",
+    "do_not": [
+      "add inventory or pricing to Product ordinary module dependencies",
+      "move Inventory or Pricing ORM entities into Product",
+      "replace atomic owner collaboration with unproven best-effort post-commit writes",
+      "claim standalone Product write activation"
+    ]
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "standalone_activation_proven": false,
+    "transaction_rollback_proven": false
+  }
+}

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,0 +1,79 @@
+# Product lifecycle owner collaboration
+
+Status: contained source boundary, unresolved activation contract, unvalidated.
+
+## Problem
+
+Product creation persists Product-owned variants and also accepts initial inventory and price input. The first Inventory and Pricing rows must commit or roll back with the Product write. Current source performs that collaboration through owner-owned, transaction-aware bootstrap services.
+
+The module graph cannot represent this by adding ordinary Product dependencies:
+
+- Inventory depends on Product;
+- Pricing depends on Product;
+- making Product depend on either owner would create a dependency cycle.
+
+The default ecommerce deployment currently enables Product, Pricing, and Inventory together, but that does not prove Product write behavior for every optional-module selection.
+
+## Current contained boundary
+
+Product owns:
+
+- products, variants, options, translations, images, tags, and Product events;
+- Product transaction admission and commit;
+- collection of initial inventory and price requests from Product input.
+
+Inventory owns:
+
+- stock locations, inventory items, inventory levels, and reservation cleanup;
+- `rustok_inventory::BootstrapService`;
+- `InitialInventory` and the transaction-aware create/read/delete operations.
+
+Pricing owns:
+
+- price persistence and decimal/legacy amount normalization;
+- `rustok_pricing_persistence::BootstrapService`;
+- `InitialPrice` and the transaction-aware create/read/delete operations.
+
+Product source imports only those owner bootstrap contracts. It does not import foreign Inventory/Pricing ORM entities and does not issue direct SQL against their tables.
+
+## Atomicity
+
+The owner bootstrap methods accept the same SeaORM transaction connection used by `ProductWriteTransaction`. Product variant state, initial inventory, initial prices, the Product event, and the outbox write therefore share one transaction boundary in the embedded profile.
+
+This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, or FBA transport contract. No remote write fallback is claimed.
+
+## Guarded invariants
+
+`scripts/verify/verify-product-lifecycle-collaboration.mjs` requires:
+
+- Product's ordinary module dependency remains Taxonomy only;
+- Inventory and Pricing continue to depend on Product;
+- the default deployment bundle contains Product, Pricing, and Inventory;
+- Product uses the exact owner bootstrap services and operations;
+- Product does not import foreign owner entities or query known foreign tables directly;
+- the owner services remain explicitly transaction-aware;
+- evidence remains unvalidated and does not claim standalone activation.
+
+## Open architecture decision
+
+Choose one design before calling the dependency contract resolved:
+
+1. add a control-plane co-requisite concept that affects module selection without creating dependency-order cycles; or
+2. publish host-injected transaction participant ports through a neutral contract crate and compose embedded Inventory/Pricing adapters without changing atomicity.
+
+The selected design must prove:
+
+- Product write startup and activation for non-default module selections;
+- clean migration ordering;
+- create/delete rollback across all three owners;
+- no silent post-commit partial state;
+- no ordinary cyclic dependency;
+- no Product ownership of Inventory or Pricing persistence.
+
+## Evidence
+
+Source evidence is stored at:
+
+`crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
+
+No tests, Cargo commands, formatting, verifier execution, workflow checks, standalone activation, or transaction rollback evidence are claimed by this source wave.

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const modules = read('modules.toml');
+const productManifest = read('crates/rustok-product/rustok-module.toml');
+const inventoryManifest = read('crates/rustok-inventory/rustok-module.toml');
+const pricingManifest = read('crates/rustok-pricing/rustok-module.toml');
+const productCargo = read('crates/rustok-product/Cargo.toml');
+const productRuntime = read('crates/rustok-product/src/lib.rs');
+const catalog = read('crates/rustok-product/src/services/catalog.rs');
+const commands = read('crates/rustok-product/src/services/catalog/commands.rs');
+const inventoryBootstrap = read('crates/rustok-inventory/src/services/bootstrap.rs');
+const pricingBootstrap = read('crates/rustok-pricing-persistence/src/lib.rs');
+const note = read('crates/rustok-product/docs/product-lifecycle-collaboration.md');
+const evidence = JSON.parse(
+  read('crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json'),
+);
+
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const productModuleEntry = between(
+  modules,
+  'product = {',
+  '\nprofiles = {',
+  'root Product module entry',
+);
+const pricingModuleEntry = between(
+  modules,
+  'pricing = {',
+  '\ninventory = {',
+  'root Pricing module entry',
+);
+const inventoryModuleEntry = between(
+  modules,
+  'inventory = {',
+  '\norder = {',
+  'root Inventory module entry',
+);
+const defaultEnabled = modules.slice(modules.indexOf('[settings]'));
+const productDependencySection = between(
+  productManifest,
+  '[dependencies]',
+  '\n[provides.admin_ui]',
+  'Product package dependency section',
+);
+const inventoryDependencySection = between(
+  inventoryManifest,
+  '[dependencies]',
+  '\n[crate]',
+  'Inventory package dependency section',
+);
+const pricingDependencySection = between(
+  pricingManifest,
+  '[dependencies]',
+  '\n[crate]',
+  'Pricing package dependency section',
+);
+
+for (const [source, value, label] of [
+  [productModuleEntry, 'depends_on = ["taxonomy"]', 'root Product dependency'],
+  [pricingModuleEntry, 'depends_on = ["product"]', 'root Pricing dependency'],
+  [inventoryModuleEntry, 'depends_on = ["product"]', 'root Inventory dependency'],
+  [defaultEnabled, '"product"', 'default Product activation'],
+  [defaultEnabled, '"pricing"', 'default Pricing activation'],
+  [defaultEnabled, '"inventory"', 'default Inventory activation'],
+  [productDependencySection, 'taxonomy = { version_req = ">=0.1.0" }', 'Product Taxonomy dependency'],
+  [inventoryDependencySection, 'product = { version_req = ">=0.1.0" }', 'Inventory Product dependency'],
+  [pricingDependencySection, 'product = { version_req = ">=0.1.0" }', 'Pricing Product dependency'],
+  [productRuntime, '&["taxonomy"]', 'Product runtime dependency'],
+  [productCargo, 'rustok-inventory.workspace = true', 'Inventory owner crate dependency'],
+  [productCargo, 'rustok-pricing-persistence.workspace = true', 'Pricing persistence dependency'],
+  [catalog, 'use rustok_inventory::{BootstrapService, InitialInventory};', 'Inventory bootstrap import'],
+  [catalog, 'use rustok_pricing_persistence::{BootstrapService as PricingBootstrapService, InitialPrice};', 'Pricing bootstrap import'],
+  [commands, 'BootstrapService::ensure_default_location_in_tx(&txn, tenant_id)', 'default inventory location collaboration'],
+  [commands, 'BootstrapService::create_initial_records_in_tx(', 'initial inventory collaboration'],
+  [commands, 'PricingBootstrapService::create_initial_prices_in_tx(&txn, initial_prices)', 'initial price collaboration'],
+  [commands, 'BootstrapService::delete_records_for_variants_in_tx(&txn, &variant_ids)', 'inventory cleanup collaboration'],
+  [commands, 'PricingBootstrapService::delete_prices_for_variants_in_tx(&txn, &variant_ids)', 'price cleanup collaboration'],
+  [inventoryBootstrap, 'Owner-owned, transaction-aware inventory bootstrap operations.', 'Inventory owner contract'],
+  [inventoryBootstrap, 'C: ConnectionTrait', 'Inventory transaction connection'],
+  [pricingBootstrap, 'Pricing-owned transaction-aware operations required by Product lifecycle writes.', 'Pricing owner contract'],
+  [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
+  [note, 'Status: contained source boundary, unresolved activation contract, unvalidated.', 'focused note status'],
+  [note, 'control-plane co-requisite concept', 'co-requisite decision'],
+  [note, 'host-injected transaction participant ports', 'port decision'],
+]) requireText(source, value, label);
+
+for (const [source, value, label] of [
+  [productModuleEntry, '"inventory"', 'cyclic Product-to-Inventory dependency'],
+  [productModuleEntry, '"pricing"', 'cyclic Product-to-Pricing dependency'],
+  [productDependencySection, 'inventory =', 'cyclic Product package Inventory dependency'],
+  [productDependencySection, 'pricing =', 'cyclic Product package Pricing dependency'],
+  [productRuntime, '"inventory"', 'cyclic Product runtime Inventory dependency'],
+  [productRuntime, '"pricing"', 'cyclic Product runtime Pricing dependency'],
+  [catalog, 'rustok_commerce_foundation::entities', 'foreign foundation entity import'],
+  [commands, 'rustok_commerce_foundation::entities', 'foreign foundation entity import in commands'],
+  [commands, 'inventory_item::Entity', 'direct Inventory entity access'],
+  [commands, 'inventory_level::Entity', 'direct Inventory level access'],
+  [commands, 'stock_location::Entity', 'direct stock location access'],
+  [commands, 'reservation_item::Entity', 'direct reservation access'],
+  [commands, 'price::Entity', 'direct Pricing entity access'],
+  [commands, 'FROM inventory_', 'direct Inventory SQL'],
+  [commands, 'INTO inventory_', 'direct Inventory SQL write'],
+  [commands, 'FROM prices', 'direct Pricing SQL'],
+  [commands, 'INTO prices', 'direct Pricing SQL write'],
+]) forbidText(source, value, label);
+
+if (evidence.status !== 'product_lifecycle_collaboration_contained_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (evidence.module_topology?.ordinary_reverse_dependencies_forbidden !== true) {
+  failures.push('evidence must forbid ordinary reverse dependencies');
+}
+if (evidence.module_topology?.standalone_product_write_activation_proven !== false) {
+  failures.push('standalone Product write activation must remain unproven');
+}
+if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
+    evidence.product_boundary?.foreign_owner_tables_queried_directly !== false ||
+    evidence.product_boundary?.owner_bootstrap_services_only !== true) {
+  failures.push('evidence Product owner boundary mismatch');
+}
+if (evidence.decision?.containment_complete !== true ||
+    evidence.decision?.dependency_contract_resolved !== false) {
+  failures.push('evidence decision must keep dependency resolution open');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'standalone_activation_proven',
+  'transaction_rollback_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Product lifecycle collaboration verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Product uses transaction-aware Inventory/Pricing owner bootstrap contracts without direct foreign entities or cyclic module dependencies; activation contract and runtime evidence remain open',
+);


### PR DESCRIPTION
## Summary
- record the current Product create/delete collaboration with Inventory and Pricing owners as explicit source evidence
- add a focused note explaining why ordinary Product dependencies would create a module cycle
- add a static verifier that requires owner-owned transaction-aware bootstrap services and forbids direct foreign entities/tables
- require the default ecommerce bundle to include Product, Pricing, and Inventory
- keep standalone Product write activation and rollback evidence explicitly unproven

## Recheck
- Product ordinary dependencies are Taxonomy only
- Inventory and Pricing both depend on Product, so reversing either edge would create a cycle
- Product create/delete uses `rustok_inventory::BootstrapService` and `rustok_pricing_persistence::BootstrapService` with the same transaction connection
- Product source does not import Inventory/Pricing ORM entities or issue known direct SQL against their tables
- the current manifest schema has no co-requisite concept distinct from dependency ordering

## Boundary
This PR does not change runtime behavior, module activation, migrations, Product DTOs, transaction semantics, or FBA/FFA status. It does not claim that Product writes work when Pricing or Inventory are omitted. The dependency-contract P0 remains open for a control-plane co-requisite design or host-injected transaction participant ports.

## Verification
Not run per maintainer instruction. No tests, Node verifier execution, Cargo commands, formatting, workflow checks, or CI are claimed.