### PR TITLE
fix(payment): sanitize storefront native failures

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-storefront-native-error-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-native-error-safety-source.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "payment_storefront_native_error_safety_source_unvalidated",
+  "scope": "payment-owned storefront native server functions for refund summary and payment collection read/create",
+  "source_contract": {
+    "request_context_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "auth_context_static_public_envelope": true,
+    "runtime_composition_static_public_envelope": true,
+    "owner_runtime_static_public_envelopes": true,
+    "correlation_logging": true,
+    "tenant_logging": true,
+    "channel_logging": true,
+    "locale_logging": true,
+    "stable_owner_operations": true,
+    "outer_transport_variant_changed": false,
+    "graphql_adapter_changed": false,
+    "request_response_dto_changed": false,
+    "raw_internal_error_public": false,
+    "collection_read_request_context_for_diagnostics": true
+  },
+  "stable_public_messages": {
+    "request_context_unavailable": "Payment storefront request context is unavailable",
+    "tenant_context_unavailable": "Payment storefront tenant context is unavailable",
+    "auth_context_unavailable": "Payment storefront authentication context is unavailable",
+    "runtime_unavailable": "Payment storefront runtime is temporarily unavailable",
+    "refund_summary_unavailable": "Storefront refund summary is temporarily unavailable",
+    "payment_collection_unavailable": "Storefront payment collection is temporarily unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-payment-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-payment-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/storefront-native-error-safety.md
+++ b/crates/rustok-payment/docs/storefront-native-error-safety.md
@@ -1,0 +1,73 @@
+# Payment storefront native error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the payment-owned native server-function adapter in:
+
+- `crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs`.
+
+It covers refund-summary read, payment-collection read, and payment-collection create/reuse. The GraphQL adapter, public DTOs, transport selection, commerce runtime operations, and payment facade variants are unchanged.
+
+## Delivered source contract
+
+Each native operation now obtains a request context before tenant, authentication, runtime-composition, and owner calls. Internal failures are logged server-side with the available:
+
+- payment owner and exact owner operation;
+- correlation id and tenant id;
+- channel id, channel slug, and locale;
+- stable internal code and native boundary;
+- original internal error where one exists.
+
+Public `ServerFnError` messages are static for:
+
+- request-context extraction;
+- tenant-context extraction;
+- authentication-context extraction;
+- missing host-composed payment runtime dependencies;
+- refund-summary owner failure;
+- payment-collection read failure;
+- payment-collection create/reuse failure.
+
+The payment-collection read endpoint now extracts `RequestContext` solely to retain correlation-safe diagnostics. Its owner request and response remain unchanged.
+
+## Preserved behavior
+
+This slice preserves:
+
+- all three `#[server]` endpoint paths;
+- `read_storefront_order_refunds`;
+- `read_storefront_payment_collection`;
+- `create_storefront_payment_collection` and its metadata payload;
+- UUID validation messages;
+- the three outer `PaymentTransportError::ServerFn` wrappers;
+- the payment GraphQL adapter and native/GraphQL selection policy;
+- payment FBA/FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-payment-storefront-native-error-safety.mjs` guards:
+
+- the diagnostics dependency;
+- exact operation and endpoint markers;
+- context-aware extraction/runtime/owner mappings;
+- correlation, tenant, channel, locale, code, owner, and boundary logs;
+- static public messages;
+- removal of raw `ServerFnError` mappings;
+- unchanged facade wrapper count and source-only validation flags.
+
+## Remaining gaps
+
+The master ecommerce mapper-cleanup task remains open for payment compensation/execution consumers, other ecommerce transports, remaining owner adapters, and non-`PortError` public envelopes. Compile, mounted parity, remote transport, and runtime evidence are also still open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-payment-storefront-native-error-safety.mjs
+node scripts/verify/verify-payment-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-payment-storefront --all-features
+```

--- a/crates/rustok-payment/storefront/Cargo.toml
+++ b/crates/rustok-payment/storefront/Cargo.toml
@@ -31,6 +31,7 @@ rustok-payment = { workspace = true, optional = true }
 rust_decimal.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -278,7 +278,7 @@ async fn storefront_payment_create_collection_native(
                 tenant_id,
                 owner_operation,
                 "payment.storefront_collection_create_failed",
-                "Storefront payment collection could not be created",
+                "Storefront payment collection is temporarily unavailable",
                 error,
             )
         })?;

--- a/crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -9,6 +9,96 @@ use super::super::{
     PaymentTransportError, RefundSummary, RefundSummaryFetchRequest,
 };
 
