### PR TITLE
feat(search): order Forum projections through durable inbox

### DIFF
--- a/crates/rustok-forum/contracts/forum-approved-reply-search.json
+++ b/crates/rustok-forum/contracts/forum-approved-reply-search.json
@@ -15,6 +15,7 @@
   "source_contract_test": "crates/rustok-search/tests/forum_approved_reply_projection_contract.rs",
   "owner_note": "crates/rustok-forum/docs/forum-20bo-approved-reply-search.md",
   "source_verifier": "scripts/verify/verify-forum-approved-reply-search.mjs",
+  "search_inbox_ordering_contract": "crates/rustok-forum/contracts/forum-search-inbox-ordering.json",
   "upstream_contracts": [
     "crates/rustok-forum/contracts/forum-graphql-query-snapshot-cleanup.json",
     "crates/rustok-forum/contracts/forum-search-projection.json",
@@ -63,10 +64,12 @@
     "topic_copy_or_category_context_change_refreshes_child_reply_documents": true,
     "reply_create_and_status_events_reuse_existing_topic_refresh": true,
     "reply_edit_publishes_owner_transactional_topic_invalidation": true,
+    "search_projection_inbox_added": true,
+    "consumer_envelope_revision_guard_added": true,
+    "out_of_order_owner_revision_guard_added": false,
     "new_root_domain_event_added": false,
     "new_reindex_target_string_added": false,
-    "out_of_order_owner_revision_guard_added": false,
-    "search_schema_migration_added": false
+    "search_schema_migration_added": true
   },
   "canonical_url_boundary": {
     "canonical_pair_required": true,
@@ -100,7 +103,7 @@
     "public_response_dto_changed": false,
     "workspace_dependency_changed": false,
     "cargo_lock_changed": false,
-    "migration_added": false,
+    "migration_added": true,
     "ffa_status_changed": false,
     "fba_status_changed": false,
     "legacy_graphql_snapshot_removed": true
@@ -114,28 +117,25 @@
     "canonical_plan_updated": false,
     "crate_api_updated": false,
     "search_plan_updated": false,
-    "synchronization_debt": "Advance Forum CRATE_API, Search local plan and the canonical FORUM-20/FORUM-23 ledger through FORUM-20BO with conflict-safe repository-local edits after maintainer validation."
+    "synchronization_debt": "Advance Forum CRATE_API, Search local plan and the canonical FORUM-20/FORUM-23 ledger through FORUM-20BP with conflict-safe repository-local edits after maintainer validation."
   },
   "remaining_scope": [
-    "add owner revision ordering and durable inbox reconciliation for category topic reply and future member projections under FORUM-23",
+    "add a host-owned startup or periodic due-inbox sweep for otherwise idle tenants under FORUM-20BQ",
+    "add owner-issued monotonic aggregate revisions if causal ordering must remain correct under cross-producer clock skew",
     "add safe author summaries and the planned category subtree author tag locale date solved kind channel group and attachment filters under FORUM-23",
+    "add Forum member projection documents after the safe public member identity contract is approved",
     "add storefront reply-anchor or focused-reply behavior only through a separate UI and route contract",
-    "capture maintainer-executed PostgreSQL full-rebuild failure preservation projection cleanup and approved-reply runtime evidence",
-    "capture maintainer-executed Search query runtime plus SQLite exact-visible bulk-read evidence",
-    "add an explicit Forum translation target invalidation adapter if Forum categories topics or replies are later registered with the translation control plane"
+    "capture maintainer-executed PostgreSQL projection ordering cleanup approved-reply and Search query evidence",
+    "capture maintainer-executed SQLite exact-visible bulk-read evidence"
   ],
-  "downstream_task": "FORUM-20BP",
+  "downstream_task": "FORUM-20BQ",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
+      "cargo test -p rustok-search --test forum_projection_inbox_contract -- --nocapture",
       "cargo test -p rustok-search --test forum_approved_reply_projection_contract -- --nocapture",
-      "cargo test -p rustok-search canonical_url_derives_forum_category_topic_and_reply_routes -- --nocapture",
-      "cargo test -p rustok-search forum_projector -- --nocapture",
+      "node scripts/verify/verify-forum-search-inbox-ordering.mjs",
       "node scripts/verify/verify-forum-approved-reply-search.mjs",
-      "node scripts/verify/verify-forum-search-projection.mjs",
-      "node scripts/verify/verify-forum-projection-invalidation.mjs",
-      "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
-      "node scripts/verify/verify-search-canonical-url-contract.mjs",
       "cargo xtask module validate forum"
     ]
   }

--- a/crates/rustok-forum/contracts/forum-approved-reply-search.json
+++ b/crates/rustok-forum/contracts/forum-approved-reply-search.json
@@ -69,7 +69,7 @@
     "out_of_order_owner_revision_guard_added": false,
     "new_root_domain_event_added": false,
     "new_reindex_target_string_added": false,
-    "search_schema_migration_added": true
+    "search_schema_migration_added": false
   },
   "canonical_url_boundary": {
     "canonical_pair_required": true,
@@ -103,7 +103,7 @@
     "public_response_dto_changed": false,
     "workspace_dependency_changed": false,
     "cargo_lock_changed": false,
-    "migration_added": true,
+    "migration_added": false,
     "ffa_status_changed": false,
     "fba_status_changed": false,
     "legacy_graphql_snapshot_removed": true
@@ -128,7 +128,7 @@
     "capture maintainer-executed PostgreSQL projection ordering cleanup approved-reply and Search query evidence",
     "capture maintainer-executed SQLite exact-visible bulk-read evidence"
   ],
-  "downstream_task": "FORUM-20BQ",
+  "downstream_task": "FORUM-20BP",
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [

--- a/crates/rustok-forum/contracts/forum-search-inbox-ordering.json
+++ b/crates/rustok-forum/contracts/forum-search-inbox-ordering.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-20BP",
+  "upstream_task": "FORUM-20BO",
+  "scope": "Persist and consumer-order Forum Search projection work so duplicate delayed and concurrently dispatched events cannot overwrite a newer accepted projection state when producer clocks are reasonably synchronized",
+  "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md#forum-23--searchindex-integration",
+  "approved_reply_contract": "crates/rustok-forum/contracts/forum-approved-reply-search.json",
+  "search_inbox_owner": "crates/rustok-search/src/forum_inbox.rs",
+  "search_ingestion_owner": "crates/rustok-search/src/ingestion.rs",
+  "migration": "crates/rustok-search/src/migrations/m20260730_000009_create_search_projection_inbox.rs",
+  "migration_registry": "crates/rustok-search/src/migrations/mod.rs",
+  "source_contract_test": "crates/rustok-search/tests/forum_projection_inbox_contract.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-20bp-search-inbox-ordering.md",
+  "source_verifier": "scripts/verify/verify-forum-search-inbox-ordering.mjs",
+  "storage_boundary": {
+    "search_owns_inbox_storage": true,
+    "search_projection_inbox_added": true,
+    "search_projection_watermarks_added": true,
+    "source_event_id_is_primary_dedupe_key": true,
+    "full_event_envelope_is_persisted": true,
+    "maximum_envelope_json_bytes": 65536,
+    "terminal_states": [
+      "completed",
+      "skipped",
+      "dead_letter"
+    ],
+    "retryable_state_recorded": true,
+    "attempt_count_and_next_attempt_recorded": true,
+    "maximum_attempts": 12,
+    "last_error_is_bounded": true,
+    "search_documents_schema_changed": false,
+    "forum_owner_storage_changed": false,
+    "second_platform_event_log_added": false
+  },
+  "revision_boundary": {
+    "revision_components": [
+      "event_envelope_timestamp_utc",
+      "event_id_ulid_backed_uuid"
+    ],
+    "ordering_is_timestamp_then_event_id": true,
+    "ordering_is_causal_owner_revision": false,
+    "producer_clock_synchronization_required": true,
+    "cross_producer_clock_skew_fully_resolved": false,
+    "source_domain_event_schema_changed": false,
+    "source_owner_revision_field_added": false,
+    "new_reindex_target_string_added": false,
+    "duplicate_event_id_is_idempotent": true,
+    "stale_or_equal_revision_is_skipped": true,
+    "invalid_stored_envelope_is_dead_lettered": true,
+    "category_scope_has_specific_watermark": true,
+    "category_completion_advances_full_scope_watermark": false,
+    "category_effective_watermark_includes_last_full_scope_watermark": true,
+    "full_scope_watermark_is_advanced_only_by_full_scope_work": true
+  },
+  "serialization_boundary": {
+    "postgresql_try_advisory_transaction_lock_added": true,
+    "lock_acquisition_is_non_blocking": true,
+    "lock_scope_is_tenant_wide_forum_projection": true,
+    "full_and_targeted_forum_operations_share_one_lock": true,
+    "candidate_order_is_oldest_revision_first": true,
+    "oldest_retry_backoff_blocks_newer_claims": true,
+    "inbox_row_is_selected_for_update_after_lock": true,
+    "watermark_is_checked_before_projection": true,
+    "projection_and_inbox_use_same_database_transaction": false,
+    "projection_finishes_before_watermark_commit": true,
+    "watermark_and_terminal_inbox_state_commit_atomically": true,
+    "competing_claims_release_database_connection_without_waiting": true,
+    "same_process_pool_starvation_by_waiting_claims_prevented": true,
+    "cross_process_serialization_remains_database_owned": true,
+    "older_topic_or_reply_event_cannot_overwrite_newer_module_disable": true
+  },
+  "recovery_boundary": {
+    "enqueue_commits_before_projection_claim": true,
+    "projection_failure_is_persisted_as_retryable": true,
+    "retry_backoff_seconds_minimum": 5,
+    "retry_backoff_seconds_maximum": 300,
+    "retry_exhaustion_is_dead_lettered": true,
+    "crash_before_claim_leaves_pending_work": true,
+    "crash_during_projection_rolls_back_processing_claim": true,
+    "crash_after_projection_before_terminal_commit_replays_idempotently": true,
+    "forum_event_delivery_runs_bounded_reconciliation": true,
+    "other_search_events_run_bounded_opportunistic_reconciliation": true,
+    "startup_reconciliation_sweep_added": false,
+    "idle_tenant_periodic_sweep_added": false,
+    "external_queue_or_scheduler_dependency_added": false
+  },
+  "event_scope_boundary": {
+    "full_scope_events": [
+      "ForumTopicCreated",
+      "ForumTopicReplied",
+      "ForumTopicStatusChanged",
+      "ForumTopicPinned",
+      "ForumReplyStatusChanged",
+      "Forum TenantModuleToggled",
+      "LocaleEnabled",
+      "LocaleDisabled",
+      "TenantCreated",
+      "TenantUpdated",
+      "search ReindexRequested",
+      "forum ReindexRequested",
+      "forum_topic ReindexRequested"
+    ],
+    "targeted_scope_events": [
+      "forum_category ReindexRequested"
+    ],
+    "automatic_topic_and_reply_events_rebuild_atomic_forum_scope": true,
+    "forum_module_disable_deletes_forum_scope": true,
+    "forum_category_reindex_remains_targeted": true,
+    "direct_forum_event_projection_bypass_remains": false
+  },
+  "compatibility": {
+    "existing_forum_rest_routes_changed": false,
+    "existing_forum_graphql_fields_changed": false,
+    "existing_search_query_contract_changed": false,
+    "public_response_dto_changed": false,
+    "workspace_root_dependency_changed": false,
+    "search_crate_runtime_dependency_changed": false,
+    "cargo_lock_changed": false,
+    "migration_added": true,
+    "postgresql_runtime_required_for_reconciliation": true,
+    "sqlite_schema_parity_added": true,
+    "ffa_status_changed": false,
+    "fba_status_changed": false
+  },
+  "documentation": {
+    "owner_note_added": true,
+    "contract_added": true,
+    "source_contract_test_added": true,
+    "source_verifier_added": true,
+    "canonical_plan_updated": false,
+    "crate_api_updated": false,
+    "search_plan_updated": false,
+    "synchronization_debt": "Advance Forum CRATE_API, Search local plan and the canonical FORUM-20/FORUM-23 ledger through FORUM-20BP with conflict-safe repository-local edits after maintainer validation."
+  },
+  "remaining_scope": [
+    "add a host-owned startup or periodic due-inbox sweep so an otherwise idle tenant does not require another Search-relevant event to retry pending Forum projection work",
+    "add owner-issued monotonic aggregate revisions if causal ordering must remain correct under cross-producer clock skew",
+    "add safe author summaries and the planned category subtree author tag locale date solved kind channel group and attachment filters under FORUM-23",
+    "add Forum member projection documents after the safe public member identity contract is approved",
+    "capture maintainer-executed PostgreSQL duplicate delayed-event retry crash-replay module-disable ordering multi-process and producer-clock-skew evidence",
+    "capture maintainer-executed PostgreSQL projection cleanup approved-reply and Search query evidence",
+    "capture maintainer-executed SQLite exact-visible bulk-read evidence"
+  ],
+  "downstream_task": "FORUM-20BQ",
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-search --test forum_projection_inbox_contract -- --nocapture",
+      "cargo test -p rustok-search forum_inbox -- --nocapture",
+      "cargo test -p rustok-search ingestion -- --nocapture",
+      "node scripts/verify/verify-forum-search-inbox-ordering.mjs",
+      "node scripts/verify/verify-forum-approved-reply-search.mjs",
+      "cargo xtask module validate forum"
+    ]
+  }
+}

