### PR TITLE
fix(inventory): sanitize admin native failures

### DIFF
--- a/crates/rustok-inventory/admin/Cargo.toml
+++ b/crates/rustok-inventory/admin/Cargo.toml
@@ -32,4 +32,5 @@ rustok-outbox = { workspace = true, optional = true }
 leptos-ui-routing.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing.workspace = true
 uuid = { workspace = true, optional = true }

--- a/crates/rustok-inventory/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-inventory/admin/src/transport/native_server_adapter.rs
@@ -6,6 +6,11 @@ use crate::model::{
     InventoryReservationWriteResult,
 };
 
+#[cfg(feature = "ssr")]
+const INVENTORY_ADMIN_OWNER: &str = "rustok_inventory.admin_transport";
+#[cfg(feature = "ssr")]
+const INVENTORY_ADMIN_BOUNDARY: &str = "inventory_admin_native_transport";
+
 pub(crate) async fn fetch_bootstrap() -> Result<InventoryAdminBootstrap, ServerFnError> {
     inventory_bootstrap_native().await
 }
@@ -68,6 +73,136 @@ pub(crate) async fn release_reservation_quantity(
 }
 
 #[cfg(feature = "ssr")]
+fn inventory_admin_correlation_id(operation: &'static str) -> String {
+    format!("inventory-admin:{operation}:{}", uuid::Uuid::new_v4())
+}
+
+#[cfg(feature = "ssr")]
+fn inventory_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    context_kind: &'static str,
+    correlation_id: &str,
+    code: &'static str,
+    public_message: &'static str,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = INVENTORY_ADMIN_OWNER,
+        owner_operation,
+        context_kind,
+        correlation_id,
+        code,
+        boundary = INVENTORY_ADMIN_BOUNDARY,
+        "inventory admin request context extraction failed"
+    );
+    ServerFnError::new(public_message)
+}
+
+#[cfg(feature = "ssr")]
+fn auth_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> ServerFnError {
+    inventory_context_error(
+        error,
+        owner_operation,
+        "auth",
+        correlation_id,
+        "inventory.admin_auth_context_unavailable",
+        "Inventory authentication context is temporarily unavailable",
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn tenant_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> ServerFnError {
+    inventory_context_error(
+        error,
+        owner_operation,
+        "tenant",
+        correlation_id,
+        "inventory.admin_tenant_context_unavailable",
+        "Inventory tenant context is temporarily unavailable",
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn request_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> ServerFnError {
+    inventory_context_error(
+        error,
+        owner_operation,
+        "request",
+        correlation_id,
+        "inventory.admin_request_context_unavailable",
+        "Inventory request context is temporarily unavailable",
+    )
+}
+
+#[cfg(feature = "ssr")]
+async fn optional_request_context(
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> Option<rustok_api::RequestContext> {
+    match leptos_axum::extract::<rustok_api::RequestContext>().await {
+        Ok(context) => Some(context),
+        Err(error) => {
+            tracing::warn!(
+                error = ?error,
+                owner = INVENTORY_ADMIN_OWNER,
+                owner_operation,
+                context_kind = "request",
+                correlation_id,
+                code = "inventory.admin_optional_request_context_unavailable",
+                boundary = INVENTORY_ADMIN_BOUNDARY,
+                "inventory admin optional request context extraction failed"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn inventory_owner_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+    tenant_id: uuid::Uuid,
+    actor_id: Option<uuid::Uuid>,
+    subject_id: Option<uuid::Uuid>,
+    request_context: Option<&rustok_api::RequestContext>,
+    code: &'static str,
+    public_message: &'static str,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = "rustok_inventory",
+        consumer = INVENTORY_ADMIN_OWNER,
+        owner_operation,
+        correlation_id,
+        tenant_id = %tenant_id,
+        actor_id = ?actor_id,
+        subject_id = ?subject_id,
+        request_tenant_id = ?request_context.map(|context| context.tenant_id),
+        channel_id = ?request_context.and_then(|context| context.channel_id),
+        channel_slug = ?request_context.and_then(|context| context.channel_slug.as_deref()),
+        locale = ?request_context.map(|context| context.locale.as_str()),
+        code,
+        boundary = INVENTORY_ADMIN_BOUNDARY,
+        "inventory admin owner operation failed"
+    );
+    ServerFnError::new(public_message)
+}
+
+#[cfg(feature = "ssr")]
 fn ensure_permission(
     permissions: &[rustok_api::Permission],
     required: &[rustok_api::Permission],
@@ -87,14 +222,33 @@ fn inventory_read_service_from_context() -> rustok_inventory::AdminInventoryRead
 }
 
 #[cfg(feature = "ssr")]
-fn inventory_service_from_context() -> Result<rustok_inventory::InventoryService, ServerFnError> {
+fn inventory_service_from_context(
+    owner_operation: &'static str,
+    correlation_id: &str,
+    tenant_id: uuid::Uuid,
+    actor_id: uuid::Uuid,
+    request_context: Option<&rustok_api::RequestContext>,
+) -> Result<rustok_inventory::InventoryService, ServerFnError> {
     let runtime_ctx = leptos::prelude::expect_context::<rustok_api::HostRuntimeContext>();
     let event_bus = runtime_ctx
         .shared_get::<rustok_outbox::TransactionalEventBus>()
         .ok_or_else(|| {
-            ServerFnError::new(
-                "inventory/admin native transport requires TransactionalEventBus in host runtime context",
-            )
+            tracing::error!(
+                owner = "rustok_inventory",
+                consumer = INVENTORY_ADMIN_OWNER,
+                owner_operation,
+                correlation_id,
+                tenant_id = %tenant_id,
+                actor_id = %actor_id,
+                request_tenant_id = ?request_context.map(|context| context.tenant_id),
+                channel_id = ?request_context.and_then(|context| context.channel_id),
+                channel_slug = ?request_context.and_then(|context| context.channel_slug.as_deref()),
+                locale = ?request_context.map(|context| context.locale.as_str()),
+                code = "inventory.admin_event_bus_unavailable",
+                boundary = INVENTORY_ADMIN_BOUNDARY,
+                "inventory admin transactional event bus is missing"
+            );
+            ServerFnError::new("Inventory runtime is temporarily unavailable")
         })?;
     Ok(rustok_inventory::InventoryService::new(
         runtime_ctx.db_clone(),
@@ -274,12 +428,14 @@ async fn inventory_bootstrap_native() -> Result<InventoryAdminBootstrap, ServerF
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "bootstrap";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_LIST, Permission::INVENTORY_READ],
@@ -311,15 +467,17 @@ async fn inventory_products_native(
         use rustok_api::{AuthContext, RequestContext, TenantContext};
         use rustok_inventory::AdminInventoryProductsFilter;
 
+        let owner_operation = "list_products";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
         let request_context = leptos_axum::extract::<RequestContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| request_context_error(error, owner_operation, &correlation_id))?;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_LIST],
@@ -342,7 +500,19 @@ async fn inventory_products_native(
                 },
             )
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                inventory_owner_error(
+                    error,
+                    owner_operation,
+                    &correlation_id,
+                    tenant.id,
+                    Some(auth.user_id),
+                    None,
+                    Some(&request_context),
+                    "inventory.admin_products_unavailable",
+                    "Inventory products are temporarily unavailable",
+                )
+            })?;
 
         Ok(map_product_list(products))
     }
@@ -366,15 +536,17 @@ async fn inventory_product_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, RequestContext, TenantContext};
 
+        let owner_operation = "get_product";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
         let request_context = leptos_axum::extract::<RequestContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| request_context_error(error, owner_operation, &correlation_id))?;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_READ],
@@ -389,7 +561,19 @@ async fn inventory_product_native(
         let product = service
             .get_product(tenant.id, product_id, Some(requested_locale.as_str()))
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                inventory_owner_error(
+                    error,
+                    owner_operation,
+                    &correlation_id,
+                    tenant.id,
+                    Some(auth.user_id),
+                    Some(product_id),
+                    Some(&request_context),
+                    "inventory.admin_product_unavailable",
+                    "Inventory product is temporarily unavailable",
+                )
+            })?;
 
         Ok(product.map(map_product_detail))
     }
