### PR TITLE
fix(order): add checkout runtime error diagnostics

### DIFF
--- a/crates/rustok-order/contracts/evidence/storefront-runtime-error-diagnostics-source.json
+++ b/crates/rustok-order/contracts/evidence/storefront-runtime-error-diagnostics-source.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "order_storefront_runtime_error_diagnostics_source_unvalidated",
+  "scope": "order storefront native checkout runtime error mapper",
+  "source_contract": {
+    "runtime_cause_logged_server_side": true,
+    "owner_operation_logged": true,
+    "correlation_logged": true,
+    "tenant_logged": true,
+    "channel_logged": true,
+    "locale_logged": true,
+    "stable_code_logged": true,
+    "boundary_logged": true,
+    "public_code_message_envelope_preserved": true,
+    "endpoint_changed": false,
+    "command_payload_changed": false,
+    "dependency_composition_changed": false,
+    "context_extraction_changed": false,
+    "validation_messages_changed": false,
+    "outer_transport_envelope_changed": false
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs",
+    "node scripts/verify/verify-order-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-order-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-order/docs/storefront-runtime-error-diagnostics.md
+++ b/crates/rustok-order/docs/storefront-runtime-error-diagnostics.md
@@ -1,0 +1,66 @@
+# Order storefront checkout runtime error diagnostics
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the runtime-error mapper used by the Order-owned native checkout endpoint:
+
+- `crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs`.
+
+The underlying Commerce runtime already exposes stable public checkout codes and messages. This slice keeps that public contract intact and adds correlation-safe SSR diagnostics at the Order transport boundary.
+
+## Delivered source contract
+
+When `complete_storefront_checkout_with_product_port` returns `StorefrontStagedCheckoutRuntimeError`, the native adapter logs:
+
+- Order storefront owner;
+- exact owner operation;
+- request correlation id;
+- tenant id;
+- channel id and channel slug;
+- locale;
+- stable internal code and transport boundary;
+- public checkout code and retryability;
+- the original runtime error on the server.
+
+The returned `ServerFnError` remains exactly:
+
+```text
+<public_code>: <public_message>
+```
+
+Both values still come from `StorefrontStagedCheckoutRuntimeError::public_code()` and `public_message()`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the `order/complete-checkout` endpoint;
+- `CompleteCheckoutRequest` or `CheckoutCompletion` DTOs;
+- event-bus, payment-provider, or Product runtime composition;
+- request, tenant, or optional-auth extraction;
+- cart-id or idempotency-key validation messages;
+- `StorefrontCheckoutCompletionCommand` fields or metadata payload;
+- checkout completion DTO mapping;
+- the outer `CheckoutCompletionTransportError::ServerFn("Checkout transport is temporarily unavailable")` envelope;
+- GraphQL transport or transport selection.
+
+## Static evidence
+
+`scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs` guards the structured diagnostics, unchanged public envelope, endpoint and command payload, validation messages, dependency composition, and source-only validation flags.
+
+## Remaining gaps
+
+Compilation, mounted parity, native runtime, remote transport, browser evidence, compensation execution evidence, and the broader ecommerce mapper cleanup remain open.
+
+## Suggested maintainer checks
+
+```bash
+node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
+node scripts/verify/verify-order-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-order-storefront --all-features
+```
+
+These commands were intentionally not run by the implementation agent.

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -8,6 +8,11 @@ use uuid::Uuid;
 use super::super::CheckoutAdjustment;
 use super::super::{CheckoutCompletion, CheckoutCompletionTransportError, CompleteCheckoutRequest};
 
+#[cfg(feature = "ssr")]
+const ORDER_STOREFRONT_NATIVE_OWNER: &str = "rustok_order.storefront";
+#[cfg(feature = "ssr")]
+const ORDER_STOREFRONT_NATIVE_BOUNDARY: &str = "order_storefront_native_transport";
+
 pub async fn complete_checkout_server(
     request: CompleteCheckoutRequest,
 ) -> Result<CheckoutCompletion, CheckoutCompletionTransportError> {
@@ -105,7 +110,7 @@ async fn storefront_order_complete_checkout_native(
             },
         )
         .await
-        .map_err(native_checkout_runtime_error)?;
+        .map_err(|error| native_checkout_runtime_error(&request_context, tenant.id, error))?;
 
         Ok(map_checkout_completion(completion))
     }
