### PR TITLE
feat(index): add explicit many-link aggregate ordering

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -25,7 +25,8 @@ and scheduler implementations remain outside the engine core.
 - `IndexSchema`, `IndexField`, `IndexLink`, `SchemaFingerprint`
 - `IndexRecord`, `IndexLinkValue`, `LinkedEntityKey`
 - `IndexMutation`
-- `IndexQueryScope`, `IndexQuery`, `FilterExpr`, `OrderExpr`, `OrderDirection`, `Pagination`
+- `IndexQueryScope`, `IndexQuery`, `FilterExpr`, `OrderExpr`, `OrderDirection`,
+  `ManyOrderAggregate`, `Pagination`
 - `DomainError`
 
 ### Application
@@ -35,7 +36,7 @@ and scheduler implementations remain outside the engine core.
 - `IndexSchemaSourceCatalog`, `IndexSchemaSourceDescriptor`, `IndexSchemaSourceError`
 - `SharedIndexSchemaRegistry`
 - `register_index_schema_source`, `materialize_index_schema_registry`
-- `RecordValidationError`, `QueryValidationError`
+- `RecordValidationError`, `QueryValidationError`, `AggregateOrderValidationError`
 - `IndexCursor`, `CursorCodec`, `CursorCodecError`, `CursorValidationError`
 - `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedManyProjection`, `PlannedOrder`
 - `QueryPlanFingerprint`, `QueryPlanError`
@@ -79,9 +80,10 @@ and partition admission remain Index-owned and fail closed on identity or eviden
 
 M4 provides validated executable plans, controlled PostgreSQL SQL and ordered binds,
 root/one-link projection and ordering, correlated many-link filtering, deterministic nested
-many-link projection aggregates, exact count, bounded offset, query-scoped keyset pagination,
-one-row lookahead, strict row decoding, and PostgreSQL execution through one read-only
-repeatable-read snapshot.
+many-link projection aggregates, explicit `min` / `max` many-link ordering for bounded offset
+pages, exact count, query-scoped keyset pagination for ordinary order expressions, one-row
+lookahead, strict row decoding, and PostgreSQL execution through one read-only repeatable-read
+snapshot.
 
 Source modules now publish generic schema contracts through `IndexSchemaSourceCatalog`.
 The catalog fixes one owner for every exact schema reference and for the complete schema
@@ -96,8 +98,9 @@ SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
 `HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
 connection, persisted tenant schema readiness, authorization, or successful query execution.
 
-Many-link aggregate ordering, additional source schemas, transport authorization, first
-storefront/admin/search consumer cutover, and live PostgreSQL/reference evidence remain open.
+Aggregate cursor continuation, retained PostgreSQL/reference aggregate evidence, additional
+source schemas, transport authorization, and first storefront/admin/search authoritative
+consumer cutover remain open.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`, `DocumentType`, old
 ports/adapters, source DTOs/indexers/models/migrations, `IndexerRuntimeConfig`,
@@ -135,6 +138,14 @@ builders or DTOs.
 - `IndexQueryScope` carries tenant and locale independently from caller filters.
 - Selected, filtered, and ordered fields resolve through registered typed paths.
 - Query shape, depth, selected fields, ordering expressions, page size, and offset are bounded.
+- Plain `asc` / `desc` through a `many` path remains ambiguous and rejected.
+- Explicit `min_asc`, `min_desc`, `max_asc`, and `max_desc` are accepted only for sortable
+  scalar integer, decimal, string, or timestamp fields reached through at least one `many`
+  link and only with bounded offset pagination.
+- Empty or all-null aggregate relation sets produce a nullable derived order value; ascending
+  uses `NULLS LAST`, descending uses `NULLS FIRST`, and root entity ID remains the final tie-break.
+- Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate orders
+  fail closed.
 - `SchemaRegistry::compile_postgres_page_query` preserves the compiled query and changes only
   the validated page-limit bind from `N` to `N + 1`.
 - `CompiledPostgresQuery::many_relations` binds every aggregate alias to exact plan metadata.
@@ -171,7 +182,8 @@ builders or DTOs.
   rows or exact counts.
 - Projection through `many` paths returns deterministic nested items with complete identity
   chains and aligned tagged values.
-- Sorting through a `many` link remains rejected until an explicit aggregate policy is added.
+- Ordering through `many` paths requires an explicit supported `min` / `max` mode; implicit
+  first-row, link-ordinal, and storage-order semantics remain forbidden.
 - Source versions and tombstones prevent stale mutation overwrite.
 - Generic engine types remain source-domain agnostic.
 - Runtime composition is not an authorization decision or persisted-readiness assertion.
@@ -180,13 +192,18 @@ builders or DTOs.
 
 - `SchemaRegistry::plan_query` validates first, assigns stable aliases, resolves joins, propagates
   `traverses_many`, captures typed fields, groups many projections, and emits a v4 fingerprint.
+- Aggregate-aware validation preserves legacy planner error variants for ordinary queries and
+  marks derived many-order values nullable without changing the `PlannedOrder` shape.
 - Many-traversing filters compile as independent nested correlated `EXISTS` chains.
 - Many projections compile as correlated JSONB aggregates outside the outer root rowset and use
   stored link ordinal, entity identity, and locale for deterministic item order.
+- Explicit many ordering compiles as a correlated typed `MIN` / `MAX` scalar subquery outside
+  the outer root rowset; the selected order column remains tagged `IndexValue` JSONB.
 - `decode_postgres_query_page` re-plans and verifies the plan fingerprint, scalar/many metadata,
   tagged values, nested identity/value arity, uniqueness, page bounds, and optional exact count.
 - Cursor pages remove lookahead and produce a next scoped cursor from the last retained
-  entity/order tuple; offset pages report `has_more` without a cursor.
+  entity/order tuple for ordinary ordering; aggregate cursor pages remain rejected.
+- Offset pages report `has_more` without a cursor.
 
 ## Errors / Failure Codes
 
@@ -195,7 +212,8 @@ builders or DTOs.
 - `IndexSchemaSourceError` defines invalid owner identity, duplicate exact ownership, owner drift
   across schema versions, empty materialization, invalid schema, and registry failures.
 - `IndexQueryRuntimeCompositionError` currently rejects duplicate shared runtime materialization.
-- `RecordValidationError` and `QueryValidationError` define registry-backed data/query failures.
+- `RecordValidationError`, `QueryValidationError`, and `AggregateOrderValidationError` define
+  registry-backed data/query failures and the bounded aggregate-order policy.
 - `CursorCodecError` and `CursorValidationError` separate malformed cursors from scope, schema,
   fingerprint, query-shape, arity, and value-type mismatches.
 - `QueryPlanError`, `PostgresQueryBuildError`, and `PostgresQueryCompileError` separate
@@ -217,9 +235,6 @@ builders or DTOs.
 - Calling `PostgresIndexQueryPort::new` outside the Index-owned runtime materializer.
 - Treating `SharedIndexQueryRuntime` presence as authorization or proof that a tenant query works.
 - Publishing a consumer query without owner/transport authorization and bounded error mapping.
+- Using plain `asc` / `desc`, link ordinal, first related row, or caller SQL as a many-order policy.
+- Treating a source-complete aggregate compiler as PostgreSQL/reference execution evidence.
 - Executing compiler SQL outside `PostgresIndexQueryPort` or splitting page/count snapshots.
-- Accepting cursors without verifying tenant, schema, fingerprint, locale, filters, order shape,
-  value types, and entity tie-breaker identity.
-- Compiling many filters as outer joins or flattening many projection into independent arrays.
-- Sorting through a `many` relation without an explicit aggregate policy.
-- Restoring deleted v1/source-specific code as a compatibility layer.

--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -98,9 +98,9 @@ SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
 `HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
 connection, persisted tenant schema readiness, authorization, or successful query execution.
 
-Aggregate cursor continuation, retained PostgreSQL/reference aggregate evidence, additional
-source schemas, transport authorization, and first storefront/admin/search authoritative
-consumer cutover remain open.
+Exact Decimal tagged-order transport, aggregate cursor continuation, retained
+PostgreSQL/reference aggregate evidence, additional source schemas, transport authorization,
+and first storefront/admin/search authoritative consumer cutover remain open.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`, `DocumentType`, old
 ports/adapters, source DTOs/indexers/models/migrations, `IndexerRuntimeConfig`,
@@ -140,12 +140,12 @@ builders or DTOs.
 - Query shape, depth, selected fields, ordering expressions, page size, and offset are bounded.
 - Plain `asc` / `desc` through a `many` path remains ambiguous and rejected.
 - Explicit `min_asc`, `min_desc`, `max_asc`, and `max_desc` are accepted only for sortable
-  scalar integer, decimal, string, or timestamp fields reached through at least one `many`
-  link and only with bounded offset pagination.
+  scalar integer, string, or timestamp fields reached through at least one `many` link and only
+  with bounded offset pagination.
 - Empty or all-null aggregate relation sets produce a nullable derived order value; ascending
   uses `NULLS LAST`, descending uses `NULLS FIRST`, and root entity ID remains the final tie-break.
-- Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate orders
-  fail closed.
+- Boolean, Decimal, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate
+  orders fail closed. Decimal requires a separate exact tagged-wire contract before enablement.
 - `SchemaRegistry::compile_postgres_page_query` preserves the compiled query and changes only
   the validated page-limit bind from `N` to `N + 1`.
 - `CompiledPostgresQuery::many_relations` binds every aggregate alias to exact plan metadata.
@@ -198,7 +198,8 @@ builders or DTOs.
 - Many projections compile as correlated JSONB aggregates outside the outer root rowset and use
   stored link ordinal, entity identity, and locale for deterministic item order.
 - Explicit many ordering compiles as a correlated typed `MIN` / `MAX` scalar subquery outside
-  the outer root rowset; the selected order column remains tagged `IndexValue` JSONB.
+  the outer root rowset; the selected order column remains tagged `IndexValue` JSONB for the
+  currently admitted integer, string, and timestamp wire types.
 - `decode_postgres_query_page` re-plans and verifies the plan fingerprint, scalar/many metadata,
   tagged values, nested identity/value arity, uniqueness, page bounds, and optional exact count.
 - Cursor pages remove lookahead and produce a next scoped cursor from the last retained
@@ -236,5 +237,6 @@ builders or DTOs.
 - Treating `SharedIndexQueryRuntime` presence as authorization or proof that a tenant query works.
 - Publishing a consumer query without owner/transport authorization and bounded error mapping.
 - Using plain `asc` / `desc`, link ordinal, first related row, or caller SQL as a many-order policy.
+- Enabling Decimal aggregate ordering before an exact tagged-order wire contract is source-complete.
 - Treating a source-complete aggregate compiler as PostgreSQL/reference execution evidence.
 - Executing compiler SQL outside `PostgresIndexQueryPort` or splitting page/count snapshots.

--- a/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
+++ b/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "owner": "rustok-index",
+  "status": "source_complete_execution_pending",
+  "query_contract": {
+    "order_expr_shape_changed": false,
+    "legacy_directions": ["asc", "desc"],
+    "many_link_modes": ["min_asc", "min_desc", "max_asc", "max_desc"],
+    "plain_many_link_asc_desc_rejected": true,
+    "aggregate_requires_many_link": true,
+    "aggregate_cursor_supported": false,
+    "pagination": "bounded_offset"
+  },
+  "supported_terminal_types": ["integer", "decimal", "string", "timestamp"],
+  "rejected_terminal_types": ["boolean", "uuid", "list"],
+  "postgresql": {
+    "strategy": "correlated_scalar_subquery",
+    "aggregates": ["MIN", "MAX"],
+    "outer_many_join": false,
+    "empty_or_all_null_result": "null",
+    "ascending_nulls": "last",
+    "descending_nulls": "first",
+    "final_tie_break": "root_entity_id_asc",
+    "order_value_transport": "tagged_index_value_jsonb",
+    "caller_sql": false,
+    "implicit_first_row": false,
+    "implicit_link_ordinal": false
+  },
+  "compatibility": {
+    "plan_version": 4,
+    "plan_shape_changed": false,
+    "legacy_enum_discriminants_preserved": true,
+    "legacy_planner_error_mapping_preserved": true
+  },
+  "guardrails": {
+    "validator": "crates/rustok-index/src/application/aggregate_ordering.rs",
+    "compiler": "crates/rustok-index/src/application/postgres_compiler.rs",
+    "sql": "crates/rustok-index/src/application/postgres_query_sql.rs",
+    "tests": "crates/rustok-index/src/application/aggregate_ordering_tests.rs",
+    "verifier": "scripts/verify/verify-index-many-link-aggregate-ordering.mjs"
+  },
+  "validation": {
+    "cargo_run": false,
+    "tests_run": false,
+    "postgresql_run": false,
+    "node_verifiers_run": false,
+    "workflows_run": false,
+    "ci_run": false
+  },
+  "remaining": [
+    "aggregate cursor identity and continuation",
+    "independent reference materialization for aggregate values",
+    "PostgreSQL/reference aggregate offset scenarios",
+    "retained aggregate equivalence capture and admission"
+  ]
+}

--- a/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
+++ b/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
@@ -11,8 +11,8 @@
     "aggregate_cursor_supported": false,
     "pagination": "bounded_offset"
   },
