### PR TITLE
feat(index): compose shared query runtime

### DIFF
--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -72,7 +72,89 @@ pub mod mcp_management_guard;
 pub mod mcp_management_mutation_provider;
 pub mod mcp_runtime;
 pub mod mcp_scaffold_workspace;
-pub mod module_event_dispatcher;
+#[path = "module_event_dispatcher.rs"]
+mod module_event_dispatcher_base;
+pub mod module_event_dispatcher {
+    use std::sync::Arc;
+
+    use rustok_auth::AuthConfig;
+    use rustok_core::{ModuleRegistry, ModuleRuntimeExtensions};
+
+    use crate::common::settings::RustokSettings;
+    use crate::error::{Error, Result};
+    use crate::services::server_runtime_context::ServerRuntimeContext;
+
+    pub use super::module_event_dispatcher_base::{
+        build_module_event_dispatcher, build_shared_runtime_extensions,
+        spawn_module_event_dispatcher,
+    };
+
+    /// Adds host-owned adapters after module/distribution registration and finally
+    /// materializes the canonical Index query runtime from the complete source registry.
+    pub fn build_shared_runtime_extensions_with_host_providers(
+        registry: &ModuleRegistry,
+        settings: &RustokSettings,
+        runtime_ctx: ServerRuntimeContext,
+        auth_config: AuthConfig,
+    ) -> Result<Arc<ModuleRuntimeExtensions>> {
+        let db = runtime_ctx.db_clone();
+        let base = super::module_event_dispatcher_base::build_shared_runtime_extensions_with_host_providers(
+            registry,
+            settings,
+            runtime_ctx,
+            auth_config,
+        )?;
+        let mut extensions = base.as_ref().clone();
+        rustok_index::materialize_postgres_index_query_runtime(&mut extensions, db).map_err(
+            |error| Error::Message(format!("Index query runtime composition failed: {error}")),
+        )?;
+        Ok(Arc::new(extensions))
+    }
+
+    #[cfg(all(test, feature = "mod-social_graph"))]
+    mod tests {
+        use rustok_core::{ModuleRegistry, ModuleRuntimeExtensions};
+        use rustok_index::{IndexModule, SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
+        use sea_orm::Database;
+
+        use super::build_shared_runtime_extensions_with_host_providers;
+        use crate::auth::AuthConfig;
+        use crate::common::settings::RustokSettings;
+        use crate::services::server_runtime_context::ServerRuntimeContext;
+
+        #[tokio::test]
+        async fn host_materializes_index_query_runtime_after_source_registry() {
+            let registry = ModuleRegistry::new()
+                .register(IndexModule)
+                .register(rustok_social_graph::SocialGraphModule);
+            let settings = RustokSettings::default();
+            let db = Database::connect("sqlite::memory:")
+                .await
+                .expect("in-memory sqlite should connect");
+            let runtime_ctx = ServerRuntimeContext::new(db.clone(), settings.clone());
+
+            let extensions = build_shared_runtime_extensions_with_host_providers(
+                &registry,
+                &settings,
+                runtime_ctx,
+                AuthConfig::new("test-secret-key-for-unit-tests-only-32bytes!".to_string()),
+            )
+            .expect("host Index runtime should compose");
+
+            assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+            assert!(extensions.contains::<SharedIndexQueryRuntime>());
+            let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+            assert!(host.shared_get::<SharedIndexQueryRuntime>().is_some());
+        }
+
+        #[test]
+        fn facade_keeps_module_extensions_type_visible() {
+            fn accepts(_: &ModuleRuntimeExtensions) {}
+            let extensions = ModuleRuntimeExtensions::default();
+            accepts(&extensions);
+        }
+    }
+}
 pub mod module_lifecycle;
 #[cfg(feature = "mod-notifications")]
 pub mod notification_candidate_worker;

--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -7,12 +7,12 @@
 - `infrastructure`
 - `migrations`
 
-The domain/application contract remains database independent. M3 adds module-owned
-production migrations, an Index-owned PostgreSQL mutation adapter, tenant-scoped
-source schema persistence, durable schema-application leases, schema-derived
-secondary-index lifecycle, and a fail-closed measured partition-admission contract;
-source-specific Content, Product, Flex, search, legacy migration, runtime, and
-scheduler modules remain deleted.
+The domain/application contract remains database independent. M3 owns the canonical
+PostgreSQL storage, mutation, schema-registration, lease, secondary-index, and measured
+partition-admission boundaries. M4 owns typed query planning, controlled SQL compilation,
+strict decoding, PostgreSQL execution, source-owned schema catalog composition, and the
+neutral shared query runtime. Source-specific Product, Content, Flex, search, migration,
+and scheduler implementations remain outside the engine core.
 
 ## Primary Public Types
 
@@ -25,396 +25,201 @@ scheduler modules remain deleted.
 - `IndexSchema`, `IndexField`, `IndexLink`, `SchemaFingerprint`
 - `IndexRecord`, `IndexLinkValue`, `LinkedEntityKey`
 - `IndexMutation`
-- `IndexQueryScope`, `IndexQuery`, `FilterExpr`, `OrderExpr`,
-  `OrderDirection`, `Pagination`
+- `IndexQueryScope`, `IndexQuery`, `FilterExpr`, `OrderExpr`, `OrderDirection`, `Pagination`
 - `DomainError`
 
 ### Application
 
 - `SchemaRegistry`, `RegisteredSchema`, `RegistrationOutcome`
 - `SchemaRegistryError`, `LinkPathStep`
+- `IndexSchemaSourceCatalog`, `IndexSchemaSourceDescriptor`, `IndexSchemaSourceError`
+- `SharedIndexSchemaRegistry`
+- `register_index_schema_source`, `materialize_index_schema_registry`
 - `RecordValidationError`, `QueryValidationError`
 - `IndexCursor`, `CursorCodec`, `CursorCodecError`, `CursorValidationError`
-- `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedManyProjection`,
-  `PlannedOrder`
+- `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedManyProjection`, `PlannedOrder`
 - `QueryPlanFingerprint`, `QueryPlanError`
-- `PostgresBindValue`, `CompiledQueryColumn`, `CompiledManyRelationColumn`,
-  `CompiledPostgresCount`
+- `PostgresBindValue`, `CompiledQueryColumn`, `CompiledManyRelationColumn`, `CompiledPostgresCount`
 - `CompiledPostgresQuery`, `PostgresQueryBuildError`, `PostgresQueryCompileError`
 - `CompiledPostgresCell`, `CompiledPostgresRow`, `CompiledPostgresPageQuery`
-- `IndexProjectedValue`, `IndexRelationIdentity`, `IndexNestedRelationItem`,
-  `IndexNestedRelationProjection`, `IndexQueryItem`, `IndexQueryPage`
+- `IndexProjectedValue`, `IndexRelationIdentity`, `IndexNestedRelationItem`
+- `IndexNestedRelationProjection`, `IndexQueryItem`, `IndexQueryPage`
 - `PostgresQueryPageBuildError`, `PostgresQueryDecodeError`
-- `IndexQueryPort`, `IndexQueryExecutionError`, `PersistedSchemaReadinessFailure`
+- `IndexQueryPort`, `SharedIndexQueryRuntime`
+- `IndexQueryExecutionError`, `PersistedSchemaReadinessFailure`
 
 ### Infrastructure
 
 - `PostgresIndexQueryPort`
-- `PostgresMutationStore`
-- `MutationDelivery`
-- `MutationApplyOutcome`
-- `MutationStorageError`
-- `PostgresSchemaRegistrationStore`
-- `PersistedSchemaRegistrationOutcome`
-- `SchemaRegistrationError`
-- `PostgresSchemaLeaseStore`
-- `SchemaApplicationLeaseRequest`
-- `SchemaApplicationLease`
-- `SchemaLeaseAcquireOutcome`
-- `SchemaLeaseError`
-- `SecondaryIndexPlan`
-- `SecondaryIndexSpec`
-- `SecondaryIndexKind`
-- `SecondaryIndexOperation`
-- `SecondaryIndexRequest`
-- `SecondaryIndexLease`
-- `SecondaryIndexClaimOutcome`
-- `SecondaryIndexExecutionOutcome`
-- `SecondaryIndexError`
-- `PostgresSecondaryIndexManager`
-- `PartitionStrategy`
-- `PartitionAdmissionPolicy`
-- `PartitionBaselineEvidence`
-- `PartitionMeasurementCoverage`
-- `PartitionShadowEvidence`
-- `PartitionEvidence`
-- `PartitionAdmissionReason`
-- `PartitionAdmissionOutcome`
-- `PartitionRelationPlan`
-- `PartitionShadowPlan`
-- `PartitionAdmissionError`
-- `evaluate_partition_admission`
+- `materialize_postgres_index_query_runtime`
+- `IndexQueryRuntimeCompositionError`
+- `PostgresMutationStore`, `MutationDelivery`, `MutationApplyOutcome`, `MutationStorageError`
+- `PostgresSchemaRegistrationStore`, `PersistedSchemaRegistrationOutcome`, `SchemaRegistrationError`
+- `PostgresSchemaLeaseStore`, `SchemaApplicationLeaseRequest`, `SchemaApplicationLease`
+- `SchemaLeaseAcquireOutcome`, `SchemaLeaseError`
+- `SecondaryIndexPlan`, `SecondaryIndexSpec`, `SecondaryIndexKind`, `SecondaryIndexOperation`
+- `SecondaryIndexRequest`, `SecondaryIndexLease`, `SecondaryIndexClaimOutcome`
+- `SecondaryIndexExecutionOutcome`, `SecondaryIndexError`, `PostgresSecondaryIndexManager`
+- `PartitionStrategy`, `PartitionAdmissionPolicy`, `PartitionBaselineEvidence`
+- `PartitionMeasurementCoverage`, `PartitionShadowEvidence`, `PartitionEvidence`
+- `PartitionAdmissionReason`, `PartitionAdmissionOutcome`, `PartitionRelationPlan`
+- `PartitionShadowPlan`, `PartitionAdmissionError`, `evaluate_partition_admission`
 
 ## Contract Status
 
-M1 domain/application contracts are active. They provide canonical identifiers
-and locales, stable schema fingerprints, atomic schema registration,
-deterministic link paths, record/query validation, bounded query complexity,
-and query-scoped keyset cursors.
+M1 generic domain/application contracts are active. They provide canonical identifiers and
+locales, stable schema fingerprints, atomic schema registration, deterministic link paths,
+record/query validation, bounded query complexity, and query-scoped cursors.
 
-The accepted M2 ADR selects JSONB, and M3 registers the canonical schema for
-`index_schemas`, `index_entities`, `index_links`, `index_inbox`, `index_jobs`,
-`index_checkpoints`, and `index_consistency_findings`.
-`PostgresSchemaRegistrationStore` is the generic Index-owned boundary for
-source-published tenant schemas. It validates the domain contract, serializes one
-tenant/schema identity under a PostgreSQL transaction advisory lock, inserts an
-active schema idempotently, rejects same-version contract reuse, lower-version
-insertion, retired reactivation, nil tenants, and unsupported backends. Source
-owners do not write `index_schemas` directly.
+M3 owns the canonical `index_schemas`, `index_entities`, `index_links`, `index_inbox`,
+`index_jobs`, `index_checkpoints`, and `index_consistency_findings` schema. Source modules
+persist tenant schema readiness only through `PostgresSchemaRegistrationStore`; they never
+write Index tables directly. Mutation persistence, schema leases, secondary-index lifecycle,
+and partition admission remain Index-owned and fail closed on identity or evidence drift.
 
-`PostgresMutationStore` atomically applies validated entity/link upserts and
-deletes through the durable inbox. `PostgresSchemaLeaseStore` serializes exact
-tenant/schema application, reclaims expired jobs with attempt fencing, and
-requires current ownership for heartbeat and terminal completion.
-`SecondaryIndexPlan` derives stable indexes from filterable/sortable schema fields,
-and `PostgresSecondaryIndexManager` coordinates concurrent ensure/reindex/retire
-execution through durable fenced jobs and PostgreSQL catalog readiness checks.
-Partition admission requires an exact retained evidence identifier, complete
-query/mutation/maintenance/cutover measurement coverage, and an explicit policy
-before producing deterministic tenant-hash shadow relation names and bootstrap
-SQL. It does not execute copy, constraint/index attachment, dual-write/replay,
-cutover, or rollback.
+M4 provides validated executable plans, controlled PostgreSQL SQL and ordered binds,
+root/one-link projection and ordering, correlated many-link filtering, deterministic nested
+many-link projection aggregates, exact count, bounded offset, query-scoped keyset pagination,
+one-row lookahead, strict row decoding, and PostgreSQL execution through one read-only
+repeatable-read snapshot.
 
-M4 provides validated typed executable plans, controlled PostgreSQL SQL and bind
-DTOs for root/one-link projection, filtering, ordering, counting and pagination,
-correlated many-link filtering, deterministic nested many-link projection aggregates,
-query-scoped cursor continuation, one-row page lookahead, strict scalar/nested result
-decoding, exact-count decoding, `has_more`, and next-cursor construction.
-`PostgresIndexQueryPort` now performs PostgreSQL-only execution with exact persisted
-schema readiness, one read-only repeatable-read page/count snapshot, exhaustive
-SeaORM bind conversion, and compiler-metadata-driven row mapping. It does not order
-through many links, authorize callers, compose into server/storefront/admin/search,
-or claim live PostgreSQL/reference-engine equivalence. Multi-source catalog
-composition, batch ingestion, rebuild, consumer cutover, partition cutover, and
-operator APIs remain later work.
+Source modules now publish generic schema contracts through `IndexSchemaSourceCatalog`.
+The catalog fixes one owner for every exact schema reference and for the complete schema
+identity across versions. `rustok-distribution` materializes all contributions through one
+atomic `SchemaRegistry::register_batch` and publishes `SharedIndexSchemaRegistry` only for a
+non-empty valid catalog. Social Graph is the first source owner.
 
-No compatibility contract exists for deleted behavior. `IndexDocument`,
-`DocumentType`, old ports/adapters, source DTOs/indexers/models/migrations,
-`IndexerRuntimeConfig`, `IndexerContext`, and the old scheduler must not return.
+The server composes `SharedIndexQueryRuntime` through the Index-owned
+`materialize_postgres_index_query_runtime`. The materializer binds the exact immutable shared
+registry to the host `DatabaseConnection`, refuses duplicate runtime publication, performs no
+SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
+`HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
+connection, persisted tenant schema readiness, authorization, or successful query execution.
+
+Many-link aggregate ordering, additional source schemas, transport authorization, first
+storefront/admin/search consumer cutover, and live PostgreSQL/reference evidence remain open.
+
+No compatibility contract exists for deleted behavior. `IndexDocument`, `DocumentType`, old
+ports/adapters, source DTOs/indexers/models/migrations, `IndexerRuntimeConfig`,
+`IndexerContext`, and the old scheduler must not return.
 
 ## Dependencies on Other RusToK Crates
 
-The generic engine core does not depend on source-domain crates. `rustok-core`
-is used only for module metadata and platform contracts. Source adapters belong
-to owner modules or explicit integration crates and register through Index-owned
-APIs.
-
-## Common AI Mistakes
-
-- Adding Product, Content, Flex, Pricing, or Inventory fields to engine-core
-  enums or structs.
-- Reading source-module tables from Index.
-- Writing `index_schemas` directly from a source module instead of calling
-  `PostgresSchemaRegistrationStore`.
-- Treating in-memory `SchemaRegistry` registration as persisted tenant schema
-  readiness for mutation or query execution.
-- Reactivating a retired schema or silently replacing a contract under the same
-  schema version.
-- Treating Index as a ranking/full-text search engine.
-- Reintroducing a catch-all JSON document as the public contract.
-- Implementing rebuild by collecting every source ID before processing.
-- Publishing unvalidated JSON filters instead of the typed query AST.
-- Accepting a cursor without checking tenant, schema, fingerprint, locale, filter,
-  ordered fields/directions, order arity, and order-value types.
-- Executing a page query through raw `compile_postgres_query` instead of the
-  one-row-lookahead `compile_postgres_page_query` handoff.
-- Executing compiler SQL outside `PostgresIndexQueryPort` or bypassing its exact
-  tenant-scoped persisted schema preflight.
-- Executing page and exact-count statements in separate snapshots.
-- Decoding rows without rechecking the plan fingerprint and exact scalar/nested
-  column contracts.
-- Reading arbitrary driver columns instead of compiler-declared UUID/JSONB/bigint
-  aliases.
-- Compiling a many-link filter as an ordinary outer join; it must remain a correlated
-  predicate so child multiplicity cannot duplicate root rows or counts.
-- Flattening many-link projection into outer rows or independent value arrays; one
-  aggregate item must retain its full identity chain and aligned selected values.
-- Sorting through a `many` link without an explicit aggregate ordering policy.
-- Completing or heartbeating schema/index work without exact worker and attempt
-  fencing.
-- Building expression indexes against `payload ->> field`; stored `IndexValue`
-  payloads are tagged and scalar/list values live under each field's `value` key.
-- Creating bespoke Product or other owner-specific indexes instead of deriving
-  them from the generic schema contract.
-- Enabling partitioning because a relation is merely large, without retained
-  tenant-scoped baseline and shadow evidence.
-- Treating zero measured runs or less than 100% tenant-predicate coverage as
-  acceptable partition evidence.
-- Treating `PartitionShadowPlan::bootstrap_statements` as cutover-ready DDL; it
-  intentionally contains no production rename/drop or constraint/index attachment.
-- Restoring deleted v1 or source-specific code as a compatibility layer.
+The generic engine core does not depend on source-domain crates. `rustok-core` supplies module
+metadata and `ModuleRuntimeExtensions`. Source adapters remain in owner modules and publish
+only generic Index contracts. Distribution and server composition must not import owner schema
+builders or DTOs.
 
 ## Minimum Contract Set
 
-### Input DTOs/Commands
+### Schema source and runtime composition
 
-- `IndexSchema`, `IndexRecord`, `IndexMutation`, and `IndexQuery` are the current
-  input contracts.
+- `IndexModule::register_runtime_extensions` seeds `IndexSchemaSourceCatalog`.
+- `register_index_schema_source` accepts one owner slug and one validated generic schema.
+- Duplicate exact references fail even when fingerprints match.
+- Different owners cannot split versions of one `(module, entity)` identity.
+- `materialize_index_schema_registry` returns `None` for an absent or empty catalog.
+- Non-empty materialization uses one atomic registration batch so cross-source links validate
+  without partial registry state.
+- `SharedIndexSchemaRegistry` wraps the exact immutable `Arc<SchemaRegistry>`; its constructor
+  is not public.
+- `SharedIndexQueryRuntime` exposes only the transport-neutral `IndexQueryPort` capability.
+- `materialize_postgres_index_query_runtime` is the production constructor for the PostgreSQL
+  runtime and fails when the runtime is already present.
+- Runtime composition performs no SQL and does not replace tenant-scoped persisted schema
+  registration or preflight.
+- Executable hosts transfer the capability through the existing typed runtime-extension seam.
+
+### Query input and execution
+
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
-- `IndexQueryPort::execute_query` is the transport-neutral owner boundary for one
-  structured query and typed page result.
-- `SchemaRegistry::compile_postgres_page_query` is the page-execution compiler
-  handoff; it preserves SQL and increases only the validated limit bind by one.
-- `CompiledPostgresQuery::many_relations` binds every aggregate output alias to its
-  exact `PlannedManyProjection` metadata.
-- `CompiledPostgresRow` is the narrow adapter handoff for compiler-owned UUID,
-  tagged JSON, nested aggregate JSON, SQL-null, and exact-count cells.
-- `PostgresIndexQueryPort` binds one PostgreSQL connection to one immutable
-  `Arc<SchemaRegistry>` and never accepts arbitrary SQL or result metadata.
-- `PostgresSchemaRegistrationStore::register(tenant_id, schema)` binds one non-nil
-  tenant to one validated exact schema contract and calculated fingerprint.
-- `SchemaApplicationLeaseRequest` binds one tenant, exact schema reference,
-  computed fingerprint, worker identity, and bounded whole-second lease duration.
-- `SecondaryIndexPlan` binds one tenant and exact schema fingerprint to all
-  filterable/sortable field indexes.
-- `SecondaryIndexRequest` binds one immutable index spec, operation, worker, and
-  bounded whole-second lease duration.
-- `PartitionEvidence` binds measured unpartitioned baseline facts to one exact
-  SHA-256 identified tenant-hash shadow packet.
-- `PartitionMeasurementCoverage` records non-zero query, mutation, maintenance,
-  and cutover-rehearsal run counts. A missing group is a typed rejection reason.
-- `PartitionAdmissionPolicy` supplies explicit minimum scale and maximum
-  regression/skew/lock thresholds; no production default silently admits rollout,
-  and tenant-predicate coverage is fixed at 10000 basis points.
-- Construction and validation preserve tenant, schema, entity, locale, and
-  source-version identity.
-- Identifiers use bounded lowercase ASCII grammar; locales use ICU4X
-  canonicalization.
-- Public field changes require a new `SchemaVersion`; incompatible content under
-  the same version is rejected by both in-memory and persisted registration.
+- Selected, filtered, and ordered fields resolve through registered typed paths.
+- Query shape, depth, selected fields, ordering expressions, page size, and offset are bounded.
+- `SchemaRegistry::compile_postgres_page_query` preserves the compiled query and changes only
+  the validated page-limit bind from `N` to `N + 1`.
+- `CompiledPostgresQuery::many_relations` binds every aggregate alias to exact plan metadata.
+- `CompiledPostgresRow` contains only compiler-owned UUID, tagged JSON, nested aggregate JSON,
+  SQL-null, and exact-count cells.
+- `PostgresIndexQueryPort` owns one connection and one immutable registry. It accepts no raw SQL
+  or caller-provided result metadata.
+- Every execution verifies root/source/target schemas against the query tenant's exact active
+  persisted fingerprint and semantic JSON contract.
+- Page and optional exact-count statements execute in one read-only repeatable-read snapshot.
+- Authentication and transport policy remain caller responsibilities and must not widen the
+  tenant or locale scope already present in `IndexQuery`.
 
-### Domain Invariants
+### Mutation and storage
 
-- Every record and query is explicitly tenant scoped.
+- `PostgresSchemaRegistrationStore::register` binds one non-nil tenant to one exact validated
+  schema and calculated fingerprint.
+- `PostgresMutationStore` applies one `MutationDelivery` with inbox deduplication, complete
+  entity-key serialization, monotonic source versions, tombstones, and atomic link replacement.
+- `SchemaApplicationLeaseRequest` and `SecondaryIndexRequest` use exact worker/attempt fencing.
+- Partition admission requires one exact retained evidence identity, non-zero coverage groups,
+  100% tenant-predicate coverage, parity, catch-up, integrity, regression, WAL, skew, and lock
+  gates before producing shadow-only planning output.
+- Production partition copy, constraint/index attachment, replay/dual-write, cutover, rollback,
+  and global operation ownership remain outside the current source-complete boundary.
+
+## Domain Invariants
+
+- Every record and query is tenant scoped.
 - Locale presence follows the registered schema's `LocaleMode`.
-- Every record belongs to an exact registered schema version.
-- Record values match field type, nullability, and cardinality.
-- Link targets match registered target schemas, fields, join types, locale mode,
-  and cardinality.
-- Selected, filtered, and ordered fields are resolved through typed link paths.
-- Query complexity, path depth, page size, and offset depth are bounded.
-- Filtering through `many` paths uses correlated existential semantics.
-- Projection through `many` paths returns deterministic nested items with complete
-  relation identity chains and aligned tagged values.
-- Sorting through a `many` link is rejected until aggregate ordering is explicit.
+- Records belong to one exact schema version and values match type, cardinality, and nullability.
+- Link targets match registered target schemas, join fields, types, locale modes, and cardinality.
+- Filtering through `many` paths uses correlated existential semantics and cannot duplicate root
+  rows or exact counts.
+- Projection through `many` paths returns deterministic nested items with complete identity
+  chains and aligned tagged values.
+- Sorting through a `many` link remains rejected until an explicit aggregate policy is added.
 - Source versions and tombstones prevent stale mutation overwrite.
 - Generic engine types remain source-domain agnostic.
+- Runtime composition is not an authorization decision or persisted-readiness assertion.
 
-### Schema Registry
+## Query Planning, Compilation, and Decoding
 
-- In-memory registration is atomic for a batch.
-- Re-registering an identical schema version is idempotent.
-- Changing a contract under the same version is an error.
-- Versions for a schema identity are monotonic.
-- Link paths resolve deterministically through the registered graph.
-- Schema fingerprints ignore declaration order but include all semantic field,
-  link, locale, and version metadata.
+- `SchemaRegistry::plan_query` validates first, assigns stable aliases, resolves joins, propagates
+  `traverses_many`, captures typed fields, groups many projections, and emits a v4 fingerprint.
+- Many-traversing filters compile as independent nested correlated `EXISTS` chains.
+- Many projections compile as correlated JSONB aggregates outside the outer root rowset and use
+  stored link ordinal, entity identity, and locale for deterministic item order.
+- `decode_postgres_query_page` re-plans and verifies the plan fingerprint, scalar/many metadata,
+  tagged values, nested identity/value arity, uniqueness, page bounds, and optional exact count.
+- Cursor pages remove lookahead and produce a next scoped cursor from the last retained
+  entity/order tuple; offset pages report `has_more` without a cursor.
 
-### Persisted Source Schema Registration
-
-- Registration is tenant scoped and supports PostgreSQL and SQLite only.
-- PostgreSQL serializes the tenant/module/entity identity with a transaction-scoped
-  advisory lock before exact/latest-version checks.
-- An exact active schema with matching fingerprint and semantic JSON is
-  `Unchanged`; a new greater version is `Inserted`.
-- Same-version contract drift, an unregistered lower version, retired state, nil
-  tenant, malformed persisted values, and storage failures fail closed.
-- Registration commits before an owner mutation may rely on the schema foreign key.
-- The store contains no source-domain types or table reads outside Index-owned
-  storage.
-
-### Schema Application Lease
-
-- Acquisition is scoped by tenant, module, entity, and schema version.
-- PostgreSQL acquisition takes a transaction-scoped advisory lock before reading
-  persisted schema and job state.
-- The persisted schema must be active and match the request fingerprint.
-- A non-expired running owner returns `Busy`; a succeeded application returns
-  `AlreadyApplied`.
-- Expired work is reclaimed by increasing `attempt_count` on the same job.
-- Heartbeat, success, and failure require the exact job, worker, attempt, running
-  state, and an unexpired lease.
-- Failed terminal jobs permit a new job; succeeded jobs remain terminal.
-
-### Secondary Index Lifecycle
-
-- Plans include only fields declared filterable or sortable by the exact schema.
-- Scalar fields use deterministic typed partial B-tree expressions ordered by
-  locale, value, and entity identity.
-- Filterable `many` fields use field-local JSONB containment GIN.
-- Expressions read the tagged production `IndexValue` payload through the field's
-  `value` member; timestamp keys use an immutable canonical UTC-digit expression.
-- Names bind tenant, schema reference, schema fingerprint, field type,
-  cardinality, index kind, and payload contract through SHA-256.
-- Ensure, reindex, and retire use `CREATE INDEX CONCURRENTLY`,
-  `REINDEX INDEX CONCURRENTLY`, and `DROP INDEX CONCURRENTLY` in PostgreSQL.
-- Active jobs are serialized by a transaction advisory lock and fenced by worker,
-  attempt count, state, and lease expiry.
-- PostgreSQL owner comments bind the index name to its full definition hash;
-  conflicting ownership fails closed.
-- Completion requires catalog `indisready` and `indisvalid`; retirement remains
-  available after a schema is retired.
-
-### Partition Admission and Shadow Planning
-
-- The canonical `index_entities` and `index_links` tables remain unpartitioned by
-  default because M2 did not measure partitioning.
-- Tenant-hash modulus must be a power of two between 2 and 128.
-- Evidence identity is a lowercase 64-character SHA-256 digest.
-- Admission requires exactly 10000 basis points of tenant-predicate coverage.
-- Query, mutation, maintenance, and cutover-rehearsal measurement counts must each
-  be non-zero.
-- Admission also checks measured total rows/bytes, distinct tenants, entity/link
-  digest parity, catch-up, foreign keys, orphan links, query-plan regressions, p95
-  query/mutation regressions, WAL amplification, partition-size skew, and
-  cutover-lock duration.
-- Any failed gate returns `KeepUnpartitioned` with typed reasons.
-- An admitted plan derives deterministic shadow parent/partition names from the
-  evidence identity, strategy, modulus, and plan-contract version.
-- Bootstrap SQL creates only shadow hash-partition parents and children. It never
-  renames, drops, or alters the production entity/link relations.
-- Copy, constraints, indexes, replay/dual-write, cutover, rollback, durable global
-  ownership, and PostgreSQL evidence remain mandatory future work.
-
-### Query Planning, Compilation, Result Decoding, and Execution
-
-- `SchemaRegistry::plan_query` validates first and captures deterministic aliases,
-  joins, typed referenced fields, propagated `traverses_many`, scalar projection,
-  grouped `PlannedManyProjection` metadata, filters, ordering, pagination, and a v4
-  plan fingerprint.
-- Many projection groups preserve first terminal-path appearance and requested field
-  order; each group records every relation-prefix identity path.
-- `compile_postgres_query` emits controlled SQL plus ordered bind DTOs for root and
-  one-link projection/ordering, nested many projection aggregates, and all validated
-  filters; caller values and contract names remain binds.
-- Every many-traversing atomic filter emits an independent nested correlated `EXISTS`
-  chain. No many join enters the outer rowset or identity-column contract.
-- Every selected many path emits one correlated JSONB aggregate ordered by stored link
-  ordinal, target entity identity, and locale at every hop. Empty reachability emits
-  an empty array rather than a null relation.
-- Aggregate items carry parallel identity/value arrays whose exact arity and metadata
-  are fixed by the compiled plan; the public decoder reconstructs typed nested items.
-- Many-link `Ne` requires at least one stored reachable value and no reachable null or
-  equal value; `IsNull` tests the absence of any reachable non-null value.
-- `compile_postgres_page_query` changes only the validated main-statement page-limit
-  bind from `N` to `N + 1`; offset and exact-count binds are preserved.
-- `decode_postgres_query_page` re-plans the query, compares the plan fingerprint and
-  complete unique scalar/many metadata, validates every tagged field value, nested
-  identity/value arity, nil or duplicate identity chains, and rejects more than
-  `N + 1` rows.
-- The lookahead row is removed. Cursor pages produce `has_more` and a scoped next
-  cursor from the last retained entity/order tuple; offset pages produce
-  `has_more` without a cursor.
-- `PostgresIndexQueryPort` requires PostgreSQL, verifies every root/source/target
-  schema against the query tenant's exact active persisted fingerprint and JSON
-  contract, and performs preflight/page/count/decode in one read-only repeatable-read
-  transaction.
-- `PostgresBindValue` conversion is exhaustive for boolean, integer, decimal, text,
-  UUID, UTC timestamp, and JSONB.
-- The row adapter reads only compiler-declared identity, scalar, order, nested, and
-  count aliases and delegates semantic validation to the strict decoder.
-- Many-link ordering, server/consumer composition, and live equivalence evidence
-  remain separate future boundaries.
-
-### Cursor Contract
-
-- Cursor formats are explicitly versioned.
-- Payloads use postcard and URL-safe Base64.
-- A checksum detects corruption.
-- Production continuation tokens bind tenant, schema, locale, filter, ordered
-  fields, and directions through a query fingerprint.
-- Cursor application validates schema fingerprint, ordering arity, order-value
-  types, and non-nil entity tie-breaker identity.
-- Cursor integrity is not an authorization substitute; transport and query
-  policy still enforce caller access.
-
-### Events / Outbox Side Effects
-
-- Source events are converted to `IndexMutation` through owner-published adapters.
-- The source schema is persisted through the Index owner before a mutation relies
-  on it.
-- Delivery is replayable and idempotent.
-- `MutationDelivery` binds a source name and delivery ID to one exact serialized
-  `IndexMutation` payload.
-- `PostgresMutationStore` claims the tenant/source/delivery inbox identity,
-  rejects payload reuse, and commits the inbox terminal state with the entity/link
-  mutation.
-- Exact redelivery is `Duplicate`; stale source versions are terminally ignored;
-  live upserts and tombstones replace links atomically.
-
-### Errors / Failure Codes
+## Errors / Failure Codes
 
 - `DomainError` defines identifier, schema-shape, and query-shape failures.
-- `SchemaRegistryError` defines in-memory registration and graph failures.
-- `SchemaRegistrationError` separates nil tenant, invalid schema, same-version
-  conflict, non-monotonic version, retired state, and generic storage failure.
-- `RecordValidationError` and `QueryValidationError` define registry-backed data
-  and query failures.
-- `CursorCodecError` and `CursorValidationError` separate malformed cursors from
-  scope/schema/query-fingerprint/type mismatches.
-- `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError`
-  separate validation/planning failures from unsupported or corrupted compiler
-  contracts. Many-link ordering, missing join plans, inconsistent traversal metadata,
-  and inconsistent nested projection plans are distinct typed compiler failures.
-- `PostgresQueryPageBuildError` rejects missing or mismatched pagination binds;
-  `PostgresQueryDecodeError` rejects plan/scalar/many/count mismatches, malformed
-  cells, invalid tagged values, invalid nested JSON, identity/value arity drift,
-  nil/duplicate nested identities, unexpected nulls, and oversized result batches.
-- `IndexQueryExecutionError` separates plan/build/decode failures, unsupported
-  backends, missing/inactive/drifted persisted schemas, missing counts, invalid driver
-  column types, contract preparation, and storage operations. Storage diagnostic
-  details are retained in fields while top-level display remains operation-level.
-- `MutationStorageError` separates validation, delivery identity conflict,
-  in-progress/rejected replay, stored-version corruption, backend limits, and
-  database failure. Its public display is generic; transport adapters must still
-  map owner errors rather than returning storage details directly.
-- `SchemaLeaseError` separates request validation, missing/retired/conflicting
-  schema state, malformed durable jobs, lost ownership, and database failure.
-- `SecondaryIndexError` separates plan/request validation, schema conflicts,
-  malformed jobs, lease loss, ownership conflicts, missing/not-ready indexes,
-  unsupported backends, and storage failures.
-- `PartitionAdmissionError` separates invalid policy, invalid evidence, metric
-  overflow, and unsupported hash modulus. Typed admission reasons explain every
-  rejected evidence gate without exposing storage internals.
-- Later milestones add source catalog, retry, cancellation, rebuild, transport, and
-  consumer composition errors.
+- `SchemaRegistryError` defines atomic registration and graph failures.
+- `IndexSchemaSourceError` defines invalid owner identity, duplicate exact ownership, owner drift
+  across schema versions, empty materialization, invalid schema, and registry failures.
+- `IndexQueryRuntimeCompositionError` currently rejects duplicate shared runtime materialization.
+- `RecordValidationError` and `QueryValidationError` define registry-backed data/query failures.
+- `CursorCodecError` and `CursorValidationError` separate malformed cursors from scope, schema,
+  fingerprint, query-shape, arity, and value-type mismatches.
+- `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError` separate
+  validation/planning from unsupported or corrupted compiler contracts.
+- `PostgresQueryDecodeError` rejects plan/column/count mismatch, malformed tagged values, nested
+  arity drift, nil/duplicate identities, unexpected nulls, and oversized batches.
+- `IndexQueryExecutionError` separates unsupported backend, missing/inactive/drifted persisted
+  schemas, build/decode failures, missing counts, invalid driver columns, contract preparation,
+  and storage operations while keeping top-level display bounded.
+- Storage, lease, secondary-index, and partition errors retain their typed ownership and evidence
+  boundaries; transport adapters must not expose raw database details.
+
+## Common AI Mistakes
+
+- Adding Product, Content, Flex, Pricing, Inventory, or other source fields to engine enums.
+- Reading source-module tables from Index or writing Index tables from source modules.
+- Treating in-memory registry composition as tenant-scoped persisted schema readiness.
+- Constructing an ad hoc `SchemaRegistry` or `SharedIndexSchemaRegistry` in server/consumer code.
+- Calling `PostgresIndexQueryPort::new` outside the Index-owned runtime materializer.
+- Treating `SharedIndexQueryRuntime` presence as authorization or proof that a tenant query works.
+- Publishing a consumer query without owner/transport authorization and bounded error mapping.
+- Executing compiler SQL outside `PostgresIndexQueryPort` or splitting page/count snapshots.
+- Accepting cursors without verifying tenant, schema, fingerprint, locale, filters, order shape,
+  value types, and entity tie-breaker identity.
+- Compiling many filters as outer joins or flattening many projection into independent arrays.
+- Sorting through a `many` relation without an explicit aggregate policy.
+- Restoring deleted v1/source-specific code as a compatibility layer.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -57,23 +57,25 @@ a rewrite goal.
 - M4 deterministic query planning and controlled SQL compilation: complete
 - M4 root/one and many-link query result semantics: complete
 - M4 PostgreSQL query port and row adapter: source complete
+- M4 source-owned registry and server query-runtime composition: source complete
 - Real retained PostgreSQL packet execution: open
-- Query-port server/consumer composition and live equivalence evidence: open
+- Query-port authorization/consumer cutover and live equivalence evidence: open
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
-configuration, scheduler, errors, and server composition have been deleted. M3
-registers the canonical production schema, publishes an Index-owned transactional
-mutation adapter, owns durable schema-application leases, manages deterministic
-schema-derived secondary indexes, and rejects partition rollout until measured
-shadow evidence passes an explicit policy. Owner-operated tooling captures and
-validates the nine-file retained bundle, renders a read-only review, emits an
+configuration, scheduler, and errors from the rejected source-specific design remain
+deleted. M3 registers the canonical production schema, publishes an Index-owned
+transactional mutation adapter, owns durable schema-application leases, manages
+deterministic schema-derived secondary indexes, and rejects partition rollout until
+measured shadow evidence passes an explicit policy. Owner-operated tooling captures
+and validates the nine-file retained bundle, renders a read-only review, emits an
 admitted-only archive manifest outside the bundle, and verifies the saved manifest
 against an exact recursive filesystem snapshot.
 
 M4 now provides deterministic typed planning, controlled PostgreSQL compilation,
 correlated many-link filtering, nested many-link projection aggregation, strict
-result decoding, lookahead pagination, exact count, scoped cursors, and an
-Index-owned PostgreSQL execution port. Server/storefront/admin/search composition,
+result decoding, lookahead pagination, exact count, scoped cursors, an Index-owned
+PostgreSQL execution port, a source-owned immutable schema catalog, and a server-owned
+neutral query runtime. Storefront/admin/search authorization and consumer cutover,
 many-link aggregate ordering policy, live PostgreSQL/reference equivalence, and
 production partition cutover remain open.
 
@@ -151,6 +153,15 @@ compiler-declared UUID/JSONB/bigint aliases, and delegates semantic validation a
 cursor construction to `decode_postgres_query_page`. Authentication and transport
 policy remain caller responsibilities.
 
+`IndexSchemaSourceCatalog` collects owner-published generic contracts during module
+registration and fixes one owner for each complete schema identity across versions.
+`rustok-distribution` materializes all entries through one atomic batch and publishes
+`SharedIndexSchemaRegistry` only for a non-empty catalog. The server then calls the
+Index-owned `materialize_postgres_index_query_runtime`, which binds that exact immutable
+registry to the host database and publishes `SharedIndexQueryRuntime` through
+`ModuleRuntimeExtensions`. Composition performs no SQL and does not claim tenant schema
+readiness; execution still fails closed through the query-port preflight.
+
 ## Current entry points
 
 - `IndexModule`
@@ -165,9 +176,12 @@ policy remain caller responsibilities.
 - `PartitionAdmissionPolicy`, `PartitionEvidence`, `PartitionAdmissionOutcome`,
   `PartitionShadowPlan`, and `evaluate_partition_admission`
 - `SchemaRegistry`, `IndexSchema`, `IndexRecord`, and `IndexMutation`
+- `IndexSchemaSourceCatalog`, `SharedIndexSchemaRegistry`, and
+  `register_index_schema_source`
 - `IndexQuery`, `IndexQueryScope`, `FilterExpr`, and typed `FieldPath`
 - `ExecutableQueryPlan`, `CompiledPostgresQuery`, and `CompiledPostgresPageQuery`
-- `IndexQueryPort`, `PostgresIndexQueryPort`, `IndexQueryExecutionError`, and
+- `IndexQueryPort`, `PostgresIndexQueryPort`, `SharedIndexQueryRuntime`,
+  `materialize_postgres_index_query_runtime`, `IndexQueryExecutionError`, and
   `IndexQueryPage`
 - `CursorCodec`, `IndexCursor`, and query-scope cursor validation
 
@@ -203,7 +217,10 @@ policy remain caller responsibilities.
   decoded column contracts, exact count, lookahead, and scoped cursor construction;
 - PostgreSQL-only query execution with exact persisted schema preflight, one
   read-only repeatable-read page/count snapshot, exhaustive bind conversion, and
-  compiler-metadata-driven row mapping.
+  compiler-metadata-driven row mapping;
+- deterministic source ownership, atomic cross-source registry materialization,
+  no false empty runtime, one Index-owned PostgreSQL runtime constructor, and neutral
+  capability transfer into `HostRuntimeContext`.
 
 ## M2 benchmark
 
@@ -222,6 +239,8 @@ DDL remains benchmark-only and must not be copied into production migrations.
 
 - [Module documentation](./docs/README.md)
 - [Live implementation plan](./docs/implementation-plan.md)
+- [M4 source-owned schema registry](./docs/m4-source-schema-registry.md)
+- [M4 query runtime composition](./docs/m4-query-runtime-composition.md)
 - [M4 PostgreSQL query port contract](./docs/m4-postgres-query-port.md)
 - [M4 many-link projection contract](./docs/m4-many-link-projection.md)
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -13,11 +13,12 @@ detection. The repository owner still needs to execute and admit one fresh real
 PostgreSQL partition packet. That owner gate blocks production partition lifecycle
 design but does not block M4 query source work.
 
-The previous server-composition blocker is now narrowed. Source modules can publish
-generic schema contracts into an Index-owned catalog, and the selected distribution
-materializes one non-empty immutable registry after all module registrations. Social
-Graph is the first source publication. The server still does not construct an
-`IndexQueryPort`, authorize callers, or cut any consumer over.
+The previous server-composition blocker is now removed at the capability level. Source
+modules publish generic schema contracts into an Index-owned catalog, the selected
+distribution materializes one non-empty immutable registry after all module registrations,
+and the server binds that registry to its database through the Index-owned PostgreSQL
+runtime materializer. Social Graph is the first source publication. Authorization,
+transport endpoints, tenant schema readiness, and consumer cutover remain separate gates.
 
 ## Actualized status
 
@@ -35,6 +36,7 @@ Graph is the first source publication. The server still does not construct an
 - M4 retained PostgreSQL/reference capture source: `source_complete_owner_execution_pending`.
 - M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
 - M4 source-owned immutable schema registry: `source_complete_execution_pending`.
+- M4 server-owned shared query runtime composition: `source_complete_execution_pending`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -135,21 +137,33 @@ the bundle. The receipt records `production_lifecycle_authorized: false`.
 Both tools are source complete but have not been run. A capture exit alone does not admit
 the bundle; an admission receipt alone does not authorize deployment or partition work.
 
-## Source-owned schema registry
+## Source-owned schema registry and runtime
 
 `IndexModule` seeds `IndexSchemaSourceCatalog` in `ModuleRuntimeExtensions`. Source
 modules publish exact generic contracts with `register_index_schema_source`; duplicate
-ownership for one `SchemaRef` fails even when fingerprints match.
+ownership for one `SchemaRef` and owner drift across versions of one schema identity fail
+closed.
 
 After all modules and selected bridges register, `rustok-distribution` materializes the
 complete catalog through one `SchemaRegistry::register_batch`. This permits cross-source
 links, preserves deterministic `BTreeMap` order, and publishes one
 `SharedIndexSchemaRegistry` wrapping an immutable `Arc<SchemaRegistry>`. Missing or empty
-catalogs do not publish a false query runtime.
+catalogs do not publish a false registry or query runtime.
 
 With its `index` feature enabled, `SocialGraphModule` is the first source owner. It
 publishes the existing relation schema under owner slug `social_graph`; distribution and
 server code do not import the schema builder or Social Graph DTOs.
+
+`SharedIndexQueryRuntime` is a neutral cloneable `IndexQueryPort` capability. The
+Index-owned `materialize_postgres_index_query_runtime` is the only production constructor:
+it combines the final shared registry with the host database, rejects duplicate runtime
+publication, performs no SQL, and inserts the capability into module extensions. The
+server facade invokes it after all existing host-provider composition, and those
+extensions transfer unchanged into `HostRuntimeContext`.
+
+Runtime presence does not establish persisted tenant schema readiness. Every execution
+still performs the exact active fingerprint and semantic JSON preflight inside
+`PostgresIndexQueryPort`.
 
 ## Remaining bounded M4 work
 
@@ -158,9 +172,9 @@ admits the retained bundle, and preserves both bundle and receipt. Additional bo
 remain:
 
 - aggregate ordering semantics for paths traversing `many`;
-- construct an Index-owned query runtime from `SharedIndexSchemaRegistry` and host DB;
-- publish schemas from additional source owners as their consumers are selected;
-- server/storefront/admin/search authorization and consumer cutover.
+- publish schemas from additional source owners as consumers are selected;
+- server/storefront/admin/search authorization and first consumer cutover;
+- transport-specific error mapping that preserves bounded query-port failures.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.
@@ -174,12 +188,14 @@ Suggested commands:
 ```bash
 cargo test -p rustok-index planner_tests -- --nocapture
 cargo test -p rustok-index source_schema_registry -- --nocapture
+cargo test -p rustok-index query_runtime -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo test -p rustok-index postgres_many_projection_tests -- --nocapture
 cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index query_snapshot_tests -- --nocapture
 cargo test -p rustok-social-graph --features index module_publishes_its_index_schema_through_runtime_extensions -- --nocapture
 cargo test -p rustok-distribution source_schema_catalog_materializes_after_all_modules_register -- --nocapture
+cargo test -p rustok-server host_materializes_index_query_runtime_after_source_registry -- --nocapture
 RUSTOK_INDEX_TEST_DATABASE_URL=postgres://... \
   cargo test -p rustok-index postgres_query_port_matches_reference_fixture -- --nocapture
 INDEX_QUERY_EQUIVALENCE_ALLOW_CAPTURE=1 \
@@ -196,6 +212,7 @@ INDEX_QUERY_EQUIVALENCE_ADMISSION_OUTPUT=<existing-parent>/equivalence-admission
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-social-graph --features index --all-targets
 cargo check -p rustok-distribution --all-targets
+cargo check -p rustok-server --all-targets
 cargo check -p rustok-benchmarks --bin index-query-equivalence-capture
 cargo check -p rustok-benchmarks --bin index-query-equivalence-admission
 node scripts/verify/verify-index-query-contract.mjs
@@ -208,5 +225,6 @@ node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs
 node scripts/verify/verify-index-query-equivalence-admission.mjs
 node scripts/verify/verify-index-source-schema-registry.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-runtime-composition.md
+++ b/crates/rustok-index/docs/m4-query-runtime-composition.md
@@ -1,0 +1,80 @@
+# M4 Index query runtime composition
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice composes the canonical Index query capability after source-owned schemas have
+been collected and materialized. The runtime is host-owned, transport neutral to consumers,
+and backed by `PostgresIndexQueryPort` without exposing its database connection or mutable
+registry internals.
+
+## Runtime contract
+
+`SharedIndexQueryRuntime` is a cloneable wrapper around one `Arc<dyn IndexQueryPort>`.
+Its production constructor is crate-owned. Consumers can clone the neutral capability or
+invoke the `IndexQueryPort` contract, but cannot substitute arbitrary SQL, result metadata,
+or an ad hoc registry while claiming the canonical runtime.
+
+`materialize_postgres_index_query_runtime(extensions, db)` is the single production
+materializer. It:
+
+- refuses a second `SharedIndexQueryRuntime` in the same extension set;
+- returns `None` when no `SharedIndexSchemaRegistry` exists;
+- reuses the exact immutable `Arc<SchemaRegistry>` produced from source publications;
+- constructs `PostgresIndexQueryPort` with the host-owned `DatabaseConnection`;
+- inserts the resulting neutral runtime into `ModuleRuntimeExtensions`;
+- performs no SQL, migration, persisted-schema read, or tenant readiness check.
+
+Backend support and exact tenant-scoped persisted schema readiness remain execution-time
+responsibilities of `PostgresIndexQueryPort`. Runtime presence therefore means the adapter is
+composed, not that a specific tenant query will succeed.
+
+## Server composition
+
+The public server `module_event_dispatcher` facade delegates all existing provider setup to
+the retained base implementation. It then invokes the Index-owned materializer as the final
+host-provider step. This ordering guarantees that:
+
+1. every compiled module has published its schema contribution;
+2. `rustok-distribution` has atomically materialized the complete source registry;
+3. existing server-owned providers remain unchanged;
+4. the query runtime is built from the final registry and the host database;
+5. the resulting extension set transfers unchanged into `HostRuntimeContext`.
+
+The server does not call `PostgresIndexQueryPort::new` directly and does not import any
+source schema builder or owner DTO.
+
+## Boundary
+
+This slice does not:
+
+- authorize callers or tenant scopes;
+- add GraphQL, storefront, admin, search, or native-server query endpoints;
+- cut any consumer over to Index;
+- publish Product, Content, Flex, or other source schemas;
+- persist tenant schema readiness;
+- execute a query during startup;
+- add ordering through a `many` relation;
+- execute PostgreSQL/reference capture or admission;
+- authorize production partition lifecycle work.
+
+The next consumer slice must resolve `SharedIndexQueryRuntime`, apply owner/transport
+authorization before constructing a typed `IndexQuery`, and preserve all query-port errors
+without exposing database details.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-index query_runtime -- --nocapture
+cargo test -p rustok-server host_materializes_index_query_runtime_after_source_registry -- --nocapture
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-server --all-targets
+node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo xtask module validate index
+```

--- a/crates/rustok-index/docs/m4-source-schema-registry.md
+++ b/crates/rustok-index/docs/m4-source-schema-registry.md
@@ -53,30 +53,34 @@ cannot bypass catalog validation with an ad hoc registry.
 
 ## First source publication
 
-With the Social Graph `index` feature enabled, `SocialGraphModule` now declares an
-explicit dependency on core module `index` and publishes
+With the Social Graph `index` feature enabled, `SocialGraphModule` declares an explicit
+dependency on core module `index` and publishes
 `social_graph_relation_index_schema()` under owner slug `social_graph`.
 
 The projector continues using the same owner-defined schema and existing Index-owned
-persistence APIs. This slice does not move source authority into Index and does not make
-the distribution import Social Graph DTOs or construct its schema directly.
+persistence APIs. This boundary does not move source authority into Index and does not make
+the distribution or server import Social Graph DTOs or construct its schema directly.
 
-## Boundary
+## Runtime handoff
 
-This slice does not:
+The follow-up query-runtime slice is now source complete. The server invokes
+`materialize_postgres_index_query_runtime` only after distribution has published the final
+`SharedIndexSchemaRegistry`. That Index-owned materializer binds the immutable registry to
+the host database and publishes `SharedIndexQueryRuntime` without executing SQL or claiming
+tenant readiness. See `m4-query-runtime-composition.md`.
 
-- construct `PostgresIndexQueryPort`;
-- connect the registry to server/storefront/admin/search consumers;
+## Remaining boundary
+
+This registry boundary still does not:
+
+- connect the runtime to storefront/admin/search or other query consumers;
+- authorize callers or construct transport-facing queries;
 - persist tenant schema readiness or replace `PostgresSchemaRegistrationStore`;
 - change mutation delivery, replay, or Social Graph source storage;
 - add schemas for Product, Content, Flex, or other owners;
 - add ordering through a `many` relation;
 - execute PostgreSQL/reference capture or admission;
 - authorize production partition lifecycle work.
-
-The next composition slice may construct an Index-owned query runtime from
-`SharedIndexSchemaRegistry` and the host database without importing any source-domain
-schema builder. Consumer authorization and cutover remain separate changes.
 
 ## Owner validation
 
@@ -93,6 +97,7 @@ cargo check -p rustok-index --all-targets
 cargo check -p rustok-social-graph --features index --all-targets
 cargo check -p rustok-distribution --all-targets
 node scripts/verify/verify-index-source-schema-registry.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -4,6 +4,7 @@ mod postgres_compiler;
 mod postgres_query_result;
 mod postgres_query_sql;
 mod query_port;
+mod query_runtime;
 mod registry;
 mod source_schema_registry;
 mod validation;
@@ -40,6 +41,7 @@ pub use postgres_query_result::{
 pub use query_port::{
     IndexQueryExecutionError, IndexQueryPort, PersistedSchemaReadinessFailure,
 };
+pub use query_runtime::SharedIndexQueryRuntime;
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
 };

--- a/crates/rustok-index/src/application/query_runtime.rs
+++ b/crates/rustok-index/src/application/query_runtime.rs
@@ -1,0 +1,45 @@
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+
+use crate::domain::IndexQuery;
+
+use super::{IndexQueryExecutionError, IndexQueryPage, IndexQueryPort};
+
+/// Cloneable transport-neutral Index query capability published by executable hosts.
+///
+/// Construction is crate-owned so production hosts cannot wrap an arbitrary adapter while
+/// claiming the canonical Index runtime. Consumers depend only on [`IndexQueryPort`] and do
+/// not receive the PostgreSQL connection or mutable schema-registry internals.
+#[derive(Clone)]
+pub struct SharedIndexQueryRuntime {
+    port: Arc<dyn IndexQueryPort>,
+}
+
+impl SharedIndexQueryRuntime {
+    pub(crate) fn new(port: Arc<dyn IndexQueryPort>) -> Self {
+        Self { port }
+    }
+
+    pub fn shared_port(&self) -> Arc<dyn IndexQueryPort> {
+        self.port.clone()
+    }
+}
+
+impl fmt::Debug for SharedIndexQueryRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedIndexQueryRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl IndexQueryPort for SharedIndexQueryRuntime {
+    async fn execute_query(
+        &self,
+        query: IndexQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        self.port.execute_query(query).await
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,6 +1,7 @@
 mod mutation_store;
 mod partition_admission;
 mod query_port;
+mod query_runtime;
 mod schema_lease;
 mod schema_registration;
 mod secondary_index;
@@ -28,6 +29,9 @@ pub use partition_admission::{
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
 };
 pub use query_port::PostgresIndexQueryPort;
+pub use query_runtime::{
+    IndexQueryRuntimeCompositionError, materialize_postgres_index_query_runtime,
+};
 pub use schema_lease::{
     PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,
     SchemaLeaseAcquireOutcome, SchemaLeaseError,

--- a/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use crate::application::{SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
+
+use super::PostgresIndexQueryPort;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexQueryRuntimeCompositionError {
+    #[error("shared Index query runtime is already materialized")]
+    AlreadyMaterialized,
+}
+
+/// Materializes the canonical PostgreSQL-backed query runtime from the complete source registry.
+///
+/// Absence of a source registry is represented as `Ok(None)` and never produces an empty or
+/// partially useful runtime. The function performs no database I/O and makes no tenant schema
+/// readiness claim; those checks remain inside [`PostgresIndexQueryPort::execute_query`].
+pub fn materialize_postgres_index_query_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<Option<SharedIndexQueryRuntime>, IndexQueryRuntimeCompositionError> {
+    if extensions.contains::<SharedIndexQueryRuntime>() {
+        return Err(IndexQueryRuntimeCompositionError::AlreadyMaterialized);
+    }
+
+    let Some(registry) = extensions.get::<SharedIndexSchemaRegistry>().cloned() else {
+        return Ok(None);
+    };
+
+    let runtime = SharedIndexQueryRuntime::new(Arc::new(PostgresIndexQueryPort::new(
+        db,
+        registry.shared(),
+    )));
+    extensions.insert(runtime.clone());
+    Ok(Some(runtime))
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_core::ModuleRuntimeExtensions;
+    use sea_orm::Database;
+
+    use crate::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+        LocaleMode, ModuleName, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
+        materialize_index_schema_registry, register_index_schema_source,
+    };
+
+    use super::{
+        IndexQueryRuntimeCompositionError, materialize_postgres_index_query_runtime,
+    };
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("runtime-owner").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    async fn connection() -> sea_orm::DatabaseConnection {
+        Database::connect("sqlite::memory:")
+            .await
+            .expect("test connection should initialize")
+    }
+
+    #[tokio::test]
+    async fn missing_source_registry_does_not_publish_false_runtime() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let runtime = materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect("missing registry should be accepted");
+
+        assert!(runtime.is_none());
+        assert!(!extensions.contains::<SharedIndexQueryRuntime>());
+    }
+
+    #[tokio::test]
+    async fn complete_source_registry_materializes_one_shared_runtime() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        register_index_schema_source(&mut extensions, "runtime_owner", schema())
+            .expect("source schema should register");
+        let registry = materialize_index_schema_registry(&extensions)
+            .expect("source registry should validate")
+            .expect("non-empty source registry should materialize");
+        extensions.insert(registry);
+
+        let runtime = materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect("query runtime should materialize")
+            .expect("registry should produce a runtime");
+
+        assert!(extensions.contains::<SharedIndexQueryRuntime>());
+        assert!(Arc::ptr_eq(
+            &runtime.shared_port(),
+            &extensions
+                .get::<SharedIndexQueryRuntime>()
+                .expect("runtime should be published")
+                .shared_port(),
+        ));
+    }
+
+    #[tokio::test]
+    async fn duplicate_query_runtime_materialization_fails_closed() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        register_index_schema_source(&mut extensions, "runtime_owner", schema()).unwrap();
+        let registry = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("registry");
+        extensions.insert(registry);
+        materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect("first materialization")
+            .expect("runtime");
+
+        let error = materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect_err("duplicate materialization must fail");
+        assert_eq!(
+            error,
+            IndexQueryRuntimeCompositionError::AlreadyMaterialized
+        );
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
@@ -18,7 +18,7 @@ pub enum IndexQueryRuntimeCompositionError {
 ///
 /// Absence of a source registry is represented as `Ok(None)` and never produces an empty or
 /// partially useful runtime. The function performs no database I/O and makes no tenant schema
-/// readiness claim; those checks remain inside [`PostgresIndexQueryPort::execute_query`].
+/// readiness claim; those checks remain inside the query port when a request executes.
 pub fn materialize_postgres_index_query_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -106,7 +106,7 @@ mod tests {
             .expect("registry should produce a runtime");
 
         assert!(extensions.contains::<SharedIndexQueryRuntime>());
-        assert!(Arc::ptr_eq(
+        assert!(std::sync::Arc::ptr_eq(
             &runtime.shared_port(),
             &extensions
                 .get::<SharedIndexQueryRuntime>()

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -22,15 +22,16 @@ pub mod migrations;
 pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
-    evaluate_partition_admission, MutationApplyOutcome, MutationDelivery, MutationStorageError,
-    PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
-    PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
-    PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
-    PartitionShadowPlan, PartitionStrategy, PersistedSchemaRegistrationOutcome,
-    PostgresIndexQueryPort, PostgresMutationStore, PostgresSchemaLeaseStore,
-    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
-    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
-    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    evaluate_partition_admission, materialize_postgres_index_query_runtime,
+    IndexQueryRuntimeCompositionError, MutationApplyOutcome, MutationDelivery,
+    MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
+    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
+    PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
+    PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
+    PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort, PostgresMutationStore,
+    PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
+    SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
+    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -15,6 +15,7 @@ const scripts = [
   'verify-index-query-equivalence-capture.mjs',
   'verify-index-query-equivalence-admission.mjs',
   'verify-index-source-schema-registry.mjs',
+  'verify-index-query-runtime-composition.mjs',
 ];
 
 for (const script of scripts) {

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -110,8 +110,24 @@ for (const relative of [
   }
 }
 
+requireMarkers('xtask/src/server_event_runtime_contracts.rs', [
+  'direct_dispatcher_export',
+  'dispatcher_facade_export',
+  'reviewed base-module facade',
+]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-query-runtime-composition.mjs'",
+]);
+requireMarkers('crates/rustok-index/CRATE_API.md', [
+  '`SharedIndexQueryRuntime`',
+  '`materialize_postgres_index_query_runtime`',
+  'Runtime presence does not claim',
+  'Calling `PostgresIndexQueryPort::new` outside the Index-owned runtime materializer',
+]);
+requireMarkers('crates/rustok-index/README.md', [
+  'M4 source-owned registry and server query-runtime composition: source complete',
+  '`SharedIndexQueryRuntime`',
+  'Composition performs no SQL',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-query-runtime-composition.md', [
   'Status: `source_complete_execution_pending`',

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-query-runtime-composition] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const neutralPath = 'crates/rustok-index/src/application/query_runtime.rs';
+const neutral = requireMarkers(neutralPath, [
+  'pub struct SharedIndexQueryRuntime',
+  'port: Arc<dyn IndexQueryPort>',
+  'pub(crate) fn new(',
+  'pub fn shared_port(&self) -> Arc<dyn IndexQueryPort>',
+  'impl IndexQueryPort for SharedIndexQueryRuntime',
+  'self.port.execute_query(query).await',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresIndexQueryPort',
+  'ModuleRuntimeExtensions',
+  'SchemaRegistry',
+  'index_schemas',
+]) {
+  if (neutral.includes(forbidden)) {
+    fail(`${neutralPath} contains infrastructure/composition marker ${forbidden}`);
+  }
+}
+
+const materializerPath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
+const materializer = requireMarkers(materializerPath, [
+  'pub enum IndexQueryRuntimeCompositionError',
+  'AlreadyMaterialized',
+  'pub fn materialize_postgres_index_query_runtime(',
+  'extensions.contains::<SharedIndexQueryRuntime>()',
+  'extensions.get::<SharedIndexSchemaRegistry>().cloned()',
+  'PostgresIndexQueryPort::new(',
+  'registry.shared()',
+  'extensions.insert(runtime.clone())',
+  'return Ok(None);',
+  'missing_source_registry_does_not_publish_false_runtime',
+  'complete_source_registry_materializes_one_shared_runtime',
+  'duplicate_query_runtime_materialization_fails_closed',
+]);
+for (const forbidden of [
+  '.query_one(',
+  '.query_all(',
+  '.execute(',
+  '.begin()',
+  'index_schemas',
+  'social_graph_relation_index_schema',
+]) {
+  if (materializer.includes(forbidden)) {
+    fail(`${materializerPath} performs forbidden startup I/O or imports owner contracts: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod query_runtime;',
+  'pub use query_runtime::SharedIndexQueryRuntime;',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod query_runtime;',
+  'IndexQueryRuntimeCompositionError',
+  'materialize_postgres_index_query_runtime',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'materialize_postgres_index_query_runtime',
+  'IndexQueryRuntimeCompositionError',
+]);
+
+const serverPath = 'apps/server/src/services/mod.rs';
+const server = requireMarkers(serverPath, [
+  '#[path = "module_event_dispatcher.rs"]',
+  'mod module_event_dispatcher_base;',
+  'pub mod module_event_dispatcher {',
+  'build_shared_runtime_extensions_with_host_providers(',
+  'module_event_dispatcher_base::build_shared_runtime_extensions_with_host_providers(',
+  'materialize_postgres_index_query_runtime(&mut extensions, db)',
+  'Index query runtime composition failed',
+  'host_materializes_index_query_runtime_after_source_registry',
+  'extensions.contains::<SharedIndexSchemaRegistry>()',
+  'extensions.contains::<SharedIndexQueryRuntime>()',
+  'host.shared_get::<SharedIndexQueryRuntime>().is_some()',
+]);
+if (server.includes('PostgresIndexQueryPort::new')) {
+  fail(`${serverPath} must call the Index-owned materializer instead of constructing the port`);
+}
+
+for (const relative of [
+  'crates/rustok-distribution/src/lib.rs',
+  'crates/rustok-social-graph/src/lib.rs',
+  'crates/rustok-social-graph/src/index_consumer.rs',
+]) {
+  const source = read(relative);
+  if (source.includes('PostgresIndexQueryPort::new')) {
+    fail(`${relative} must not construct the Index query port directly`);
+  }
+}
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-query-runtime-composition.mjs'",
+]);
+requireMarkers('crates/rustok-index/docs/m4-query-runtime-composition.md', [
+  'Status: `source_complete_execution_pending`',
+  '`SharedIndexQueryRuntime`',
+  '`materialize_postgres_index_query_runtime(extensions, db)`',
+  'performs no SQL',
+  'does not:',
+  'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
+  'M4 server-owned shared query runtime composition: `source_complete_execution_pending`',
+  '`SharedIndexQueryRuntime` is a neutral cloneable `IndexQueryPort` capability',
+  'Runtime presence does not establish persisted tenant schema readiness',
+]);
+
+console.log('[verify-index-query-runtime-composition] OK');

