### PR TITLE
fix(pricing): sanitize storefront native failures

### DIFF
--- a/crates/rustok-pricing/contracts/evidence/storefront-native-error-safety-source.json
+++ b/crates/rustok-pricing/contracts/evidence/storefront-native-error-safety-source.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "pricing_storefront_native_error_safety_source_unvalidated",
+  "scope": "pricing-owned storefront native server-function transport",
+  "source_contract": {
+    "runtime_dependency_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "optional_request_context_preserved": true,
+    "optional_request_context_failure_logged": true,
+    "owner_runtime_static_public_envelope": true,
+    "internal_variant_id_failure_static_public_envelope": true,
+    "correlation_logging_when_available": true,
+    "tenant_logging_when_available": true,
+    "channel_logging_when_available": true,
+    "locale_logging_when_available": true,
+    "transport_validation_messages_preserved": true,
+    "query_contract_changed": false,
+    "resolution_context_changed": false,
+    "pagination_changed": false,
+    "locale_fallback_changed": false,
+    "channel_fallback_changed": false,
+    "request_response_dto_changed": false,
+    "outer_error_variant_changed": false,
+    "raw_runtime_error_public": false
+  },
+  "stable_public_messages": {
+    "pricing_unavailable": "Storefront pricing is temporarily unavailable",
+    "context_unavailable": "Pricing storefront context is unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-pricing-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-pricing-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-pricing-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-pricing/docs/storefront-native-error-safety.md
+++ b/crates/rustok-pricing/docs/storefront-native-error-safety.md
@@ -1,0 +1,82 @@
+# Pricing storefront native error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Pricing-owned native storefront server function in:
+
+- `crates/rustok-pricing/storefront/src/transport/native_server_adapter.rs`.
+
+The endpoint composes channel options, active price lists, published product pricing, selected-product detail, and effective variant prices.
+
+## Delivered source contract
+
+Static public `ServerFnError` messages now cover:
+
+- missing host-composed `TransactionalEventBus`;
+- tenant-context extraction failure;
+- channel listing failure;
+- active price-list loading failure;
+- published pricing list failure;
+- selected product pricing detail failure;
+- internal variant-id projection failure;
+- effective variant-price resolution failure.
+
+Internal causes remain only in SSR diagnostics with the available:
+
+- Pricing storefront owner and exact owner operation;
+- correlation id, tenant id, channel id, channel slug, and locale when optional `RequestContext` is available;
+- stable internal code and native boundary;
+- original runtime, extraction, service, or projection error.
+
+`RequestContext` remains optional. Extraction failure is logged and still falls back to `None`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the `pricing/storefront-data` endpoint;
+- `StorefrontPricingQuery`, `StorefrontPricingData`, or nested DTOs;
+- the external `ApiError::ServerFn` transport variant;
+- transport selection or GraphQL behavior;
+- explicit channel-id validation;
+- resolution-context validation;
+- locale fallback to the tenant default locale;
+- request-context channel id and channel slug fallback;
+- channel listing pagination at page `1`, per-page `250`;
+- product pricing pagination at page `1`, per-page `8`;
+- active price-list, product list, product detail, or effective-price operation payloads;
+- selected-handle fallback behavior.
+
+The two transport-validation errors intentionally remain user-facing. Runtime, context, owner-service, and internal projection errors use static envelopes.
+
+## Static evidence
+
+`scripts/verify/verify-pricing-storefront-native-error-safety.mjs` guards:
+
+- SSR tracing dependency composition;
+- the endpoint and external error variant;
+- optional request-context behavior and diagnostics;
+- static runtime, context, owner-service, and projection envelopes;
+- owner operation, correlation, tenant, channel, locale, stable code, and boundary logging;
+- preservation of exactly two transport-validation mappings;
+- unchanged locale/channel fallback, resolution context, pagination, service operations, and DTO result composition;
+- source-only validation flags.
+
+## Remaining gaps
+
+Compile, mounted parity, native runtime, remote transport, and browser evidence remain open. The broader ecommerce mapper-cleanup task also remains open for other transports, compensation/execution adapters, and non-`PortError` public envelopes.
+
+This slice does not change Product/Pricing dependency topology or make marketplace financial integration an optional Commerce capability.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-pricing-storefront-native-error-safety.mjs
+node scripts/verify/verify-pricing-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-pricing-storefront --all-features
+```

--- a/crates/rustok-pricing/storefront/Cargo.toml
+++ b/crates/rustok-pricing/storefront/Cargo.toml
@@ -14,6 +14,7 @@ ssr = [
   "dep:rustok-channel",
   "dep:rustok-pricing",
   "dep:rustok-outbox",
+  "dep:tracing",
   "rustok-api/server",
 ]
 
@@ -30,6 +31,7 @@ rustok-ui-i18n-leptos.workspace = true
 rustok-channel = { workspace = true, optional = true }
 rustok-pricing = { workspace = true, optional = true }
 rustok-outbox = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 futures = "0.3"
 serde = { workspace = true, features = ["derive"] }
 uuid.workspace = true

--- a/crates/rustok-pricing/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-pricing/storefront/src/transport/native_server_adapter.rs
@@ -18,6 +18,103 @@ use crate::model::{
 #[cfg(feature = "ssr")]
 use crate::model::{PricingEffectivePrice, PricingPrice};
 
+#[cfg(feature = "ssr")]
+const PRICING_STOREFRONT_NATIVE_OWNER: &str = "rustok_pricing.storefront";
+#[cfg(feature = "ssr")]
+const PRICING_STOREFRONT_NATIVE_BOUNDARY: &str = "pricing_storefront_native_transport";
+
+#[cfg(feature = "ssr")]
+fn map_runtime_dependency_error(dependency: &'static str) -> ServerFnError {
+    tracing::error!(
+        owner = PRICING_STOREFRONT_NATIVE_OWNER,
+        owner_operation = "storefront_pricing_native",
+        dependency,
+        code = "pricing.storefront_runtime_unavailable",
+        boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+        "pricing storefront native runtime dependency is unavailable"
+    );
+    ServerFnError::new("Storefront pricing is temporarily unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn record_optional_request_context_error<E: std::fmt::Display>(error: E) {
+    tracing::warn!(
+        error = %error,
+        owner = PRICING_STOREFRONT_NATIVE_OWNER,
+        owner_operation = "storefront_pricing_native",
+        code = "pricing.storefront_request_context_unavailable",
+        boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+        "optional pricing storefront request context extraction failed"
+    );
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Display>(
+    request_context: Option<&rustok_api::RequestContext>,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = %error,
+            owner = PRICING_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "storefront_pricing_native",
+            correlation_id = %request_context.correlation_id,
+            tenant_id = %request_context.tenant_id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "pricing.storefront_tenant_context_unavailable",
+            boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+            "pricing storefront tenant context extraction failed"
+        );
+    } else {
+        tracing::error!(
+            error = %error,
+            owner = PRICING_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "storefront_pricing_native",
+            code = "pricing.storefront_tenant_context_unavailable",
+            boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+            "pricing storefront tenant context extraction failed without request context"
+        );
+    }
+    ServerFnError::new("Pricing storefront context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_owner_runtime_error<E: std::fmt::Display>(
+    operation: &'static str,
+    tenant_id: Uuid,
+    request_context: Option<&rustok_api::RequestContext>,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = %error,
+            owner = PRICING_STOREFRONT_NATIVE_OWNER,
+            owner_operation = operation,
+            correlation_id = %request_context.correlation_id,
+            tenant_id = %tenant_id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "pricing.storefront_owner_runtime_failed",
+            boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+            "pricing storefront owner operation failed"
+        );
+    } else {
+        tracing::error!(
+            error = %error,
+            owner = PRICING_STOREFRONT_NATIVE_OWNER,
+            owner_operation = operation,
+            tenant_id = %tenant_id,
+            code = "pricing.storefront_owner_runtime_failed",
+            boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY,
+            "pricing storefront owner operation failed without request context"
+        );
+    }
+    ServerFnError::new("Storefront pricing is temporarily unavailable")
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiError {
     Graphql(String),
@@ -199,18 +296,18 @@ async fn storefront_pricing_native(
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let event_bus = runtime_ctx
             .shared_get::<TransactionalEventBus>()
-            .ok_or_else(|| {
-                ServerFnError::new(
-                    "pricing/storefront-data requires TransactionalEventBus in host runtime context",
-                )
-            })?;
+            .ok_or_else(|| map_runtime_dependency_error("TransactionalEventBus"))?;
         let db = runtime_ctx.db_clone();
-        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
-            .await
-            .ok();
+        let request_context = match leptos_axum::extract::<rustok_api::RequestContext>().await {
+            Ok(request_context) => Some(request_context),
+            Err(error) => {
+                record_optional_request_context_error(error);
+                None
+            }
+        };
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| map_tenant_context_error(request_context.as_ref(), error))?;
         let requested_locale = resolve_requested_locale(
             query.locale,
             request_context.as_ref().map(|ctx| ctx.locale.as_str()),
@@ -268,7 +365,14 @@ async fn storefront_pricing_native(
         let (available_channels, _) = channel_service
             .list_channels(tenant.id, 1, 250)
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                map_owner_runtime_error(
+                    "list_channels",
+                    tenant.id,
+                    request_context.as_ref(),
+                    error,
+                )
+            })?;
         let active_price_lists = service
             .list_active_price_lists_for_channel(
                 tenant.id,
@@ -278,7 +382,14 @@ async fn storefront_pricing_native(
                 Some(tenant.default_locale.as_str()),
             )
             .await
-            .map_err(ServerFnError::new)?
+            .map_err(|error| {
+                map_owner_runtime_error(
+                    "list_active_price_lists_for_channel",
+                    tenant.id,
+                    request_context.as_ref(),
+                    error,
+                )
+            })?
             .into_iter()
             .map(map_native_price_list_option)
             .collect();
@@ -292,7 +403,14 @@ async fn storefront_pricing_native(
                 8,
             )
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                map_owner_runtime_error(
+                    "list_published_product_pricing_with_locale_fallback",
+                    tenant.id,
+                    request_context.as_ref(),
+                    error,
+                )
+            })?;
         let resolved_handle = query
             .selected_handle
             .as_deref()
@@ -310,18 +428,39 @@ async fn storefront_pricing_native(
                     selected_channel_slug.as_deref(),
                 )
                 .await
-                .map_err(ServerFnError::new)?
+                .map_err(|error| {
+                    map_owner_runtime_error(
+                        "get_published_product_pricing_by_handle_with_locale_fallback",
+                        tenant.id,
+                        request_context.as_ref(),
+                        error,
+                    )
+                })?
                 .map(map_native_detail);
 
             if let (Some(detail_ref), Some(context)) =
                 (detail.as_mut(), native_resolution_context.as_ref())
             {
                 for variant in &mut detail_ref.variants {
-                    let variant_id = Uuid::parse_str(&variant.id).map_err(ServerFnError::new)?;
+                    let variant_id = Uuid::parse_str(&variant.id).map_err(|error| {
+                        map_owner_runtime_error(
+                            "parse_pricing_variant_id",
+                            tenant.id,
+                            request_context.as_ref(),
+                            error,
+                        )
+                    })?;
                     let effective_price = service
                         .resolve_variant_price(tenant.id, variant_id, context.clone())
                         .await
-                        .map_err(ServerFnError::new)?;
+                        .map_err(|error| {
+                            map_owner_runtime_error(
+                                "resolve_variant_price",
+                                tenant.id,
+                                request_context.as_ref(),
+                                error,
+                            )
+                        })?;
                     variant.effective_price = effective_price.map(map_native_effective_price);
                 }
             }

--- a/scripts/verify/verify-pricing-storefront-native-error-safety.mjs
+++ b/scripts/verify/verify-pricing-storefront-native-error-safety.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const cargo = read("crates/rustok-pricing/storefront/Cargo.toml");
+const source = read(
+  "crates/rustok-pricing/storefront/src/transport/native_server_adapter.rs",
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-pricing/contracts/evidence/storefront-native-error-safety-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ['"dep:tracing"', "Pricing storefront SSR tracing feature"],
+  ["tracing = { workspace = true, optional = true }", "Pricing storefront tracing dependency"],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ["const PRICING_STOREFRONT_NATIVE_OWNER", "native owner constant"],
+  ["const PRICING_STOREFRONT_NATIVE_BOUNDARY", "native boundary constant"],
+  ["fn map_runtime_dependency_error(", "runtime dependency mapper"],
+  ["fn record_optional_request_context_error<E: std::fmt::Display>(", "optional request context logger"],
+  ["fn map_tenant_context_error<E: std::fmt::Display>(", "tenant context mapper"],
+  ["fn map_owner_runtime_error<E: std::fmt::Display>(", "owner runtime mapper"],
+  ["owner = PRICING_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
+  ["owner_operation = operation", "owner operation diagnostics"],
+  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
+  ["locale = %request_context.locale", "locale diagnostics"],
+  ["boundary = PRICING_STOREFRONT_NATIVE_BOUNDARY", "boundary diagnostics"],
+  ["error = %error", "internal cause diagnostics"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "pricing/storefront-data"', "pricing endpoint"],
+  ["expect_context::<HostRuntimeContext>()", "host runtime composition"],
+  ["shared_get::<TransactionalEventBus>()", "event-bus composition"],
+  ["resolve_requested_locale(", "locale fallback"],
+  ["normalize_public_channel_slug(ctx.channel_slug.as_deref())", "channel slug fallback"],
+  ["sanitize_resolution_context(", "resolution-context validation"],
+  [".list_channels(tenant.id, 1, 250)", "channel pagination"],
+  [".list_active_price_lists_for_channel(", "active price-list operation"],
+  [".list_published_product_pricing_with_locale_fallback(", "pricing list operation"],
+  [".get_published_product_pricing_by_handle_with_locale_fallback(", "pricing detail operation"],
+  [".resolve_variant_price(tenant.id, variant_id, context.clone())", "effective price operation"],
+  ["Self::ServerFn(value.to_string())", "outer ServerFn error variant"],
+  ["products: map_native_list(products)", "product result composition"],
+  ["selected_product,", "selected product result composition"],
+  ["resolution_context,", "resolution context result composition"],
+  ["active_price_lists,", "price-list result composition"],
+]) requireText(source, value, label);
+
+for (const operation of [
+  "list_channels",
+  "list_active_price_lists_for_channel",
+  "list_published_product_pricing_with_locale_fallback",
+  "get_published_product_pricing_by_handle_with_locale_fallback",
+  "parse_pricing_variant_id",
+  "resolve_variant_price",
+]) {
+  requireText(source, `"${operation}"`, `owner operation ${operation}`);
+}
+
+for (const [value, label] of [
+  ["pricing.storefront_runtime_unavailable", "runtime stable code"],
+  ["pricing.storefront_request_context_unavailable", "request context stable code"],
+  ["pricing.storefront_tenant_context_unavailable", "tenant context stable code"],
+  ["pricing.storefront_owner_runtime_failed", "owner runtime stable code"],
+  ["Storefront pricing is temporarily unavailable", "pricing unavailable public message"],
+  ["Pricing storefront context is unavailable", "context unavailable public message"],
+]) requireText(source, value, label);
+
+if (countText(source, "map_owner_runtime_error(") !== 7) {
+  failures.push("owner runtime mapper must cover six operations plus its definition");
+}
+if (countText(source, ".map_err(|err| ServerFnError::new(err.to_string()))?;") !== 2) {
+  failures.push("exactly two transport-validation mappings must remain user-facing");
+}
+if (countText(source, 'ServerFnError::new("Storefront pricing is temporarily unavailable")') !== 2) {
+  failures.push("runtime dependency and owner failures must share two stable pricing envelope definitions");
+}
+if (countText(source, 'ServerFnError::new("Pricing storefront context is unavailable")') !== 1) {
+  failures.push("tenant extraction must use exactly one stable context envelope definition");
+}
+if (countText(source, "Self::ServerFn(value.to_string())") !== 1) {
+  failures.push("outer native facade must preserve exactly one ServerFn conversion");
+}
+
+for (const value of [
+  "pricing/storefront-data requires TransactionalEventBus in host runtime context",
+  ".map_err(ServerFnError::new)?",
+  "Uuid::parse_str(&variant.id).map_err(ServerFnError::new)?",
+]) forbidText(source, value, "raw Pricing storefront runtime mapping");
+
+if (evidence.status !== "pricing_storefront_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  runtime_dependency_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  optional_request_context_preserved: true,
+  optional_request_context_failure_logged: true,
+  owner_runtime_static_public_envelope: true,
+  internal_variant_id_failure_static_public_envelope: true,
+  transport_validation_messages_preserved: true,
+  query_contract_changed: false,
+  resolution_context_changed: false,
+  pagination_changed: false,
+  locale_fallback_changed: false,
+  channel_fallback_changed: false,
+  request_response_dto_changed: false,
+  outer_error_variant_changed: false,
+  raw_runtime_error_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Pricing storefront native error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ Pricing storefront native runtime and owner failures use static public envelopes; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace raw Pricing storefront runtime, tenant-context, ChannelService, PricingService, and internal variant-id failure text with static public `ServerFnError` messages
- retain optional request-context extraction and log failures with owner, operation, stable code, boundary, and correlation/tenant/channel/locale when available
- preserve transport validation, locale/channel fallback, resolution context, pagination, service operation payloads, DTOs, selected-handle behavior, and `ApiError::ServerFn`
- add source-only evidence, documentation, and a focused verifier

## Boundary
No Product/Pricing dependency topology, GraphQL transport, FBA/FFA status, plan checkbox, compile evidence, mounted parity, or runtime evidence is changed.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.