### PR TITLE
fix(commerce): sanitize storefront transport failures

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
@@ -12,6 +12,7 @@
     "native_locale_logging": true,
     "shared_static_public_envelopes": true,
     "shared_transport_path_logging": true,
+    "shared_raw_cause_logging": false,
     "cart_validation_compatibility_preserved": true,
     "foreign_transport_error_text_public": false,
     "checkout_dto_changed": false,

--- a/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "storefront_transport_error_safety_source_unvalidated",
+  "scope": "mounted commerce storefront aggregate cart and payment transport error mapping",
+  "source_contract": {
+    "native_static_public_envelopes": true,
+    "native_context_logging": true,
+    "native_correlation_logging": true,
+    "native_tenant_logging": true,
+    "native_channel_logging": true,
+    "native_locale_logging": true,
+    "shared_static_public_envelopes": true,
+    "shared_transport_path_logging": true,
+    "cart_validation_compatibility_preserved": true,
+    "foreign_transport_error_text_public": false,
+    "checkout_dto_changed": false,
+    "transport_selection_changed": false
+  },
+  "stable_public_messages": {
+    "invalid_cart_selection": "Invalid cart selection",
+    "cart_unavailable": "Storefront cart data is temporarily unavailable",
+    "payment_collection_unavailable": "Storefront payment collection is temporarily unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs",
+    "node scripts/verify/verify-commerce-storefront-transport-handoff.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-commerce-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json
@@ -13,6 +13,7 @@
     "shared_static_public_envelopes": true,
     "shared_transport_path_logging": true,
     "shared_raw_cause_logging": false,
+    "cart_error_variant_preserved": true,
     "cart_validation_compatibility_preserved": true,
     "foreign_transport_error_text_public": false,
     "checkout_dto_changed": false,

--- a/crates/rustok-commerce/docs/storefront-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-transport-error-safety.md
@@ -23,7 +23,7 @@ The SSR-native server function now maps invalid cart selection, cart transport f
 
 The shared transport mapper no longer exposes `UiTransportError::to_string()` through `ApiError::ServerFn` or `ApiError::Graphql`. It records only safe failed-path, fallback, owner, operation, and stable-code fields, never the raw transport cause, then returns a static cart or payment-collection message.
 
-The existing cart UUID validation compatibility remains explicit and static.
+The existing cart UUID validation compatibility and the prior non-validation cart `ApiError::ServerFn` variant remain unchanged. Payment failures continue to preserve their native/GraphQL variant selection.
 
 ## Preserved behavior
 
@@ -47,6 +47,7 @@ This slice does not change:
 - stable codes and static public messages;
 - removal of foreign adapter `to_string()` public mapping;
 - absence of raw causes from shared/client-side tracing;
+- preserved cart error variant behavior;
 - unchanged source-only validation flags.
 
 ## Remaining gaps

--- a/crates/rustok-commerce/docs/storefront-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-transport-error-safety.md
@@ -1,0 +1,64 @@
+# Commerce storefront transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the mounted Commerce storefront aggregate read in:
+
+- `crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs`;
+- `crates/rustok-commerce/storefront/src/transport/shared_adapter.rs`.
+
+The aggregate still delegates cart reads to `rustok-cart-storefront` and payment collection reads to `rustok-payment-storefront`. It does not reconstruct owner services, change checkout DTOs, or change native/GraphQL transport selection.
+
+## Delivered source contract
+
+The SSR-native server function now maps invalid cart selection, cart transport failure, and payment transport failure through static public messages. Internal causes are retained only in structured logs with:
+
+- owner and owner operation;
+- Commerce consumer operation and boundary;
+- correlation id and tenant id;
+- channel id, channel slug, and locale;
+- stable internal code.
+
+The shared transport mapper no longer exposes `UiTransportError::to_string()` through `ApiError::ServerFn` or `ApiError::Graphql`. It records the failed transport path and fallback state internally, then returns a static cart or payment-collection message.
+
+The existing cart UUID validation compatibility remains explicit and static.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `FetchCommerceRequest`;
+- `StorefrontCommerceData` or `StorefrontCheckoutWorkspace`;
+- cart/payment owner request DTOs;
+- cart/payment owner response mapping;
+- native versus GraphQL selection policy;
+- checkout commands or staged checkout orchestration;
+- FBA or FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-commerce-storefront-transport-error-safety.mjs` guards:
+
+- the storefront package diagnostics dependency;
+- native correlation/tenant/channel/locale diagnostics;
+- cart and payment owner identities and operations;
+- stable codes and static public messages;
+- removal of foreign adapter `to_string()` public mapping;
+- unchanged source-only validation flags.
+
+## Remaining gaps
+
+The master mapper-cleanup task remains open for other promotion consumers, compensation adapters, remaining ecommerce transports, and non-`PortError` public envelopes. Runtime, native/GraphQL parity, remote transport, and compiled evidence are also still open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-handoff.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce-storefront --all-features
+```

--- a/crates/rustok-commerce/docs/storefront-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-transport-error-safety.md
@@ -13,7 +13,7 @@ The aggregate still delegates cart reads to `rustok-cart-storefront` and payment
 
 ## Delivered source contract
 
-The SSR-native server function now maps invalid cart selection, cart transport failure, and payment transport failure through static public messages. Internal causes are retained only in structured logs with:
+The SSR-native server function now maps invalid cart selection, cart transport failure, and payment transport failure through static public messages. Internal causes are retained only in structured server logs with:
 
 - owner and owner operation;
 - Commerce consumer operation and boundary;
@@ -21,7 +21,7 @@ The SSR-native server function now maps invalid cart selection, cart transport f
 - channel id, channel slug, and locale;
 - stable internal code.
 
-The shared transport mapper no longer exposes `UiTransportError::to_string()` through `ApiError::ServerFn` or `ApiError::Graphql`. It records the failed transport path and fallback state internally, then returns a static cart or payment-collection message.
+The shared transport mapper no longer exposes `UiTransportError::to_string()` through `ApiError::ServerFn` or `ApiError::Graphql`. It records only safe failed-path, fallback, owner, operation, and stable-code fields, never the raw transport cause, then returns a static cart or payment-collection message.
 
 The existing cart UUID validation compatibility remains explicit and static.
 
@@ -46,6 +46,7 @@ This slice does not change:
 - cart and payment owner identities and operations;
 - stable codes and static public messages;
 - removal of foreign adapter `to_string()` public mapping;
+- absence of raw causes from shared/client-side tracing;
 - unchanged source-only validation flags.
 
 ## Remaining gaps

--- a/crates/rustok-commerce/storefront/Cargo.toml
+++ b/crates/rustok-commerce/storefront/Cargo.toml
@@ -33,6 +33,7 @@ rustok-order-storefront.workspace = true
 sea-orm.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs
@@ -8,6 +8,63 @@ use crate::core::FetchCommerceRequest;
 use crate::model::StorefrontCheckoutWorkspace;
 use crate::model::StorefrontCommerceData;
 
+#[cfg(feature = "ssr")]
+const STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY: &str =
+    "commerce_storefront_native_transport";
+#[cfg(feature = "ssr")]
+const STOREFRONT_COMMERCE_CONSUMER_OPERATION: &str = "fetch_storefront_commerce";
+
+#[cfg(feature = "ssr")]
+fn map_storefront_native_validation_error(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: uuid::Uuid,
+    owner_operation: &'static str,
+    error: ApiError,
+) -> ServerFnError {
+    tracing::warn!(
+        error = ?error,
+        owner = "rustok_commerce.storefront_transport",
+        owner_operation,
+        consumer_operation = STOREFRONT_COMMERCE_CONSUMER_OPERATION,
+        correlation_id = %request_context.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        code = "commerce.storefront_cart_id_invalid",
+        boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
+        "storefront commerce request validation failed"
+    );
+    ServerFnError::new("Invalid cart selection")
+}
+
+#[cfg(feature = "ssr")]
+fn map_storefront_native_owner_error<E: std::fmt::Debug>(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: uuid::Uuid,
+    owner: &'static str,
+    owner_operation: &'static str,
+    code: &'static str,
+    public_message: &'static str,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner,
+        owner_operation,
+        consumer_operation = STOREFRONT_COMMERCE_CONSUMER_OPERATION,
+        correlation_id = %request_context.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        code,
+        boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
+        "storefront commerce owner transport failed"
+    );
+    ServerFnError::new(public_message)
+}
+
 pub async fn fetch_storefront_commerce(
     request: FetchCommerceRequest,
 ) -> Result<StorefrontCommerceData, ApiError> {
@@ -29,6 +86,7 @@ async fn storefront_commerce_native(
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
             .map_err(ServerFnError::new)?;
+        let tenant_id = tenant.id;
         let normalized_locale = shared_adapter::resolve_requested_locale(
             locale,
             Some(request_context.locale.as_str()),
@@ -48,7 +106,14 @@ async fn storefront_commerce_native(
         };
 
         let Some((normalized_cart_id, _)) = shared_adapter::parse_cart_id(selected_cart_id)
-            .map_err(|err| ServerFnError::new(err.to_string()))?
+            .map_err(|error| {
+                map_storefront_native_validation_error(
+                    &request_context,
+                    tenant_id,
+                    "parse_cart_id",
+                    error,
+                )
+            })?
         else {
             return Ok(data);
         };
@@ -59,7 +124,17 @@ async fn storefront_commerce_native(
             ),
         )
         .await
-        .map_err(|err| ServerFnError::new(err.to_string()))?;
+        .map_err(|error| {
+            map_storefront_native_owner_error(
+                &request_context,
+                tenant_id,
+                "rustok_cart.storefront",
+                "fetch_cart",
+                "commerce.storefront_cart_unavailable",
+                "Storefront cart data is temporarily unavailable",
+                error,
+            )
+        })?;
         let payment_collection = if cart_data.cart.is_some() {
             rustok_payment_storefront::transport::fetch_payment_collection(
                 rustok_payment_storefront::transport::build_payment_collection_fetch_request(
@@ -67,7 +142,17 @@ async fn storefront_commerce_native(
                 ),
             )
             .await
-            .map_err(|err| ServerFnError::new(err.to_string()))?
+            .map_err(|error| {
+                map_storefront_native_owner_error(
+                    &request_context,
+                    tenant_id,
+                    "rustok_payment.storefront",
+                    "fetch_payment_collection",
+                    "commerce.storefront_payment_collection_unavailable",
+                    "Storefront payment collection is temporarily unavailable",
+                    error,
+                )
+            })?
         } else {
             None
         };

--- a/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
+++ b/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
@@ -9,6 +9,9 @@ use crate::model::{
     StorefrontCheckoutShippingOption, StorefrontCheckoutWorkspace, StorefrontCommerceData,
 };
 
+const STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY: &str =
+    "commerce_storefront_aggregate_transport";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiError {
     Graphql(String),
@@ -100,21 +103,74 @@ fn fallback_storefront_commerce(
     }
 }
 
+fn is_cart_id_validation_error(error: &rustok_ui_transport::UiTransportError) -> bool {
+    error
+        .native_error
+        .as_deref()
+        .is_some_and(|message| message.contains("cart_id must be a valid UUID"))
+        || error
+            .graphql_error
+            .as_deref()
+            .is_some_and(|message| message.contains("cart_id must be a valid UUID"))
+}
+
 fn map_cart_transport_error(
     error: rustok_cart_storefront::transport::CartTransportError,
 ) -> ApiError {
-    let message = error.to_string();
-    if message.contains("cart_id must be a valid UUID") {
-        ApiError::Validation("cart_id must be a valid UUID".to_string())
-    } else {
-        ApiError::ServerFn(message)
+    let failed_path = error.failed_path;
+    if is_cart_id_validation_error(&error) {
+        tracing::warn!(
+            error = ?error,
+            owner = "rustok_cart.storefront",
+            owner_operation = "fetch_cart",
+            failed_path = failed_path.as_str(),
+            fallback_attempted = error.fallback_attempted,
+            code = "commerce.storefront_cart_id_invalid",
+            boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
+            "storefront commerce cart transport validation failed"
+        );
+        return ApiError::Validation("cart_id must be a valid UUID".to_string());
+    }
+
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_cart.storefront",
+        owner_operation = "fetch_cart",
+        failed_path = failed_path.as_str(),
+        fallback_attempted = error.fallback_attempted,
+        code = "commerce.storefront_cart_unavailable",
+        boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
+        "storefront commerce cart transport failed"
+    );
+    match failed_path {
+        rustok_ui_transport::UiTransportPath::NativeServer => {
+            ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())
+        }
+        rustok_ui_transport::UiTransportPath::Graphql => {
+            ApiError::Graphql("Storefront cart data is temporarily unavailable".to_string())
+        }
     }
 }
 
 fn map_payment_transport_error(error: rustok_ui_transport::UiTransportError) -> ApiError {
-    match error.failed_path {
-        rustok_ui_transport::UiTransportPath::NativeServer => ApiError::ServerFn(error.to_string()),
-        rustok_ui_transport::UiTransportPath::Graphql => ApiError::Graphql(error.to_string()),
+    let failed_path = error.failed_path;
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_payment.storefront",
+        owner_operation = "fetch_payment_collection",
+        failed_path = failed_path.as_str(),
+        fallback_attempted = error.fallback_attempted,
+        code = "commerce.storefront_payment_collection_unavailable",
+        boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
+        "storefront commerce payment transport failed"
+    );
+    match failed_path {
+        rustok_ui_transport::UiTransportPath::NativeServer => ApiError::ServerFn(
+            "Storefront payment collection is temporarily unavailable".to_string(),
+        ),
+        rustok_ui_transport::UiTransportPath::Graphql => ApiError::Graphql(
+            "Storefront payment collection is temporarily unavailable".to_string(),
+        ),
     }
 }
 

--- a/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
+++ b/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
@@ -140,14 +140,7 @@ fn map_cart_transport_error(
         boundary = STOREFRONT_COMMERCE_TRANSPORT_BOUNDARY,
         "storefront commerce cart transport failed"
     );
-    match failed_path {
-        rustok_ui_transport::UiTransportPath::NativeServer => {
-            ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())
-        }
-        rustok_ui_transport::UiTransportPath::Graphql => {
-            ApiError::Graphql("Storefront cart data is temporarily unavailable".to_string())
-        }
-    }
+    ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())
 }
 
 fn map_payment_transport_error(error: rustok_ui_transport::UiTransportError) -> ApiError {

--- a/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
+++ b/crates/rustok-commerce/storefront/src/transport/shared_adapter.rs
@@ -120,7 +120,6 @@ fn map_cart_transport_error(
     let failed_path = error.failed_path;
     if is_cart_id_validation_error(&error) {
         tracing::warn!(
-            error = ?error,
             owner = "rustok_cart.storefront",
             owner_operation = "fetch_cart",
             failed_path = failed_path.as_str(),
@@ -133,7 +132,6 @@ fn map_cart_transport_error(
     }
 
     tracing::error!(
-        error = ?error,
         owner = "rustok_cart.storefront",
         owner_operation = "fetch_cart",
         failed_path = failed_path.as_str(),
@@ -155,7 +153,6 @@ fn map_cart_transport_error(
 fn map_payment_transport_error(error: rustok_ui_transport::UiTransportError) -> ApiError {
     let failed_path = error.failed_path;
     tracing::error!(
-        error = ?error,
         owner = "rustok_payment.storefront",
         owner_operation = "fetch_payment_collection",
         failed_path = failed_path.as_str(),

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -84,11 +84,12 @@ for (const [value, label] of [
 ]) requireText(shared, value, label);
 
 for (const value of [
+  'error = ?error',
   'let message = error.to_string();',
   'ApiError::ServerFn(error.to_string())',
   'ApiError::Graphql(error.to_string())',
   'ApiError::ServerFn(message)',
-]) forbidText(shared, value, 'shared raw public transport mapping');
+]) forbidText(shared, value, 'shared raw transport cause exposure');
 
 if (evidence.status !== 'storefront_transport_error_safety_source_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
@@ -97,6 +98,7 @@ for (const [key, expected] of Object.entries({
   native_static_public_envelopes: true,
   native_context_logging: true,
   shared_static_public_envelopes: true,
+  shared_raw_cause_logging: false,
   foreign_transport_error_text_public: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
@@ -125,5 +127,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ commerce storefront cart/payment transport failures retain internal diagnostics and static public envelopes; runtime evidence remains open',
+  '✔ commerce storefront cart/payment transport failures retain SSR diagnostics and static public envelopes without client-side raw causes; runtime evidence remains open',
 );

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL('../../', import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), 'utf8');
+
+const cargo = read('crates/rustok-commerce/storefront/Cargo.toml');
+const native = read(
+  'crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs',
+);
+const shared = read(
+  'crates/rustok-commerce/storefront/src/transport/shared_adapter.rs',
+);
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-commerce/contracts/evidence/storefront-transport-error-safety-source.json',
+  ),
+);
+
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+requireText(cargo, 'tracing.workspace = true', 'storefront diagnostics dependency');
+
+for (const [value, label] of [
+  ['fn map_storefront_native_validation_error(', 'native validation mapper'],
+  ['fn map_storefront_native_owner_error<E: std::fmt::Debug>(', 'native owner mapper'],
+  ['correlation_id = %request_context.correlation_id', 'native correlation log'],
+  ['tenant_id = %tenant_id', 'native tenant log'],
+  ['channel_id = ?request_context.channel_id', 'native channel id log'],
+  ['channel_slug = ?request_context.channel_slug', 'native channel slug log'],
+  ['locale = %request_context.locale', 'native locale log'],
+  ['owner_operation,', 'native owner operation log'],
+  ['consumer_operation = STOREFRONT_COMMERCE_CONSUMER_OPERATION', 'native consumer operation log'],
+  ['code = "commerce.storefront_cart_id_invalid"', 'native validation stable code'],
+  ['"commerce.storefront_cart_unavailable"', 'native cart stable code'],
+  ['"commerce.storefront_payment_collection_unavailable"', 'native payment stable code'],
+  ['ServerFnError::new("Invalid cart selection")', 'native validation public envelope'],
+  ['"Storefront cart data is temporarily unavailable"', 'native cart public envelope'],
+  ['"Storefront payment collection is temporarily unavailable"', 'native payment public envelope'],
+  ['owner = "rustok_cart.storefront"', 'native cart owner identity'],
+  ['owner = "rustok_payment.storefront"', 'native payment owner identity'],
+]) requireText(native, value, label);
+
+for (const value of [
+  '.map_err(|err| ServerFnError::new(err.to_string()))',
+  'ServerFnError::new(error.to_string())',
+  'ServerFnError::new(err.to_string())',
+]) forbidText(native, value, 'native raw public transport mapping');
+
+if (countText(native, 'ApiError::ServerFn(error.to_string())') !== 1) {
+  failures.push(
+    'native outer server-function wrapper must be the only remaining error.to_string conversion',
+  );
+}
+
+for (const [value, label] of [
+  ['fn is_cart_id_validation_error(', 'shared typed validation classifier'],
+  ['tracing::warn!(', 'shared validation diagnostics'],
+  ['tracing::error!(', 'shared owner diagnostics'],
+  ['failed_path = failed_path.as_str()', 'shared failed-path diagnostics'],
+  ['fallback_attempted = error.fallback_attempted', 'shared fallback diagnostics'],
+  ['owner = "rustok_cart.storefront"', 'shared cart owner identity'],
+  ['owner = "rustok_payment.storefront"', 'shared payment owner identity'],
+  ['code = "commerce.storefront_cart_id_invalid"', 'shared validation stable code'],
+  ['code = "commerce.storefront_cart_unavailable"', 'shared cart stable code'],
+  ['code = "commerce.storefront_payment_collection_unavailable"', 'shared payment stable code'],
+  ['ApiError::Validation("cart_id must be a valid UUID".to_string())', 'shared validation public envelope'],
+  ['ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())', 'shared native cart public envelope'],
+  ['ApiError::Graphql("Storefront cart data is temporarily unavailable".to_string())', 'shared GraphQL cart public envelope'],
+  ['"Storefront payment collection is temporarily unavailable".to_string()', 'shared payment public envelope'],
+]) requireText(shared, value, label);
+
+for (const value of [
+  'let message = error.to_string();',
+  'ApiError::ServerFn(error.to_string())',
+  'ApiError::Graphql(error.to_string())',
+  'ApiError::ServerFn(message)',
+]) forbidText(shared, value, 'shared raw public transport mapping');
+
+if (evidence.status !== 'storefront_transport_error_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  native_static_public_envelopes: true,
+  native_context_logging: true,
+  shared_static_public_envelopes: true,
+  foreign_transport_error_text_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'native_runtime_proven',
+  'graphql_runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront transport error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ commerce storefront cart/payment transport failures retain internal diagnostics and static public envelopes; runtime evidence remains open',
+);

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -45,13 +45,13 @@ for (const [value, label] of [
   ['owner_operation,', 'native owner operation log'],
   ['consumer_operation = STOREFRONT_COMMERCE_CONSUMER_OPERATION', 'native consumer operation log'],
   ['code = "commerce.storefront_cart_id_invalid"', 'native validation stable code'],
+  ['"rustok_cart.storefront",\n                "fetch_cart",', 'native cart owner callsite'],
+  ['"rustok_payment.storefront",\n                    "fetch_payment_collection",', 'native payment owner callsite'],
   ['"commerce.storefront_cart_unavailable"', 'native cart stable code'],
   ['"commerce.storefront_payment_collection_unavailable"', 'native payment stable code'],
   ['ServerFnError::new("Invalid cart selection")', 'native validation public envelope'],
   ['"Storefront cart data is temporarily unavailable"', 'native cart public envelope'],
   ['"Storefront payment collection is temporarily unavailable"', 'native payment public envelope'],
-  ['owner = "rustok_cart.storefront"', 'native cart owner identity'],
-  ['owner = "rustok_payment.storefront"', 'native payment owner identity'],
 ]) requireText(native, value, label);
 
 for (const value of [
@@ -67,7 +67,7 @@ if (countText(native, 'ApiError::ServerFn(error.to_string())') !== 1) {
 }
 
 for (const [value, label] of [
-  ['fn is_cart_id_validation_error(', 'shared typed validation classifier'],
+  ['fn is_cart_id_validation_error(', 'shared validation classifier'],
   ['tracing::warn!(', 'shared validation diagnostics'],
   ['tracing::error!(', 'shared owner diagnostics'],
   ['failed_path = failed_path.as_str()', 'shared failed-path diagnostics'],

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -78,8 +78,7 @@ for (const [value, label] of [
   ['code = "commerce.storefront_cart_unavailable"', 'shared cart stable code'],
   ['code = "commerce.storefront_payment_collection_unavailable"', 'shared payment stable code'],
   ['ApiError::Validation("cart_id must be a valid UUID".to_string())', 'shared validation public envelope'],
-  ['ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())', 'shared native cart public envelope'],
-  ['ApiError::Graphql("Storefront cart data is temporarily unavailable".to_string())', 'shared GraphQL cart public envelope'],
+  ['ApiError::ServerFn("Storefront cart data is temporarily unavailable".to_string())', 'shared preserved cart error variant'],
   ['"Storefront payment collection is temporarily unavailable".to_string()', 'shared payment public envelope'],
 ]) requireText(shared, value, label);
 
@@ -89,7 +88,8 @@ for (const value of [
   'ApiError::ServerFn(error.to_string())',
   'ApiError::Graphql(error.to_string())',
   'ApiError::ServerFn(message)',
-]) forbidText(shared, value, 'shared raw transport cause exposure');
+  'ApiError::Graphql("Storefront cart data is temporarily unavailable".to_string())',
+]) forbidText(shared, value, 'shared raw transport cause or variant drift');
 
 if (evidence.status !== 'storefront_transport_error_safety_source_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
@@ -99,6 +99,7 @@ for (const [key, expected] of Object.entries({
   native_context_logging: true,
   shared_static_public_envelopes: true,
   shared_raw_cause_logging: false,
+  cart_error_variant_preserved: true,
   foreign_transport_error_text_public: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
@@ -127,5 +128,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ commerce storefront cart/payment transport failures retain SSR diagnostics and static public envelopes without client-side raw causes; runtime evidence remains open',
+  '✔ commerce storefront cart/payment transport failures retain SSR diagnostics, existing error variants, and static public envelopes without client-side raw causes; runtime evidence remains open',
 );


### PR DESCRIPTION
## Summary
- replace mounted Commerce storefront cart/payment transport `to_string()` envelopes with stable public messages
- retain full internal causes only in SSR-native structured logs with correlation, tenant, channel, locale, owner, and operation context
- keep shared/client-side tracing limited to safe path/fallback/code fields without raw causes
- preserve cart validation and non-validation `ApiError::ServerFn` behavior plus payment path-specific variants
- add source-only evidence, documentation, and a focused static guard

## Boundary
No checkout DTOs, owner request/response contracts, transport selection, staged checkout behavior, FBA/FFA status, or runtime evidence are changed.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.