### PR TITLE
feat(index): add exact Decimal aggregate order wire

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -98,9 +98,9 @@ SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
 `HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
 connection, persisted tenant schema readiness, authorization, or successful query execution.
 
-Exact Decimal tagged-order transport, aggregate cursor continuation, retained
-PostgreSQL/reference aggregate evidence, additional source schemas, transport authorization,
-and first storefront/admin/search authoritative consumer cutover remain open.
+Exact Decimal tagged-order transport is source-complete. Aggregate cursor continuation,
+retained PostgreSQL/reference aggregate evidence, additional source schemas, transport
+authorization, and first storefront/admin/search authoritative consumer cutover remain open.
 
 No compatibility contract exists for deleted behavior. `IndexDocument`, `DocumentType`, old
 ports/adapters, source DTOs/indexers/models/migrations, `IndexerRuntimeConfig`,
@@ -140,12 +140,15 @@ builders or DTOs.
 - Query shape, depth, selected fields, ordering expressions, page size, and offset are bounded.
 - Plain `asc` / `desc` through a `many` path remains ambiguous and rejected.
 - Explicit `min_asc`, `min_desc`, `max_asc`, and `max_desc` are accepted only for sortable
-  scalar integer, string, or timestamp fields reached through at least one `many` link and only
-  with bounded offset pagination.
+  scalar integer, Decimal, string, or timestamp fields reached through at least one `many` link
+  and only with bounded offset pagination.
+- Decimal aggregation and `ORDER BY` use PostgreSQL `numeric`; the hidden tagged order value uses
+  a JSON string derived from `numeric::text`, matching the exact `IndexValue::Decimal` Serde wire
+  without JSON-number or float conversion.
 - Empty or all-null aggregate relation sets produce a nullable derived order value; ascending
   uses `NULLS LAST`, descending uses `NULLS FIRST`, and root entity ID remains the final tie-break.
-- Boolean, Decimal, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate
-  orders fail closed. Decimal requires a separate exact tagged-wire contract before enablement.
+- Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate orders
+  fail closed.
 - `SchemaRegistry::compile_postgres_page_query` preserves the compiled query and changes only
   the validated page-limit bind from `N` to `N + 1`.
 - `CompiledPostgresQuery::many_relations` binds every aggregate alias to exact plan metadata.
@@ -198,8 +201,10 @@ builders or DTOs.
 - Many projections compile as correlated JSONB aggregates outside the outer root rowset and use
   stored link ordinal, entity identity, and locale for deterministic item order.
 - Explicit many ordering compiles as a correlated typed `MIN` / `MAX` scalar subquery outside
-  the outer root rowset; the selected order column remains tagged `IndexValue` JSONB for the
-  currently admitted integer, string, and timestamp wire types.
+  the outer root rowset; the selected order column remains tagged `IndexValue` JSONB for integer,
+  Decimal, string, and timestamp wire types.
+- Decimal hidden order JSON uses an exact string while its aggregate and ordering expressions
+  remain typed `numeric`.
 - `decode_postgres_query_page` re-plans and verifies the plan fingerprint, scalar/many metadata,
   tagged values, nested identity/value arity, uniqueness, page bounds, and optional exact count.
 - Cursor pages remove lookahead and produce a next scoped cursor from the last retained
@@ -237,6 +242,6 @@ builders or DTOs.
 - Treating `SharedIndexQueryRuntime` presence as authorization or proof that a tenant query works.
 - Publishing a consumer query without owner/transport authorization and bounded error mapping.
 - Using plain `asc` / `desc`, link ordinal, first related row, or caller SQL as a many-order policy.
-- Enabling Decimal aggregate ordering before an exact tagged-order wire contract is source-complete.
+- Encoding Decimal aggregate order values as JSON numbers or floats instead of exact strings.
 - Treating a source-complete aggregate compiler as PostgreSQL/reference execution evidence.
 - Executing compiler SQL outside `PostgresIndexQueryPort` or splitting page/count snapshots.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -56,6 +56,7 @@ a rewrite goal.
 - M3 retained bundle review and archive verification: complete
 - M4 deterministic query planning and controlled SQL compilation: complete
 - M4 root/one and many-link query result semantics: complete
+- M4 explicit many-link aggregate ordering and Decimal tagged wire: source complete
 - M4 PostgreSQL query port and row adapter: source complete
 - M4 source-owned registry and server query-runtime composition: source complete
 - Real retained PostgreSQL packet execution: open
@@ -72,12 +73,14 @@ admitted-only archive manifest outside the bundle, and verifies the saved manife
 against an exact recursive filesystem snapshot.
 
 M4 now provides deterministic typed planning, controlled PostgreSQL compilation,
-correlated many-link filtering, nested many-link projection aggregation, strict
-result decoding, lookahead pagination, exact count, scoped cursors, an Index-owned
-PostgreSQL execution port, a source-owned immutable schema catalog, and a server-owned
-neutral query runtime. Storefront/admin/search authorization and consumer cutover,
-many-link aggregate ordering policy, live PostgreSQL/reference equivalence, and
-production partition cutover remain open.
+correlated many-link filtering, nested many-link projection aggregation, explicit bounded
+`MIN` / `MAX` many-link ordering for integer, Decimal, string, and timestamp, strict result
+decoding, lookahead pagination, exact count, scoped cursors for ordinary order expressions,
+an Index-owned PostgreSQL execution port, a source-owned immutable schema catalog, and a
+server-owned neutral query runtime. Decimal aggregate ordering remains numeric while its
+hidden tagged value uses an exact JSON string. Aggregate cursor continuation,
+PostgreSQL/reference aggregate evidence, storefront/admin/search authorization and consumer
+cutover, and production partition cutover remain open.
 
 The module-owned migration source creates:
 
@@ -195,7 +198,10 @@ readiness; execution still fails closed through the query-port preflight.
 - tenant/locale-scoped records and queries;
 - registry-backed type, cardinality, field, link, and operator validation;
 - bounded query complexity and pagination;
-- no ambiguous ordering through `many` links;
+- plain `asc` / `desc` remains ambiguous through `many`; explicit bounded `min` / `max`
+  supports integer, Decimal, string, and timestamp;
+- Decimal many-order `MIN` / `MAX` and `ORDER BY` use `numeric`, while hidden tagged JSON uses
+  an exact string from `numeric::text` without float conversion;
 - checksummed keyset cursors bound to tenant, schema, fingerprint, locale, and
   order shape;
 - reference mutation/query engine and property-based invariants for future
@@ -242,6 +248,8 @@ DDL remains benchmark-only and must not be copied into production migrations.
 - [M4 source-owned schema registry](./docs/m4-source-schema-registry.md)
 - [M4 query runtime composition](./docs/m4-query-runtime-composition.md)
 - [M4 PostgreSQL query port contract](./docs/m4-postgres-query-port.md)
+- [M4 many-link aggregate ordering](./docs/m4-many-link-aggregate-ordering.md)
+- [M4 Decimal aggregate order wire](./docs/m4-decimal-aggregate-order-wire.md)
 - [M4 many-link projection contract](./docs/m4-many-link-projection.md)
 - [M2 storage benchmark contract](./docs/storage-benchmark.md)
 - [M2 replacement evidence runbook](./docs/storage-evidence-runbook.md)

--- a/crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json
+++ b/crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "owner": "rustok-index",
+  "status": "source_complete_execution_pending",
+  "domain_wire": {
+    "rust_type": "rust_decimal::Decimal",
+    "index_value_tag": "decimal",
+    "json_value_kind": "string",
+    "example": {
+      "type": "decimal",
+      "value": "123.4500"
+    },
+    "round_trip_test": "decimal_tagged_json_uses_exact_string_wire"
+  },
+  "postgresql_wire": {
+    "stored_source": "tagged JSON string",
+    "typed_scalar": "numeric",
+    "aggregate_functions": ["MIN", "MAX"],
+    "hidden_order_value": "jsonb_build_object with to_jsonb((aggregate_scalar)::text)",
+    "json_number_allowed": false,
+    "float_conversion_allowed": false,
+    "ordering_uses_text": false,
+    "ordering_uses_numeric": true
+  },
+  "query_boundary": {
+    "many_link_modes": ["min_asc", "min_desc", "max_asc", "max_desc"],
+    "pagination": "bounded_offset",
+    "aggregate_cursor_supported": false,
+    "empty_or_all_null_result": "null"
+  },
+  "guardrails": {
+    "domain": "crates/rustok-index/src/domain/value.rs",
+    "validator": "crates/rustok-index/src/application/aggregate_ordering.rs",
+    "compiler": "crates/rustok-index/src/application/postgres_compiler.rs",
+    "sql": "crates/rustok-index/src/application/postgres_query_sql.rs",
+    "tests": "crates/rustok-index/src/application/aggregate_ordering_tests.rs",
+    "verifier": "scripts/verify/verify-index-decimal-aggregate-wire.mjs"
+  },
+  "validation": {
+    "cargo_run": false,
+    "tests_run": false,
+    "postgresql_run": false,
+    "node_verifiers_run": false,
+    "workflows_run": false,
+    "ci_run": false
+  },
+  "non_claims": [
+    "PostgreSQL execution proof",
+    "PostgreSQL/reference equivalence",
+    "aggregate cursor continuation",
+    "retained evidence admission"
+  ]
+}

--- a/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
+++ b/crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json
@@ -11,8 +11,8 @@
     "aggregate_cursor_supported": false,
     "pagination": "bounded_offset"
   },
-  "supported_terminal_types": ["integer", "string", "timestamp"],
-  "rejected_terminal_types": ["boolean", "decimal", "uuid", "list"],
+  "supported_terminal_types": ["integer", "decimal", "string", "timestamp"],
+  "rejected_terminal_types": ["boolean", "uuid", "list"],
   "postgresql": {
     "strategy": "correlated_scalar_subquery",
     "aggregates": ["MIN", "MAX"],
@@ -22,6 +22,8 @@
     "descending_nulls": "first",
     "final_tie_break": "root_entity_id_asc",
     "order_value_transport": "tagged_index_value_jsonb",
+    "decimal_order_scalar": "numeric",
+    "decimal_tagged_value": "json_string_from_numeric_text",
     "caller_sql": false,
     "implicit_first_row": false,
     "implicit_link_ordinal": false
@@ -37,6 +39,7 @@
     "compiler": "crates/rustok-index/src/application/postgres_compiler.rs",
     "sql": "crates/rustok-index/src/application/postgres_query_sql.rs",
     "tests": "crates/rustok-index/src/application/aggregate_ordering_tests.rs",
+    "decimal_contract": "crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json",
     "verifier": "scripts/verify/verify-index-many-link-aggregate-ordering.mjs"
   },
   "validation": {
@@ -48,7 +51,6 @@
     "ci_run": false
   },
   "remaining": [
-    "exact decimal tagged-order wire contract",
     "aggregate cursor identity and continuation",
     "independent reference materialization for aggregate values",
     "PostgreSQL/reference aggregate offset scenarios",

--- a/crates/rustok-index/docs/m4-decimal-aggregate-order-wire.md
+++ b/crates/rustok-index/docs/m4-decimal-aggregate-order-wire.md
@@ -1,0 +1,99 @@
+# M4 Decimal aggregate order wire
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice enables Decimal as a terminal type for explicit many-link `min_*` / `max_*`
+ordering while preserving an exact tagged `IndexValue` JSON contract.
+
+The machine-readable contract is
+`crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json`.
+
+## Domain wire
+
+`IndexValue::Decimal` uses the ordinary Serde representation owned by `rust_decimal`:
+
+```json
+{
+  "type": "decimal",
+  "value": "123.4500"
+}
+```
+
+The JSON value is a string, not a JSON number. A source test serializes a scaled Decimal,
+asserts the exact tagged payload, deserializes it, and reserializes it byte-semantically to the
+same JSON value. No float conversion or alternate arbitrary-precision JSON feature is introduced.
+
+## PostgreSQL wire
+
+Stored Decimal fields are already read from the tagged JSON string and cast to PostgreSQL
+`numeric` for filtering and ordering. Many-link aggregation continues to evaluate typed
+`MIN(numeric)` or `MAX(numeric)` in the correlated scalar subquery.
+
+The hidden `__order_N` handoff deliberately uses a different representation from the ordering
+expression:
+
+- `ORDER BY` uses the typed `numeric` aggregate;
+- the tagged JSON value uses `to_jsonb((aggregate_scalar)::text)`;
+- the resulting object remains `{ "type": "decimal", "value": "..." }`;
+- the strict decoder therefore receives the same Decimal wire shape as an ordinary stored
+  `IndexValue`.
+
+This separation prevents conversion through a JSON number or `f64` while retaining numeric,
+not lexical, ordering.
+
+## Query boundary
+
+Decimal is accepted under the same bounded aggregate policy as integer, string, and timestamp:
+
+- the field path crosses at least one `many` link;
+- the terminal field is scalar and sortable;
+- the caller explicitly selects `min_asc`, `min_desc`, `max_asc`, or `max_desc`;
+- pagination is bounded offset pagination.
+
+Plain `asc` / `desc` through `many`, UUID aggregate ordering, singular aggregate paths, and
+aggregate cursor continuation remain rejected.
+
+An empty or all-null relation set still produces SQL `NULL`; ascending uses `NULLS LAST`,
+descending uses `NULLS FIRST`, and root entity ID remains the deterministic final tie-break.
+
+## Compatibility
+
+The `OrderExpr`, `PlannedOrder`, compiled-column, and result DTO shapes are unchanged. Existing
+ordinary v4 plan/SQL snapshots do not contain aggregate Decimal ordering and remain outside this
+slice. Root/one-link Decimal filtering and ordering are unchanged.
+
+No new dependency or feature flag is added. The contract relies on the existing `rust_decimal`
+Serde string representation and existing PostgreSQL `numeric` casts.
+
+## Non-claims
+
+This source slice does not:
+
+- enable aggregate cursor continuation;
+- add Decimal scenarios to the independent PostgreSQL/reference fixture;
+- run PostgreSQL or prove driver decoding;
+- update or admit a retained equivalence bundle;
+- change runtime composition, authorization, or consumer cutover.
+
+## Owner validation
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-index decimal_tagged_json_uses_exact_string_wire -- --nocapture
+cargo test -p rustok-index decimal_aggregate_uses_numeric_order_and_exact_string_wire -- --nocapture
+cargo test -p rustok-index aggregate_ordering -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-decimal-aggregate-wire.mjs
+node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo xtask module validate index
+```
+
+A later owner-operated PostgreSQL/reference scenario must persist Decimals with representative
+scale and precision, execute `MIN` / `MAX` offset pages through `PostgresIndexQueryPort`, and
+compare the decoded page before this path is considered execution proven.