--- a/scripts/verify/verify-index-source-schema-registry.mjs
+++ b/scripts/verify/verify-index-source-schema-registry.mjs
@@ -99,18 +99,20 @@ for (const forbidden of [
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",
+  "'verify-index-query-runtime-composition.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-source-schema-registry.md', [
   'Status: `source_complete_execution_pending`',
   '`social_graph`',
   'entire schema identity across versions',
-  '- construct `PostgresIndexQueryPort`;',
+  '`materialize_postgres_index_query_runtime`',
+  'does not:',
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
   'M4 source-owned immutable schema registry: `source_complete_execution_pending`',
   '`SharedIndexSchemaRegistry`',
-  'construct an Index-owned query runtime',
+  'M4 server-owned shared query runtime composition: `source_complete_execution_pending`',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',

--- a/xtask/src/server_event_runtime_contracts.rs
+++ b/xtask/src/server_event_runtime_contracts.rs
@@ -41,9 +41,14 @@ pub(crate) fn validate_server_event_runtime_contract(manifest_path: &Path) -> Re
             legacy_search_dispatcher_path.display()
         );
     }
-    if !services_mod.contains("pub mod module_event_dispatcher;") {
+    let direct_dispatcher_export = services_mod.contains("pub mod module_event_dispatcher;");
+    let dispatcher_facade_export = services_mod.contains("#[path = \"module_event_dispatcher.rs\"]")
+        && services_mod.contains("mod module_event_dispatcher_base;")
+        && services_mod.contains("pub mod module_event_dispatcher {")
+        && services_mod.contains("pub use super::module_event_dispatcher_base::{");
+    if !direct_dispatcher_export && !dispatcher_facade_export {
         anyhow::bail!(
-            "Server event runtime contract drift: {} must export module_event_dispatcher",
+            "Server event runtime contract drift: {} must export module_event_dispatcher directly or through the reviewed base-module facade",
             services_mod_path.display()
         );
     }


### PR DESCRIPTION
## Summary

- add transport-neutral `SharedIndexQueryRuntime` around one `Arc<dyn IndexQueryPort>`
- keep the canonical runtime constructor crate-owned so hosts cannot wrap arbitrary adapters
- add `materialize_postgres_index_query_runtime` as the single PostgreSQL production materializer
- reuse the exact immutable `SharedIndexSchemaRegistry` produced from source-owned catalog registration
- return no runtime when the source registry is absent rather than publishing a false capability
- reject duplicate shared-runtime materialization
- perform no SQL or tenant-readiness checks during composition
- preserve all existing server provider setup through a reviewed facade over `module_event_dispatcher.rs`
- compose the Index runtime as the final host-provider step and transfer it through `ModuleRuntimeExtensions` / `HostRuntimeContext`
- keep `PostgresIndexQueryPort::new` out of server, distribution, and source modules
- update the xtask event-runtime contract to accept the explicit facade while preserving the original dispatcher file and legacy-dispatcher bans
- add source-level tests, documentation, public API actualization, and a unified static guard

## Recheck findings

`PostgresIndexQueryPort` already owned execution, persisted-schema preflight, page/count snapshotting, row adaptation, and strict decoding. PR #2477 supplied the missing immutable source-owned `SchemaRegistry`. The remaining safe composition step was therefore only to bind that registry to the host database behind a neutral capability; no consumer API or authorization policy is required in this PR.

The branch started from `6a0312b6dbdabeff1c902aa005829e734805931b`. `main` advanced during implementation, but none of the changed paths overlap this PR. The adjacent distribution change was rechecked and still materializes source schemas after all modules and runtime bridges.

## Boundary

This PR does not authorize callers, create GraphQL/storefront/admin/search endpoints, cut any consumer over, publish schemas for additional owners, persist tenant schema readiness, execute queries during startup, add many-link aggregate ordering, execute PostgreSQL/reference capture or admission, or authorize production partition lifecycle work.

Runtime presence means the canonical adapter is composed. Every real query still performs exact tenant-scoped persisted-schema readiness inside `PostgresIndexQueryPort`.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, capture/admission, Node verifiers, workflow checks, or CI were run.

Suggested commands:

```bash
cargo test -p rustok-index query_runtime -- --nocapture
cargo test -p rustok-server host_materializes_index_query_runtime_after_source_registry -- --nocapture
cargo check -p rustok-index --all-targets
cargo check -p rustok-server --all-targets
node scripts/verify/verify-index-query-runtime-composition.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo xtask module validate index
```