### PR TITLE
chore(region): register storefront native error guard

### DIFF
--- a/scripts/verify/verify-region-storefront-boundary.mjs
+++ b/scripts/verify/verify-region-storefront-boundary.mjs
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import "./verify-region-storefront-native-error-safety.mjs";
+
 const root = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");


### PR DESCRIPTION
## Summary
- make `verify:region:storefront-boundary` execute the focused Region storefront native error-safety guard
- retain the existing npm command and FFA aggregates without rewriting `package.json`

## Boundary
No production code, evidence, plan checkbox, npm metadata, Region domain behavior, tax calculation, Product/Commerce topology, FBA/FFA status, or runtime validation is changed.

## Verification
Not run per maintainer instruction. No npm commands, Node verifiers, Cargo commands, formatting, workflows, or CI are claimed.