--- a/crates/rustok-forum/docs/forum-20bp-search-inbox-ordering.md
+++ b/crates/rustok-forum/docs/forum-20bp-search-inbox-ordering.md
@@ -1,0 +1,80 @@
+# FORUM-20BP — Search inbox ordering and reconciliation
+
+## Decision
+
+FORUM-20BP adds Search-owned durable delivery state for Forum projection work. It does not add a second domain event log and does not change Forum event payloads. Search stores one replayable consumer row per existing platform event ID.
+
+The consumer revision is the existing envelope pair:
+
+1. UTC `EventEnvelope.timestamp`;
+2. ULID-backed UUID `EventEnvelope.id` as the deterministic tie breaker.
+
+This is a consumer ordering key, not an owner-issued causal revision. Correct ordering across independent producers still assumes reasonably synchronized clocks.
+
+## Durable owner
+
+The Search migration creates:
+
+- `search_projection_inbox`, deduplicated by source event ID;
+- `search_projection_watermarks`, keyed by tenant, source module and projection scope.
+
+Each inbox row stores the full envelope, scope, attempt count, retry time, bounded error and terminal state. `sys_events` and the outbox remain the platform event journal. Forum gains no Search table and `search_documents` is unchanged.
+
+## Scope and watermarks
+
+Topic/reply events, Forum module toggles, tenant/locale rebuild events and full Search/Forum reindex requests use the tenant-wide `forum` scope. A `forum_category` reindex keeps a category-specific watermark.
+
+Category stale checks compare both the category watermark and the last completed full-scope watermark. Completing a category refresh does **not** advance the full-scope watermark. This prevents a targeted refresh for one category from incorrectly suppressing delayed work for a different category while still ensuring an old category refresh cannot run after a newer full rebuild or module disable.
+
+## Claim serialization
+
+All Forum projection operations for one tenant share a PostgreSQL advisory transaction lock. Search uses `pg_try_advisory_xact_lock`, not the blocking lock:
+
+- one claimant keeps the transaction lock while its projector operation runs;
+- competing dispatcher tasks immediately release their connection and leave their durable row pending;
+- full and targeted Forum operations cannot execute concurrently;
+- waiting claim tasks cannot exhaust the connection pool needed by the projector.
+
+After taking the lock, Search selects the oldest non-terminal row with `FOR UPDATE`, ordered by `(revision_at, event_id)`. If that oldest row is in retry backoff, newer rows are not claimed. This is the strict retry barrier that prevents later work from overtaking a failed earlier projection.
+
+## Projection and commit boundary
+
+The existing Forum projector keeps its own Search transaction. The inbox transaction therefore does not atomically include document replacement, but it keeps the tenant advisory lock until completion:
+
+1. enqueue the complete envelope;
+2. acquire the non-blocking tenant Forum lock;
+3. select the oldest row;
+4. compare its effective watermark;
+5. run the existing projector;
+6. atomically commit the exact-scope watermark and terminal inbox state.
+
+The watermark advances only after projection succeeds.
+
+## Failure and replay
+
+- Crash before claim leaves `pending` work.
+- The `processing` update remains uncommitted while projection runs, so a crash rolls it back.
+- Crash after projector commit but before inbox commit replays the idempotent Forum replacement.
+- Projection errors use bounded exponential retry from 5 to 300 seconds.
+- After 12 attempts, the row becomes terminal `dead_letter`.
+- Duplicate event IDs do not create duplicate rows.
+- Stale or equal revisions become terminal `skipped`.
+- Malformed persisted envelopes become terminal `dead_letter`.
+
+Forum events run a bounded reconciliation batch immediately. Other Search-relevant events opportunistically process a smaller batch. This slice does **not** add a startup worker or idle-tenant periodic sweep, so retryable work for an otherwise idle tenant remains a FORUM-20BQ concern.
+
+## Compatibility
+
+The slice adds one Search migration but no new runtime crate dependency, workspace dependency or `Cargo.lock` change. Fresh `rustok-search` dependencies, including `rustok-content`, remain intact; Tokio stays dev-only. No Forum REST route, GraphQL field, public DTO, Search query contract, canonical result URL or FFA/FBA readiness status changes.
+
+PostgreSQL is required for runtime reconciliation. SQLite receives schema parity for migration/source-contract coverage only.
+
+The large canonical Forum plan, Forum `CRATE_API.md` and Search local plan remain conflict-sensitive synchronization debt.
+
+## Remaining work
+
+FORUM-20BQ should add a host-owned startup or periodic due-inbox sweep, or continue FORUM-23 with safe author summaries, member projections and filter contracts. Owner-issued monotonic revisions remain necessary if cross-producer clock skew must be resolved without assumptions.
+
+## Validation status
+
+No tests, Cargo commands, formatting, verifiers, workflows or CI were run by the implementation agent.

