### PR TITLE
verify(email): record blocked cycle-001 handoff

### DIFF
--- a/crates/rustok-email/docs/implementation-plan.md
+++ b/crates/rustok-email/docs/implementation-plan.md
@@ -5,11 +5,23 @@
 `rustok-email` is a capability-only core module. It owns SMTP delivery,
 template rendering, typed delivery requests and receipts, and the
 `EmailDeliveryPort`; authorization remains with the calling module or host.
-The disabled-provider path returns a typed noop receipt, and the port requires
-deadline and write-idempotency semantics.
+The disabled-provider path returns a typed noop receipt, and the published port
+requires deadline and write-idempotency semantics.
 
-Targeted runtime evidence has established the current delivery policy and
-validation behavior. The module has no module-owned UI.
+Cycle-001 inspection found that these published semantics are not yet the
+runtime delivery contract. The port previously validated the presence of a
+deadline and idempotency key but did not apply either value. Built-in auth email
+continues to use a server-owned sender and detached tasks instead of the owner
+port or durable delivery state. Tenant email settings are persisted separately
+from the bootstrap configuration actually used by the SMTP sender.
+
+Draft PR #2490 stages bounded process-local idempotency, real delivery deadlines,
+input bounds, HTML autoescaping, recipient-log redaction, and secret-safe email
+settings projections. It also closes a confirmed exposure where callers with
+`settings:read` could receive the runtime SMTP password and where the native
+admin path returned historical email settings JSON without redaction. These
+changes are not in `main` and have no successful Cargo Check/test/Clippy evidence
+on one SHA, so they do not count as a completed release fix.
 
 ## FFA/FBA status block
 
@@ -23,30 +35,69 @@ validation behavior. The module has no module-owned UI.
   and `crates/rustok-email/contracts/evidence/email-runtime-fallback-smoke.json`.
 - `npm run verify:email:fba` and `npm run verify:foundation:fba-runtime-smoke`
   lock provider metadata, policy semantics, typed validation, and fallback
-  behavior.
+  behavior, but do not prove durable SMTP delivery or host adoption.
 
 ## Open results
 
-1. **Extend typed delivery payloads only with an owned contract.** Add a new
+1. **Adopt one durable email-delivery execution path.** Persist delivery intent
+   and idempotency identity in durable owner state or a transactionally coupled
+   outbox, supervise retries, and store a terminal receipt before acknowledging
+   completion. Process-local reservations may remain an optimization only.
+   **Depends on:** email migration ownership and the platform outbox contract.
+   **Done when:** duplicate, timeout, cancellation, process restart, provider
+   failure and replay tests prove at-most-one accepted delivery per identity or
+   a documented provider-safe retry contract.
+
+2. **Remove the server-owned auth delivery bypass.** Password-reset and email
+   verification flows currently render and send through `apps/server` and use
+   detached `tokio::spawn`; restart or cancellation can lose delivery. Move the
+   flow to the published owner port and durable execution path without keeping
+   a parallel compatibility sender.
+   **Depends on:** durable delivery receipts and auth-owner request identity.
+   **Done when:** auth no longer owns SMTP/rendering policy, background work is
+   supervised, and targeted restart/cancellation tests preserve delivery intent.
+
+3. **Make the settings control plane authoritative or remove it.** GraphQL and
+   admin write tenant email JSON, while the actual sender reads bootstrap
+   `ctx.settings()`. A successful save therefore does not change runtime SMTP
+   behavior. Define which non-secret tenant fields are supported and resolve
+   them in the owner sender, or remove the misleading write surface.
+   **Depends on:** provider/configuration ownership and reload semantics.
+   **Done when:** reads, writes, runtime delivery, health and operator docs use
+   one configuration source with explicit restart or live-reload behavior.
+
+4. **Scrub historical email secrets with an owned migration.** Existing
+   `platform_settings.email` rows may contain SMTP passwords or other secret
+   fields. Draft PR #2490 prevents further reads/writes of these fields, but it
+   does not remove data already at rest. `EmailModule` is not currently present
+   in the global migration-source registry, so migration ownership must be made
+   explicit before cleanup.
+   **Depends on:** platform migration aggregation and secret-rotation procedure.
+   **Done when:** historical rows are scrubbed, affected credentials are rotated,
+   migration replay is tested, and no API or native surface returns the secret.
+
+5. **Merge and verify the staged security/port hardening.** Draft PR #2490
+   applies deadlines, bounded request identity, HTML escaping, PII-safe logs and
+   email-settings redaction. Fix every email-specific compile, test or Clippy
+   failure before merging; queued or pre-compilation failures are not evidence.
+   **Depends on:** a working locked dependency graph and Rust runners.
+   **Done when:** targeted owner, server and admin tests pass on one PR SHA and
+   the reviewed changes are merged without weakening the explicit blockers.
+
+6. **Probe SMTP readiness rather than configuration shape only.** Current health
+   validates configured fields but does not prove DNS/connectivity/TLS/auth.
+   Add a bounded provider probe or document a deliberately weaker readiness
+   contract with separate delivery-failure alerting.
+   **Depends on:** provider operational policy and safe probe semantics.
+   **Done when:** outage/authentication failure is observable without leaking
+   credentials or blocking unrelated traffic indefinitely.
+
+7. **Extend typed delivery payloads only with an owned contract.** Add a new
    template, delivery field, or receipt behavior together with module docs and
    host integration tests.
    **Depends on:** the consuming module's public delivery requirement.
    **Done when:** request validation, idempotency, template-error retry policy,
    and disabled-provider behavior are covered by targeted tests.