+#[cfg(feature = "ssr")]
+const PAYMENT_STOREFRONT_NATIVE_OWNER: &str = "rustok_payment.storefront";
+#[cfg(feature = "ssr")]
+const PAYMENT_STOREFRONT_NATIVE_BOUNDARY: &str = "payment_storefront_native_transport";
+
+#[cfg(feature = "ssr")]
+fn map_request_context_error<E: std::fmt::Debug>(
+    owner_operation: &'static str,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = PAYMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation,
+        code = "payment.storefront_request_context_unavailable",
+        boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "payment storefront request context extraction failed"
+    );
+    ServerFnError::new("Payment storefront request context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Debug>(
+    request_context: &rustok_api::RequestContext,
+    owner_operation: &'static str,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = PAYMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation,
+        correlation_id = %request_context.correlation_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        code = "payment.storefront_tenant_context_unavailable",
+        boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "payment storefront tenant context extraction failed"
+    );
+    ServerFnError::new("Payment storefront tenant context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_auth_context_error<E: std::fmt::Debug>(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: Uuid,
+    owner_operation: &'static str,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = PAYMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation,
+        correlation_id = %request_context.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        code = "payment.storefront_auth_context_unavailable",
+        boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "payment storefront authentication context extraction failed"
+    );
+    ServerFnError::new("Payment storefront authentication context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_owner_runtime_error<E: std::fmt::Debug>(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: Uuid,
+    owner_operation: &'static str,
+    code: &'static str,
+    public_message: &'static str,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = PAYMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation,
+        correlation_id = %request_context.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        code,
+        boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "payment storefront owner runtime call failed"
+    );
+    ServerFnError::new(public_message)
+}
+
 pub async fn fetch_refund_summary_server(
     request: RefundSummaryFetchRequest,
 ) -> Result<RefundSummary, PaymentTransportError> {
@@ -25,16 +115,20 @@ async fn storefront_refund_summary_native(
     {
         use rustok_commerce::storefront_checkout_runtime;
 
-        let runtime = checkout_runtime()?;
+        let owner_operation = "read_storefront_order_refunds";
         let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_request_context_error(owner_operation, error))?;
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_tenant_context_error(&request_context, owner_operation, error))?;
+        let tenant_id = tenant.id;
+        let runtime = checkout_runtime(&request_context, tenant_id, owner_operation)?;
         let auth = leptos_axum::extract::<rustok_api::OptionalAuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                map_auth_context_error(&request_context, tenant_id, owner_operation, error)
+            })?;
         let order_id = Uuid::parse_str(request.order_id.trim())
             .map_err(|_| ServerFnError::new("order_id must be a valid UUID"))?;
 
@@ -46,7 +140,16 @@ async fn storefront_refund_summary_native(
             order_id,
         )
         .await
-        .map_err(|error| ServerFnError::new(error.to_string()))?;
+        .map_err(|error| {
+            map_owner_runtime_error(
+                &request_context,
+                tenant_id,
+                owner_operation,
+                "payment.storefront_refund_summary_unavailable",
+                "Storefront refund summary is temporarily unavailable",
+                error,
+            )
+        })?;
 
         Ok(summarize_native_refunds(items, total))
     }
@@ -75,13 +178,20 @@ async fn storefront_payment_collection_native(
     {
         use rustok_commerce::storefront_checkout_runtime;
 
-        let runtime = checkout_runtime()?;
+        let owner_operation = "read_storefront_payment_collection";
+        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
+            .await
+            .map_err(|error| map_request_context_error(owner_operation, error))?;
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_tenant_context_error(&request_context, owner_operation, error))?;
+        let tenant_id = tenant.id;
+        let runtime = checkout_runtime(&request_context, tenant_id, owner_operation)?;
         let auth = leptos_axum::extract::<rustok_api::OptionalAuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                map_auth_context_error(&request_context, tenant_id, owner_operation, error)
+            })?;
         let cart_id = Uuid::parse_str(request.cart_id.trim())
             .map_err(|_| ServerFnError::new("cart_id must be a valid UUID"))?;
 
@@ -90,7 +200,16 @@ async fn storefront_payment_collection_native(
         )
         .await
         .map(|collection| collection.map(map_payment_collection))