--- a/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
+++ b/crates/rustok-index/docs/m4-many-link-aggregate-ordering.md
@@ -17,26 +17,28 @@ The `OrderExpr` shape is unchanged. Existing `asc` / `desc` payloads, source lit
 legacy plan/cursor discriminants therefore retain their old representation.
 
 The machine-readable contract is
-`crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json`.
+`crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json`. Decimal's exact hidden-order
+handoff is separately fixed by
+`crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json`.
 
 ## Validation policy
 
 Aggregate ordering is accepted only when all of the following are true:
 
 1. the field path crosses at least one `LinkCardinality::Many` edge;
-2. the terminal field has scalar cardinality, is sortable, and has type `integer`, `string`,
-   or `timestamp`;
+2. the terminal field has scalar cardinality, is sortable, and has type `integer`, `decimal`,
+   `string`, or `timestamp`;
 3. pagination is bounded offset pagination under the existing limit/depth caps.
 
 Aggregate ordering on a root or one-link-only path is rejected. Plain `asc` / `desc` over a
-many path is still rejected as `AmbiguousManyLinkSort`. Boolean, Decimal and UUID, list-valued,
-and unsortable fields are rejected.
+many path is still rejected as `AmbiguousManyLinkSort`. Boolean, UUID, list-valued, and
+unsortable fields are rejected. UUID remains outside the bounded PostgreSQL `MIN` / `MAX`
+contract.
 
