### PR TITLE
chore(order): register checkout runtime diagnostics guard

### DIFF
--- a/scripts/verify/verify-order-storefront-boundary.mjs
+++ b/scripts/verify/verify-order-storefront-boundary.mjs
@@ -6,6 +6,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import "./verify-order-storefront-runtime-error-diagnostics.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)


### PR DESCRIPTION
## Summary
- make `verify:order:storefront-boundary` execute the focused Order storefront checkout runtime diagnostics guard
- retain the existing npm command and FFA aggregates without rewriting `package.json`

## Boundary
No production code, evidence, plan checkbox, npm metadata, checkout lifecycle policy, compensation behavior, Commerce topology, FBA/FFA status, or runtime validation is changed.

## Verification
Not run per maintainer instruction. No npm commands, Node verifiers, Cargo commands, formatting, workflows, or CI are claimed.