-        .map_err(|error| ServerFnError::new(error.to_string()))
+        .map_err(|error| {
+            map_owner_runtime_error(
+                &request_context,
+                tenant_id,
+                owner_operation,
+                "payment.storefront_collection_unavailable",
+                "Storefront payment collection is temporarily unavailable",
+                error,
+            )
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -119,16 +238,20 @@ async fn storefront_payment_create_collection_native(
             self, StorefrontPaymentCollectionCommand,
         };
 
-        let runtime = checkout_runtime()?;
+        let owner_operation = "create_storefront_payment_collection";
         let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_request_context_error(owner_operation, error))?;
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_tenant_context_error(&request_context, owner_operation, error))?;
+        let tenant_id = tenant.id;
+        let runtime = checkout_runtime(&request_context, tenant_id, owner_operation)?;
         let auth = leptos_axum::extract::<rustok_api::OptionalAuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                map_auth_context_error(&request_context, tenant_id, owner_operation, error)
+            })?;
         let cart_id = Uuid::parse_str(request.cart_id.trim())
             .map_err(|_| ServerFnError::new("cart_id must be a valid UUID"))?;
         let metadata = request.metadata;
@@ -149,7 +272,16 @@ async fn storefront_payment_create_collection_native(
             },
         )
         .await
-        .map_err(|error| ServerFnError::new(error.to_string()))?;
+        .map_err(|error| {
+            map_owner_runtime_error(
+                &request_context,
+                tenant_id,
+                owner_operation,
+                "payment.storefront_collection_create_failed",
+                "Storefront payment collection could not be created",
+                error,
+            )
+        })?;
 
         Ok(map_payment_collection(collection))
     }
@@ -163,8 +295,11 @@ async fn storefront_payment_create_collection_native(
 }
 
 #[cfg(feature = "ssr")]