-Decimal remains fail-closed because the hidden order column must round-trip through the exact
-tagged `IndexValue` JSON representation. The current PostgreSQL numeric JSON emission is not
-an admitted exact tagged-wire contract for `rust_decimal`; that contract needs a separate
-source and equivalence slice before Decimal ordering can be enabled. UUID also remains excluded
-from the bounded PostgreSQL `MIN` / `MAX` contract.
+Decimal uses an exact split wire. PostgreSQL evaluates `MIN` / `MAX` and `ORDER BY` through the
+typed `numeric` scalar. The hidden `__order_N` tagged payload converts that scalar through
+`numeric::text`, producing a JSON string that matches `IndexValue::Decimal` Serde. It never
+passes the Decimal through a JSON number or float conversion.
 
 Aggregate cursor continuation remains open. This slice deliberately does not reinterpret the
 existing cursor envelope or silently encode a derived many-link value into a legacy cursor.
@@ -75,19 +77,20 @@ the typed terminal scalar. SQL aggregate null semantics are intentional:
 The aggregate relation does not enter the outer rowset, so root cardinality, exact count, and
 bounded offset pagination remain duplicate free. The selected `__order_N` column is encoded as
 tagged `IndexValue` JSONB for the existing strict decoder, while `ORDER BY` uses the typed
-scalar expression.
+scalar expression. Decimal is the only supported aggregate type whose tagged value uses a JSON
+string derived from typed text; the ordering expression itself remains `numeric`.
 
 ## Compatibility boundary
 
 The two test-only reference engines normalize physical direction through
 `OrderDirection::base_direction()` so adding explicit modes cannot create an exhaustive-match
 compile break. Their aggregate result materialization is not extended in this slice because
-aggregate cursor/reference equivalence is still owner-execution work.
+aggregate reference equivalence is still owner-execution work.
 
 This slice does not:
 
 - enable aggregate cursor pagination;
-- enable Decimal or UUID aggregate ordering;
+- enable UUID aggregate ordering;
 - change ordinary root or one-link ordering;
 - choose the first related row, link ordinal, or storage order as an implicit aggregate;
 - add `array_agg` or caller-defined SQL;
