### PR TITLE
fix(outbox): enforce tenant-scoped DLQ administration

### DIFF
--- a/apps/server/src/controllers/admin_events.rs
+++ b/apps/server/src/controllers/admin_events.rs
@@ -210,15 +210,19 @@ fn default_limit() -> u64 {
 }
 
 fn sys_event_tenant_condition(backend: DbBackend, tenant_id: Uuid) -> SimpleExpr {
-    let tenant_id = tenant_id.to_string();
-    let sql = match backend {
-        DbBackend::Sqlite => {
-            "json_extract(payload, '$.tenant_id') = ?1 OR json_extract(payload, '$.event.tenant_id') = ?1"
-        }
-        _ => "payload->>'tenant_id' = $1 OR payload->'event'->>'tenant_id' = $1",
-    };
+    Expr::cust_with_values(
+        sys_event_tenant_sql(backend),
+        vec![Value::from(tenant_id.to_string())],
+    )
+}
 
-    Expr::cust_with_values(sql, vec![Value::from(tenant_id)])
+fn sys_event_tenant_sql(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Sqlite => {
+            "(json_extract(payload, '$.tenant_id') = ?1 OR json_extract(payload, '$.event.tenant_id') = ?1)"
+        }
+        _ => "(payload->>'tenant_id' = $1 OR payload->'event'->>'tenant_id' = $1)",
+    }
 }
 
 fn forbidden_error(description: impl Into<String>) -> Error {
@@ -229,9 +233,8 @@ fn forbidden_error(description: impl Into<String>) -> Error {
 mod tests {
     use rustok_api::{Action, Permission, Resource};
     use sea_orm::DbBackend;
-    use uuid::Uuid;
 
-    use super::sys_event_tenant_condition;
+    use super::sys_event_tenant_sql;
 
     #[test]
     fn dlq_replay_permission_is_manage_not_read() {
@@ -243,18 +246,12 @@ mod tests {
 
     #[test]
     fn tenant_condition_covers_current_and_legacy_envelope_shapes() {
-        let tenant_id = Uuid::new_v4();
-        let postgres = format!(
-            "{:?}",
-            sys_event_tenant_condition(DbBackend::Postgres, tenant_id)
-        );
-        let sqlite = format!(
-            "{:?}",
-            sys_event_tenant_condition(DbBackend::Sqlite, tenant_id)
-        );
-        assert!(postgres.contains("tenant_id"));
-        assert!(postgres.contains("event"));
-        assert!(sqlite.contains("tenant_id"));
-        assert!(sqlite.contains("event"));
+        for backend in [DbBackend::Postgres, DbBackend::Sqlite] {
+            let sql = sys_event_tenant_sql(backend);
+            assert!(sql.starts_with('('));
+            assert!(sql.ends_with(')'));
+            assert!(sql.contains("tenant_id"));
+            assert!(sql.contains("event"));
+        }
     }
 }

--- a/apps/server/src/controllers/admin_events.rs
+++ b/apps/server/src/controllers/admin_events.rs
@@ -1,10 +1,10 @@
-use crate::error::Error;
-use crate::error::Result;
+use crate::error::{Error, Result, http_error};
 use axum::{
     Json,
     extract::{Path, Query, State},
 };
 use chrono::{DateTime, Utc};
+use rustok_api::{Action, Permission, Resource, has_effective_permission};
 use rustok_outbox::entity::{self, SysEventStatus};
 use rustok_telemetry::metrics;
 use sea_orm::{
@@ -17,12 +17,13 @@ use std::time::Instant;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::extractors::rbac::RequireLogsRead;
+use crate::extractors::{
+    auth::CurrentUser, rbac::RequireLogsRead, tenant::CurrentTenant,
+};
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
 #[derive(Debug, Deserialize)]
 pub struct DlqQuery {
-    pub tenant_id: Option<Uuid>,
     pub event_type: Option<String>,
     pub created_after: Option<DateTime<Utc>>,
     #[serde(default = "default_limit")]
@@ -55,12 +56,11 @@ pub struct DlqReplayResponse {
     get,
     path = "/api/admin/events/dlq",
     params(
-        ("tenant_id" = Option<Uuid>, Query, description = "Filter by tenant UUID"),
         ("event_type" = Option<String>, Query, description = "Filter by event type"),
         ("limit" = Option<u64>, Query, description = "Maximum number of results (1-200)"),
     ),
     responses(
-        (status = 200, description = "DLQ event list", body = DlqListResponse),
+        (status = 200, description = "Tenant-scoped DLQ event list", body = DlqListResponse),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden"),
     ),
@@ -69,6 +69,7 @@ pub struct DlqReplayResponse {
 )]
 pub async fn list_dlq(
     State(ctx): State<ServerRuntimeContext>,
+    CurrentTenant(tenant): CurrentTenant,
     _user: RequireLogsRead,
     Query(query): Query<DlqQuery>,
 ) -> Result<Json<DlqListResponse>> {
@@ -77,6 +78,10 @@ pub async fn list_dlq(
 
     let mut db_query = entity::Entity::find()
         .filter(entity::Column::Status.eq(SysEventStatus::Failed))
+        .filter(sys_event_tenant_condition(
+            ctx.db().get_database_backend(),
+            tenant.id,
+        ))
         .order_by_desc(entity::Column::CreatedAt)
         .limit(limit);
 
@@ -86,13 +91,6 @@ pub async fn list_dlq(
 
     if let Some(created_after) = query.created_after {
         db_query = db_query.filter(entity::Column::CreatedAt.gte(created_after));
-    }
-
-    if let Some(tenant_id) = query.tenant_id {
-        db_query = db_query.filter(sys_event_tenant_condition(
-            ctx.db().get_database_backend(),
-            tenant_id,
-        ));
     }
 
     let query_started_at = Instant::now();
@@ -138,28 +136,39 @@ pub async fn list_dlq(
     post,
     path = "/api/admin/events/dlq/{id}/replay",
     params(
-        ("id" = Uuid, Path, description = "DLQ event UUID to replay"),
+        ("id" = Uuid, Path, description = "Tenant-owned DLQ event UUID to replay"),
     ),
     responses(
         (status = 200, description = "Event requeued for processing", body = DlqReplayResponse),
         (status = 400, description = "Event is not in failed status"),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "Forbidden"),
-        (status = 404, description = "Event not found"),
+        (status = 403, description = "logs:manage required"),
+        (status = 404, description = "Tenant-owned event not found"),
     ),
     security(("bearer_auth" = [])),
     tag = "admin"
 )]
 pub async fn replay_dlq_event(
     State(ctx): State<ServerRuntimeContext>,
-    _user: RequireLogsRead,
+    CurrentTenant(tenant): CurrentTenant,
+    user: CurrentUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<DlqReplayResponse>> {
-    let model = entity::Entity::find_by_id(id)
+    let required_permission = Permission::new(Resource::Logs, Action::Manage);
+    if !has_effective_permission(&user.permissions, &required_permission) {
+        return Err(forbidden_error("Permission denied: logs:manage required"));
+    }
+
+    let model = entity::Entity::find()
+        .filter(entity::Column::Id.eq(id))
+        .filter(sys_event_tenant_condition(
+            ctx.db().get_database_backend(),
+            tenant.id,
+        ))
         .one(ctx.db())
         .await
         .map_err(|e| Error::BadRequest(format!("Failed to fetch sys_event: {e}")))?
-        .ok_or_else(|| Error::NotFound)?;
+        .ok_or(Error::NotFound)?;
 
     if model.status != SysEventStatus::Failed {
         return Err(Error::BadRequest(
@@ -210,4 +219,42 @@ fn sys_event_tenant_condition(backend: DbBackend, tenant_id: Uuid) -> SimpleExpr
     };
 
     Expr::cust_with_values(sql, vec![Value::from(tenant_id)])
+}
+
+fn forbidden_error(description: impl Into<String>) -> Error {
+    http_error(rustok_web::HttpError::forbidden("forbidden", description))
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{Action, Permission, Resource};
+    use sea_orm::DbBackend;
+    use uuid::Uuid;
+
+    use super::sys_event_tenant_condition;
+
+    #[test]
+    fn dlq_replay_permission_is_manage_not_read() {
+        assert_ne!(
+            Permission::new(Resource::Logs, Action::Manage),
+            Permission::LOGS_READ
+        );
+    }
+
+    #[test]
+    fn tenant_condition_covers_current_and_legacy_envelope_shapes() {
+        let tenant_id = Uuid::new_v4();
+        let postgres = format!(
+            "{:?}",
+            sys_event_tenant_condition(DbBackend::Postgres, tenant_id)
+        );
+        let sqlite = format!(
+            "{:?}",
+            sys_event_tenant_condition(DbBackend::Sqlite, tenant_id)
+        );
+        assert!(postgres.contains("tenant_id"));
+        assert!(postgres.contains("event"));
+        assert!(sqlite.contains("tenant_id"));
+        assert!(sqlite.contains("event"));
+    }
 }

--- a/crates/rustok-outbox/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-outbox/admin/src/transport/native_server_adapter.rs
@@ -24,8 +24,9 @@ async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError
             .map_err(ServerFnError::new)?;
         let tenant = leptos_axum::extract::<OptionalTenant>()
             .await
-            .ok()
-            .and_then(|value| value.0);
+            .map_err(ServerFnError::new)?
+            .0
+            .ok_or_else(|| ServerFnError::new("tenant context is required for outbox inspection"))?;
 
         if !has_effective_permission(&auth.permissions, &Permission::LOGS_READ) {
             return Err(ServerFnError::new(
@@ -38,7 +39,7 @@ async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError
 
         let module = rustok_outbox::OutboxModule;
         Ok(OutboxAdminBootstrap {
-            tenant_slug: tenant.map(|tenant| tenant.slug),
+            tenant_slug: Some(tenant.slug),
             health: match module.health().await {
                 HealthStatus::Healthy => "healthy",
                 HealthStatus::Degraded => "degraded",
@@ -49,34 +50,30 @@ async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError
                 OutboxCounterSnapshot {
                     key: "pending".to_string(),
                     label: "Pending events".to_string(),
-                    value: query_status_count(&db, backend, "pending")
+                    value: query_status_count(&db, backend, tenant.id, "pending")
                         .await
                         .map_err(ServerFnError::new)?,
                 },
                 OutboxCounterSnapshot {
                     key: "dispatched".to_string(),
                     label: "Dispatched events".to_string(),
-                    value: query_status_count(&db, backend, "dispatched")
+                    value: query_status_count(&db, backend, tenant.id, "dispatched")
                         .await
                         .map_err(ServerFnError::new)?,
                 },
                 OutboxCounterSnapshot {
                     key: "failed".to_string(),
                     label: "Failed events".to_string(),
-                    value: query_status_count(&db, backend, "failed")
+                    value: query_status_count(&db, backend, tenant.id, "failed")
                         .await
                         .map_err(ServerFnError::new)?,
                 },
                 OutboxCounterSnapshot {
                     key: "retries".to_string(),
                     label: "Max retry count".to_string(),
-                    value: query_scalar_i64(
-                        &db,
-                        backend,
-                        "SELECT COALESCE(MAX(retry_count), 0) AS value FROM sys_events",
-                    )
-                    .await
-                    .map_err(ServerFnError::new)? as u64,
+                    value: query_max_retry_count(&db, backend, tenant.id)
+                        .await
+                        .map_err(ServerFnError::new)?,
                 },
             ],
             relay_notes: vec![
@@ -98,15 +95,17 @@ async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError
 async fn query_status_count(
     db: &sea_orm::DatabaseConnection,
     backend: sea_orm::DbBackend,
+    tenant_id: uuid::Uuid,
     status: &str,
 ) -> Result<u64, sea_orm::DbErr> {
     use sea_orm::{ConnectionTrait, QueryResult, Statement};
 
+    let sql = tenant_scoped_status_sql(backend);
     let row = db
         .query_one(Statement::from_sql_and_values(
             backend,
-            "SELECT COUNT(*) AS value FROM sys_events WHERE status = $1",
-            [status.into()],
+            sql,
+            [status.into(), tenant_id.to_string().into()],
         ))
         .await?;
     Ok(row
@@ -115,17 +114,65 @@ async fn query_status_count(
 }
 
 #[cfg(feature = "ssr")]
-async fn query_scalar_i64(
+async fn query_max_retry_count(
     db: &sea_orm::DatabaseConnection,
     backend: sea_orm::DbBackend,
-    sql: &str,
-) -> Result<i64, sea_orm::DbErr> {
+    tenant_id: uuid::Uuid,
+) -> Result<u64, sea_orm::DbErr> {
     use sea_orm::{ConnectionTrait, QueryResult, Statement};
 
+    let sql = tenant_scoped_max_retry_sql(backend);
     let row = db
-        .query_one(Statement::from_string(backend, sql.to_string()))
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            sql,
+            [tenant_id.to_string().into()],
+        ))
         .await?;
     Ok(row
         .and_then(|row: QueryResult| row.try_get::<i64>("", "value").ok())
-        .unwrap_or_default())
+        .unwrap_or_default() as u64)
+}
+
+#[cfg(feature = "ssr")]
+fn tenant_scoped_status_sql(backend: sea_orm::DbBackend) -> &'static str {
+    match backend {
+        sea_orm::DbBackend::Sqlite => {
+            "SELECT COUNT(*) AS value FROM sys_events WHERE status = ?1 AND (json_extract(payload, '$.tenant_id') = ?2 OR json_extract(payload, '$.event.tenant_id') = ?2)"
+        }
+        _ => {
+            "SELECT COUNT(*) AS value FROM sys_events WHERE status = $1 AND (payload->>'tenant_id' = $2 OR payload->'event'->>'tenant_id' = $2)"
+        }
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn tenant_scoped_max_retry_sql(backend: sea_orm::DbBackend) -> &'static str {
+    match backend {
+        sea_orm::DbBackend::Sqlite => {
+            "SELECT COALESCE(MAX(retry_count), 0) AS value FROM sys_events WHERE json_extract(payload, '$.tenant_id') = ?1 OR json_extract(payload, '$.event.tenant_id') = ?1"
+        }
+        _ => {
+            "SELECT COALESCE(MAX(retry_count), 0) AS value FROM sys_events WHERE payload->>'tenant_id' = $1 OR payload->'event'->>'tenant_id' = $1"
+        }
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use sea_orm::DbBackend;
+
+    use super::{tenant_scoped_max_retry_sql, tenant_scoped_status_sql};
+
+    #[test]
+    fn operational_queries_are_tenant_scoped_for_supported_backends() {
+        for backend in [DbBackend::Postgres, DbBackend::Sqlite] {
+            let status = tenant_scoped_status_sql(backend);
+            let retries = tenant_scoped_max_retry_sql(backend);
+            assert!(status.contains("tenant_id"));
+            assert!(status.contains("event"));
+            assert!(retries.contains("tenant_id"));
+            assert!(retries.contains("event"));
+        }
+    }
 }

--- a/crates/rustok-outbox/docs/README.md
+++ b/crates/rustok-outbox/docs/README.md
@@ -31,6 +31,14 @@ infrastructure for the platform event runtime.
 - A transient error leaves the event in `pending`, increments `retry_count`, writes `last_error`, clears the claim and sets `next_attempt_at`.
 - A terminal error moves the event to `failed`/DLQ, saves `last_error`, clears the claim and is reflected in metrics/admin DLQ surface.
 
+## Tenant and authorization boundary
+
+- Tenant-facing DLQ list and native dashboard reads always derive tenant scope from the trusted request context. They do not accept a client-selected tenant identifier.
+- DLQ inspection requires `logs:read`; replay/requeue is a state-changing operator action and requires `logs:manage`.
+- Replay looks up the event by both event id and trusted tenant scope. Missing and cross-tenant targets fail closed as not found.
+- Native pending, dispatched, failed and retry counters require tenant context and filter both current root-envelope and legacy nested-envelope tenant shapes in `sys_events.payload`.
+- A platform-global operational view is not exposed through tenant admin transport. Platform on-call investigation uses owner metrics, health and controlled database/operator procedures.
+
 ## Incident response
 
 Primary owner for outbox/event delivery is the Platform foundation on-call. Escalation path: owner of `crates/rustok-outbox`, then owner of server runtime composition.
@@ -60,6 +68,7 @@ When backlog, retry or DLQ grows:
 - `cargo xtask module test outbox`
 - `node scripts/verify/verify-outbox-admin-boundary.mjs`
 - `node scripts/verify/verify-outbox-admin-boundary.test.mjs`
+- `node scripts/verify/verify-outbox-dlq-tenant-rbac.mjs`
 - `npm run verify:outbox:fba`
 - targeted event-runtime tests for transactional publish, relay and backlog semantics
 

--- a/crates/rustok-outbox/docs/implementation-plan.md
+++ b/crates/rustok-outbox/docs/implementation-plan.md
@@ -21,6 +21,12 @@ The read-only operator dashboard is an accepted single-adapter owner fragment:
 it has no public/headless outbox-admin contract, so its native `#[server]`
 bootstrap remains the only package transport and no GraphQL fallback is added.
 
+Tenant-facing DLQ administration is fail-closed. REST list and native counters
+derive tenant scope from trusted request context, while replay requires
+`logs:manage` and looks up the event by both id and tenant. Tenant admins cannot
+select another tenant or inspect platform-global relay state through these
+surfaces.
+
 ## FFA/FBA status block
 
 - FFA status: `in_progress`
@@ -32,7 +38,8 @@ bootstrap remains the only package transport and no GraphQL fallback is added.
   `crates/rustok-outbox/contracts/evidence/outbox-contract-test-static-matrix.json`
   and `crates/rustok-outbox/contracts/evidence/outbox-provider-runtime-order-smoke.json`.
 - `npm run verify:outbox:admin-boundary` and `npm run verify:outbox:fba` lock
-  the UI boundary, provider metadata, and owner-service invocation order.
+  the UI boundary, provider metadata, owner-service invocation order, and
+  tenant/RBAC invariants for DLQ administration.
 - The server relay worker consumes `OutboxRelayPort::process_pending_once` with
   a service actor, deadline, and per-tick idempotency key; it does not invoke
   the relay service method directly.
@@ -42,7 +49,18 @@ bootstrap remains the only package transport and no GraphQL fallback is added.
 
 ## Open results
 
-1. **Execute relay, backlog, retry, and DLQ runtime contracts.** Replace static
+1. **Close the transport-to-consumer durability gap.** `sys_events=dispatched`
+   currently means the configured `EventTransport::publish` returned success.
+   In local fan-out modes, module handlers can still fail after that point or
+   miss events through broadcast lag without a durable consumer receipt,
+   consumer DLQ, or automatic source rebuild.
+   **Depends on:** server event transport, `rustok-core` dispatcher semantics,
+   and projection consumers such as Search.
+   **Done when:** terminal consumer failure is durably observable and replayable,
+   restart/lag recovery is executable, and projection consumers prove
+   idempotent duplicate/out-of-order handling.
+
+2. **Execute relay, backlog, retry, and DLQ runtime contracts.** Replace static
    evidence with targeted provider execution and fallback proof for relay
    control before any FBA promotion.
    **Depends on:** a runtime-composed relay and representative delivery
@@ -50,28 +68,31 @@ bootstrap remains the only package transport and no GraphQL fallback is added.
    **Done when:** transactional publish, retry, DLQ transition, degraded mode,
    and typed port errors are covered by executable tests.
 
-2. **Prepare safe incremental operational adoption.** Define rollout,
+3. **Prepare safe incremental operational adoption.** Define rollout,
    migration, tenant, RBAC, and security requirements that belong to relay
    control rather than to the host UI.
    **Depends on:** deployment topology and operator authorization model.
    **Done when:** staged enablement has explicit guardrails, permissions, and a
    rollback path without duplicated relay ownership.
 
-3. **Maintain observability and incident guidance with delivery semantics.**
+4. **Maintain observability and incident guidance with delivery semantics.**
    Update metrics, alerting, and the runbook whenever relay/backlog/DLQ behavior
    changes.
    **Depends on:** the changed outbox runtime contract.
    **Done when:** operators can identify stalled relay, growing backlog, DLQ,
-   and retry failures with an owner-specific recovery procedure.
+   consumer-side terminal failures, and retry failures with an owner-specific
+   recovery procedure.
 
 ## Verification
 
 - `npm run verify:outbox:admin-boundary`
 - `npm run test:verify:outbox:admin-boundary`
+- `node scripts/verify/verify-outbox-dlq-tenant-rbac.mjs`
 - `npm run verify:outbox:fba`
 - `cargo xtask module validate outbox`
 - `cargo xtask module test outbox`
-- Targeted transactional publish, relay, retry, and DLQ runtime tests.
+- Targeted transactional publish, relay, retry, DLQ, tenant-isolation, and
+  consumer-recovery runtime tests.
 
 ## Change rules
 
@@ -80,3 +101,16 @@ bootstrap remains the only package transport and no GraphQL fallback is added.
    contract change.
 3. Update this status block and `docs/modules/registry.md` with an FFA/FBA
    boundary change.
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `blocked`
+- Last verified at (UTC): `2026-07-30`
+- Scope inspected: `relay claim/dispatch/retry/DLQ state machine, REST DLQ list/replay, native admin counters, tenant/RBAC trust boundaries, and server local-delivery composition`
+- Findings: `P0=1, P1=1, P2=0, P3=0`
+- Fixed in this pass: `P0 tenant isolation and authorization: tenant admins can no longer select or inspect another tenant's DLQ events; replay now requires logs:manage and a tenant-qualified event lookup; native operational counters require tenant context and are tenant-scoped`
+- Remaining risks or blockers: `P1: outbox dispatched state proves transport acceptance only; local module handler terminal failure or broadcast lag can leave Search and other projections stale without a durable consumer receipt/DLQ/replay contract`
+- Evidence: `source regressions in admin_events.rs and rustok-outbox-admin native adapter; scripts/verify/verify-outbox-dlq-tenant-rbac.mjs is included by npm run verify:outbox:fba; same-SHA Actions are required before merge`
+- Next action: `design and execute a durable consumer completion/recovery contract with server event delivery, rustok-core dispatcher, and Search projection owners; then run relay and restart E2E evidence`
+- Resume command: `node scripts/verify/verify-outbox-dlq-tenant-rbac.mjs && npm run verify:outbox:fba && cargo test -p rustok-outbox && cargo test -p rustok-server admin_events`

--- a/docs/verification/PLATFORM_VERIFICATION_PLAN.md
+++ b/docs/verification/PLATFORM_VERIFICATION_PLAN.md
@@ -42,7 +42,7 @@ This block is the first place an agent reads after `docs/index.md`.
 - Next item: `core/index`
 - Started at (UTC): `2026-07-20`
 - Last handoff at (UTC): `2026-07-30`
-- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/search P1: the generic settings projection serializes search.api_key`
+- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/search P1: the generic settings projection serializes search.api_key; core/outbox P1: sys_events dispatched state proves transport acceptance only, while terminal local handler failure or broadcast lag lacks a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale`
 - Release readiness: `not_assessed`
 - Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started, an earlier smoke stopped before compilation because Cargo.lock required an Athanor update, and dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
 
@@ -183,12 +183,16 @@ These are Core modules because the current `modules.toml` declares them with
 - [x] `core/email` — `crates/rustok-email` — blocked
 - [ ] `core/index` — `crates/rustok-index`
 - [ ] `core/search` — `crates/rustok-search`
-- [ ] `core/outbox` — `crates/rustok-outbox`
+- [x] `core/outbox` — `crates/rustok-outbox` — blocked
 - [ ] `core/tenant` — `crates/rustok-tenant`
 - [ ] `core/rbac` — `crates/rustok-rbac`
 - [ ] Core interaction sweep — auth/tenant/RBAC generation and caches; channel/locale
   cache dimensions; transactional events/outbox; index/search replay and rebuild;
   Core module lifecycle and migration ordering.
+
+`core/outbox` was visited ahead of the normal cursor to remove a confirmed P0 tenant
+isolation defect. The normal resume point remains `core/index`; Outbox must be revisited
+at the closing gate for its consumer-durability P1.
 
 For each manifest module, run at minimum:
 

--- a/scripts/verify/verify-outbox-dlq-tenant-rbac.mjs
+++ b/scripts/verify/verify-outbox-dlq-tenant-rbac.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-outbox-dlq-tenant-rbac] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (source, markers, label) => {
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${label} is missing ${marker}`);
+  }
+};
+
+const controllerPath = 'apps/server/src/controllers/admin_events.rs';
+const nativePath = 'crates/rustok-outbox/admin/src/transport/native_server_adapter.rs';
+const controller = read(controllerPath);
+const native = read(nativePath);
+
+requireMarkers(controller, [
+  'CurrentTenant(tenant): CurrentTenant',
+  '_user: RequireLogsRead',
+  'Permission::new(Resource::Logs, Action::Manage)',
+  'Permission denied: logs:manage required',
+  '.filter(entity::Column::Id.eq(id))',
+  'sys_event_tenant_condition(',
+  'tenant.id',
+  "payload->>'tenant_id' = $1 OR payload->'event'->>'tenant_id' = $1",
+  "json_extract(payload, '$.tenant_id') = ?1 OR json_extract(payload, '$.event.tenant_id') = ?1",
+  'dlq_replay_permission_is_manage_not_read',
+  'tenant_condition_covers_current_and_legacy_envelope_shapes',
+], controllerPath);
+
+if (/pub struct DlqQuery[\s\S]*?tenant_id\s*:/u.test(controller)) {
+  fail('DLQ query accepts a client-selected tenant_id');
+}
+if (/replay_dlq_event[\s\S]*?RequireLogsRead/u.test(controller)) {
+  fail('DLQ replay is still authorized by logs:read');
+}
+if (/find_by_id\(id\)/u.test(controller)) {
+  fail('DLQ replay performs an unqualified event lookup');
+}
+if (!controller.includes('.ok_or(Error::NotFound)?;')) {
+  fail('cross-tenant or missing replay targets must fail closed as not found');
+}
+
+requireMarkers(native, [
+  'tenant context is required for outbox inspection',
+  'tenant_slug: Some(tenant.slug)',
+  'query_status_count(&db, backend, tenant.id, "pending")',
+  'query_status_count(&db, backend, tenant.id, "dispatched")',
+  'query_status_count(&db, backend, tenant.id, "failed")',
+  'query_max_retry_count(&db, backend, tenant.id)',
+  'fn tenant_scoped_status_sql(',
+  'fn tenant_scoped_max_retry_sql(',
+  "payload->>'tenant_id' = $2 OR payload->'event'->>'tenant_id' = $2",
+  "json_extract(payload, '$.tenant_id') = ?2 OR json_extract(payload, '$.event.tenant_id') = ?2",
+  'operational_queries_are_tenant_scoped_for_supported_backends',
+], nativePath);
+
+if (native.includes('tenant.map(|tenant| tenant.slug)')) {
+  fail('native bootstrap still treats tenant context as optional');
+}
+if (native.includes('query_scalar_i64(')) {
+  fail('native bootstrap retains an unscoped arbitrary SQL counter helper');
+}
+if (native.includes('SELECT COUNT(*) AS value FROM sys_events WHERE status = $1"')) {
+  fail('native status counters remain unscoped');
+}
+if (native.includes('SELECT COALESCE(MAX(retry_count), 0) AS value FROM sys_events"')) {
+  fail('native retry counter remains unscoped');
+}
+
+console.log('[verify-outbox-dlq-tenant-rbac] OK');

--- a/scripts/verify/verify-outbox-fba.mjs
+++ b/scripts/verify/verify-outbox-fba.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 const root = new URL('../../', import.meta.url);
 const read = (path) => readFileSync(new URL(path, root), 'utf8');
@@ -6,6 +7,7 @@ const fail = (message) => { console.error(`[verify-outbox-fba] ${message}`); pro
 const sameSet = (actual, expected) => Array.isArray(actual) && Array.isArray(expected) && actual.length === expected.length && expected.every((item) => actual.includes(item));
 const registryPath = 'crates/rustok-outbox/contracts/outbox-fba-registry.json';
 const evidencePath = 'crates/rustok-outbox/contracts/evidence/outbox-contract-test-static-matrix.json';
+const dlqGuardPath = 'scripts/verify/verify-outbox-dlq-tenant-rbac.mjs';
 const registry = json(registryPath);
 const evidence = json(evidencePath);
 const runtimeOrderSmoke = json(registry.evidence.runtime_order_smoke);
@@ -16,7 +18,7 @@ const pkg = json('package.json');
 const lib = read('crates/rustok-outbox/src/lib.rs');
 const ports = read('crates/rustok-outbox/src/ports.rs');
 const serverRelayWorker = read('apps/server/src/services/event_transport_factory.rs');
-if (pkg.scripts?.['verify:outbox:fba'] !== 'node scripts/verify/verify-outbox-fba.mjs && npm run verify:owner:fba-runtime-order') fail('package script verify:outbox:fba drift');
+if (pkg.scripts?.['verify:outbox:fba'] !== 'node scripts/verify/verify-outbox-fba.mjs' && npm run verify:owner:fba-runtime-order') fail('package script verify:outbox:fba drift');
 if (registry.schema_version !== 1 || registry.module !== 'outbox' || registry.role !== 'provider' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 if (registry.contract_version !== 'outbox.relay_control.v1') fail('contract version drift');
 const [port] = registry.ports ?? [];
@@ -54,4 +56,6 @@ for (const smokeCase of runtimeOrderSmoke.cases) {
     if (!ports.includes(marker)) fail(`${smokeCase.operation} runtime order source marker missing ${marker}`);
   }
 }
-console.log('[verify-outbox-fba] Outbox FBA provider metadata, port semantics and static evidence are consistent');
+const dlqGuard = spawnSync(process.execPath, [dlqGuardPath], { encoding: 'utf8' });
+if (dlqGuard.status !== 0) fail(`DLQ tenant/RBAC guard failed: ${dlqGuard.stderr || dlqGuard.stdout}`);
+console.log('[verify-outbox-fba] Outbox FBA provider metadata, port semantics, tenant-scoped DLQ administration and static evidence are consistent');

--- a/scripts/verify/verify-outbox-fba.mjs
+++ b/scripts/verify/verify-outbox-fba.mjs
@@ -18,7 +18,7 @@ const pkg = json('package.json');
 const lib = read('crates/rustok-outbox/src/lib.rs');
 const ports = read('crates/rustok-outbox/src/ports.rs');
 const serverRelayWorker = read('apps/server/src/services/event_transport_factory.rs');
-if (pkg.scripts?.['verify:outbox:fba'] !== 'node scripts/verify/verify-outbox-fba.mjs' && npm run verify:owner:fba-runtime-order') fail('package script verify:outbox:fba drift');
+if (pkg.scripts?.['verify:outbox:fba'] !== 'node scripts/verify/verify-outbox-fba.mjs && npm run verify:owner:fba-runtime-order') fail('package script verify:outbox:fba drift');
 if (registry.schema_version !== 1 || registry.module !== 'outbox' || registry.role !== 'provider' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 if (registry.contract_version !== 'outbox.relay_control.v1') fail('contract version drift');
 const [port] = registry.ports ?? [];


### PR DESCRIPTION
## Confirmed P0

Tenant admins receive `logs:read`. The REST DLQ list accepted an optional client-selected `tenant_id`, replay was authorized by `logs:read`, and replay loaded `sys_events` by UUID without trusted tenant qualification. The module-owned native dashboard also extracted tenant context only for display while counting all rows in `sys_events`.

This allowed cross-tenant DLQ metadata disclosure and cross-tenant requeue when an event UUID was known.

## Fix

- derive REST DLQ list scope only from `CurrentTenant`
- remove the client-selected `tenant_id` query field
- require canonical `logs:manage` for replay
- qualify replay lookup by event id and trusted tenant scope
- fail cross-tenant and missing targets closed as `404`
- require tenant context in the native Outbox dashboard
- tenant-scope pending, dispatched, failed, and max-retry counters for current and legacy envelope payload shapes
- add Rust source regressions and a static verifier
- run the tenant/RBAC verifier from the standard Outbox FBA gate
- update owner docs, local verification handoff, and the master release cursor

## Remaining blocker

`sys_events=dispatched` proves only successful transport publication. Local module handler terminal failures or broadcast lag still lack a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale. Outbox remains blocked for the cycle.

## Evidence status

Same-SHA GitHub Actions and targeted Outbox FBA/Cargo checks are required before merge.