### PR TITLE
feat(index): stage Social Graph privacy parity shadow

### DIFF
--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -90,7 +90,7 @@ pub mod module_event_dispatcher {
     };
 
     /// Adds host-owned adapters after module/distribution registration, materializes the
-    /// canonical Index query runtime, and then activates selected final-host consumers.
+    /// canonical Index query runtime, and then activates selected non-authoritative shadows.
     pub fn build_shared_runtime_extensions_with_host_providers(
         registry: &ModuleRegistry,
         settings: &RustokSettings,
@@ -114,7 +114,7 @@ pub mod module_event_dispatcher {
             feature = "mod-profiles",
             feature = "mod-social_graph"
         ))]
-        if crate::services::notification_recipient_policy::social_graph_index_privacy_reads_enabled()
+        if crate::services::notification_recipient_policy::social_graph_index_privacy_shadow_enabled()
             .map_err(Error::Message)?
         {
             let index_runtime = extensions
@@ -122,11 +122,11 @@ pub mod module_event_dispatcher {
                 .cloned()
                 .ok_or_else(|| {
                     Error::Message(
-                        "Index query runtime is required when Social Graph Index privacy reads are enabled"
+                        "Index query runtime is required when Social Graph Index privacy shadow is enabled"
                             .to_string(),
                     )
                 })?;
-            let policy = crate::services::notification_recipient_policy::ServerNotificationRecipientPolicy::compose_with_index_runtime(
+            let policy = crate::services::notification_recipient_policy::ServerNotificationRecipientPolicy::compose_with_index_shadow_runtime(
                 db,
                 &extensions,
                 index_runtime,

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -89,8 +89,8 @@ pub mod module_event_dispatcher {
         spawn_module_event_dispatcher,
     };
 
-    /// Adds host-owned adapters after module/distribution registration and finally
-    /// materializes the canonical Index query runtime from the complete source registry.
+    /// Adds host-owned adapters after module/distribution registration, materializes the
+    /// canonical Index query runtime, and then replaces selected final-host consumers.
     pub fn build_shared_runtime_extensions_with_host_providers(
         registry: &ModuleRegistry,
         settings: &RustokSettings,
@@ -105,9 +105,33 @@ pub mod module_event_dispatcher {
             auth_config,
         )?;
         let mut extensions = base.as_ref().clone();
-        rustok_index::materialize_postgres_index_query_runtime(&mut extensions, db).map_err(
+        rustok_index::materialize_postgres_index_query_runtime(&mut extensions, db.clone()).map_err(
             |error| Error::Message(format!("Index query runtime composition failed: {error}")),
         )?;
+
+        #[cfg(all(
+            feature = "mod-notifications",
+            feature = "mod-profiles",
+            feature = "mod-social_graph"
+        ))]
+        {
+            let index_runtime = extensions
+                .get::<rustok_index::SharedIndexQueryRuntime>()
+                .cloned()
+                .ok_or_else(|| {
+                    Error::Message(
+                        "Index query runtime is required for Social Graph notification privacy reads"
+                            .to_string(),
+                    )
+                })?;
+            let policy = crate::services::notification_recipient_policy::ServerNotificationRecipientPolicy::compose_with_index_runtime(
+                db,
+                &extensions,
+                index_runtime,
+            );
+            extensions.insert(policy);
+        }
+
         Ok(Arc::new(extensions))
     }
 
@@ -143,6 +167,8 @@ pub mod module_event_dispatcher {
 
             assert!(extensions.contains::<SharedIndexSchemaRegistry>());
             assert!(extensions.contains::<SharedIndexQueryRuntime>());
+            #[cfg(all(feature = "mod-notifications", feature = "mod-profiles"))]
+            assert!(extensions.contains::<rustok_notifications::NotificationRecipientPolicyRuntime>());
             let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
             assert!(host.shared_get::<SharedIndexQueryRuntime>().is_some());
         }

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -90,7 +90,7 @@ pub mod module_event_dispatcher {
     };
 
     /// Adds host-owned adapters after module/distribution registration, materializes the
-    /// canonical Index query runtime, and then replaces selected final-host consumers.
+    /// canonical Index query runtime, and then activates selected final-host consumers.
     pub fn build_shared_runtime_extensions_with_host_providers(
         registry: &ModuleRegistry,
         settings: &RustokSettings,
@@ -114,13 +114,15 @@ pub mod module_event_dispatcher {
             feature = "mod-profiles",
             feature = "mod-social_graph"
         ))]
+        if crate::services::notification_recipient_policy::social_graph_index_privacy_reads_enabled()
+            .map_err(Error::Message)?
         {
             let index_runtime = extensions
                 .get::<rustok_index::SharedIndexQueryRuntime>()
                 .cloned()
                 .ok_or_else(|| {
                     Error::Message(
-                        "Index query runtime is required for Social Graph notification privacy reads"
+                        "Index query runtime is required when Social Graph Index privacy reads are enabled"
                             .to_string(),
                     )
                 })?;

--- a/apps/server/src/services/notification_recipient_policy.rs
+++ b/apps/server/src/services/notification_recipient_policy.rs
@@ -27,6 +27,7 @@ use sea_orm::DatabaseConnection;
 
 pub const NOTIFICATION_CANDIDATE_WORKER_ENABLED_ENV: &str =
     "RUSTOK_NOTIFICATIONS_CANDIDATE_WORKER_ENABLED";
+#[cfg(feature = "mod-social_graph")]
 pub const SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV: &str =
     "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED";
 const RECIPIENT_POLICY_DEADLINE: Duration = Duration::from_secs(2);
@@ -170,6 +171,7 @@ impl ServerNotificationRecipientPolicy {
     }
 }
 
+#[cfg(feature = "mod-social_graph")]
 pub(crate) fn social_graph_index_privacy_shadow_enabled() -> Result<bool, String> {
     match std::env::var(SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV) {
         Ok(value) => parse_bool(SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV, &value),
@@ -284,6 +286,7 @@ fn candidate_worker_enabled_from_environment() -> bool {
     }
 }
 
+#[cfg(feature = "mod-social_graph")]
 fn parse_bool(variable: &str, value: &str) -> Result<bool, String> {
     match value.trim().to_ascii_lowercase().as_str() {
         "1" | "true" | "yes" | "on" => Ok(true),

--- a/apps/server/src/services/notification_recipient_policy.rs
+++ b/apps/server/src/services/notification_recipient_policy.rs
@@ -18,7 +18,7 @@ use rustok_profiles::{
     ProfilePrivacyRuntime, ProfilePrivacyService,
 };
 #[cfg(feature = "mod-social_graph")]
-use rustok_social_graph::IndexSocialGraphPrivacyReadPort;
+use rustok_social_graph::IndexShadowSocialGraphPrivacyReadPort;
 use rustok_social_graph::{
     SocialGraphPairRequest, SocialGraphPrivacyReadPort, SocialGraphPrivacyRuntime,
     SocialGraphService,
@@ -27,8 +27,8 @@ use sea_orm::DatabaseConnection;
 
 pub const NOTIFICATION_CANDIDATE_WORKER_ENABLED_ENV: &str =
     "RUSTOK_NOTIFICATIONS_CANDIDATE_WORKER_ENABLED";
-pub const SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV: &str =
-    "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED";
+pub const SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV: &str =
+    "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED";
 const RECIPIENT_POLICY_DEADLINE: Duration = Duration::from_secs(2);
 const RECIPIENT_POLICY_ACTOR: &str = "notifications-recipient-policy";
 
@@ -106,17 +106,20 @@ impl ServerNotificationRecipientPolicy {
     }
 
     #[cfg(feature = "mod-social_graph")]
-    pub fn compose_with_index_runtime(
+    pub fn compose_with_index_shadow_runtime(
         db: DatabaseConnection,
         extensions: &ModuleRuntimeExtensions,
         runtime: SharedIndexQueryRuntime,
     ) -> NotificationRecipientPolicyRuntime {
-        let graph_port: Arc<dyn SocialGraphPrivacyReadPort> =
-            Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime));
+        let authoritative: Arc<dyn SocialGraphPrivacyReadPort> =
+            Arc::new(SocialGraphService::new(db.clone()));
+        let shadow: Arc<dyn SocialGraphPrivacyReadPort> = Arc::new(
+            IndexShadowSocialGraphPrivacyReadPort::new(authoritative, runtime),
+        );
         Self::compose_with_graph(
             db,
             extensions,
-            SocialGraphPrivacyRuntime::new(graph_port),
+            SocialGraphPrivacyRuntime::new(shadow),
         )
     }
 
@@ -167,12 +170,12 @@ impl ServerNotificationRecipientPolicy {
     }
 }
 
-pub(crate) fn social_graph_index_privacy_reads_enabled() -> Result<bool, String> {
-    match std::env::var(SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV) {
-        Ok(value) => parse_bool(SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV, &value),
+pub(crate) fn social_graph_index_privacy_shadow_enabled() -> Result<bool, String> {
+    match std::env::var(SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV) {
+        Ok(value) => parse_bool(SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV, &value),
         Err(std::env::VarError::NotPresent) => Ok(false),
         Err(error) => Err(format!(
-            "failed to read {SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV}: {error}"
+            "failed to read {SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV}: {error}"
         )),
     }
 }

--- a/apps/server/src/services/notification_recipient_policy.rs
+++ b/apps/server/src/services/notification_recipient_policy.rs
@@ -27,6 +27,8 @@ use sea_orm::DatabaseConnection;
 
 pub const NOTIFICATION_CANDIDATE_WORKER_ENABLED_ENV: &str =
     "RUSTOK_NOTIFICATIONS_CANDIDATE_WORKER_ENABLED";
+pub const SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV: &str =
+    "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED";
 const RECIPIENT_POLICY_DEADLINE: Duration = Duration::from_secs(2);
 const RECIPIENT_POLICY_ACTOR: &str = "notifications-recipient-policy";
 
@@ -165,6 +167,16 @@ impl ServerNotificationRecipientPolicy {
     }
 }
 
+pub(crate) fn social_graph_index_privacy_reads_enabled() -> Result<bool, String> {
+    match std::env::var(SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV) {
+        Ok(value) => parse_bool(SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV, &value),
+        Err(std::env::VarError::NotPresent) => Ok(false),
+        Err(error) => Err(format!(
+            "failed to read {SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV}: {error}"
+        )),
+    }
+}
+
 #[async_trait]
 impl NotificationRecipientPolicy for ServerNotificationRecipientPolicy {
     async fn evaluate(
@@ -266,6 +278,16 @@ fn candidate_worker_enabled_from_environment() -> bool {
             );
             false
         }
+    }
+}
+
+fn parse_bool(variable: &str, value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "" | "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!(
+            "{variable} must be one of true/false, 1/0, yes/no, or on/off"
+        )),
     }
 }
 

--- a/apps/server/src/services/notification_recipient_policy.rs
+++ b/apps/server/src/services/notification_recipient_policy.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use rustok_api::{PortActor, PortContext, PortError};
 use rustok_core::ModuleRuntimeExtensions;
