### PR TITLE
chore(fulfillment): register storefront native error guard

### DIFF
--- a/scripts/verify/verify-fulfillment-storefront-boundary.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-boundary.mjs
@@ -6,6 +6,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import "./verify-fulfillment-storefront-native-error-safety.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)


### PR DESCRIPTION
## Summary
- make `verify:fulfillment:storefront-boundary` execute the focused fulfillment storefront native error-safety guard
- retain the existing npm command and FFA aggregate without rewriting `package.json`

## Boundary
No production code, evidence, plan checkbox, npm metadata, FBA/FFA status, or runtime validation is changed.

## Verification
Not run per maintainer instruction. No npm commands, Node verifiers, Cargo commands, formatting, workflows, or CI are claimed.