@@ -128,13 +133,28 @@ fn native_context_error(operation: &'static str, error: impl std::fmt::Display) 
 
 #[cfg(feature = "ssr")]
 fn native_checkout_runtime_error(
+    request_context: &rustok_api::RequestContext,
+    tenant_id: Uuid,
     error: rustok_commerce::services::storefront_staged_checkout_runtime::StorefrontStagedCheckoutRuntimeError,
 ) -> ServerFnError {
-    ServerFnError::new(format!(
-        "{}: {}",
-        error.public_code(),
-        error.public_message()
-    ))
+    let public_code = error.public_code();
+    let public_message = error.public_message();
+    tracing::error!(
+        error = ?error,
+        owner = ORDER_STOREFRONT_NATIVE_OWNER,
+        owner_operation = "complete_storefront_checkout",
+        correlation_id = %request_context.correlation_id,
+        tenant_id = %tenant_id,
+        channel_id = ?request_context.channel_id,
+        channel_slug = ?request_context.channel_slug,
+        locale = %request_context.locale,
+        public_code = %public_code,
+        public_retryable = error.retryable(),
+        code = "order.storefront_checkout_runtime_failed",
+        boundary = ORDER_STOREFRONT_NATIVE_BOUNDARY,
+        "order storefront checkout runtime failed"
+    );
+    ServerFnError::new(format!("{public_code}: {public_message}"))
 }
 
 #[cfg(feature = "ssr")]

--- a/scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
+++ b/scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const source = read(
+  "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-order/contracts/evidence/storefront-runtime-error-diagnostics-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ["const ORDER_STOREFRONT_NATIVE_OWNER", "native owner constant"],
+  ["const ORDER_STOREFRONT_NATIVE_BOUNDARY", "native boundary constant"],
+  ["fn native_checkout_runtime_error(", "runtime error mapper"],
+  ["request_context: &rustok_api::RequestContext", "request context mapper input"],
+  ["tenant_id: Uuid", "tenant mapper input"],
+  ["owner = ORDER_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
+  ['owner_operation = "complete_storefront_checkout"', "operation diagnostics"],
+  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
+  ["locale = %request_context.locale", "locale diagnostics"],
+  ["public_code = %public_code", "public code diagnostics"],
+  ["public_retryable = error.retryable()", "retryability diagnostics"],
+  ['code = "order.storefront_checkout_runtime_failed"', "stable internal code"],
+  ["boundary = ORDER_STOREFRONT_NATIVE_BOUNDARY", "boundary diagnostics"],
+  ["error = ?error", "server-side runtime cause"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "order/complete-checkout"', "endpoint"],
+  ["shared_get::<TransactionalEventBus>()", "event bus composition"],
+  ["shared_get::<PaymentProviderRegistry>()", "payment registry composition"],
+  ["shared_get::<ProductCatalogReadRuntime>()", "Product runtime composition"],
+  ["extract::<rustok_api::RequestContext>()", "request context extraction"],
+  ["extract::<rustok_api::TenantContext>()", "tenant context extraction"],
+  ["extract::<rustok_api::OptionalAuthContext>()", "optional auth extraction"],
+  ['ServerFnError::new("Checkout request is invalid")', "checkout validation message"],
+  ["StorefrontCheckoutCompletionCommand {", "owner command"],
+  ['"source_module": metadata.source_module', "source module payload"],
+  ['"source_surface": metadata.source_surface', "source surface payload"],
+  ['"command": metadata.command', "command metadata payload"],
+  ['"owner_module": metadata.owner_module', "owner module payload"],
+  ['"create_fulfillment": metadata.create_fulfillment', "fulfillment metadata payload"],
+  ["map_checkout_completion(completion)", "completion mapping"],
+  ["CheckoutCompletionTransportError::ServerFn(", "outer transport variant"],
+  ['"Checkout transport is temporarily unavailable".to_string()', "outer transport message"],
+]) requireText(source, value, label);
+
+requireText(
+  source,
+  ".map_err(|error| native_checkout_runtime_error(&request_context, tenant.id, error))?;",
+  "correlation-aware runtime mapper call",
+);
+requireText(source, "let public_code = error.public_code();", "public code source");
+requireText(source, "let public_message = error.public_message();", "public message source");
+requireText(
+  source,
+  'ServerFnError::new(format!("{public_code}: {public_message}"))',
+  "unchanged public code-message envelope",
+);
+
+if (countText(source, 'ServerFnError::new("Checkout request is invalid")') !== 2) {
+  failures.push("cart id and idempotency validation must preserve two static invalid-request envelopes");
+}
+if (countText(source, 'ServerFnError::new("Checkout service is temporarily unavailable")') !== 2) {
+  failures.push("two required runtime dependencies must preserve their static unavailable envelopes");
+}
+forbidText(
+  source,
+  ".map_err(native_checkout_runtime_error)?;",
+  "runtime mapper without request diagnostics",
+);
+
+if (evidence.status !== "order_storefront_runtime_error_diagnostics_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  runtime_cause_logged_server_side: true,
+  owner_operation_logged: true,
+  correlation_logged: true,
+  tenant_logged: true,
+  channel_logged: true,
+  locale_logged: true,
+  stable_code_logged: true,
+  boundary_logged: true,
+  public_code_message_envelope_preserved: true,
+  endpoint_changed: false,
+  command_payload_changed: false,
+  dependency_composition_changed: false,
+  context_extraction_changed: false,
+  validation_messages_changed: false,
+  outer_transport_envelope_changed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Order storefront runtime-error diagnostics verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ Order storefront checkout runtime failures retain the public envelope and add correlation-safe SSR diagnostics; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- add correlation-safe SSR diagnostics when the Order storefront maps `StorefrontStagedCheckoutRuntimeError`
- log owner, operation, correlation id, tenant, channel, locale, stable code, boundary, public code, retryability, and the server-side runtime cause
- preserve the exact `<public_code>: <public_message>` `ServerFnError` envelope
- preserve endpoint, context extraction, validation messages, runtime dependencies, command payload, completion DTO mapping, and outer transport envelope
- add source-only evidence, documentation, and a focused verifier

## Boundary
No checkout lifecycle policy, compensation behavior, Commerce topology, marketplace optionalization, DTO, GraphQL transport, FBA/FFA status, plan checkbox, compile evidence, or runtime evidence is changed. The branch is behind only in an unrelated commit; the target file SHA matches current `main`.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.