@@ -413,12 +597,15 @@ async fn inventory_set_quantity_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "set_variant_quantity";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_UPDATE, Permission::INVENTORY_MANAGE],
@@ -427,14 +614,32 @@ async fn inventory_set_quantity_native(
         assert_requested_tenant(&tenant, &tenant_id)?;
 
         let variant_id = parse_uuid(&variant_id, "variant_id")?;
-        inventory_service_from_context()?
-            .set_variant_quantity(tenant.id, auth.user_id, variant_id, quantity)
-            .await
-            .map(|result| InventoryQuantityWriteResult {
-                quantity: result.quantity,
-                in_stock: result.in_stock,
-            })
-            .map_err(ServerFnError::new)
+        inventory_service_from_context(
+            owner_operation,
+            &correlation_id,
+            tenant.id,
+            auth.user_id,
+            request_context.as_ref(),
+        )?
+        .set_variant_quantity(tenant.id, auth.user_id, variant_id, quantity)
+        .await
+        .map(|result| InventoryQuantityWriteResult {
+            quantity: result.quantity,
+            in_stock: result.in_stock,
+        })
+        .map_err(|error| {
+            inventory_owner_error(
+                error,
+                owner_operation,
+                &correlation_id,
+                tenant.id,
+                Some(auth.user_id),
+                Some(variant_id),
+                request_context.as_ref(),
+                "inventory.admin_set_quantity_failed",
+                "Inventory quantity could not be updated",
+            )
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -456,12 +661,15 @@ async fn inventory_adjust_quantity_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "adjust_variant_quantity";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_UPDATE, Permission::INVENTORY_MANAGE],
@@ -470,20 +678,38 @@ async fn inventory_adjust_quantity_native(
         assert_requested_tenant(&tenant, &tenant_id)?;
 
         let variant_id = parse_uuid(&variant_id, "variant_id")?;
-        inventory_service_from_context()?
-            .adjust_variant_quantity(
+        inventory_service_from_context(
+            owner_operation,
+            &correlation_id,
+            tenant.id,
+            auth.user_id,
+            request_context.as_ref(),
+        )?
+        .adjust_variant_quantity(
+            tenant.id,
+            auth.user_id,
+            variant_id,
+            adjustment,
+            Some("Inventory admin native adjust endpoint".to_string()),
+        )
+        .await
+        .map(|result| InventoryQuantityWriteResult {
+            quantity: result.quantity,
+            in_stock: result.in_stock,
+        })
+        .map_err(|error| {
+            inventory_owner_error(
+                error,
+                owner_operation,
+                &correlation_id,
                 tenant.id,
-                auth.user_id,
-                variant_id,
-                adjustment,
-                Some("Inventory admin native adjust endpoint".to_string()),
+                Some(auth.user_id),
+                Some(variant_id),
+                request_context.as_ref(),
+                "inventory.admin_adjust_quantity_failed",
+                "Inventory quantity could not be updated",
             )
-            .await
-            .map(|result| InventoryQuantityWriteResult {
-                quantity: result.quantity,
-                in_stock: result.in_stock,
-            })
-            .map_err(ServerFnError::new)
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -505,12 +731,15 @@ async fn inventory_reserve_quantity_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "reserve_variant_quantity";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_UPDATE, Permission::INVENTORY_MANAGE],
@@ -519,11 +748,29 @@ async fn inventory_reserve_quantity_native(
         assert_requested_tenant(&tenant, &tenant_id)?;
 
         let variant_id = parse_uuid(&variant_id, "variant_id")?;
-        inventory_service_from_context()?
-            .reserve(tenant.id, variant_id, quantity)
-            .await
-            .map(map_reservation_result)
-            .map_err(ServerFnError::new)
+        inventory_service_from_context(
+            owner_operation,
+            &correlation_id,
+            tenant.id,
+            auth.user_id,
+            request_context.as_ref(),
+        )?
+        .reserve(tenant.id, variant_id, quantity)
+        .await
+        .map(map_reservation_result)
+        .map_err(|error| {
+            inventory_owner_error(
+                error,
+                owner_operation,
+                &correlation_id,
+                tenant.id,
+                Some(auth.user_id),
+                Some(variant_id),
+                request_context.as_ref(),
+                "inventory.admin_reservation_failed",
+                "Inventory reservation could not be completed",
+            )
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -545,12 +792,15 @@ async fn inventory_check_availability_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "check_variant_availability";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_READ, Permission::INVENTORY_UPDATE],
@@ -559,11 +809,29 @@ async fn inventory_check_availability_native(
         assert_requested_tenant(&tenant, &tenant_id)?;
 
         let variant_id = parse_uuid(&variant_id, "variant_id")?;
-        inventory_service_from_context()?
-            .check_variant_availability(tenant.id, variant_id, requested_quantity)
-            .await
-            .map(map_availability_result)
-            .map_err(ServerFnError::new)
+        inventory_service_from_context(
+            owner_operation,
+            &correlation_id,
+            tenant.id,
+            auth.user_id,
+            request_context.as_ref(),
+        )?
+        .check_variant_availability(tenant.id, variant_id, requested_quantity)
+        .await
+        .map(map_availability_result)
+        .map_err(|error| {
+            inventory_owner_error(
+                error,
+                owner_operation,
+                &correlation_id,
+                tenant.id,
+                Some(auth.user_id),
+                Some(variant_id),
+                request_context.as_ref(),
+                "inventory.admin_availability_unavailable",
+                "Inventory availability is temporarily unavailable",
+            )
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -585,12 +853,15 @@ async fn inventory_release_reservation_native(
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "release_reservation_quantity";
+        let correlation_id = inventory_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
         ensure_permission(
             &auth.permissions,
             &[Permission::INVENTORY_UPDATE, Permission::INVENTORY_MANAGE],
@@ -599,11 +870,29 @@ async fn inventory_release_reservation_native(
         assert_requested_tenant(&tenant, &tenant_id)?;
 
         let variant_id = parse_uuid(&variant_id, "variant_id")?;
-        inventory_service_from_context()?
-            .release_reservation_quantity(tenant.id, variant_id, quantity)
-            .await
-            .map(map_release_result)
-            .map_err(ServerFnError::new)
+        inventory_service_from_context(
+            owner_operation,
+            &correlation_id,
+            tenant.id,
+            auth.user_id,
+            request_context.as_ref(),
+        )?
+        .release_reservation_quantity(tenant.id, variant_id, quantity)
+        .await
+        .map(map_release_result)
+        .map_err(|error| {
+            inventory_owner_error(
+                error,
+                owner_operation,
+                &correlation_id,
+                tenant.id,
+                Some(auth.user_id),
+                Some(variant_id),
+                request_context.as_ref(),
+                "inventory.admin_reservation_release_failed",
+                "Inventory reservation could not be released",
+            )
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {

--- a/crates/rustok-inventory/contracts/evidence/admin-native-error-safety-source.json
+++ b/crates/rustok-inventory/contracts/evidence/admin-native-error-safety-source.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "status": "inventory_admin_native_error_safety_source_unvalidated",
+  "scope": "Mounted Inventory admin native bootstrap, product read, quantity, reservation, and availability error envelopes",
+  "source_contract": {
+    "mounted_endpoints_preserved": true,
+    "auth_context_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "request_context_static_public_envelope": true,
+    "runtime_dependency_static_public_envelope": true,
+    "read_owner_raw_error_public": false,
+    "write_owner_raw_error_public": false,
+    "original_causes_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "request_channel_locale_logging_when_available": true,
+    "dto_changed": false,
+    "permission_policy_changed": false,
+    "tenant_policy_changed": false
+  },
+  "public_messages": {
+    "auth_context": "Inventory authentication context is temporarily unavailable",
+    "tenant_context": "Inventory tenant context is temporarily unavailable",
+    "request_context": "Inventory request context is temporarily unavailable",
+    "runtime": "Inventory runtime is temporarily unavailable",
+    "products": "Inventory products are temporarily unavailable",
+    "product": "Inventory product is temporarily unavailable",
+    "quantity": "Inventory quantity could not be updated",
+    "reservation": "Inventory reservation could not be completed",
+    "availability": "Inventory availability is temporarily unavailable",
+    "reservation_release": "Inventory reservation could not be released"
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false
+  }
+}

--- a/crates/rustok-inventory/docs/admin-native-error-safety.md
+++ b/crates/rustok-inventory/docs/admin-native-error-safety.md
@@ -1,0 +1,50 @@
+# Inventory admin native error safety
+
+Status: source-ready, runtime-unvalidated.
+
+## Scope
+
+This slice hardens the mounted Inventory admin native server-function boundary:
+
+- bootstrap context extraction;
+- product list and product detail reads;
+- set and adjust quantity writes;
+- reserve and release reservation writes;
+- availability checks;
+- host `TransactionalEventBus` resolution.
+
+Endpoint names, request and response DTOs, effective permissions, tenant matching,
+locale fallback, inventory policy, and owner service behavior are unchanged.
+
+## Public boundary
+
+Framework extraction failures, missing host runtime dependencies, database/read
+failures, event publication failures, validation internals, and owner mutation
+causes are not serialized through `ServerFnError`.
+
+The transport returns static operation-specific messages. Input errors that are
+already transport-owned, such as invalid UUIDs, invalid product status, permission
+denial, or requested/effective tenant mismatch, retain their existing public
+contract.
+
+## Private diagnostics
+
+Every mounted call creates a separate transport correlation id. Original typed
+causes are retained only in structured logs together with the owner operation,
+tenant, actor, subject identity, stable error code, and transport boundary.
+Request tenant, channel, and locale are included when `RequestContext` is
+available. Write endpoints treat that additional request context as diagnostic
+only so its absence does not change write admission.
+
+## Evidence boundary
+
+The retained source evidence is:
+
+`crates/rustok-inventory/contracts/evidence/admin-native-error-safety-source.json`
+
+The fail-closed source guard is:
+
+`scripts/verify/verify-inventory-admin-native-error-safety.mjs`
+
+No test, verifier, Cargo, formatting, workflow, CI, or runtime pass is claimed by
+this document. FBA and FFA state are unchanged.

--- a/crates/rustok-inventory/docs/implementation-plan.md
+++ b/crates/rustok-inventory/docs/implementation-plan.md
@@ -13,6 +13,14 @@ availability. The admin package uses `HostRuntimeContext` and a typed
 transactional event bus, is host-neutral, and intentionally has no GraphQL
 fallback for this current operator surface.
 
+Mounted Inventory admin native endpoints use static public error envelopes for
+framework extraction, runtime dependency, read, and write failures. Original
+owner causes remain in structured diagnostics with per-call correlation,
+tenant, actor, subject, and request channel/locale context when available. The
+source contract is guarded by
+`scripts/verify/verify-inventory-admin-native-error-safety.mjs`; runtime evidence
+has not been executed or promoted.
+
 `BootstrapService` owns default-location creation, initial item/level creation,
 variant-record cleanup, and batched available-quantity reads when product
 creates or deletes variants. This is a native transaction-sharing bootstrap
@@ -24,6 +32,7 @@ and reservation contracts remain inventory-owned.
 - FFA status: `in_progress`
 - FBA status: `boundary_ready`
 - Structural shape: `core_transport_ui`
+- Admin native error safety: `source_ready_unvalidated`
 - FBA provider contract: `InventoryReservationPort` /
   `inventory.reservation.v1` in
   `crates/rustok-inventory/contracts/inventory-fba-registry.json`.
@@ -32,6 +41,9 @@ and reservation contracts remain inventory-owned.
   and `crates/rustok-inventory/contracts/evidence/inventory-runtime-contract-smoke.json`.
 - `scripts/verify/verify-inventory-admin-boundary.mjs` locks the native
   core/transport/UI split and absence of pre-FFA/GraphQL admin paths.
+- `scripts/verify/verify-inventory-admin-native-error-safety.mjs` locks static
+  public envelopes and private owner-cause diagnostics without claiming a
+  runtime pass.
 
 ## Open results
 
@@ -50,18 +62,22 @@ and reservation contracts remain inventory-owned.
    **Done when:** integration tests prove that cart, checkout, and storefront
    read models cannot diverge from `InventoryService` policy.
 
-3. **Run the verification/CI evidence slice for `InventoryReservationPort`.**
-   Execute the remote-adapter contract and fallback profiles before a
-   `boundary_ready` promotion; retain native-only admin transport unless a
-   public parity contract is introduced.
+3. **Run the verification/CI evidence slice for `InventoryReservationPort` and
+   admin native error safety.** Execute the remote-adapter contract and fallback
+   profiles before a `boundary_ready` promotion; retain native-only admin
+   transport unless a public parity contract is introduced. Execute the focused
+   admin error-safety guard, compile the SSR package, and retain mounted failure
+   evidence before promoting its source-only status.
    **Depends on:** a runtime-composed commerce consumer and remote adapter
    environment.
-   **Done when:** deadline, idempotency, typed-error, degraded-mode, and owner
-   invocation evidence covers every published port operation.
+   **Done when:** deadline, idempotency, typed-error, degraded-mode, owner
+   invocation, and mounted public-envelope evidence covers every published port
+   operation and native admin endpoint.
 
 ## Verification
 
 - `npm run verify:inventory:admin-boundary`
+- `node scripts/verify/verify-inventory-admin-native-error-safety.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo xtask module validate inventory`
 - `cargo xtask module test inventory`

--- a/scripts/verify/verify-inventory-admin-native-error-safety.mjs
+++ b/scripts/verify/verify-inventory-admin-native-error-safety.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+function requireText(source, value, label) {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+}
+
+function forbidText(source, value, label) {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+}
+
+function requireCount(source, value, minimum, label) {
+  const count = source.split(value).length - 1;
+  if (count < minimum) failures.push(`${label}: expected at least ${minimum}, found ${count}`);
+}
+
+const adapterPath =
+  "crates/rustok-inventory/admin/src/transport/native_server_adapter.rs";
+const evidencePath =
+  "crates/rustok-inventory/contracts/evidence/admin-native-error-safety-source.json";
+const adapter = read(adapterPath);
+const evidence = JSON.parse(read(evidencePath));
+
+for (const [value, label] of [
+  ["const INVENTORY_ADMIN_OWNER", "owner constant"],
+  ["const INVENTORY_ADMIN_BOUNDARY", "boundary constant"],
+  ["fn inventory_admin_correlation_id", "per-call correlation helper"],
+  ["fn inventory_context_error", "context mapper"],
+  ["fn auth_context_error", "auth mapper"],
+  ["fn tenant_context_error", "tenant mapper"],
+  ["fn request_context_error", "request mapper"],
+  ["fn optional_request_context", "optional write request context"],
+  ["fn inventory_owner_error", "owner error mapper"],
+  ["error = ?error", "private original cause"],
+  ["owner_operation", "owner operation diagnostics"],
+  ["correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["actor_id = ?actor_id", "actor diagnostics"],
+  ["subject_id = ?subject_id", "subject diagnostics"],
+  ["channel_id = ?request_context", "channel diagnostics"],
+  ["Inventory authentication context is temporarily unavailable", "auth public envelope"],
+  ["Inventory tenant context is temporarily unavailable", "tenant public envelope"],
+  ["Inventory request context is temporarily unavailable", "request public envelope"],
+  ["Inventory runtime is temporarily unavailable", "runtime public envelope"],
+  ["Inventory products are temporarily unavailable", "list public envelope"],
+  ["Inventory product is temporarily unavailable", "detail public envelope"],
+  ["Inventory quantity could not be updated", "quantity public envelope"],
+  ["Inventory reservation could not be completed", "reservation public envelope"],
+  ["Inventory availability is temporarily unavailable", "availability public envelope"],
+  ["Inventory reservation could not be released", "release public envelope"],
+]) requireText(adapter, value, label);
+
+for (const endpoint of [
+  'endpoint = "inventory/bootstrap"',
+  'endpoint = "inventory/products"',
+  'endpoint = "inventory/product"',
+  'endpoint = "inventory/variant/set-quantity"',
+  'endpoint = "inventory/variant/adjust-quantity"',
+  'endpoint = "inventory/variant/reserve-quantity"',
+  'endpoint = "inventory/variant/check-availability"',
+  'endpoint = "inventory/variant/release-reservation"',
+]) requireText(adapter, endpoint, `mounted endpoint ${endpoint}`);
+
+requireCount(adapter, ".map_err(|error| auth_context_error", 8, "auth extraction mapping");
+requireCount(adapter, ".map_err(|error| tenant_context_error", 8, "tenant extraction mapping");
+requireCount(adapter, "inventory_owner_error(", 7, "owner operation mapping");
+requireCount(adapter, "inventory_admin_correlation_id(owner_operation)", 8, "per-call correlation creation");
+
+for (const value of [
+  ".map_err(ServerFnError::new)",
+  "native transport requires TransactionalEventBus in host runtime context",
+  "ServerFnError::new(error.to_string())",
+  "ServerFnError::new(err.to_string())",
+]) forbidText(adapter, value, "inventory admin native adapter");
+
+if (evidence.status !== "inventory_admin_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  mounted_endpoints_preserved: true,
+  auth_context_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  request_context_static_public_envelope: true,
+  runtime_dependency_static_public_envelope: true,
+  read_owner_raw_error_public: false,
+  write_owner_raw_error_public: false,
+  original_causes_logged_privately: true,
+  per_call_correlation_logging: true,
+  request_channel_locale_logging_when_available: true,
+  dto_changed: false,
+  permission_policy_changed: false,
+  tenant_policy_changed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Inventory admin native error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Inventory admin native endpoints use static public envelopes with private owner causes; source evidence remains unvalidated",
+);


### PR DESCRIPTION
## Summary
- replace direct public serialization of auth, tenant, request-context, read-service, runtime dependency, and inventory owner failures across all eight mounted Inventory admin native endpoints
- return static operation-specific `ServerFnError` envelopes while retaining original typed causes only in structured server diagnostics
- add per-call transport correlation together with tenant, actor, subject, request channel/locale, stable code, and boundary context when available
- keep write-side `RequestContext` diagnostic-only so its absence does not change mutation admission
- preserve endpoint names, request/response DTOs, permissions, tenant matching, locale fallback, inventory policy, and owner service behavior
- add a focused fail-closed verifier, retained source evidence, boundary documentation, and local implementation-plan tracking

## Recheck
The ecommerce master plan still has the correlation-safe mapper cleanup item open for Inventory and remaining non-`PortError` envelopes. The mounted Inventory admin native adapter directly used `.map_err(ServerFnError::new)` for framework extraction, product reads, quantity writes, reservation operations, availability checks, and raw `CommerceError` values. Missing `TransactionalEventBus` also exposed host runtime composition details.

## Public boundary
- context and runtime failures use static availability messages
- product list/detail failures use static read envelopes
- quantity, reservation, availability, and release failures use static operation envelopes
- existing transport-owned permission, UUID, status, and tenant-mismatch validation messages remain unchanged

## Evidence boundary
Source status is `inventory_admin_native_error_safety_source_unvalidated`. No FFA/FBA or runtime status is promoted.

## Verification
The current source, actual `RequestContext` fields, dependency graph, mounted endpoint set, branch base, and final diff were re-read. Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.