### PR TITLE
fix(product): sanitize catalog native context failures

### DIFF
--- a/crates/rustok-product/contracts/evidence/storefront-catalog-native-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/storefront-catalog-native-error-safety-source.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "product_storefront_catalog_native_error_safety_source_unvalidated",
+  "scope": "product-owned storefront catalog-list native server function",
+  "source_contract": {
+    "runtime_dependency_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "optional_request_context_preserved": true,
+    "optional_request_context_failure_logged": true,
+    "correlation_logging_when_available": true,
+    "channel_logging_when_available": true,
+    "locale_logging_when_available": true,
+    "stable_owner_operation": true,
+    "product_public_error_mapper_preserved": true,
+    "catalog_query_contract_changed": false,
+    "pagination_changed": false,
+    "locale_fallback_changed": false,
+    "channel_fallback_changed": false,
+    "request_response_dto_changed": false,
+    "raw_context_error_public": false
+  },
+  "stable_public_messages": {
+    "catalog_runtime_unavailable": "Product catalog is temporarily unavailable",
+    "catalog_context_unavailable": "Product catalog context is unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs",
+    "node scripts/verify/verify-product-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-product-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-product/docs/storefront-catalog-native-error-safety.md
+++ b/crates/rustok-product/docs/storefront-catalog-native-error-safety.md
@@ -1,0 +1,71 @@
+# Product storefront catalog native error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Product-owned native catalog-list server-function adapter in:
+
+- `crates/rustok-product/storefront/src/transport/catalog_list_native.rs`.
+
+It covers missing host-composed `TransactionalEventBus`, optional request-context diagnostics, and tenant-context extraction. Product catalog query validation and service failures continue to use the existing Product public-error mapper.
+
+## Delivered source contract
+
+The native adapter now returns static public messages for:
+
+- missing `TransactionalEventBus` runtime composition;
+- tenant-context extraction failure.
+
+Internal context failures remain only in SSR diagnostics with the available:
+
+- Product storefront owner and exact operation;
+- correlation id, channel id, channel slug, and locale when optional `RequestContext` is available;
+- stable internal code and native boundary;
+- original context extraction error.
+
+`RequestContext` remains optional. Extraction failure is logged and still falls back to `None`, preserving locale and channel fallback behavior.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the `product/storefront/catalog-list` endpoint;
+- `CatalogListInput`, `FetchRequest`, `ProductList`, or `StorefrontProductsData`;
+- selected-handle fallback;
+- `StorefrontProductListQuery::try_from_transport_with_attribute_filters`;
+- pagination at page `1`, per-page `12`;
+- locale fallback to the tenant default locale;
+- request-context channel-slug fallback;
+- Product `map_product_public_error` handling for input and catalog service failures;
+- Product dependency topology or lifecycle collaboration contracts.
+
+## Static evidence
+
+`scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs` guards:
+
+- existing SSR tracing composition;
+- exact endpoint, operation, query, pagination, locale, and channel markers;
+- static runtime and tenant-context public envelopes;
+- optional request-context preservation and diagnostics;
+- correlation, channel, locale, owner, code, and boundary logging;
+- removal of raw runtime/context public mappings;
+- unchanged Product public-error mapper calls;
+- source-only validation flags.
+
+## Remaining gaps
+
+The Product dependency contract remains unresolved. This slice does not change Product/Inventory/Pricing topology, lifecycle transactions, host composition, or module enablement semantics.
+
+The broader ecommerce mapper-cleanup task also remains open for remaining transports, compensation/execution adapters, and non-`PortError` public envelopes. Compile, mounted parity, remote transport, and runtime evidence remain open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs
+node scripts/verify/verify-product-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-product-storefront --all-features
+```

--- a/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
+++ b/crates/rustok-product/storefront/src/transport/catalog_list_native.rs
@@ -6,6 +6,69 @@ use crate::model::{ProductList, ProductListItem, StorefrontProductsData};
 
 use super::native_server_adapter::{self, ApiError};
 
+#[cfg(feature = "ssr")]
+const PRODUCT_STOREFRONT_CATALOG_OWNER: &str = "rustok_product.storefront";
+#[cfg(feature = "ssr")]
+const PRODUCT_STOREFRONT_CATALOG_OPERATION: &str = "storefront_catalog_list";
+#[cfg(feature = "ssr")]
+const PRODUCT_STOREFRONT_CATALOG_BOUNDARY: &str = "product_storefront_catalog_list_native";
+
+#[cfg(feature = "ssr")]
+fn map_runtime_dependency_error(dependency: &'static str) -> ServerFnError {
+    tracing::error!(
+        owner = PRODUCT_STOREFRONT_CATALOG_OWNER,
+        owner_operation = PRODUCT_STOREFRONT_CATALOG_OPERATION,
+        dependency,
+        code = "product.storefront_catalog_runtime_unavailable",
+        boundary = PRODUCT_STOREFRONT_CATALOG_BOUNDARY,
+        "product storefront catalog runtime dependency is unavailable"
+    );
+    ServerFnError::new("Product catalog is temporarily unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn record_optional_request_context_error<E: std::fmt::Debug>(error: E) {
+    tracing::warn!(
+        error = ?error,
+        owner = PRODUCT_STOREFRONT_CATALOG_OWNER,
+        owner_operation = PRODUCT_STOREFRONT_CATALOG_OPERATION,
+        code = "product.storefront_catalog_request_context_unavailable",
+        boundary = PRODUCT_STOREFRONT_CATALOG_BOUNDARY,
+        "optional product storefront catalog request context extraction failed"
+    );
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Debug>(
+    request_context: Option<&rustok_api::RequestContext>,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = ?error,
+            owner = PRODUCT_STOREFRONT_CATALOG_OWNER,
+            owner_operation = PRODUCT_STOREFRONT_CATALOG_OPERATION,
+            correlation_id = %request_context.correlation_id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "product.storefront_catalog_tenant_context_unavailable",
+            boundary = PRODUCT_STOREFRONT_CATALOG_BOUNDARY,
+            "product storefront catalog tenant context extraction failed"
+        );
+    } else {
+        tracing::error!(
+            error = ?error,
+            owner = PRODUCT_STOREFRONT_CATALOG_OWNER,
+            owner_operation = PRODUCT_STOREFRONT_CATALOG_OPERATION,
+            code = "product.storefront_catalog_tenant_context_unavailable",
+            boundary = PRODUCT_STOREFRONT_CATALOG_BOUNDARY,
+            "product storefront catalog tenant context extraction failed without request context"
+        );
+    }
+    ServerFnError::new("Product catalog context is unavailable")
+}
+
 pub async fn fetch_products(
     mut request: FetchRequest,
     controls: CatalogListInput,
@@ -113,17 +176,17 @@ async fn storefront_catalog_list_native(
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let event_bus = runtime_ctx
             .shared_get::<TransactionalEventBus>()
-            .ok_or_else(|| {
-                ServerFnError::new(
-                    "product/storefront catalog list requires TransactionalEventBus in host runtime context",
-                )
-            })?;
-        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
-            .await
-            .ok();
+            .ok_or_else(|| map_runtime_dependency_error("TransactionalEventBus"))?;
+        let request_context = match leptos_axum::extract::<rustok_api::RequestContext>().await {
+            Ok(request_context) => Some(request_context),
+            Err(error) => {
+                record_optional_request_context_error(error);
+                None
+            }
+        };
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_tenant_context_error(request_context.as_ref(), error))?;
         let requested_locale = crate::core::resolve_requested_locale(
             locale,
             request_context

--- a/scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs
+++ b/scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const cargo = read("crates/rustok-product/storefront/Cargo.toml");
+const source = read(
+  "crates/rustok-product/storefront/src/transport/catalog_list_native.rs",
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-product/contracts/evidence/storefront-catalog-native-error-safety-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ['"dep:tracing"', "Product storefront SSR tracing feature"],
+  ["tracing = { workspace = true, optional = true }", "Product storefront tracing dependency"],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ["const PRODUCT_STOREFRONT_CATALOG_OWNER", "catalog owner constant"],
+  ["const PRODUCT_STOREFRONT_CATALOG_OPERATION", "catalog operation constant"],
+  ["const PRODUCT_STOREFRONT_CATALOG_BOUNDARY", "catalog boundary constant"],
+  ["fn map_runtime_dependency_error(", "runtime dependency mapper"],
+  ["fn record_optional_request_context_error<E: std::fmt::Debug>(", "optional request context logger"],
+  ["fn map_tenant_context_error<E: std::fmt::Debug>(", "tenant context mapper"],
+  ["owner = PRODUCT_STOREFRONT_CATALOG_OWNER", "owner diagnostics"],
+  ["owner_operation = PRODUCT_STOREFRONT_CATALOG_OPERATION", "operation diagnostics"],
+  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
+  ["locale = %request_context.locale", "locale diagnostics"],
+  ["boundary = PRODUCT_STOREFRONT_CATALOG_BOUNDARY", "boundary diagnostics"],
+  ["error = ?error", "internal context diagnostics"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "product/storefront/catalog-list"', "catalog endpoint"],
+  ["StorefrontProductListQuery::try_from_transport_with_attribute_filters(", "catalog query builder"],
+  [".with_pagination(1, 12)", "catalog pagination"],
+  ["crate::core::resolve_requested_locale(", "locale fallback"],
+  ["normalize_public_channel_slug(context.channel_slug.as_deref())", "channel fallback"],
+  ["rustok_product::map_product_public_error(", "Product public error mapper"],
+  ['map_product_service_error(error, "storefront_catalog_list_input")', "catalog input mapper operation"],
+  ['map_product_service_error(error, "storefront_catalog_list")', "catalog service mapper operation"],
+  ["native_server_adapter::fetch_products(request).await?", "detail transport composition"],
+  ["data.products = products;", "catalog result composition"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ["product.storefront_catalog_runtime_unavailable", "runtime stable code"],
+  ["product.storefront_catalog_request_context_unavailable", "request context stable code"],
+  ["product.storefront_catalog_tenant_context_unavailable", "tenant context stable code"],
+  ["Product catalog is temporarily unavailable", "runtime public message"],
+  ["Product catalog context is unavailable", "context public message"],
+]) requireText(source, value, label);
+
+if (countText(source, "request_context.as_ref()") !== 3) {
+  failures.push("optional request context must remain in tenant, locale, and channel handling");
+}
+if (countText(source, "map_product_service_error(error,") !== 2) {
+  failures.push("Product public mapper must remain on input and catalog service failures");
+}
+if (countText(source, "ServerFnError::new(\"Product catalog is temporarily unavailable\")") !== 1) {
+  failures.push("runtime composition must use exactly one stable catalog envelope");
+}
+if (countText(source, "ServerFnError::new(\"Product catalog context is unavailable\")") !== 1) {
+  failures.push("tenant extraction must use exactly one stable context envelope");
+}
+
+for (const value of [
+  ".map_err(ServerFnError::new)?",
+  "product/storefront catalog list requires TransactionalEventBus in host runtime context",
+  ".await\n            .ok();",
+]) forbidText(source, value, "raw Product catalog native context mapping");
+
+if (evidence.status !== "product_storefront_catalog_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  runtime_dependency_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  optional_request_context_preserved: true,
+  optional_request_context_failure_logged: true,
+  product_public_error_mapper_preserved: true,
+  catalog_query_contract_changed: false,
+  pagination_changed: false,
+  locale_fallback_changed: false,
+  channel_fallback_changed: false,
+  request_response_dto_changed: false,
+  raw_context_error_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Product storefront catalog native error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ Product storefront catalog native context failures use static public envelopes; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace raw Product storefront catalog runtime and tenant-context error text with static public `ServerFnError` messages
- retain optional request-context extraction and log failures with owner, operation, stable code, boundary, and correlation/channel/locale when available
- preserve Product public-error mapping, catalog query construction, pagination, locale/channel fallback, selected-handle composition, DTOs, and transport behavior
- add source-only evidence, documentation, and a focused verifier

## Boundary
No Product dependency topology, lifecycle collaboration, query contract, pagination, DTO, GraphQL transport, FBA/FFA status, or runtime evidence is changed.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.