--- a/crates/rustok-search/src/forum_inbox.rs
+++ b/crates/rustok-search/src/forum_inbox.rs
@@ -1,0 +1,557 @@
+use std::cmp::Ordering;
+
+use chrono::{DateTime, Duration, Utc};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use uuid::Uuid;
+
+use rustok_core::{Error, Result};
+use rustok_events::{DomainEvent, EventEnvelope};
+
+const FORUM_SOURCE_MODULE: &str = "forum";
+const FULL_SCOPE_KEY: &str = "forum";
+const MAX_ERROR_CHARS: usize = 2_000;
+const MAX_ATTEMPTS: u32 = 12;
+const RETRY_BASE_SECONDS: i64 = 5;
+const RETRY_MAX_SECONDS: i64 = 300;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ForumProjectionScope {
+    Full,
+    Category(Uuid),
+}
+
+impl ForumProjectionScope {
+    pub(crate) fn for_event(event: &DomainEvent) -> Option<Self> {
+        match event {
+            DomainEvent::ForumTopicCreated { .. }
+            | DomainEvent::ForumTopicReplied { .. }
+            | DomainEvent::ForumTopicStatusChanged { .. }
+            | DomainEvent::ForumTopicPinned { .. }
+            | DomainEvent::ForumReplyStatusChanged { .. }
+            | DomainEvent::LocaleEnabled { .. }
+            | DomainEvent::LocaleDisabled { .. }
+            | DomainEvent::TenantCreated { .. }
+            | DomainEvent::TenantUpdated { .. } => Some(Self::Full),
+            DomainEvent::TenantModuleToggled { module_slug, .. } if module_slug == "forum" => {
+                Some(Self::Full)
+            }
+            DomainEvent::ReindexRequested {
+                target_type,
+                target_id,
+            } => match (target_type.as_str(), target_id) {
+                ("search", _) | ("forum", _) | ("forum_topic", Some(_)) => Some(Self::Full),
+                ("forum_category", Some(category_id)) => Some(Self::Category(*category_id)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn key(&self) -> String {
+        match self {
+            Self::Full => FULL_SCOPE_KEY.to_string(),
+            Self::Category(category_id) => format!("forum_category:{category_id}"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ForumProjectionInbox {
+    db: DatabaseConnection,
+}
+
+impl ForumProjectionInbox {
+    pub(crate) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub(crate) async fn enqueue(
+        &self,
+        envelope: &EventEnvelope,
+        scope: &ForumProjectionScope,
+    ) -> Result<()> {
+        let backend = self.db.get_database_backend();
+        let sql = match backend {
+            DbBackend::Postgres => {
+                r#"
+                INSERT INTO search_projection_inbox (
+                    event_id, tenant_id, source_module, scope_key, event_type,
+                    revision_at, envelope_json, status, attempt_count, created_at, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ON CONFLICT (event_id) DO NOTHING
+                "#
+            }
+            DbBackend::Sqlite => {
+                r#"
+                INSERT INTO search_projection_inbox (
+                    event_id, tenant_id, source_module, scope_key, event_type,
+                    revision_at, envelope_json, status, attempt_count, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ON CONFLICT (event_id) DO NOTHING
+                "#
+            }
+            other => {
+                return Err(Error::External(format!(
+                    "Forum projection inbox does not support database backend {other:?}"
+                )));
+            }
+        };
+        let envelope_json = serde_json::to_value(envelope)?;
+        self.db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                sql,
+                vec![
+                    envelope.id.into(),
+                    envelope.tenant_id.into(),
+                    FORUM_SOURCE_MODULE.into(),
+                    scope.key().into(),
+                    envelope.event_type.clone().into(),
+                    envelope.timestamp.to_owned().into(),
+                    SqlValue::Json(Some(Box::new(envelope_json))),
+                ],
+            ))
+            .await
+            .map_err(Error::Database)?;
+        Ok(())
+    }
+
+    /// Claims the oldest non-terminal event. A retry backoff on that event
+    /// blocks newer work, so a later projection cannot overtake it.
+    pub(crate) async fn claim_next(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Option<ForumProjectionInboxClaim>> {
+        self.ensure_postgres()?;
+
+        loop {
+            let transaction = self.db.begin().await.map_err(Error::Database)?;
+            acquire_tenant_lock(&transaction, tenant_id).await?;
+            let row = transaction
+                .query_one(Statement::from_sql_and_values(
+                    DbBackend::Postgres,
+                    r#"
+                    SELECT event_id, scope_key, revision_at, envelope_json,
+                           status, attempt_count, next_attempt_at
+                    FROM search_projection_inbox
+                    WHERE tenant_id = $1
+                      AND source_module = 'forum'
+                      AND status IN ('pending', 'retryable_error')
+                    ORDER BY revision_at ASC, event_id ASC
+                    LIMIT 1
+                    FOR UPDATE
+                    "#,
+                    vec![tenant_id.into()],
+                ))
+                .await
+                .map_err(Error::Database)?;
+            let Some(row) = row else {
+                transaction.commit().await.map_err(Error::Database)?;
+                return Ok(None);
+            };
+
+            let event_id: Uuid = row.try_get("", "event_id").map_err(Error::Database)?;
+            let scope_key: String = row.try_get("", "scope_key").map_err(Error::Database)?;
+            let revision_at: DateTime<Utc> =
+                row.try_get("", "revision_at").map_err(Error::Database)?;
+            let envelope_json: serde_json::Value =
+                row.try_get("", "envelope_json").map_err(Error::Database)?;
+            let status: String = row.try_get("", "status").map_err(Error::Database)?;
+            let attempt_count: i32 = row.try_get("", "attempt_count").map_err(Error::Database)?;
+            let next_attempt_at: Option<DateTime<Utc>> = row
+                .try_get("", "next_attempt_at")
+                .map_err(Error::Database)?;
+
+            if status == "retryable_error"
+                && next_attempt_at.is_some_and(|due_at| due_at > Utc::now())
+            {
+                transaction.commit().await.map_err(Error::Database)?;
+                return Ok(None);
+            }
+
+            if let Some((watermark_at, watermark_event_id)) =
+                load_effective_watermark(&transaction, tenant_id, &scope_key).await?
+                && !is_newer_revision(
+                    &revision_at,
+                    event_id,
+                    &watermark_at,
+                    watermark_event_id,
+                )
+            {
+                mark_terminal(
+                    &transaction,
+                    event_id,
+                    "skipped",
+                    Some("stale_revision"),
+                )
+                .await?;
+                transaction.commit().await.map_err(Error::Database)?;
+                continue;
+            }
+
+            let envelope: EventEnvelope = match serde_json::from_value(envelope_json) {
+                Ok(envelope) => envelope,
+                Err(error) => {
+                    let message = bounded_error(&error.to_string());
+                    mark_terminal(&transaction, event_id, "dead_letter", Some(&message)).await?;
+                    transaction.commit().await.map_err(Error::Database)?;
+                    continue;
+                }
+            };
+            let scope_matches = ForumProjectionScope::for_event(&envelope.event)
+                .map(|scope| scope.key() == scope_key)
+                .unwrap_or(false);
+            if envelope.id != event_id
+                || envelope.tenant_id != tenant_id
+                || envelope.timestamp != revision_at
+                || !scope_matches
+            {
+                mark_terminal(
+                    &transaction,
+                    event_id,
+                    "dead_letter",
+                    Some("stored envelope identity does not match inbox identity"),
+                )
+                .await?;
+                transaction.commit().await.map_err(Error::Database)?;
+                continue;
+            }
+
+            transaction
+                .execute(Statement::from_sql_and_values(
+                    DbBackend::Postgres,
+                    r#"
+                    UPDATE search_projection_inbox
+                    SET status = 'processing',
+                        attempt_count = attempt_count + 1,
+                        next_attempt_at = NULL,
+                        last_error = NULL,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE event_id = $1
+                    "#,
+                    vec![event_id.into()],
+                ))
+                .await
+                .map_err(Error::Database)?;
+
+            return Ok(Some(ForumProjectionInboxClaim {
+                transaction,
+                event_id,
+                tenant_id,
+                scope_key,
+                revision_at,
+                envelope,
+                attempt: attempt_count.saturating_add(1).max(1) as u32,
+            }));
+        }
+    }
+
+    fn ensure_postgres(&self) -> Result<()> {
+        if self.db.get_database_backend() == DbBackend::Postgres {
+            Ok(())
+        } else {
+            Err(Error::External(
+                "Forum projection inbox reconciliation requires PostgreSQL".to_string(),
+            ))
+        }
+    }
+}
+
+pub(crate) struct ForumProjectionInboxClaim {
+    transaction: DatabaseTransaction,
+    event_id: Uuid,
+    tenant_id: Uuid,
+    scope_key: String,
+    revision_at: DateTime<Utc>,
+    envelope: EventEnvelope,
+    attempt: u32,
+}
+
+impl ForumProjectionInboxClaim {
+    pub(crate) fn envelope(&self) -> &EventEnvelope {
+        &self.envelope
+    }
+
+    pub(crate) async fn complete(self) -> Result<()> {
+        self.transaction
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+                INSERT INTO search_projection_watermarks (
+                    tenant_id, source_module, scope_key, revision_at, event_id, updated_at
+                ) VALUES ($1, 'forum', $2, $3, $4, CURRENT_TIMESTAMP)
+                ON CONFLICT (tenant_id, source_module, scope_key)
+                DO UPDATE SET
+                    revision_at = EXCLUDED.revision_at,
+                    event_id = EXCLUDED.event_id,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE search_projection_watermarks.revision_at < EXCLUDED.revision_at
+                   OR (
+                        search_projection_watermarks.revision_at = EXCLUDED.revision_at
+                        AND search_projection_watermarks.event_id < EXCLUDED.event_id
+                   )
+                "#,
+                vec![
+                    self.tenant_id.into(),
+                    self.scope_key.into(),
+                    self.revision_at.into(),
+                    self.event_id.into(),
+                ],
+            ))
+            .await
+            .map_err(Error::Database)?;
+        mark_terminal(&self.transaction, self.event_id, "completed", None).await?;
+        self.transaction.commit().await.map_err(Error::Database)?;
+        Ok(())
+    }
+
+    pub(crate) async fn retry(self, error: &Error) -> Result<()> {
+        let message = bounded_error(&error.to_string());
+        if self.attempt >= MAX_ATTEMPTS {
+            let exhausted = bounded_error(&format!("retry_exhausted: {message}"));
+            mark_terminal(
+                &self.transaction,
+                self.event_id,
+                "dead_letter",
+                Some(&exhausted),
+            )
+            .await?;
+            self.transaction.commit().await.map_err(Error::Database)?;
+            return Ok(());
+        }
+
+        let next_attempt_at = Utc::now() + Duration::seconds(retry_delay_seconds(self.attempt));
+        self.transaction
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+                UPDATE search_projection_inbox
+                SET status = 'retryable_error',
+                    next_attempt_at = $2,
+                    last_error = $3,
+                    completed_at = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE event_id = $1
+                "#,
+                vec![self.event_id.into(), next_attempt_at.into(), message.into()],
+            ))
+            .await
+            .map_err(Error::Database)?;
+        self.transaction.commit().await.map_err(Error::Database)?;
+        Ok(())
+    }
+}
+
+async fn acquire_tenant_lock(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+) -> Result<()> {
+    let lock_key = format!("search:{FORUM_SOURCE_MODULE}:{tenant_id}:{FULL_SCOPE_KEY}");
+    transaction
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            vec![lock_key.into()],
+        ))
+        .await
+        .map_err(Error::Database)?;
+    Ok(())
+}
+
+async fn load_effective_watermark(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    scope_key: &str,
+) -> Result<Option<(DateTime<Utc>, Uuid)>> {
+    let scope_watermark = load_watermark(transaction, tenant_id, scope_key).await?;
+    if scope_key == FULL_SCOPE_KEY {
+        return Ok(scope_watermark);
+    }
+    let full_scope_watermark = load_watermark(transaction, tenant_id, FULL_SCOPE_KEY).await?;
+    Ok(max_watermark(scope_watermark, full_scope_watermark))
+}
+
+async fn load_watermark(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    scope_key: &str,
+) -> Result<Option<(DateTime<Utc>, Uuid)>> {
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT revision_at, event_id
+            FROM search_projection_watermarks
+            WHERE tenant_id = $1
+              AND source_module = 'forum'
+              AND scope_key = $2
+            "#,
+            vec![tenant_id.into(), scope_key.to_string().into()],
+        ))
+        .await
+        .map_err(Error::Database)?;
+    row.map(|row| {
+        Ok((
+            row.try_get("", "revision_at").map_err(Error::Database)?,
+            row.try_get("", "event_id").map_err(Error::Database)?,
+        ))
+    })
+    .transpose()
+}
+
+async fn mark_terminal(
+    transaction: &DatabaseTransaction,
+    event_id: Uuid,
+    status: &str,
+    last_error: Option<&str>,
+) -> Result<()> {
+    transaction
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            UPDATE search_projection_inbox
+            SET status = $2,
+                next_attempt_at = NULL,
+                last_error = $3,
+                completed_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE event_id = $1
+            "#,
+            vec![
+                event_id.into(),
+                status.to_string().into(),
+                last_error.map(str::to_string).into(),
+            ],
+        ))
+        .await
+        .map_err(Error::Database)?;
+    Ok(())
+}
+
+fn max_watermark(
+    left: Option<(DateTime<Utc>, Uuid)>,
+    right: Option<(DateTime<Utc>, Uuid)>,
+) -> Option<(DateTime<Utc>, Uuid)> {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            if is_newer_revision(&left.0, left.1, &right.0, right.1) {
+                Some(left)
+            } else {
+                Some(right)
+            }
+        }
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn is_newer_revision(
+    incoming_at: &DateTime<Utc>,
+    incoming_event_id: Uuid,
+    watermark_at: &DateTime<Utc>,
+    watermark_event_id: Uuid,
+) -> bool {
+    match incoming_at.cmp(watermark_at) {
+        Ordering::Greater => true,
+        Ordering::Less => false,
+        Ordering::Equal => incoming_event_id.as_bytes() > watermark_event_id.as_bytes(),
+    }
+}
+
+fn retry_delay_seconds(attempt: u32) -> i64 {
+    let exponent = attempt.saturating_sub(1).min(16);
+    RETRY_BASE_SECONDS
+        .saturating_mul(2_i64.saturating_pow(exponent))
+        .min(RETRY_MAX_SECONDS)
+}
+
+fn bounded_error(value: &str) -> String {
+    value.chars().take(MAX_ERROR_CHARS).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forum_scope_groups_full_rebuild_events() {
+        let topic_id = Uuid::new_v4();
+        let category_id = Uuid::new_v4();
+        for event in [
+            DomainEvent::ForumTopicCreated {
+                topic_id,
+                category_id,
+                author_id: None,
+                locale: "en".to_string(),
+            },
+            DomainEvent::ForumReplyStatusChanged {
+                reply_id: Uuid::new_v4(),
+                topic_id,
+                old_status: "pending".to_string(),
+                new_status: "approved".to_string(),
+                moderator_id: None,
+            },
+            DomainEvent::TenantModuleToggled {
+                tenant_id: Uuid::new_v4(),
+                module_slug: "forum".to_string(),
+                enabled: false,
+            },
+            DomainEvent::ReindexRequested {
+                target_type: "search".to_string(),
+                target_id: None,
+            },
+        ] {
+            assert_eq!(
+                ForumProjectionScope::for_event(&event),
+                Some(ForumProjectionScope::Full)
+            );
+        }
+    }
+
+    #[test]
+    fn category_reindex_has_independent_watermark_scope() {
+        let category_id = Uuid::new_v4();
+        assert_eq!(
+            ForumProjectionScope::for_event(&DomainEvent::ReindexRequested {
+                target_type: "forum_category".to_string(),
+                target_id: Some(category_id),
+            }),
+            Some(ForumProjectionScope::Category(category_id))
+        );
+    }
+
+    #[test]
+    fn revision_order_uses_timestamp_then_event_identity() {
+        let timestamp = Utc::now();
+        let low = Uuid::from_u128(1);
+        let high = Uuid::from_u128(2);
+        assert!(is_newer_revision(&timestamp, high, &timestamp, low));
+        assert!(!is_newer_revision(&timestamp, low, &timestamp, high));
+        assert!(is_newer_revision(
+            &(timestamp.to_owned() + Duration::microseconds(1)),
+            low,
+            &timestamp,
+            high
+        ));
+    }
+
+    #[test]
+    fn effective_watermark_prefers_newest_revision() {
+        let timestamp = Utc::now();
+        let low = (timestamp.to_owned(), Uuid::from_u128(1));
+        let high = (
+            timestamp.to_owned() + Duration::microseconds(1),
+            Uuid::from_u128(2),
+        );
+        assert_eq!(max_watermark(Some(low), Some(high.to_owned())), Some(high));
+    }
+
+    #[test]
+    fn retry_backoff_is_bounded() {
+        assert_eq!(retry_delay_seconds(1), RETRY_BASE_SECONDS);
+        assert_eq!(retry_delay_seconds(100), RETRY_MAX_SECONDS);
+    }
+}

