### PR TITLE
fix(fulfillment): sanitize storefront native failures

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "fulfillment_storefront_native_error_safety_source_unvalidated",
+  "scope": "fulfillment-owned storefront native shipping-selection server function",
+  "source_contract": {
+    "runtime_dependency_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "auth_context_static_public_envelope": true,
+    "owner_runtime_static_public_envelope": true,
+    "optional_request_context_preserved": true,
+    "optional_request_context_failure_logged": true,
+    "correlation_logging_when_available": true,
+    "tenant_logging": true,
+    "channel_logging_when_available": true,
+    "locale_logging_when_available": true,
+    "stable_owner_operation": true,
+    "outer_transport_variant_changed": false,
+    "validation_messages_changed": false,
+    "graphql_adapter_changed": false,
+    "request_response_dto_changed": false,
+    "raw_internal_error_public": false
+  },
+  "stable_public_messages": {
+    "shipping_selection_unavailable": "Shipping selection is temporarily unavailable",
+    "shipping_selection_context_unavailable": "Shipping selection context is unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-fulfillment-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
@@ -1,0 +1,71 @@
+# Fulfillment storefront native error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the fulfillment-owned native shipping-selection server-function adapter in:
+
+- `crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs`.
+
+It covers host runtime dependency resolution, tenant and authentication context extraction, optional request-context diagnostics, and the Commerce checkout runtime call used to select a shipping option.
+
+## Delivered source contract
+
+Internal failures are retained only in server-side diagnostics with the available:
+
+- fulfillment owner and exact owner operation;
+- tenant id;
+- correlation id, channel id, channel slug, and locale when optional `RequestContext` extraction succeeds;
+- stable internal code and native boundary;
+- original internal error where one exists.
+
+Public `ServerFnError` messages are static for:
+
+- missing `TransactionalEventBus` runtime composition;
+- tenant-context extraction;
+- authentication-context extraction;
+- shipping-selection owner runtime failure.
+
+`RequestContext` remains optional for the owner call. A failed extraction is logged and still results in `None`, preserving the previous runtime behavior.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `SelectShippingOptionRequest` or fulfillment storefront response types;
+- the `fulfillment/select-shipping-option` endpoint;
+- `build_shipping_selection_updates` validation messages;
+- cart and shipping-option UUID validation messages;
+- `StorefrontShippingSelectionCommand` or its payload;
+- the outer `ShippingSelectionTransportError::ServerFn` wrapper;
+- the GraphQL adapter or native/GraphQL transport selection;
+- fulfillment FBA or FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs` guards:
+
+- the storefront diagnostics dependency;
+- exact endpoint and owner-operation markers;
+- static runtime, context, and owner public envelopes;
+- optional request-context preservation;
+- correlation, tenant, channel, locale, owner, code, and boundary logs;
+- removal of raw native owner/context error mapping;
+- unchanged validation and outer transport semantics;
+- source-only validation flags.
+
+## Remaining gaps
+
+The master ecommerce mapper-cleanup task remains open for other ecommerce transports, compensation/execution adapters, remaining owner consumers, and non-`PortError` public envelopes. Compile, mounted parity, remote transport, and runtime evidence are also still open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
+node scripts/verify/verify-fulfillment-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-fulfillment-storefront --all-features
+```

--- a/crates/rustok-fulfillment/storefront/Cargo.toml
+++ b/crates/rustok-fulfillment/storefront/Cargo.toml
@@ -27,6 +27,7 @@ rustok-api.workspace = true
 rustok-commerce = { workspace = true, optional = true }
 rustok-outbox = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
+tracing.workspace = true
 uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -6,6 +6,100 @@ use uuid::Uuid;
 use super::super::build_shipping_selection_updates;
 use super::super::{SelectShippingOptionRequest, ShippingSelectionTransportError};
 
+#[cfg(feature = "ssr")]
+const FULFILLMENT_STOREFRONT_NATIVE_OWNER: &str = "rustok_fulfillment.storefront";
+#[cfg(feature = "ssr")]
+const FULFILLMENT_STOREFRONT_NATIVE_OPERATION: &str = "select_storefront_shipping_option";
+#[cfg(feature = "ssr")]
+const FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY: &str = "fulfillment_storefront_native_transport";
+
+#[cfg(feature = "ssr")]
+fn map_runtime_dependency_error(dependency: &'static str) -> ServerFnError {
+    tracing::error!(
+        owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+        dependency,
+        code = "fulfillment.storefront_runtime_unavailable",
+        boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "fulfillment storefront runtime dependency is unavailable"
+    );
+    ServerFnError::new("Shipping selection is temporarily unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Debug>(error: E) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+        code = "fulfillment.storefront_tenant_context_unavailable",
+        boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "fulfillment storefront tenant context extraction failed"
+    );
+    ServerFnError::new("Shipping selection context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_auth_context_error<E: std::fmt::Debug>(tenant_id: Uuid, error: E) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+        tenant_id = %tenant_id,
+        code = "fulfillment.storefront_auth_context_unavailable",
+        boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "fulfillment storefront authentication context extraction failed"
+    );
+    ServerFnError::new("Shipping selection context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn record_optional_request_context_error<E: std::fmt::Debug>(tenant_id: Uuid, error: E) {
+    tracing::warn!(
+        error = ?error,
+        owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+        owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+        tenant_id = %tenant_id,
+        code = "fulfillment.storefront_request_context_unavailable",
+        boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+        "optional fulfillment storefront request context extraction failed"
+    );
+}
+
+#[cfg(feature = "ssr")]
+fn map_owner_runtime_error<E: std::fmt::Debug>(
+    request_context: Option<&rustok_api::RequestContext>,
+    tenant_id: Uuid,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = ?error,
+            owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+            owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+            correlation_id = %request_context.correlation_id,
+            tenant_id = %tenant_id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "fulfillment.storefront_shipping_selection_failed",
+            boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+            "fulfillment storefront owner runtime call failed"
+        );
+    } else {
+        tracing::error!(
+            error = ?error,
+            owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
+            owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
+            tenant_id = %tenant_id,
+            code = "fulfillment.storefront_shipping_selection_failed",
+            boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
+            "fulfillment storefront owner runtime call failed without request context"
+        );
+    }
+    ServerFnError::new("Shipping selection is temporarily unavailable")
+}
+
 pub async fn select_shipping_option_server(
     request: SelectShippingOptionRequest,
 ) -> Result<(), ShippingSelectionTransportError> {
@@ -30,24 +124,25 @@ async fn storefront_fulfillment_select_shipping_option_native(
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let event_bus = runtime_ctx
             .shared_get::<TransactionalEventBus>()
-            .ok_or_else(|| {
-                ServerFnError::new(
-                    "fulfillment/select-shipping-option requires TransactionalEventBus in host runtime context",
-                )
-            })?;
+            .ok_or_else(|| map_runtime_dependency_error("TransactionalEventBus"))?;
         let runtime = storefront_checkout_runtime::StorefrontCheckoutRuntime::new(
             runtime_ctx.db_clone(),
             event_bus,
         );
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(map_tenant_context_error)?;
+        let tenant_id = tenant.id;
         let auth = leptos_axum::extract::<rustok_api::OptionalAuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
-        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
-            .await
-            .ok();
+            .map_err(|error| map_auth_context_error(tenant_id, error))?;
+        let request_context = match leptos_axum::extract::<rustok_api::RequestContext>().await {
+            Ok(request_context) => Some(request_context),
+            Err(error) => {
+                record_optional_request_context_error(tenant_id, error);
+                None
+            }
+        };
         let cart_id = Uuid::parse_str(request.cart_id.trim())
             .map_err(|_| ServerFnError::new("cart_id must be a valid UUID"))?;
 
@@ -77,7 +172,7 @@ async fn storefront_fulfillment_select_shipping_option_native(
             },
         )
         .await
-        .map_err(|error| ServerFnError::new(error.to_string()))
+        .map_err(|error| map_owner_runtime_error(request_context.as_ref(), tenant_id, error))
     }
     #[cfg(not(feature = "ssr"))]
     {

--- a/scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const cargo = read("crates/rustok-fulfillment/storefront/Cargo.toml");
+const source = read(
+  "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+requireText(cargo, "tracing.workspace = true", "fulfillment storefront diagnostics dependency");
+
+for (const [value, label] of [
+  ["const FULFILLMENT_STOREFRONT_NATIVE_OWNER", "native owner constant"],
+  ["const FULFILLMENT_STOREFRONT_NATIVE_OPERATION", "native operation constant"],
+  ["const FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY", "native boundary constant"],
+  ["fn map_runtime_dependency_error(", "runtime dependency mapper"],
+  ["fn map_tenant_context_error<E: std::fmt::Debug>(", "tenant context mapper"],
+  ["fn map_auth_context_error<E: std::fmt::Debug>(", "auth context mapper"],
+  ["fn record_optional_request_context_error<E: std::fmt::Debug>(", "optional request context logger"],
+  ["fn map_owner_runtime_error<E: std::fmt::Debug>(", "owner runtime mapper"],
+  ["owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
+  ["owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION", "operation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
+  ["locale = %request_context.locale", "locale diagnostics"],
+  ["boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY", "boundary diagnostics"],
+  ["error = ?error", "internal cause diagnostics"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ["endpoint = \"fulfillment/select-shipping-option\"", "shipping-selection endpoint"],
+  ["select_storefront_shipping_option(", "owner runtime call"],
+  ["StorefrontShippingSelectionCommand {", "owner command payload"],
+  ["cart_id,", "cart command field"],
+  ["shipping_selections,", "shipping selections command field"],
+  ["request_context.as_ref(),", "optional owner request context"],
+  ["build_shipping_selection_updates(&request)", "selection validation seam"],
+  ["ServerFnError::new(error.message().to_string())", "selection validation compatibility"],
+  ["ServerFnError::new(\"cart_id must be a valid UUID\")", "cart UUID validation compatibility"],
+  ["ServerFnError::new(format!(\"{field_name} must be a valid UUID\"))", "option UUID validation compatibility"],
+  ["ShippingSelectionTransportError::ServerFn(error.to_string())", "outer transport wrapper"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ["fulfillment.storefront_runtime_unavailable", "runtime stable code"],
+  ["fulfillment.storefront_tenant_context_unavailable", "tenant stable code"],
+  ["fulfillment.storefront_auth_context_unavailable", "auth stable code"],
+  ["fulfillment.storefront_request_context_unavailable", "optional request context stable code"],
+  ["fulfillment.storefront_shipping_selection_failed", "owner runtime stable code"],
+  ["Shipping selection is temporarily unavailable", "shipping selection public message"],
+  ["Shipping selection context is unavailable", "shipping context public message"],
+]) requireText(source, value, label);
+
+if (countText(source, "ShippingSelectionTransportError::ServerFn(error.to_string())") !== 1) {
+  failures.push("the outer native transport wrapper must remain unchanged exactly once");
+}
+if (countText(source, "ServerFnError::new(\"Shipping selection is temporarily unavailable\")") !== 2) {
+  failures.push("runtime and owner failures must share the stable shipping-selection envelope");
+}
+if (countText(source, "ServerFnError::new(\"Shipping selection context is unavailable\")") !== 2) {
+  failures.push("tenant and auth failures must share the stable context envelope");
+}
+if (countText(source, "request_context.as_ref()") !== 2) {
+  failures.push("optional request context must be passed to the owner call and owner error mapper");
+}
+
+for (const value of [
+  ".map_err(ServerFnError::new)",
+  "ServerFnError::new(error.to_string())",
+  "ServerFnError::new(err.to_string())",
+  ".map_err(|error| ServerFnError::new(error.to_string()))",
+  "fulfillment/select-shipping-option requires TransactionalEventBus in host runtime context",
+]) forbidText(source, value, "raw fulfillment storefront native public mapping");
+
+if (evidence.status !== "fulfillment_storefront_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  runtime_dependency_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  auth_context_static_public_envelope: true,
+  owner_runtime_static_public_envelope: true,
+  optional_request_context_preserved: true,
+  optional_request_context_failure_logged: true,
+  outer_transport_variant_changed: false,
+  validation_messages_changed: false,
+  graphql_adapter_changed: false,
+  request_response_dto_changed: false,
+  raw_internal_error_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Fulfillment storefront native error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ fulfillment storefront native failures retain server diagnostics and static public envelopes; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace raw fulfillment storefront native runtime, context, and owner failure text with static public `ServerFnError` messages
- retain internal causes in structured SSR logs with owner operation, tenant, and correlation/channel/locale when optional request context is available
- preserve optional `RequestContext`, shipping-selection validation, UUID validation, command payload, outer transport variant, GraphQL adapter, and transport selection
- add source-only evidence, documentation, and a focused verifier

## Boundary
No fulfillment DTOs, GraphQL transport, Commerce runtime operation, shipping command payload, validation compatibility, FBA/FFA status, or runtime evidence are changed.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.