### PR TITLE
fix(marketplace-listing): sanitize admin native request failures

### DIFF
--- a/crates/rustok-marketplace-listing/admin/Cargo.toml
+++ b/crates/rustok-marketplace-listing/admin/Cargo.toml
@@ -16,6 +16,7 @@ ssr = [
   "rustok-api/server",
   "dep:leptos_axum",
   "dep:rustok-marketplace-listing",
+  "dep:tracing",
 ]
 
 [dependencies]
@@ -29,4 +30,5 @@ rustok-ui-i18n-leptos.workspace = true
 rustok-ui-transport.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing = { workspace = true, optional = true }
 uuid.workspace = true

--- a/crates/rustok-marketplace-listing/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-marketplace-listing/admin/src/transport/native_server_adapter.rs
@@ -11,6 +11,108 @@ use crate::model::{
     MarketplaceListingAdminFilters,
 };
 
+#[cfg(feature = "ssr")]
+const MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER: &str = "rustok_marketplace_listing.admin";
+#[cfg(feature = "ssr")]
+const MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION: &str = "native_request";
+#[cfg(feature = "ssr")]
+const MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY: &str =
+    "marketplace_listing_admin_native_transport";
+
+#[cfg(feature = "ssr")]
+fn map_runtime_dependency_error(
+    action: MarketplaceListingAdminAction,
+    dependency: &'static str,
+) -> ServerFnError {
+    tracing::error!(
+        owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER,
+        owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION,
+        action = ?action,
+        dependency,
+        code = "marketplace_listing.admin_runtime_unavailable",
+        boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY,
+        "marketplace listing admin native runtime dependency is unavailable"
+    );
+    ServerFnError::new("Marketplace listing service is temporarily unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_auth_context_error<E: std::fmt::Display>(
+    action: MarketplaceListingAdminAction,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = %error,
+        owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER,
+        owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION,
+        action = ?action,
+        code = "marketplace_listing.admin_auth_context_unavailable",
+        boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY,
+        "marketplace listing admin authentication context extraction failed"
+    );
+    ServerFnError::new("Marketplace listing request context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Display>(
+    action: MarketplaceListingAdminAction,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = %error,
+        owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER,
+        owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION,
+        action = ?action,
+        code = "marketplace_listing.admin_tenant_context_unavailable",
+        boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY,
+        "marketplace listing admin tenant context extraction failed"
+    );
+    ServerFnError::new("Marketplace listing request context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_request_context_error<E: std::fmt::Display>(
+    action: MarketplaceListingAdminAction,
+    tenant_id: uuid::Uuid,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = %error,
+        owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER,
+        owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION,
+        action = ?action,
+        tenant_id = %tenant_id,
+        code = "marketplace_listing.admin_request_context_unavailable",
+        boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY,
+        "marketplace listing admin request context extraction failed"
+    );
+    ServerFnError::new("Marketplace listing request context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_module_availability_error<E: std::fmt::Display>(
+    action: MarketplaceListingAdminAction,
+    tenant_id: uuid::Uuid,
+    request: &rustok_api::request::RequestContext,
+    error: E,
+) -> ServerFnError {
+    tracing::error!(
+        error = %error,
+        owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER,
+        owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION,
+        action = ?action,
+        correlation_id = %request.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request.channel_id,
+        channel_slug = ?request.channel_slug,
+        locale = %request.locale,
+        code = "marketplace_listing.admin_module_availability_failed",
+        boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY,
+        "marketplace listing admin module availability check failed"
+    );
+    ServerFnError::new("Marketplace listing service is temporarily unavailable")
+}
+
 #[derive(Debug, Clone)]
 pub struct NativeMarketplaceListingAdminError(pub String);
 
@@ -311,19 +413,19 @@ async fn native_request(
     use rustok_api::{AuthContext, HostRuntimeContext, PortActor, TenantContext};
 
     let host = use_context::<HostRuntimeContext>()
-        .ok_or_else(|| ServerFnError::new("marketplace listing host runtime is not mounted"))?;
+        .ok_or_else(|| map_runtime_dependency_error(action, "HostRuntimeContext"))?;
     let runtime = host
         .shared_get::<rustok_marketplace_listing::MarketplaceListingRuntime>()
-        .ok_or_else(|| ServerFnError::new("marketplace listing owner ports are not composed"))?;
+        .ok_or_else(|| map_runtime_dependency_error(action, "MarketplaceListingRuntime"))?;
     let auth = leptos_axum::extract::<AuthContext>()
         .await
-        .map_err(ServerFnError::new)?;
+        .map_err(|error| map_auth_context_error(action, error))?;
     let tenant = leptos_axum::extract::<TenantContext>()
         .await
-        .map_err(ServerFnError::new)?;
+        .map_err(|error| map_tenant_context_error(action, error))?;
     let request = leptos_axum::extract::<RequestContext>()
         .await
-        .map_err(ServerFnError::new)?;
+        .map_err(|error| map_request_context_error(action, tenant.id, error))?;
 
     if !rustok_api::has_effective_permission(&auth.permissions, &action.permission()) {
         return Err(ServerFnError::new(
@@ -341,8 +443,8 @@ async fn native_request(
     let module_enabled =
         rustok_api::is_tenant_module_enabled(host.db(), tenant.id, "marketplace_listing")
             .await
-            .map_err(|_| {
-                ServerFnError::new("marketplace listing module availability check failed")
+            .map_err(|error| {
+                map_module_availability_error(action, tenant.id, &request, error)
             })?;
     if !module_enabled {
         return Err(ServerFnError::new(

--- a/crates/rustok-marketplace-listing/contracts/evidence/admin-native-request-error-safety-source.json
+++ b/crates/rustok-marketplace-listing/contracts/evidence/admin-native-request-error-safety-source.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "marketplace_listing_admin_native_request_error_safety_source_unvalidated",
+  "scope": "marketplace-listing admin shared native request boundary",
+  "source_contract": {
+    "host_runtime_static_public_envelope": true,
+    "owner_runtime_static_public_envelope": true,
+    "auth_context_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "request_context_static_public_envelope": true,
+    "module_availability_failure_static_public_envelope": true,
+    "correlation_logging_for_module_check_failure": true,
+    "tenant_logging_when_available": true,
+    "channel_logging_when_available": true,
+    "locale_logging_when_available": true,
+    "permission_messages_changed": false,
+    "identity_mismatch_message_changed": false,
+    "module_disabled_message_changed": false,
+    "port_error_mapper_changed": false,
+    "port_context_contract_changed": false,
+    "endpoint_contract_changed": false,
+    "command_payload_changed": false,
+    "raw_request_boundary_error_public": false
+  },
+  "stable_public_messages": {
+    "runtime_unavailable": "Marketplace listing service is temporarily unavailable",
+    "request_context_unavailable": "Marketplace listing request context is unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-marketplace-listing-admin-native-request-error-safety.mjs",
+    "node scripts/verify/verify-marketplace-listing-admin-ffa.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-marketplace-listing-admin --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-marketplace-listing/docs/admin-native-request-error-safety.md
+++ b/crates/rustok-marketplace-listing/docs/admin-native-request-error-safety.md
@@ -1,0 +1,78 @@
+# Marketplace listing admin native request error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the shared marketplace-listing admin native request boundary in:
+
+- `crates/rustok-marketplace-listing/admin/src/transport/native_server_adapter.rs`.
+
+The boundary is shared by directory, detail, and command server functions. It resolves the host runtime, owner runtime, authentication, tenant and request contexts, tenant-module availability, and the owner `PortContext`.
+
+## Delivered source contract
+
+Static public `ServerFnError` messages now cover:
+
+- missing `HostRuntimeContext`;
+- missing host-composed `MarketplaceListingRuntime`;
+- authentication-context extraction failure;
+- tenant-context extraction failure;
+- request-context extraction failure;
+- failure to read tenant module availability.
+
+Internal causes remain only in SSR diagnostics with the available:
+
+- marketplace-listing admin owner and shared native operation;
+- requested admin action;
+- tenant id;
+- request correlation id, channel id, channel slug and locale for module-availability failures;
+- stable internal code and boundary;
+- original extraction or module-check error.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the directory, detail or command endpoint paths;
+- request or response DTOs;
+- directory filters, pagination or event limit;
+- command variants or command payloads;
+- action-to-permission mapping;
+- permission-denied messages;
+- request identity checks or their message;
+- the module-disabled message;
+- the 5-second owner-port deadline;
+- native PortContext locale, generated correlation id, channel or idempotency-key composition;
+- the existing `PortErrorKind` public mapper;
+- GraphQL transport or transport selection;
+- marketplace-listing FBA/FFA status.
+
+## Static evidence
+
+`scripts/verify/verify-marketplace-listing-admin-native-request-error-safety.mjs` guards:
+
+- SSR tracing feature composition;
+- stable owner, operation, action, code and boundary diagnostics;
+- static runtime and request-context public envelopes;
+- correlation, tenant, channel and locale logging for module-check failures;
+- removal of raw host/runtime/context error mapping;
+- unchanged endpoint, permission, module-disabled, PortContext and `PortError` contracts;
+- source-only validation flags.
+
+## Remaining gaps
+
+Compile, mounted parity, runtime and remote transport evidence remain open. The broader ecommerce mapper-cleanup task also remains open for other owner consumers, compensation/execution adapters, remaining transports and non-`PortError` public envelopes.
+
+This slice does not make the marketplace financial integration an optional Commerce capability and does not change marketplace topology.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-marketplace-listing-admin-native-request-error-safety.mjs
+node scripts/verify/verify-marketplace-listing-admin-ffa.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-marketplace-listing-admin --all-features
+```

--- a/scripts/verify/verify-marketplace-listing-admin-native-request-error-safety.mjs
+++ b/scripts/verify/verify-marketplace-listing-admin-native-request-error-safety.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const cargo = read("crates/rustok-marketplace-listing/admin/Cargo.toml");
+const source = read(
+  "crates/rustok-marketplace-listing/admin/src/transport/native_server_adapter.rs",
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-marketplace-listing/contracts/evidence/admin-native-request-error-safety-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ['"dep:tracing"', "admin SSR tracing feature"],
+  ["tracing = { workspace = true, optional = true }", "admin tracing dependency"],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ["const MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER", "native owner constant"],
+  ["const MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION", "native operation constant"],
+  ["const MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY", "native boundary constant"],
+  ["fn map_runtime_dependency_error(", "runtime dependency mapper"],
+  ["fn map_auth_context_error<E: std::fmt::Display>(", "auth context mapper"],
+  ["fn map_tenant_context_error<E: std::fmt::Display>(", "tenant context mapper"],
+  ["fn map_request_context_error<E: std::fmt::Display>(", "request context mapper"],
+  ["fn map_module_availability_error<E: std::fmt::Display>(", "module availability mapper"],
+  ["owner = MARKETPLACE_LISTING_ADMIN_NATIVE_OWNER", "owner diagnostics"],
+  ["owner_operation = MARKETPLACE_LISTING_ADMIN_NATIVE_OPERATION", "operation diagnostics"],
+  ["action = ?action", "action diagnostics"],
+  ["correlation_id = %request.correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["channel_id = ?request.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request.channel_slug", "channel slug diagnostics"],
+  ["locale = %request.locale", "locale diagnostics"],
+  ["boundary = MARKETPLACE_LISTING_ADMIN_NATIVE_BOUNDARY", "boundary diagnostics"],
+  ["error = %error", "internal cause diagnostics"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "marketplace-listing/directory"', "directory endpoint"],
+  ['endpoint = "marketplace-listing/detail"', "detail endpoint"],
+  ['endpoint = "marketplace-listing/command"', "command endpoint"],
+  ["native_request(MarketplaceListingAdminAction::List, None)", "directory request action"],
+  ["native_request(MarketplaceListingAdminAction::Read, None)", "detail request action"],
+  ["native_request(command_action(&command), Some(idempotency_key))", "command request action"],
+  ["action.permission()", "action permission mapping"],
+  ["request.user_id != Some(auth.user_id)", "request identity check"],
+  ['is_tenant_module_enabled(host.db(), tenant.id, "marketplace_listing")', "module availability check"],
+  ["Permission denied: marketplace listing permission required", "permission public message"],
+  ["Permission denied: marketplace listing request identity mismatch", "identity public message"],
+  ["Marketplace listing module is not enabled for this tenant", "module-disabled public message"],
+  [".with_deadline(std::time::Duration::from_secs(5))", "owner port deadline"],
+  ['format!("native-marketplace-listing-{}", uuid::Uuid::new_v4())', "owner correlation composition"],
+  ["request.locale,", "owner locale composition"],
+  ["if let Some(channel) = request.channel_slug", "owner channel composition"],
+  ["context.with_idempotency_key(key.to_string())", "owner idempotency composition"],
+  ["fn map_port_error(error: rustok_api::PortError)", "PortError mapper"],
+  ["PortErrorKind::Validation | PortErrorKind::NotFound | PortErrorKind::Conflict", "domain-safe PortError variants"],
+  ["PortErrorKind::Unavailable | PortErrorKind::Timeout", "availability PortError variants"],
+  ["PortErrorKind::InvariantViolation", "invariant PortError variant"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ["marketplace_listing.admin_runtime_unavailable", "runtime stable code"],
+  ["marketplace_listing.admin_auth_context_unavailable", "auth stable code"],
+  ["marketplace_listing.admin_tenant_context_unavailable", "tenant stable code"],
+  ["marketplace_listing.admin_request_context_unavailable", "request stable code"],
+  ["marketplace_listing.admin_module_availability_failed", "module-check stable code"],
+  ["Marketplace listing service is temporarily unavailable", "runtime public message"],
+  ["Marketplace listing request context is unavailable", "context public message"],
+]) requireText(source, value, label);
+
+if (countText(source, 'ServerFnError::new("Marketplace listing service is temporarily unavailable")') !== 2) {
+  failures.push("runtime dependency and module-check failures must share two stable service envelopes");
+}
+if (countText(source, 'ServerFnError::new("Marketplace listing request context is unavailable")') !== 3) {
+  failures.push("auth, tenant and request extraction must share three stable context envelopes");
+}
+if (countText(source, ".map_err(map_port_error)") !== 4) {
+  failures.push("directory, detail and command owner calls must preserve four PortError mappings");
+}
+if (countText(source, "NativeMarketplaceListingAdminError") < 6) {
+  failures.push("native facade error wrapper must remain present");
+}
+
+for (const value of [
+  "marketplace listing host runtime is not mounted",
+  "marketplace listing owner ports are not composed",
+  ".map_err(ServerFnError::new)?",
+  'ServerFnError::new("marketplace listing module availability check failed")',
+]) forbidText(source, value, "raw marketplace-listing admin request-boundary mapping");
+
+if (evidence.status !== "marketplace_listing_admin_native_request_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  host_runtime_static_public_envelope: true,
+  owner_runtime_static_public_envelope: true,
+  auth_context_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  request_context_static_public_envelope: true,
+  module_availability_failure_static_public_envelope: true,
+  permission_messages_changed: false,
+  identity_mismatch_message_changed: false,
+  module_disabled_message_changed: false,
+  port_error_mapper_changed: false,
+  port_context_contract_changed: false,
+  endpoint_contract_changed: false,
+  command_payload_changed: false,
+  raw_request_boundary_error_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Marketplace-listing admin native request error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ marketplace-listing admin native request failures retain SSR diagnostics and static public envelopes; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace raw marketplace-listing admin host/runtime/context/module-check error text with static public `ServerFnError` messages
- retain internal causes in structured SSR logs with owner, operation, action, stable code, boundary, and correlation/tenant/channel/locale when available
- preserve directory/detail/command endpoints, DTOs, command payloads, permissions, identity checks, module-disabled behavior, PortContext composition, and `PortError` mapping
- add source-only evidence, documentation, and a focused verifier

## Boundary
No marketplace topology, Commerce optional-capability status, owner ports, GraphQL transport, FBA/FFA status, plan checkbox, compile evidence, or runtime evidence is changed. The branch is behind only in unrelated Blog commits; target file SHAs match current `main`.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.