@@ -101,15 +104,18 @@ Not run by the implementation agent, per maintainer instruction.
 Suggested commands:
 
 ```bash
+cargo test -p rustok-index decimal_tagged_json_uses_exact_string_wire -- --nocapture
+cargo test -p rustok-index decimal_aggregate_uses_numeric_order_and_exact_string_wire -- --nocapture
 cargo test -p rustok-index aggregate_ordering -- --nocapture
 cargo test -p rustok-index aggregate_ordering_tests -- --nocapture
 cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-decimal-aggregate-wire.mjs
 node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo xtask module validate index
 ```
 
-A later slice should define the exact Decimal tagged-wire contract and extend the independent
-reference fixture plus retained PostgreSQL/reference capture with aggregate offset scenarios
-before aggregate ordering is treated as execution proven. Cursor support should be designed and
-admitted separately.
+A later slice should extend the independent reference fixture plus retained
+PostgreSQL/reference capture with Decimal and other aggregate offset scenarios before aggregate
+ordering is treated as execution proven. Cursor support should be designed and admitted
+separately.

--- a/crates/rustok-index/docs/m4-postgres-query-compiler.md
+++ b/crates/rustok-index/docs/m4-postgres-query-compiler.md
@@ -72,14 +72,16 @@ by the invariant ascending root `entity_id` tie-breaker. Plain `asc` / `desc` th
 many link remains rejected. Callers must select `min_asc`, `min_desc`, `max_asc`, or
 `max_desc`.
 
-Many-link aggregate ordering is accepted only for sortable scalar integer, string, or
-timestamp fields and only with bounded offset pagination. Boolean, Decimal, UUID, list-valued,
+Many-link aggregate ordering is accepted only for sortable scalar integer, Decimal, string, or
+timestamp fields and only with bounded offset pagination. Boolean, UUID, list-valued,
 singular-path, cursor-paginated, and unsortable aggregate orders fail closed.
 
-Decimal ordinary filters and root/one-link ordering remain supported. Only Decimal many-link
-aggregation is deferred because the hidden order column must round-trip through the exact tagged
-`IndexValue` JSON representation; the current PostgreSQL numeric JSON emission is not yet an
-admitted exact `rust_decimal` wire contract.
+Decimal uses the exact tagged wire fixed by
+`crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json`. The correlated aggregate
+and `ORDER BY` remain typed PostgreSQL `numeric`; only the hidden tagged `__order_N` value is
+converted through `numeric::text` and stored as a JSON string. That matches
+`IndexValue::Decimal` Serde without a JSON-number or float round-trip. Ordinary Decimal filters
+and root/one-link ordering are unchanged.
 
 ## Many-link filter boundary
 
@@ -135,9 +137,9 @@ PostgreSQL aggregate null behavior is the contract:
 - the selected `__order_N` value is SQL null or tagged `IndexValue` JSONB;
 - `ORDER BY` uses the typed scalar expression, explicit null placement, and root ID tie-break.
 
-The admitted aggregate order wire types in this slice are integer, string, and timestamp.
-Decimal and UUID remain rejected until their exact hidden-order transport is independently
-specified and covered by PostgreSQL/reference evidence.
+The admitted aggregate order wire types are integer, Decimal, string, and timestamp. Decimal
+uses `numeric` for aggregation and ordering, but its tagged JSON value is a string produced from
+`numeric::text`. UUID remains rejected by the bounded aggregate type policy.
 
 Compiler validation independently rejects forged plans that omit the aggregate on a many path,
 place an aggregate on a singular path, use an unsupported type, mutate nullable metadata, or
@@ -210,10 +212,12 @@ child multiplicity cannot inflate the count.
 
 Aggregate cursor continuation remains rejected until a stable derived-value cursor identity,
 strict null/value continuation semantics, and independent reference coverage are implemented.
-Decimal aggregate ordering remains rejected until an exact tagged-wire contract and retained
-PostgreSQL/reference scenario exist. Compiler validation recalculates propagated many metadata
-and nested projection groups, and rejects missing or inconsistent join/field/result contracts
-before SQL emission.
+Compiler validation recalculates propagated many metadata and nested projection groups, and
+rejects missing or inconsistent join/field/result contracts before SQL emission.
+
+Decimal source semantics are complete, but Decimal aggregate execution remains unproven until a
+PostgreSQL/reference scenario covers representative scale and precision through the production
+query port and retained evidence flow.
 
 ## Non-claims
 
@@ -223,7 +227,6 @@ This source chain does not:
 - add aggregate scenarios to the retained PostgreSQL/reference fixture or evidence bundle;
 - authorize callers;
 - weaken persisted schema readiness checks;
-- support Decimal aggregate ordering;
 - support aggregate cursor continuation;
 - read source-module tables;
 - change migrations, runtime composition, or production partition lifecycle state.

--- a/crates/rustok-index/docs/m4-query-planner.md
+++ b/crates/rustok-index/docs/m4-query-planner.md
@@ -33,7 +33,7 @@ source-complete offline retained-window capture/admission tooling.
 - M4 many-link `EXISTS` filtering: `source_complete_execution_pending`.
 - M4 nested many-link projection aggregation: `source_complete_execution_pending`.
 - M4 explicit many-link `min` / `max` bounded-offset ordering: `source_complete_execution_pending`.
-- M4 Decimal aggregate tagged-wire contract: `open_source_work`.
+- M4 Decimal aggregate tagged-wire contract: `source_complete_execution_pending`.
 - M4 aggregate cursor continuation: `open_source_work`.
 - M4 PostgreSQL query port and strict row adapter: `source_complete_execution_pending`.
 - M4 retained plan/SQL snapshots: `source_complete_owner_execution_pending`.
@@ -86,13 +86,15 @@ lookahead, and exact count remain duplicate free.
 
 Explicit many-link order modes are `min_asc`, `min_desc`, `max_asc`, and `max_desc`.
 Plain `asc` / `desc` over a many path remains rejected. The aggregate path must end at a
-sortable scalar integer, string, or timestamp field and must use bounded offset pagination.
-Boolean, Decimal, UUID, list-valued, singular-path, cursor-paginated, and unsortable aggregate
-requests fail closed.
+sortable scalar integer, Decimal, string, or timestamp field and must use bounded offset
+pagination. Boolean, UUID, list-valued, singular-path, cursor-paginated, and unsortable
+aggregate requests fail closed.
 