-fn checkout_runtime()
--> Result<rustok_commerce::storefront_checkout_runtime::StorefrontCheckoutRuntime, ServerFnError> {
+fn checkout_runtime(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: Uuid,
+    owner_operation: &'static str,
+) -> Result<rustok_commerce::storefront_checkout_runtime::StorefrontCheckoutRuntime, ServerFnError> {
     use leptos::prelude::expect_context;
     use rustok_api::HostRuntimeContext;
     use rustok_outbox::TransactionalEventBus;
@@ -173,9 +308,19 @@ fn checkout_runtime()
     let event_bus = runtime_ctx
         .shared_get::<TransactionalEventBus>()
         .ok_or_else(|| {
-            ServerFnError::new(
-                "payment storefront native transport requires TransactionalEventBus in host runtime context",
-            )
+            tracing::error!(
+                owner = PAYMENT_STOREFRONT_NATIVE_OWNER,
+                owner_operation,
+                correlation_id = %request_context.correlation_id,
+                tenant_id = %tenant_id,
+                channel_id = ?request_context.channel_id,
+                channel_slug = ?request_context.channel_slug,
+                locale = %request_context.locale,
+                code = "payment.storefront_runtime_unavailable",
+                boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY,
+                "payment storefront TransactionalEventBus is unavailable"
+            );
+            ServerFnError::new("Payment storefront runtime is temporarily unavailable")
         })?;
 
     Ok(

--- a/scripts/verify/verify-payment-storefront-native-error-safety.mjs
+++ b/scripts/verify/verify-payment-storefront-native-error-safety.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL('../../', import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), 'utf8');
+
+const cargo = read('crates/rustok-payment/storefront/Cargo.toml');
+const source = read(
+  'crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs',
+);
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-storefront-native-error-safety-source.json',
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+requireText(cargo, 'tracing.workspace = true', 'payment storefront diagnostics dependency');
+
+for (const [value, label] of [
+  ['const PAYMENT_STOREFRONT_NATIVE_OWNER', 'native owner constant'],
+  ['const PAYMENT_STOREFRONT_NATIVE_BOUNDARY', 'native boundary constant'],
+  ['fn map_request_context_error<E: std::fmt::Debug>(', 'request context mapper'],
+  ['fn map_tenant_context_error<E: std::fmt::Debug>(', 'tenant context mapper'],
+  ['fn map_auth_context_error<E: std::fmt::Debug>(', 'auth context mapper'],
+  ['fn map_owner_runtime_error<E: std::fmt::Debug>(', 'owner runtime mapper'],
+  ['correlation_id = %request_context.correlation_id', 'correlation diagnostics'],
+  ['tenant_id = %tenant_id', 'tenant diagnostics'],
+  ['channel_id = ?request_context.channel_id', 'channel id diagnostics'],
+  ['channel_slug = ?request_context.channel_slug', 'channel slug diagnostics'],
+  ['locale = %request_context.locale', 'locale diagnostics'],
+  ['boundary = PAYMENT_STOREFRONT_NATIVE_BOUNDARY', 'boundary diagnostics'],
+  ['error = ?error', 'internal cause diagnostics'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "payment/refund-summary"', 'refund endpoint'],
+  ['endpoint = "payment/payment-collection"', 'collection read endpoint'],
+  ['endpoint = "payment/create-payment-collection"', 'collection create endpoint'],
+  ['let owner_operation = "read_storefront_order_refunds";', 'refund owner operation'],
+  ['let owner_operation = "read_storefront_payment_collection";', 'collection read owner operation'],
+  ['let owner_operation = "create_storefront_payment_collection";', 'collection create owner operation'],
+  ['storefront_checkout_runtime::read_storefront_order_refunds(', 'refund owner call'],
+  ['storefront_checkout_runtime::read_storefront_payment_collection(', 'collection read owner call'],
+  ['storefront_checkout_runtime::create_storefront_payment_collection(', 'collection create owner call'],
+  ['"source_module": metadata.source_module', 'create metadata source module'],
+  ['"source_surface": metadata.source_surface', 'create metadata source surface'],
+  ['"command": metadata.command', 'create metadata command'],
+  ['"owner_module": metadata.owner_module', 'create metadata owner module'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['payment.storefront_request_context_unavailable', 'request context stable code'],
+  ['payment.storefront_tenant_context_unavailable', 'tenant context stable code'],
+  ['payment.storefront_auth_context_unavailable', 'auth context stable code'],
+  ['payment.storefront_runtime_unavailable', 'runtime stable code'],
+  ['payment.storefront_refund_summary_unavailable', 'refund stable code'],
+  ['payment.storefront_collection_unavailable', 'collection read stable code'],
+  ['payment.storefront_collection_create_failed', 'collection create stable code'],
+  ['Payment storefront request context is unavailable', 'request context public message'],
+  ['Payment storefront tenant context is unavailable', 'tenant context public message'],
+  ['Payment storefront authentication context is unavailable', 'auth context public message'],
+  ['Payment storefront runtime is temporarily unavailable', 'runtime public message'],
+  ['Storefront refund summary is temporarily unavailable', 'refund public message'],
+  ['Storefront payment collection is temporarily unavailable', 'collection public message'],
+]) requireText(source, value, label);
+
+if (
+  countText(
+    source,
+    '.map_err(|error| map_request_context_error(owner_operation, error))?',
+  ) !== 3
+) {
+  failures.push('all three native operations must sanitize request-context extraction');
+}
+if (
+  countText(
+    source,
+    'map_tenant_context_error(&request_context, owner_operation, error)',
+  ) !== 3
+) {
+  failures.push('all three native operations must sanitize tenant-context extraction');
+}
+if (
+  countText(
+    source,
+    'map_auth_context_error(&request_context, tenant_id, owner_operation, error)',
+  ) !== 3
+) {
+  failures.push('all three native operations must sanitize authentication-context extraction');
+}
+if (
+  countText(source, 'checkout_runtime(&request_context, tenant_id, owner_operation)?;') !== 3
+) {
+  failures.push('all three native operations must compose runtime with correlation context');
+}
+if (countText(source, 'PaymentTransportError::ServerFn(error.to_string())') !== 3) {
+  failures.push('the three outer native transport wrappers must remain unchanged');
+}
+
+for (const value of [
+  '.map_err(ServerFnError::new)',
+  'ServerFnError::new(error.to_string())',
+  'ServerFnError::new(err.to_string())',
+  '.map_err(|error| ServerFnError::new(error.to_string()))',
+  'payment storefront native transport requires TransactionalEventBus in host runtime context',
+]) forbidText(source, value, 'raw payment storefront native public mapping');
+
+if (evidence.status !== 'payment_storefront_native_error_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  request_context_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  auth_context_static_public_envelope: true,
+  runtime_composition_static_public_envelope: true,
+  owner_runtime_static_public_envelopes: true,
+  outer_transport_variant_changed: false,
+  graphql_adapter_changed: false,
+  request_response_dto_changed: false,
+  raw_internal_error_public: false,
+  collection_read_request_context_for_diagnostics: true,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'native_runtime_proven',
+  'mounted_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Payment storefront native error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ payment storefront native failures retain server diagnostics and static public envelopes; runtime evidence remains open',
+);


### PR DESCRIPTION
## Summary
- replace raw payment storefront native context/runtime/owner error text with static public `ServerFnError` messages
- retain internal causes only in structured server logs with owner operation, correlation, tenant, channel, locale, stable code, and boundary
- preserve refund/payment collection operations, request metadata, UUID validation, facade wrapper variants, GraphQL adapter, and transport selection
- add source-only evidence, documentation, and a focused verifier

## Boundary
No payment DTOs, commerce runtime operations, GraphQL transport, provider behavior, FBA/FFA status, or runtime evidence are changed. Payment collection read now extracts `RequestContext` only for diagnostics.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.