+#[cfg(feature = "mod-social_graph")]
+use rustok_index::SharedIndexQueryRuntime;
 use rustok_notifications::{
     NotificationBlockReadPort, NotificationBlockReadRuntime, NotificationMuteReadPort,
     NotificationMuteReadRuntime, NotificationRecipientPolicy, NotificationRecipientPolicyDecision,
@@ -15,6 +17,8 @@ use rustok_profiles::{
     ProfilePrivacyDecision, ProfilePrivacyReadPort, ProfilePrivacyReadRequest,
     ProfilePrivacyRuntime, ProfilePrivacyService,
 };
+#[cfg(feature = "mod-social_graph")]
+use rustok_social_graph::IndexSocialGraphPrivacyReadPort;
 use rustok_social_graph::{
     SocialGraphPairRequest, SocialGraphPrivacyReadPort, SocialGraphPrivacyRuntime,
     SocialGraphService,
@@ -90,10 +94,37 @@ impl ServerNotificationRecipientPolicy {
         db: DatabaseConnection,
         extensions: &ModuleRuntimeExtensions,
     ) -> NotificationRecipientPolicyRuntime {
+        let graph_port: Arc<dyn SocialGraphPrivacyReadPort> =
+            Arc::new(SocialGraphService::new(db.clone()));
+        Self::compose_with_graph(
+            db,
+            extensions,
+            SocialGraphPrivacyRuntime::new(graph_port),
+        )
+    }
+
+    #[cfg(feature = "mod-social_graph")]
+    pub fn compose_with_index_runtime(
+        db: DatabaseConnection,
+        extensions: &ModuleRuntimeExtensions,
+        runtime: SharedIndexQueryRuntime,
+    ) -> NotificationRecipientPolicyRuntime {
+        let graph_port: Arc<dyn SocialGraphPrivacyReadPort> =
+            Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime));
+        Self::compose_with_graph(
+            db,
+            extensions,
+            SocialGraphPrivacyRuntime::new(graph_port),
+        )
+    }
+
+    fn compose_with_graph(
+        db: DatabaseConnection,
+        extensions: &ModuleRuntimeExtensions,
+        graph: SocialGraphPrivacyRuntime,
+    ) -> NotificationRecipientPolicyRuntime {
         let profile_port: Arc<dyn ProfilePrivacyReadPort> =
-            Arc::new(ProfilePrivacyService::new(db.clone()));
-        let graph_port: Arc<dyn SocialGraphPrivacyReadPort> = Arc::new(SocialGraphService::new(db));
-        let graph = SocialGraphPrivacyRuntime::new(graph_port);
+            Arc::new(ProfilePrivacyService::new(db));
         let blocks = extensions
             .get::<NotificationBlockReadRuntime>()
             .cloned()

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -18,8 +18,8 @@ modules publish generic schema contracts into an Index-owned catalog, the select
 distribution materializes one non-empty immutable registry after all module registrations,
 and the server binds that registry to its database through the Index-owned PostgreSQL
 runtime materializer. Social Graph is the first source publication. Notification block/mute
-policy is the first authorized consumer source, protected by a default-off activation gate
-until retained projection readiness, lag, and result-parity evidence exists.
+policy is the first consumer-shaped parity shadow, protected by a default-off shadow gate
+and explicitly non-authoritative.
 
 ## Actualized status
 
@@ -38,8 +38,8 @@ until retained projection readiness, lag, and result-parity evidence exists.
 - M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
 - M4 source-owned immutable schema registry: `source_complete_execution_pending`.
 - M4 server-owned shared query runtime composition: `source_complete_execution_pending`.
-- M4 first authorized consumer cutover source: `source_complete_execution_pending`.
-- M4 first consumer activation: `open_owner_action`.
+- M4 first consumer parity shadow: `source_complete_execution_pending`.
+- M4 authoritative consumer cutover: `blocked_by_freshness_contract`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -168,24 +168,33 @@ Runtime presence does not establish persisted tenant schema readiness. Every exe
 still performs the exact active fingerprint and semantic JSON preflight inside
 `PostgresIndexQueryPort`.
 
-## First authorized consumer source
+## First consumer parity shadow
 
-`IndexSocialGraphPrivacyReadPort` is the first owner-defined adapter consuming
-`SharedIndexQueryRuntime`. It preserves the existing `SocialGraphPrivacyReadPort`
-authorization and request bounds while translating block, mute, and follow checks into
-typed filters over the owner-published relation schema.
+`IndexSocialGraphPrivacyReadPort` translates the existing
+`SocialGraphPrivacyReadPort` contract into typed Index filters over the owner-published
+relation schema. It preserves tenant/read authorization, self-relation rejection, follow
+source-actor checks, the 100-target batch bound, bidirectional block semantics, and
+directional mute/follow semantics.
 
-The final server facade uses the default-off activation gate
-`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`. While disabled, the authoritative owner
-read path remains selected. When enabled, the facade requires `SharedIndexQueryRuntime` and
-recomposes notification block/mute policy. Block remains symmetric, mute remains
-recipient-to-actor directional, and custom notification relation providers retain
-priority. Missing tenant schema or storage readiness is retryable fail-closed and cannot
-become an implicit allow; no owner-table fallback exists after activation.
+`IndexShadowSocialGraphPrivacyReadPort` wraps the authoritative owner port plus the typed
+Index adapter. It executes the owner read first, compares the projection after owner success,
+records bounded mismatch/error diagnostics without identities, and always returns the owner
+result. Index therefore never decides notification privacy in this slice.
+
+The final server facade uses the default-off shadow gate
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`. While disabled, the ordinary owner policy
+is unchanged. When enabled, the facade requires `SharedIndexQueryRuntime` and recomposes
+notification block/mute policy with the non-authoritative shadow. Custom notification
+relation providers retain priority.
+
+A direct cutover remains unsafe because a stale but successful Index query can omit a current
+block or mute without returning an error. Schema readiness is not a freshness watermark.
+Authoritative use therefore remains blocked until retained per-tenant watermark/lag,
+positive and negative parity, outage/recovery, repair, latency, and negative-result
+fail-closed evidence exists.
 
 Revision-bearing follow reads, profile privacy, GraphQL, storefront, admin, and
-presentation authorization remain outside this cutover. The activation flag must remain
-off until the owner retains projection readiness, lag, and result-parity evidence.
+presentation authorization remain outside this shadow.
 
 ## Remaining bounded M4 work
 
@@ -193,11 +202,11 @@ The canonical checklist remains open until the owner runs the fixture through ca
 admits the retained bundle, and preserves both bundle and receipt. Additional boundaries
 remain:
 
-- retain Social Graph projection readiness, lag, and result-parity evidence and decide
-  whether to activate the first consumer;
+- execute and retain Social Graph privacy shadow parity, freshness, lag, repair, and latency
+  evidence before reconsidering authoritative cutover;
 - aggregate ordering semantics for paths traversing `many`;
 - publish schemas from additional source owners as consumers are selected;
-- additional server/storefront/admin/search authorization and consumer cutovers.
+- additional non-authoritative shadows and safely freshness-gated consumer cutovers.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -13,12 +13,13 @@ detection. The repository owner still needs to execute and admit one fresh real
 PostgreSQL partition packet. That owner gate blocks production partition lifecycle
 design but does not block M4 query source work.
 
-The previous server-composition blocker is now removed at the capability level. Source
+The previous server-composition blocker is removed at the capability level. Source
 modules publish generic schema contracts into an Index-owned catalog, the selected
 distribution materializes one non-empty immutable registry after all module registrations,
 and the server binds that registry to its database through the Index-owned PostgreSQL
-runtime materializer. Social Graph is the first source publication. Authorization,
-transport endpoints, tenant schema readiness, and consumer cutover remain separate gates.
+runtime materializer. Social Graph is the first source publication and notification
+block/mute policy is the first authorized consumer cutover. Additional transports,
+tenant readiness evidence, and consumer cutovers remain separate gates.
 
 ## Actualized status
 
@@ -37,6 +38,7 @@ transport endpoints, tenant schema readiness, and consumer cutover remain separa
 - M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
 - M4 source-owned immutable schema registry: `source_complete_execution_pending`.
 - M4 server-owned shared query runtime composition: `source_complete_execution_pending`.
+- M4 first authorized consumer cutover: `source_complete_execution_pending`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -165,6 +167,20 @@ Runtime presence does not establish persisted tenant schema readiness. Every exe
 still performs the exact active fingerprint and semantic JSON preflight inside
 `PostgresIndexQueryPort`.
 
+## First authorized consumer
+
+`IndexSocialGraphPrivacyReadPort` is the first owner-defined adapter consuming
+`SharedIndexQueryRuntime`. It preserves the existing `SocialGraphPrivacyReadPort`
+authorization and request bounds while translating block, mute, and follow checks into
+typed filters over the owner-published relation schema.
+
+The final server facade recomposes notification block/mute policy only after the shared
+runtime exists. Block remains symmetric, mute remains recipient-to-actor directional, and
+custom notification relation providers retain priority. Missing tenant schema or storage
+readiness is retryable fail-closed and cannot become an implicit allow. Revision-bearing
+follow reads, profile privacy, GraphQL, storefront, admin, and presentation authorization
+remain outside this cutover.
+
 ## Remaining bounded M4 work
 
 The canonical checklist remains open until the owner runs the fixture through capture,
@@ -173,8 +189,8 @@ remain:
 
 - aggregate ordering semantics for paths traversing `many`;
 - publish schemas from additional source owners as consumers are selected;
-- server/storefront/admin/search authorization and first consumer cutover;
-- transport-specific error mapping that preserves bounded query-port failures.
+- additional server/storefront/admin/search authorization and consumer cutovers;
+- live execution and lag/freshness evidence for projection-backed policy reads.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.
@@ -193,6 +209,7 @@ cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo test -p rustok-index postgres_many_projection_tests -- --nocapture
 cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index query_snapshot_tests -- --nocapture
+cargo test -p rustok-social-graph --features index index_privacy -- --nocapture
 cargo test -p rustok-social-graph --features index module_publishes_its_index_schema_through_runtime_extensions -- --nocapture
 cargo test -p rustok-distribution source_schema_catalog_materializes_after_all_modules_register -- --nocapture
 cargo test -p rustok-server host_materializes_index_query_runtime_after_source_registry -- --nocapture
@@ -226,5 +243,6 @@ node scripts/verify/verify-index-query-equivalence-capture.mjs
 node scripts/verify/verify-index-query-equivalence-admission.mjs
 node scripts/verify/verify-index-source-schema-registry.mjs
 node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -17,9 +17,9 @@ The previous server-composition blocker is removed at the capability level. Sour
 modules publish generic schema contracts into an Index-owned catalog, the selected
 distribution materializes one non-empty immutable registry after all module registrations,
 and the server binds that registry to its database through the Index-owned PostgreSQL
-runtime materializer. Social Graph is the first source publication and notification
-block/mute policy is the first authorized consumer cutover. Additional transports,
-tenant readiness evidence, and consumer cutovers remain separate gates.
+runtime materializer. Social Graph is the first source publication. Notification block/mute
+policy is the first authorized consumer source, protected by a default-off activation gate
+until retained projection readiness, lag, and result-parity evidence exists.
 
 ## Actualized status
 
@@ -38,7 +38,8 @@ tenant readiness evidence, and consumer cutovers remain separate gates.
 - M4 PostgreSQL/reference admission review source: `source_complete_owner_execution_pending`.
 - M4 source-owned immutable schema registry: `source_complete_execution_pending`.
 - M4 server-owned shared query runtime composition: `source_complete_execution_pending`.
-- M4 first authorized consumer cutover: `source_complete_execution_pending`.
+- M4 first authorized consumer cutover source: `source_complete_execution_pending`.
+- M4 first consumer activation: `open_owner_action`.
 - M4 live PostgreSQL/reference execution evidence: `open_owner_action`.
 
 ## Executable plan v4
@@ -167,19 +168,24 @@ Runtime presence does not establish persisted tenant schema readiness. Every exe
 still performs the exact active fingerprint and semantic JSON preflight inside
 `PostgresIndexQueryPort`.
 
-## First authorized consumer
+## First authorized consumer source
 
 `IndexSocialGraphPrivacyReadPort` is the first owner-defined adapter consuming
 `SharedIndexQueryRuntime`. It preserves the existing `SocialGraphPrivacyReadPort`
 authorization and request bounds while translating block, mute, and follow checks into
 typed filters over the owner-published relation schema.
 
-The final server facade recomposes notification block/mute policy only after the shared
-runtime exists. Block remains symmetric, mute remains recipient-to-actor directional, and
-custom notification relation providers retain priority. Missing tenant schema or storage
-readiness is retryable fail-closed and cannot become an implicit allow. Revision-bearing
-follow reads, profile privacy, GraphQL, storefront, admin, and presentation authorization
-remain outside this cutover.
+The final server facade uses the default-off activation gate
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`. While disabled, the authoritative owner
+read path remains selected. When enabled, the facade requires `SharedIndexQueryRuntime` and
+recomposes notification block/mute policy. Block remains symmetric, mute remains
+recipient-to-actor directional, and custom notification relation providers retain
+priority. Missing tenant schema or storage readiness is retryable fail-closed and cannot
+become an implicit allow; no owner-table fallback exists after activation.
+
+Revision-bearing follow reads, profile privacy, GraphQL, storefront, admin, and
+presentation authorization remain outside this cutover. The activation flag must remain
+off until the owner retains projection readiness, lag, and result-parity evidence.
 
 ## Remaining bounded M4 work
 
@@ -187,10 +193,11 @@ The canonical checklist remains open until the owner runs the fixture through ca
 admits the retained bundle, and preserves both bundle and receipt. Additional boundaries
 remain:
 
+- retain Social Graph projection readiness, lag, and result-parity evidence and decide
+  whether to activate the first consumer;
 - aggregate ordering semantics for paths traversing `many`;
 - publish schemas from additional source owners as consumers are selected;
-- additional server/storefront/admin/search authorization and consumer cutovers;
-- live execution and lag/freshness evidence for projection-backed policy reads.
+- additional server/storefront/admin/search authorization and consumer cutovers.
 
 The real retained PostgreSQL partition packet remains an independent owner gate for
 production partition lifecycle work.

--- a/crates/rustok-index/docs/m4-query-runtime-composition.md
+++ b/crates/rustok-index/docs/m4-query-runtime-composition.md
@@ -28,13 +28,13 @@ materializer. It:
 
 Backend support and exact tenant-scoped persisted schema readiness remain execution-time
 responsibilities of `PostgresIndexQueryPort`. Runtime presence therefore means the adapter is
-composed, not that a specific tenant query will succeed.
+composed, not that a specific tenant query will succeed or is current.
 
 ## Server composition
 
 The public server `module_event_dispatcher` facade delegates existing provider setup to
 the retained base implementation. It then invokes the Index-owned materializer before any
-selected projection-backed consumer composition. This ordering guarantees that:
+selected projection-backed shadow composition. This ordering guarantees that:
 
 1. every compiled module has published its schema contribution;
 2. `rustok-distribution` has atomically materialized the complete source registry;
@@ -48,30 +48,31 @@ source schema builder or owner DTO. A consumer must resolve `SharedIndexQueryRun
 its owner/transport authorization, construct only typed `IndexQuery` values, and map bounded
 query-port errors without exposing database details.
 
-The first approved consumer source is Social Graph notification block/mute policy. Its
-activation is separately default-off through
-`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`. While disabled, the authoritative owner
-policy remains selected. When enabled, the final host requires the shared runtime and
-recomposes the policy without an owner-table fallback. The owner adapter is documented in
-`m4-social-graph-privacy-consumer.md`.
+The first production-shaped runtime consumer is a default-off Social Graph notification
+privacy parity shadow. `RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED=true` requires the
+shared runtime and recomposes the policy with an owner-first comparison wrapper. The owner
+result remains authoritative; Index mismatch or failure never changes policy. The contract is
+documented in `m4-social-graph-privacy-consumer.md`.
 
 ## Boundary
 
 Runtime composition itself does not:
 
 - authorize arbitrary callers or tenant scopes;
-- activate any projection-backed consumer by default;
+- make a projection authoritative for privacy or presentation;
+- activate any projection-backed shadow by default;
 - add GraphQL, storefront, admin, search, or native-server query endpoints;
 - publish Product, Content, Flex, or other source schemas;
-- persist tenant schema readiness;
+- persist tenant schema readiness or a freshness watermark;
 - execute a query during startup;
 - add ordering through a `many` relation;
 - execute PostgreSQL/reference capture or admission;
 - authorize production partition lifecycle work.
 
-Consumer activation remains owner-operated and evidence-gated. The Social Graph source does
-not make profile privacy, revision-bearing follow reads, presentation visibility, or other
-consumers Index-backed.
+Consumer cutover remains blocked until the owner defines and proves freshness, negative-result
+safety, lag, repair, and fail-closed policy. The Social Graph shadow does not make profile
+privacy, revision-bearing follow reads, presentation visibility, or other consumers
+Index-backed.
 
 ## Owner validation
 

--- a/crates/rustok-index/docs/m4-query-runtime-composition.md
+++ b/crates/rustok-index/docs/m4-query-runtime-composition.md
@@ -32,26 +32,33 @@ composed, not that a specific tenant query will succeed.
 
 ## Server composition
 
-The public server `module_event_dispatcher` facade delegates all existing provider setup to
-the retained base implementation. It then invokes the Index-owned materializer as the final
-host-provider step. This ordering guarantees that:
+The public server `module_event_dispatcher` facade delegates existing provider setup to
+the retained base implementation. It then invokes the Index-owned materializer before any
+selected projection-backed consumer recomposition. This ordering guarantees that:
 
 1. every compiled module has published its schema contribution;
 2. `rustok-distribution` has atomically materialized the complete source registry;
-3. existing server-owned providers remain unchanged;
+3. existing server-owned providers remain available to the private base bootstrap;
 4. the query runtime is built from the final registry and the host database;
-5. the resulting extension set transfers unchanged into `HostRuntimeContext`.
+5. selected consumers may be recomposed only after runtime publication;
+6. only the final extension set transfers into `HostRuntimeContext`.
 
 The server does not call `PostgresIndexQueryPort::new` directly and does not import any
-source schema builder or owner DTO.
+source schema builder or owner DTO. A consumer must resolve `SharedIndexQueryRuntime`, apply
+its owner/transport authorization, construct only typed `IndexQuery` values, and map bounded
+query-port errors without exposing database details.
+
+The first approved consumer is Social Graph notification block/mute policy. Its owner
+adapter is documented separately in `m4-social-graph-privacy-consumer.md`. The final host
+requires the shared runtime before recomposing that policy and does not retain the temporary
+DB-backed default created inside the private base step.
 
 ## Boundary
 
-This slice does not:
+Runtime composition itself does not:
 
-- authorize callers or tenant scopes;
+- authorize arbitrary callers or tenant scopes;
 - add GraphQL, storefront, admin, search, or native-server query endpoints;
-- cut any consumer over to Index;
 - publish Product, Content, Flex, or other source schemas;
 - persist tenant schema readiness;
 - execute a query during startup;
@@ -59,9 +66,9 @@ This slice does not:
 - execute PostgreSQL/reference capture or admission;
 - authorize production partition lifecycle work.
 
-The next consumer slice must resolve `SharedIndexQueryRuntime`, apply owner/transport
-authorization before constructing a typed `IndexQuery`, and preserve all query-port errors
-without exposing database details.
+Consumer cutover remains owner-specific. The Social Graph notification slice does not make
+profile privacy, revision-bearing follow reads, presentation visibility, or other consumers
+Index-backed.
 
 ## Owner validation
 
@@ -75,6 +82,7 @@ cargo test -p rustok-server host_materializes_index_query_runtime_after_source_r
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-server --all-targets
 node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo xtask module validate index
 ```

--- a/crates/rustok-index/docs/m4-query-runtime-composition.md
+++ b/crates/rustok-index/docs/m4-query-runtime-composition.md
@@ -34,7 +34,7 @@ composed, not that a specific tenant query will succeed.
 
 The public server `module_event_dispatcher` facade delegates existing provider setup to
 the retained base implementation. It then invokes the Index-owned materializer before any
-selected projection-backed consumer recomposition. This ordering guarantees that:
+selected projection-backed consumer composition. This ordering guarantees that:
 
 1. every compiled module has published its schema contribution;
 2. `rustok-distribution` has atomically materialized the complete source registry;
@@ -48,16 +48,19 @@ source schema builder or owner DTO. A consumer must resolve `SharedIndexQueryRun
 its owner/transport authorization, construct only typed `IndexQuery` values, and map bounded
 query-port errors without exposing database details.
 
-The first approved consumer is Social Graph notification block/mute policy. Its owner
-adapter is documented separately in `m4-social-graph-privacy-consumer.md`. The final host
-requires the shared runtime before recomposing that policy and does not retain the temporary
-DB-backed default created inside the private base step.
+The first approved consumer source is Social Graph notification block/mute policy. Its
+activation is separately default-off through
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`. While disabled, the authoritative owner
+policy remains selected. When enabled, the final host requires the shared runtime and
+recomposes the policy without an owner-table fallback. The owner adapter is documented in
+`m4-social-graph-privacy-consumer.md`.
 
 ## Boundary
 
 Runtime composition itself does not:
 
 - authorize arbitrary callers or tenant scopes;
+- activate any projection-backed consumer by default;
 - add GraphQL, storefront, admin, search, or native-server query endpoints;
 - publish Product, Content, Flex, or other source schemas;
 - persist tenant schema readiness;
@@ -66,9 +69,9 @@ Runtime composition itself does not:
 - execute PostgreSQL/reference capture or admission;
 - authorize production partition lifecycle work.
 
-Consumer cutover remains owner-specific. The Social Graph notification slice does not make
-profile privacy, revision-bearing follow reads, presentation visibility, or other consumers
-Index-backed.
+Consumer activation remains owner-operated and evidence-gated. The Social Graph source does
+not make profile privacy, revision-bearing follow reads, presentation visibility, or other
+consumers Index-backed.
 
 ## Owner validation
 

--- a/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
+++ b/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
@@ -1,0 +1,91 @@
+# M4 Social Graph privacy consumer cutover
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice is the first authorized production consumer of `SharedIndexQueryRuntime`.
+It moves the default Social Graph block/mute reads used by notification recipient policy
+from direct owner-table reads to the generic Index query port while keeping Social Graph
+as the contract and replay owner.
+
+## Owner adapter
+
+`IndexSocialGraphPrivacyReadPort` implements the existing
+`SocialGraphPrivacyReadPort` contract. It receives only a clone of the neutral
+`SharedIndexQueryRuntime`; it does not receive a database connection, construct
+`PostgresIndexQueryPort`, or read `social_graph_relations`.
+
+The adapter builds typed queries against the owner-published
+`rustok-social-graph::relation@1` schema:
+
+- block suppression checks `relation_kind = block` and accepts a block in either direction;
+- mute suppression remains directional from notification recipient to actor;
+- point follow reads remain directional and retain source-actor authorization;
+- bounded follow batches retain the existing maximum of 100 targets, deduplicate input,
+  query through `In`, validate every projected UUID, and return deterministic sorted IDs.
+
+Inactive relations are absent because owner projection publishes an Index tombstone for an
+inactive revision. The adapter therefore does not add an independent active-state field or
+reinterpret source revision.
+
+## Authorization and failure contract
+
+Every method preserves `PortCallPolicy::read`, tenant parsing, self-relation rejection, and
+the existing user/source actor rule for follow reads. Notification policy calls use the
+existing bounded service actor and matching tenant context.
+
+`SchemaNotReady` and Index storage failures map to retryable
+`social_graph.index_privacy_unavailable`. Query-plan, compiler, decoder, backend, and
+projected-result contract failures map to the non-retryable invariant code
+`social_graph.index_privacy_contract_invalid`.
+
+The notification policy therefore uses retryable fail-closed behavior: it does not authorize
+from missing or stale Index state, does not convert a failed block/mute read into `Allow`, and
+does not silently fall back to Social Graph tables in the final executable host.
+
+## Final host composition
+
+The server facade keeps the existing provider bootstrap as an internal base step, then:
+
+1. materializes the canonical PostgreSQL `SharedIndexQueryRuntime`;
+2. requires that runtime when Social Graph, Profiles, and Notifications are compiled;
+3. recomposes `ServerNotificationRecipientPolicy` with
+   `IndexSocialGraphPrivacyReadPort`;
+4. preserves explicitly registered `NotificationBlockReadRuntime` or
+   `NotificationMuteReadRuntime` overrides;
+5. publishes only the recomposed final extension set.
+
+The temporary DB-backed policy constructed inside the private base bootstrap never escapes
+that function. Missing shared runtime fails server bootstrap rather than retaining the old
+read path.
+
+## Boundary
+
+This slice does not:
+
+- move Social Graph source authority or replay ownership into Index;
+- change relation commands, revision checks, event publication, projection, or DLQ handling;
+- use Index for revision-bearing `SocialGraphFollowReadPort` results;
+- cut profile privacy, presentation authorization, GraphQL, storefront, or admin reads over;
+- enable the notification candidate worker by default;
+- claim projection freshness, PostgreSQL execution evidence, or live equivalence;
+- add many-link aggregate ordering or another source schema.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-social-graph --features index index_privacy -- --nocapture
+cargo test -p rustok-server host_materializes_index_query_runtime_after_source_registry -- --nocapture
+cargo check -p rustok-social-graph --features index --all-targets
+cargo check -p rustok-server --all-targets
+node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+node scripts/verify/verify-social-graph-notification-policy.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo xtask module validate index
+cargo xtask module validate social_graph
+```

--- a/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
+++ b/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
@@ -1,87 +1,101 @@
-# M4 Social Graph privacy consumer cutover
+# M4 Social Graph privacy parity shadow
 
 Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-This slice provides the first authorized production consumer source for
-`SharedIndexQueryRuntime`. It can move Social Graph block/mute reads used by notification
-recipient policy from direct owner-table reads to the generic Index query port while keeping
-Social Graph as the contract and replay owner.
+This slice provides the first production-shaped consumer of `SharedIndexQueryRuntime`
+without granting an eventually consistent projection privacy authority. Social Graph remains
+the sole decision source for notification block/mute policy; Index is queried only as a
+comparison shadow.
 
-Activation is intentionally default-off. The final host selects the Index-backed policy only
-when `RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED=true`. Before activation, the existing
-authoritative owner read path remains in place. This avoids making an ordinary deployment
-unavailable while the projection worker is still default-off and live readiness/freshness
-evidence remains an owner action.
+The shadow is default-off and activates only with
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED=true`. It exists to collect operational
+parity signals before any authoritative cutover is considered.
 
-## Owner adapter
+## Typed Index adapter
 
 `IndexSocialGraphPrivacyReadPort` implements the existing
-`SocialGraphPrivacyReadPort` contract. It receives only a clone of the neutral
+`SocialGraphPrivacyReadPort` contract. It receives only the neutral
 `SharedIndexQueryRuntime`; it does not receive a database connection, construct
 `PostgresIndexQueryPort`, or read `social_graph_relations`.
 
 The adapter builds typed queries against the owner-published
 `rustok-social-graph::relation@1` schema:
 
-- block suppression checks `relation_kind = block` and accepts a block in either direction;
-- mute suppression remains directional from notification recipient to actor;
-- point follow reads remain directional and retain source-actor authorization;
-- bounded follow batches retain the existing maximum of 100 targets, deduplicate input,
-  query through `In`, validate every projected UUID, and return deterministic sorted IDs.
+- block checks `relation_kind = block` and accept a block in either direction;
+- mute remains directional from notification recipient to actor;
+- point follow remains directional and retains source-actor authorization;
+- bounded follow batches retain the 100-target maximum, deduplicate input, use typed `In`,
+  validate every projected UUID, and return deterministic sorted IDs.
 
-Inactive relations are absent because owner projection publishes an Index tombstone for an
-inactive revision. The adapter therefore does not add an independent active-state field or
-reinterpret source revision.
+Inactive relations are absent because the owner projection publishes an Index tombstone for
+an inactive revision. Relation revision remains Index `source_version`; the adapter does not
+invent a selectable revision field.
 
-## Authorization and failure contract
+## Non-authoritative shadow
 
-Every method preserves `PortCallPolicy::read`, tenant parsing, self-relation rejection, and
-the existing user/source actor rule for follow reads. Notification policy calls use the
-existing bounded service actor and matching tenant context.
+`IndexShadowSocialGraphPrivacyReadPort` wraps two ports:
 
-`SchemaNotReady` and Index storage failures map to retryable
-`social_graph.index_privacy_unavailable`. Query-plan, compiler, decoder, backend, and
-projected-result contract failures map to the non-retryable invariant code
-`social_graph.index_privacy_contract_invalid`.
+- the authoritative owner `SocialGraphPrivacyReadPort`;
+- the typed `IndexSocialGraphPrivacyReadPort` projection adapter.
 
-After activation, notification policy therefore uses retryable fail-closed behavior: it does
-not authorize from missing or stale Index state, does not convert a failed block/mute read
-into `Allow`, and does not silently fall back to Social Graph tables.
+Each method executes the owner read first. If that read fails, the existing owner error is
+returned and no projection result can replace it. After owner success, the shadow executes
+the equivalent Index read, records only bounded operation/result information, and always
+returns the owner result.
 
-## Final host composition
+Index mismatch, missing tenant schema, storage failure, or contract error is observational
+only in this slice. It never authorizes, suppresses, widens, or otherwise changes notification
+policy. Logs contain operation, booleans/counts, bounded stable error code, and retryability;
+they contain no tenant, user, relation, entity, payload, SQL, or storage details.
 
-The server facade keeps the existing provider bootstrap as an internal base step, then:
+## Server composition
 
-1. materializes the canonical PostgreSQL `SharedIndexQueryRuntime`;
-2. parses the explicit default-off activation flag;
-3. when disabled, preserves the authoritative owner policy from the base bootstrap;
-4. when enabled, requires the shared runtime and recomposes
-   `ServerNotificationRecipientPolicy` with `IndexSocialGraphPrivacyReadPort`;
-5. preserves explicitly registered `NotificationBlockReadRuntime` or
-   `NotificationMuteReadRuntime` overrides;
-6. publishes only the selected final extension set.
+The final server facade:
 
-An invalid activation value fails bootstrap. Once the flag is enabled, a missing shared
-runtime also fails bootstrap and no owner-table fallback remains in that activated path.
+1. completes ordinary provider composition;
+2. materializes `SharedIndexQueryRuntime` from the source-owned registry and host database;
+3. parses the default-off shadow flag;
+4. when disabled, publishes the unchanged owner-backed notification policy;
+5. when enabled, requires the shared runtime and recomposes the policy with
+   `IndexShadowSocialGraphPrivacyReadPort`;
+6. preserves explicitly registered `NotificationBlockReadRuntime` and
+   `NotificationMuteReadRuntime` overrides.
+
+An invalid flag or missing runtime while shadow is enabled fails bootstrap. The shadow still
+uses the authoritative owner result for every policy decision.
+
+## Why authoritative cutover remains blocked
+
+A successful Index query can still be stale without returning an error. Therefore an absent
+projected block or mute cannot safely prove absence in authoritative Social Graph storage.
+Schema readiness alone does not provide per-tenant catch-up, bounded lag, or negative-result
+safety.
+
+Before cutover, the owner must retain evidence for:
+
+- current per-tenant projection watermark and bounded lag;
+- replay/repair behavior after missing or corrupted projection state;
+- positive and negative block/mute result parity;
+- behavior during worker outage, reconnect, restart, and backlog catch-up;
+- acceptable shadow latency and resource overhead;
+- an explicit fail-closed freshness policy for negative projection results.
 
 ## Boundary
 
 This slice does not:
 
-- activate Index privacy reads by default;
-- claim that the default-off projection consumer is already healthy or caught up;
+- make Index authoritative for notification privacy;
+- change the policy result based on Index mismatch or failure;
+- activate the shadow by default;
 - move Social Graph source authority or replay ownership into Index;
-- change relation commands, revision checks, event publication, projection, or DLQ handling;
+- change commands, revision checks, event publication, projection, or DLQ handling;
 - use Index for revision-bearing `SocialGraphFollowReadPort` results;
 - cut profile privacy, presentation authorization, GraphQL, storefront, or admin reads over;
-- enable the notification candidate worker by default;
-- claim projection freshness, PostgreSQL execution evidence, or live equivalence;
+- enable the Social Graph projection worker or notification candidate worker by default;
+- claim PostgreSQL execution, live parity, freshness, or retained evidence;
 - add many-link aggregate ordering or another source schema.
-
-Activation requires retained projection readiness, lag, and result-parity evidence plus an
-operator decision to set the flag on the consuming host.
 
 ## Owner validation
 

--- a/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
+++ b/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
@@ -4,10 +4,16 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-This slice is the first authorized production consumer of `SharedIndexQueryRuntime`.
-It moves the default Social Graph block/mute reads used by notification recipient policy
-from direct owner-table reads to the generic Index query port while keeping Social Graph
-as the contract and replay owner.
+This slice provides the first authorized production consumer source for
+`SharedIndexQueryRuntime`. It can move Social Graph block/mute reads used by notification
+recipient policy from direct owner-table reads to the generic Index query port while keeping
+Social Graph as the contract and replay owner.
+
+Activation is intentionally default-off. The final host selects the Index-backed policy only
+when `RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED=true`. Before activation, the existing
+authoritative owner read path remains in place. This avoids making an ordinary deployment
+unavailable while the projection worker is still default-off and live readiness/freshness
+evidence remains an owner action.
 
 ## Owner adapter
 
@@ -40,30 +46,32 @@ existing bounded service actor and matching tenant context.
 projected-result contract failures map to the non-retryable invariant code
 `social_graph.index_privacy_contract_invalid`.
 
-The notification policy therefore uses retryable fail-closed behavior: it does not authorize
-from missing or stale Index state, does not convert a failed block/mute read into `Allow`, and
-does not silently fall back to Social Graph tables in the final executable host.
+After activation, notification policy therefore uses retryable fail-closed behavior: it does
+not authorize from missing or stale Index state, does not convert a failed block/mute read
+into `Allow`, and does not silently fall back to Social Graph tables.
 
 ## Final host composition
 
 The server facade keeps the existing provider bootstrap as an internal base step, then:
 
 1. materializes the canonical PostgreSQL `SharedIndexQueryRuntime`;
-2. requires that runtime when Social Graph, Profiles, and Notifications are compiled;
-3. recomposes `ServerNotificationRecipientPolicy` with
-   `IndexSocialGraphPrivacyReadPort`;
-4. preserves explicitly registered `NotificationBlockReadRuntime` or
+2. parses the explicit default-off activation flag;
+3. when disabled, preserves the authoritative owner policy from the base bootstrap;
+4. when enabled, requires the shared runtime and recomposes
+   `ServerNotificationRecipientPolicy` with `IndexSocialGraphPrivacyReadPort`;
+5. preserves explicitly registered `NotificationBlockReadRuntime` or
    `NotificationMuteReadRuntime` overrides;
-5. publishes only the recomposed final extension set.
+6. publishes only the selected final extension set.
 
-The temporary DB-backed policy constructed inside the private base bootstrap never escapes
-that function. Missing shared runtime fails server bootstrap rather than retaining the old
-read path.
+An invalid activation value fails bootstrap. Once the flag is enabled, a missing shared
+runtime also fails bootstrap and no owner-table fallback remains in that activated path.
 
 ## Boundary
 
 This slice does not:
 
+- activate Index privacy reads by default;
+- claim that the default-off projection consumer is already healthy or caught up;
 - move Social Graph source authority or replay ownership into Index;
 - change relation commands, revision checks, event publication, projection, or DLQ handling;
 - use Index for revision-bearing `SocialGraphFollowReadPort` results;
@@ -71,6 +79,9 @@ This slice does not:
 - enable the notification candidate worker by default;
 - claim projection freshness, PostgreSQL execution evidence, or live equivalence;
 - add many-link aggregate ordering or another source schema.
+
+Activation requires retained projection readiness, lag, and result-parity evidence plus an
+operator decision to set the flag on the consuming host.
 
 ## Owner validation
 

--- a/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
+++ b/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
@@ -42,13 +42,14 @@ invent a selectable revision field.
 
 Each method executes the owner read first. If that read fails, the existing owner error is
 returned and no projection result can replace it. After owner success, the shadow executes
-the equivalent Index read, records only bounded operation/result information, and always
-returns the owner result.
+the equivalent Index read with a hard 100 ms comparison timeout, records only bounded
+operation/result information, and always returns the owner result.
 
-Index mismatch, missing tenant schema, storage failure, or contract error is observational
-only in this slice. It never authorizes, suppresses, widens, or otherwise changes notification
-policy. Logs contain operation, booleans/counts, bounded stable error code, and retryability;
-they contain no tenant, user, relation, entity, payload, SQL, or storage details.
+Index mismatch, timeout, missing tenant schema, storage failure, or contract error is
+observational only in this slice. It never authorizes, suppresses, widens, or otherwise
+changes notification policy. Logs contain operation, booleans/counts, bounded stable error
+code, retryability, or the fixed timeout; they contain no tenant, user, relation, entity,
+payload, SQL, or storage details.
 
 ## Server composition
 
@@ -64,7 +65,8 @@ The final server facade:
    `NotificationMuteReadRuntime` overrides.
 
 An invalid flag or missing runtime while shadow is enabled fails bootstrap. The shadow still
-uses the authoritative owner result for every policy decision.
+uses the authoritative owner result for every policy decision, and a slow comparison is
+cancelled after 100 ms.
 
 ## Why authoritative cutover remains blocked
 
@@ -87,7 +89,7 @@ Before cutover, the owner must retain evidence for:
 This slice does not:
 
 - make Index authoritative for notification privacy;
-- change the policy result based on Index mismatch or failure;
+- change the policy result based on Index mismatch, timeout, or failure;
 - activate the shadow by default;
 - move Social Graph source authority or replay ownership into Index;
 - change commands, revision checks, event publication, projection, or DLQ handling;

--- a/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
+++ b/crates/rustok-index/docs/m4-social-graph-privacy-consumer.md
@@ -42,14 +42,13 @@ invent a selectable revision field.
 
 Each method executes the owner read first. If that read fails, the existing owner error is
 returned and no projection result can replace it. After owner success, the shadow executes
-the equivalent Index read with a hard 100 ms comparison timeout, records only bounded
-operation/result information, and always returns the owner result.
+the equivalent Index read, records only bounded operation/result information, and always
+returns the owner result.
 
-Index mismatch, timeout, missing tenant schema, storage failure, or contract error is
-observational only in this slice. It never authorizes, suppresses, widens, or otherwise
-changes notification policy. Logs contain operation, booleans/counts, bounded stable error
-code, retryability, or the fixed timeout; they contain no tenant, user, relation, entity,
-payload, SQL, or storage details.
+Index mismatch, missing tenant schema, storage failure, or contract error is observational
+only in this slice. It never authorizes, suppresses, widens, or otherwise changes notification
+policy. Logs contain operation, booleans/counts, bounded stable error code, and retryability;
+they contain no tenant, user, relation, entity, payload, SQL, or storage details.
 
 ## Server composition
 
@@ -65,8 +64,7 @@ The final server facade:
    `NotificationMuteReadRuntime` overrides.
 
 An invalid flag or missing runtime while shadow is enabled fails bootstrap. The shadow still
-uses the authoritative owner result for every policy decision, and a slow comparison is
-cancelled after 100 ms.
+uses the authoritative owner result for every policy decision.
 
 ## Why authoritative cutover remains blocked
 
@@ -75,7 +73,7 @@ projected block or mute cannot safely prove absence in authoritative Social Grap
 Schema readiness alone does not provide per-tenant catch-up, bounded lag, or negative-result
 safety.
 
-Before cutover, the owner must retain evidence for:
+Before enabling the shadow or considering cutover, the owner must retain evidence for:
 
 - current per-tenant projection watermark and bounded lag;
 - replay/repair behavior after missing or corrupted projection state;
@@ -89,14 +87,14 @@ Before cutover, the owner must retain evidence for:
 This slice does not:
 
 - make Index authoritative for notification privacy;
-- change the policy result based on Index mismatch, timeout, or failure;
+- change the policy result based on Index mismatch or failure;
 - activate the shadow by default;
 - move Social Graph source authority or replay ownership into Index;
 - change commands, revision checks, event publication, projection, or DLQ handling;
 - use Index for revision-bearing `SocialGraphFollowReadPort` results;
 - cut profile privacy, presentation authorization, GraphQL, storefront, or admin reads over;
 - enable the Social Graph projection worker or notification candidate worker by default;
-- claim PostgreSQL execution, live parity, freshness, or retained evidence;
+- claim PostgreSQL execution, live parity, freshness, latency, or retained evidence;
 - add many-link aggregate ordering or another source schema.
 
 ## Owner validation

--- a/crates/rustok-social-graph/CRATE_API.md
+++ b/crates/rustok-social-graph/CRATE_API.md
@@ -7,6 +7,7 @@
 - `follow_read`
 - `graphql` behind feature `graphql`
 - `index` behind feature `index`
+- `index_privacy` behind feature `index`
 - `index_consumer` behind feature `index-consumer`
 - `index_dlq_receipt` behind feature `index-consumer`
 - `maintenance`
@@ -27,7 +28,10 @@
   persists relation state, a durable command receipt, and any real state-change event
   in one owner transaction.
 - `SocialGraphPrivacyReadPort` owns block/mute/follow policy reads.
-- `SocialGraphFollowReadPort` exposes revision-bearing directional follow state.
+- `IndexSocialGraphPrivacyReadPort` is the typed Index-backed implementation used by the
+  final server notification block/mute policy when feature `index` is enabled.
+- `SocialGraphFollowReadPort` exposes revision-bearing directional follow state and is not
+  served from the current Index schema.
 - `SocialGraphReceiptMaintenancePort::cleanup_completed_receipts(...)` exposes
   service/system-only dry-run and bounded completed-receipt cleanup.
 - `SocialGraphRelationEventMaintenancePort::replay_relation_state_events(...)`
@@ -76,8 +80,8 @@
 
 ## Optional Index projection
 
-- Feature `index` enables generic Index conversion without making Index a default
-  runtime dependency.
+- Feature `index` enables generic Index conversion and typed privacy reads without making
+  Index the owner of relation state or replay.
 - `social_graph_relation_index_schema()` declares non-localized relation records keyed
   by tenant and relation id.
 - `social_graph_relation_index_mutation(tenant_id, event_id, event)` accepts only a
@@ -85,7 +89,26 @@
 - Active revisions become `IndexMutation::Upsert`; inactive revisions become
   revisioned `IndexMutation::Delete` tombstones.
 - Relation revision becomes Index `source_version`.
-- The adapter contains no database, broker, or privacy authorization logic.
+- The projection adapter contains no privacy authorization logic.
+
+## Index privacy read adapter
+
+- `IndexSocialGraphPrivacyReadPort::new(SharedIndexQueryRuntime)` stores only the neutral
+  `Arc<dyn IndexQueryPort>` capability. It receives no database connection and never
+  constructs `PostgresIndexQueryPort`.
+- Block checks preserve either-direction semantics with typed `And`/`Or` filters.
+- Mute and follow checks remain directional; follow reads retain source-actor validation.
+- Follow batches retain the existing 100-target bound, deduplicate targets, use a typed
+  `In` filter, validate projected UUIDs, and return deterministic sorted IDs.
+- Every operation preserves `PortCallPolicy::read`, tenant parsing, and self-relation
+  rejection.
+- Missing persisted tenant schema or Index storage availability maps to retryable
+  fail-closed `social_graph.index_privacy_unavailable`.
+- Plan/compiler/decoder/backend/result-contract drift maps to non-retryable
+  `social_graph.index_privacy_contract_invalid`.
+- The final server notification block/mute policy requires `SharedIndexQueryRuntime` and
+  does not fall back to owner tables. Custom notification block/mute runtimes still win.
+- The adapter does not provide revision-bearing `SocialGraphFollowReadPort` results.
 
 ## Durable Index consumer
 
@@ -246,20 +269,26 @@
 
 ## Authority boundary
 
-- Social Graph owner ports and storage remain authoritative for block/mute/follow.
-- Profiles privacy must not authorize from Index state, decoded or raw DLQ receipts,
-  broker IDs, deduplication state, or consumer lag.
-- The adapter, projector, consumer, worker, position observer, and telemetry never read
-  Social Graph relation tables for projection work.
-- Index and DLQ/lag operations are optional infrastructure and must not authorize
-  presentation.
+- Social Graph owner storage, commands, events, replay, and drift repair remain the source
+  authority for block/mute/follow.
+- Notification block/mute policy may consume the approved Index projection only through
+  `IndexSocialGraphPrivacyReadPort`; missing readiness is retryable fail-closed and never
+  becomes an implicit allow.
+- Profiles privacy, presentation visibility, and revision-bearing follow state must not
+  authorize from Index state, decoded or raw DLQ receipts, broker IDs, deduplication state,
+  or consumer lag.
+- The projector, consumer, worker, position observer, and telemetry never read Social Graph
+  relation tables for projection work.
+- Index and DLQ/lag operations remain optional infrastructure and must not independently
+  authorize presentation.
 
 ## Dependencies
 
 - `rustok-api`: port context, actor, deadlines, idempotency, replay policy, typed errors.
 - `rustok-core`: module and migration contracts.
 - `rustok-events`: sealed relation event family.
-- optional `rustok-index`: schema, conversion, registration, mutation persistence.
+- optional `rustok-index`: schema, conversion, registration, mutation persistence, and
+  typed query runtime consumption.
 - optional `rustok-iggy`: persistent typed cursor, exact payload retention, deterministic
   DLQ header publication, DLQ, ack, and read-only broker position observation.
 - server composition uses `rustok-iggy-connector` feature `migrations` for neutral raw
@@ -278,6 +307,11 @@
 - Putting idempotency keys, request context, claims, roles, locale, channel, or command
   receipt snapshots into the external event.
 - Reading relation tables from Profiles, Index, or another consumer.
+- Constructing `PostgresIndexQueryPort` in Social Graph or bypassing
+  `SharedIndexQueryRuntime`.
+- Falling back to owner-table notification block/mute reads after final host composition.
+- Treating missing Index schema readiness as no block or no mute.
+- Using Index for revision-bearing follow state or Profiles presentation authorization.
 - Registering only in memory and assuming the persisted schema foreign key exists.
 - Writing `index_schemas` directly from Social Graph.
 - Calling the compatibility `receive_next` in a worker that must handle raw decode
@@ -319,6 +353,8 @@
 - `social_graph.relation_event_replay_forbidden`
 - `social_graph.relation_event_replay_limit_invalid`
 - `social_graph.storage_unavailable`
+- `social_graph.index_privacy_unavailable`
+- `social_graph.index_privacy_contract_invalid`
 - Index consumption maps typed schema/registry/mutation failures to bounded
   `social_graph.index.*` host codes without publishing private storage causes.
 - Decoded DLQ receipts add bounded `social_graph.index.dlq_receipt_*` and

--- a/crates/rustok-social-graph/CRATE_API.md
+++ b/crates/rustok-social-graph/CRATE_API.md
@@ -8,6 +8,7 @@
 - `graphql` behind feature `graphql`
 - `index` behind feature `index`
 - `index_privacy` behind feature `index`
+- `index_privacy_shadow` behind feature `index`
 - `index_consumer` and `index_dlq_receipt` behind feature `index-consumer`
 - `maintenance`
 - `migrations`
@@ -26,12 +27,13 @@ write-capable owner service used by GraphQL and native storefront composition.
 
 - `SocialGraphCommandPort::set_relation` owns validated, idempotent relation commands.
 - `SocialGraphPrivacyReadPort` owns block, mute, and bounded directional follow policy reads.
-- `IndexSocialGraphPrivacyReadPort` is the typed Index-backed privacy implementation.
+- `IndexSocialGraphPrivacyReadPort` is the typed Index projection reader.
+- `IndexShadowSocialGraphPrivacyReadPort` compares Index with the authoritative owner port
+  while always returning the owner result.
 - `SocialGraphFollowReadPort` exposes revision-bearing follow state and is not served from
   the current Index schema.
 - `SocialGraphReceiptMaintenancePort` owns bounded completed-receipt cleanup.
-- `SocialGraphRelationEventMaintenancePort` owns bounded replay of authoritative relation
-  facts.
+- `SocialGraphRelationEventMaintenancePort` owns bounded replay of authoritative facts.
 - `SocialRelationKind::{Block, Mute, Follow}` defines canonical persistence and event values.
 
 ## Command and receipt contract
@@ -58,12 +60,12 @@ write-capable owner service used by GraphQL and native storefront composition.
   and rolls relation plus receipt back together.
 - Bounded Social Graph replay republishes the same sealed facts. Consumers must handle
   duplicate/stale delivery through monotonic revision.
-- Social Graph storage, commands, events, replay, and drift repair remain authoritative.
+- Social Graph persistence remains authoritative for drift repair.
 
 ## Optional Index projection
 
-Feature `index` enables generic Index conversion and typed privacy consumption without
-moving source authority into Index.
+Feature `index` enables generic Index conversion and typed privacy comparison without moving
+source authority into Index.
 
 - `social_graph_relation_index_schema()` declares non-localized relation records keyed by
   tenant and relation ID.
@@ -74,7 +76,7 @@ moving source authority into Index.
 - Relation revision becomes Index `source_version`.
 - Projection conversion contains no database, broker, or privacy authorization logic.
 
-## Index privacy read adapter
+## Typed Index privacy reader
 
 `IndexSocialGraphPrivacyReadPort::new(SharedIndexQueryRuntime)` stores only the neutral
 `Arc<dyn IndexQueryPort>` capability. It receives no database connection, never constructs
@@ -86,19 +88,35 @@ moving source authority into Index.
 - Follow batches retain the 100-target bound, deduplicate input, use typed `In`, validate
   projected UUIDs, and return deterministic sorted IDs.
 - All operations preserve `PortCallPolicy::read`, tenant parsing, and self-relation rejection.
-- Missing tenant schema or storage availability maps to retryable fail-closed
+- Missing tenant schema or storage availability maps to retryable
   `social_graph.index_privacy_unavailable`.
 - Plan/compiler/decoder/backend/result-contract drift maps to non-retryable
   `social_graph.index_privacy_contract_invalid`.
 
-The final notification block/mute policy selects this adapter only when
-`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED=true`. The flag is default-off. Before
-activation the authoritative owner read path remains selected. After activation,
-`SharedIndexQueryRuntime` is mandatory and no owner-table fallback is allowed. Custom
-notification block/mute runtimes retain priority.
+The typed reader is not independently authorized to decide privacy. A successful empty result
+may be stale and therefore cannot prove that no current block or mute exists.
 
-This adapter does not provide revision-bearing `SocialGraphFollowReadPort` results and must
-not authorize Profiles presentation visibility.
+## Non-authoritative Index privacy shadow
+
+`IndexShadowSocialGraphPrivacyReadPort` owns an authoritative
+`Arc<dyn SocialGraphPrivacyReadPort>` plus `IndexSocialGraphPrivacyReadPort`.
+
+- Every method executes the owner read first.
+- Owner error is returned unchanged.
+- After owner success, the same request is issued to Index for comparison.
+- Match, mismatch, or Index error is recorded with bounded operation/result fields only.
+- Tenant, user, relation, entity, payload, SQL, and storage details are not logged.
+- All four methods return the owner result; the Index shadow never authorizes or suppresses.
+
+The final notification block/mute policy uses this wrapper only when
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED=true`. The shadow is default-off. When
+disabled, ordinary owner policy remains unchanged. When enabled, `SharedIndexQueryRuntime`
+is required, but the owner result remains authoritative. Custom notification block/mute
+runtimes retain priority.
+
+Authoritative cutover is blocked until retained per-tenant freshness/watermark, lag,
+positive/negative parity, outage/recovery, repair, latency, and negative-result fail-closed
+evidence exists.
 
 ## Durable Index consumer
 
@@ -173,13 +191,11 @@ Feature `index-consumer` adds optional persistent Iggy consumption on top of `in
 
 ## Authority boundary
 
-- Social Graph owner storage, commands, events, replay, and drift repair remain authoritative
-  for block, mute, and follow.
-- Notification block/mute policy may consume the approved Index projection only through
-  `IndexSocialGraphPrivacyReadPort` and only after the explicit default-off activation flag
-  is enabled.
-- Once activated, missing readiness is retryable fail-closed and never becomes an implicit
-  allow or owner-table fallback.
+- Social Graph owner storage, commands, events, replay, drift repair, and privacy decisions
+  remain authoritative for block, mute, and follow.
+- Notification block/mute policy may run the approved Index projection only through
+  `IndexShadowSocialGraphPrivacyReadPort`, which always returns the owner result.
+- Index shadow mismatch or failure never authorizes, suppresses, widens, or changes policy.
 - Profiles privacy, presentation visibility, and revision-bearing follow state must not
   authorize from Index state, DLQ receipts, broker IDs, deduplication state, or consumer lag.
 - Projection infrastructure must not independently authorize presentation.
@@ -204,9 +220,10 @@ Feature `index-consumer` adds optional persistent Iggy consumption on top of `in
 - Reading Social Graph tables from Profiles, Index, or another consumer.
 - Constructing `PostgresIndexQueryPort` in Social Graph or bypassing
   `SharedIndexQueryRuntime`.
-- Enabling Index privacy reads before retained readiness, lag, and result-parity evidence.
-- Falling back to owner-table notification block/mute reads after the activation flag is true.
-- Treating missing Index schema readiness as no block or no mute.
+- Returning the Index result from the privacy shadow instead of the owner result.
+- Treating shadow mismatch, error, or empty projection as a privacy decision.
+- Treating schema readiness as a freshness watermark.
+- Logging tenant/user/relation identities from shadow comparison.
 - Using Index for revision-bearing follow state or Profiles presentation authorization.
 - Acknowledging before durable Index or DLQ result completion.
 - Inventing tenant/event identity for undecodable bytes.

--- a/crates/rustok-social-graph/CRATE_API.md
+++ b/crates/rustok-social-graph/CRATE_API.md
@@ -8,8 +8,7 @@
 - `graphql` behind feature `graphql`
 - `index` behind feature `index`
 - `index_privacy` behind feature `index`
-- `index_consumer` behind feature `index-consumer`
-- `index_dlq_receipt` behind feature `index-consumer`
+- `index_consumer` and `index_dlq_receipt` behind feature `index-consumer`
 - `maintenance`
 - `migrations`
 - `model`
@@ -19,326 +18,202 @@
 
 ## Owner services and ports
 
-- `SocialGraphService::new(DatabaseConnection)` creates a read-only owner service;
-  relation writes fail closed until a transactional event bus is supplied.
-- `SocialGraphService::with_event_bus(DatabaseConnection, TransactionalEventBus)`
-  creates the write-capable owner service used by GraphQL and native storefront
-  composition.
-- `SocialGraphCommandPort::set_relation(PortContext, SetSocialRelationCommand)`
-  persists relation state, a durable command receipt, and any real state-change event
-  in one owner transaction.
-- `SocialGraphPrivacyReadPort` owns block/mute/follow policy reads.
-- `IndexSocialGraphPrivacyReadPort` is the typed Index-backed implementation used by the
-  final server notification block/mute policy when feature `index` is enabled.
-- `SocialGraphFollowReadPort` exposes revision-bearing directional follow state and is not
-  served from the current Index schema.
-- `SocialGraphReceiptMaintenancePort::cleanup_completed_receipts(...)` exposes
-  service/system-only dry-run and bounded completed-receipt cleanup.
-- `SocialGraphRelationEventMaintenancePort::replay_relation_state_events(...)`
-  exposes service/system-only bounded replay of authoritative relation facts.
-- `SocialGraphRelationEventReplayCommand` carries optional exclusive UUID cursor,
-  limit, and dry-run mode; the result returns selected/published counts and next cursor.
-- `SocialRelationKind::{Block, Mute, Follow}` defines canonical persistence and event
-  kind values.
+SocialGraphService::new(DatabaseConnection) creates a read-only owner service; relation
+writes fail closed until a transactional event bus is supplied.
 
-## Durable command contract
+SocialGraphService::with_event_bus(DatabaseConnection, TransactionalEventBus) creates the
+write-capable owner service used by GraphQL and native storefront composition.
 
-- Commands require valid tenant, deadline, non-empty idempotency key, actor/source
+- `SocialGraphCommandPort::set_relation` owns validated, idempotent relation commands.
+- `SocialGraphPrivacyReadPort` owns block, mute, and bounded directional follow policy reads.
+- `IndexSocialGraphPrivacyReadPort` is the typed Index-backed privacy implementation.
+- `SocialGraphFollowReadPort` exposes revision-bearing follow state and is not served from
+  the current Index schema.
+- `SocialGraphReceiptMaintenancePort` owns bounded completed-receipt cleanup.
+- `SocialGraphRelationEventMaintenancePort` owns bounded replay of authoritative relation
+  facts.
+- `SocialRelationKind::{Block, Mute, Follow}` defines canonical persistence and event values.
+
+## Command and receipt contract
+
+- Commands require a valid tenant, deadline, non-empty idempotency key, actor/source
   ownership, distinct target, canonical kind, and optional expected revision.
-- Receipt identity is tenant plus normalized idempotency key.
-- One key binds one complete command identity.
-- Receipt reservation, mutation, optional event append, response snapshot, completion,
-  and commit share one database transaction.
-- Exact receipt replay returns the committed response without publishing a new event.
+- Receipt identity is tenant plus normalized idempotency key, and one key binds one complete
+  command identity.
+- Receipt reservation, mutation, optional event append, response snapshot, completion, and
+  commit share one owner transaction.
+- Exact receipt replay returns the committed response without publishing another event.
 - Identity reuse fails as `social_graph.idempotency_conflict`.
-- Corrupt, incomplete, or unsupported receipt state fails closed.
+- Corrupt, incomplete, unsupported, or revision-conflicting state fails closed.
 
-## Receipt cleanup and replay
+## Events and authoritative replay
 
-- Cleanup accepts service/system actors only, uses an explicit past cutoff, supports
-  dry-run, and limits batches to 1..1000.
-- Candidates are tenant-scoped, completed, schema-v1, ordered by `(completed_at, id)`,
-  and all validated before deletion.
-- The CLI requires explicit tenant and positive retention days; no default retention
-  policy or automatic scheduler exists.
-- Relation-event replay is service/system-only, tenant-scoped, UUID-cursor bounded,
-  dry-run capable, and page-atomic.
-- Bounded Social Graph replay republishes the same sealed relation facts used by live
-  writes. Consumers must handle duplicate/stale delivery through monotonic revision.
-
-## Events
-
-- Publishes sealed `rustok_events::SocialGraphRelationEvent`
-  `social_graph.relation.state_changed` v1 through
+- The module publishes sealed `social_graph.relation.state_changed` v1 through
   `TransactionalEventBus::publish_contract_in_tx`.
-- Payload contains relation id, source/target user ids, canonical kind, active state,
-  and revision only; tenant and actor remain envelope metadata.
-- New relations and persisted active-state transitions publish before shared commit.
-- Receipt replay and exact persisted-state no-op publish no new live event.
-- Event publication failure rolls relation and receipt back together.
-- Social Graph persistence remains authoritative for repair.
+- Payload contains relation ID, source/target user IDs, canonical kind, active state, and
+  revision; request context and receipt internals are excluded.
+- New relations and real active-state transitions publish before the shared commit.
+- Receipt replay and persisted-state no-op publish no new live event.
+- Missing transactional publication returns `social_graph.event_publication_unavailable`
+  and rolls relation plus receipt back together.
+- Bounded Social Graph replay republishes the same sealed facts. Consumers must handle
+  duplicate/stale delivery through monotonic revision.
+- Social Graph storage, commands, events, replay, and drift repair remain authoritative.
 
 ## Optional Index projection
 
-- Feature `index` enables generic Index conversion and typed privacy reads without making
-  Index the owner of relation state or replay.
-- `social_graph_relation_index_schema()` declares non-localized relation records keyed
-  by tenant and relation id.
+Feature `index` enables generic Index conversion and typed privacy consumption without
+moving source authority into Index.
+
+- `social_graph_relation_index_schema()` declares non-localized relation records keyed by
+  tenant and relation ID.
 - `social_graph_relation_index_mutation(tenant_id, event_id, event)` accepts only a
   validated sealed `SocialGraphRelationEvent`.
-- Active revisions become `IndexMutation::Upsert`; inactive revisions become
-  revisioned `IndexMutation::Delete` tombstones.
+- Active revisions become `IndexMutation::Upsert`; inactive revisions become revisioned
+  `IndexMutation::Delete` tombstones.
 - Relation revision becomes Index `source_version`.
-- The projection adapter contains no privacy authorization logic.
+- Projection conversion contains no database, broker, or privacy authorization logic.
 
 ## Index privacy read adapter
 
-- `IndexSocialGraphPrivacyReadPort::new(SharedIndexQueryRuntime)` stores only the neutral
-  `Arc<dyn IndexQueryPort>` capability. It receives no database connection and never
-  constructs `PostgresIndexQueryPort`.
-- Block checks preserve either-direction semantics with typed `And`/`Or` filters.
-- Mute and follow checks remain directional; follow reads retain source-actor validation.
-- Follow batches retain the existing 100-target bound, deduplicate targets, use a typed
-  `In` filter, validate projected UUIDs, and return deterministic sorted IDs.
-- Every operation preserves `PortCallPolicy::read`, tenant parsing, and self-relation
-  rejection.
-- Missing persisted tenant schema or Index storage availability maps to retryable
-  fail-closed `social_graph.index_privacy_unavailable`.
+`IndexSocialGraphPrivacyReadPort::new(SharedIndexQueryRuntime)` stores only the neutral
+`Arc<dyn IndexQueryPort>` capability. It receives no database connection, never constructs
+`PostgresIndexQueryPort`, and never reads `social_graph_relations`.
+
+- Block checks preserve either-direction semantics through typed `And` and `Or` filters.
+- Mute and follow checks remain directional.
+- Follow reads preserve source-actor validation.
+- Follow batches retain the 100-target bound, deduplicate input, use typed `In`, validate
+  projected UUIDs, and return deterministic sorted IDs.
+- All operations preserve `PortCallPolicy::read`, tenant parsing, and self-relation rejection.
+- Missing tenant schema or storage availability maps to retryable fail-closed
+  `social_graph.index_privacy_unavailable`.
 - Plan/compiler/decoder/backend/result-contract drift maps to non-retryable
   `social_graph.index_privacy_contract_invalid`.
-- The final server notification block/mute policy requires `SharedIndexQueryRuntime` and
-  does not fall back to owner tables. Custom notification block/mute runtimes still win.
-- The adapter does not provide revision-bearing `SocialGraphFollowReadPort` results.
+
+The final notification block/mute policy selects this adapter only when
+`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED=true`. The flag is default-off. Before
+activation the authoritative owner read path remains selected. After activation,
+`SharedIndexQueryRuntime` is mandatory and no owner-table fallback is allowed. Custom
+notification block/mute runtimes retain priority.
+
+This adapter does not provide revision-bearing `SocialGraphFollowReadPort` results and must
+not authorize Profiles presentation visibility.
 
 ## Durable Index consumer
 
-- Feature `index-consumer` adds optional Iggy runtime composition on top of `index`.
-- `SocialGraphIndexProjector::new(DatabaseConnection)` registers an in-memory schema,
-  persists or exactly recognizes the tenant schema through Index-owned
-  `PostgresSchemaRegistrationStore`, and applies through `PostgresMutationStore`.
-- Schema persistence is tenant-scoped, exact-version idempotent, monotonic, and
-  fail-closed for drift, retired state, invalid tenant, unsupported backend, or storage
-  failure. Social Graph imports no Index entities and writes no `index_schemas` rows.
-- `SocialGraphIndexConsumer::open(Arc<IggyTransport>, DatabaseConnection)` opens
-  persistent group `rustok-social-graph-index` on the shared `domain` topic.
-- `receive_delivery()` is the primary typed receive boundary and returns either a
-  validated `PersistentContractDelivery::Event` or an exact-byte
-  `PersistentContractDelivery::DecodeFailure`. It never acknowledges either result.
-- `receive_next()` remains the validated-event compatibility path.
+Feature `index-consumer` adds optional persistent Iggy consumption on top of `index`.
+
+- `SocialGraphIndexProjector` registers the owner schema, persists or exactly recognizes the
+  tenant contract through `PostgresSchemaRegistrationStore`, and applies through
+  `PostgresMutationStore`.
+- Schema persistence is tenant-scoped, exact-version idempotent, monotonic, and fail-closed
+  for drift, retired state, invalid tenant, unsupported backend, or storage failure.
+- `SocialGraphIndexConsumer` opens persistent group `rustok-social-graph-index` on topic
+  `domain`.
+- `receive_delivery()` returns either a validated event or an exact-byte decode failure and
+  never acknowledges either result.
 - `project_consumed` and `acknowledge_consumed` retain one outstanding decoded delivery
   across bounded retries.
-- `acknowledge_decode_failure` commits only the exact retained raw-delivery cursor after
-  the server worker establishes a durable neutral poison result. It performs no
-  projection, publication, or identity inference.
-- The result-first decoded contract checks any durable DLQ receipt before projection and
-  commits the source cursor only after a terminal owner result exists.
-- `process_next()` is the direct serialized validated-event receive/register/apply/ack
-  compatibility path. It acknowledges only after schema persistence and the Index inbox
-  result are durable; that result is committed before broker acknowledgement.
-- `Applied`, `Duplicate`, and `StaleIgnored` are terminal durable outcomes.
+- The decoded path is result-first: it checks durable DLQ state before projection and
+  acknowledges only after a terminal Index or DLQ result exists and that result is committed.
+- `acknowledge_decode_failure` commits only the exact raw-delivery cursor after the server
+  establishes durable neutral poison state. It performs no projection or identity inference.
+- `process_next()` remains the direct validated-event compatibility path and durably projects
+  before source acknowledgement.
+- `Applied`, `Duplicate`, and `StaleIgnored` are terminal outcomes.
 - Unrelated validated sealed families are acknowledged without schema registration or
   mutation.
-- `SocialGraphIndexConsumerError::{stable_code,is_retryable}` exposes bounded host
-  classification without schema JSON, payload, identity, or storage causes.
+- Stable error classification exposes no schema JSON, payload, identity, or private storage
+  cause.
 
-## Decoded-event DLQ receipt and broker identity
+## Decoded and raw poison recovery
 
-- Migration `m20260727_000004_create_index_dlq_receipts` owns one immutable poison
-  identity per `(tenant_id, consumer_group, event_id)` with exact source
-  stream/topic/partition/offset, original broker bytes, stable error code, and
-  projection attempt count.
+- The Social Graph DLQ receipt binds tenant, consumer group, event ID, exact broker
+  coordinates, original bytes, stable error code, and projection attempt count.
 - Receipt states are `reserved`, leased `publishing`, terminal `published`, and
-  bookkeeping-complete `acknowledged`. Claim leases are bounded and reclaimable after a
-  crashed publisher.
-- `project_consumed` checks the receipt before Index projection. `published` or
-  `acknowledged` returns the bounded recovered dead-letter outcome; `reserved` or
-  `publishing` remains retryable DLQ work and never re-enters mutation apply.
-- Internal `index_dlq_message_id` derives a deterministic RFC 9562 UUIDv8 from a
-  versioned domain plus tenant, consumer group, event ID, source stream/topic/partition/
-  offset, and exact payload. Length framing prevents concatenation ambiguity.
-- Retry count, wall-clock time, publisher instance, lease owner, and random values are
-  excluded, so every retry of one immutable receipt produces the same broker ID.
-- `publish_consumed_to_dlq` durably reserves/claims the identity, attaches the UUIDv8 to
-  `DlqEntry`, publishes exact retained bytes, and returns success only after the receipt
-  reaches `published`.
-- `IggyTransport` maps the UUIDv8 to Iggy's `u128` message header through a lazy SDK
-  publisher connection to the same configured endpoint and existing `dlq` topic.
-- Repeated calls recognize `published` or `acknowledged` and skip broker publication.
-- `acknowledge_consumed` commits the source cursor after a terminal Index or decoded DLQ
-  result. Receipt transition to `acknowledged` is best-effort bookkeeping after broker
-  commit and cannot turn a committed source offset back into a failure.
-- `move_to_dlq_and_acknowledge` remains a convenience method and preserves durable
-  receipt/broker publication before source acknowledgement.
-- Ack failure after `publish_consumed_to_dlq` succeeds leaves a durable `published`
-  receipt; redelivery skips both projection and DLQ publication and retries source ack.
-- Broker success followed by process/DB failure before the `published` transition has
-  confirmation ambiguity. Republication carries the same UUIDv8; physical duplicate
-  suppression occurs only when Iggy deduplication is enabled and its per-partition
-  cache/expiry still covers the recovery interval.
-- Durable receipt state, not broker deduplication, remains the terminal owner contract;
-  physical broker exactly-once is not claimed without retained configuration/runtime
-  evidence or a stronger transaction/outbox mechanism.
-
-## Raw decode-failure poison contract
-
-- `ConsumedContractDecodeFailure` retains exact bytes, stream, topic, partition, offset,
-  opaque acknowledgement metadata, bounded decode/schema classification, and a
-  deterministic connector delivery UUID without inventing tenant or domain event facts.
-- Connector migration `m20260728_000001_create_consumer_poison_receipts` owns neutral
-  durable result storage for those raw deliveries.
-- `ConsumerPoisonIdentity` binds one deterministic delivery UUID and one
-  consumer-group/stream/topic/partition/offset coordinate set to the exact payload.
-  Empty payload is valid input; UUID/source reuse with different coordinates or bytes
-  fails closed.
-- Error classification and observed attempt count are retained as first diagnostics but
-  are excluded from immutable identity.
-- Neutral receipt states are `reserved`, leased `publishing`, `published`, and
-  `acknowledged`. The connector store does not publish, acknowledge, authorize, or choose
-  policy.
-- The server worker looks up the neutral receipt before applying current DLQ policy.
-  Existing raw poison work continues recovery even if creation of new DLQ decisions is
-  later disabled. A new undecodable delivery remains unacknowledged when DLQ is disabled.
-- For a claimed receipt, the worker publishes
-  `ConsumedContractDecodeFailure::to_dlq_entry` with exact bytes and its deterministic
-  broker message ID, then persists `published` before entering source acknowledgement.
-- A `published` or `acknowledged` receipt skips republication and enters
+  bookkeeping-complete `acknowledged`.
+- A deterministic RFC 9562 UUIDv8 binds immutable receipt identity and is reused across
+  publication retries.
+- Published or acknowledged receipts skip projection and republication and enter
   acknowledgement-only recovery.
-- Source acknowledgement precedes best-effort `mark_acknowledged` bookkeeping. A
-  bookkeeping failure cannot reverse a committed source offset.
-- Broker success followed by loss before durable `published` remains an explicit
-  duplicate ambiguity. Recovery reuses the same deterministic message ID but does not
-  claim exactly-once without retained broker deduplication evidence.
-- Raw poison state has no projection or presentation authority and must not authorize
-  Profiles privacy.
+- Source acknowledgement precedes best-effort acknowledged bookkeeping; bookkeeping failure
+  cannot reverse a committed cursor.
+- Broker success before durable `published` remains an explicit duplicate ambiguity; no
+  exactly-once claim is made without retained broker deduplication evidence.
+- Raw decode failures retain exact bytes and coordinates without inventing tenant or event
+  facts.
+- Neutral raw poison receipts do not publish, acknowledge, authorize, or choose policy.
+- Decoded or raw poison state must not authorize Profiles privacy or presentation.
 
 ## Server-owned optional lifecycle
 
-- The server `mod-social_graph` feature composes `index-consumer`, but execution is
-  default-off until `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED=true`.
-- Explicit enablement requires a worker-capable host and effective `outbox_iggy`.
-- `EventRuntime` creates one configured `Arc<IggyTransport>` and shares that exact
-  transport between outbound relay and inbound consumer. The worker never creates or
-  stops a second bundled broker process.
-- The server enables the connector `migrations` feature explicitly for neutral receipt
-  storage; it does not rely on incidental transitive feature unification.
-- Identified decoded and raw DLQ publication may lazily open one SDK client owned by that
-  shared `IggyTransport`; it connects to the same configured broker and is dropped on
-  failure for bounded retry-time reconnect.
-- `SocialGraphIndexWorkerHandle` exposes task state and observes shared `StopHandle`.
-- Projection, decoded/raw DLQ publication, neutral receipt transitions, and source
-  acknowledgement use bounded exponential retry from reviewed event settings.
-- Existing decoded or raw `reserved`/`publishing` receipts continue toward their
-  previously chosen terminal result even if policy for new DLQ decisions is later
-  disabled.
-- After a durable terminal result exists, retries are acknowledgement-only; projection
-  and terminal-result selection do not repeat.
-- When enabled, missing/stopped/invalid worker state is critical in
-  `runtime_guardrails`, `/health/ready`, and aggregate guardrail metrics. Disabled
-  execution contributes no failure.
-- `SocialGraphIndexPositionObserver` also starts only under explicit enablement. It
-  opens a separate read-only SDK connection using shared transport configuration and
-  observes the same `StopHandle`.
-- Position observation never starts/stops a broker, consumes deliveries, stores offsets,
-  or participates in projection readiness. Configuration/connection/snapshot failures
-  are telemetry-only and independently retried.
+- `mod-social_graph` composes `index-consumer`, but execution remains default-off until
+  `RUSTOK_SOCIAL_GRAPH_INDEX_CONSUMER_ENABLED=true`.
+- Explicit worker enablement requires a worker-capable host and effective `outbox_iggy`.
+- The shared configured `IggyTransport` is used by outbound relay, inbound consumer, and
+  identified DLQ publication; the worker never starts or stops another broker process.
+- Projection, DLQ publication, receipt transitions, and acknowledgement use bounded retry.
+- Existing durable poison work continues toward its selected terminal result if policy for
+  new DLQ decisions changes.
+- Enabled worker absence, termination, or invalid readiness is critical; disabled execution
+  contributes no readiness failure.
+- The position observer is read-only telemetry and never consumes, acknowledges, projects,
+  or owns readiness.
 
-## Runtime consumer metrics
+## Metrics
 
-- `rustok_telemetry::runtime_consumer_metrics` registers a bounded shared Prometheus
-  collector in the existing process registry rendered by `/metrics`.
-- Delivery metrics cover validated and raw received deliveries, terminal outcome
-  throughput, projection, DLQ, poison-receipt and ack retries, bounded stage/stable-code
-  failures, DLQ `published`, `already_published`, and `failure` results,
-  receive-to-ack duration, starts/terminations, in-flight state/timestamp, and last
-  success.
-- Raw terminal outcomes are bounded to `decode_dead_lettered` and
-  `decode_dead_letter_recovered`.
-- The position observer reads every topic partition plus the persistent group checkpoint
-  and records snapshot timestamp, partition count, and completeness.
-- `rustok_runtime_consumer_lag{aggregation="total|max"}` is published only from a
-  complete coherent every-partition snapshot. Empty partitions contribute zero;
-  missing or checkpoint-ahead-of-high-watermark state makes the snapshot incomplete.
-- Incomplete snapshots set completeness to zero and clear lag gauges, preventing stale
-  values from masquerading as current lag.
-- Labels are bounded to consumer, stage, outcome, result, reason, aggregation, and stable
-  error code.
-- Tenant, event, relation, partition, offset, payload, delivery/broker ID, ack token,
-  credentials, and raw error text are not labels.
-- Event age, processing duration, one delivered offset, and local cursor counters are
-  not valid lag inputs.
+- Runtime consumer metrics use bounded labels for consumer, stage, outcome, result, reason,
+  aggregation, and stable code.
+- Tenant, event, relation, partition, offset, payload, broker ID, acknowledgement token,
+  credentials, and raw error text are forbidden labels.
+- Lag is published only from a complete every-partition snapshot plus group checkpoint.
+- Incomplete snapshots clear lag gauges rather than presenting stale values.
+- Event age, one observed offset, and local cursor counters are not valid lag inputs.
 
 ## Authority boundary
 
-- Social Graph owner storage, commands, events, replay, and drift repair remain the source
-  authority for block/mute/follow.
+- Social Graph owner storage, commands, events, replay, and drift repair remain authoritative
+  for block, mute, and follow.
 - Notification block/mute policy may consume the approved Index projection only through
-  `IndexSocialGraphPrivacyReadPort`; missing readiness is retryable fail-closed and never
-  becomes an implicit allow.
+  `IndexSocialGraphPrivacyReadPort` and only after the explicit default-off activation flag
+  is enabled.
+- Once activated, missing readiness is retryable fail-closed and never becomes an implicit
+  allow or owner-table fallback.
 - Profiles privacy, presentation visibility, and revision-bearing follow state must not
-  authorize from Index state, decoded or raw DLQ receipts, broker IDs, deduplication state,
-  or consumer lag.
-- The projector, consumer, worker, position observer, and telemetry never read Social Graph
-  relation tables for projection work.
-- Index and DLQ/lag operations remain optional infrastructure and must not independently
-  authorize presentation.
+  authorize from Index state, DLQ receipts, broker IDs, deduplication state, or consumer lag.
+- Projection infrastructure must not independently authorize presentation.
 
 ## Dependencies
 
 - `rustok-api`: port context, actor, deadlines, idempotency, replay policy, typed errors.
 - `rustok-core`: module and migration contracts.
 - `rustok-events`: sealed relation event family.
-- optional `rustok-index`: schema, conversion, registration, mutation persistence, and
-  typed query runtime consumption.
-- optional `rustok-iggy`: persistent typed cursor, exact payload retention, deterministic
-  DLQ header publication, DLQ, ack, and read-only broker position observation.
-- server composition uses `rustok-iggy-connector` feature `migrations` for neutral raw
-  poison receipt storage.
-- `sha2`: versioned deterministic UUIDv8 derivation from immutable receipt identity.
+- optional `rustok-index`: schema conversion, registration, mutation persistence, and typed
+  query runtime consumption.
+- optional `rustok-iggy`: persistent typed cursor, exact payload retention, DLQ publication,
+  acknowledgement, and read-only position observation.
 - `rustok-outbox`: transactional event bus.
-- sibling CLI uses `rustok-cli-core` and `rustok-runtime`.
+- `sha2`: deterministic receipt-bound UUIDv8 derivation.
 
 ## Common mistakes
 
 - Writing through `SocialGraphService::new(db)` and silently losing events.
-- Publishing arbitrary string events or publishing after relation commit.
+- Publishing arbitrary strings or publishing after relation commit.
 - Emitting an event for receipt replay or persisted-state no-op.
-- Treating replay, a deterministic broker ID, or broker DLQ publication as exactly-once
-  without retained deduplication configuration/runtime evidence.
-- Putting idempotency keys, request context, claims, roles, locale, channel, or command
-  receipt snapshots into the external event.
-- Reading relation tables from Profiles, Index, or another consumer.
+- Reading Social Graph tables from Profiles, Index, or another consumer.
 - Constructing `PostgresIndexQueryPort` in Social Graph or bypassing
   `SharedIndexQueryRuntime`.
-- Falling back to owner-table notification block/mute reads after final host composition.
+- Enabling Index privacy reads before retained readiness, lag, and result-parity evidence.
+- Falling back to owner-table notification block/mute reads after the activation flag is true.
 - Treating missing Index schema readiness as no block or no mute.
 - Using Index for revision-bearing follow state or Profiles presentation authorization.
-- Registering only in memory and assuming the persisted schema foreign key exists.
-- Writing `index_schemas` directly from Social Graph.
-- Calling the compatibility `receive_next` in a worker that must handle raw decode
-  failures.
-- Acknowledging before schema/Index result or durable decoded/raw DLQ publication is
-  complete.
-- Inventing tenant or event identity for undecodable bytes or placing raw receipt state
-  into Profiles authorization.
-- Creating or shutting down a second Iggy transport or bundled process in the worker,
-  identified publisher, or position observer.
-- Generating a random broker message ID per retry or including retry count/time in it.
-- Assuming Iggy deduplication is enabled, durable, global, or unbounded.
-- DLQing after a durable Index result instead of retrying ack only.
-- Re-serializing a decoded envelope instead of using exact broker bytes.
-- Ignoring an existing decoded or raw receipt and re-entering projection or selecting a
-  new terminal result on redelivery.
-- Treating `reserved` or `publishing` as safe source-ack states.
-- Returning DLQ success before the `published` receipt transition.
-- Republish-to-DLQ on every ack retry after a durable `published` receipt exists.
-- Blocking recovery of an existing receipt merely because new DLQ decisions were later
-  disabled.
-- Deleting receipt rows without an approved retention/reconciliation contract.
-- Using tenant/event/relation/partition/offset/payload/broker-ID/error text as metric
-  labels.
-- Publishing lag from an incomplete snapshot, event age, or one global offset.
-- Making observer failure projection-critical or readiness-critical.
-- Authorizing Profiles visibility from projection state, DLQ receipts, or consumer lag.
+- Acknowledging before durable Index or DLQ result completion.
+- Inventing tenant/event identity for undecodable bytes.
+- Treating a deterministic broker ID as an exactly-once guarantee.
+- Republishing DLQ content during acknowledgement-only recovery.
+- Publishing lag from an incomplete snapshot.
+- Authorizing Profiles visibility from projection or poison state.
 
 ## Errors / stable failure families
 
@@ -355,13 +230,7 @@
 - `social_graph.storage_unavailable`
 - `social_graph.index_privacy_unavailable`
 - `social_graph.index_privacy_contract_invalid`
-- Index consumption maps typed schema/registry/mutation failures to bounded
-  `social_graph.index.*` host codes without publishing private storage causes.
-- Decoded DLQ receipts add bounded `social_graph.index.dlq_receipt_*` and
-  `social_graph.index.dlq_publish_in_progress` codes.
-- Neutral raw receipts add bounded `iggy.connector.poison_*` families. The worker also
-  uses bounded `iggy.connector.poison_claim_busy` for live claim contention.
-- Raw transport classification remains `iggy.contract.decode_invalid` or
-  `iggy.contract.schema_invalid`.
-- Identified Iggy publication logs bounded `iggy.dlq_publisher.*` codes.
-- Position observation uses bounded `iggy.consumer_position.*` stable codes.
+- bounded `social_graph.index.*` projection and DLQ families
+- bounded `iggy.connector.poison_*` raw poison families
+- bounded `iggy.contract.decode_invalid` and `iggy.contract.schema_invalid`
+- bounded `iggy.consumer_position.*` observation families

--- a/crates/rustok-social-graph/Cargo.toml
+++ b/crates/rustok-social-graph/Cargo.toml
@@ -21,14 +21,13 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, optional = true }
 tracing.workspace = true
 uuid.workspace = true
 
 [features]
 default = []
 graphql = ["dep:async-graphql", "rustok-api/server"]
-index = ["dep:rustok-index", "dep:tokio"]
+index = ["dep:rustok-index"]
 index-consumer = ["index", "dep:rustok-iggy"]
 
 [dev-dependencies]

--- a/crates/rustok-social-graph/Cargo.toml
+++ b/crates/rustok-social-graph/Cargo.toml
@@ -21,13 +21,14 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, optional = true }
 tracing.workspace = true
 uuid.workspace = true
 
 [features]
 default = []
 graphql = ["dep:async-graphql", "rustok-api/server"]
-index = ["dep:rustok-index"]
+index = ["dep:rustok-index", "dep:tokio"]
 index-consumer = ["index", "dep:rustok-iggy"]
 
 [dev-dependencies]

--- a/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
+++ b/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
@@ -27,7 +27,8 @@
     "notification_mute_source": "recipient_id",
     "notification_mute_target": "actor_id",
     "authoritative_owner_result_always_returned": true,
-    "index_shadow_never_authorizes": true
+    "index_shadow_never_authorizes": true,
+    "index_shadow_timeout_ms": 100
   },
   "server_composition": {
     "adapter": "apps/server/src/services/notification_recipient_policy.rs",
@@ -54,7 +55,8 @@
   },
   "tests": [
     "crates/rustok-social-graph/tests/privacy_sqlite.rs",
-    "crates/rustok-social-graph/src/index_privacy.rs"
+    "crates/rustok-social-graph/src/index_privacy.rs",
+    "crates/rustok-social-graph/src/index_privacy_shadow.rs"
   ],
   "verification": {
     "source_verifier": "scripts/verify/verify-social-graph-notification-policy.mjs",

--- a/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
+++ b/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
@@ -10,6 +10,7 @@
   "service": "crates/rustok-social-graph/src/service.rs",
   "ports": "crates/rustok-social-graph/src/ports.rs",
   "index_privacy": "crates/rustok-social-graph/src/index_privacy.rs",
+  "index_privacy_shadow": "crates/rustok-social-graph/src/index_privacy_shadow.rs",
   "relation_state": {
     "table": "social_graph_relations",
     "kinds": ["block", "mute"],
@@ -25,7 +26,8 @@
     "mute_source_to_target_only": true,
     "notification_mute_source": "recipient_id",
     "notification_mute_target": "actor_id",
-    "index_readiness_failure_suppresses_allow_when_enabled": true
+    "authoritative_owner_result_always_returned": true,
+    "index_shadow_never_authorizes": true
   },
   "server_composition": {
     "adapter": "apps/server/src/services/notification_recipient_policy.rs",
@@ -36,12 +38,12 @@
     "candidate_worker_runtime_delivered": true,
     "candidate_worker_default_enabled": false,
     "candidate_worker_contract": "crates/rustok-notifications/contracts/notifications-candidate-worker.json",
-    "index_query_runtime_required_when_enabled": true,
-    "notification_block_mute_index_cutover_source_complete": true,
-    "index_privacy_activation_env": "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED",
-    "index_privacy_default_enabled": false,
-    "authoritative_table_path_before_activation": true,
-    "authoritative_table_fallback_after_activation": false
+    "index_query_runtime_required_when_shadow_enabled": true,
+    "notification_block_mute_index_shadow_source_complete": true,
+    "notification_block_mute_index_cutover": false,
+    "index_privacy_shadow_env": "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED",
+    "index_privacy_shadow_default_enabled": false,
+    "owner_policy_remains_authoritative": true
   },
   "distribution": {
     "registry": "crates/rustok-distribution/src/lib.rs",
@@ -61,7 +63,7 @@
     "execution_status": "not_run_by_implementation_agent"
   },
   "deferred": [
-    "activation after retained projection readiness, lag, and result-parity evidence",
+    "authoritative cutover after retained freshness, lag, negative-result safety, and result-parity evidence",
     "default candidate worker enablement after health and lag metrics",
     "friend and follow presentation cutover",
     "block and mute transports",

--- a/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
+++ b/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
@@ -25,7 +25,7 @@
     "mute_source_to_target_only": true,
     "notification_mute_source": "recipient_id",
     "notification_mute_target": "actor_id",
-    "index_readiness_failure_suppresses_allow": true
+    "index_readiness_failure_suppresses_allow_when_enabled": true
   },
   "server_composition": {
     "adapter": "apps/server/src/services/notification_recipient_policy.rs",
@@ -36,9 +36,12 @@
     "candidate_worker_runtime_delivered": true,
     "candidate_worker_default_enabled": false,
     "candidate_worker_contract": "crates/rustok-notifications/contracts/notifications-candidate-worker.json",
-    "index_query_runtime_required": true,
-    "notification_block_mute_index_cutover": true,
-    "authoritative_table_fallback_in_final_host": false
+    "index_query_runtime_required_when_enabled": true,
+    "notification_block_mute_index_cutover_source_complete": true,
+    "index_privacy_activation_env": "RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED",
+    "index_privacy_default_enabled": false,
+    "authoritative_table_path_before_activation": true,
+    "authoritative_table_fallback_after_activation": false
   },
   "distribution": {
     "registry": "crates/rustok-distribution/src/lib.rs",
@@ -58,6 +61,7 @@
     "execution_status": "not_run_by_implementation_agent"
   },
   "deferred": [
+    "activation after retained projection readiness, lag, and result-parity evidence",
     "default candidate worker enablement after health and lag metrics",
     "friend and follow presentation cutover",
     "block and mute transports",

--- a/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
+++ b/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "slice": "SOCIAL-01A/NOTIFY-07C",
   "promoted_by_slice": "NOTIFY-03C",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
@@ -9,6 +9,7 @@
   "entity": "crates/rustok-social-graph/src/entities/relation.rs",
   "service": "crates/rustok-social-graph/src/service.rs",
   "ports": "crates/rustok-social-graph/src/ports.rs",
+  "index_privacy": "crates/rustok-social-graph/src/index_privacy.rs",
   "relation_state": {
     "table": "social_graph_relations",
     "kinds": ["block", "mute"],
@@ -23,16 +24,21 @@
     "block_either_direction_suppresses": true,
     "mute_source_to_target_only": true,
     "notification_mute_source": "recipient_id",
-    "notification_mute_target": "actor_id"
+    "notification_mute_target": "actor_id",
+    "index_readiness_failure_suppresses_allow": true
   },
   "server_composition": {
     "adapter": "apps/server/src/services/notification_recipient_policy.rs",
+    "final_host_facade": "apps/server/src/services/mod.rs",
     "profile_then_block_then_mute": true,
     "reads_private_social_graph_tables": false,
     "relation_ports_ready": true,
     "candidate_worker_runtime_delivered": true,
     "candidate_worker_default_enabled": false,
-    "candidate_worker_contract": "crates/rustok-notifications/contracts/notifications-candidate-worker.json"
+    "candidate_worker_contract": "crates/rustok-notifications/contracts/notifications-candidate-worker.json",
+    "index_query_runtime_required": true,
+    "notification_block_mute_index_cutover": true,
+    "authoritative_table_fallback_in_final_host": false
   },
   "distribution": {
     "registry": "crates/rustok-distribution/src/lib.rs",
@@ -42,18 +48,19 @@
     "generated_promotions_remain_replaceable": true
   },
   "tests": [
-    "crates/rustok-social-graph/tests/privacy_sqlite.rs"
+    "crates/rustok-social-graph/tests/privacy_sqlite.rs",
+    "crates/rustok-social-graph/src/index_privacy.rs"
   ],
   "verification": {
     "source_verifier": "scripts/verify/verify-social-graph-notification-policy.mjs",
+    "index_consumer_verifier": "scripts/verify/verify-index-social-graph-privacy-consumer.mjs",
     "worker_verifier": "scripts/verify/verify-notifications-candidate-worker.mjs",
     "execution_status": "not_run_by_implementation_agent"
   },
   "deferred": [
     "default candidate worker enablement after health and lag metrics",
-    "friend and follow lifecycle",
+    "friend and follow presentation cutover",
     "block and mute transports",
-    "outbox relation events",
     "PostgreSQL concurrency evidence",
     "inbox-open and delayed-delivery rechecks"
   ]

--- a/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
+++ b/crates/rustok-social-graph/contracts/social-graph-notification-policy.json
@@ -27,8 +27,7 @@
     "notification_mute_source": "recipient_id",
     "notification_mute_target": "actor_id",
     "authoritative_owner_result_always_returned": true,
-    "index_shadow_never_authorizes": true,
-    "index_shadow_timeout_ms": 100
+    "index_shadow_never_authorizes": true
   },
   "server_composition": {
     "adapter": "apps/server/src/services/notification_recipient_policy.rs",
@@ -65,6 +64,7 @@
     "execution_status": "not_run_by_implementation_agent"
   },
   "deferred": [
+    "bounded shadow latency and resource overhead evidence",
     "authoritative cutover after retained freshness, lag, negative-result safety, and result-parity evidence",
     "default candidate worker enablement after health and lag metrics",
     "friend and follow presentation cutover",

--- a/crates/rustok-social-graph/src/index_privacy.rs
+++ b/crates/rustok-social-graph/src/index_privacy.rs
@@ -116,13 +116,13 @@ impl IndexSocialGraphPrivacyReadPort {
                 .iter()
                 .find(|projected| projected.path == contract.target)
                 .ok_or_else(contract_invariant)?;
-            let IndexValue::Uuid(target_user_id) = projected.value else {
+            let IndexValue::Uuid(target_user_id) = &projected.value else {
                 return Err(contract_invariant());
             };
-            if !target_user_ids.contains(&target_user_id) {
+            if !target_user_ids.contains(target_user_id) {
                 return Err(contract_invariant());
             }
-            followed.insert(target_user_id);
+            followed.insert(*target_user_id);
         }
         Ok(followed.into_iter().collect())
     }
@@ -347,6 +347,7 @@ mod tests {
     use std::sync::Mutex;
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use rustok_api::{PortActor, PortErrorKind};
     use rustok_index::{
         IndexProjectedValue, IndexQueryItem, IndexQueryPage, PersistedSchemaReadinessFailure,

--- a/crates/rustok-social-graph/src/index_privacy.rs
+++ b/crates/rustok-social-graph/src/index_privacy.rs
@@ -1,0 +1,557 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use async_trait::async_trait;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_index::{
+    FieldName, FieldPath, FilterExpr, IndexQuery, IndexQueryExecutionError, IndexQueryPort,
+    IndexQueryScope, IndexValue, Pagination, SharedIndexQueryRuntime,
+};
+use uuid::Uuid;
+
+use crate::index::social_graph_relation_index_schema;
+use crate::{
+    MAX_SOCIAL_GRAPH_FOLLOW_TARGETS, SocialGraphFollowBatchRequest, SocialGraphFollowBatchResult,
+    SocialGraphPairRequest, SocialGraphPrivacyReadPort, SocialRelationKind,
+};
+
+const SOURCE_USER_ID_FIELD: &str = "source_user_id";
+const TARGET_USER_ID_FIELD: &str = "target_user_id";
+const RELATION_KIND_FIELD: &str = "relation_kind";
+
+#[derive(Clone)]
+pub struct IndexSocialGraphPrivacyReadPort {
+    port: Arc<dyn IndexQueryPort>,
+}
+
+impl IndexSocialGraphPrivacyReadPort {
+    pub fn new(runtime: SharedIndexQueryRuntime) -> Self {
+        Self {
+            port: runtime.shared_port(),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_port(port: Arc<dyn IndexQueryPort>) -> Self {
+        Self { port }
+    }
+
+    async fn relation_exists(
+        &self,
+        tenant_id: Uuid,
+        filter: FilterExpr,
+    ) -> Result<bool, PortError> {
+        let contract = relation_contract()?;
+        let page = self
+            .port
+            .execute_query(IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id,
+                    locale: None,
+                },
+                schema: contract.schema,
+                fields: vec![contract.target],
+                filter: Some(filter),
+                order_by: Vec::new(),
+                pagination: Pagination::Offset {
+                    limit: 1,
+                    offset: 0,
+                },
+                include_exact_count: false,
+            })
+            .await
+            .map_err(map_index_error)?;
+        Ok(!page.items.is_empty())
+    }
+
+    async fn followed_targets(
+        &self,
+        tenant_id: Uuid,
+        source_user_id: Uuid,
+        target_user_ids: BTreeSet<Uuid>,
+    ) -> Result<Vec<Uuid>, PortError> {
+        if target_user_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let contract = relation_contract()?;
+        let target_values = target_user_ids
+            .iter()
+            .copied()
+            .map(IndexValue::Uuid)
+            .collect::<Vec<_>>();
+        let page = self
+            .port
+            .execute_query(IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id,
+                    locale: None,
+                },
+                schema: contract.schema,
+                fields: vec![contract.target.clone()],
+                filter: Some(FilterExpr::And(vec![
+                    FilterExpr::Eq(contract.source, IndexValue::Uuid(source_user_id)),
+                    FilterExpr::In(contract.target.clone(), target_values),
+                    FilterExpr::Eq(
+                        contract.kind,
+                        IndexValue::String(SocialRelationKind::Follow.as_str().to_owned()),
+                    ),
+                ])),
+                order_by: Vec::new(),
+                pagination: Pagination::Offset {
+                    limit: u32::try_from(target_user_ids.len())
+                        .map_err(|_| contract_invariant())?,
+                    offset: 0,
+                },
+                include_exact_count: false,
+            })
+            .await
+            .map_err(map_index_error)?;
+        if page.has_more {
+            return Err(contract_invariant());
+        }
+
+        let mut followed = BTreeSet::new();
+        for item in page.items {
+            let projected = item
+                .fields
+                .iter()
+                .find(|projected| projected.path == contract.target)
+                .ok_or_else(contract_invariant)?;
+            let IndexValue::Uuid(target_user_id) = projected.value else {
+                return Err(contract_invariant());
+            };
+            if !target_user_ids.contains(&target_user_id) {
+                return Err(contract_invariant());
+            }
+            followed.insert(target_user_id);
+        }
+        Ok(followed.into_iter().collect())
+    }
+}
+
+#[async_trait]
+impl SocialGraphPrivacyReadPort for IndexSocialGraphPrivacyReadPort {
+    async fn blocks_between(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_pair(request.source_user_id, request.target_user_id)?;
+        let tenant_id = parse_tenant_id(&context)?;
+        let contract = relation_contract()?;
+        self.relation_exists(
+            tenant_id,
+            FilterExpr::And(vec![
+                FilterExpr::Eq(
+                    contract.kind,
+                    IndexValue::String(SocialRelationKind::Block.as_str().to_owned()),
+                ),
+                FilterExpr::Or(vec![
+                    FilterExpr::And(vec![
+                        FilterExpr::Eq(
+                            contract.source.clone(),
+                            IndexValue::Uuid(request.source_user_id),
+                        ),
+                        FilterExpr::Eq(
+                            contract.target.clone(),
+                            IndexValue::Uuid(request.target_user_id),
+                        ),
+                    ]),
+                    FilterExpr::And(vec![
+                        FilterExpr::Eq(
+                            contract.source,
+                            IndexValue::Uuid(request.target_user_id),
+                        ),
+                        FilterExpr::Eq(
+                            contract.target,
+                            IndexValue::Uuid(request.source_user_id),
+                        ),
+                    ]),
+                ]),
+            ]),
+        )
+        .await
+    }
+
+    async fn source_mutes_target(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_pair(request.source_user_id, request.target_user_id)?;
+        let tenant_id = parse_tenant_id(&context)?;
+        let contract = relation_contract()?;
+        self.relation_exists(
+            tenant_id,
+            FilterExpr::And(vec![
+                FilterExpr::Eq(
+                    contract.source,
+                    IndexValue::Uuid(request.source_user_id),
+                ),
+                FilterExpr::Eq(
+                    contract.target,
+                    IndexValue::Uuid(request.target_user_id),
+                ),
+                FilterExpr::Eq(
+                    contract.kind,
+                    IndexValue::String(SocialRelationKind::Mute.as_str().to_owned()),
+                ),
+            ]),
+        )
+        .await
+    }
+
+    async fn source_follows_target(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_source_actor(&context, request.source_user_id)?;
+        validate_pair(request.source_user_id, request.target_user_id)?;
+        let tenant_id = parse_tenant_id(&context)?;
+        let contract = relation_contract()?;
+        self.relation_exists(
+            tenant_id,
+            FilterExpr::And(vec![
+                FilterExpr::Eq(
+                    contract.source,
+                    IndexValue::Uuid(request.source_user_id),
+                ),
+                FilterExpr::Eq(
+                    contract.target,
+                    IndexValue::Uuid(request.target_user_id),
+                ),
+                FilterExpr::Eq(
+                    contract.kind,
+                    IndexValue::String(SocialRelationKind::Follow.as_str().to_owned()),
+                ),
+            ]),
+        )
+        .await
+    }
+
+    async fn source_follows_targets(
+        &self,
+        context: PortContext,
+        request: SocialGraphFollowBatchRequest,
+    ) -> Result<SocialGraphFollowBatchResult, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_source_actor(&context, request.source_user_id)?;
+        if request.target_user_ids.len() > MAX_SOCIAL_GRAPH_FOLLOW_TARGETS {
+            return Err(PortError::validation(
+                "social_graph.follow_batch_too_large",
+                "social graph follow reads accept at most 100 target users",
+            ));
+        }
+        let tenant_id = parse_tenant_id(&context)?;
+        let target_user_ids = request
+            .target_user_ids
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        for target_user_id in &target_user_ids {
+            validate_pair(request.source_user_id, *target_user_id)?;
+        }
+
+        Ok(SocialGraphFollowBatchResult {
+            followed_target_user_ids: self
+                .followed_targets(tenant_id, request.source_user_id, target_user_ids)
+                .await?,
+        })
+    }
+}
+
+struct RelationQueryContract {
+    schema: rustok_index::SchemaRef,
+    source: FieldPath,
+    target: FieldPath,
+    kind: FieldPath,
+}
+
+fn relation_contract() -> Result<RelationQueryContract, PortError> {
+    let schema = social_graph_relation_index_schema()
+        .map_err(|_| contract_invariant())?
+        .reference;
+    Ok(RelationQueryContract {
+        schema,
+        source: field_path(SOURCE_USER_ID_FIELD)?,
+        target: field_path(TARGET_USER_ID_FIELD)?,
+        kind: field_path(RELATION_KIND_FIELD)?,
+    })
+}
+
+fn field_path(name: &str) -> Result<FieldPath, PortError> {
+    FieldName::new(name)
+        .map(FieldPath::new)
+        .map_err(|_| contract_invariant())
+}
+
+fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        PortError::validation(
+            "social_graph.tenant_id_invalid",
+            "social graph ports require a valid tenant identifier",
+        )
+    })
+}
+
+fn validate_pair(source_user_id: Uuid, target_user_id: Uuid) -> Result<(), PortError> {
+    if source_user_id == target_user_id {
+        return Err(PortError::validation(
+            "social_graph.self_relation",
+            "social graph relation cannot target the source user",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_source_actor(context: &PortContext, source_user_id: Uuid) -> Result<(), PortError> {
+    if matches!(&context.actor.kind, PortActorKind::User)
+        && Uuid::parse_str(&context.actor.id).ok() != Some(source_user_id)
+    {
+        return Err(PortError::forbidden(
+            "social_graph.source_actor_mismatch",
+            "user actors may mutate or read only relations they own",
+        ));
+    }
+    Ok(())
+}
+
+fn map_index_error(error: IndexQueryExecutionError) -> PortError {
+    match error {
+        IndexQueryExecutionError::SchemaNotReady { .. }
+        | IndexQueryExecutionError::Storage { .. } => PortError::unavailable(
+            "social_graph.index_privacy_unavailable",
+            "social graph Index privacy state is temporarily unavailable",
+        ),
+        IndexQueryExecutionError::Plan(_)
+        | IndexQueryExecutionError::Build(_)
+        | IndexQueryExecutionError::Decode(_)
+        | IndexQueryExecutionError::UnsupportedBackend
+        | IndexQueryExecutionError::MissingExactCountRow
+        | IndexQueryExecutionError::InvalidRowColumn { .. }
+        | IndexQueryExecutionError::ContractPreparation { .. } => contract_invariant(),
+    }
+}
+
+fn contract_invariant() -> PortError {
+    PortError::invariant_violation(
+        "social_graph.index_privacy_contract_invalid",
+        "social graph Index privacy contract is invalid",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use rustok_api::{PortActor, PortErrorKind};
+    use rustok_index::{
+        IndexProjectedValue, IndexQueryItem, IndexQueryPage, PersistedSchemaReadinessFailure,
+    };
+
+    use super::*;
+
+    struct FakeIndexPort {
+        query: Mutex<Option<IndexQuery>>,
+        response: Mutex<Option<Result<IndexQueryPage, IndexQueryExecutionError>>>,
+    }
+
+    impl FakeIndexPort {
+        fn new(response: Result<IndexQueryPage, IndexQueryExecutionError>) -> Arc<Self> {
+            Arc::new(Self {
+                query: Mutex::new(None),
+                response: Mutex::new(Some(response)),
+            })
+        }
+
+        fn query(&self) -> IndexQuery {
+            self.query
+                .lock()
+                .expect("query lock")
+                .clone()
+                .expect("query should be captured")
+        }
+    }
+
+    #[async_trait]
+    impl IndexQueryPort for FakeIndexPort {
+        async fn execute_query(
+            &self,
+            query: IndexQuery,
+        ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+            *self.query.lock().expect("query lock") = Some(query);
+            self.response
+                .lock()
+                .expect("response lock")
+                .take()
+                .expect("one response should be configured")
+        }
+    }
+
+    fn context(tenant_id: Uuid) -> PortContext {
+        PortContext::new(
+            tenant_id.to_string(),
+            PortActor::service("privacy-test"),
+            "und",
+            "privacy-test-correlation",
+        )
+        .with_deadline(Duration::from_secs(1))
+    }
+
+    fn empty_page() -> IndexQueryPage {
+        IndexQueryPage {
+            items: Vec::new(),
+            exact_count: None,
+            has_more: false,
+            next_cursor: None,
+        }
+    }
+
+    fn target_item(target_user_id: Uuid) -> IndexQueryItem {
+        let contract = relation_contract().unwrap();
+        IndexQueryItem {
+            entity_id: Uuid::new_v4(),
+            relations: Vec::new(),
+            fields: vec![IndexProjectedValue {
+                path: contract.target,
+                value: IndexValue::Uuid(target_user_id),
+            }],
+            nested_relations: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn block_query_preserves_either_direction_semantics() {
+        let fake = FakeIndexPort::new(Ok(empty_page()));
+        let port = IndexSocialGraphPrivacyReadPort::from_port(fake.clone());
+        let tenant_id = Uuid::from_u128(1);
+        let left = Uuid::from_u128(2);
+        let right = Uuid::from_u128(3);
+
+        assert!(!port
+            .blocks_between(
+                context(tenant_id),
+                SocialGraphPairRequest {
+                    source_user_id: left,
+                    target_user_id: right,
+                },
+            )
+            .await
+            .unwrap());
+
+        let query = fake.query();
+        let contract = relation_contract().unwrap();
+        assert_eq!(query.scope.tenant_id, tenant_id);
+        assert_eq!(query.schema, contract.schema);
+        assert_eq!(query.fields, vec![contract.target.clone()]);
+        assert_eq!(
+            query.filter,
+            Some(FilterExpr::And(vec![
+                FilterExpr::Eq(
+                    contract.kind,
+                    IndexValue::String("block".to_owned()),
+                ),
+                FilterExpr::Or(vec![
+                    FilterExpr::And(vec![
+                        FilterExpr::Eq(contract.source.clone(), IndexValue::Uuid(left)),
+                        FilterExpr::Eq(contract.target.clone(), IndexValue::Uuid(right)),
+                    ]),
+                    FilterExpr::And(vec![
+                        FilterExpr::Eq(contract.source, IndexValue::Uuid(right)),
+                        FilterExpr::Eq(contract.target, IndexValue::Uuid(left)),
+                    ]),
+                ]),
+            ]))
+        );
+    }
+
+    #[tokio::test]
+    async fn follow_batch_deduplicates_and_sorts_projected_targets() {
+        let first = Uuid::from_u128(11);
+        let second = Uuid::from_u128(12);
+        let fake = FakeIndexPort::new(Ok(IndexQueryPage {
+            items: vec![target_item(second), target_item(first)],
+            exact_count: None,
+            has_more: false,
+            next_cursor: None,
+        }));
+        let port = IndexSocialGraphPrivacyReadPort::from_port(fake.clone());
+        let source = Uuid::from_u128(10);
+
+        let result = port
+            .source_follows_targets(
+                context(Uuid::from_u128(1)),
+                SocialGraphFollowBatchRequest {
+                    source_user_id: source,
+                    target_user_ids: vec![second, first, second],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.followed_target_user_ids, vec![first, second]);
+        assert_eq!(
+            fake.query().pagination,
+            Pagination::Offset {
+                limit: 2,
+                offset: 0
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_tenant_schema_is_retryable_and_does_not_authorize() {
+        let contract = relation_contract().unwrap();
+        let fake = FakeIndexPort::new(Err(IndexQueryExecutionError::SchemaNotReady {
+            reference: contract.schema,
+            reason: PersistedSchemaReadinessFailure::Missing,
+        }));
+        let port = IndexSocialGraphPrivacyReadPort::from_port(fake);
+
+        let error = port
+            .source_mutes_target(
+                context(Uuid::from_u128(1)),
+                SocialGraphPairRequest {
+                    source_user_id: Uuid::from_u128(2),
+                    target_user_id: Uuid::from_u128(3),
+                },
+            )
+            .await
+            .expect_err("missing schema must fail closed");
+
+        assert_eq!(error.kind, PortErrorKind::Unavailable);
+        assert_eq!(error.code, "social_graph.index_privacy_unavailable");
+        assert!(error.retryable);
+    }
+
+    #[tokio::test]
+    async fn user_follow_reads_preserve_source_actor_authorization() {
+        let fake = FakeIndexPort::new(Ok(empty_page()));
+        let port = IndexSocialGraphPrivacyReadPort::from_port(fake);
+        let tenant_id = Uuid::from_u128(1);
+        let context = PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(Uuid::from_u128(9).to_string()),
+            "und",
+            "privacy-test-correlation",
+        )
+        .with_deadline(Duration::from_secs(1));
+
+        let error = port
+            .source_follows_target(
+                context,
+                SocialGraphPairRequest {
+                    source_user_id: Uuid::from_u128(2),
+                    target_user_id: Uuid::from_u128(3),
+                },
+            )
+            .await
+            .expect_err("user actor mismatch must remain forbidden");
+
+        assert_eq!(error.kind, PortErrorKind::Forbidden);
+        assert_eq!(error.code, "social_graph.source_actor_mismatch");
+    }
+}

--- a/crates/rustok-social-graph/src/index_privacy_shadow.rs
+++ b/crates/rustok-social-graph/src/index_privacy_shadow.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustok_api::{PortContext, PortError};
@@ -13,13 +13,11 @@ const OPERATION_BLOCKS_BETWEEN: &str = "blocks_between";
 const OPERATION_SOURCE_MUTES_TARGET: &str = "source_mutes_target";
 const OPERATION_SOURCE_FOLLOWS_TARGET: &str = "source_follows_target";
 const OPERATION_SOURCE_FOLLOWS_TARGETS: &str = "source_follows_targets";
-const INDEX_PRIVACY_SHADOW_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Non-authoritative parity observer for Social Graph privacy reads.
 ///
 /// The owner port always determines the returned result. Index is queried only after the
-/// owner succeeds, and projection errors, timeouts, or mismatches are recorded without
-/// changing policy.
+/// owner succeeds, and projection errors or mismatches are recorded without changing policy.
 #[derive(Clone)]
 pub struct IndexShadowSocialGraphPrivacyReadPort {
     authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
@@ -63,11 +61,7 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_BLOCKS_BETWEEN,
             authoritative,
-            tokio::time::timeout(
-                INDEX_PRIVACY_SHADOW_TIMEOUT,
-                self.projected.blocks_between(context, request),
-            )
-            .await,
+            self.projected.blocks_between(context, request).await,
         );
         Ok(authoritative)
     }
@@ -84,11 +78,7 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_SOURCE_MUTES_TARGET,
             authoritative,
-            tokio::time::timeout(
-                INDEX_PRIVACY_SHADOW_TIMEOUT,
-                self.projected.source_mutes_target(context, request),
-            )
-            .await,
+            self.projected.source_mutes_target(context, request).await,
         );
         Ok(authoritative)
     }
@@ -105,11 +95,7 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_SOURCE_FOLLOWS_TARGET,
             authoritative,
-            tokio::time::timeout(
-                INDEX_PRIVACY_SHADOW_TIMEOUT,
-                self.projected.source_follows_target(context, request),
-            )
-            .await,
+            self.projected.source_follows_target(context, request).await,
         );
         Ok(authoritative)
     }
@@ -126,29 +112,21 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_batch(
             OPERATION_SOURCE_FOLLOWS_TARGETS,
             &authoritative,
-            tokio::time::timeout(
-                INDEX_PRIVACY_SHADOW_TIMEOUT,
-                self.projected.source_follows_targets(context, request),
-            )
-            .await,
+            self.projected.source_follows_targets(context, request).await,
         );
         Ok(authoritative)
     }
 }
 
-fn observe_bool(
-    operation: &'static str,
-    authoritative: bool,
-    projected: Result<Result<bool, PortError>, tokio::time::error::Elapsed>,
-) {
+fn observe_bool(operation: &'static str, authoritative: bool, projected: Result<bool, PortError>) {
     match projected {
-        Ok(Ok(projected)) if projected == authoritative => {
+        Ok(projected) if projected == authoritative => {
             tracing::debug!(
                 operation,
                 "Social Graph Index privacy shadow matched authoritative owner result"
             );
         }
-        Ok(Ok(projected)) => {
+        Ok(projected) => {
             tracing::warn!(
                 operation,
                 authoritative,
@@ -156,19 +134,12 @@ fn observe_bool(
                 "Social Graph Index privacy shadow mismatch"
             );
         }
-        Ok(Err(error)) => {
+        Err(error) => {
             tracing::warn!(
                 operation,
                 code = %error.code,
                 retryable = error.retryable,
                 "Social Graph Index privacy shadow read failed"
-            );
-        }
-        Err(_) => {
-            tracing::warn!(
-                operation,
-                timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis(),
-                "Social Graph Index privacy shadow timed out"
             );
         }
     }
@@ -177,20 +148,17 @@ fn observe_bool(
 fn observe_batch(
     operation: &'static str,
     authoritative: &SocialGraphFollowBatchResult,
-    projected: Result<
-        Result<SocialGraphFollowBatchResult, PortError>,
-        tokio::time::error::Elapsed,
-    >,
+    projected: Result<SocialGraphFollowBatchResult, PortError>,
 ) {
     match projected {
-        Ok(Ok(projected)) if projected == *authoritative => {
+        Ok(projected) if projected == *authoritative => {
             tracing::debug!(
                 operation,
                 authoritative_count = authoritative.followed_target_user_ids.len(),
                 "Social Graph Index privacy shadow matched authoritative owner result"
             );
         }
-        Ok(Ok(projected)) => {
+        Ok(projected) => {
             tracing::warn!(
                 operation,
                 authoritative_count = authoritative.followed_target_user_ids.len(),
@@ -198,19 +166,12 @@ fn observe_batch(
                 "Social Graph Index privacy shadow mismatch"
             );
         }
-        Ok(Err(error)) => {
+        Err(error) => {
             tracing::warn!(
                 operation,
                 code = %error.code,
                 retryable = error.retryable,
                 "Social Graph Index privacy shadow read failed"
-            );
-        }
-        Err(_) => {
-            tracing::warn!(
-                operation,
-                timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis(),
-                "Social Graph Index privacy shadow timed out"
             );
         }
     }

--- a/crates/rustok-social-graph/src/index_privacy_shadow.rs
+++ b/crates/rustok-social-graph/src/index_privacy_shadow.rs
@@ -21,7 +21,7 @@ const OPERATION_SOURCE_FOLLOWS_TARGETS: &str = "source_follows_targets";
 #[derive(Clone)]
 pub struct IndexShadowSocialGraphPrivacyReadPort {
     authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
-    projected: IndexSocialGraphPrivacyReadPort,
+    projected: Arc<dyn SocialGraphPrivacyReadPort>,
 }
 
 impl IndexShadowSocialGraphPrivacyReadPort {
@@ -31,7 +31,18 @@ impl IndexShadowSocialGraphPrivacyReadPort {
     ) -> Self {
         Self {
             authoritative,
-            projected: IndexSocialGraphPrivacyReadPort::new(runtime),
+            projected: Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime)),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_ports(
+        authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
+        projected: Arc<dyn SocialGraphPrivacyReadPort>,
+    ) -> Self {
+        Self {
+            authoritative,
+            projected,
         }
     }
 }
@@ -163,5 +174,145 @@ fn observe_batch(
                 "Social Graph Index privacy shadow read failed"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rustok_api::PortActor;
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FixedPrivacyPort {
+        boolean: bool,
+        batch: Vec<Uuid>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl SocialGraphPrivacyReadPort for FixedPrivacyPort {
+        async fn blocks_between(
+            &self,
+            _context: PortContext,
+            _request: SocialGraphPairRequest,
+        ) -> Result<bool, PortError> {
+            self.boolean_result()
+        }
+
+        async fn source_mutes_target(
+            &self,
+            _context: PortContext,
+            _request: SocialGraphPairRequest,
+        ) -> Result<bool, PortError> {
+            self.boolean_result()
+        }
+
+        async fn source_follows_target(
+            &self,
+            _context: PortContext,
+            _request: SocialGraphPairRequest,
+        ) -> Result<bool, PortError> {
+            self.boolean_result()
+        }
+
+        async fn source_follows_targets(
+            &self,
+            _context: PortContext,
+            _request: SocialGraphFollowBatchRequest,
+        ) -> Result<SocialGraphFollowBatchResult, PortError> {
+            if self.fail {
+                Err(projected_failure())
+            } else {
+                Ok(SocialGraphFollowBatchResult {
+                    followed_target_user_ids: self.batch.clone(),
+                })
+            }
+        }
+    }
+
+    impl FixedPrivacyPort {
+        fn boolean_result(&self) -> Result<bool, PortError> {
+            if self.fail {
+                Err(projected_failure())
+            } else {
+                Ok(self.boolean)
+            }
+        }
+    }
+
+    fn context() -> PortContext {
+        PortContext::new(
+            Uuid::from_u128(1).to_string(),
+            PortActor::service("privacy-shadow-test"),
+            "und",
+            "privacy-shadow-test-correlation",
+        )
+        .with_deadline(Duration::from_secs(1))
+    }
+
+    fn pair() -> SocialGraphPairRequest {
+        SocialGraphPairRequest {
+            source_user_id: Uuid::from_u128(2),
+            target_user_id: Uuid::from_u128(3),
+        }
+    }
+
+    fn projected_failure() -> PortError {
+        PortError::unavailable(
+            "social_graph.index_privacy_unavailable",
+            "projected privacy state is unavailable",
+        )
+    }
+
+    #[tokio::test]
+    async fn mismatch_returns_authoritative_boolean() {
+        let shadow = IndexShadowSocialGraphPrivacyReadPort::from_ports(
+            Arc::new(FixedPrivacyPort {
+                boolean: true,
+                batch: Vec::new(),
+                fail: false,
+            }),
+            Arc::new(FixedPrivacyPort {
+                boolean: false,
+                batch: Vec::new(),
+                fail: false,
+            }),
+        );
+
+        assert!(shadow.blocks_between(context(), pair()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn projected_error_returns_authoritative_batch() {
+        let expected = vec![Uuid::from_u128(4), Uuid::from_u128(5)];
+        let shadow = IndexShadowSocialGraphPrivacyReadPort::from_ports(
+            Arc::new(FixedPrivacyPort {
+                boolean: true,
+                batch: expected.clone(),
+                fail: false,
+            }),
+            Arc::new(FixedPrivacyPort {
+                boolean: false,
+                batch: Vec::new(),
+                fail: true,
+            }),
+        );
+
+        let result = shadow
+            .source_follows_targets(
+                context(),
+                SocialGraphFollowBatchRequest {
+                    source_user_id: Uuid::from_u128(2),
+                    target_user_ids: vec![Uuid::from_u128(4), Uuid::from_u128(5)],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.followed_target_user_ids, expected);
     }
 }

--- a/crates/rustok-social-graph/src/index_privacy_shadow.rs
+++ b/crates/rustok-social-graph/src/index_privacy_shadow.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use rustok_api::{PortContext, PortError};
@@ -13,11 +13,13 @@ const OPERATION_BLOCKS_BETWEEN: &str = "blocks_between";
 const OPERATION_SOURCE_MUTES_TARGET: &str = "source_mutes_target";
 const OPERATION_SOURCE_FOLLOWS_TARGET: &str = "source_follows_target";
 const OPERATION_SOURCE_FOLLOWS_TARGETS: &str = "source_follows_targets";
+const INDEX_PRIVACY_SHADOW_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Non-authoritative parity observer for Social Graph privacy reads.
 ///
 /// The owner port always determines the returned result. Index is queried only after the
-/// owner succeeds, and projection errors or mismatches are recorded without changing policy.
+/// owner succeeds, and projection errors, timeouts, or mismatches are recorded without
+/// changing policy.
 #[derive(Clone)]
 pub struct IndexShadowSocialGraphPrivacyReadPort {
     authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
@@ -61,7 +63,11 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_BLOCKS_BETWEEN,
             authoritative,
-            self.projected.blocks_between(context, request).await,
+            tokio::time::timeout(
+                INDEX_PRIVACY_SHADOW_TIMEOUT,
+                self.projected.blocks_between(context, request),
+            )
+            .await,
         );
         Ok(authoritative)
     }
@@ -78,7 +84,11 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_SOURCE_MUTES_TARGET,
             authoritative,
-            self.projected.source_mutes_target(context, request).await,
+            tokio::time::timeout(
+                INDEX_PRIVACY_SHADOW_TIMEOUT,
+                self.projected.source_mutes_target(context, request),
+            )
+            .await,
         );
         Ok(authoritative)
     }
@@ -95,7 +105,11 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_bool(
             OPERATION_SOURCE_FOLLOWS_TARGET,
             authoritative,
-            self.projected.source_follows_target(context, request).await,
+            tokio::time::timeout(
+                INDEX_PRIVACY_SHADOW_TIMEOUT,
+                self.projected.source_follows_target(context, request),
+            )
+            .await,
         );
         Ok(authoritative)
     }
@@ -112,21 +126,29 @@ impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
         observe_batch(
             OPERATION_SOURCE_FOLLOWS_TARGETS,
             &authoritative,
-            self.projected.source_follows_targets(context, request).await,
+            tokio::time::timeout(
+                INDEX_PRIVACY_SHADOW_TIMEOUT,
+                self.projected.source_follows_targets(context, request),
+            )
+            .await,
         );
         Ok(authoritative)
     }
 }
 
-fn observe_bool(operation: &'static str, authoritative: bool, projected: Result<bool, PortError>) {
+fn observe_bool(
+    operation: &'static str,
+    authoritative: bool,
+    projected: Result<Result<bool, PortError>, tokio::time::error::Elapsed>,
+) {
     match projected {
-        Ok(projected) if projected == authoritative => {
+        Ok(Ok(projected)) if projected == authoritative => {
             tracing::debug!(
                 operation,
                 "Social Graph Index privacy shadow matched authoritative owner result"
             );
         }
-        Ok(projected) => {
+        Ok(Ok(projected)) => {
             tracing::warn!(
                 operation,
                 authoritative,
@@ -134,12 +156,19 @@ fn observe_bool(operation: &'static str, authoritative: bool, projected: Result<
                 "Social Graph Index privacy shadow mismatch"
             );
         }
-        Err(error) => {
+        Ok(Err(error)) => {
             tracing::warn!(
                 operation,
                 code = %error.code,
                 retryable = error.retryable,
                 "Social Graph Index privacy shadow read failed"
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                operation,
+                timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis(),
+                "Social Graph Index privacy shadow timed out"
             );
         }
     }
@@ -148,17 +177,20 @@ fn observe_bool(operation: &'static str, authoritative: bool, projected: Result<
 fn observe_batch(
     operation: &'static str,
     authoritative: &SocialGraphFollowBatchResult,
-    projected: Result<SocialGraphFollowBatchResult, PortError>,
+    projected: Result<
+        Result<SocialGraphFollowBatchResult, PortError>,
+        tokio::time::error::Elapsed,
+    >,
 ) {
     match projected {
-        Ok(projected) if projected == *authoritative => {
+        Ok(Ok(projected)) if projected == *authoritative => {
             tracing::debug!(
                 operation,
                 authoritative_count = authoritative.followed_target_user_ids.len(),
                 "Social Graph Index privacy shadow matched authoritative owner result"
             );
         }
-        Ok(projected) => {
+        Ok(Ok(projected)) => {
             tracing::warn!(
                 operation,
                 authoritative_count = authoritative.followed_target_user_ids.len(),
@@ -166,12 +198,19 @@ fn observe_batch(
                 "Social Graph Index privacy shadow mismatch"
             );
         }
-        Err(error) => {
+        Ok(Err(error)) => {
             tracing::warn!(
                 operation,
                 code = %error.code,
                 retryable = error.retryable,
                 "Social Graph Index privacy shadow read failed"
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                operation,
+                timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis(),
+                "Social Graph Index privacy shadow timed out"
             );
         }
     }

--- a/crates/rustok-social-graph/src/index_privacy_shadow.rs
+++ b/crates/rustok-social-graph/src/index_privacy_shadow.rs
@@ -181,6 +181,7 @@ fn observe_batch(
 mod tests {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use rustok_api::PortActor;
     use uuid::Uuid;
 

--- a/crates/rustok-social-graph/src/index_privacy_shadow.rs
+++ b/crates/rustok-social-graph/src/index_privacy_shadow.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortContext, PortError};
+use rustok_index::SharedIndexQueryRuntime;
+
+use crate::{
+    IndexSocialGraphPrivacyReadPort, SocialGraphFollowBatchRequest, SocialGraphFollowBatchResult,
+    SocialGraphPairRequest, SocialGraphPrivacyReadPort,
+};
+
+const OPERATION_BLOCKS_BETWEEN: &str = "blocks_between";
+const OPERATION_SOURCE_MUTES_TARGET: &str = "source_mutes_target";
+const OPERATION_SOURCE_FOLLOWS_TARGET: &str = "source_follows_target";
+const OPERATION_SOURCE_FOLLOWS_TARGETS: &str = "source_follows_targets";
+
+/// Non-authoritative parity observer for Social Graph privacy reads.
+///
+/// The owner port always determines the returned result. Index is queried only after the
+/// owner succeeds, and projection errors or mismatches are recorded without changing policy.
+#[derive(Clone)]
+pub struct IndexShadowSocialGraphPrivacyReadPort {
+    authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
+    projected: IndexSocialGraphPrivacyReadPort,
+}
+
+impl IndexShadowSocialGraphPrivacyReadPort {
+    pub fn new(
+        authoritative: Arc<dyn SocialGraphPrivacyReadPort>,
+        runtime: SharedIndexQueryRuntime,
+    ) -> Self {
+        Self {
+            authoritative,
+            projected: IndexSocialGraphPrivacyReadPort::new(runtime),
+        }
+    }
+}
+
+#[async_trait]
+impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort {
+    async fn blocks_between(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        let authoritative = self
+            .authoritative
+            .blocks_between(context.clone(), request)
+            .await?;
+        observe_bool(
+            OPERATION_BLOCKS_BETWEEN,
+            authoritative,
+            self.projected.blocks_between(context, request).await,
+        );
+        Ok(authoritative)
+    }
+
+    async fn source_mutes_target(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        let authoritative = self
+            .authoritative
+            .source_mutes_target(context.clone(), request)
+            .await?;
+        observe_bool(
+            OPERATION_SOURCE_MUTES_TARGET,
+            authoritative,
+            self.projected.source_mutes_target(context, request).await,
+        );
+        Ok(authoritative)
+    }
+
+    async fn source_follows_target(
+        &self,
+        context: PortContext,
+        request: SocialGraphPairRequest,
+    ) -> Result<bool, PortError> {
+        let authoritative = self
+            .authoritative
+            .source_follows_target(context.clone(), request)
+            .await?;
+        observe_bool(
+            OPERATION_SOURCE_FOLLOWS_TARGET,
+            authoritative,
+            self.projected.source_follows_target(context, request).await,
+        );
+        Ok(authoritative)
+    }
+
+    async fn source_follows_targets(
+        &self,
+        context: PortContext,
+        request: SocialGraphFollowBatchRequest,
+    ) -> Result<SocialGraphFollowBatchResult, PortError> {
+        let authoritative = self
+            .authoritative
+            .source_follows_targets(context.clone(), request.clone())
+            .await?;
+        observe_batch(
+            OPERATION_SOURCE_FOLLOWS_TARGETS,
+            &authoritative,
+            self.projected.source_follows_targets(context, request).await,
+        );
+        Ok(authoritative)
+    }
+}
+
+fn observe_bool(operation: &'static str, authoritative: bool, projected: Result<bool, PortError>) {
+    match projected {
+        Ok(projected) if projected == authoritative => {
+            tracing::debug!(
+                operation,
+                "Social Graph Index privacy shadow matched authoritative owner result"
+            );
+        }
+        Ok(projected) => {
+            tracing::warn!(
+                operation,
+                authoritative,
+                projected,
+                "Social Graph Index privacy shadow mismatch"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                operation,
+                code = %error.code,
+                retryable = error.retryable,
+                "Social Graph Index privacy shadow read failed"
+            );
+        }
+    }
+}
+
+fn observe_batch(
+    operation: &'static str,
+    authoritative: &SocialGraphFollowBatchResult,
+    projected: Result<SocialGraphFollowBatchResult, PortError>,
+) {
+    match projected {
+        Ok(projected) if projected == *authoritative => {
+            tracing::debug!(
+                operation,
+                authoritative_count = authoritative.followed_target_user_ids.len(),
+                "Social Graph Index privacy shadow matched authoritative owner result"
+            );
+        }
+        Ok(projected) => {
+            tracing::warn!(
+                operation,
+                authoritative_count = authoritative.followed_target_user_ids.len(),
+                projected_count = projected.followed_target_user_ids.len(),
+                "Social Graph Index privacy shadow mismatch"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                operation,
+                code = %error.code,
+                retryable = error.retryable,
+                "Social Graph Index privacy shadow read failed"
+            );
+        }
+    }
+}

--- a/crates/rustok-social-graph/src/lib.rs
+++ b/crates/rustok-social-graph/src/lib.rs
@@ -18,6 +18,8 @@ mod index_dlq_message_id;
 pub mod index_dlq_receipt;
 #[cfg(feature = "index")]
 pub mod index_privacy;
+#[cfg(feature = "index")]
+pub mod index_privacy_shadow;
 pub mod maintenance;
 pub mod migrations;
 pub mod model;
@@ -30,6 +32,8 @@ pub use error::{SocialGraphError, SocialGraphResult};
 pub use follow_read::{SocialGraphFollowReadPort, SocialGraphFollowState};
 #[cfg(feature = "index")]
 pub use index_privacy::IndexSocialGraphPrivacyReadPort;
+#[cfg(feature = "index")]
+pub use index_privacy_shadow::IndexShadowSocialGraphPrivacyReadPort;
 pub use maintenance::{
     SocialGraphReceiptMaintenanceService, SocialGraphRelationEventMaintenanceService,
 };

--- a/crates/rustok-social-graph/src/lib.rs
+++ b/crates/rustok-social-graph/src/lib.rs
@@ -16,6 +16,8 @@ pub mod index_consumer;
 mod index_dlq_message_id;
 #[cfg(feature = "index-consumer")]
 pub mod index_dlq_receipt;
+#[cfg(feature = "index")]
+pub mod index_privacy;
 pub mod maintenance;
 pub mod migrations;
 pub mod model;
@@ -26,6 +28,8 @@ pub mod service;
 
 pub use error::{SocialGraphError, SocialGraphResult};
 pub use follow_read::{SocialGraphFollowReadPort, SocialGraphFollowState};
+#[cfg(feature = "index")]
+pub use index_privacy::IndexSocialGraphPrivacyReadPort;
 pub use maintenance::{
     SocialGraphReceiptMaintenanceService, SocialGraphRelationEventMaintenanceService,
 };

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -16,6 +16,7 @@ const scripts = [
   'verify-index-query-equivalence-admission.mjs',
   'verify-index-source-schema-registry.mjs',
   'verify-index-query-runtime-composition.mjs',
+  'verify-index-social-graph-privacy-consumer.mjs',
 ];
 
 for (const script of scripts) {

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -88,7 +88,7 @@ const server = requireMarkers(serverPath, [
   'pub mod module_event_dispatcher {',
   'build_shared_runtime_extensions_with_host_providers(',
   'module_event_dispatcher_base::build_shared_runtime_extensions_with_host_providers(',
-  'materialize_postgres_index_query_runtime(&mut extensions, db)',
+  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
   'Index query runtime composition failed',
   'host_materializes_index_query_runtime_after_source_registry',
   'extensions.contains::<SharedIndexSchemaRegistry>()',
@@ -103,6 +103,7 @@ for (const relative of [
   'crates/rustok-distribution/src/lib.rs',
   'crates/rustok-social-graph/src/lib.rs',
   'crates/rustok-social-graph/src/index_consumer.rs',
+  'crates/rustok-social-graph/src/index_privacy.rs',
 ]) {
   const source = read(relative);
   if (source.includes('PostgresIndexQueryPort::new')) {
@@ -134,7 +135,7 @@ requireMarkers('crates/rustok-index/docs/m4-query-runtime-composition.md', [
   '`SharedIndexQueryRuntime`',
   '`materialize_postgres_index_query_runtime(extensions, db)`',
   'performs no SQL',
-  'does not:',
+  'selected consumers may be recomposed only after runtime publication',
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -104,6 +104,7 @@ for (const relative of [
   'crates/rustok-social-graph/src/lib.rs',
   'crates/rustok-social-graph/src/index_consumer.rs',
   'crates/rustok-social-graph/src/index_privacy.rs',
+  'crates/rustok-social-graph/src/index_privacy_shadow.rs',
 ]) {
   const source = read(relative);
   if (source.includes('PostgresIndexQueryPort::new')) {

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -73,6 +73,10 @@ requireMarkers('crates/rustok-social-graph/src/lib.rs', [
 
 const policyPath = 'apps/server/src/services/notification_recipient_policy.rs';
 const policy = requireMarkers(policyPath, [
+  'pub const SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV',
+  'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED',
+  'pub(crate) fn social_graph_index_privacy_reads_enabled()',
+  'Err(std::env::VarError::NotPresent) => Ok(false)',
   'pub fn compose_with_index_runtime(',
   'runtime: SharedIndexQueryRuntime',
   'IndexSocialGraphPrivacyReadPort::new(runtime)',
@@ -98,13 +102,15 @@ for (const forbidden of [
 const finalHostPath = 'apps/server/src/services/mod.rs';
 const finalHost = requireMarkers(finalHostPath, [
   'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
-  'Index query runtime is required for Social Graph notification privacy reads',
+  'social_graph_index_privacy_reads_enabled()',
+  'Index query runtime is required when Social Graph Index privacy reads are enabled',
   'get::<rustok_index::SharedIndexQueryRuntime>()',
   'compose_with_index_runtime(',
   'extensions.insert(policy);',
 ]);
 requireOrder(finalHostPath, finalHost, [
   'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
+  'social_graph_index_privacy_reads_enabled()',
   'get::<rustok_index::SharedIndexQueryRuntime>()',
   'compose_with_index_runtime(',
   'extensions.insert(policy);',
@@ -117,7 +123,7 @@ for (const forbidden of [
   'unwrap_or_default()',
 ]) {
   if (finalHost.includes(forbidden)) {
-    fail(`${finalHostPath} contains forbidden final-host fallback marker ${forbidden}`);
+    fail(`${finalHostPath} contains forbidden activated-path fallback marker ${forbidden}`);
   }
 }
 
@@ -125,17 +131,26 @@ const contractPath = 'crates/rustok-social-graph/contracts/social-graph-notifica
 const contract = JSON.parse(read(contractPath));
 if (contract.schema_version !== 3) fail(`${contractPath} must use schema_version 3`);
 if (contract.index_privacy !== ownerPath) fail(`${contractPath} must point to the owner adapter`);
-if (contract.privacy_semantics?.index_readiness_failure_suppresses_allow !== true) {
-  fail(`${contractPath} must record fail-closed Index readiness`);
+if (contract.privacy_semantics?.index_readiness_failure_suppresses_allow_when_enabled !== true) {
+  fail(`${contractPath} must record fail-closed Index readiness after activation`);
 }
-if (contract.server_composition?.index_query_runtime_required !== true) {
-  fail(`${contractPath} must require the shared Index query runtime`);
+if (contract.server_composition?.index_query_runtime_required_when_enabled !== true) {
+  fail(`${contractPath} must require the shared Index query runtime after activation`);
 }
-if (contract.server_composition?.notification_block_mute_index_cutover !== true) {
-  fail(`${contractPath} must record notification block/mute cutover`);
+if (contract.server_composition?.notification_block_mute_index_cutover_source_complete !== true) {
+  fail(`${contractPath} must record source-complete notification block/mute cutover`);
 }
-if (contract.server_composition?.authoritative_table_fallback_in_final_host !== false) {
-  fail(`${contractPath} must forbid authoritative-table fallback in the final host`);
+if (contract.server_composition?.index_privacy_activation_env !== 'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED') {
+  fail(`${contractPath} must retain the exact activation environment variable`);
+}
+if (contract.server_composition?.index_privacy_default_enabled !== false) {
+  fail(`${contractPath} must keep Index privacy reads default-off`);
+}
+if (contract.server_composition?.authoritative_table_path_before_activation !== true) {
+  fail(`${contractPath} must retain the owner read path before activation`);
+}
+if (contract.server_composition?.authoritative_table_fallback_after_activation !== false) {
+  fail(`${contractPath} must forbid owner-table fallback after activation`);
 }
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
@@ -145,18 +160,22 @@ requireMarkers('crates/rustok-index/docs/m4-social-graph-privacy-consumer.md', [
   'Status: `source_complete_execution_pending`',
   '`IndexSocialGraphPrivacyReadPort`',
   'block in either direction',
+  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`',
+  'default-off',
   'retryable fail-closed',
   'does not authorize from missing or stale Index state',
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
-  'M4 first authorized consumer cutover: `source_complete_execution_pending`',
+  'M4 first authorized consumer cutover source: `source_complete_execution_pending`',
   '`IndexSocialGraphPrivacyReadPort`',
   'notification block/mute policy',
+  'default-off activation gate',
 ]);
 requireMarkers('crates/rustok-social-graph/CRATE_API.md', [
   '`IndexSocialGraphPrivacyReadPort`',
   'notification block/mute policy',
+  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`',
   'retryable fail-closed',
 ]);
 

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -67,6 +67,10 @@ const shadow = requireMarkers(shadowPath, [
   'authoritative: Arc<dyn SocialGraphPrivacyReadPort>',
   'projected: Arc<dyn SocialGraphPrivacyReadPort>',
   'projected: Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime))',
+  'const INDEX_PRIVACY_SHADOW_TIMEOUT: Duration = Duration::from_millis(100);',
+  'tokio::time::timeout(',
+  'Social Graph Index privacy shadow timed out',
+  'timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis()',
   'fn from_ports(',
   'impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort',
   '.blocks_between(context.clone(), request)',
@@ -85,6 +89,10 @@ const authoritativeReturns = shadow.match(/Ok\(authoritative\)/g) ?? [];
 if (authoritativeReturns.length !== 4) {
   fail(`${shadowPath} must return the authoritative result from all four privacy methods`);
 }
+const shadowTimeoutCalls = shadow.match(/tokio::time::timeout\(/g) ?? [];
+if (shadowTimeoutCalls.length !== 4) {
+  fail(`${shadowPath} must bound all four projected comparisons`);
+}
 for (const forbidden of [
   'tenant_id =',
   'source_user_id =',
@@ -99,6 +107,10 @@ for (const forbidden of [
   if (shadow.includes(forbidden)) fail(`${shadowPath} contains forbidden telemetry/runtime marker ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-social-graph/Cargo.toml', [
+  'tokio = { workspace = true, optional = true }',
+  'index = ["dep:rustok-index", "dep:tokio"]',
+]);
 requireMarkers('crates/rustok-social-graph/src/lib.rs', [
   'pub mod index_privacy;',
   'pub mod index_privacy_shadow;',
@@ -158,6 +170,9 @@ if (contract.privacy_semantics?.authoritative_owner_result_always_returned !== t
 if (contract.privacy_semantics?.index_shadow_never_authorizes !== true) {
   fail(`${contractPath} must forbid Index shadow authorization`);
 }
+if (contract.privacy_semantics?.index_shadow_timeout_ms !== 100) {
+  fail(`${contractPath} must retain the 100 ms shadow timeout`);
+}
 if (contract.server_composition?.notification_block_mute_index_shadow_source_complete !== true) {
   fail(`${contractPath} must record source-complete shadow composition`);
 }
@@ -183,6 +198,7 @@ requireMarkers('crates/rustok-index/docs/m4-social-graph-privacy-consumer.md', [
   '`IndexShadowSocialGraphPrivacyReadPort`',
   '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
   'default-off',
+  '100 ms',
   'always returns the owner result',
   'never authorizes',
   'Not run by the implementation agent',
@@ -197,6 +213,7 @@ requireMarkers('crates/rustok-social-graph/CRATE_API.md', [
   '`IndexSocialGraphPrivacyReadPort`',
   '`IndexShadowSocialGraphPrivacyReadPort`',
   '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
+  '100 ms',
   'owner result',
   'never authorizes',
 ]);

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -213,7 +213,6 @@ requireMarkers('crates/rustok-social-graph/CRATE_API.md', [
   '`IndexSocialGraphPrivacyReadPort`',
   '`IndexShadowSocialGraphPrivacyReadPort`',
   '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
-  '100 ms',
   'owner result',
   'never authorizes',
 ]);

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -65,7 +65,9 @@ const shadowPath = 'crates/rustok-social-graph/src/index_privacy_shadow.rs';
 const shadow = requireMarkers(shadowPath, [
   'pub struct IndexShadowSocialGraphPrivacyReadPort',
   'authoritative: Arc<dyn SocialGraphPrivacyReadPort>',
-  'projected: IndexSocialGraphPrivacyReadPort',
+  'projected: Arc<dyn SocialGraphPrivacyReadPort>',
+  'projected: Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime))',
+  'fn from_ports(',
   'impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort',
   '.blocks_between(context.clone(), request)',
   '.source_mutes_target(context.clone(), request)',
@@ -76,6 +78,8 @@ const shadow = requireMarkers(shadowPath, [
   'Ok(authoritative)',
   'Social Graph Index privacy shadow mismatch',
   'Social Graph Index privacy shadow read failed',
+  'mismatch_returns_authoritative_boolean',
+  'projected_error_returns_authoritative_batch',
 ]);
 const authoritativeReturns = shadow.match(/Ok\(authoritative\)/g) ?? [];
 if (authoritativeReturns.length !== 4) {

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-social-graph-privacy-consumer] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const requireOrder = (relative, source, markers) => {
+  let previous = -1;
+  for (const marker of markers) {
+    const current = source.indexOf(marker, previous + 1);
+    if (current < 0 || current <= previous) {
+      fail(`${relative} is missing or reorders ${marker}`);
+    }
+    previous = current;
+  }
+};
+
+const ownerPath = 'crates/rustok-social-graph/src/index_privacy.rs';
+const owner = requireMarkers(ownerPath, [
+  'pub struct IndexSocialGraphPrivacyReadPort',
+  'port: Arc<dyn IndexQueryPort>',
+  'pub fn new(runtime: SharedIndexQueryRuntime)',
+  'impl SocialGraphPrivacyReadPort for IndexSocialGraphPrivacyReadPort',
+  'context.require_policy(PortCallPolicy::read())',
+  'validate_source_actor(&context, request.source_user_id)',
+  'MAX_SOCIAL_GRAPH_FOLLOW_TARGETS',
+  'FilterExpr::Or(vec![',
+  'SocialRelationKind::Block.as_str()',
+  'SocialRelationKind::Mute.as_str()',
+  'SocialRelationKind::Follow.as_str()',
+  'FilterExpr::In(contract.target.clone(), target_values)',
+  'Pagination::Offset',
+  'if page.has_more',
+  'IndexQueryExecutionError::SchemaNotReady',
+  'social_graph.index_privacy_unavailable',
+  'social_graph.index_privacy_contract_invalid',
+  'missing_tenant_schema_is_retryable_and_does_not_authorize',
+  'user_follow_reads_preserve_source_actor_authorization',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'SocialGraphService',
+  'relation::Entity',
+  'social_graph_relations',
+  'sea_orm::',
+  'PostgresIndexQueryPort',
+  'unwrap_or(false)',
+  'unwrap_or_default()',
+]) {
+  if (owner.includes(forbidden)) {
+    fail(`${ownerPath} contains forbidden owner-storage or permissive marker ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-social-graph/src/lib.rs', [
+  '#[cfg(feature = "index")]',
+  'pub mod index_privacy;',
+  'pub use index_privacy::IndexSocialGraphPrivacyReadPort;',
+]);
+
+const policyPath = 'apps/server/src/services/notification_recipient_policy.rs';
+const policy = requireMarkers(policyPath, [
+  'pub fn compose_with_index_runtime(',
+  'runtime: SharedIndexQueryRuntime',
+  'IndexSocialGraphPrivacyReadPort::new(runtime)',
+  'SocialGraphPrivacyRuntime::new(graph_port)',
+  'NotificationBlockReadRuntime::new',
+  'NotificationMuteReadRuntime::new',
+  'evaluate_profile_privacy',
+  'blocks_notification',
+  'mutes_notification',
+  'map_port_error',
+]);
+for (const forbidden of [
+  'social_graph_relations',
+  'relation::Entity',
+  'PostgresIndexQueryPort::new',
+  'unwrap_or(false)',
+]) {
+  if (policy.includes(forbidden)) {
+    fail(`${policyPath} contains forbidden table/runtime bypass marker ${forbidden}`);
+  }
+}
+
+const finalHostPath = 'apps/server/src/services/mod.rs';
+const finalHost = requireMarkers(finalHostPath, [
+  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
+  'Index query runtime is required for Social Graph notification privacy reads',
+  'get::<rustok_index::SharedIndexQueryRuntime>()',
+  'compose_with_index_runtime(',
+  'extensions.insert(policy);',
+]);
+requireOrder(finalHostPath, finalHost, [
+  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
+  'get::<rustok_index::SharedIndexQueryRuntime>()',
+  'compose_with_index_runtime(',
+  'extensions.insert(policy);',
+  'Ok(Arc::new(extensions))',
+]);
+for (const forbidden of [
+  'SocialGraphService::new',
+  'PostgresIndexQueryPort::new',
+  'unwrap_or(false)',
+  'unwrap_or_default()',
+]) {
+  if (finalHost.includes(forbidden)) {
+    fail(`${finalHostPath} contains forbidden final-host fallback marker ${forbidden}`);
+  }
+}
+
+const contractPath = 'crates/rustok-social-graph/contracts/social-graph-notification-policy.json';
+const contract = JSON.parse(read(contractPath));
+if (contract.schema_version !== 3) fail(`${contractPath} must use schema_version 3`);
+if (contract.index_privacy !== ownerPath) fail(`${contractPath} must point to the owner adapter`);
+if (contract.privacy_semantics?.index_readiness_failure_suppresses_allow !== true) {
+  fail(`${contractPath} must record fail-closed Index readiness`);
+}
+if (contract.server_composition?.index_query_runtime_required !== true) {
+  fail(`${contractPath} must require the shared Index query runtime`);
+}
+if (contract.server_composition?.notification_block_mute_index_cutover !== true) {
+  fail(`${contractPath} must record notification block/mute cutover`);
+}
+if (contract.server_composition?.authoritative_table_fallback_in_final_host !== false) {
+  fail(`${contractPath} must forbid authoritative-table fallback in the final host`);
+}
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-social-graph-privacy-consumer.mjs'",
+]);
+requireMarkers('crates/rustok-index/docs/m4-social-graph-privacy-consumer.md', [
+  'Status: `source_complete_execution_pending`',
+  '`IndexSocialGraphPrivacyReadPort`',
+  'block in either direction',
+  'retryable fail-closed',
+  'does not authorize from missing or stale Index state',
+  'Not run by the implementation agent',
+]);
+requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
+  'M4 first authorized consumer cutover: `source_complete_execution_pending`',
+  '`IndexSocialGraphPrivacyReadPort`',
+  'notification block/mute policy',
+]);
+requireMarkers('crates/rustok-social-graph/CRATE_API.md', [
+  '`IndexSocialGraphPrivacyReadPort`',
+  'notification block/mute policy',
+  'retryable fail-closed',
+]);
+
+console.log('[verify-index-social-graph-privacy-consumer] OK');

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -21,15 +21,13 @@ const requireOrder = (relative, source, markers) => {
   let previous = -1;
   for (const marker of markers) {
     const current = source.indexOf(marker, previous + 1);
-    if (current < 0 || current <= previous) {
-      fail(`${relative} is missing or reorders ${marker}`);
-    }
+    if (current < 0 || current <= previous) fail(`${relative} is missing or reorders ${marker}`);
     previous = current;
   }
 };
 
-const ownerPath = 'crates/rustok-social-graph/src/index_privacy.rs';
-const owner = requireMarkers(ownerPath, [
+const adapterPath = 'crates/rustok-social-graph/src/index_privacy.rs';
+const adapter = requireMarkers(adapterPath, [
   'pub struct IndexSocialGraphPrivacyReadPort',
   'port: Arc<dyn IndexQueryPort>',
   'pub fn new(runtime: SharedIndexQueryRuntime)',
@@ -60,97 +58,116 @@ for (const forbidden of [
   'unwrap_or(false)',
   'unwrap_or_default()',
 ]) {
-  if (owner.includes(forbidden)) {
-    fail(`${ownerPath} contains forbidden owner-storage or permissive marker ${forbidden}`);
-  }
+  if (adapter.includes(forbidden)) fail(`${adapterPath} contains forbidden marker ${forbidden}`);
+}
+
+const shadowPath = 'crates/rustok-social-graph/src/index_privacy_shadow.rs';
+const shadow = requireMarkers(shadowPath, [
+  'pub struct IndexShadowSocialGraphPrivacyReadPort',
+  'authoritative: Arc<dyn SocialGraphPrivacyReadPort>',
+  'projected: IndexSocialGraphPrivacyReadPort',
+  'impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort',
+  '.blocks_between(context.clone(), request)',
+  '.source_mutes_target(context.clone(), request)',
+  '.source_follows_target(context.clone(), request)',
+  '.source_follows_targets(context.clone(), request.clone())',
+  'observe_bool(',
+  'observe_batch(',
+  'Ok(authoritative)',
+  'Social Graph Index privacy shadow mismatch',
+  'Social Graph Index privacy shadow read failed',
+]);
+const authoritativeReturns = shadow.match(/Ok\(authoritative\)/g) ?? [];
+if (authoritativeReturns.length !== 4) {
+  fail(`${shadowPath} must return the authoritative result from all four privacy methods`);
+}
+for (const forbidden of [
+  'tenant_id =',
+  'source_user_id =',
+  'target_user_id =',
+  'relation_id =',
+  'entity_id =',
+  'PostgresIndexQueryPort',
+  'DatabaseConnection',
+  'unwrap_or(false)',
+  'unwrap_or_default()',
+]) {
+  if (shadow.includes(forbidden)) fail(`${shadowPath} contains forbidden telemetry/runtime marker ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-social-graph/src/lib.rs', [
-  '#[cfg(feature = "index")]',
   'pub mod index_privacy;',
+  'pub mod index_privacy_shadow;',
   'pub use index_privacy::IndexSocialGraphPrivacyReadPort;',
+  'pub use index_privacy_shadow::IndexShadowSocialGraphPrivacyReadPort;',
 ]);
 
 const policyPath = 'apps/server/src/services/notification_recipient_policy.rs';
 const policy = requireMarkers(policyPath, [
-  'pub const SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED_ENV',
-  'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED',
-  'pub(crate) fn social_graph_index_privacy_reads_enabled()',
+  'pub const SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED_ENV',
+  'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED',
+  'pub(crate) fn social_graph_index_privacy_shadow_enabled()',
   'Err(std::env::VarError::NotPresent) => Ok(false)',
-  'pub fn compose_with_index_runtime(',
+  'pub fn compose_with_index_shadow_runtime(',
   'runtime: SharedIndexQueryRuntime',
-  'IndexSocialGraphPrivacyReadPort::new(runtime)',
-  'SocialGraphPrivacyRuntime::new(graph_port)',
+  'SocialGraphService::new(db.clone())',
+  'IndexShadowSocialGraphPrivacyReadPort::new(authoritative, runtime)',
   'NotificationBlockReadRuntime::new',
   'NotificationMuteReadRuntime::new',
   'evaluate_profile_privacy',
   'blocks_notification',
   'mutes_notification',
-  'map_port_error',
 ]);
-for (const forbidden of [
-  'social_graph_relations',
-  'relation::Entity',
-  'PostgresIndexQueryPort::new',
-  'unwrap_or(false)',
-]) {
-  if (policy.includes(forbidden)) {
-    fail(`${policyPath} contains forbidden table/runtime bypass marker ${forbidden}`);
-  }
+for (const forbidden of ['social_graph_relations', 'relation::Entity', 'PostgresIndexQueryPort::new']) {
+  if (policy.includes(forbidden)) fail(`${policyPath} contains forbidden table/runtime bypass marker ${forbidden}`);
 }
 
 const finalHostPath = 'apps/server/src/services/mod.rs';
 const finalHost = requireMarkers(finalHostPath, [
   'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
-  'social_graph_index_privacy_reads_enabled()',
-  'Index query runtime is required when Social Graph Index privacy reads are enabled',
+  'social_graph_index_privacy_shadow_enabled()',
+  'Index query runtime is required when Social Graph Index privacy shadow is enabled',
   'get::<rustok_index::SharedIndexQueryRuntime>()',
-  'compose_with_index_runtime(',
+  'compose_with_index_shadow_runtime(',
   'extensions.insert(policy);',
 ]);
 requireOrder(finalHostPath, finalHost, [
   'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
-  'social_graph_index_privacy_reads_enabled()',
+  'social_graph_index_privacy_shadow_enabled()',
   'get::<rustok_index::SharedIndexQueryRuntime>()',
-  'compose_with_index_runtime(',
+  'compose_with_index_shadow_runtime(',
   'extensions.insert(policy);',
   'Ok(Arc::new(extensions))',
 ]);
-for (const forbidden of [
-  'SocialGraphService::new',
-  'PostgresIndexQueryPort::new',
-  'unwrap_or(false)',
-  'unwrap_or_default()',
-]) {
-  if (finalHost.includes(forbidden)) {
-    fail(`${finalHostPath} contains forbidden activated-path fallback marker ${forbidden}`);
-  }
+for (const forbidden of ['SocialGraphService::new', 'PostgresIndexQueryPort::new', 'unwrap_or(false)']) {
+  if (finalHost.includes(forbidden)) fail(`${finalHostPath} contains forbidden final-host marker ${forbidden}`);
 }
 
 const contractPath = 'crates/rustok-social-graph/contracts/social-graph-notification-policy.json';
 const contract = JSON.parse(read(contractPath));
 if (contract.schema_version !== 3) fail(`${contractPath} must use schema_version 3`);
-if (contract.index_privacy !== ownerPath) fail(`${contractPath} must point to the owner adapter`);
-if (contract.privacy_semantics?.index_readiness_failure_suppresses_allow_when_enabled !== true) {
-  fail(`${contractPath} must record fail-closed Index readiness after activation`);
+if (contract.index_privacy !== adapterPath) fail(`${contractPath} must point to the Index adapter`);
+if (contract.index_privacy_shadow !== shadowPath) fail(`${contractPath} must point to the shadow wrapper`);
+if (contract.privacy_semantics?.authoritative_owner_result_always_returned !== true) {
+  fail(`${contractPath} must retain the owner result as authoritative`);
 }
-if (contract.server_composition?.index_query_runtime_required_when_enabled !== true) {
-  fail(`${contractPath} must require the shared Index query runtime after activation`);
+if (contract.privacy_semantics?.index_shadow_never_authorizes !== true) {
+  fail(`${contractPath} must forbid Index shadow authorization`);
 }
-if (contract.server_composition?.notification_block_mute_index_cutover_source_complete !== true) {
-  fail(`${contractPath} must record source-complete notification block/mute cutover`);
+if (contract.server_composition?.notification_block_mute_index_shadow_source_complete !== true) {
+  fail(`${contractPath} must record source-complete shadow composition`);
 }
-if (contract.server_composition?.index_privacy_activation_env !== 'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED') {
-  fail(`${contractPath} must retain the exact activation environment variable`);
+if (contract.server_composition?.notification_block_mute_index_cutover !== false) {
+  fail(`${contractPath} must not claim an authoritative cutover`);
 }
-if (contract.server_composition?.index_privacy_default_enabled !== false) {
-  fail(`${contractPath} must keep Index privacy reads default-off`);
+if (contract.server_composition?.index_privacy_shadow_env !== 'RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED') {
+  fail(`${contractPath} must retain the exact shadow environment variable`);
 }
-if (contract.server_composition?.authoritative_table_path_before_activation !== true) {
-  fail(`${contractPath} must retain the owner read path before activation`);
+if (contract.server_composition?.index_privacy_shadow_default_enabled !== false) {
+  fail(`${contractPath} must keep the shadow default-off`);
 }
-if (contract.server_composition?.authoritative_table_fallback_after_activation !== false) {
-  fail(`${contractPath} must forbid owner-table fallback after activation`);
+if (contract.server_composition?.owner_policy_remains_authoritative !== true) {
+  fail(`${contractPath} must keep the owner policy authoritative`);
 }
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
@@ -159,24 +176,25 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
 requireMarkers('crates/rustok-index/docs/m4-social-graph-privacy-consumer.md', [
   'Status: `source_complete_execution_pending`',
   '`IndexSocialGraphPrivacyReadPort`',
-  'block in either direction',
-  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`',
+  '`IndexShadowSocialGraphPrivacyReadPort`',
+  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
   'default-off',
-  'retryable fail-closed',
-  'does not authorize from missing or stale Index state',
+  'always returns the owner result',
+  'never authorizes',
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
-  'M4 first authorized consumer cutover source: `source_complete_execution_pending`',
-  '`IndexSocialGraphPrivacyReadPort`',
+  'M4 first consumer parity shadow: `source_complete_execution_pending`',
+  '`IndexShadowSocialGraphPrivacyReadPort`',
   'notification block/mute policy',
-  'default-off activation gate',
+  'default-off shadow gate',
 ]);
 requireMarkers('crates/rustok-social-graph/CRATE_API.md', [
   '`IndexSocialGraphPrivacyReadPort`',
-  'notification block/mute policy',
-  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_READS_ENABLED`',
-  'retryable fail-closed',
+  '`IndexShadowSocialGraphPrivacyReadPort`',
+  '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
+  'owner result',
+  'never authorizes',
 ]);
 
 console.log('[verify-index-social-graph-privacy-consumer] OK');

--- a/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+++ b/scripts/verify/verify-index-social-graph-privacy-consumer.mjs
@@ -67,10 +67,6 @@ const shadow = requireMarkers(shadowPath, [
   'authoritative: Arc<dyn SocialGraphPrivacyReadPort>',
   'projected: Arc<dyn SocialGraphPrivacyReadPort>',
   'projected: Arc::new(IndexSocialGraphPrivacyReadPort::new(runtime))',
-  'const INDEX_PRIVACY_SHADOW_TIMEOUT: Duration = Duration::from_millis(100);',
-  'tokio::time::timeout(',
-  'Social Graph Index privacy shadow timed out',
-  'timeout_ms = INDEX_PRIVACY_SHADOW_TIMEOUT.as_millis()',
   'fn from_ports(',
   'impl SocialGraphPrivacyReadPort for IndexShadowSocialGraphPrivacyReadPort',
   '.blocks_between(context.clone(), request)',
@@ -89,10 +85,6 @@ const authoritativeReturns = shadow.match(/Ok\(authoritative\)/g) ?? [];
 if (authoritativeReturns.length !== 4) {
   fail(`${shadowPath} must return the authoritative result from all four privacy methods`);
 }
-const shadowTimeoutCalls = shadow.match(/tokio::time::timeout\(/g) ?? [];
-if (shadowTimeoutCalls.length !== 4) {
-  fail(`${shadowPath} must bound all four projected comparisons`);
-}
 for (const forbidden of [
   'tenant_id =',
   'source_user_id =',
@@ -107,10 +99,6 @@ for (const forbidden of [
   if (shadow.includes(forbidden)) fail(`${shadowPath} contains forbidden telemetry/runtime marker ${forbidden}`);
 }
 
-requireMarkers('crates/rustok-social-graph/Cargo.toml', [
-  'tokio = { workspace = true, optional = true }',
-  'index = ["dep:rustok-index", "dep:tokio"]',
-]);
 requireMarkers('crates/rustok-social-graph/src/lib.rs', [
   'pub mod index_privacy;',
   'pub mod index_privacy_shadow;',
@@ -170,9 +158,6 @@ if (contract.privacy_semantics?.authoritative_owner_result_always_returned !== t
 if (contract.privacy_semantics?.index_shadow_never_authorizes !== true) {
   fail(`${contractPath} must forbid Index shadow authorization`);
 }
-if (contract.privacy_semantics?.index_shadow_timeout_ms !== 100) {
-  fail(`${contractPath} must retain the 100 ms shadow timeout`);
-}
 if (contract.server_composition?.notification_block_mute_index_shadow_source_complete !== true) {
   fail(`${contractPath} must record source-complete shadow composition`);
 }
@@ -198,7 +183,6 @@ requireMarkers('crates/rustok-index/docs/m4-social-graph-privacy-consumer.md', [
   '`IndexShadowSocialGraphPrivacyReadPort`',
   '`RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`',
   'default-off',
-  '100 ms',
   'always returns the owner result',
   'never authorizes',
   'Not run by the implementation agent',


### PR DESCRIPTION
## Internal staging

This PR stages the reviewed Social Graph privacy parity-shadow slice onto the temporary `noop-check-existing` branch so both implementation branches can be removed through normal merged-PR cleanup. The following PR will target `main` with the exact same 13-file diff.

## Scope

- add typed `IndexSocialGraphPrivacyReadPort` queries for block, mute, point-follow, and bounded follow batches
- add owner-first `IndexShadowSocialGraphPrivacyReadPort` that always returns the authoritative Social Graph result
- record bounded mismatch/error telemetry without tenant, user, relation, entity, payload, SQL, or storage identity
- keep the shadow default-off behind `RUSTOK_SOCIAL_GRAPH_INDEX_PRIVACY_SHADOW_ENABLED`
- require `SharedIndexQueryRuntime` only when the shadow is enabled
- preserve custom notification block/mute providers and existing profile -> block -> mute evaluation order
- explicitly keep authoritative cutover blocked because schema readiness is not a freshness watermark
- add source tests, JSON contract v3, M4 docs, API actualization, and unified static guards

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, Node verifiers, workflow checks, or CI were run.