### PR TITLE
fix(customer): sanitize admin native failures

### DIFF
--- a/crates/rustok-customer/admin/Cargo.toml
+++ b/crates/rustok-customer/admin/Cargo.toml
@@ -32,4 +32,5 @@ rustok-customer = { workspace = true, optional = true }
 rustok-profiles = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing.workspace = true
 uuid.workspace = true

--- a/crates/rustok-customer/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-customer/admin/src/transport/native_server_adapter.rs
@@ -9,6 +9,11 @@ use crate::model::{CustomerAdminBootstrap, CustomerDetail, CustomerDraft, Custom
 #[cfg(feature = "ssr")]
 use crate::model::{CurrentTenant, CustomerListItem, CustomerProfileRecord, CustomerRecord};
 
+#[cfg(feature = "ssr")]
+const CUSTOMER_ADMIN_OWNER: &str = "rustok_customer.admin_transport";
+#[cfg(feature = "ssr")]
+const CUSTOMER_ADMIN_BOUNDARY: &str = "customer_admin_native_transport";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ApiError {
     ServerFn(String),
@@ -61,6 +66,176 @@ pub async fn update_customer(
     customer_update_native(customer_id, payload)
         .await
         .map_err(Into::into)
+}
+
+#[cfg(feature = "ssr")]
+fn customer_admin_correlation_id(owner_operation: &'static str) -> String {
+    format!("customer-admin:{owner_operation}:{}", uuid::Uuid::new_v4())
+}
+
+#[cfg(feature = "ssr")]
+fn customer_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    context_kind: &'static str,
+    correlation_id: &str,
+    code: &'static str,
+    public_message: &'static str,
+) -> ServerFnError {
+    tracing::error!(
+        error = ?error,
+        owner = CUSTOMER_ADMIN_OWNER,
+        owner_operation,
+        context_kind,
+        correlation_id,
+        code,
+        boundary = CUSTOMER_ADMIN_BOUNDARY,
+        "customer admin request context extraction failed"
+    );
+    ServerFnError::new(public_message)
+}
+
+#[cfg(feature = "ssr")]
+fn auth_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> ServerFnError {
+    customer_context_error(
+        error,
+        owner_operation,
+        "auth",
+        correlation_id,
+        "customer.admin_auth_context_unavailable",
+        "Customer authentication context is temporarily unavailable",
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn tenant_context_error<E: std::fmt::Debug>(
+    error: E,
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> ServerFnError {
+    customer_context_error(
+        error,
+        owner_operation,
+        "tenant",
+        correlation_id,
+        "customer.admin_tenant_context_unavailable",
+        "Customer tenant context is temporarily unavailable",
+    )
+}
+
+#[cfg(feature = "ssr")]
+async fn optional_request_context(
+    owner_operation: &'static str,
+    correlation_id: &str,
+) -> Option<rustok_api::RequestContext> {
+    match leptos_axum::extract::<rustok_api::RequestContext>().await {
+        Ok(context) => Some(context),
+        Err(error) => {
+            tracing::warn!(
+                error = ?error,
+                owner = CUSTOMER_ADMIN_OWNER,
+                owner_operation,
+                context_kind = "request",
+                correlation_id,
+                code = "customer.admin_optional_request_context_unavailable",
+                boundary = CUSTOMER_ADMIN_BOUNDARY,
+                "customer admin optional request context extraction failed"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn customer_owner_error(
+    error: rustok_customer::CustomerError,
+    owner_operation: &'static str,
+    correlation_id: &str,
+    tenant_id: uuid::Uuid,
+    actor_id: uuid::Uuid,
+    customer_id: Option<uuid::Uuid>,
+    request_context: Option<&rustok_api::RequestContext>,
+) -> ServerFnError {
+    use rustok_customer::CustomerError;
+
+    let (public_message, public_code, technical) = match &error {
+        CustomerError::Validation(_) => (
+            "Customer request is invalid",
+            "customer.admin_request_invalid",
+            false,
+        ),
+        CustomerError::CustomerNotFound(_) | CustomerError::CustomerByUserNotFound(_) => (
+            "Customer was not found",
+            "customer.admin_not_found",
+            false,
+        ),
+        CustomerError::DuplicateEmail(_) => (
+            "Customer email already exists",
+            "customer.admin_duplicate_email",
+            false,
+        ),
+        CustomerError::DuplicateUserLink(_) => (
+            "Customer is already linked to a user",
+            "customer.admin_duplicate_user_link",
+            false,
+        ),
+        CustomerError::Profile(_) => (
+            "Customer profile is temporarily unavailable",
+            "customer.admin_profile_unavailable",
+            true,
+        ),
+        CustomerError::Database(_) => (
+            "Customer data is temporarily unavailable",
+            "customer.admin_storage_unavailable",
+            true,
+        ),
+    };
+
+    if technical {
+        tracing::error!(
+            error = ?error,
+            owner = "rustok_customer",
+            consumer = CUSTOMER_ADMIN_OWNER,
+            owner_operation,
+            correlation_id,
+            tenant_id = %tenant_id,
+            actor_id = %actor_id,
+            customer_id = ?customer_id,
+            request_tenant_id = ?request_context.map(|context| context.tenant_id),
+            request_user_id = ?request_context.and_then(|context| context.user_id),
+            channel_id = ?request_context.and_then(|context| context.channel_id),
+            channel_slug = ?request_context.and_then(|context| context.channel_slug.as_deref()),
+            locale = ?request_context.map(|context| context.locale.as_str()),
+            public_code,
+            boundary = CUSTOMER_ADMIN_BOUNDARY,
+            "customer admin owner operation failed"
+        );
+    } else {
+        tracing::warn!(
+            error = ?error,
+            owner = "rustok_customer",
+            consumer = CUSTOMER_ADMIN_OWNER,
+            owner_operation,
+            correlation_id,
+            tenant_id = %tenant_id,
+            actor_id = %actor_id,
+            customer_id = ?customer_id,
+            request_tenant_id = ?request_context.map(|context| context.tenant_id),
+            request_user_id = ?request_context.and_then(|context| context.user_id),
+            channel_id = ?request_context.and_then(|context| context.channel_id),
+            channel_slug = ?request_context.and_then(|context| context.channel_slug.as_deref()),
+            locale = ?request_context.map(|context| context.locale.as_str()),
+            public_code,
+            boundary = CUSTOMER_ADMIN_BOUNDARY,
+            "customer admin owner operation was rejected"
+        );
+    }
+
+    ServerFnError::new(public_message)
 }
 
 #[cfg(feature = "ssr")]
@@ -195,8 +370,12 @@ async fn load_customer_detail(
     customer_service: &rustok_customer::CustomerService,
     profile_service: &rustok_profiles::ProfilePresentationService,
     tenant: &rustok_api::TenantContext,
+    actor_id: uuid::Uuid,
     customer_id: uuid::Uuid,
     requested_locale: Option<&str>,
+    request_context: Option<&rustok_api::RequestContext>,
+    correlation_id: &str,
+    owner_operation: &'static str,
 ) -> Result<CustomerDetail, ServerFnError> {
     let detail = customer_service
         .get_customer_with_profile(
@@ -207,7 +386,17 @@ async fn load_customer_detail(
             Some(tenant.default_locale.as_str()),
         )
         .await
-        .map_err(ServerFnError::new)?;
+        .map_err(|error| {
+            customer_owner_error(
+                error,
+                owner_operation,
+                correlation_id,
+                tenant.id,
+                actor_id,
+                Some(customer_id),
+                request_context,
+            )
+        })?;
 
     Ok(CustomerDetail {
         customer: map_customer_record(detail.customer),
@@ -222,12 +411,14 @@ async fn customer_bootstrap_native() -> Result<CustomerAdminBootstrap, ServerFnE
         use rustok_api::Permission;
         use rustok_api::{AuthContext, TenantContext};
 
+        let owner_operation = "bootstrap";
+        let correlation_id = customer_admin_correlation_id(owner_operation);
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
 
         ensure_permission(
             &auth.permissions,
@@ -260,13 +451,16 @@ async fn customer_list_native(
         use rustok_api::{AuthContext, HostRuntimeContext, TenantContext};
         use rustok_customer::ListCustomersInput;
 
+        let owner_operation = "list_customers";
+        let correlation_id = customer_admin_correlation_id(owner_operation);
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
 
         ensure_permission(
             &auth.permissions,
@@ -295,7 +489,17 @@ async fn customer_list_native(
                 },
             )
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                customer_owner_error(
+                    error,
+                    owner_operation,
+                    &correlation_id,
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    request_context.as_ref(),
+                )
+            })?;
 
         Ok(CustomerList {
             items: items.into_iter().map(map_customer_list_item).collect(),
@@ -322,13 +526,16 @@ async fn customer_detail_native(customer_id: String) -> Result<CustomerDetail, S
         use rustok_api::Permission;
         use rustok_api::{AuthContext, HostRuntimeContext, TenantContext};
 
+        let owner_operation = "get_customer_detail";
+        let correlation_id = customer_admin_correlation_id(owner_operation);
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
 
         ensure_permission(
             &auth.permissions,
@@ -344,8 +551,12 @@ async fn customer_detail_native(customer_id: String) -> Result<CustomerDetail, S
             &customer_service,
             &profile_service,
             &tenant,
+            auth.user_id,
             customer_id,
             Some(tenant.default_locale.as_str()),
+            request_context.as_ref(),
+            &correlation_id,
+            owner_operation,
         )
         .await
     }
@@ -367,13 +578,16 @@ async fn customer_create_native(payload: CustomerDraft) -> Result<CustomerDetail
         use rustok_api::{AuthContext, HostRuntimeContext, TenantContext};
         use rustok_customer::CreateCustomerInput;
 
+        let owner_operation = "create_customer";
+        let correlation_id = customer_admin_correlation_id(owner_operation);
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
 
         ensure_permission(
             &auth.permissions,
@@ -402,14 +616,28 @@ async fn customer_create_native(payload: CustomerDraft) -> Result<CustomerDetail
                 },
             )
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                customer_owner_error(
+                    error,
+                    owner_operation,
+                    &correlation_id,
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    request_context.as_ref(),
+                )
+            })?;
 
         load_customer_detail(
             &customer_service,
             &profile_service,
             &tenant,
+            auth.user_id,
             created.id,
             Some(requested_locale.as_str()),
+            request_context.as_ref(),
+            &correlation_id,
+            owner_operation,
         )
         .await
     }
@@ -434,13 +662,16 @@ async fn customer_update_native(
         use rustok_api::{AuthContext, HostRuntimeContext, TenantContext};
         use rustok_customer::UpdateCustomerInput;
 
+        let owner_operation = "update_customer";
+        let correlation_id = customer_admin_correlation_id(owner_operation);
         let runtime_ctx = expect_context::<HostRuntimeContext>();
         let auth = leptos_axum::extract::<AuthContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| auth_context_error(error, owner_operation, &correlation_id))?;
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| tenant_context_error(error, owner_operation, &correlation_id))?;
+        let request_context = optional_request_context(owner_operation, &correlation_id).await;
 
         ensure_permission(
             &auth.permissions,
@@ -473,14 +704,28 @@ async fn customer_update_native(
                 },
             )
             .await
-            .map_err(ServerFnError::new)?;
+            .map_err(|error| {
+                customer_owner_error(
+                    error,
+                    owner_operation,
+                    &correlation_id,
+                    tenant.id,
+                    auth.user_id,
+                    Some(customer_id),
+                    request_context.as_ref(),
+                )
+            })?;
 
         load_customer_detail(
             &customer_service,
             &profile_service,
             &tenant,
+            auth.user_id,
             customer_id,
             Some(locale.as_str()),
+            request_context.as_ref(),
+            &correlation_id,
+            owner_operation,
         )
         .await
     }

--- a/crates/rustok-customer/contracts/evidence/admin-native-error-safety-review.json
+++ b/crates/rustok-customer/contracts/evidence/admin-native-error-safety-review.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "status": "source_review_complete_runtime_unvalidated",
+  "reviewed_against_main": "36739625d6c244b8d96112591981550138aac667",
+  "reviewed_paths": [
+    "crates/rustok-customer/admin/Cargo.toml",
+    "crates/rustok-customer/admin/src/transport/native_server_adapter.rs",
+    "crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json",
+    "crates/rustok-customer/docs/admin-native-error-safety.md",
+    "crates/rustok-customer/docs/implementation-plan.md",
+    "scripts/verify/verify-customer-admin-native-error-safety.mjs"
+  ],
+  "findings": {
+    "branch_behind_main": false,
+    "mounted_endpoints_preserved": true,
+    "permission_policy_preserved": true,
+    "profile_audience_policy_preserved": true,
+    "raw_framework_map_err_remaining": false,
+    "raw_customer_map_err_remaining": false,
+    "payload_logging_added": false
+  },
+  "execution": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json
+++ b/crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "status": "customer_admin_native_error_safety_source_unvalidated",
+  "scope": "rustok-customer-admin mounted native bootstrap, list, detail, create, and update error envelopes",
+  "source_contract": {
+    "mounted_endpoint_set_preserved": true,
+    "auth_context_static_public_envelope": true,
+    "tenant_context_static_public_envelope": true,
+    "request_context_diagnostic_only": true,
+    "customer_validation_static_public_envelope": true,
+    "customer_not_found_static_public_envelope": true,
+    "duplicate_email_static_public_envelope": true,
+    "duplicate_user_link_static_public_envelope": true,
+    "profile_failure_static_public_envelope": true,
+    "storage_failure_static_public_envelope": true,
+    "owner_context_logging": true,
+    "raw_customer_error_public": false,
+    "raw_profile_error_public": false,
+    "raw_framework_error_public": false,
+    "permissions_changed": false,
+    "request_response_dto_changed": false,
+    "profile_audience_policy_changed": false,
+    "ffa_status_promoted": false,
+    "fba_status_promoted": false
+  },
+  "public_messages": {
+    "auth_context": "Customer authentication context is temporarily unavailable",
+    "tenant_context": "Customer tenant context is temporarily unavailable",
+    "validation": "Customer request is invalid",
+    "not_found": "Customer was not found",
+    "duplicate_email": "Customer email already exists",
+    "duplicate_user_link": "Customer is already linked to a user",
+    "profile": "Customer profile is temporarily unavailable",
+    "storage": "Customer data is temporarily unavailable"
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "profile_audience_runtime_proven": false
+  }
+}

--- a/crates/rustok-customer/docs/admin-native-error-safety-review.md
+++ b/crates/rustok-customer/docs/admin-native-error-safety-review.md
@@ -1,0 +1,16 @@
+# Customer admin native error-safety source review
+
+Reviewed against `main` commit `36739625d6c244b8d96112591981550138aac667`.
+
+The branch is not behind `main`. The intervening repository change is Index-owned and does not overlap Customer paths.
+
+Source review confirms:
+
+- all five mounted customer-admin native endpoints remain present;
+- permissions, pagination, UUID validation, locale fallback, profile audience selection, DTOs, and customer/profile bridge behavior remain unchanged;
+- direct framework and typed customer error conversion through `.map_err(ServerFnError::new)` is absent from the adapter;
+- technical profile/storage causes are private diagnostics;
+- validation, not-found, duplicate-email, and duplicate-user-link outcomes retain bounded public meaning;
+- no customer email, name, phone, search text, profile payload, or request body was added to diagnostics.
+
+Tests, verifiers, Cargo, formatting, workflows, CI, and runtime traces were not executed. The source review does not promote FFA or FBA status.

--- a/crates/rustok-customer/docs/admin-native-error-safety.md
+++ b/crates/rustok-customer/docs/admin-native-error-safety.md
@@ -1,0 +1,59 @@
+# Customer admin native error safety
+
+Status: `customer_admin_native_error_safety_source_unvalidated`
+
+## Scope
+
+This source slice covers the mounted `rustok-customer-admin` native server-function endpoints for bootstrap, list, detail, create, and update.
+
+Before this slice, framework extraction and typed `CustomerError` values were converted directly with `ServerFnError::new`. Database, profile, validation, duplicate-email, duplicate-user-link, and not-found details could therefore cross the native transport boundary as raw error text.
+
+## Public boundary
+
+The adapter now returns static public messages for:
+
+- authentication and tenant-context extraction failures;
+- customer request validation;
+- customer not-found outcomes;
+- duplicate email and duplicate user-link conflicts;
+- profile presentation failures;
+- customer storage failures.
+
+Permission and UUID validation remain transport-owned and unchanged.
+
+## Private diagnostics
+
+The original typed error remains server-side and is logged with bounded context when available:
+
+- owner and consumer;
+- owner operation;
+- per-call correlation id;
+- tenant and actor ids;
+- optional customer id;
+- request tenant/user, channel, and locale;
+- stable public code;
+- native transport boundary.
+
+No customer email, name, phone, search text, profile payload, or request body is logged.
+
+`RequestContext` extraction is diagnostic-only. Its absence is logged but does not change the existing customer operation admission path.
+
+## Preserved behavior
+
+The endpoint set, request/response DTOs, permissions, pagination, profile audience selection, locale fallback, and customer/profile bridge remain unchanged.
+
+## Verification boundary
+
+The focused source guard is:
+
+```text
+node scripts/verify/verify-customer-admin-native-error-safety.mjs
+```
+
+The retained evidence file is:
+
+```text
+crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json
+```
+
+Tests, Cargo commands, formatting, verifiers, workflows, CI, native runtime behavior, and the profile audience matrix remain unvalidated until executed and retained separately. No FFA or FBA status is promoted by this source inspection.

--- a/crates/rustok-customer/docs/implementation-plan.md
+++ b/crates/rustok-customer/docs/implementation-plan.md
@@ -12,6 +12,8 @@ Customer detail/create/update enrichment now constructs `ProfilePresentationServ
 
 Canonical root `CustomerReadPort` construction now uses `InProcessCustomerReadPort`, which retains the complete delegated `PortContext` plus safe operation-specific request facts for exact stable local outcomes and returns the same public-safe `PortError`. The persistent implementation in `ports.rs` remains unchanged and available as an explicit compatibility path. Raw search, email, customer rows, profile names, preferred locales, and profile payloads are not logged.
 
+The mounted customer-admin native bootstrap, list, detail, create, and update endpoints now use static public context and typed owner envelopes. Original framework, customer storage, and profile causes remain in bounded server diagnostics with per-call correlation, tenant, actor, optional customer, channel, locale, stable code, and boundary context. `RequestContext` remains diagnostic-only, so this source slice does not change operation admission or profile audience policy.
+
 ## FFA/FBA boundary
 
 - FFA status: `in_progress`
@@ -21,7 +23,8 @@ Canonical root `CustomerReadPort` construction now uses `InProcessCustomerReadPo
 - `read_customer_projection_by_user` is the owner boundary for storefront authenticated-customer lookup; commerce must not construct `CustomerService`.
 - Canonical root construction is `InProcessCustomerReadPort` / `in_process_customer_read_port`; `rustok_customer::ports` remains a compatibility path rather than the covered root entrypoint.
 - Static and source-locked runtime evidence: `crates/rustok-customer/contracts/evidence/customer-contract-test-static-matrix.json`, `crates/rustok-customer/contracts/evidence/customer-runtime-contract-smoke.json`, and `crates/rustok-customer/contracts/evidence/customer-read-projection-runtime-smoke.json`.
-- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers; `node scripts/verify/verify-customer-read-local-context.mjs` locks canonical local context retention.
+- Customer-admin native error-safety source evidence is `crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json`; it remains explicitly unvalidated.
+- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-admin-native-error-safety.mjs` locks the mounted static error envelopes; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers; `node scripts/verify/verify-customer-read-local-context.mjs` locks canonical local context retention.
 
 ## Open results
 
@@ -47,13 +50,20 @@ Canonical root `CustomerReadPort` construction now uses `InProcessCustomerReadPo
    **Remaining evidence:** execute the focused guard, compile the owner and mounted consumers, and retain runtime traces for not-found, invalid-context, storage, profile-unavailable, and list-validation outcomes. Audit direct compatibility-path callers separately.
    **Done when:** runtime evidence proves canonical root consumers emit actionable diagnostics without raw customer/profile payloads and compatibility bypasses are either removed or explicitly accepted.
 
+5. **Validate customer-admin native public error safety.**
+   **Status:** source-ready / unvalidated. Mounted bootstrap, list, detail, create, and update endpoints no longer directly serialize framework or typed customer/profile causes. Domain validation, not-found, and duplicate outcomes retain stable public meaning; technical profile and storage causes are internal-only.
+   **Remaining evidence:** run `verify-customer-admin-native-error-safety.mjs`, compile `rustok-customer-admin` with `ssr`, exercise all five endpoints against validation, not-found, duplicate, profile, and database failures, and retain server logs proving correlation without customer/profile payload leakage.
+   **Done when:** source guard, compile, runtime envelope, tenant isolation, profile audience, restart, and remote-profile evidence are retained without promoting FFA/FBA from source inspection alone.
+
 ## Verification
 
 - `npm run verify:customer:admin-boundary`
+- `node scripts/verify/verify-customer-admin-native-error-safety.mjs`
 - `node scripts/verify/verify-customer-read-local-context.mjs`
 - `node scripts/verify/verify-customer-read-policy-context.mjs`
 - `node scripts/verify/verify-customer-fba-no-compile.mjs`
 - `npm run verify:ecommerce:fba`
+- `cargo check -p rustok-customer-admin --features ssr`
 - `cargo xtask module validate customer`
 - `cargo xtask module test customer`
 - targeted customer CRUD, identity, ownership, profile-bridge, audience-matrix, and local-outcome tests

--- a/scripts/verify/verify-customer-admin-native-error-safety.mjs
+++ b/scripts/verify/verify-customer-admin-native-error-safety.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const adapterPath = "crates/rustok-customer/admin/src/transport/native_server_adapter.rs";
+const cargoPath = "crates/rustok-customer/admin/Cargo.toml";
+const evidencePath = "crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json";
+const adapter = read(adapterPath);
+const cargo = read(cargoPath);
+const evidence = JSON.parse(read(evidencePath));
+
+for (const endpoint of [
+  'endpoint = "customer/bootstrap"',
+  'endpoint = "customer/list"',
+  'endpoint = "customer/detail"',
+  'endpoint = "customer/create"',
+  'endpoint = "customer/update"',
+]) requireText(adapter, endpoint, "mounted customer admin endpoint");
+
+for (const [value, label] of [
+  ["const CUSTOMER_ADMIN_OWNER", "consumer owner constant"],
+  ["const CUSTOMER_ADMIN_BOUNDARY", "transport boundary constant"],
+  ["fn customer_admin_correlation_id", "per-call correlation helper"],
+  ["fn customer_context_error", "context error mapper"],
+  ["fn auth_context_error", "auth context mapper"],
+  ["fn tenant_context_error", "tenant context mapper"],
+  ["async fn optional_request_context", "diagnostic request context"],
+  ["fn customer_owner_error", "typed owner error mapper"],
+  ['owner = "rustok_customer"', "customer owner diagnostics"],
+  ["consumer = CUSTOMER_ADMIN_OWNER", "consumer diagnostics"],
+  ["owner_operation", "owner operation diagnostics"],
+  ["correlation_id", "correlation diagnostics"],
+  ["tenant_id = %tenant_id", "tenant diagnostics"],
+  ["actor_id = %actor_id", "actor diagnostics"],
+  ["customer_id = ?customer_id", "customer diagnostics"],
+  ["channel_id = ?request_context.and_then", "channel diagnostics"],
+  ["locale = ?request_context.map", "locale diagnostics"],
+  ["public_code", "stable public code diagnostics"],
+  ["Customer authentication context is temporarily unavailable", "auth public envelope"],
+  ["Customer tenant context is temporarily unavailable", "tenant public envelope"],
+  ["Customer request is invalid", "validation public envelope"],
+  ["Customer was not found", "not-found public envelope"],
+  ["Customer email already exists", "duplicate-email public envelope"],
+  ["Customer is already linked to a user", "duplicate-link public envelope"],
+  ["Customer profile is temporarily unavailable", "profile public envelope"],
+  ["Customer data is temporarily unavailable", "storage public envelope"],
+]) requireText(adapter, value, label);
+
+for (const operation of [
+  'owner_operation = "bootstrap"',
+  'owner_operation = "list_customers"',
+  'owner_operation = "get_customer_detail"',
+  'owner_operation = "create_customer"',
+  'owner_operation = "update_customer"',
+]) requireText(adapter, operation, "mounted owner operation");
+
+for (const forbidden of [
+  ".map_err(ServerFnError::new)",
+  "ServerFnError::new(error.to_string())",
+  "ServerFnError::new(err.to_string())",
+  "ServerFnError::new(format!(\"Database",
+  "ServerFnError::new(format!(\"validation failed",
+  "ServerFnError::new(format!(\"customer email already exists",
+]) forbidText(adapter, forbidden, "customer admin native adapter");
+
+for (const preserved of [
+  'Permission denied: {message}',
+  'Invalid {field_name}',
+  "ProfileAccessAudience::TrustedService",
+  "ProfileAccessAudience::Authenticated",
+  "get_customer_with_profile",
+]) requireText(adapter, preserved, "preserved customer admin behavior");
+
+requireText(cargo, "tracing.workspace = true", "diagnostics dependency");
+
+if (evidence.status !== "customer_admin_native_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  mounted_endpoint_set_preserved: true,
+  auth_context_static_public_envelope: true,
+  tenant_context_static_public_envelope: true,
+  request_context_diagnostic_only: true,
+  customer_validation_static_public_envelope: true,
+  customer_not_found_static_public_envelope: true,
+  duplicate_email_static_public_envelope: true,
+  duplicate_user_link_static_public_envelope: true,
+  profile_failure_static_public_envelope: true,
+  storage_failure_static_public_envelope: true,
+  owner_context_logging: true,
+  raw_customer_error_public: false,
+  raw_profile_error_public: false,
+  raw_framework_error_public: false,
+  permissions_changed: false,
+  request_response_dto_changed: false,
+  profile_audience_policy_changed: false,
+  ffa_status_promoted: false,
+  fba_status_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "profile_audience_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Customer admin native error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ customer admin native transport uses static public envelopes with private owner causes; source evidence remains unvalidated",
+);


### PR DESCRIPTION
## Summary
- replace direct public serialization of auth, tenant, database, profile, validation, not-found, and duplicate customer errors across the five mounted Customer admin native endpoints
- preserve bounded public meaning for validation, customer not-found, duplicate email, and duplicate user-link outcomes
- use static availability envelopes for framework, profile, and storage failures while retaining original typed causes only in structured SSR diagnostics
- add per-call correlation with tenant, actor, optional customer, request user/channel/locale, stable code, owner, consumer, and boundary context when available
- keep `RequestContext` diagnostic-only so its absence does not change existing operation admission
- preserve endpoint names, DTOs, permissions, pagination, locale fallback, and Profiles audience policy
- add focused source guard, retained source evidence/review, boundary documentation, and owner-plan tracking

## Recheck
The ecommerce master plan still has customer and remaining non-`PortError` mapper cleanup open. The separate `rustok-customer-admin` package still used `.map_err(ServerFnError::new)` for framework extraction, list/detail reads, create/update mutations, and profile-enriched detail loading. This was independent of the earlier Commerce customer admin slice.

## Public boundary
- validation: `Customer request is invalid`
- not found: `Customer was not found`
- duplicate email and user link retain stable conflict messages
- profile and storage failures use static temporary-unavailability messages
- auth and tenant extraction use static context-unavailability messages
- existing permission and UUID validation messages remain unchanged

## Evidence boundary
Source status is `customer_admin_native_error_safety_source_unvalidated`. No FFA/FBA or runtime status is promoted.

## Verification
The current source, `CustomerError` variants, `RequestContext` fields, profile audience construction, mounted endpoint set, branch base, and final Customer-only diff were re-read. Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.