### PR TITLE
fix(region): sanitize storefront native failures

### DIFF
--- a/crates/rustok-region/contracts/evidence/storefront-native-error-safety-source.json
+++ b/crates/rustok-region/contracts/evidence/storefront-native-error-safety-source.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "region_storefront_native_error_safety_source_unvalidated",
+  "scope": "region-owned storefront native server-function transport",
+  "source_contract": {
+    "tenant_context_static_public_envelope": true,
+    "optional_request_context_preserved": true,
+    "optional_request_context_failure_logged": true,
+    "owner_runtime_static_public_envelope": true,
+    "correlation_logging_when_available": true,
+    "tenant_logging_when_available": true,
+    "channel_logging_when_available": true,
+    "locale_logging_when_available": true,
+    "stable_code_logged": true,
+    "boundary_logged": true,
+    "endpoint_changed": false,
+    "locale_precedence_changed": false,
+    "selected_region_resolution_changed": false,
+    "country_tax_policy_mapping_changed": false,
+    "response_dto_changed": false,
+    "outer_error_variant_changed": false,
+    "raw_owner_error_public": false
+  },
+  "stable_public_messages": {
+    "context_unavailable": "Region storefront context is unavailable",
+    "regions_unavailable": "Storefront regions are temporarily unavailable"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-region-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-region-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-region-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-region/docs/storefront-native-error-safety.md
+++ b/crates/rustok-region/docs/storefront-native-error-safety.md
@@ -1,0 +1,74 @@
+# Region storefront native error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Region-owned native storefront server function in:
+
+- `crates/rustok-region/storefront/src/transport/native_server_adapter.rs`.
+
+The endpoint loads tenant regions, resolves locale fallback, maps country tax policy data, and selects the active region for the storefront response.
+
+## Delivered source contract
+
+Static public `ServerFnError` messages now cover:
+
+- tenant-context extraction failure;
+- Region owner service failure while listing storefront regions.
+
+Internal causes remain only in SSR diagnostics with the available:
+
+- Region storefront owner and exact owner operation;
+- correlation id, tenant id, channel id, channel slug, and locale when `RequestContext` is available;
+- stable internal code and native boundary;
+- original extraction or owner-service error.
+
+`RequestContext` remains optional. Extraction failure is logged and still falls back to `None`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the `region/storefront-data` endpoint;
+- `StorefrontRegionsData`, `StorefrontRegion`, or country tax-policy DTOs;
+- the external `ApiError` conversion;
+- transport selection or GraphQL behavior;
+- requested locale precedence: explicit request, request context, tenant default;
+- tenant-default locale fallback passed to `RegionService::list_regions`;
+- selected-region resolution through `resolve_storefront_regions`;
+- region, country, tax-rate, tax-inclusion, or currency mapping.
+
+## Static public messages
+
+- `Region storefront context is unavailable`
+- `Storefront regions are temporarily unavailable`
+
+## Static evidence
+
+`scripts/verify/verify-region-storefront-native-error-safety.mjs` guards:
+
+- SSR tracing dependency composition;
+- endpoint and host runtime composition;
+- optional request-context behavior and diagnostics;
+- static tenant-context and owner-service envelopes;
+- owner operation, correlation, tenant, channel, locale, stable code, and boundary logging;
+- unchanged locale precedence, service inputs, selected-region resolution, country tax-policy mapping, DTO result composition, and outer `ApiError` conversion;
+- source-only validation flags.
+
+## Remaining gaps
+
+Compilation, mounted parity, native runtime, remote transport, and browser evidence remain open. The broader ecommerce mapper-cleanup task also remains open for inventory, customer, tax, promotion, compensation/execution adapters, and non-`PortError` public envelopes.
+
+This slice does not change Product dependency topology or make marketplace financial integration an optional Commerce capability.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-region-storefront-native-error-safety.mjs
+node scripts/verify/verify-region-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-region-storefront --all-features
+```

--- a/crates/rustok-region/storefront/Cargo.toml
+++ b/crates/rustok-region/storefront/Cargo.toml
@@ -12,6 +12,7 @@ ssr = [
   "leptos/ssr",
   "dep:leptos_axum",
   "dep:rustok-region",
+  "dep:tracing",
   "rustok-api/server",
 ]
 
@@ -26,4 +27,5 @@ rustok-ui-transport.workspace = true
 
 rustok-ui-i18n-leptos.workspace = true
 rustok-region = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rustok-region/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-region/storefront/src/transport/native_server_adapter.rs
@@ -11,6 +11,89 @@ use crate::model::StorefrontRegionsData;
 use super::ApiError;
 
 #[cfg(feature = "ssr")]
+const REGION_STOREFRONT_NATIVE_OWNER: &str = "rustok_region.storefront";
+#[cfg(feature = "ssr")]
+const REGION_STOREFRONT_NATIVE_BOUNDARY: &str = "region_storefront_native_transport";
+
+#[cfg(feature = "ssr")]
+fn record_optional_request_context_error<E: std::fmt::Display>(error: E) {
+    tracing::warn!(
+        error = %error,
+        owner = REGION_STOREFRONT_NATIVE_OWNER,
+        owner_operation = "storefront_regions",
+        code = "region.storefront_request_context_unavailable",
+        boundary = REGION_STOREFRONT_NATIVE_BOUNDARY,
+        "optional region storefront request context extraction failed"
+    );
+}
+
+#[cfg(feature = "ssr")]
+fn map_tenant_context_error<E: std::fmt::Display>(
+    request_context: Option<&rustok_api::RequestContext>,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = %error,
+            owner = REGION_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "storefront_regions",
+            correlation_id = %request_context.correlation_id,
+            tenant_id = %request_context.tenant_id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "region.storefront_tenant_context_unavailable",
+            boundary = REGION_STOREFRONT_NATIVE_BOUNDARY,
+            "region storefront tenant context extraction failed"
+        );
+    } else {
+        tracing::error!(
+            error = %error,
+            owner = REGION_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "storefront_regions",
+            code = "region.storefront_tenant_context_unavailable",
+            boundary = REGION_STOREFRONT_NATIVE_BOUNDARY,
+            "region storefront tenant context extraction failed without request context"
+        );
+    }
+    ServerFnError::new("Region storefront context is unavailable")
+}
+
+#[cfg(feature = "ssr")]
+fn map_region_runtime_error<E: std::fmt::Display>(
+    tenant: &rustok_api::TenantContext,
+    request_context: Option<&rustok_api::RequestContext>,
+    error: E,
+) -> ServerFnError {
+    if let Some(request_context) = request_context {
+        tracing::error!(
+            error = %error,
+            owner = REGION_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "list_regions",
+            correlation_id = %request_context.correlation_id,
+            tenant_id = %tenant.id,
+            channel_id = ?request_context.channel_id,
+            channel_slug = ?request_context.channel_slug,
+            locale = %request_context.locale,
+            code = "region.storefront_owner_runtime_failed",
+            boundary = REGION_STOREFRONT_NATIVE_BOUNDARY,
+            "region storefront owner operation failed"
+        );
+    } else {
+        tracing::error!(
+            error = %error,
+            owner = REGION_STOREFRONT_NATIVE_OWNER,
+            owner_operation = "list_regions",
+            tenant_id = %tenant.id,
+            code = "region.storefront_owner_runtime_failed",
+            boundary = REGION_STOREFRONT_NATIVE_BOUNDARY,
+            "region storefront owner operation failed without request context"
+        );
+    }
+    ServerFnError::new("Storefront regions are temporarily unavailable")
+}
+
+#[cfg(feature = "ssr")]
 fn map_region(value: rustok_region::RegionResponse) -> StorefrontRegion {
     StorefrontRegion {
         id: value.id.to_string(),
@@ -68,12 +151,16 @@ async fn fetch_storefront_regions_server(
         use rustok_region::RegionService;
 
         let runtime_ctx = expect_context::<HostRuntimeContext>();
+        let request_context = match leptos_axum::extract::<rustok_api::RequestContext>().await {
+            Ok(request_context) => Some(request_context),
+            Err(error) => {
+                record_optional_request_context_error(error);
+                None
+            }
+        };
         let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
-        let request_context = leptos_axum::extract::<rustok_api::RequestContext>()
-            .await
-            .ok();
+            .map_err(|error| map_tenant_context_error(request_context.as_ref(), error))?;
         let requested_locale = resolve_requested_locale(
             locale,
             request_context
@@ -88,7 +175,9 @@ async fn fetch_storefront_regions_server(
                 Some(tenant.default_locale.as_str()),
             )
             .await
-            .map_err(ServerFnError::new)?
+            .map_err(|error| {
+                map_region_runtime_error(&tenant, request_context.as_ref(), error)
+            })?
             .into_iter()
             .map(map_region)
             .collect();

--- a/scripts/verify/verify-region-storefront-native-error-safety.mjs
+++ b/scripts/verify/verify-region-storefront-native-error-safety.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL("../../", import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
+
+const source = read(
+  "crates/rustok-region/storefront/src/transport/native_server_adapter.rs",
+);
+const cargo = read("crates/rustok-region/storefront/Cargo.toml");
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-region/contracts/evidence/storefront-native-error-safety-source.json",
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ['"dep:tracing"', "SSR tracing feature"],
+  ["tracing = { workspace = true, optional = true }", "optional tracing dependency"],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ["const REGION_STOREFRONT_NATIVE_OWNER", "native owner constant"],
+  ["const REGION_STOREFRONT_NATIVE_BOUNDARY", "native boundary constant"],
+  ["fn record_optional_request_context_error", "optional context diagnostic"],
+  ["fn map_tenant_context_error", "tenant context mapper"],
+  ["fn map_region_runtime_error", "Region owner mapper"],
+  ["owner = REGION_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
+  ['owner_operation = "storefront_regions"', "request operation diagnostics"],
+  ['owner_operation = "list_regions"', "owner operation diagnostics"],
+  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant.id", "tenant diagnostics"],
+  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
+  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
+  ["locale = %request_context.locale", "locale diagnostics"],
+  ['code = "region.storefront_request_context_unavailable"', "request context code"],
+  ['code = "region.storefront_tenant_context_unavailable"', "tenant context code"],
+  ['code = "region.storefront_owner_runtime_failed"', "owner runtime code"],
+  ["boundary = REGION_STOREFRONT_NATIVE_BOUNDARY", "boundary diagnostics"],
+  ['ServerFnError::new("Region storefront context is unavailable")', "context envelope"],
+  ['ServerFnError::new("Storefront regions are temporarily unavailable")', "owner envelope"],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  ['endpoint = "region/storefront-data"', "endpoint"],
+  ["expect_context::<HostRuntimeContext>()", "host runtime composition"],
+  ["RegionService::new(runtime_ctx.db_clone())", "Region service composition"],
+  ["extract::<rustok_api::RequestContext>()", "request context extraction"],
+  ["Ok(request_context) => Some(request_context)", "optional context success"],
+  ["record_optional_request_context_error(error);", "optional context failure logging"],
+  ["extract::<rustok_api::TenantContext>()", "tenant extraction"],
+  ["resolve_requested_locale(", "locale resolver"],
+  ["request_context_locale", "request-context locale fallback"],
+  ["tenant_default_locale", "tenant-default locale fallback"],
+  [".list_regions(", "Region owner operation"],
+  ["Some(requested_locale.as_str())", "requested locale input"],
+  ["Some(tenant.default_locale.as_str())", "tenant-default fallback input"],
+  ["resolve_storefront_regions(regions, selected_region_id)", "selected-region resolution"],
+  ["country_tax_policies: value", "country tax-policy mapping"],
+  ["tax_rate: policy.tax_rate.normalize().to_string()", "country tax-rate mapping"],
+  ["tax_included: policy.tax_included", "country tax-inclusion mapping"],
+  [".map_err(ApiError::from)", "outer error conversion"],
+]) requireText(source, value, label);
+
+if (countText(source, 'ServerFnError::new("Region storefront context is unavailable")') !== 1) {
+  failures.push("tenant context must expose exactly one static context envelope");
+}
+if (countText(source, 'ServerFnError::new("Storefront regions are temporarily unavailable")') !== 1) {
+  failures.push("Region owner failure must expose exactly one static unavailable envelope");
+}
+forbidText(
+  source,
+  ".map_err(ServerFnError::new)?",
+  "raw extraction or owner error mapping",
+);
+forbidText(
+  source,
+  ".await\n            .ok();",
+  "silent optional request-context fallback",
+);
+
+if (evidence.status !== "region_storefront_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  tenant_context_static_public_envelope: true,
+  optional_request_context_preserved: true,
+  optional_request_context_failure_logged: true,
+  owner_runtime_static_public_envelope: true,
+  correlation_logging_when_available: true,
+  tenant_logging_when_available: true,
+  channel_logging_when_available: true,
+  locale_logging_when_available: true,
+  stable_code_logged: true,
+  boundary_logged: true,
+  endpoint_changed: false,
+  locale_precedence_changed: false,
+  selected_region_resolution_changed: false,
+  country_tax_policy_mapping_changed: false,
+  response_dto_changed: false,
+  outer_error_variant_changed: false,
+  raw_owner_error_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Region storefront native error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ Region storefront native failures use static public envelopes with correlation-safe SSR diagnostics; runtime evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace raw Region storefront tenant-context and RegionService failures with static public envelopes
- keep optional RequestContext optional while logging extraction failure
- retain SSR diagnostics with owner, operation, correlation, tenant, channel, locale, stable code, boundary, and server-side cause
- preserve endpoint, locale precedence, selected-region resolution, country tax-policy mapping, DTOs, and outer ApiError conversion
- add source-only evidence, documentation, and a focused verifier

## Boundary
No GraphQL transport, transport selection, Region domain policy, tax calculation, Product dependency topology, marketplace optionalization, FBA/FFA status, plan checkbox, compile evidence, or runtime evidence is changed.

## Verification
Not run per maintainer instruction. No tests, Cargo commands, Node verifiers, formatting, workflows, or CI are claimed.