-
-2. **Keep SMTP and rendering ownership out of the server host.** New host
-   wiring must consume the published delivery port rather than reimplementing
-   provider mode, rendering, or delivery policy.
-   **Depends on:** host runtime composition.
-   **Done when:** no server-local email business path exists and the module docs
-   and manifest match the exposed delivery contract.
-
-3. **Document a new delivery flow before publishing it.** Record the calling
-   contract, recovery behavior, and operational owner whenever a flow becomes
-   available to a host or domain module.
-   **Depends on:** the change-owning delivery consumer.
-   **Done when:** module and consumer documentation describe the same failure
-   and retry semantics.
 
 ## Verification
 
@@ -54,13 +105,32 @@ validation behavior. The module has no module-owned UI.
 - `npm run verify:foundation:fba-runtime-smoke`
 - `cargo xtask module validate email`
 - `cargo xtask module test email`
+- `cargo check -p rustok-email --lib`
 - `cargo test -p rustok-email ports::tests`
-- Targeted host integration tests when runtime wiring changes.
+- `cargo test -p rustok-email template::tests service::tests`
+- Targeted server settings, auth delivery and admin native-adapter tests.
+- Restart/replay/provider-failure evidence after durable delivery is implemented.
 
 ## Change rules
 
-1. Keep delivery policy, rendering, and provider behavior in this module.
-2. Update the root README, local docs, and `rustok-module.toml` with a public
+1. Keep delivery policy, rendering, provider behavior and receipts in this module.
+2. Do not acknowledge durable delivery from process-local state or a detached task.
+3. Keep credentials in a secret-bearing runtime source; tenant settings and public
+   projections may contain only explicitly supported non-secret fields.
+4. Update the root README, local docs and `rustok-module.toml` with a public
    delivery contract change.