-  "supported_terminal_types": ["integer", "decimal", "string", "timestamp"],
-  "rejected_terminal_types": ["boolean", "uuid", "list"],
+  "supported_terminal_types": ["integer", "string", "timestamp"],
+  "rejected_terminal_types": ["boolean", "decimal", "uuid", "list"],
   "postgresql": {
     "strategy": "correlated_scalar_subquery",
     "aggregates": ["MIN", "MAX"],
@@ -48,6 +48,7 @@
     "ci_run": false
   },
   "remaining": [
+    "exact decimal tagged-order wire contract",
     "aggregate cursor identity and continuation",
     "independent reference materialization for aggregate values",
     "PostgreSQL/reference aggregate offset scenarios",

--- a/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
+++ b/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
@@ -24,14 +24,19 @@ The machine-readable contract is
 Aggregate ordering is accepted only when all of the following are true:
 
 1. the field path crosses at least one `LinkCardinality::Many` edge;
-2. the terminal field has scalar cardinality, is sortable, and has type `integer`, `decimal`,
-   `string`, or `timestamp`;
+2. the terminal field has scalar cardinality, is sortable, and has type `integer`, `string`,
+   or `timestamp`;
 3. pagination is bounded offset pagination under the existing limit/depth caps.
 
 Aggregate ordering on a root or one-link-only path is rejected. Plain `asc` / `desc` over a
-many path is still rejected as `AmbiguousManyLinkSort`. Boolean, UUID, list-valued, and
-unsortable fields are rejected. UUID remains excluded because PostgreSQL 16 does not provide
-the same built-in `MIN`/`MAX` aggregate contract used by the supported types.
+many path is still rejected as `AmbiguousManyLinkSort`. Boolean, Decimal and UUID, list-valued,
+and unsortable fields are rejected.
+
+Decimal remains fail-closed because the hidden order column must round-trip through the exact
+tagged `IndexValue` JSON representation. The current PostgreSQL numeric JSON emission is not
+an admitted exact tagged-wire contract for `rust_decimal`; that contract needs a separate
+source and equivalence slice before Decimal ordering can be enabled. UUID also remains excluded
+from the bounded PostgreSQL `MIN` / `MAX` contract.
 
 Aggregate cursor continuation remains open. This slice deliberately does not reinterpret the
 existing cursor envelope or silently encode a derived many-link value into a legacy cursor.
@@ -82,6 +87,7 @@ aggregate cursor/reference equivalence is still owner-execution work.
 This slice does not:
 
 - enable aggregate cursor pagination;
+- enable Decimal or UUID aggregate ordering;
 - change ordinary root or one-link ordering;
 - choose the first related row, link ordinal, or storage order as an implicit aggregate;
 - add `array_agg` or caller-defined SQL;
@@ -103,6 +109,7 @@ node scripts/verify/verify-index-query-contract.mjs
 cargo xtask module validate index
 ```
 
-A later slice should extend the independent reference fixture and retained PostgreSQL/reference
-capture with aggregate offset scenarios before aggregate ordering is treated as execution
-proven. Cursor support should be designed and admitted separately.
+A later slice should define the exact Decimal tagged-wire contract and extend the independent
+reference fixture plus retained PostgreSQL/reference capture with aggregate offset scenarios
+before aggregate ordering is treated as execution proven. Cursor support should be designed and
+admitted separately.

--- a/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
+++ b/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
@@ -16,6 +16,9 @@ ambiguous and continue to fail closed. Callers must select one of four serialize
 The `OrderExpr` shape is unchanged. Existing `asc` / `desc` payloads, source literals, and
 legacy plan/cursor discriminants therefore retain their old representation.
 
+The machine-readable contract is
+`crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json`.
+
 ## Validation policy
 
 Aggregate ordering is accepted only when all of the following are true:
@@ -49,6 +52,7 @@ The compiler independently rejects:
 - a many-path order without an explicit aggregate;
 - an aggregate on a singular path;
 - a forged aggregate plan with an unsupported value type;
+- a forged aggregate cursor plan;
 - aggregate metadata that does not match the registry-derived field contract.
 
 ## PostgreSQL semantics

--- a/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
+++ b/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
@@ -1,0 +1,104 @@
+# M4 many-link aggregate ordering
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice replaces the previous blanket rejection of all many-link ordering with one explicit,
+bounded policy. Ordinary `asc` and `desc` over a path that crosses a `many` link remain
+ambiguous and continue to fail closed. Callers must select one of four serialized modes:
+
+- `min_asc`;
+- `min_desc`;
+- `max_asc`;
+- `max_desc`.
+
+The `OrderExpr` shape is unchanged. Existing `asc` / `desc` payloads, source literals, and
+legacy plan/cursor discriminants therefore retain their old representation.
+
+## Validation policy
+
+Aggregate ordering is accepted only when all of the following are true:
+
+1. the field path crosses at least one `LinkCardinality::Many` edge;
+2. the terminal field has scalar cardinality, is sortable, and has type `integer`, `decimal`,
+   `string`, or `timestamp`;
+3. pagination is bounded offset pagination under the existing limit/depth caps.
+
+Aggregate ordering on a root or one-link-only path is rejected. Plain `asc` / `desc` over a
+many path is still rejected as `AmbiguousManyLinkSort`. Boolean, UUID, list-valued, and
+unsortable fields are rejected. UUID remains excluded because PostgreSQL 16 does not provide
+the same built-in `MIN`/`MAX` aggregate contract used by the supported types.
+
+Aggregate cursor continuation remains open. This slice deliberately does not reinterpret the
+existing cursor envelope or silently encode a derived many-link value into a legacy cursor.
+
+## Plan and compiler contract
+
+`SchemaRegistry::plan_query` uses the aggregate-aware validation boundary while preserving the
+legacy `QueryPlanError::Validation` and `QueryPlanError::Registry` mapping for old queries.
+Only new aggregate-policy failures use `QueryPlanError::AggregateValidation`.
+
+The existing `PlannedOrder` shape remains unchanged. An aggregate order field is marked
+nullable in the plan because an empty or all-null relation set produces a derived SQL `NULL`,
+even when every present terminal value is non-nullable. Existing non-aggregate v4 plan bytes
+are unchanged because the old enum variants remain first and no plan fields were added.
+
+The compiler independently rejects:
+
+- a many-path order without an explicit aggregate;
+- an aggregate on a singular path;
+- a forged aggregate plan with an unsupported value type;
+- aggregate metadata that does not match the registry-derived field contract.
+
+## PostgreSQL semantics
+
+For every aggregate order expression the compiler emits a correlated scalar subquery rooted at
+the current root entity. It walks the complete relation path and evaluates `MIN` or `MAX` over
+the typed terminal scalar. SQL aggregate null semantics are intentional:
+
+- null terminal values do not participate in `MIN` / `MAX`;
+- an empty relation set or a set containing only null values yields SQL `NULL`;
+- ascending order uses `NULLS LAST`;
+- descending order uses `NULLS FIRST`;
+- root `entity_id ASC` remains the deterministic final tie-break.
+
+The aggregate relation does not enter the outer rowset, so root cardinality, exact count, and
+bounded offset pagination remain duplicate free. The selected `__order_N` column is encoded as
+tagged `IndexValue` JSONB for the existing strict decoder, while `ORDER BY` uses the typed
+scalar expression.
+
+## Compatibility boundary
+
+The two test-only reference engines normalize physical direction through
+`OrderDirection::base_direction()` so adding explicit modes cannot create an exhaustive-match
+compile break. Their aggregate result materialization is not extended in this slice because
+aggregate cursor/reference equivalence is still owner-execution work.
+
+This slice does not:
+
+- enable aggregate cursor pagination;
+- change ordinary root or one-link ordering;
+- choose the first related row, link ordinal, or storage order as an implicit aggregate;
+- add `array_agg` or caller-defined SQL;
+- run PostgreSQL or update the retained PostgreSQL/reference evidence bundle;
+- change Social Graph privacy authority, freshness policy, or any consumer cutover.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-index aggregate_ordering -- --nocapture
+cargo test -p rustok-index aggregate_ordering_tests -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo xtask module validate index
+```
+
+A later slice should extend the independent reference fixture and retained PostgreSQL/reference
+capture with aggregate offset scenarios before aggregate ordering is treated as execution
+proven. Cursor support should be designed and admitted separately.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -72,9 +72,14 @@ by the invariant ascending root `entity_id` tie-breaker. Plain `asc` / `desc` th
 many link remains rejected. Callers must select `min_asc`, `min_desc`, `max_asc`, or
 `max_desc`.
 
-Many-link aggregate ordering is accepted only for sortable scalar integer, decimal, string,
-or timestamp fields and only with bounded offset pagination. Boolean, UUID, list-valued,
+Many-link aggregate ordering is accepted only for sortable scalar integer, string, or
+timestamp fields and only with bounded offset pagination. Boolean, Decimal, UUID, list-valued,
 singular-path, cursor-paginated, and unsortable aggregate orders fail closed.
+
+Decimal ordinary filters and root/one-link ordering remain supported. Only Decimal many-link
+aggregation is deferred because the hidden order column must round-trip through the exact tagged
+`IndexValue` JSON representation; the current PostgreSQL numeric JSON emission is not yet an
+admitted exact `rust_decimal` wire contract.
 
 ## Many-link filter boundary
 
@@ -129,6 +134,10 @@ PostgreSQL aggregate null behavior is the contract:
 - an empty or all-null relation set produces SQL `NULL`;
 - the selected `__order_N` value is SQL null or tagged `IndexValue` JSONB;
 - `ORDER BY` uses the typed scalar expression, explicit null placement, and root ID tie-break.
+
+The admitted aggregate order wire types in this slice are integer, string, and timestamp.
+Decimal and UUID remain rejected until their exact hidden-order transport is independently
+specified and covered by PostgreSQL/reference evidence.
 
 Compiler validation independently rejects forged plans that omit the aggregate on a many path,
 place an aggregate on a singular path, use an unsupported type, mutate nullable metadata, or
@@ -201,8 +210,10 @@ child multiplicity cannot inflate the count.
 
 Aggregate cursor continuation remains rejected until a stable derived-value cursor identity,
 strict null/value continuation semantics, and independent reference coverage are implemented.
-Compiler validation recalculates propagated many metadata and nested projection groups, and
-rejects missing or inconsistent join/field/result contracts before SQL emission.
+Decimal aggregate ordering remains rejected until an exact tagged-wire contract and retained
+PostgreSQL/reference scenario exist. Compiler validation recalculates propagated many metadata
+and nested projection groups, and rejects missing or inconsistent join/field/result contracts
+before SQL emission.
 
 ## Non-claims
 
@@ -212,6 +223,7 @@ This source chain does not:
 - add aggregate scenarios to the retained PostgreSQL/reference fixture or evidence bundle;
 - authorize callers;
 - weaken persisted schema readiness checks;
+- support Decimal aggregate ordering;
 - support aggregate cursor continuation;
 - read source-module tables;
 - change migrations, runtime composition, or production partition lifecycle state.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -3,7 +3,7 @@
 This M4 chain compiles the database-independent `ExecutableQueryPlan` into
 controlled PostgreSQL statements plus ordered typed bind lists. The compiler does not
 connect to PostgreSQL or execute SQL. Deterministic compiled-row decoding lives in a
-separate application handoff; neither slice publishes an `IndexQueryPort`.
+separate application handoff; execution remains owned by `PostgresIndexQueryPort`.
 
 ## Planner contract
 
@@ -24,6 +24,11 @@ relation identity prefix. The plan fingerprint domain is
 `rustok-index-query-plan-v4`, so older or altered nested-result plans cannot be
 confused with current compiler input.
 
+Aggregate ordering does not add plan fields. Explicit `min_*` / `max_*` directions use the
+existing `PlannedOrder` and mark the derived order field nullable because an empty or all-null
+relation set yields SQL `NULL`. Existing `asc` / `desc` variants retain their original enum
+positions and plan representation.
+
 ## Supported query semantics
 
 `SchemaRegistry::compile_postgres_query` validates and plans the query, decodes
@@ -35,18 +40,17 @@ and validates any continuation cursor, and then compiles:
 - filtering through paths that cross one or more many-cardinality links;
 - typed PostgreSQL casts for boolean, integer, decimal, string, UUID, and
   timestamp fields;
-- deterministic multi-column ordering with explicit null placement;
-- lexicographic keyset continuation with an ascending root `entity_id`
-  tie-breaker;
+- deterministic multi-column root/one-link ordering with explicit null placement;
+- explicit `MIN` / `MAX` ordering through many links for bounded offset pages;
+- lexicographic keyset continuation for ordinary non-aggregate ordering;
 - bounded cursor limits;
 - bounded compatibility offset pagination;
 - an optional separate exact-count statement over the same scope and filters,
   without cursor, limit, offset, or projection leakage.
 
 The main page statement selects hidden tagged JSONB order values when explicit
-ordering is present. `decode_postgres_query_page` uses those values to construct
-the next `IndexCursor` even when an order field was not requested in the public
-projection.
+ordering is present. Ordinary cursor pages use those values to construct the next
+`IndexCursor`. Aggregate cursor pagination remains rejected by both validator and compiler.
 
 ## Predicate and ordering contract
 
@@ -64,8 +68,13 @@ semantics:
   null.
 
 Ascending order uses `NULLS LAST`; descending order uses `NULLS FIRST`, followed
-by the invariant ascending `entity_id` tie-breaker. Ordering through a many link
-remains rejected because no aggregate order policy exists.
+by the invariant ascending root `entity_id` tie-breaker. Plain `asc` / `desc` through a
+many link remains rejected. Callers must select `min_asc`, `min_desc`, `max_asc`, or
+`max_desc`.
+
+Many-link aggregate ordering is accepted only for sortable scalar integer, decimal, string,
+or timestamp fields and only with bounded offset pagination. Boolean, UUID, list-valued,
+singular-path, cursor-paginated, and unsortable aggregate orders fail closed.
 
 ## Many-link filter boundary
 
@@ -108,6 +117,23 @@ ancestry and field alignment. It rejects malformed JSON, arity drift, nil identi
 duplicate identity chains, invalid tagged values, and source type/cardinality/
 nullability mismatches.
 
+## Many-link aggregate ordering boundary
+
+Every explicit aggregate order compiles as a correlated scalar subquery rooted at the current
+outer entity. The subquery walks the complete relation path and evaluates typed `MIN` or `MAX`
+over the terminal scalar. It does not join the relation into the outer rowset.
+
+PostgreSQL aggregate null behavior is the contract:
+
+- null terminal values do not participate;
+- an empty or all-null relation set produces SQL `NULL`;
+- the selected `__order_N` value is SQL null or tagged `IndexValue` JSONB;
+- `ORDER BY` uses the typed scalar expression, explicit null placement, and root ID tie-break.
+
+Compiler validation independently rejects forged plans that omit the aggregate on a many path,
+place an aggregate on a singular path, use an unsupported type, mutate nullable metadata, or
+switch an aggregate plan to cursor pagination.
+
 ## Cursor boundary
 
 Raw v1 cursor envelopes remain available only for codec round trips and the
@@ -130,14 +156,15 @@ and ordered field/direction semantics. A continuation query must use
 Changing a filter, ordered field, or order direction therefore produces
 `QueryFingerprintMismatch` before keyset SQL is emitted. Projection changes alter the
 v4 executable plan and compiled-column contract without invalidating a cursor whose
-filter/order scope is otherwise unchanged.
+filter/order scope is otherwise unchanged. Aggregate directions are rejected before cursor
+encoding or continuation until a separate derived-value cursor contract exists.
 
 ## Bind and SQL boundary
 
 Tenant UUID, schema identities, locale, link metadata, field names, filter values,
 cursor values, limit, and offset are bind values. Only fixed
 `index_entities`/`index_links` table and column names plus compiler-owned `tN`, `lN`,
-`mx_*`, and `mpN_*` aliases appear in SQL.
+`mx_*`, `mpN_*`, and `mo_*` aliases appear in SQL.
 
 The compiler contract, SQL emission, and page/result handoff live in separate modules:
 
@@ -145,7 +172,7 @@ The compiler contract, SQL emission, and page/result handoff live in separate mo
 - `application/postgres_compiler.rs` owns public SQL/bind types, scoped cursor entry
   points, compiled column metadata, and plan invariant checks;
 - `application/postgres_query_sql.rs` owns controlled SQL, correlated many-link
-  predicates/aggregates, and deterministic bind emission;
+  predicates/projections/order aggregates, and deterministic bind emission;
 - `application/postgres_query_result.rs` owns one-row lookahead wrapping, strict
   compiled-column and nested-payload decoding, exact count, `has_more`, and scoped
   next cursors.
@@ -157,10 +184,10 @@ only the main page-limit bind from `N` to `N + 1`. The SQL string, filters, proj
 ordering, keyset predicate, offset, plan fingerprint, and optional count statement
 remain unchanged.
 
-A later database adapter executes the compiled statements and maps driver values into
-`CompiledPostgresRow`. `decode_postgres_query_page` then rechecks the v4 plan
-fingerprint and complete `CompiledQueryColumn` contract, validates flat and nested
-tagged values, removes the lookahead row, and returns `IndexQueryPage`.
+`PostgresIndexQueryPort` maps driver values into `CompiledPostgresRow`.
+`decode_postgres_query_page` then rechecks the v4 plan fingerprint and complete
+`CompiledQueryColumn` contract, validates flat and nested tagged values, removes the
+lookahead row, and returns `IndexQueryPage`.
 
 ## Exact count
 
@@ -172,23 +199,22 @@ child multiplicity cannot inflate the count.
 
 ## Remaining fail-closed semantics
 
-Many-link ordering remains rejected until an explicit aggregate policy exists.
-Compiler validation recalculates propagated many metadata and nested projection groups,
-and rejects missing or inconsistent join/field/result contracts before SQL emission.
+Aggregate cursor continuation remains rejected until a stable derived-value cursor identity,
+strict null/value continuation semantics, and independent reference coverage are implemented.
+Compiler validation recalculates propagated many metadata and nested projection groups, and
+rejects missing or inconsistent join/field/result contracts before SQL emission.
 
 ## Non-claims
 
 This source chain does not:
 
-- prepare or execute a statement;
-- convert abstract bind values into SeaORM/sqlx parameters;
-- decode directly from SeaORM `QueryResult`;
+- execute PostgreSQL in this implementation pass;
+- add aggregate scenarios to the retained PostgreSQL/reference fixture or evidence bundle;
 - authorize callers;
-- verify persisted schema readiness;
-- support aggregate ordering through many links;
-- claim plan/SQL snapshots or PostgreSQL/reference-engine equivalence;
+- weaken persisted schema readiness checks;
+- support aggregate cursor continuation;
 - read source-module tables;
-- change migrations or production partition lifecycle state.
+- change migrations, runtime composition, or production partition lifecycle state.
 
-Formatting, compilation, tests, static verifiers, and later PostgreSQL/reference-engine
-equivalence evidence are reserved for the owner-operated verification phase.
+Formatting, compilation, tests, static verifiers, and PostgreSQL/reference aggregate evidence
+are reserved for the owner-operated verification phase.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -33,6 +33,7 @@ source-complete offline retained-window capture/admission tooling.
 - M4 many-link `EXISTS` filtering: `source_complete_execution_pending`.
 - M4 nested many-link projection aggregation: `source_complete_execution_pending`.
 - M4 explicit many-link `min` / `max` bounded-offset ordering: `source_complete_execution_pending`.
+- M4 Decimal aggregate tagged-wire contract: `open_source_work`.
 - M4 aggregate cursor continuation: `open_source_work`.
 - M4 PostgreSQL query port and strict row adapter: `source_complete_execution_pending`.
 - M4 retained plan/SQL snapshots: `source_complete_owner_execution_pending`.
@@ -85,9 +86,13 @@ lookahead, and exact count remain duplicate free.
 
 Explicit many-link order modes are `min_asc`, `min_desc`, `max_asc`, and `max_desc`.
 Plain `asc` / `desc` over a many path remains rejected. The aggregate path must end at a
-sortable scalar integer, decimal, string, or timestamp field and must use bounded offset
-pagination. Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable
-aggregate requests fail closed.
+sortable scalar integer, string, or timestamp field and must use bounded offset pagination.
+Boolean, Decimal, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate
+requests fail closed.
+
+Decimal remains excluded from aggregate ordering until its hidden `__order_N` value has an
+exact tagged `IndexValue` JSON wire contract. Ordinary Decimal filters and root/one-link
+ordering remain supported; only the many-link aggregate handoff is deferred.
 
 The compiler emits a correlated typed `MIN` / `MAX` scalar subquery outside the outer rowset.
 Null terminal values do not participate; an empty or all-null relation set yields SQL `NULL`.
@@ -261,6 +266,8 @@ The canonical checklist remains open until the owner runs the PostgreSQL/referen
 through capture, admits the retained bundle, and preserves both bundle and receipt. Additional
 boundaries remain:
 
+- define and verify the exact Decimal tagged-order wire contract before Decimal many-link
+  aggregation can be enabled;
 - extend explicit aggregate ordering to query-scoped cursor continuation with a stable cursor
   identity and strict null/value semantics;
 - add aggregate offset scenarios to the independent PostgreSQL/reference fixture and retained

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -32,6 +32,8 @@ source-complete offline retained-window capture/admission tooling.
 - M4 query-scoped cursors and lookahead pagination: `source_complete_execution_pending`.
 - M4 many-link `EXISTS` filtering: `source_complete_execution_pending`.
 - M4 nested many-link projection aggregation: `source_complete_execution_pending`.
+- M4 explicit many-link `min` / `max` bounded-offset ordering: `source_complete_execution_pending`.
+- M4 aggregate cursor continuation: `open_source_work`.
 - M4 PostgreSQL query port and strict row adapter: `source_complete_execution_pending`.
 - M4 retained plan/SQL snapshots: `source_complete_owner_execution_pending`.
 - M4 PostgreSQL/reference fixture source: `source_complete_owner_execution_pending`.
@@ -63,7 +65,9 @@ source-complete offline retained-window capture/admission tooling.
 10. retains filters, ordering, pagination, and exact-count intent.
 
 The deterministic fingerprint domain is `rustok-index-query-plan-v4` because grouped
-many-projection metadata is part of executable plan identity and compiler safety.
+many-projection metadata is part of executable plan identity and compiler safety. Existing
+`asc` / `desc` plans retain their serialized representation; explicit aggregate modes append
+new order-direction discriminants without adding plan fields.
 
 ## Controlled PostgreSQL boundary
 
@@ -79,6 +83,18 @@ produce deterministic item ordering. Missing reachable rows yield an empty array
 Because many projection does not enter the outer rowset, root pagination, one-row
 lookahead, and exact count remain duplicate free.
 
+Explicit many-link order modes are `min_asc`, `min_desc`, `max_asc`, and `max_desc`.
+Plain `asc` / `desc` over a many path remains rejected. The aggregate path must end at a
+sortable scalar integer, decimal, string, or timestamp field and must use bounded offset
+pagination. Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable
+aggregate requests fail closed.
+
+The compiler emits a correlated typed `MIN` / `MAX` scalar subquery outside the outer rowset.
+Null terminal values do not participate; an empty or all-null relation set yields SQL `NULL`.
+Ascending uses `NULLS LAST`, descending uses `NULLS FIRST`, and root entity ID remains the final
+tie-break. The selected order column is still tagged `IndexValue` JSONB for strict decoding.
+No first-row, link-ordinal, storage-order, `array_agg`, or caller-SQL policy is introduced.
+
 ## Result and execution handoff
 
 `SchemaRegistry::compile_postgres_page_query` changes only the validated page-limit bind
@@ -93,8 +109,10 @@ from `N` to `N + 1`. `decode_postgres_query_page` re-plans and verifies:
 - non-nil and non-duplicate complete nested identity chains;
 - optional exact count.
 
-The lookahead row is removed. Cursor pages derive the next scoped cursor from the last
-retained root/order tuple; offset pages report `has_more` without creating a cursor.
+The lookahead row is removed. Ordinary cursor pages derive the next scoped cursor from the last
+retained root/order tuple; offset pages report `has_more` without creating a cursor. Aggregate
+cursor continuation remains rejected until a separate cursor identity and reference/evidence
+contract is implemented.
 
 `PostgresIndexQueryPort` is the Index-owned execution boundary. It verifies exact active
 persisted schema contracts for the query tenant, converts every `PostgresBindValue`
@@ -112,7 +130,8 @@ canonical query against three retained files:
 - ordered bind, scalar-column, and many-relation metadata.
 
 The fixture uses fixed identifiers and forbids automatic snapshot rewriting. SQL keeps
-all contract values in `$N` binds.
+all contract values in `$N` binds. Existing retained snapshots do not include aggregate
+ordering and should remain byte-stable for ordinary queries.
 
 ## PostgreSQL/reference fixture
 
@@ -124,7 +143,8 @@ stores, executes through `PostgresIndexQueryPort`, and compares the complete
 The source scenarios cover scoped cursor continuation, exact count, bounded offset,
 one-link filtering/projection, many-link `Gte`/`Contains`/`Ne`/`IsNull`, and nested
 identity/value alignment. The fixture is env-gated and has not been run by the
-implementation agent.
+implementation agent. Aggregate offset scenarios are not yet part of the retained equivalence
+contract and remain an explicit follow-up.
 
 ## Retained equivalence capture and admission
 
@@ -241,11 +261,14 @@ The canonical checklist remains open until the owner runs the PostgreSQL/referen
 through capture, admits the retained bundle, and preserves both bundle and receipt. Additional
 boundaries remain:
 
+- extend explicit aggregate ordering to query-scoped cursor continuation with a stable cursor
+  identity and strict null/value semantics;
+- add aggregate offset scenarios to the independent PostgreSQL/reference fixture and retained
+  capture/admission contract;
 - execute one live Social Graph privacy-shadow window from the merged commit, publish its
   canonical bundle, and complete independent admission with explicit reviewer thresholds;
 - retain per-tenant projection watermark/lag, outage/recovery, repair, and negative-result
   freshness evidence before reconsidering authoritative cutover;
-- aggregate ordering semantics for paths traversing `many`;
 - publish schemas from additional source owners as consumers are selected;
 - additional non-authoritative shadows and safely freshness-gated consumer cutovers.
 
@@ -260,6 +283,8 @@ Suggested commands:
 
 ```bash
 cargo test -p rustok-index planner_tests -- --nocapture
+cargo test -p rustok-index aggregate_ordering -- --nocapture
+cargo test -p rustok-index aggregate_ordering_tests -- --nocapture
 cargo test -p rustok-index source_schema_registry -- --nocapture
 cargo test -p rustok-index query_runtime -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
@@ -297,6 +322,7 @@ node scripts/verify/verify-index-query-planner.mjs
 node scripts/verify/verify-index-postgres-query-compiler.mjs
 node scripts/verify/verify-index-query-result-decoder.mjs
 node scripts/verify/verify-index-many-link-filtering.mjs
+node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
 node scripts/verify/verify-index-query-snapshots.mjs
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 use crate::domain::{
     FieldCardinality, FieldName, FieldPath, IndexQuery, IndexValueType, LinkCardinality, LinkName,
-    SchemaRef,
+    Pagination, SchemaRef,
 };
 
 use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
@@ -17,6 +17,8 @@ pub enum AggregateOrderValidationError {
     AggregateRequiresManyLink(FieldPath),
     #[error("many-link aggregate ordering requires an ordered scalar field: {0:?}")]
     AggregateRequiresOrderedScalar(FieldPath),
+    #[error("many-link aggregate ordering currently requires bounded offset pagination")]
+    AggregateRequiresOffsetPagination,
 }
 
 impl SchemaRegistry {
@@ -27,6 +29,10 @@ impl SchemaRegistry {
     /// reject every many-link order as ambiguous. Planning and execution use this
     /// stronger boundary so aggregate ordering cannot silently inherit first-row
     /// or storage-order semantics.
+    ///
+    /// This first bounded policy supports offset pages only. Aggregate cursor
+    /// encoding and continuation remain a separate contract because they must bind
+    /// the derived value without changing legacy cursor semantics.
     pub fn validate_query_with_aggregate_ordering(
         &self,
         query: &IndexQuery,
@@ -34,6 +40,14 @@ impl SchemaRegistry {
         query
             .validate_shape()
             .map_err(QueryValidationError::from)?;
+
+        let has_aggregate = query
+            .order_by
+            .iter()
+            .any(|order| order.direction.aggregate().is_some());
+        if has_aggregate && !matches!(query.pagination, Pagination::Offset { .. }) {
+            return Err(AggregateOrderValidationError::AggregateRequiresOffsetPagination);
+        }
 
         let mut ordinary = query.clone();
         ordinary
@@ -60,7 +74,7 @@ impl SchemaRegistry {
                 .into());
             }
             if resolved.cardinality != FieldCardinality::One
-                || !is_ordered_type(resolved.value_type)
+                || !is_aggregate_ordered_type(resolved.value_type)
             {
                 return Err(
                     AggregateOrderValidationError::AggregateRequiresOrderedScalar(
@@ -129,13 +143,12 @@ fn resolve_order_field(
     })
 }
 
-fn is_ordered_type(value_type: IndexValueType) -> bool {
+fn is_aggregate_ordered_type(value_type: IndexValueType) -> bool {
     matches!(
         value_type,
         IndexValueType::Integer
             | IndexValueType::Decimal
             | IndexValueType::String
-            | IndexValueType::Uuid
             | IndexValueType::Timestamp
     )
 }
@@ -212,9 +225,9 @@ mod tests {
             fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
             filter: None,
             order_by: vec![OrderExpr { field, direction }],
-            pagination: Pagination::Cursor {
-                first: 20,
-                after: None,
+            pagination: Pagination::Offset {
+                limit: 20,
+                offset: 0,
             },
             include_exact_count: false,
         }
@@ -257,11 +270,17 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_requires_sortable_ordered_scalar() {
+    fn aggregate_requires_supported_sortable_scalar() {
         let boolean = registry(IndexValueType::Boolean, true);
         assert!(matches!(
             boolean
                 .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true)),
+            Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
+        ));
+
+        let uuid = registry(IndexValueType::Uuid, true);
+        assert!(matches!(
+            uuid.validate_query_with_aggregate_ordering(&query(OrderDirection::MaxAsc, true)),
             Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
         ));
 
@@ -273,5 +292,19 @@ mod tests {
                 QueryValidationError::FieldNotSortable { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn aggregate_cursor_pagination_remains_rejected() {
+        let registry = registry(IndexValueType::Integer, true);
+        let mut query = query(OrderDirection::MinAsc, true);
+        query.pagination = Pagination::Cursor {
+            first: 20,
+            after: None,
+        };
+        assert_eq!(
+            registry.validate_query_with_aggregate_ordering(&query),
+            Err(AggregateOrderValidationError::AggregateRequiresOffsetPagination)
+        );
     }
 }

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -193,7 +193,7 @@ mod tests {
         let root = IndexSchema {
             reference: reference("root"),
             locale_mode: LocaleMode::Required,
-            fields: vec![field("id", IndexValueType::Uuid, true)],
+            fields: vec![field("id", child_type, true)],
             links: vec![IndexLink {
                 name: LinkName::new("children").unwrap(),
                 source_fields: vec![FieldName::new("id").unwrap()],

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -15,7 +15,7 @@ pub enum AggregateOrderValidationError {
     Registry(#[from] SchemaRegistryError),
     #[error("aggregate ordering requires a path that traverses a many-cardinality link: {0:?}")]
     AggregateRequiresManyLink(FieldPath),
-    #[error("many-link aggregate ordering requires an ordered scalar field: {0:?}")]
+    #[error("many-link aggregate ordering requires a supported ordered scalar field: {0:?}")]
     AggregateRequiresOrderedScalar(FieldPath),
     #[error("many-link aggregate ordering currently requires bounded offset pagination")]
     AggregateRequiresOffsetPagination,
@@ -146,10 +146,7 @@ fn resolve_order_field(
 fn is_aggregate_ordered_type(value_type: IndexValueType) -> bool {
     matches!(
         value_type,
-        IndexValueType::Integer
-            | IndexValueType::Decimal
-            | IndexValueType::String
-            | IndexValueType::Timestamp
+        IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp
     )
 }
 
@@ -271,11 +268,16 @@ mod tests {
 
     #[test]
     fn aggregate_requires_supported_sortable_scalar() {
-        let uuid = registry(IndexValueType::Uuid, true);
-        assert!(matches!(
-            uuid.validate_query_with_aggregate_ordering(&query(OrderDirection::MaxAsc, true)),
-            Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
-        ));
+        for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid] {
+            let registry = registry(unsupported, true);
+            assert!(matches!(
+                registry.validate_query_with_aggregate_ordering(&query(
+                    OrderDirection::MaxAsc,
+                    true
+                )),
+                Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
+            ));
+        }
 
         let unsortable = registry(IndexValueType::Integer, false);
         assert!(matches!(

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -271,13 +271,6 @@ mod tests {
 
     #[test]
     fn aggregate_requires_supported_sortable_scalar() {
-        let boolean = registry(IndexValueType::Boolean, true);
-        assert!(matches!(
-            boolean
-                .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true)),
-            Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
-        ));
-
         let uuid = registry(IndexValueType::Uuid, true);
         assert!(matches!(
             uuid.validate_query_with_aggregate_ordering(&query(OrderDirection::MaxAsc, true)),

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -1,0 +1,277 @@
+use thiserror::Error;
+
+use crate::domain::{
+    FieldCardinality, FieldName, FieldPath, IndexQuery, IndexValueType, LinkCardinality, LinkName,
+    SchemaRef,
+};
+
+use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AggregateOrderValidationError {
+    #[error(transparent)]
+    Query(#[from] QueryValidationError),
+    #[error(transparent)]
+    Registry(#[from] SchemaRegistryError),
+    #[error("aggregate ordering requires a path that traverses a many-cardinality link: {0:?}")]
+    AggregateRequiresManyLink(FieldPath),
+    #[error("many-link aggregate ordering requires an ordered scalar field: {0:?}")]
+    AggregateRequiresOrderedScalar(FieldPath),
+}
+
+impl SchemaRegistry {
+    /// Validate ordinary query semantics plus explicit `min_*` / `max_*` ordering
+    /// over paths that cross at least one many-cardinality link.
+    ///
+    /// The legacy `validate_query` contract remains unchanged and continues to
+    /// reject every many-link order as ambiguous. Planning and execution use this
+    /// stronger boundary so aggregate ordering cannot silently inherit first-row
+    /// or storage-order semantics.
+    pub fn validate_query_with_aggregate_ordering(
+        &self,
+        query: &IndexQuery,
+    ) -> Result<(), AggregateOrderValidationError> {
+        query
+            .validate_shape()
+            .map_err(QueryValidationError::from)?;
+
+        let mut ordinary = query.clone();
+        ordinary
+            .order_by
+            .retain(|order| order.direction.aggregate().is_none());
+        self.validate_query(&ordinary)?;
+
+        for order in query
+            .order_by
+            .iter()
+            .filter(|order| order.direction.aggregate().is_some())
+        {
+            let resolved = resolve_order_field(self, &query.schema, &order.field)?;
+            if !resolved.traverses_many {
+                return Err(AggregateOrderValidationError::AggregateRequiresManyLink(
+                    order.field.clone(),
+                ));
+            }
+            if !resolved.sortable {
+                return Err(QueryValidationError::FieldNotSortable {
+                    schema: resolved.schema,
+                    field: resolved.field,
+                }
+                .into());
+            }
+            if resolved.cardinality != FieldCardinality::One
+                || !is_ordered_type(resolved.value_type)
+            {
+                return Err(
+                    AggregateOrderValidationError::AggregateRequiresOrderedScalar(
+                        order.field.clone(),
+                    ),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct ResolvedOrderField {
+    schema: SchemaRef,
+    field: FieldName,
+    cardinality: FieldCardinality,
+    value_type: IndexValueType,
+    sortable: bool,
+    traverses_many: bool,
+}
+
+fn resolve_order_field(
+    registry: &SchemaRegistry,
+    root: &SchemaRef,
+    path: &FieldPath,
+) -> Result<ResolvedOrderField, AggregateOrderValidationError> {
+    let mut registered = registry
+        .get(root)
+        .ok_or_else(|| SchemaRegistryError::SchemaNotFound(root.clone()))?;
+    let mut traverses_many = false;
+
+    for link_name in path.links() {
+        let link = registered
+            .schema
+            .links
+            .iter()
+            .find(|link| link.name == *link_name)
+            .ok_or_else(|| QueryValidationError::UnknownLink {
+                schema: registered.schema.reference.clone(),
+                link: link_name.clone(),
+            })?;
+        traverses_many |= link.cardinality == LinkCardinality::Many;
+        registered = registry.get(&link.target_schema).ok_or_else(|| {
+            SchemaRegistryError::SchemaNotFound(link.target_schema.clone())
+        })?;
+    }
+
+    let field = registered
+        .schema
+        .fields
+        .iter()
+        .find(|field| field.name == *path.field())
+        .ok_or_else(|| QueryValidationError::UnknownField {
+            schema: registered.schema.reference.clone(),
+            field: path.field().clone(),
+        })?;
+
+    Ok(ResolvedOrderField {
+        schema: registered.schema.reference.clone(),
+        field: field.name.clone(),
+        cardinality: field.cardinality,
+        value_type: field.value_type,
+        sortable: field.sortable,
+        traverses_many,
+    })
+}
+
+fn is_ordered_type(value_type: IndexValueType) -> bool {
+    matches!(
+        value_type,
+        IndexValueType::Integer
+            | IndexValueType::Decimal
+            | IndexValueType::String
+            | IndexValueType::Uuid
+            | IndexValueType::Timestamp
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldName, IndexField, IndexLink, IndexQueryScope, IndexSchema, LocaleKey,
+        LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaVersion,
+    };
+
+    fn reference(entity: &str) -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("test").unwrap(),
+            entity: EntityName::new(entity).unwrap(),
+            version: SchemaVersion::INITIAL,
+        }
+    }
+
+    fn field(name: &str, value_type: IndexValueType, sortable: bool) -> IndexField {
+        IndexField {
+            name: FieldName::new(name).unwrap(),
+            value_type,
+            cardinality: FieldCardinality::One,
+            nullable: true,
+            selectable: true,
+            filterable: true,
+            sortable,
+        }
+    }
+
+    fn registry(child_type: IndexValueType, child_sortable: bool) -> SchemaRegistry {
+        let child = IndexSchema {
+            reference: reference("child"),
+            locale_mode: LocaleMode::Required,
+            fields: vec![field("score", child_type, child_sortable)],
+            links: Vec::new(),
+        };
+        let root = IndexSchema {
+            reference: reference("root"),
+            locale_mode: LocaleMode::Required,
+            fields: vec![field("id", IndexValueType::Uuid, true)],
+            links: vec![IndexLink {
+                name: LinkName::new("children").unwrap(),
+                source_fields: vec![FieldName::new("id").unwrap()],
+                target_schema: child.reference.clone(),
+                target_fields: vec![FieldName::new("score").unwrap()],
+                cardinality: LinkCardinality::Many,
+            }],
+        };
+        let mut registry = SchemaRegistry::new();
+        registry.register_batch([root, child]).unwrap();
+        registry
+    }
+
+    fn query(direction: OrderDirection, linked: bool) -> IndexQuery {
+        let field = if linked {
+            FieldPath::linked(
+                [LinkName::new("children").unwrap()],
+                FieldName::new("score").unwrap(),
+            )
+        } else {
+            FieldPath::new(FieldName::new("id").unwrap())
+        };
+        IndexQuery {
+            scope: IndexQueryScope {
+                tenant_id: Uuid::new_v4(),
+                locale: Some(LocaleKey::new("en-US").unwrap()),
+            },
+            schema: reference("root"),
+            fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+            filter: None,
+            order_by: vec![OrderExpr { field, direction }],
+            pagination: Pagination::Cursor {
+                first: 20,
+                after: None,
+            },
+            include_exact_count: false,
+        }
+    }
+
+    #[test]
+    fn accepts_explicit_min_and_max_over_many_link() {
+        let registry = registry(IndexValueType::Integer, true);
+        assert!(
+            registry
+                .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true))
+                .is_ok()
+        );
+        assert!(
+            registry
+                .validate_query_with_aggregate_ordering(&query(OrderDirection::MaxDesc, true))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn ordinary_many_link_order_remains_ambiguous() {
+        let registry = registry(IndexValueType::Integer, true);
+        assert!(matches!(
+            registry.validate_query_with_aggregate_ordering(&query(OrderDirection::Asc, true)),
+            Err(AggregateOrderValidationError::Query(
+                QueryValidationError::AmbiguousManyLinkSort(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn aggregate_mode_is_rejected_on_singular_path() {
+        let registry = registry(IndexValueType::Integer, true);
+        assert!(matches!(
+            registry
+                .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, false)),
+            Err(AggregateOrderValidationError::AggregateRequiresManyLink(_))
+        ));
+    }
+
+    #[test]
+    fn aggregate_requires_sortable_ordered_scalar() {
+        let boolean = registry(IndexValueType::Boolean, true);
+        assert!(matches!(
+            boolean
+                .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true)),
+            Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
+        ));
+
+        let unsortable = registry(IndexValueType::Integer, false);
+        assert!(matches!(
+            unsortable
+                .validate_query_with_aggregate_ordering(&query(OrderDirection::MaxDesc, true)),
+            Err(AggregateOrderValidationError::Query(
+                QueryValidationError::FieldNotSortable { .. }
+            ))
+        ));
+    }
+}

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::domain::{
-    FieldCardinality, FieldName, FieldPath, IndexQuery, IndexValueType, LinkCardinality, LinkName,
+    FieldCardinality, FieldName, FieldPath, IndexQuery, IndexValueType, LinkCardinality,
     Pagination, SchemaRef,
 };
 
@@ -45,7 +45,7 @@ impl SchemaRegistry {
             .order_by
             .iter()
             .any(|order| order.direction.aggregate().is_some());
-        if has_aggregate && !matches!(query.pagination, Pagination::Offset { .. }) {
+        if has_aggregate && !matches!(&query.pagination, Pagination::Offset { .. }) {
             return Err(AggregateOrderValidationError::AggregateRequiresOffsetPagination);
         }
 
@@ -159,8 +159,8 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        EntityName, FieldName, IndexField, IndexLink, IndexQueryScope, IndexSchema, LocaleKey,
-        LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaVersion,
+        EntityName, FieldName, IndexField, IndexLink, IndexQueryScope, IndexSchema, LinkName,
+        LocaleKey, LocaleMode, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaVersion,
     };
 
     fn reference(entity: &str) -> SchemaRef {

--- a/crates/rustok-index/src/application/aggregate_ordering_tests.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering_tests.rs
@@ -1,6 +1,8 @@
 use uuid::Uuid;
 
-use super::{AggregateOrderValidationError, PostgresQueryCompileError, QueryPlanError, SchemaRegistry};
+use super::{
+    AggregateOrderValidationError, PostgresQueryCompileError, QueryPlanError, SchemaRegistry,
+};
 use crate::domain::{
     EntityName, FieldCardinality, FieldName, FieldPath, IndexField, IndexLink, IndexQuery,
     IndexQueryScope, IndexSchema, IndexValueType, LinkCardinality, LinkName, LocaleKey, LocaleMode,
@@ -98,10 +100,14 @@ fn min_asc_compiles_correlated_tagged_order_value() {
     let compiled = registry.compile_postgres_query(&query).unwrap();
     assert!(compiled.sql.contains("SELECT MIN("));
     assert!(compiled.sql.contains("FROM index_links AS \"mo_l1\""));
-    assert!(compiled.sql.contains("jsonb_build_object('type', 'integer'"));
+    assert!(compiled
+        .sql
+        .contains("jsonb_build_object('type', 'integer'"));
     assert!(compiled.sql.contains("ASC NULLS LAST"));
     assert!(compiled.sql.contains("\"t0\".entity_id ASC"));
-    assert!(!compiled.sql.contains(" LEFT JOIN index_links AS \"l1\""));
+    assert!(!compiled
+        .sql
+        .contains(" LEFT JOIN index_links AS \"l1\""));
 }
 
 #[test]
@@ -111,7 +117,9 @@ fn max_desc_compiles_explicit_null_policy() {
         .compile_postgres_query(&query(OrderDirection::MaxDesc))
         .unwrap();
     assert!(compiled.sql.contains("SELECT MAX("));
-    assert!(compiled.sql.contains("jsonb_build_object('type', 'decimal'"));
+    assert!(compiled
+        .sql
+        .contains("jsonb_build_object('type', 'decimal'"));
     assert!(compiled.sql.contains("DESC NULLS FIRST"));
 }
 
@@ -142,6 +150,19 @@ fn aggregate_cursor_and_uuid_modes_fail_closed() {
 #[test]
 fn forged_plans_cannot_bypass_explicit_aggregate_policy() {
     let registry = registry(IndexValueType::Integer);
+
+    let mut aggregate_cursor = registry
+        .plan_query(&query(OrderDirection::MinAsc))
+        .unwrap();
+    aggregate_cursor.pagination = Pagination::Cursor {
+        first: 20,
+        after: None,
+    };
+    assert!(matches!(
+        aggregate_cursor.compile_postgres(),
+        Err(PostgresQueryCompileError::AggregateOrderingRequiresOffsetPagination)
+    ));
+
     let mut ambiguous = registry
         .plan_query(&query(OrderDirection::MinAsc))
         .unwrap();

--- a/crates/rustok-index/src/application/aggregate_ordering_tests.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering_tests.rs
@@ -112,19 +112,19 @@ fn min_asc_compiles_correlated_tagged_order_value() {
 
 #[test]
 fn max_desc_compiles_explicit_null_policy() {
-    let registry = registry(IndexValueType::Decimal);
+    let registry = registry(IndexValueType::String);
     let compiled = registry
         .compile_postgres_query(&query(OrderDirection::MaxDesc))
         .unwrap();
     assert!(compiled.sql.contains("SELECT MAX("));
     assert!(compiled
         .sql
-        .contains("jsonb_build_object('type', 'decimal'"));
+        .contains("jsonb_build_object('type', 'string'"));
     assert!(compiled.sql.contains("DESC NULLS FIRST"));
 }
 
 #[test]
-fn aggregate_cursor_and_uuid_modes_fail_closed() {
+fn aggregate_cursor_decimal_and_uuid_modes_fail_closed() {
     let integer = registry(IndexValueType::Integer);
     let mut cursor_query = query(OrderDirection::MinAsc);
     cursor_query.pagination = Pagination::Cursor {
@@ -138,17 +138,19 @@ fn aggregate_cursor_and_uuid_modes_fail_closed() {
         ))
     ));
 
-    let uuid = registry(IndexValueType::Uuid);
-    assert!(matches!(
-        uuid.plan_query(&query(OrderDirection::MaxAsc)),
-        Err(QueryPlanError::AggregateValidation(
-            AggregateOrderValidationError::AggregateRequiresOrderedScalar(_)
-        ))
-    ));
+    for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid] {
+        let registry = registry(unsupported);
+        assert!(matches!(
+            registry.plan_query(&query(OrderDirection::MaxAsc)),
+            Err(QueryPlanError::AggregateValidation(
+                AggregateOrderValidationError::AggregateRequiresOrderedScalar(_)
+            ))
+        ));
+    }
 }
 
 #[test]
-fn forged_plans_cannot_bypass_explicit_aggregate_policy() {
+fn forged_plans_remain_fail_closed() {
     let registry = registry(IndexValueType::Integer);
 
     let mut aggregate_cursor = registry

--- a/crates/rustok-index/src/application/aggregate_ordering_tests.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering_tests.rs
@@ -1,0 +1,167 @@
+use uuid::Uuid;
+
+use super::{AggregateOrderValidationError, PostgresQueryCompileError, QueryPlanError, SchemaRegistry};
+use crate::domain::{
+    EntityName, FieldCardinality, FieldName, FieldPath, IndexField, IndexLink, IndexQuery,
+    IndexQueryScope, IndexSchema, IndexValueType, LinkCardinality, LinkName, LocaleKey, LocaleMode,
+    ModuleName, OrderDirection, OrderExpr, Pagination, SchemaRef, SchemaVersion,
+};
+
+fn reference(entity: &str) -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("test").unwrap(),
+        entity: EntityName::new(entity).unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn field(
+    name: &str,
+    value_type: IndexValueType,
+    nullable: bool,
+    sortable: bool,
+) -> IndexField {
+    IndexField {
+        name: FieldName::new(name).unwrap(),
+        value_type,
+        cardinality: FieldCardinality::One,
+        nullable,
+        selectable: true,
+        filterable: true,
+        sortable,
+    }
+}
+
+fn registry(score_type: IndexValueType) -> SchemaRegistry {
+    let child = IndexSchema {
+        reference: reference("child"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![
+            field("root_id", IndexValueType::Uuid, false, false),
+            field("score", score_type, false, true),
+        ],
+        links: Vec::new(),
+    };
+    let root = IndexSchema {
+        reference: reference("root"),
+        locale_mode: LocaleMode::Required,
+        fields: vec![field("id", IndexValueType::Uuid, false, true)],
+        links: vec![IndexLink {
+            name: LinkName::new("children").unwrap(),
+            source_fields: vec![FieldName::new("id").unwrap()],
+            target_schema: child.reference.clone(),
+            target_fields: vec![FieldName::new("root_id").unwrap()],
+            cardinality: LinkCardinality::Many,
+        }],
+    };
+    let mut registry = SchemaRegistry::new();
+    registry.register_batch([root, child]).unwrap();
+    registry
+}
+
+fn linked_score() -> FieldPath {
+    FieldPath::linked(
+        [LinkName::new("children").unwrap()],
+        FieldName::new("score").unwrap(),
+    )
+}
+
+fn query(direction: OrderDirection) -> IndexQuery {
+    IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: Uuid::new_v4(),
+            locale: Some(LocaleKey::new("en-US").unwrap()),
+        },
+        schema: reference("root"),
+        fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+        filter: None,
+        order_by: vec![OrderExpr {
+            field: linked_score(),
+            direction,
+        }],
+        pagination: Pagination::Offset {
+            limit: 20,
+            offset: 0,
+        },
+        include_exact_count: false,
+    }
+}
+
+#[test]
+fn min_asc_compiles_correlated_tagged_order_value() {
+    let registry = registry(IndexValueType::Integer);
+    let query = query(OrderDirection::MinAsc);
+    let plan = registry.plan_query(&query).unwrap();
+    assert!(plan.order_by[0].field.traverses_many);
+    assert!(plan.order_by[0].field.nullable);
+
+    let compiled = registry.compile_postgres_query(&query).unwrap();
+    assert!(compiled.sql.contains("SELECT MIN("));
+    assert!(compiled.sql.contains("FROM index_links AS \"mo_l1\""));
+    assert!(compiled.sql.contains("jsonb_build_object('type', 'integer'"));
+    assert!(compiled.sql.contains("ASC NULLS LAST"));
+    assert!(compiled.sql.contains("\"t0\".entity_id ASC"));
+    assert!(!compiled.sql.contains(" LEFT JOIN index_links AS \"l1\""));
+}
+
+#[test]
+fn max_desc_compiles_explicit_null_policy() {
+    let registry = registry(IndexValueType::Decimal);
+    let compiled = registry
+        .compile_postgres_query(&query(OrderDirection::MaxDesc))
+        .unwrap();
+    assert!(compiled.sql.contains("SELECT MAX("));
+    assert!(compiled.sql.contains("jsonb_build_object('type', 'decimal'"));
+    assert!(compiled.sql.contains("DESC NULLS FIRST"));
+}
+
+#[test]
+fn aggregate_cursor_and_uuid_modes_fail_closed() {
+    let integer = registry(IndexValueType::Integer);
+    let mut cursor_query = query(OrderDirection::MinAsc);
+    cursor_query.pagination = Pagination::Cursor {
+        first: 20,
+        after: None,
+    };
+    assert!(matches!(
+        integer.plan_query(&cursor_query),
+        Err(QueryPlanError::AggregateValidation(
+            AggregateOrderValidationError::AggregateRequiresOffsetPagination
+        ))
+    ));
+
+    let uuid = registry(IndexValueType::Uuid);
+    assert!(matches!(
+        uuid.plan_query(&query(OrderDirection::MaxAsc)),
+        Err(QueryPlanError::AggregateValidation(
+            AggregateOrderValidationError::AggregateRequiresOrderedScalar(_)
+        ))
+    ));
+}
+
+#[test]
+fn forged_plans_cannot_bypass_explicit_aggregate_policy() {
+    let registry = registry(IndexValueType::Integer);
+    let mut ambiguous = registry
+        .plan_query(&query(OrderDirection::MinAsc))
+        .unwrap();
+    ambiguous.order_by[0].direction = OrderDirection::Asc;
+    ambiguous.order_by[0].field.nullable = false;
+    assert!(matches!(
+        ambiguous.compile_postgres(),
+        Err(PostgresQueryCompileError::ManyLinkOrderingPending(_))
+    ));
+
+    let mut root_query = query(OrderDirection::MinAsc);
+    root_query.order_by = vec![OrderExpr {
+        field: FieldPath::new(FieldName::new("id").unwrap()),
+        direction: OrderDirection::Asc,
+    }];
+    let mut singular = registry.plan_query(&root_query).unwrap();
+    singular.order_by[0].direction = OrderDirection::MinAsc;
+    singular.order_by[0].field.nullable = true;
+    assert!(matches!(
+        singular.compile_postgres(),
+        Err(PostgresQueryCompileError::AggregateOrderingWithoutManyLink(_))
+    ));
+}

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,3 +1,4 @@
+mod aggregate_ordering;
 mod cursor;
 mod planner;
 mod postgres_compiler;
@@ -22,6 +23,7 @@ mod query_snapshot_tests;
 #[cfg(test)]
 mod reference;
 
+pub use aggregate_ordering::AggregateOrderValidationError;
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};
 pub use planner::{
     ExecutableQueryPlan, PlannedField, PlannedJoin, PlannedManyProjection, PlannedOrder,

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -11,6 +11,8 @@ mod source_schema_registry;
 mod validation;
 
 #[cfg(test)]
+mod aggregate_ordering_tests;
+#[cfg(test)]
 mod planner_tests;
 #[cfg(test)]
 mod postgres_compiler_tests;

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -250,8 +250,12 @@ impl SchemaRegistry {
             .order_by
             .iter()
             .map(|order| {
+                let mut field = planned_field(&referenced_fields, &order.field)?;
+                if order.direction.aggregate().is_some() {
+                    field.nullable = true;
+                }
                 Ok(PlannedOrder {
-                    field: planned_field(&referenced_fields, &order.field)?,
+                    field,
                     direction: order.direction,
                 })
             })

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -131,7 +131,7 @@ pub enum QueryPlanError {
     #[error(transparent)]
     Validation(#[from] QueryValidationError),
     #[error(transparent)]
-    AggregateValidation(#[from] AggregateOrderValidationError),
+    AggregateValidation(AggregateOrderValidationError),
     #[error(transparent)]
     Registry(#[from] SchemaRegistryError),
     #[error("validated query path has no relation alias: {0:?}")]
@@ -142,7 +142,16 @@ pub enum QueryPlanError {
 
 impl SchemaRegistry {
     pub fn plan_query(&self, query: &IndexQuery) -> Result<ExecutableQueryPlan, QueryPlanError> {
-        self.validate_query_with_aggregate_ordering(query)?;
+        match self.validate_query_with_aggregate_ordering(query) {
+            Ok(()) => {}
+            Err(AggregateOrderValidationError::Query(error)) => {
+                return Err(QueryPlanError::Validation(error));
+            }
+            Err(AggregateOrderValidationError::Registry(error)) => {
+                return Err(QueryPlanError::Registry(error));
+            }
+            Err(error) => return Err(QueryPlanError::AggregateValidation(error)),
+        }
 
         let paths = collect_link_prefixes(query);
         let mut aliases = BTreeMap::from([(Vec::new(), ROOT_ALIAS.to_owned())]);

--- a/crates/rustok-index/src/application/planner.rs
+++ b/crates/rustok-index/src/application/planner.rs
@@ -12,7 +12,9 @@ use crate::domain::{
     IndexValueType, LinkCardinality, LinkName, OrderDirection, Pagination, SchemaRef,
 };
 
-use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
+use super::{
+    AggregateOrderValidationError, QueryValidationError, SchemaRegistry, SchemaRegistryError,
+};
 
 const ROOT_ALIAS: &str = "t0";
 
@@ -129,6 +131,8 @@ pub enum QueryPlanError {
     #[error(transparent)]
     Validation(#[from] QueryValidationError),
     #[error(transparent)]
+    AggregateValidation(#[from] AggregateOrderValidationError),
+    #[error(transparent)]
     Registry(#[from] SchemaRegistryError),
     #[error("validated query path has no relation alias: {0:?}")]
     ValidatedAliasMissing(FieldPath),
@@ -138,7 +142,7 @@ pub enum QueryPlanError {
 
 impl SchemaRegistry {
     pub fn plan_query(&self, query: &IndexQuery) -> Result<ExecutableQueryPlan, QueryPlanError> {
-        self.validate_query(query)?;
+        self.validate_query_with_aggregate_ordering(query)?;
 
         let paths = collect_link_prefixes(query);
         let mut aliases = BTreeMap::from([(Vec::new(), ROOT_ALIAS.to_owned())]);

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -82,6 +82,8 @@ pub enum PostgresQueryCompileError {
     CursorContextMismatch,
     #[error("many-cardinality ordering requires an explicit aggregate policy: {0:?}")]
     ManyLinkOrderingPending(FieldPath),
+    #[error("aggregate ordering requires a many-cardinality path: {0:?}")]
+    AggregateOrderingWithoutManyLink(FieldPath),
     #[error("query plan has no join contract for path {0:?}")]
     MissingJoinPlan(Vec<LinkName>),
     #[error("query plan many-link traversal metadata is inconsistent for path {0:?}")]
@@ -231,10 +233,20 @@ impl ExecutableQueryPlan {
                     order.field.path.clone(),
                 ));
             }
-            if order.field.traverses_many {
-                return Err(PostgresQueryCompileError::ManyLinkOrderingPending(
-                    order.field.path.clone(),
-                ));
+            match (order.field.traverses_many, order.direction.aggregate()) {
+                (true, None) => {
+                    return Err(PostgresQueryCompileError::ManyLinkOrderingPending(
+                        order.field.path.clone(),
+                    ));
+                }
+                (false, Some(_)) => {
+                    return Err(
+                        PostgresQueryCompileError::AggregateOrderingWithoutManyLink(
+                            order.field.path.clone(),
+                        ),
+                    );
+                }
+                _ => {}
             }
         }
         if let Some(filter) = &self.filter {

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -338,10 +338,7 @@ fn validate_many_projection_contract(
 fn aggregate_type_supported(value_type: IndexValueType) -> bool {
     matches!(
         value_type,
-        IndexValueType::Integer
-            | IndexValueType::Decimal
-            | IndexValueType::String
-            | IndexValueType::Timestamp
+        IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp
     )
 }
 

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -88,6 +88,8 @@ pub enum PostgresQueryCompileError {
     AggregateOrderingWithoutManyLink(FieldPath),
     #[error("aggregate ordering uses an unsupported PostgreSQL MIN/MAX type: {0:?}")]
     AggregateOrderingUnsupportedType(FieldPath),
+    #[error("aggregate ordering currently requires bounded offset pagination")]
+    AggregateOrderingRequiresOffsetPagination,
     #[error("query plan has no join contract for path {0:?}")]
     MissingJoinPlan(Vec<LinkName>),
     #[error("query plan many-link traversal metadata is inconsistent for path {0:?}")]
@@ -231,14 +233,17 @@ impl ExecutableQueryPlan {
             }
         }
         validate_many_projection_contract(self)?;
+        let mut has_aggregate_order = false;
         for order in &self.order_by {
             let Some(referenced) = self.referenced_fields.get(&order.field.path) else {
                 return Err(PostgresQueryCompileError::MissingFieldPlan(
                     order.field.path.clone(),
                 ));
             };
+            let aggregate = order.direction.aggregate();
+            has_aggregate_order |= aggregate.is_some();
             let mut expected = referenced.clone();
-            if order.direction.aggregate().is_some() {
+            if aggregate.is_some() {
                 expected.nullable = true;
             }
             if order.field != expected {
@@ -246,7 +251,7 @@ impl ExecutableQueryPlan {
                     order.field.path.clone(),
                 ));
             }
-            match (order.field.traverses_many, order.direction.aggregate()) {
+            match (order.field.traverses_many, aggregate) {
                 (true, None) => {
                     return Err(PostgresQueryCompileError::ManyLinkOrderingPending(
                         order.field.path.clone(),
@@ -266,6 +271,9 @@ impl ExecutableQueryPlan {
                 }
                 _ => {}
             }
+        }
+        if has_aggregate_order && !matches!(&self.pagination, Pagination::Offset { .. }) {
+            return Err(PostgresQueryCompileError::AggregateOrderingRequiresOffsetPagination);
         }
         if let Some(filter) = &self.filter {
             let mut paths = Vec::new();

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -5,7 +5,9 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::domain::{FieldPath, IndexQuery, LinkCardinality, LinkName, Pagination};
+use crate::domain::{
+    FieldPath, IndexQuery, IndexValueType, LinkCardinality, LinkName, Pagination,
+};
 
 use super::{
     CursorCodec, CursorValidationError, ExecutableQueryPlan, IndexCursor, PlannedField,
@@ -84,6 +86,8 @@ pub enum PostgresQueryCompileError {
     ManyLinkOrderingPending(FieldPath),
     #[error("aggregate ordering requires a many-cardinality path: {0:?}")]
     AggregateOrderingWithoutManyLink(FieldPath),
+    #[error("aggregate ordering uses an unsupported PostgreSQL MIN/MAX type: {0:?}")]
+    AggregateOrderingUnsupportedType(FieldPath),
     #[error("query plan has no join contract for path {0:?}")]
     MissingJoinPlan(Vec<LinkName>),
     #[error("query plan many-link traversal metadata is inconsistent for path {0:?}")]
@@ -228,7 +232,16 @@ impl ExecutableQueryPlan {
         }
         validate_many_projection_contract(self)?;
         for order in &self.order_by {
-            if self.referenced_fields.get(&order.field.path) != Some(&order.field) {
+            let Some(referenced) = self.referenced_fields.get(&order.field.path) else {
+                return Err(PostgresQueryCompileError::MissingFieldPlan(
+                    order.field.path.clone(),
+                ));
+            };
+            let mut expected = referenced.clone();
+            if order.direction.aggregate().is_some() {
+                expected.nullable = true;
+            }
+            if order.field != expected {
                 return Err(PostgresQueryCompileError::MissingFieldPlan(
                     order.field.path.clone(),
                 ));
@@ -245,6 +258,11 @@ impl ExecutableQueryPlan {
                             order.field.path.clone(),
                         ),
                     );
+                }
+                (true, Some(_)) if !aggregate_type_supported(order.field.value_type) => {
+                    return Err(PostgresQueryCompileError::AggregateOrderingUnsupportedType(
+                        order.field.path.clone(),
+                    ));
                 }
                 _ => {}
             }
@@ -307,6 +325,16 @@ fn validate_many_projection_contract(
         }
     }
     Ok(())
+}
+
+fn aggregate_type_supported(value_type: IndexValueType) -> bool {
+    matches!(
+        value_type,
+        IndexValueType::Integer
+            | IndexValueType::Decimal
+            | IndexValueType::String
+            | IndexValueType::Timestamp
+    )
 }
 
 fn validate_alias(alias: &str) -> Result<(), PostgresQueryCompileError> {

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -1,10 +1,11 @@
 use crate::domain::{
-    FieldPath, FilterExpr, IndexValue, IndexValueType, OrderDirection, Pagination,
+    FieldPath, FilterExpr, IndexValue, IndexValueType, ManyOrderAggregate, OrderDirection,
+    Pagination,
 };
 
 use super::{
     cursor::IndexCursor,
-    planner::{ExecutableQueryPlan, PlannedField, PlannedManyProjection},
+    planner::{ExecutableQueryPlan, PlannedField, PlannedManyProjection, PlannedOrder},
     postgres_compiler::{
         CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
         CompiledQueryColumn, PostgresBindValue, PostgresQueryCompileError, quote_identifier,
@@ -66,7 +67,7 @@ pub(super) fn compile_postgres_plan(
     }
 
     for (index, order) in plan.order_by.iter().enumerate() {
-        let field_sql = field_sql(&order.field, &mut bindings);
+        let field_sql = order_sql(plan, order, &mut bindings)?;
         let output_alias = format!("__order_{index}");
         select.push(format!(
             "{} AS {}",
@@ -87,7 +88,7 @@ pub(super) fn compile_postgres_plan(
         predicates.push(compile_keyset(plan, cursor, &mut bindings)?);
     }
 
-    let order = compile_order(plan, &mut bindings);
+    let order = compile_order(plan, &mut bindings)?;
     let pagination = compile_pagination(&plan.pagination, &mut bindings)?;
     let sql = format!(
         "SELECT {} {} WHERE {} {order} {pagination}",
@@ -498,6 +499,96 @@ fn compile_many_exists(
     Ok(expression)
 }
 
+fn order_sql(
+    plan: &ExecutableQueryPlan,
+    order: &PlannedOrder,
+    bindings: &mut Bindings,
+) -> Result<FieldSql, PostgresQueryCompileError> {
+    match order.direction.aggregate() {
+        Some(aggregate) => compile_many_order_aggregate(plan, &order.field, aggregate, bindings),
+        None => Ok(field_sql(&order.field, bindings)),
+    }
+}
+
+fn compile_many_order_aggregate(
+    plan: &ExecutableQueryPlan,
+    field: &PlannedField,
+    aggregate: ManyOrderAggregate,
+    bindings: &mut Bindings,
+) -> Result<FieldSql, PostgresQueryCompileError> {
+    let mut path = Vec::new();
+    let mut source_alias = plan.root_alias.clone();
+    let mut from_sql = String::new();
+    let mut predicates = Vec::new();
+    let mut terminal_alias = None;
+
+    for (index, link_name) in field.path.links().iter().enumerate() {
+        path.push(link_name.clone());
+        let join = plan
+            .join_for_path(&path)
+            .ok_or_else(|| PostgresQueryCompileError::MissingJoinPlan(path.clone()))?;
+        let link_alias_name = format!("mo_l{}", index + 1);
+        let target_alias_name = format!("mo_t{}", index + 1);
+        let source_alias_q = quote_identifier(&source_alias);
+        let link_alias = quote_identifier(&link_alias_name);
+        let target_alias = quote_identifier(&target_alias_name);
+        let link_name = bindings.push(PostgresBindValue::Text(join.link.as_str().to_owned()));
+        let target_module = bindings.push(PostgresBindValue::Text(
+            join.target_schema.module.as_str().to_owned(),
+        ));
+        let target_entity = bindings.push(PostgresBindValue::Text(
+            join.target_schema.entity.as_str().to_owned(),
+        ));
+        let target_version = bindings.push(PostgresBindValue::Integer(i64::from(
+            join.target_schema.version.get(),
+        )));
+        let source_predicate = format!(
+            "{link_alias}.tenant_id = {source_alias_q}.tenant_id AND {link_alias}.source_module = {source_alias_q}.module_name AND {link_alias}.source_entity = {source_alias_q}.entity_name AND {link_alias}.source_schema_version = {source_alias_q}.schema_version AND {link_alias}.source_entity_id = {source_alias_q}.entity_id AND {link_alias}.source_locale_key = {source_alias_q}.locale_key AND {link_alias}.source_version = {source_alias_q}.source_version AND {link_alias}.link_name = {link_name} AND {link_alias}.target_module = {target_module} AND {link_alias}.target_entity = {target_entity} AND {link_alias}.target_schema_version = {target_version}"
+        );
+        let target_predicate = format!(
+            "{target_alias}.tenant_id = {link_alias}.tenant_id AND {target_alias}.module_name = {link_alias}.target_module AND {target_alias}.entity_name = {link_alias}.target_entity AND {target_alias}.schema_version = {link_alias}.target_schema_version AND {target_alias}.entity_id = {link_alias}.target_entity_id AND {target_alias}.locale_key = {link_alias}.target_locale_key AND {target_alias}.is_deleted = FALSE"
+        );
+
+        if index == 0 {
+            from_sql.push_str(&format!(
+                "FROM index_links AS {link_alias} JOIN index_entities AS {target_alias} ON {target_predicate}",
+            ));
+            predicates.push(source_predicate);
+        } else {
+            from_sql.push_str(&format!(
+                " JOIN index_links AS {link_alias} ON {source_predicate} JOIN index_entities AS {target_alias} ON {target_predicate}",
+            ));
+        }
+        source_alias = target_alias_name.clone();
+        terminal_alias = Some(target_alias_name);
+    }
+
+    let terminal_alias = terminal_alias.ok_or_else(|| {
+        PostgresQueryCompileError::ManyTraversalMismatch(field.path.links().to_vec())
+    })?;
+    let terminal = field_sql_for_alias(field, &terminal_alias, bindings);
+    let function = match aggregate {
+        ManyOrderAggregate::Min => "MIN",
+        ManyOrderAggregate::Max => "MAX",
+    };
+    let scalar = format!(
+        "(SELECT {function}({}) {from_sql} WHERE {})",
+        terminal.scalar,
+        predicates.join(" AND ")
+    );
+    let raw = format!(
+        "CASE WHEN {scalar} IS NULL THEN NULL ELSE jsonb_build_object('type', '{}', 'value', to_jsonb({scalar})) END",
+        value_type_tag(field.value_type),
+    );
+    Ok(FieldSql {
+        raw,
+        scalar: scalar.clone(),
+        list_values: "NULL::jsonb".to_owned(),
+        type_text: "NULL::text".to_owned(),
+        null_predicate: format!("{scalar} IS NULL"),
+    })
+}
+
 fn compile_keyset(
     plan: &ExecutableQueryPlan,
     cursor: &IndexCursor,
@@ -506,11 +597,11 @@ fn compile_keyset(
     let mut equalities = Vec::new();
     let mut disjuncts = Vec::new();
     for (order, cursor_value) in plan.order_by.iter().zip(&cursor.order_values) {
-        let sql = field_sql(&order.field, bindings);
+        let sql = order_sql(plan, order, bindings)?;
         let (equal, after) = cursor_field_predicates(
             &order.field.path,
             &sql,
-            order.direction,
+            order.direction.base_direction(),
             cursor_value,
             bindings,
         )?;
@@ -539,6 +630,7 @@ fn cursor_field_predicates(
         let after = match direction {
             OrderDirection::Asc => "FALSE".to_owned(),
             OrderDirection::Desc => non_null,
+            _ => unreachable!("cursor predicates receive a normalized direction"),
         };
         return Ok((format!("({})", sql.null_predicate), after));
     }
@@ -553,6 +645,7 @@ fn cursor_field_predicates(
         OrderDirection::Desc => {
             format!("({non_null} AND {} < {value})", sql.scalar)
         }
+        _ => unreachable!("cursor predicates receive a normalized direction"),
     };
     Ok((equal, after))
 }
@@ -563,23 +656,27 @@ fn conjunction(prefix: &[String], final_predicate: &str) -> String {
     format!("({})", predicates.join(" AND "))
 }
 
-fn compile_order(plan: &ExecutableQueryPlan, bindings: &mut Bindings) -> String {
+fn compile_order(
+    plan: &ExecutableQueryPlan,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
     let mut terms = plan
         .order_by
         .iter()
         .map(|order| {
-            let sql = field_sql(&order.field, bindings);
-            match order.direction {
+            let sql = order_sql(plan, order, bindings)?;
+            Ok(match order.direction.base_direction() {
                 OrderDirection::Asc => format!("{} ASC NULLS LAST", sql.scalar),
                 OrderDirection::Desc => format!("{} DESC NULLS FIRST", sql.scalar),
-            }
+                _ => unreachable!("order SQL receives a normalized direction"),
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, PostgresQueryCompileError>>()?;
     terms.push(format!(
         "{}.entity_id ASC",
         quote_identifier(&plan.root_alias)
     ));
-    format!("ORDER BY {}", terms.join(", "))
+    Ok(format!("ORDER BY {}", terms.join(", ")))
 }
 
 fn compile_pagination(
@@ -686,6 +783,17 @@ fn field_sql_for_alias(
         ),
         type_text,
         null_predicate,
+    }
+}
+
+fn value_type_tag(value_type: IndexValueType) -> &'static str {
+    match value_type {
+        IndexValueType::Boolean => "boolean",
+        IndexValueType::Integer => "integer",
+        IndexValueType::Decimal => "decimal",
+        IndexValueType::String => "string",
+        IndexValueType::Uuid => "uuid",
+        IndexValueType::Timestamp => "timestamp",
     }
 }
 

--- a/crates/rustok-index/src/application/reference.rs
+++ b/crates/rustok-index/src/application/reference.rs
@@ -319,9 +319,10 @@ impl<'a> ReferenceIndex<'a> {
 }
 
 fn apply_direction(ordering: Ordering, direction: OrderDirection) -> Ordering {
-    match direction {
+    match direction.base_direction() {
         OrderDirection::Asc => ordering,
         OrderDirection::Desc => ordering.reverse(),
+        _ => unreachable!("base_direction returns a physical direction"),
     }
 }
 

--- a/crates/rustok-index/src/domain/mod.rs
+++ b/crates/rustok-index/src/domain/mod.rs
@@ -12,7 +12,10 @@ pub use identifiers::{
     SchemaRef, SchemaVersion,
 };
 pub use mutation::IndexMutation;
-pub use query::{FilterExpr, IndexQuery, IndexQueryScope, OrderDirection, OrderExpr, Pagination};
+pub use query::{
+    FilterExpr, IndexQuery, IndexQueryScope, ManyOrderAggregate, OrderDirection, OrderExpr,
+    Pagination,
+};
 pub use record::{IndexLinkValue, IndexRecord, LinkedEntityKey};
 pub use schema::{
     FieldCardinality, IndexField, IndexLink, IndexSchema, LinkCardinality, LocaleMode,

--- a/crates/rustok-index/src/domain/query.rs
+++ b/crates/rustok-index/src/domain/query.rs
@@ -62,9 +62,37 @@ impl FilterExpr {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum ManyOrderAggregate {
+    Min,
+    Max,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum OrderDirection {
     Asc,
     Desc,
+    MinAsc,
+    MinDesc,
+    MaxAsc,
+    MaxDesc,
+}
+
+impl OrderDirection {
+    pub const fn aggregate(self) -> Option<ManyOrderAggregate> {
+        match self {
+            Self::MinAsc | Self::MinDesc => Some(ManyOrderAggregate::Min),
+            Self::MaxAsc | Self::MaxDesc => Some(ManyOrderAggregate::Max),
+            Self::Asc | Self::Desc => None,
+        }
+    }
+
+    pub const fn base_direction(self) -> Self {
+        match self {
+            Self::Asc | Self::MinAsc | Self::MaxAsc => Self::Asc,
+            Self::Desc | Self::MinDesc | Self::MaxDesc => Self::Desc,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -196,6 +224,22 @@ mod tests {
             },
             include_exact_count: false,
         }
+    }
+
+    #[test]
+    fn explicit_many_order_modes_expose_aggregate_and_base_direction() {
+        assert_eq!(OrderDirection::Asc.aggregate(), None);
+        assert_eq!(OrderDirection::Desc.base_direction(), OrderDirection::Desc);
+        assert_eq!(
+            OrderDirection::MinAsc.aggregate(),
+            Some(ManyOrderAggregate::Min)
+        );
+        assert_eq!(OrderDirection::MinDesc.base_direction(), OrderDirection::Desc);
+        assert_eq!(
+            OrderDirection::MaxDesc.aggregate(),
+            Some(ManyOrderAggregate::Max)
+        );
+        assert_eq!(OrderDirection::MaxAsc.base_direction(), OrderDirection::Asc);
     }
 
     #[test]

--- a/crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs
@@ -365,9 +365,10 @@ impl<'a> ReferenceFixture<'a> {
 }
 
 fn apply_direction(ordering: Ordering, direction: OrderDirection) -> Ordering {
-    match direction {
+    match direction.base_direction() {
         OrderDirection::Asc => ordering,
         OrderDirection::Desc => ordering.reverse(),
+        _ => unreachable!("base_direction returns a physical direction"),
     }
 }
 

--- a/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+++ b/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
@@ -49,14 +49,12 @@ const validation = requireMarkers(validationPath, [
   'matches!(&query.pagination, Pagination::Offset { .. })',
   'self.validate_query(&ordinary)?;',
   'resolved.traverses_many',
-  'IndexValueType::Integer',
-  'IndexValueType::Decimal',
-  'IndexValueType::String',
-  'IndexValueType::Timestamp',
+  'IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp',
+  'for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid]',
   'aggregate_cursor_pagination_remains_rejected',
 ]);
 forbidMarkers(validationPath, validation, [
-  'IndexValueType::Uuid\n            |',
+  'IndexValueType::Integer\n            | IndexValueType::Decimal',
   'unwrap_or(',
   'first()',
   'ordinal',
@@ -74,7 +72,7 @@ requireMarkers(plannerPath, [
 ]);
 
 const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
-requireMarkers(compilerPath, [
+const compiler = requireMarkers(compilerPath, [
   'AggregateOrderingWithoutManyLink',
   'AggregateOrderingUnsupportedType',
   'AggregateOrderingRequiresOffsetPagination',
@@ -82,6 +80,10 @@ requireMarkers(compilerPath, [
   'expected.nullable = true;',
   'aggregate_type_supported(order.field.value_type)',
   'has_aggregate_order && !matches!(&self.pagination, Pagination::Offset { .. })',
+  'IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp',
+]);
+forbidMarkers(compilerPath, compiler, [
+  'IndexValueType::Integer\n            | IndexValueType::Decimal',
 ]);
 
 const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
@@ -105,8 +107,10 @@ forbidMarkers(sqlPath, sql, [
 requireMarkers('crates/rustok-index/src/application/aggregate_ordering_tests.rs', [
   'min_asc_compiles_correlated_tagged_order_value',
   'max_desc_compiles_explicit_null_policy',
-  'aggregate_cursor_and_uuid_modes_fail_closed',
-  'forged_plans_cannot_bypass_explicit_aggregate_policy',
+  'aggregate_cursor_decimal_and_uuid_modes_fail_closed',
+  'forged_plans_remain_fail_closed',
+  'IndexValueType::String',
+  "jsonb_build_object('type', 'string'",
   'AggregateOrderingRequiresOffsetPagination',
   'assert!(!compiled',
   '.contains(" LEFT JOIN index_links AS \\"l1\\""));',
@@ -140,8 +144,12 @@ if (contract.query_contract?.plain_many_link_asc_desc_rejected !== true
   fail(`${contractPath} query boundary drifted`);
 }
 if (JSON.stringify(contract.supported_terminal_types)
-  !== JSON.stringify(['integer', 'decimal', 'string', 'timestamp'])) {
+  !== JSON.stringify(['integer', 'string', 'timestamp'])) {
   fail(`${contractPath} supported type contract drifted`);
+}
+if (!contract.rejected_terminal_types?.includes('decimal')
+  || !contract.remaining?.includes('exact decimal tagged-order wire contract')) {
+  fail(`${contractPath} must keep decimal fail-closed pending an exact wire contract`);
 }
 if (contract.postgresql?.strategy !== 'correlated_scalar_subquery'
   || contract.postgresql?.outer_many_join !== false
@@ -163,7 +171,8 @@ requireMarkers('crates/rustok-index/docs/m4-many-link-aggregate-ordering.md', [
   '`min_asc`',
   '`max_desc`',
   'bounded offset',
-  'UUID',
+  'Decimal and UUID',
+  'exact tagged-wire contract',
   'Aggregate cursor continuation remains open',
   'Not run by the implementation agent',
 ]);

--- a/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+++ b/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
@@ -46,7 +46,7 @@ const validation = requireMarkers(validationPath, [
   'AggregateRequiresOffsetPagination',
   'pub fn validate_query_with_aggregate_ordering',
   'order.direction.aggregate().is_some()',
-  'Pagination::Offset { .. }',
+  'matches!(&query.pagination, Pagination::Offset { .. })',
   'self.validate_query(&ordinary)?;',
   'resolved.traverses_many',
   'IndexValueType::Integer',
@@ -121,11 +121,45 @@ for (const referencePath of [
   ]);
 }
 
+const contractPath = 'crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json';
+const contract = JSON.parse(read(contractPath));
+if (contract.schema_version !== 1 || contract.owner !== 'rustok-index') {
+  fail(`${contractPath} identity drifted`);
+}
+if (contract.status !== 'source_complete_execution_pending') {
+  fail(`${contractPath} must remain execution pending`);
+}
+if (JSON.stringify(contract.query_contract?.many_link_modes)
+  !== JSON.stringify(['min_asc', 'min_desc', 'max_asc', 'max_desc'])) {
+  fail(`${contractPath} aggregate modes drifted`);
+}
+if (contract.query_contract?.plain_many_link_asc_desc_rejected !== true
+  || contract.query_contract?.aggregate_requires_many_link !== true
+  || contract.query_contract?.aggregate_cursor_supported !== false
+  || contract.query_contract?.pagination !== 'bounded_offset') {
+  fail(`${contractPath} query boundary drifted`);
+}
+if (JSON.stringify(contract.supported_terminal_types)
+  !== JSON.stringify(['integer', 'decimal', 'string', 'timestamp'])) {
+  fail(`${contractPath} supported type contract drifted`);
+}
+if (contract.postgresql?.strategy !== 'correlated_scalar_subquery'
+  || contract.postgresql?.outer_many_join !== false
+  || contract.postgresql?.caller_sql !== false
+  || contract.postgresql?.implicit_first_row !== false
+  || contract.postgresql?.implicit_link_ordinal !== false) {
+  fail(`${contractPath} PostgreSQL boundary drifted`);
+}
+for (const key of ['cargo_run', 'tests_run', 'postgresql_run', 'node_verifiers_run', 'workflows_run', 'ci_run']) {
+  if (contract.validation?.[key] !== false) fail(`${contractPath} must not claim ${key}`);
+}
+
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-many-link-aggregate-ordering.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-many-link-aggregate-ordering.md', [
   'Status: `source_complete_execution_pending`',
+  '`crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json`',
   '`min_asc`',
   '`max_desc`',
   'bounded offset',

--- a/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+++ b/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
@@ -77,9 +77,11 @@ const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
 requireMarkers(compilerPath, [
   'AggregateOrderingWithoutManyLink',
   'AggregateOrderingUnsupportedType',
+  'AggregateOrderingRequiresOffsetPagination',
   'ManyLinkOrderingPending',
   'expected.nullable = true;',
   'aggregate_type_supported(order.field.value_type)',
+  'has_aggregate_order && !matches!(&self.pagination, Pagination::Offset { .. })',
 ]);
 
 const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
@@ -105,7 +107,9 @@ requireMarkers('crates/rustok-index/src/application/aggregate_ordering_tests.rs'
   'max_desc_compiles_explicit_null_policy',
   'aggregate_cursor_and_uuid_modes_fail_closed',
   'forged_plans_cannot_bypass_explicit_aggregate_policy',
-  'assert!(!compiled.sql.contains(" LEFT JOIN index_links AS \\"l1\\""))',
+  'AggregateOrderingRequiresOffsetPagination',
+  'assert!(!compiled',
+  '.contains(" LEFT JOIN index_links AS \\"l1\\""));',
 ]);
 for (const referencePath of [
   'crates/rustok-index/src/application/reference.rs',

--- a/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+++ b/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-many-link-aggregate-ordering] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const queryPath = 'crates/rustok-index/src/domain/query.rs';
+requireMarkers(queryPath, [
+  'pub enum ManyOrderAggregate',
+  'Min,',
+  'Max,',
+  'MinAsc,',
+  'MinDesc,',
+  'MaxAsc,',
+  'MaxDesc,',
+  'pub const fn aggregate(self)',
+  'pub const fn base_direction(self)',
+  'explicit_many_order_modes_expose_aggregate_and_base_direction',
+]);
+requireMarkers('crates/rustok-index/src/domain/mod.rs', ['ManyOrderAggregate']);
+
+const validationPath = 'crates/rustok-index/src/application/aggregate_ordering.rs';
+const validation = requireMarkers(validationPath, [
+  'pub enum AggregateOrderValidationError',
+  'AggregateRequiresManyLink',
+  'AggregateRequiresOrderedScalar',
+  'AggregateRequiresOffsetPagination',
+  'pub fn validate_query_with_aggregate_ordering',
+  'order.direction.aggregate().is_some()',
+  'Pagination::Offset { .. }',
+  'self.validate_query(&ordinary)?;',
+  'resolved.traverses_many',
+  'IndexValueType::Integer',
+  'IndexValueType::Decimal',
+  'IndexValueType::String',
+  'IndexValueType::Timestamp',
+  'aggregate_cursor_pagination_remains_rejected',
+]);
+forbidMarkers(validationPath, validation, [
+  'IndexValueType::Uuid\n            |',
+  'unwrap_or(',
+  'first()',
+  'ordinal',
+]);
+
+const plannerPath = 'crates/rustok-index/src/application/planner.rs';
+requireMarkers(plannerPath, [
+  'self.validate_query_with_aggregate_ordering(query)',
+  'QueryPlanError::Validation(error)',
+  'QueryPlanError::Registry(error)',
+  'QueryPlanError::AggregateValidation(error)',
+  'if order.direction.aggregate().is_some()',
+  'field.nullable = true;',
+  'rustok-index-query-plan-v4',
+]);
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
+requireMarkers(compilerPath, [
+  'AggregateOrderingWithoutManyLink',
+  'AggregateOrderingUnsupportedType',
+  'ManyLinkOrderingPending',
+  'expected.nullable = true;',
+  'aggregate_type_supported(order.field.value_type)',
+]);
+
+const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
+const sql = requireMarkers(sqlPath, [
+  'fn compile_many_order_aggregate(',
+  'ManyOrderAggregate::Min => "MIN"',
+  'ManyOrderAggregate::Max => "MAX"',
+  'FROM index_links AS {link_alias}',
+  "jsonb_build_object('type', '{}', 'value', to_jsonb({scalar}))",
+  'order.direction.base_direction()',
+  'ASC NULLS LAST',
+  'DESC NULLS FIRST',
+  'entity_id ASC',
+]);
+forbidMarkers(sqlPath, sql, [
+  'array_agg(',
+  'ordinal LIMIT 1',
+  'target_entity_id LIMIT 1',
+]);
+
+requireMarkers('crates/rustok-index/src/application/aggregate_ordering_tests.rs', [
+  'min_asc_compiles_correlated_tagged_order_value',
+  'max_desc_compiles_explicit_null_policy',
+  'aggregate_cursor_and_uuid_modes_fail_closed',
+  'forged_plans_cannot_bypass_explicit_aggregate_policy',
+  'assert!(!compiled.sql.contains(" LEFT JOIN index_links AS \\"l1\\""))',
+]);
+for (const referencePath of [
+  'crates/rustok-index/src/application/reference.rs',
+  'crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs',
+]) {
+  requireMarkers(referencePath, [
+    'match direction.base_direction()',
+    'base_direction returns a physical direction',
+  ]);
+}
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-many-link-aggregate-ordering.mjs'",
+]);
+requireMarkers('crates/rustok-index/docs/m4-many-link-aggregate-ordering.md', [
+  'Status: `source_complete_execution_pending`',
+  '`min_asc`',
+  '`max_desc`',
+  'bounded offset',
+  'UUID',
+  'Aggregate cursor continuation remains open',
+  'Not run by the implementation agent',
+]);
+
+console.log('[verify-index-many-link-aggregate-ordering] OK');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -10,6 +10,7 @@ const scripts = [
   'verify-index-postgres-query-compiler.mjs',
   'verify-index-query-result-decoder.mjs',
   'verify-index-many-link-filtering.mjs',
+  'verify-index-many-link-aggregate-ordering.mjs',
   'verify-index-query-snapshots.mjs',
   'verify-index-postgres-reference-equivalence.mjs',
   'verify-index-query-equivalence-capture.mjs',


### PR DESCRIPTION
## Summary

- add explicit serialized many-link order modes: `min_asc`, `min_desc`, `max_asc`, and `max_desc`
- keep ordinary `asc` / `desc` through `many` paths rejected as ambiguous
- preserve the existing `OrderExpr` shape and legacy Asc/Desc enum discriminants
- add aggregate-aware validation without changing legacy planner error mapping
- support only sortable scalar integer, string, and timestamp terminal fields
- keep Decimal and UUID aggregate ordering fail-closed pending exact wire/engine contracts
- require bounded offset pagination; aggregate cursor continuation remains rejected
- mark derived aggregate order values nullable for empty/all-null relation sets
- compile correlated typed PostgreSQL `MIN` / `MAX` scalar subqueries outside the outer root rowset
- retain tagged `IndexValue` JSONB order columns, explicit null ordering, and root entity-id tie-break
- add independent compiler guards for ordinary-many, singular-aggregate, unsupported-type, metadata-drift, and aggregate-cursor plans
- normalize test-only reference engine physical direction so new enum variants do not create exhaustive-match compile breaks
- add focused source tests, machine contract, static guard, unified verifier registration, CRATE API, and M4 documentation

## Recheck findings

The previous blanket rejection was correct for plain `asc` / `desc`: choosing the first related row, link ordinal, target identity, or storage order would create hidden semantics. This slice permits only caller-explicit `MIN` / `MAX` aggregation.

Decimal is deliberately excluded from this slice. The strict hidden order column must round-trip through the exact tagged `IndexValue` JSON representation, while the current PostgreSQL numeric JSON emission is not yet an admitted exact `rust_decimal` wire contract. Ordinary Decimal filters and root/one-link ordering are unchanged.

UUID aggregate ordering also remains fail-closed, and cursor support is excluded because it requires a separate stable cursor identity for a derived many-link value.

The aggregate relation is compiled as a correlated scalar subquery and never enters the outer root rowset. Root cardinality, exact count, and bounded offset pagination therefore remain duplicate free.

`main` advanced through unrelated Blog, Commerce, Forum, storefront-adapter, verifier, and Cargo.lock changes after branch creation. None of the 17 changed paths overlap those commits.

## Boundary

This PR does not run PostgreSQL, extend the retained PostgreSQL/reference scenario contract, enable Decimal or UUID aggregate ordering, enable aggregate cursor pagination, add caller SQL or implicit first-row ordering, change runtime composition, publish a new source schema, or cut over a consumer.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, Node tests/verifiers, workflows, benchmarks, capture/admission, or CI were run.

Suggested owner validation:

```bash
cargo test -p rustok-index aggregate_ordering -- --nocapture
cargo test -p rustok-index aggregate_ordering_tests -- --nocapture
cargo test -p rustok-index planner_tests -- --nocapture
cargo test -p rustok-index query_snapshot_tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo xtask module validate index
```