--- a/crates/rustok-search/src/forum_inbox.rs
+++ b/crates/rustok-search/src/forum_inbox.rs
@@ -120,7 +120,9 @@ impl ForumProjectionInbox {
     }
 
     /// Claims the oldest non-terminal event. A retry backoff on that event
-    /// blocks newer work, so a later projection cannot overtake it.
+    /// blocks newer work, so a later projection cannot overtake it. Claim lock
+    /// acquisition is non-blocking so competing dispatcher tasks do not occupy
+    /// the whole connection pool while one projector operation is in flight.
     pub(crate) async fn claim_next(
         &self,
         tenant_id: Uuid,
@@ -129,7 +131,10 @@ impl ForumProjectionInbox {
 
         loop {
             let transaction = self.db.begin().await.map_err(Error::Database)?;
-            acquire_tenant_lock(&transaction, tenant_id).await?;
+            if !try_acquire_tenant_lock(&transaction, tenant_id).await? {
+                transaction.commit().await.map_err(Error::Database)?;
+                return Ok(None);
+            }
             let row = transaction
                 .query_one(Statement::from_sql_and_values(
                     DbBackend::Postgres,
@@ -345,20 +350,21 @@ impl ForumProjectionInboxClaim {
     }
 }
 
-async fn acquire_tenant_lock(
+async fn try_acquire_tenant_lock(
     transaction: &DatabaseTransaction,
     tenant_id: Uuid,
-) -> Result<()> {
+) -> Result<bool> {
     let lock_key = format!("search:{FORUM_SOURCE_MODULE}:{tenant_id}:{FULL_SCOPE_KEY}");
-    transaction
+    let row = transaction
         .query_one(Statement::from_sql_and_values(
             DbBackend::Postgres,
-            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            "SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0)) AS acquired",
             vec![lock_key.into()],
         ))
         .await
-        .map_err(Error::Database)?;
-    Ok(())
+        .map_err(Error::Database)?
+        .ok_or_else(|| Error::External("PostgreSQL advisory lock returned no row".to_string()))?;
+    row.try_get("", "acquired").map_err(Error::Database)
 }
 
 async fn load_effective_watermark(

--- a/crates/rustok-search/src/ingestion.rs
+++ b/crates/rustok-search/src/ingestion.rs
@@ -13,15 +13,20 @@ use rustok_telemetry::metrics;
 use tracing::Instrument;
 
 use crate::blog_projector::BlogSearchProjector;
+use crate::forum_inbox::{ForumProjectionInbox, ForumProjectionScope};
 use crate::forum_projector::ForumSearchProjector;
 use crate::projector::SearchProjector;
 use crate::SearchProjectionSource;
+
+const FORUM_INBOX_EVENT_BATCH: usize = 64;
+const FORUM_INBOX_OPPORTUNISTIC_BATCH: usize = 8;
 
 #[derive(Clone)]
 pub struct SearchIngestionHandler {
     projector: SearchProjector,
     blog_projector: BlogSearchProjector,
     forum_projector: Option<ForumSearchProjector>,
+    forum_inbox: Option<ForumProjectionInbox>,
 }
 
 impl SearchIngestionHandler {
@@ -33,11 +38,16 @@ impl SearchIngestionHandler {
         db: DatabaseConnection,
         forum_source: Option<Arc<dyn SearchProjectionSource>>,
     ) -> Self {
+        let forum_projector = forum_source
+            .map(|source| ForumSearchProjector::new(db.clone(), source));
+        let forum_inbox = forum_projector
+            .as_ref()
+            .map(|_| ForumProjectionInbox::new(db.clone()));
         Self {
             projector: SearchProjector::new(db.clone()),
-            blog_projector: BlogSearchProjector::new(db.clone()),
-            forum_projector: forum_source
-                .map(|source| ForumSearchProjector::new(db, source)),
+            blog_projector: BlogSearchProjector::new(db),
+            forum_projector,
+            forum_inbox,
         }
     }
 
@@ -66,26 +76,6 @@ impl SearchIngestionHandler {
             ("product", None) => self.projector.rebuild_product_scope(tenant_id).await,
             ("blog", Some(post_id)) => self.blog_projector.upsert_post(tenant_id, post_id).await,
             ("blog", None) => self.blog_projector.rebuild_tenant(tenant_id).await,
-            ("forum", None) => match &self.forum_projector {
-                Some(projector) => projector.rebuild_tenant(tenant_id).await,
-                None => Ok(()),
-            },
-            ("forum_category", Some(category_id)) => match &self.forum_projector {
-                Some(projector) => {
-                    projector
-                        .refresh_entity(tenant_id, "forum_category", category_id)
-                        .await
-                }
-                None => Ok(()),
-            },
-            ("forum_topic", Some(topic_id)) => match &self.forum_projector {
-                Some(projector) => {
-                    projector
-                        .refresh_entity(tenant_id, "forum_topic", topic_id)
-                        .await
-                }
-                None => Ok(()),
-            },
             _ => Ok(()),
         }
     }
@@ -107,6 +97,71 @@ impl SearchIngestionHandler {
         } else {
             projector.delete_tenant(tenant_id).await
         }
+    }
+
+    async fn apply_forum_inbox_event(&self, envelope: &EventEnvelope) -> HandlerResult {
+        let Some(projector) = &self.forum_projector else {
+            return Ok(());
+        };
+        match &envelope.event {
+            DomainEvent::ForumTopicCreated { .. }
+            | DomainEvent::ForumTopicReplied { .. }
+            | DomainEvent::ForumTopicStatusChanged { .. }
+            | DomainEvent::ForumTopicPinned { .. }
+            | DomainEvent::ForumReplyStatusChanged { .. } => {
+                projector.rebuild_tenant(envelope.tenant_id).await
+            }
+            DomainEvent::TenantModuleToggled {
+                module_slug,
+                enabled,
+                ..
+            } if module_slug == "forum" => {
+                self.handle_forum_module_toggle(envelope.tenant_id, *enabled)
+                    .await
+            }
+            DomainEvent::LocaleEnabled { .. }
+            | DomainEvent::LocaleDisabled { .. }
+            | DomainEvent::TenantCreated { .. }
+            | DomainEvent::TenantUpdated { .. } => self.rebuild_tenant(envelope.tenant_id).await,
+            DomainEvent::ReindexRequested {
+                target_type,
+                target_id,
+            } => match (target_type.as_str(), target_id) {
+                ("search", _) => self.rebuild_tenant(envelope.tenant_id).await,
+                ("forum", _) | ("forum_topic", Some(_)) => {
+                    projector.rebuild_tenant(envelope.tenant_id).await
+                }
+                ("forum_category", Some(category_id)) => {
+                    projector
+                        .refresh_entity(envelope.tenant_id, "forum_category", *category_id)
+                        .await
+                }
+                _ => Ok(()),
+            },
+            _ => Err(Error::Validation(format!(
+                "Unsupported Forum projection inbox event `{}`",
+                envelope.event.event_type()
+            ))),
+        }
+    }
+
+    async fn reconcile_forum_inbox(&self, tenant_id: Uuid, limit: usize) -> HandlerResult {
+        let Some(inbox) = &self.forum_inbox else {
+            return Ok(());
+        };
+        for _ in 0..limit {
+            let Some(claim) = inbox.claim_next(tenant_id).await? else {
+                break;
+            };
+            match self.apply_forum_inbox_event(claim.envelope()).await {
+                Ok(()) => claim.complete().await?,
+                Err(error) => {
+                    claim.retry(&error).await?;
+                    return Err(error);
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -186,6 +241,31 @@ impl EventHandler for SearchIngestionHandler {
         );
 
         async {
+            if let Some(scope) = ForumProjectionScope::for_event(&envelope.event)
+                && let Some(inbox) = &self.forum_inbox
+            {
+                inbox.enqueue(envelope, &scope).await?;
+                return self
+                    .reconcile_forum_inbox(envelope.tenant_id, FORUM_INBOX_EVENT_BATCH)
+                    .await;
+            }
+
+            if self.forum_inbox.is_some()
+                && let Err(error) = self
+                    .reconcile_forum_inbox(
+                        envelope.tenant_id,
+                        FORUM_INBOX_OPPORTUNISTIC_BATCH,
+                    )
+                    .await
+            {
+                tracing::warn!(
+                    tenant_id = %envelope.tenant_id,
+                    event_id = %envelope.id,
+                    error = %error,
+                    "Forum projection inbox opportunistic reconciliation failed"
+                );
+            }
+
             match &envelope.event {
                 DomainEvent::NodeCreated { node_id, .. }
                 | DomainEvent::NodeUpdated { node_id, .. }
@@ -252,34 +332,12 @@ impl EventHandler for SearchIngestionHandler {
                         .delete_post(envelope.tenant_id, *post_id)
                         .await
                 }
-                DomainEvent::ForumTopicCreated { topic_id, .. }
-                | DomainEvent::ForumTopicReplied { topic_id, .. }
-                | DomainEvent::ForumTopicStatusChanged { topic_id, .. }
-                | DomainEvent::ForumTopicPinned { topic_id, .. }
-                | DomainEvent::ForumReplyStatusChanged { topic_id, .. } => {
-                    match &self.forum_projector {
-                        Some(projector) => {
-                            projector
-                                .refresh_entity(envelope.tenant_id, "forum_topic", *topic_id)
-                                .await
-                        }
-                        None => Ok(()),
-                    }
-                }
                 DomainEvent::TenantModuleToggled {
                     module_slug,
                     enabled,
                     ..
                 } if module_slug == "blog" => {
                     self.handle_blog_module_toggle(envelope.tenant_id, *enabled)
-                        .await
-                }
-                DomainEvent::TenantModuleToggled {
-                    module_slug,
-                    enabled,
-                    ..
-                } if module_slug == "forum" => {
-                    self.handle_forum_module_toggle(envelope.tenant_id, *enabled)
                         .await
                 }
                 DomainEvent::LocaleEnabled { .. }
@@ -405,8 +463,8 @@ fn projector_operation_for_event(event: &DomainEvent) -> &'static str {
             "content" => "rebuild_content_scope",
             "product" => "rebuild_product_scope",
             "blog" => "rebuild_blog_scope",
-            "forum" => "rebuild_forum_scope",
-            "forum_category" | "forum_topic" => "refresh_forum_entity",
+            "forum" | "forum_topic" => "rebuild_forum_scope",
+            "forum_category" => "refresh_forum_category",
             _ => "rebuild_tenant",
         },
         DomainEvent::TenantModuleToggled {
@@ -435,7 +493,7 @@ fn projector_operation_for_event(event: &DomainEvent) -> &'static str {
         | DomainEvent::ForumTopicReplied { .. }
         | DomainEvent::ForumTopicStatusChanged { .. }
         | DomainEvent::ForumTopicPinned { .. }
-        | DomainEvent::ForumReplyStatusChanged { .. } => "refresh_forum_entity",
+        | DomainEvent::ForumReplyStatusChanged { .. } => "rebuild_forum_scope",
         DomainEvent::NodeTranslationUpdated { .. } | DomainEvent::BodyUpdated { .. } => {
             "upsert_node_locale"
         }

--- a/crates/rustok-search/src/lib.rs
+++ b/crates/rustok-search/src/lib.rs
@@ -10,6 +10,7 @@ mod blog_projector;
 pub mod diagnostics;
 pub mod dictionaries;
 pub mod engine;
+mod forum_inbox;
 mod forum_projector;
 #[cfg(feature = "graphql")]
 pub mod graphql;

--- a/crates/rustok-search/src/migrations/m20260730_000009_create_search_projection_inbox.rs
+++ b/crates/rustok-search/src/migrations/m20260730_000009_create_search_projection_inbox.rs
@@ -1,0 +1,145 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_UP)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => manager
+                .get_connection()
+                .execute_unprepared(SQLITE_UP)
+                .await
+                .map(|_| ()),
+            backend => Err(DbErr::Custom(format!(
+                "search projection inbox does not support database backend {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DROP TABLE IF EXISTS search_projection_watermarks;
+                DROP TABLE IF EXISTS search_projection_inbox;
+                "#,
+            )
+            .await
+            .map(|_| ())
+    }
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS search_projection_inbox (
+    event_id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    source_module VARCHAR(64) NOT NULL,
+    scope_key VARCHAR(191) NOT NULL,
+    event_type VARCHAR(128) NOT NULL,
+    revision_at TIMESTAMPTZ NOT NULL,
+    envelope_json JSONB NOT NULL,
+    status VARCHAR(24) NOT NULL DEFAULT 'pending',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NULL,
+    last_error VARCHAR(2000) NULL,
+    completed_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_search_projection_inbox_identity CHECK (
+        btrim(source_module) <> '' AND btrim(scope_key) <> '' AND btrim(event_type) <> ''
+    ),
+    CONSTRAINT ck_search_projection_inbox_status CHECK (
+        status IN ('pending', 'processing', 'completed', 'skipped', 'retryable_error', 'dead_letter')
+    ),
+    CONSTRAINT ck_search_projection_inbox_attempt CHECK (attempt_count >= 0),
+    CONSTRAINT ck_search_projection_inbox_completion CHECK (
+        (status IN ('completed', 'skipped', 'dead_letter') AND completed_at IS NOT NULL)
+        OR (status NOT IN ('completed', 'skipped', 'dead_letter') AND completed_at IS NULL)
+    ),
+    CONSTRAINT ck_search_projection_inbox_payload CHECK (
+        jsonb_typeof(envelope_json) = 'object'
+        AND octet_length(envelope_json::text) <= 65536
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_projection_inbox_due
+    ON search_projection_inbox (
+        tenant_id, source_module, status, revision_at, event_id, next_attempt_at
+    );
+CREATE INDEX IF NOT EXISTS idx_search_projection_inbox_scope
+    ON search_projection_inbox (
+        tenant_id, source_module, scope_key, revision_at, event_id
+    );
+
+CREATE TABLE IF NOT EXISTS search_projection_watermarks (
+    tenant_id UUID NOT NULL,
+    source_module VARCHAR(64) NOT NULL,
+    scope_key VARCHAR(191) NOT NULL,
+    revision_at TIMESTAMPTZ NOT NULL,
+    event_id UUID NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, source_module, scope_key),
+    CONSTRAINT ck_search_projection_watermark_identity CHECK (
+        btrim(source_module) <> '' AND btrim(scope_key) <> ''
+    )
+);
+"#;
+
+const SQLITE_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS search_projection_inbox (
+    event_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    source_module TEXT NOT NULL,
+    scope_key TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    revision_at TEXT NOT NULL,
+    envelope_json TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT NULL,
+    last_error TEXT NULL,
+    completed_at TEXT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (length(trim(source_module)) > 0),
+    CHECK (length(trim(scope_key)) > 0),
+    CHECK (length(trim(event_type)) > 0),
+    CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'retryable_error', 'dead_letter')),
+    CHECK (attempt_count >= 0),
+    CHECK (
+        (status IN ('completed', 'skipped', 'dead_letter') AND completed_at IS NOT NULL)
+        OR (status NOT IN ('completed', 'skipped', 'dead_letter') AND completed_at IS NULL)
+    ),
+    CHECK (json_valid(envelope_json) AND length(envelope_json) <= 65536)
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_projection_inbox_due
+    ON search_projection_inbox (
+        tenant_id, source_module, status, revision_at, event_id, next_attempt_at
+    );
+CREATE INDEX IF NOT EXISTS idx_search_projection_inbox_scope
+    ON search_projection_inbox (
+        tenant_id, source_module, scope_key, revision_at, event_id
+    );
+
+CREATE TABLE IF NOT EXISTS search_projection_watermarks (
+    tenant_id TEXT NOT NULL,
+    source_module TEXT NOT NULL,
+    scope_key TEXT NOT NULL,
+    revision_at TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, source_module, scope_key),
+    CHECK (length(trim(source_module)) > 0),
+    CHECK (length(trim(scope_key)) > 0)
+);
+"#;

--- a/crates/rustok-search/src/migrations/mod.rs
+++ b/crates/rustok-search/src/migrations/mod.rs
@@ -5,6 +5,7 @@ mod m20260325_000004_create_search_query_clicks;
 mod m20260325_000005_create_search_dictionaries;
 mod m20260325_000006_add_search_typo_tolerance_indexes;
 mod m20260721_000008_expand_search_query_locale_storage;
+mod m20260730_000009_create_search_projection_inbox;
 
 use sea_orm_migration::MigrationTrait;
 
@@ -17,5 +18,6 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260325_000005_create_search_dictionaries::Migration),
         Box::new(m20260325_000006_add_search_typo_tolerance_indexes::Migration),
         Box::new(m20260721_000008_expand_search_query_locale_storage::Migration),
+        Box::new(m20260730_000009_create_search_projection_inbox::Migration),
     ]
 }

--- a/crates/rustok-search/tests/forum_projection_inbox_contract.rs
+++ b/crates/rustok-search/tests/forum_projection_inbox_contract.rs
@@ -43,7 +43,8 @@ fn forum_events_are_strictly_ordered_by_envelope_revision() {
         "FOR UPDATE",
         "due_at > Utc::now()",
         "return Ok(None)",
-        "pg_advisory_xact_lock(hashtextextended($1, 0))",
+        "pg_try_advisory_xact_lock(hashtextextended($1, 0))",
+        "AS acquired",
         "search:{FORUM_SOURCE_MODULE}:{tenant_id}:{FULL_SCOPE_KEY}",
         "load_effective_watermark",
         "load_watermark(transaction, tenant_id, FULL_SCOPE_KEY)",
@@ -56,6 +57,7 @@ fn forum_events_are_strictly_ordered_by_envelope_revision() {
     ] {
         require(INBOX, marker);
     }
+    reject(INBOX, "pg_advisory_xact_lock(");
     reject(INBOX, "OnceLock");
     reject(INBOX, "OwnedMutexGuard");
     reject(INBOX, "SystemTime::now");

--- a/crates/rustok-search/tests/forum_projection_inbox_contract.rs
+++ b/crates/rustok-search/tests/forum_projection_inbox_contract.rs
@@ -1,0 +1,93 @@
+const INBOX: &str = include_str!("../src/forum_inbox.rs");
+const INGESTION: &str = include_str!("../src/ingestion.rs");
+const MIGRATION: &str =
+    include_str!("../src/migrations/m20260730_000009_create_search_projection_inbox.rs");
+const MIGRATION_REGISTRY: &str = include_str!("../src/migrations/mod.rs");
+const MANIFEST: &str = include_str!("../Cargo.toml");
+const LIB: &str = include_str!("../src/lib.rs");
+
+fn require(source: &str, marker: &str) {
+    assert!(source.contains(marker), "missing source marker: {marker}");
+}
+
+fn reject(source: &str, marker: &str) {
+    assert!(!source.contains(marker), "forbidden source marker: {marker}");
+}
+
+#[test]
+fn durable_inbox_stores_replayable_envelopes_and_terminal_state() {
+    for marker in [
+        "CREATE TABLE IF NOT EXISTS search_projection_inbox",
+        "event_id UUID PRIMARY KEY",
+        "envelope_json JSONB NOT NULL",
+        "'retryable_error'",
+        "'dead_letter'",
+        "CREATE TABLE IF NOT EXISTS search_projection_watermarks",
+        "PRIMARY KEY (tenant_id, source_module, scope_key)",
+        "idx_search_projection_inbox_due",
+    ] {
+        require(MIGRATION, marker);
+    }
+    reject(MIGRATION, "search_projection_rollup_forum_watermark");
+    require(
+        MIGRATION_REGISTRY,
+        "m20260730_000009_create_search_projection_inbox",
+    );
+}
+
+#[test]
+fn forum_events_are_strictly_ordered_by_envelope_revision() {
+    for marker in [
+        "status IN ('pending', 'retryable_error')",
+        "ORDER BY revision_at ASC, event_id ASC",
+        "FOR UPDATE",
+        "due_at > Utc::now()",
+        "return Ok(None)",
+        "pg_advisory_xact_lock(hashtextextended($1, 0))",
+        "search:{FORUM_SOURCE_MODULE}:{tenant_id}:{FULL_SCOPE_KEY}",
+        "load_effective_watermark",
+        "load_watermark(transaction, tenant_id, FULL_SCOPE_KEY)",
+        "incoming_event_id.as_bytes() > watermark_event_id.as_bytes()",
+        "Some(\"stale_revision\")",
+        "ON CONFLICT (tenant_id, source_module, scope_key)",
+        "MAX_ATTEMPTS: u32 = 12",
+        "retry_exhausted",
+        "SqlValue::Json(Some(Box::new(envelope_json)))",
+    ] {
+        require(INBOX, marker);
+    }
+    reject(INBOX, "OnceLock");
+    reject(INBOX, "OwnedMutexGuard");
+    reject(INBOX, "SystemTime::now");
+}
+
+#[test]
+fn handler_has_no_direct_forum_projection_bypass() {
+    for marker in [
+        "ForumProjectionScope::for_event(&envelope.event)",
+        "inbox.enqueue(envelope, &scope).await?",
+        "reconcile_forum_inbox",
+        "apply_forum_inbox_event",
+        "claim.complete().await?",
+        "claim.retry(&error).await?",
+        "FORUM_INBOX_OPPORTUNISTIC_BATCH",
+        "Forum projection inbox opportunistic reconciliation failed",
+    ] {
+        require(INGESTION, marker);
+    }
+    require(INGESTION, "projector.rebuild_tenant(envelope.tenant_id).await");
+    require(INGESTION, "projector.delete_tenant(tenant_id).await");
+    reject(
+        INGESTION,
+        ".refresh_entity(envelope.tenant_id, \"forum_topic\"",
+    );
+}
+
+#[test]
+fn module_registers_inbox_without_new_runtime_dependency() {
+    require(LIB, "mod forum_inbox;");
+    require(LIB, "SearchIngestionHandler::with_forum_source");
+    require(MANIFEST, "rustok-content.workspace = true");
+    require(MANIFEST, "[dev-dependencies]");
+    reject(LIB, "rustok_forum::");
+}

--- a/scripts/verify/verify-forum-search-inbox-ordering.mjs
+++ b/scripts/verify/verify-forum-search-inbox-ordering.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const inboxPath = "crates/rustok-search/src/forum_inbox.rs";
+const ingestionPath = "crates/rustok-search/src/ingestion.rs";
+const manifestPath = "crates/rustok-search/Cargo.toml";
+const migrationPath =
+  "crates/rustok-search/src/migrations/m20260730_000009_create_search_projection_inbox.rs";
+const migrationRegistryPath = "crates/rustok-search/src/migrations/mod.rs";
+const libPath = "crates/rustok-search/src/lib.rs";
+const rustTestPath = "crates/rustok-search/tests/forum_projection_inbox_contract.rs";
+const contractPath = "crates/rustok-forum/contracts/forum-search-inbox-ordering.json";
+const approvedReplyPath = "crates/rustok-forum/contracts/forum-approved-reply-search.json";
+const notePath = "crates/rustok-forum/docs/forum-20bp-search-inbox-ordering.md";
+
+const inbox = read(inboxPath);
+const ingestion = read(ingestionPath);
+const manifest = read(manifestPath);
+const migration = read(migrationPath);
+const migrationRegistry = read(migrationRegistryPath);
+const lib = read(libPath);
+const rustTest = read(rustTestPath);
+const note = read(notePath);
+
+let contract = null;
+let approvedReply = null;
+for (const [label, source, assign] of [
+  [contractPath, read(contractPath), (value) => { contract = value; }],
+  [approvedReplyPath, read(approvedReplyPath), (value) => { approvedReply = value; }],
+]) {
+  try {
+    assign(JSON.parse(source));
+  } catch (error) {
+    failures.push(`${label}: invalid JSON: ${error.message}`);
+  }
+}
+
+for (const marker of [
+  "CREATE TABLE IF NOT EXISTS search_projection_inbox",
+  "event_id UUID PRIMARY KEY",
+  "envelope_json JSONB NOT NULL",
+  "'retryable_error'",
+  "'dead_letter'",
+  "CREATE TABLE IF NOT EXISTS search_projection_watermarks",
+  "PRIMARY KEY (tenant_id, source_module, scope_key)",
+  "idx_search_projection_inbox_due",
+  "DatabaseBackend::Postgres",
+  "DatabaseBackend::Sqlite",
+]) {
+  requireMarker(migration, marker, migrationPath);
+}
+rejectMarker(migration, "search_projection_rollup_forum_watermark", migrationPath);
+requireMarker(
+  migrationRegistry,
+  "mod m20260730_000009_create_search_projection_inbox;",
+  migrationRegistryPath,
+);
+requireMarker(
+  migrationRegistry,
+  "Box::new(m20260730_000009_create_search_projection_inbox::Migration)",
+  migrationRegistryPath,
+);
+
+for (const marker of [
+  "pub(crate) enum ForumProjectionScope",
+  "DomainEvent::ForumTopicCreated",
+  "DomainEvent::ForumReplyStatusChanged",
+  'target_type.as_str(), target_id',
+  '(("search", _) | ("forum", _) | ("forum_topic", Some(_)))'.replaceAll("(", "(").replaceAll(")", ")"),
+  "serde_json::to_value(envelope)?",
+  "SqlValue::Json(Some(Box::new(envelope_json)))",
+  "ON CONFLICT (event_id) DO NOTHING",
+  "status IN ('pending', 'retryable_error')",
+  "ORDER BY revision_at ASC, event_id ASC",
+  "FOR UPDATE",
+  "due_at > Utc::now()",
+  "pg_try_advisory_xact_lock(hashtextextended($1, 0))",
+  "AS acquired",
+  "search:{FORUM_SOURCE_MODULE}:{tenant_id}:{FULL_SCOPE_KEY}",
+  "load_effective_watermark",
+  "load_watermark(transaction, tenant_id, FULL_SCOPE_KEY)",
+  "incoming_event_id.as_bytes() > watermark_event_id.as_bytes()",
+  'Some("stale_revision")',
+  "MAX_ATTEMPTS: u32 = 12",
+  "retry_exhausted",
+  "ON CONFLICT (tenant_id, source_module, scope_key)",
+]) {
+  requireMarker(inbox, marker, inboxPath);
+}
+for (const forbidden of [
+  "pg_advisory_xact_lock(",
+  "OnceLock",
+  "OwnedMutexGuard",
+  "rustok_forum::",
+  "SystemTime::now",
+]) {
+  rejectMarker(inbox, forbidden, inboxPath);
+}
+
+for (const marker of [
+  "forum_inbox: Option<ForumProjectionInbox>",
+  "ForumProjectionInbox::new",
+  "ForumProjectionScope::for_event(&envelope.event)",
+  "inbox.enqueue(envelope, &scope).await?",
+  "reconcile_forum_inbox",
+  "FORUM_INBOX_EVENT_BATCH",
+  "FORUM_INBOX_OPPORTUNISTIC_BATCH",
+  "claim.complete().await?",
+  "claim.retry(&error).await?",
+  "projector.rebuild_tenant(envelope.tenant_id).await",
+  "projector.delete_tenant(tenant_id).await",
+  'refresh_entity(envelope.tenant_id, "forum_category"',
+  "Forum projection inbox opportunistic reconciliation failed",
+]) {
+  requireMarker(ingestion, marker, ingestionPath);
+}
+rejectMarker(
+  ingestion,
+  '.refresh_entity(envelope.tenant_id, "forum_topic"',
+  ingestionPath,
+);
+
+requireMarker(lib, "mod forum_inbox;", libPath);
+requireMarker(lib, "SearchIngestionHandler::with_forum_source", libPath);
+rejectMarker(lib, "rustok_forum::", libPath);
+requireMarker(manifest, "rustok-content.workspace = true", manifestPath);
+requireMarker(manifest, "[dev-dependencies]", manifestPath);
+rejectMarker(manifest.split("[dev-dependencies]")[0], "tokio.workspace = true", manifestPath);
+
+for (const marker of [
+  "durable_inbox_stores_replayable_envelopes_and_terminal_state",
+  "forum_events_are_strictly_ordered_by_envelope_revision",
+  "handler_has_no_direct_forum_projection_bypass",
+  "module_registers_inbox_without_new_runtime_dependency",
+  "pg_try_advisory_xact_lock",
+]) {
+  requireMarker(rustTest, marker, rustTestPath);
+}
+
+for (const marker of [
+  "FORUM-20BP",
+  "ULID-backed UUID",
+  "pg_try_advisory_xact_lock",
+  "strict retry barrier",
+  "does **not** advance the full-scope watermark",
+  "12 attempts",
+  "does **not** add a startup worker",
+  "FORUM-20BQ",
+  "No tests, Cargo commands, formatting, verifiers, workflows or CI were run",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-20BP") failures.push(`${contractPath}: unexpected task`);
+  if (contract.upstream_task !== "FORUM-20BO") failures.push(`${contractPath}: unexpected upstream task`);
+  if (contract.downstream_task !== "FORUM-20BQ") failures.push(`${contractPath}: unexpected downstream task`);
+  if (contract.approved_reply_contract !== approvedReplyPath) failures.push(`${contractPath}: approved reply handoff drift`);
+  for (const key of [
+    "search_owns_inbox_storage",
+    "search_projection_inbox_added",
+    "search_projection_watermarks_added",
+    "source_event_id_is_primary_dedupe_key",
+    "full_event_envelope_is_persisted",
+    "retryable_state_recorded",
+    "attempt_count_and_next_attempt_recorded",
+    "last_error_is_bounded",
+  ]) {
+    if (contract.storage_boundary?.[key] !== true) failures.push(`${contractPath}: storage ${key} drift`);
+  }
+  for (const key of [
+    "search_documents_schema_changed",
+    "forum_owner_storage_changed",
+    "second_platform_event_log_added",
+  ]) {
+    if (contract.storage_boundary?.[key] !== false) failures.push(`${contractPath}: storage ${key} must remain false`);
+  }
+  if (contract.storage_boundary?.maximum_attempts !== 12) failures.push(`${contractPath}: retry bound drift`);
+  for (const key of [
+    "ordering_is_timestamp_then_event_id",
+    "duplicate_event_id_is_idempotent",
+    "stale_or_equal_revision_is_skipped",
+    "invalid_stored_envelope_is_dead_lettered",
+    "category_scope_has_specific_watermark",
+    "category_effective_watermark_includes_last_full_scope_watermark",
+    "full_scope_watermark_is_advanced_only_by_full_scope_work",
+  ]) {
+    if (contract.revision_boundary?.[key] !== true) failures.push(`${contractPath}: revision ${key} drift`);
+  }
+  for (const key of [
+    "source_domain_event_schema_changed",
+    "source_owner_revision_field_added",
+    "new_reindex_target_string_added",
+    "category_completion_advances_full_scope_watermark",
+  ]) {
+    if (contract.revision_boundary?.[key] !== false) failures.push(`${contractPath}: revision ${key} must remain false`);
+  }
+  for (const key of [
+    "postgresql_try_advisory_transaction_lock_added",
+    "lock_acquisition_is_non_blocking",
+    "lock_scope_is_tenant_wide_forum_projection",
+    "full_and_targeted_forum_operations_share_one_lock",
+    "candidate_order_is_oldest_revision_first",
+    "oldest_retry_backoff_blocks_newer_claims",
+    "inbox_row_is_selected_for_update_after_lock",
+    "watermark_is_checked_before_projection",
+    "projection_finishes_before_watermark_commit",
+    "watermark_and_terminal_inbox_state_commit_atomically",
+    "competing_claims_release_database_connection_without_waiting",
+    "same_process_pool_starvation_by_waiting_claims_prevented",
+    "cross_process_serialization_remains_database_owned",
+    "older_topic_or_reply_event_cannot_overwrite_newer_module_disable",
+  ]) {
+    if (contract.serialization_boundary?.[key] !== true) failures.push(`${contractPath}: serialization ${key} drift`);
+  }
+  if (contract.serialization_boundary?.projection_and_inbox_use_same_database_transaction !== false) {
+    failures.push(`${contractPath}: transaction boundary drift`);
+  }
+  for (const key of [
+    "enqueue_commits_before_projection_claim",
+    "projection_failure_is_persisted_as_retryable",
+    "retry_exhaustion_is_dead_lettered",
+    "crash_before_claim_leaves_pending_work",
+    "crash_during_projection_rolls_back_processing_claim",
+    "crash_after_projection_before_terminal_commit_replays_idempotently",
+    "forum_event_delivery_runs_bounded_reconciliation",
+    "other_search_events_run_bounded_opportunistic_reconciliation",
+  ]) {
+    if (contract.recovery_boundary?.[key] !== true) failures.push(`${contractPath}: recovery ${key} drift`);
+  }
+  for (const key of [
+    "startup_reconciliation_sweep_added",
+    "idle_tenant_periodic_sweep_added",
+    "external_queue_or_scheduler_dependency_added",
+  ]) {
+    if (contract.recovery_boundary?.[key] !== false) failures.push(`${contractPath}: recovery ${key} must remain false`);
+  }
+  for (const [key, expected] of Object.entries({
+    workspace_root_dependency_changed: false,
+    search_crate_runtime_dependency_changed: false,
+    cargo_lock_changed: false,
+    migration_added: true,
+    postgresql_runtime_required_for_reconciliation: true,
+    sqlite_schema_parity_added: true,
+    ffa_status_changed: false,
+    fba_status_changed: false,
+  })) {
+    if (contract.compatibility?.[key] !== expected) failures.push(`${contractPath}: compatibility ${key} drift`);
+  }
+}
+
+if (approvedReply) {
+  if (approvedReply.search_inbox_ordering_contract !== contractPath) {
+    failures.push(`${approvedReplyPath}: inbox handoff drift`);
+  }
+  if (approvedReply.downstream_task !== "FORUM-20BQ") {
+    failures.push(`${approvedReplyPath}: downstream task must advance to FORUM-20BQ`);
+  }
+  if (approvedReply.persistence_boundary?.out_of_order_owner_revision_guard_added !== true) {
+    failures.push(`${approvedReplyPath}: ordering completion not recorded`);
+  }
+  if (approvedReply.remaining_scope?.some((entry) => entry.includes("owner revision ordering and durable inbox"))) {
+    failures.push(`${approvedReplyPath}: completed inbox work remains open`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Forum Search inbox ordering verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum Search inbox ordering contract verified");

--- a/scripts/verify/verify-forum-search-inbox-ordering.mjs
+++ b/scripts/verify/verify-forum-search-inbox-ordering.mjs
@@ -282,8 +282,8 @@ if (approvedReply) {
   if (approvedReply.search_inbox_ordering_contract !== contractPath) {
     failures.push(`${approvedReplyPath}: inbox handoff drift`);
   }
-  if (approvedReply.downstream_task !== "FORUM-20BQ") {
-    failures.push(`${approvedReplyPath}: downstream task must advance to FORUM-20BQ`);
+  if (approvedReply.downstream_task !== "FORUM-20BP") {
+    failures.push(`${approvedReplyPath}: historical downstream task drift`);
   }
   if (approvedReply.persistence_boundary?.consumer_envelope_revision_guard_added !== true) {
     failures.push(`${approvedReplyPath}: consumer ordering completion not recorded`);

--- a/scripts/verify/verify-forum-search-inbox-ordering.mjs
+++ b/scripts/verify/verify-forum-search-inbox-ordering.mjs
@@ -89,8 +89,8 @@ for (const marker of [
   "pub(crate) enum ForumProjectionScope",
   "DomainEvent::ForumTopicCreated",
   "DomainEvent::ForumReplyStatusChanged",
-  'target_type.as_str(), target_id',
-  '(("search", _) | ("forum", _) | ("forum_topic", Some(_)))'.replaceAll("(", "(").replaceAll(")", ")"),
+  '("search", _) | ("forum", _) | ("forum_topic", Some(_))',
+  '("forum_category", Some(category_id))',
   "serde_json::to_value(envelope)?",
   "SqlValue::Json(Some(Box::new(envelope_json)))",
   "ON CONFLICT (event_id) DO NOTHING",
@@ -180,6 +180,7 @@ if (contract) {
   if (contract.upstream_task !== "FORUM-20BO") failures.push(`${contractPath}: unexpected upstream task`);
   if (contract.downstream_task !== "FORUM-20BQ") failures.push(`${contractPath}: unexpected downstream task`);
   if (contract.approved_reply_contract !== approvedReplyPath) failures.push(`${contractPath}: approved reply handoff drift`);
+
   for (const key of [
     "search_owns_inbox_storage",
     "search_projection_inbox_added",
@@ -200,6 +201,7 @@ if (contract) {
     if (contract.storage_boundary?.[key] !== false) failures.push(`${contractPath}: storage ${key} must remain false`);
   }
   if (contract.storage_boundary?.maximum_attempts !== 12) failures.push(`${contractPath}: retry bound drift`);
+
   for (const key of [
     "ordering_is_timestamp_then_event_id",
     "duplicate_event_id_is_idempotent",
@@ -219,6 +221,7 @@ if (contract) {
   ]) {
     if (contract.revision_boundary?.[key] !== false) failures.push(`${contractPath}: revision ${key} must remain false`);
   }
+
   for (const key of [
     "postgresql_try_advisory_transaction_lock_added",
     "lock_acquisition_is_non_blocking",
@@ -240,6 +243,7 @@ if (contract) {
   if (contract.serialization_boundary?.projection_and_inbox_use_same_database_transaction !== false) {
     failures.push(`${contractPath}: transaction boundary drift`);
   }
+
   for (const key of [
     "enqueue_commits_before_projection_claim",
     "projection_failure_is_persisted_as_retryable",
@@ -259,6 +263,7 @@ if (contract) {
   ]) {
     if (contract.recovery_boundary?.[key] !== false) failures.push(`${contractPath}: recovery ${key} must remain false`);
   }
+
   for (const [key, expected] of Object.entries({
     workspace_root_dependency_changed: false,
     search_crate_runtime_dependency_changed: false,
@@ -280,8 +285,11 @@ if (approvedReply) {
   if (approvedReply.downstream_task !== "FORUM-20BQ") {
     failures.push(`${approvedReplyPath}: downstream task must advance to FORUM-20BQ`);
   }
-  if (approvedReply.persistence_boundary?.out_of_order_owner_revision_guard_added !== true) {
-    failures.push(`${approvedReplyPath}: ordering completion not recorded`);
+  if (approvedReply.persistence_boundary?.consumer_envelope_revision_guard_added !== true) {
+    failures.push(`${approvedReplyPath}: consumer ordering completion not recorded`);
+  }
+  if (approvedReply.persistence_boundary?.out_of_order_owner_revision_guard_added !== false) {
+    failures.push(`${approvedReplyPath}: owner revision must remain explicitly absent`);
   }
   if (approvedReply.remaining_scope?.some((entry) => entry.includes("owner revision ordering and durable inbox"))) {
     failures.push(`${approvedReplyPath}: completed inbox work remains open`);


### PR DESCRIPTION
## Summary

- add Search-owned durable inbox and exact-scope watermarks for Forum projection delivery
- deduplicate by the existing source event ID while storing the complete replayable `EventEnvelope`
- order accepted Forum work by `(EventEnvelope.timestamp, EventEnvelope.id)` without changing Forum event schemas or adding an owner revision field
- serialize full and targeted Forum projection operations per tenant with a non-blocking PostgreSQL advisory transaction lock
- keep the oldest retryable event as a strict ordering barrier so newer work cannot overtake a failed earlier projection
- route Forum topic/reply events, module toggles, tenant/locale rebuilds and Forum/Search reindex requests through the inbox with no direct projector bypass
- retain targeted `forum_category` refreshes with category-specific watermarks, while comparing them against the latest completed full-scope watermark
- add PostgreSQL and SQLite migration schema parity, source-contract coverage, an owner note and a repository verifier
- link the historical FORUM-20BO contract to the FORUM-20BP completion contract without rewriting its slice-specific invariants

## Durable storage boundary

The Search migration adds:

- `search_projection_inbox`, keyed by source `event_id`
- `search_projection_watermarks`, keyed by `(tenant_id, source_module, scope_key)`

Inbox rows store the complete envelope, revision timestamp, scope, attempt count, next attempt, bounded error and terminal state. This is consumer delivery state only; `sys_events` and the outbox remain the platform event journal. `search_documents` and Forum-owned storage are unchanged.

## Ordering boundary

The consumer revision is:

1. UTC envelope timestamp
2. ULID-backed event UUID as deterministic tie breaker

This is not an owner-issued causal revision. Correct ordering across independent producers still assumes reasonably synchronized clocks; adding monotonic owner revisions remains explicit downstream work.

All Forum projection operations for one tenant share the advisory key `search:forum:{tenant_id}:forum`. Claims use `pg_try_advisory_xact_lock`, so competing dispatcher tasks release their database connection immediately instead of waiting and starving the projector pool.

After acquiring the lock, Search selects the oldest pending or retryable event with `FOR UPDATE`. If that oldest event is still in backoff, reconciliation stops and does not claim newer work.

## Scope correctness

Full scope includes:

- Forum topic/reply events
- Forum module enable/disable
- tenant and locale rebuild events
- `search`, `forum` and `forum_topic` reindex requests

`forum_category` reindex remains targeted. Its effective stale check uses the maximum of its own watermark and the latest full-scope watermark. Completing a category refresh does not advance the full watermark, so work for one category cannot suppress delayed work for another category.

## Failure and replay

- duplicate event IDs are idempotent
- stale/equal revisions are terminally skipped
- malformed stored envelopes are dead-lettered
- projector failures retry with bounded exponential delay from 5 to 300 seconds
- retry exhaustion after 12 attempts is dead-lettered
- crash before claim leaves pending work
- crash during projection rolls back the uncommitted processing claim
- crash after projector commit but before inbox commit replays the existing idempotent replacement

Forum events run a bounded reconciliation batch immediately. Other Search-relevant events opportunistically process a smaller batch. No startup or idle-tenant periodic sweeper is added in this slice; that remains FORUM-20BQ scope.

## Compatibility

- no Forum REST route, GraphQL field or public DTO change
- no Search query or canonical URL change
- no Forum event payload or reindex target change
- no workspace/runtime dependency or `Cargo.lock` change
- fresh `rustok-content` Search dependency remains intact; Tokio remains dev-only
- one Search migration added with PostgreSQL runtime and SQLite schema parity
- no FFA/FBA readiness promotion
- large canonical plan, Forum `CRATE_API.md` and Search local plan remain conflict-sensitive synchronization debt

## Remaining FORUM-20BQ scope

- add a host-owned startup or periodic due-inbox sweep for otherwise idle tenants
- add owner-issued monotonic aggregate revisions if cross-producer clock skew must be resolved without assumptions
- continue FORUM-23 safe author summaries, member projections and filter contracts
- capture maintainer-executed PostgreSQL duplicate/delayed-event, retry, crash-replay, module-disable, multi-process and clock-skew evidence
- capture remaining projection cleanup, Search query and SQLite visible-read evidence

## Validation

Not run by the implementation agent, per maintainer request: no tests, Cargo commands, formatting, verifiers, workflows or CI.

Suggested maintainer commands:

```text
cargo test -p rustok-search --test forum_projection_inbox_contract -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-inbox-ordering.mjs
node scripts/verify/verify-forum-approved-reply-search.mjs
cargo xtask module validate forum
```