### PR TITLE
chore(marketplace-listing): register admin native request error guard

### DIFF
--- a/scripts/verify/verify-marketplace-listing-admin-ffa.mjs
+++ b/scripts/verify/verify-marketplace-listing-admin-ffa.mjs
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+import "./verify-marketplace-listing-admin-native-request-error-safety.mjs";
+
 const root = process.cwd();
 const files = {
   workspace: "Cargo.toml",


### PR DESCRIPTION
## Summary
- make `verify:marketplace:listing-admin-ffa` execute the focused marketplace-listing admin native request error-safety guard
- retain the existing npm command and marketplace/FFA aggregates without rewriting `package.json`

## Boundary
No production code, evidence, plan checkbox, npm metadata, marketplace topology, FBA/FFA status, or runtime validation is changed.

## Verification
Not run per maintainer instruction. No npm commands, Node verifiers, Cargo commands, formatting, workflows, or CI are claimed.