-3. Update this status block and `docs/modules/registry.md` with an FBA boundary
+5. Update this status block and `docs/modules/registry.md` with an FBA boundary
    change.
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `blocked`
+- Last verified at (UTC): `2026-07-30`
+- Scope inspected: `EmailDeliveryPort; SMTP and disabled-provider behavior; templates and auth mailers; GraphQL/native/admin settings surfaces; password-reset and verification callers; deadlines, idempotency, retries, cancellation, restart behavior, health, secrets and PII`
+- Findings: `P0=0, P1=5, P2=1, P3=1`
+- Fixed in this pass: `staged draft PR #2490 with real delivery deadlines, bounded process-local request identity, input bounds, HTML autoescaping, PII-safe logs, SMTP-password redaction, secret-field rejection and safe email settings projections; added the missing cycle handoff`
+- Remaining risks or blockers: `draft changes are not in main or compiled verified; durable delivery/outbox is absent; auth uses a server-owned detached delivery path; saved tenant settings do not drive runtime SMTP; historical secret-bearing rows lack an owned scrub migration; SMTP readiness does not probe the provider`
+- Evidence: `PR #2490 at SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a; owner port/service/template sources; server auth/email/settings and GraphQL callers; admin native adapter; platform settings migration and migration-source registry; CI run 30519187116 had not started jobs; earlier smoke stopped before compilation on an unlocked Athanor dependency and advisory validation found two expired exceptions`
+- Next action: `resume PR #2490 when targeted runners are available, fix email-specific failures, then implement one durable owner delivery path and remove the auth/settings bypasses before closing-gate completion`
+- Resume command: `cargo xtask module validate email && cargo xtask module test email && cargo test -p rustok-email ports::tests`

--- a/docs/verification/PLATFORM_VERIFICATION_PLAN.md
+++ b/docs/verification/PLATFORM_VERIFICATION_PLAN.md
@@ -38,13 +38,13 @@ This block is the first place an agent reads after `docs/index.md`.
 
 - Cycle: `cycle-001`
 - Cycle status: `active`
-- Current item: `core/email`
-- Next item: `core/email`
+- Current item: `core/index`
+- Next item: `core/index`
 - Started at (UTC): `2026-07-20`
 - Last handoff at (UTC): `2026-07-30`
-- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued`
+- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/search P1: the generic settings projection serializes search.api_key`
 - Release readiness: `not_assessed`
-- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; these conditions are not classified as product defects`
+- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started, an earlier smoke stopped before compilation because Cargo.lock required an Athanor update, and dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
 
 Allowed cycle statuses are `ready`, `active`, and `closing`. An item uses `pending`,
 `in_progress`, `completed`, or `blocked` in its local handoff block. Only one item may
@@ -180,7 +180,7 @@ These are Core modules because the current `modules.toml` declares them with
 - [x] `core/auth` — `crates/rustok-auth` — blocked
 - [x] `core/cache` — `crates/rustok-cache` — blocked
 - [x] `core/channel` — `crates/rustok-channel` — blocked
-- [ ] `core/email` — `crates/rustok-email`
+- [x] `core/email` — `crates/rustok-email` — blocked
 - [ ] `core/index` — `crates/rustok-index`
 - [ ] `core/search` — `crates/rustok-search`
 - [ ] `core/outbox` — `crates/rustok-outbox`


### PR DESCRIPTION
## Result

`core/email` was visited in `cycle-001` and remains blocked.

### Findings

- Confirmed P1 secret exposure: `settings:read` could return runtime `smtp.password`, and the native admin path returned raw stored email JSON.
- Draft PR #2490 stages redaction, secret-field rejection, real deadlines, bounded process-local request identity, HTML escaping and PII-safe logs, but it is not in `main` or compiled verified.
- Durable delivery receipts/outbox are absent; auth still uses a server-owned detached send path.
- Saved tenant email settings do not drive the runtime SMTP sender.
- Historical secret-bearing rows lack an owned scrub migration, and SMTP readiness does not probe the provider.
- The same generic settings projection exposes `search.api_key`; that finding is carried to `core/search`.

### Handoff

- The email local plan is marked `blocked` with exact PR/run evidence and resume commands.
- The master queue marks `core/email — blocked`.
- The cursor advances to `core/index`.

This PR changes documentation and cursor state only. It does not merge or weaken the unverified code in PR #2490.