-Decimal remains excluded from aggregate ordering until its hidden `__order_N` value has an
-exact tagged `IndexValue` JSON wire contract. Ordinary Decimal filters and root/one-link
-ordering remain supported; only the many-link aggregate handoff is deferred.
+Decimal ordering uses an exact split contract. PostgreSQL reads the stored tagged JSON string
+and evaluates `MIN` / `MAX` plus `ORDER BY` as `numeric`. The hidden `__order_N` value converts
+the typed aggregate through `numeric::text` and stores it as a JSON string, matching the exact
+`IndexValue::Decimal` Serde wire without JSON-number or float conversion. Ordinary Decimal
+filters and root/one-link ordering are unchanged.
 
 The compiler emits a correlated typed `MIN` / `MAX` scalar subquery outside the outer rowset.
 Null terminal values do not participate; an empty or all-null relation set yields SQL `NULL`.
@@ -148,8 +150,8 @@ stores, executes through `PostgresIndexQueryPort`, and compares the complete
 The source scenarios cover scoped cursor continuation, exact count, bounded offset,
 one-link filtering/projection, many-link `Gte`/`Contains`/`Ne`/`IsNull`, and nested
 identity/value alignment. The fixture is env-gated and has not been run by the
-implementation agent. Aggregate offset scenarios are not yet part of the retained equivalence
-contract and remain an explicit follow-up.
+implementation agent. Aggregate offset scenarios, including Decimal scale/precision, are not
+yet part of the retained equivalence contract and remain an explicit follow-up.
 
 ## Retained equivalence capture and admission
 
@@ -266,12 +268,10 @@ The canonical checklist remains open until the owner runs the PostgreSQL/referen
 through capture, admits the retained bundle, and preserves both bundle and receipt. Additional
 boundaries remain:
 
-- define and verify the exact Decimal tagged-order wire contract before Decimal many-link
-  aggregation can be enabled;
 - extend explicit aggregate ordering to query-scoped cursor continuation with a stable cursor
   identity and strict null/value semantics;
-- add aggregate offset scenarios to the independent PostgreSQL/reference fixture and retained
-  capture/admission contract;
+- add aggregate offset scenarios, including Decimal scale and precision, to the independent
+  PostgreSQL/reference fixture and retained capture/admission contract;
 - execute one live Social Graph privacy-shadow window from the merged commit, publish its
   canonical bundle, and complete independent admission with explicit reviewer thresholds;
 - retain per-tenant projection watermark/lag, outage/recovery, repair, and negative-result
@@ -289,6 +289,8 @@ Not run by the implementation agent, per maintainer instruction.
 Suggested commands:
 
 ```bash
+cargo test -p rustok-index decimal_tagged_json_uses_exact_string_wire -- --nocapture
+cargo test -p rustok-index decimal_aggregate_uses_numeric_order_and_exact_string_wire -- --nocapture
 cargo test -p rustok-index planner_tests -- --nocapture
 cargo test -p rustok-index aggregate_ordering -- --nocapture
 cargo test -p rustok-index aggregate_ordering_tests -- --nocapture
@@ -330,6 +332,7 @@ node scripts/verify/verify-index-postgres-query-compiler.mjs
 node scripts/verify/verify-index-query-result-decoder.mjs
 node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+node scripts/verify/verify-index-decimal-aggregate-wire.mjs
 node scripts/verify/verify-index-query-snapshots.mjs
 node scripts/verify/verify-index-postgres-reference-equivalence.mjs
 node scripts/verify/verify-index-query-equivalence-capture.mjs

--- a/crates/rustok-index/src/application/aggregate_ordering.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering.rs
@@ -146,7 +146,10 @@ fn resolve_order_field(
 fn is_aggregate_ordered_type(value_type: IndexValueType) -> bool {
     matches!(
         value_type,
-        IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp
+        IndexValueType::Integer
+            | IndexValueType::Decimal
+            | IndexValueType::String
+            | IndexValueType::Timestamp
     )
 }
 
@@ -232,17 +235,24 @@ mod tests {
 
     #[test]
     fn accepts_explicit_min_and_max_over_many_link() {
-        let registry = registry(IndexValueType::Integer, true);
-        assert!(
-            registry
-                .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true))
-                .is_ok()
-        );
-        assert!(
-            registry
-                .validate_query_with_aggregate_ordering(&query(OrderDirection::MaxDesc, true))
-                .is_ok()
-        );
+        for value_type in [
+            IndexValueType::Integer,
+            IndexValueType::Decimal,
+            IndexValueType::String,
+            IndexValueType::Timestamp,
+        ] {
+            let registry = registry(value_type, true);
+            assert!(
+                registry
+                    .validate_query_with_aggregate_ordering(&query(OrderDirection::MinAsc, true))
+                    .is_ok()
+            );
+            assert!(
+                registry
+                    .validate_query_with_aggregate_ordering(&query(OrderDirection::MaxDesc, true))
+                    .is_ok()
+            );
+        }
     }
 
     #[test]
@@ -268,16 +278,11 @@ mod tests {
 
     #[test]
     fn aggregate_requires_supported_sortable_scalar() {
-        for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid] {
-            let registry = registry(unsupported, true);
-            assert!(matches!(
-                registry.validate_query_with_aggregate_ordering(&query(
-                    OrderDirection::MaxAsc,
-                    true
-                )),
-                Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
-            ));
-        }
+        let uuid = registry(IndexValueType::Uuid, true);
+        assert!(matches!(
+            uuid.validate_query_with_aggregate_ordering(&query(OrderDirection::MaxAsc, true)),
+            Err(AggregateOrderValidationError::AggregateRequiresOrderedScalar(_))
+        ));
 
         let unsortable = registry(IndexValueType::Integer, false);
         assert!(matches!(

--- a/crates/rustok-index/src/application/aggregate_ordering_tests.rs
+++ b/crates/rustok-index/src/application/aggregate_ordering_tests.rs
@@ -124,7 +124,23 @@ fn max_desc_compiles_explicit_null_policy() {
 }
 
 #[test]
-fn aggregate_cursor_decimal_and_uuid_modes_fail_closed() {
+fn decimal_aggregate_uses_numeric_order_and_exact_string_wire() {
+    let registry = registry(IndexValueType::Decimal);
+    let compiled = registry
+        .compile_postgres_query(&query(OrderDirection::MaxDesc))
+        .unwrap();
+
+    assert!(compiled.sql.contains("SELECT MAX("));
+    assert!(compiled.sql.contains(")::numeric"));
+    assert!(compiled
+        .sql
+        .contains("jsonb_build_object('type', 'decimal', 'value', to_jsonb(((SELECT MAX("));
+    assert!(compiled.sql.contains(")::text)) END AS \"__order_0\""));
+    assert!(compiled.sql.contains("DESC NULLS FIRST"));
+}
+
+#[test]
+fn aggregate_cursor_and_uuid_modes_fail_closed() {
     let integer = registry(IndexValueType::Integer);
     let mut cursor_query = query(OrderDirection::MinAsc);
     cursor_query.pagination = Pagination::Cursor {
@@ -138,15 +154,13 @@ fn aggregate_cursor_decimal_and_uuid_modes_fail_closed() {
         ))
     ));
 
-    for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid] {
-        let registry = registry(unsupported);
-        assert!(matches!(
-            registry.plan_query(&query(OrderDirection::MaxAsc)),
-            Err(QueryPlanError::AggregateValidation(
-                AggregateOrderValidationError::AggregateRequiresOrderedScalar(_)
-            ))
-        ));
-    }
+    let uuid = registry(IndexValueType::Uuid);
+    assert!(matches!(
+        uuid.plan_query(&query(OrderDirection::MaxAsc)),
+        Err(QueryPlanError::AggregateValidation(
+            AggregateOrderValidationError::AggregateRequiresOrderedScalar(_)
+        ))
+    ));
 }
 
 #[test]

--- a/crates/rustok-index/src/application/postgres_compiler.rs
+++ b/crates/rustok-index/src/application/postgres_compiler.rs
@@ -338,7 +338,10 @@ fn validate_many_projection_contract(
 fn aggregate_type_supported(value_type: IndexValueType) -> bool {
     matches!(
         value_type,
-        IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp
+        IndexValueType::Integer
+            | IndexValueType::Decimal
+            | IndexValueType::String
+            | IndexValueType::Timestamp
     )
 }
 

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -576,8 +576,9 @@ fn compile_many_order_aggregate(
         terminal.scalar,
         predicates.join(" AND ")
     );
+    let wire_value = aggregate_order_wire_value(field.value_type, &scalar);
     let raw = format!(
-        "CASE WHEN {scalar} IS NULL THEN NULL ELSE jsonb_build_object('type', '{}', 'value', to_jsonb({scalar})) END",
+        "CASE WHEN {scalar} IS NULL THEN NULL ELSE jsonb_build_object('type', '{}', 'value', {wire_value}) END",
         value_type_tag(field.value_type),
     );
     Ok(FieldSql {
@@ -587,6 +588,13 @@ fn compile_many_order_aggregate(
         type_text: "NULL::text".to_owned(),
         null_predicate: format!("{scalar} IS NULL"),
     })
+}
+
+fn aggregate_order_wire_value(value_type: IndexValueType, scalar: &str) -> String {
+    match value_type {
+        IndexValueType::Decimal => format!("to_jsonb(({scalar})::text)"),
+        _ => format!("to_jsonb({scalar})"),
+    }
 }
 
 fn compile_keyset(

--- a/crates/rustok-index/src/domain/value.rs
+++ b/crates/rustok-index/src/domain/value.rs
@@ -41,3 +41,28 @@ impl IndexValue {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal::Decimal;
+    use serde_json::json;
+
+    use super::IndexValue;
+
+    #[test]
+    fn decimal_tagged_json_uses_exact_string_wire() {
+        let value = IndexValue::Decimal(Decimal::new(1_234_500, 4));
+        let encoded = serde_json::to_value(&value).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!({
+                "type": "decimal",
+                "value": "123.4500"
+            })
+        );
+
+        let decoded: IndexValue = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), encoded);
+    }
+}

--- a/scripts/verify/verify-index-decimal-aggregate-wire.mjs
+++ b/scripts/verify/verify-index-decimal-aggregate-wire.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-decimal-aggregate-wire] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const domainPath = 'crates/rustok-index/src/domain/value.rs';
+requireMarkers(domainPath, [
+  'Decimal(Decimal)',
+  'decimal_tagged_json_uses_exact_string_wire',
+  'Decimal::new(1_234_500, 4)',
+  '"value": "123.4500"',
+  'serde_json::from_value(encoded.clone())',
+  'serde_json::to_value(decoded)',
+]);
+
+const validationPath = 'crates/rustok-index/src/application/aggregate_ordering.rs';
+requireMarkers(validationPath, [
+  'IndexValueType::Integer',
+  '| IndexValueType::Decimal',
+  '| IndexValueType::String',
+  '| IndexValueType::Timestamp',
+  'accepts_explicit_min_and_max_over_many_link',
+]);
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
+requireMarkers(compilerPath, [
+  'fn aggregate_type_supported',
+  'IndexValueType::Integer',
+  '| IndexValueType::Decimal',
+  '| IndexValueType::String',
+  '| IndexValueType::Timestamp',
+]);
+
+const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
+const sql = requireMarkers(sqlPath, [
+  'IndexValueType::Decimal => format!("({scalar_text})::numeric")',
+  'fn aggregate_order_wire_value(',
+  'IndexValueType::Decimal => format!("to_jsonb(({scalar})::text)")',
+  '_ => format!("to_jsonb({scalar})")',
+  'let wire_value = aggregate_order_wire_value(field.value_type, &scalar);',
+  "jsonb_build_object('type', '{}', 'value', {wire_value})",
+]);
+forbidMarkers(sqlPath, sql, [
+  '::double precision',
+  '::real',
+  'f64',
+  'to_jsonb(({scalar})::float',
+]);
+
+requireMarkers('crates/rustok-index/src/application/aggregate_ordering_tests.rs', [
+  'decimal_aggregate_uses_numeric_order_and_exact_string_wire',
+  'registry(IndexValueType::Decimal)',
+  'jsonb_build_object(\'type\', \'decimal\', \'value\', to_jsonb(((SELECT MAX(',
+  ')::text)) END AS \\"__order_0\\"',
+  'aggregate_cursor_and_uuid_modes_fail_closed',
+]);
+
+const contractPath = 'crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json';
+const contract = JSON.parse(read(contractPath));
+if (contract.schema_version !== 1 || contract.owner !== 'rustok-index') {
+  fail(`${contractPath} identity drifted`);
+}
+if (contract.status !== 'source_complete_execution_pending') {
+  fail(`${contractPath} must remain execution pending`);
+}
+if (contract.domain_wire?.json_value_kind !== 'string'
+  || contract.domain_wire?.example?.type !== 'decimal'
+  || contract.domain_wire?.example?.value !== '123.4500') {
+  fail(`${contractPath} domain wire drifted`);
+}
+if (contract.postgresql_wire?.typed_scalar !== 'numeric'
+  || contract.postgresql_wire?.json_number_allowed !== false
+  || contract.postgresql_wire?.float_conversion_allowed !== false
+  || contract.postgresql_wire?.ordering_uses_text !== false
+  || contract.postgresql_wire?.ordering_uses_numeric !== true) {
+  fail(`${contractPath} PostgreSQL wire drifted`);
+}
+if (contract.query_boundary?.pagination !== 'bounded_offset'
+  || contract.query_boundary?.aggregate_cursor_supported !== false) {
+  fail(`${contractPath} query boundary drifted`);
+}
+for (const key of ['cargo_run', 'tests_run', 'postgresql_run', 'node_verifiers_run', 'workflows_run', 'ci_run']) {
+  if (contract.validation?.[key] !== false) fail(`${contractPath} must not claim ${key}`);
+}
+
+const aggregateContractPath = 'crates/rustok-index/contracts/m4-many-link-aggregate-ordering.json';
+const aggregateContract = JSON.parse(read(aggregateContractPath));
+if (!aggregateContract.supported_terminal_types?.includes('decimal')
+  || aggregateContract.rejected_terminal_types?.includes('decimal')
+  || aggregateContract.remaining?.includes('exact decimal tagged-order wire contract')) {
+  fail(`${aggregateContractPath} does not activate the exact Decimal wire contract`);
+}
+if (aggregateContract.postgresql?.decimal_order_scalar !== 'numeric'
+  || aggregateContract.postgresql?.decimal_tagged_value !== 'json_string_from_numeric_text') {
+  fail(`${aggregateContractPath} Decimal PostgreSQL boundary drifted`);
+}
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-decimal-aggregate-wire.mjs'",
+]);
+requireMarkers('crates/rustok-index/docs/m4-decimal-aggregate-order-wire.md', [
+  'Status: `source_complete_execution_pending`',
+  '`numeric` for `MIN/MAX`',
+  '`to_jsonb((aggregate_scalar)::text)`',
+  'JSON value is a string',
+  'No float conversion',
+  'Not run by the implementation agent',
+]);
+
+console.log('[verify-index-decimal-aggregate-wire] OK');

--- a/scripts/verify/verify-index-decimal-aggregate-wire.mjs
+++ b/scripts/verify/verify-index-decimal-aggregate-wire.mjs
@@ -120,7 +120,7 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
 ]);
 requireMarkers('crates/rustok-index/docs/m4-decimal-aggregate-order-wire.md', [
   'Status: `source_complete_execution_pending`',
-  '`numeric` for `MIN/MAX`',
+  '`MIN(numeric)` or `MAX(numeric)`',
   '`to_jsonb((aggregate_scalar)::text)`',
   'JSON value is a string',
   'No float conversion',

--- a/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+++ b/scripts/verify/verify-index-many-link-aggregate-ordering.mjs
@@ -49,12 +49,14 @@ const validation = requireMarkers(validationPath, [
   'matches!(&query.pagination, Pagination::Offset { .. })',
   'self.validate_query(&ordinary)?;',
   'resolved.traverses_many',
-  'IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp',
-  'for unsupported in [IndexValueType::Decimal, IndexValueType::Uuid]',
+  'IndexValueType::Integer',
+  '| IndexValueType::Decimal',
+  '| IndexValueType::String',
+  '| IndexValueType::Timestamp',
+  'accepts_explicit_min_and_max_over_many_link',
   'aggregate_cursor_pagination_remains_rejected',
 ]);
 forbidMarkers(validationPath, validation, [
-  'IndexValueType::Integer\n            | IndexValueType::Decimal',
   'unwrap_or(',
   'first()',
   'ordinal',
@@ -72,7 +74,7 @@ requireMarkers(plannerPath, [
 ]);
 
 const compilerPath = 'crates/rustok-index/src/application/postgres_compiler.rs';
-const compiler = requireMarkers(compilerPath, [
+requireMarkers(compilerPath, [
   'AggregateOrderingWithoutManyLink',
   'AggregateOrderingUnsupportedType',
   'AggregateOrderingRequiresOffsetPagination',
@@ -80,10 +82,10 @@ const compiler = requireMarkers(compilerPath, [
   'expected.nullable = true;',
   'aggregate_type_supported(order.field.value_type)',
   'has_aggregate_order && !matches!(&self.pagination, Pagination::Offset { .. })',
-  'IndexValueType::Integer | IndexValueType::String | IndexValueType::Timestamp',
-]);
-forbidMarkers(compilerPath, compiler, [
-  'IndexValueType::Integer\n            | IndexValueType::Decimal',
+  'IndexValueType::Integer',
+  '| IndexValueType::Decimal',
+  '| IndexValueType::String',
+  '| IndexValueType::Timestamp',
 ]);
 
 const sqlPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
@@ -92,7 +94,9 @@ const sql = requireMarkers(sqlPath, [
   'ManyOrderAggregate::Min => "MIN"',
   'ManyOrderAggregate::Max => "MAX"',
   'FROM index_links AS {link_alias}',
-  "jsonb_build_object('type', '{}', 'value', to_jsonb({scalar}))",
+  'let wire_value = aggregate_order_wire_value(field.value_type, &scalar);',
+  "jsonb_build_object('type', '{}', 'value', {wire_value})",
+  'IndexValueType::Decimal => format!("to_jsonb(({scalar})::text)")',
   'order.direction.base_direction()',
   'ASC NULLS LAST',
   'DESC NULLS FIRST',
@@ -102,15 +106,18 @@ forbidMarkers(sqlPath, sql, [
   'array_agg(',
   'ordinal LIMIT 1',
   'target_entity_id LIMIT 1',
+  '::double precision',
+  '::real',
 ]);
 
 requireMarkers('crates/rustok-index/src/application/aggregate_ordering_tests.rs', [
   'min_asc_compiles_correlated_tagged_order_value',
   'max_desc_compiles_explicit_null_policy',
-  'aggregate_cursor_decimal_and_uuid_modes_fail_closed',
+  'decimal_aggregate_uses_numeric_order_and_exact_string_wire',
+  'aggregate_cursor_and_uuid_modes_fail_closed',
   'forged_plans_remain_fail_closed',
-  'IndexValueType::String',
-  "jsonb_build_object('type', 'string'",
+  'IndexValueType::Decimal',
+  "jsonb_build_object('type', 'decimal', 'value', to_jsonb(((SELECT MAX(",
   'AggregateOrderingRequiresOffsetPagination',
   'assert!(!compiled',
   '.contains(" LEFT JOIN index_links AS \\"l1\\""));',
@@ -144,15 +151,17 @@ if (contract.query_contract?.plain_many_link_asc_desc_rejected !== true
   fail(`${contractPath} query boundary drifted`);
 }
 if (JSON.stringify(contract.supported_terminal_types)
-  !== JSON.stringify(['integer', 'string', 'timestamp'])) {
+  !== JSON.stringify(['integer', 'decimal', 'string', 'timestamp'])) {
   fail(`${contractPath} supported type contract drifted`);
 }
-if (!contract.rejected_terminal_types?.includes('decimal')
-  || !contract.remaining?.includes('exact decimal tagged-order wire contract')) {
-  fail(`${contractPath} must keep decimal fail-closed pending an exact wire contract`);
+if (contract.rejected_terminal_types?.includes('decimal')
+  || contract.remaining?.includes('exact decimal tagged-order wire contract')) {
+  fail(`${contractPath} did not activate Decimal aggregate ordering`);
 }
 if (contract.postgresql?.strategy !== 'correlated_scalar_subquery'
   || contract.postgresql?.outer_many_join !== false
+  || contract.postgresql?.decimal_order_scalar !== 'numeric'
+  || contract.postgresql?.decimal_tagged_value !== 'json_string_from_numeric_text'
   || contract.postgresql?.caller_sql !== false
   || contract.postgresql?.implicit_first_row !== false
   || contract.postgresql?.implicit_link_ordinal !== false) {
@@ -162,8 +171,15 @@ for (const key of ['cargo_run', 'tests_run', 'postgresql_run', 'node_verifiers_r
   if (contract.validation?.[key] !== false) fail(`${contractPath} must not claim ${key}`);
 }
 
+requireMarkers('crates/rustok-index/contracts/m4-decimal-aggregate-order-wire.json', [
+  '"json_value_kind": "string"',
+  '"typed_scalar": "numeric"',
+  '"json_number_allowed": false',
+  '"aggregate_cursor_supported": false',
+]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-many-link-aggregate-ordering.mjs'",
+  "'verify-index-decimal-aggregate-wire.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-many-link-aggregate-ordering.md', [
   'Status: `source_complete_execution_pending`',
@@ -171,8 +187,9 @@ requireMarkers('crates/rustok-index/docs/m4-many-link-aggregate-ordering.md', [
   '`min_asc`',
   '`max_desc`',
   'bounded offset',
-  'Decimal and UUID',
-  'exact tagged-wire contract',
+  'Decimal',
+  '`numeric`',
+  'JSON string',
   'Aggregate cursor continuation remains open',
   'Not run by the implementation agent',
 ]);

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -11,6 +11,7 @@ const scripts = [
   'verify-index-query-result-decoder.mjs',
   'verify-index-many-link-filtering.mjs',
   'verify-index-many-link-aggregate-ordering.mjs',
+  'verify-index-decimal-aggregate-wire.mjs',
   'verify-index-query-snapshots.mjs',
   'verify-index-postgres-reference-equivalence.mjs',
   'verify-index-query-equivalence-capture.mjs',


### PR DESCRIPTION
## Summary

- activate Decimal as a supported terminal type for explicit many-link `min_asc`, `min_desc`, `max_asc`, and `max_desc`
- lock `IndexValue::Decimal` tagged JSON to an exact string wire such as `{ "type": "decimal", "value": "123.4500" }`
- retain typed PostgreSQL `numeric` for aggregate `MIN` / `MAX` and `ORDER BY`
- encode only the hidden `__order_N` Decimal value through `to_jsonb((aggregate_scalar)::text)`
- avoid JSON-number and float conversion while preserving numeric rather than lexical ordering
- keep bounded offset pagination, null placement, and root entity-ID tie-break unchanged
- keep UUID aggregate ordering and all aggregate cursor continuation fail-closed
- add focused domain/compiler source tests, a machine-readable Decimal wire contract, a dedicated static guard, unified verifier registration, and synchronized M4 docs/API

## Recheck findings

The previous Decimal rejection was appropriate until the hidden order value had an exact transport contract. `IndexValue::Decimal` uses the existing human-readable `rust_decimal` Serde string representation. PostgreSQL already reads stored Decimal strings as `numeric`; this PR keeps that typed scalar for aggregation and ordering, then converts only the hidden tagged result back to text before JSON encoding.

The aggregate relation remains a correlated scalar subquery outside the outer root rowset, so root cardinality, exact count, and bounded offset pagination remain duplicate-free.

`main` advanced through unrelated server/admin/forum/search/outbox work after branch creation. None of the 16 changed Index paths overlap those commits.

## Boundary

This PR does not enable aggregate cursor pagination, UUID aggregate ordering, add aggregate scenarios to the PostgreSQL/reference fixture, run PostgreSQL, update retained evidence, change runtime composition or authorization, publish a new source schema, or cut over a consumer.

## Validation

Not run by the implementation agent, per maintainer instruction. No Cargo commands, tests, builds, PostgreSQL execution, Node tests/verifiers, workflows, benchmarks, capture/admission, or CI were run.

Suggested owner validation:

```bash
cargo test -p rustok-index decimal_tagged_json_uses_exact_string_wire -- --nocapture
cargo test -p rustok-index decimal_aggregate_uses_numeric_order_and_exact_string_wire -- --nocapture
cargo test -p rustok-index aggregate_ordering -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-decimal-aggregate-wire.mjs
node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo xtask module validate index
```
