### PR TITLE
feat(forum): project privacy-aware Search author summaries

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-projection.json
+++ b/crates/rustok-forum/contracts/forum-search-projection.json
@@ -9,7 +9,6 @@
   "forum_source_registration": "crates/rustok-forum/src/lib.rs",
   "search_projector": "crates/rustok-search/src/forum_projector.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
-  "search_runtime_composition": "crates/rustok-search/src/lib.rs",
   "search_storage": "search_documents",
   "source_module": "forum",
   "entity_types": [
@@ -25,6 +24,7 @@
   "rebuild_scope_preservation_contract": "crates/rustok-forum/contracts/forum-search-rebuild-scope-preservation.json",
   "graphql_snapshot_cleanup_contract": "crates/rustok-forum/contracts/forum-graphql-query-snapshot-cleanup.json",
   "approved_reply_search_contract": "crates/rustok-forum/contracts/forum-approved-reply-search.json",
+  "public_author_summary_contract": "crates/rustok-forum/contracts/forum-search-public-author-summary.json",
   "source_boundary": {
     "neutral_capability_has_no_forum_dependency": true,
     "neutral_capability_has_no_search_storage_or_query_logic": true,
@@ -43,7 +43,11 @@
     "authentication_role_trust_group_explicit_user_targets_absent": true,
     "route_channel_restricted_topics_absent_without_route_channel": true,
     "cross_consumer_audience_policy_copy_added": false,
-    "per_entity_locale_fanout_bounded": true
+    "per_entity_locale_fanout_bounded": true,
+    "public_author_summary_uses_profiles_owner": true,
+    "missing_or_denied_author_projects_null": true,
+    "raw_forum_author_id_removed_from_payload": true,
+    "public_author_payload_is_bounded": true
   },
   "persistence_boundary": {
     "search_owns_projection_storage": true,
@@ -86,6 +90,9 @@
     "root_reindex_event_schema_changed": false,
     "new_reindex_target_string_added": false,
     "reply_documents_projected": true,
+    "profile_updated_rebuilds_public_author_projection": true,
+    "user_deleted_rebuilds_public_author_projection": true,
+    "author_redaction_scope_ignores_unrelated_forum_watermark": true,
     "completion_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json"
   },
   "downstream_handoff": {
@@ -100,7 +107,10 @@
     "snapshot_cleanup_contract": "crates/rustok-forum/contracts/forum-graphql-query-snapshot-cleanup.json",
     "approved_public_reply_documents_completed": true,
     "reply_completion_task": "FORUM-20BO",
-    "reply_completion_contract": "crates/rustok-forum/contracts/forum-approved-reply-search.json"
+    "reply_completion_contract": "crates/rustok-forum/contracts/forum-approved-reply-search.json",
+    "public_author_summary_completed": true,
+    "public_author_summary_task": "FORUM-23A",
+    "public_author_summary_completion_contract": "crates/rustok-forum/contracts/forum-search-public-author-summary.json"
   },
   "compatibility": {
     "existing_search_product_content_blog_projection_changed": false,
@@ -125,12 +135,13 @@
     "upstream_contract_updated": true,
     "crate_api_updated": false,
     "canonical_plan_updated": false,
-    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-20BO with conflict-safe repository-local edits after maintainer validation."
+    "synchronization_debt": "Advance CRATE_API, the Search owner plan and canonical FORUM-16/FORUM-20/FORUM-23 ledgers through FORUM-23A with conflict-safe repository-local edits after maintainer validation."
   },
   "remaining_scope": [
-    "add owner revision ordering and durable inbox reconciliation for category topic reply and future member projections under FORUM-23",
-    "add safe author summaries and the planned FORUM-23 filters",
-    "capture maintainer-executed PostgreSQL full-rebuild failure preservation projection cleanup and approved-reply runtime evidence",
+    "add owner revision ordering for category topic reply and future member projections under FORUM-23",
+    "add the planned FORUM-23 category subtree tag locale date solved kind channel group attachment and remaining author filters",
+    "add member index projections",
+    "capture maintainer-executed PostgreSQL full-rebuild failure preservation projection cleanup public-author redaction and approved-reply runtime evidence",
     "capture maintainer-executed Search query runtime plus SQLite exact-visible bulk-read evidence",
     "add an explicit Forum translation target invalidation adapter if Forum categories topics or replies are later registered with the translation control plane"
   ],
@@ -143,8 +154,12 @@
       "cargo test -p rustok-search --test search_scope_preservation_contract -- --nocapture",
       "cargo test -p rustok-search --test forum_approved_reply_projection_contract -- --nocapture",
       "cargo test -p rustok-search forum_projector -- --nocapture",
+      "cargo test -p rustok-search forum_inbox -- --nocapture",
+      "cargo test -p rustok-search ingestion -- --nocapture",
+      "cargo test -p rustok-forum search_projection_author -- --nocapture",
       "cargo test -p rustok-forum projection_invalidation -- --nocapture",
       "cargo test -p rustok-forum --test topic_visibility_bulk_read_state_sqlite -- --nocapture",
+      "node scripts/verify/verify-forum-search-public-author-summary.mjs",
       "node scripts/verify/verify-forum-approved-reply-search.mjs",
       "node scripts/verify/verify-forum-search-rebuild-scope-preservation.mjs",
       "node scripts/verify/verify-forum-search-projection.mjs",

--- a/crates/rustok-forum/contracts/forum-search-projection.json
+++ b/crates/rustok-forum/contracts/forum-search-projection.json
@@ -91,8 +91,8 @@
     "new_reindex_target_string_added": false,
     "reply_documents_projected": true,
     "profile_updated_rebuilds_public_author_projection": true,
-    "user_deleted_rebuilds_public_author_projection": true,
     "author_redaction_scope_ignores_unrelated_forum_watermark": true,
+    "account_deletion_redaction_completed": false,
     "completion_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json"
   },
   "downstream_handoff": {
@@ -139,6 +139,7 @@
   },
   "remaining_scope": [
     "add owner revision ordering for category topic reply and future member projections under FORUM-23",
+    "define an owner-ordered profile or account deletion projection invalidation contract",
     "add the planned FORUM-23 category subtree tag locale date solved kind channel group attachment and remaining author filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL full-rebuild failure preservation projection cleanup public-author redaction and approved-reply runtime evidence",

--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -30,7 +30,7 @@
     "profile_visibility_is_not_serialized": true,
     "public_handle_populates_search_handle": true,
     "public_handle_and_display_name_extend_keywords": true,
-    "author_filter_facet_is_present_only_for_public_author": true
+    "author_filter_value_is_populated_only_for_public_author": true
   },
   "redaction_boundary": {
     "profile_updated_is_durable": true,

--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -3,10 +3,11 @@
   "task": "FORUM-23A",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
-  "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after profile changes",
+  "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
   "forum_projection_source": "crates/rustok-forum/src/search_projection.rs",
   "forum_author_adapter": "crates/rustok-forum/src/search_projection_author.rs",
   "profiles_owner": "crates/rustok-profiles/src/presentation.rs",
+  "profiles_event_owner": "crates/rustok-profiles/src/graphql/mutation.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -33,7 +34,7 @@
   },
   "redaction_boundary": {
     "profile_updated_is_durable": true,
-    "user_deleted_is_durable": true,
+    "profile_updated_is_emitted_after_owner_write": true,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
     "author_change_rebuilds_current_forum_owner_state": true,
@@ -52,6 +53,7 @@
   },
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
+    "define an owner-ordered profile or account deletion projection invalidation contract",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -67,5 +69,10 @@
       "cargo xtask module validate forum"
     ]
   },
+  "non_claims": [
+    "UserDeleted is sufficient to prove Profiles state has already been removed",
+    "account deletion redaction is complete",
+    "general cross-producer owner revision ordering is complete"
+  ],
   "downstream_task": "FORUM-23B"
 }

--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23A",
+  "upstream_task": "FORUM-20BQ",
+  "status": "source_complete_execution_pending",
+  "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after profile changes",
+  "forum_projection_source": "crates/rustok-forum/src/search_projection.rs",
+  "forum_author_adapter": "crates/rustok-forum/src/search_projection_author.rs",
+  "profiles_owner": "crates/rustok-profiles/src/presentation.rs",
+  "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
+  "search_ingestion": "crates/rustok-search/src/ingestion.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
+  "verifier": "scripts/verify/verify-forum-search-public-author-summary.mjs",
+  "projection_boundary": {
+    "anonymous_profiles_presentation_is_authoritative": true,
+    "forum_does_not_copy_profile_privacy_policy": true,
+    "missing_or_denied_profile_projects_null_author": true,
+    "profile_owner_failure_is_retryable_not_empty": true,
+    "raw_topic_author_id_is_not_serialized": true,
+    "raw_reply_author_id_is_not_serialized": true,
+    "public_author_fields": [
+      "user_id",
+      "handle",
+      "display_name",
+      "avatar_media_id"
+    ],
+    "profile_tags_are_not_serialized": true,
+    "preferred_locale_is_not_serialized": true,
+    "profile_visibility_is_not_serialized": true,
+    "public_handle_populates_search_handle": true,
+    "public_handle_and_display_name_extend_keywords": true,
+    "author_filter_facet_is_present_only_for_public_author": true
+  },
+  "redaction_boundary": {
+    "profile_updated_is_durable": true,
+    "user_deleted_is_durable": true,
+    "author_scope_is_tenant_and_user_scoped": true,
+    "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
+    "author_change_rebuilds_current_forum_owner_state": true,
+    "projection_failure_remains_retryable": true,
+    "tenant_advisory_lock_is_preserved": true,
+    "schema_migration_added": false
+  },
+  "compatibility": {
+    "forum_graphql_changed": false,
+    "forum_rest_changed": false,
+    "search_query_api_changed": false,
+    "search_document_schema_changed": false,
+    "forum_owner_storage_changed": false,
+    "profiles_owner_storage_changed": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
+    "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
+    "add member index projections",
+    "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum search_projection_author -- --nocapture",
+      "cargo test -p rustok-search forum_inbox -- --nocapture",
+      "cargo test -p rustok-search ingestion -- --nocapture",
+      "node scripts/verify/verify-forum-search-public-author-summary.mjs",
+      "node scripts/verify/verify-forum-search-projection.mjs",
+      "cargo xtask module validate forum"
+    ]
+  },
+  "downstream_task": "FORUM-23B"
+}

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -1,0 +1,89 @@
+# FORUM-23A: privacy-aware Search author summaries
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
+and approved-reply documents now obtain author presentation from the Profiles owner instead of
+serializing the raw Forum author identifier.
+
+The machine-readable contract is
+`crates/rustok-forum/contracts/forum-search-public-author-summary.json`.
+
+## Owner boundary
+
+`ForumSearchProjectionSource` calls `ProfilePresentationService` with its anonymous audience.
+Profiles remains the authority for profile privacy and localized presentation; Forum does not
+copy visibility rules or read profile tables directly.
+
+When Profiles permits anonymous presentation, the Search document may contain only:
+
+- `user_id`;
+- `handle`;
+- `display_name`;
+- `avatar_media_id`.
+
+The public handle also populates the Search `handle` column, and the public handle/display name
+extend the document keywords. Profile tags, preferred locale, visibility state, biography,
+banner, and other owner data are not copied into Forum Search payloads.
+
+When the profile is absent or denied, the projected author is `null`, the Search handle remains
+empty, and no author identifier is exposed. A Profiles owner failure is not converted into an
+empty author: it fails projection so the durable Search inbox can retry.
+
+## Durable redaction
+
+Embedded summaries require invalidation when profile presentation changes. Search now treats
+`ProfileUpdated` and `UserDeleted` as Forum projection events whenever the Forum source is
+composed.
+
+Each event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
+barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
+consumer rebuilds the Forum tenant projection from current owner state, so a profile changed to
+private or a deleted user removes the previously stored public summary.
+
+The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
+inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
+ordering is solved; owner-issued monotonic revisions remain the next ordering hardening task.
+
+## Search shape
+
+Topic and approved-reply documents now use:
+
+- `payload.author` for the bounded public summary or `null`;
+- `facets.author_id` only when the Profiles owner returned a public summary;
+- `facets.has_public_author` as an explicit filterable boolean;
+- the Search `handle` column for the permitted public handle.
+
+The previous raw `payload.author_id` value is removed. Category documents and the public Forum
+discovery contract are unchanged.
+
+## Compatibility
+
+No database migration, Search query API change, Forum GraphQL/REST change, Forum owner-storage
+change, Profiles owner-storage change, or Cargo dependency change is introduced. Existing Search
+document rows are replaced by the next Forum rebuild or relevant durable event.
+
+## Remaining FORUM-23 scope
+
+- owner-issued monotonic projection revisions across Forum producers;
+- bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
+  remaining author filters;
+- member Search projections;
+- maintainer-executed PostgreSQL redaction, rebuild, and query evidence.
+
+## Maintainer verification
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-forum search_projection_author -- --nocapture
+cargo test -p rustok-search forum_inbox -- --nocapture
+cargo test -p rustok-search ingestion -- --nocapture
+node scripts/verify/verify-forum-search-public-author-summary.mjs
+node scripts/verify/verify-forum-search-projection.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -34,18 +34,21 @@ empty author: it fails projection so the durable Search inbox can retry.
 
 ## Durable redaction
 
-Embedded summaries require invalidation when profile presentation changes. Search now treats
-`ProfileUpdated` and `UserDeleted` as Forum projection events whenever the Forum source is
-composed.
+Embedded summaries require invalidation when profile presentation changes. Profiles publishes
+`ProfileUpdated` after a successful owner write for handle, display content, locale, visibility,
+and media changes. Search now treats that owner event as a Forum projection event whenever the
+Forum source is composed.
 
-Each event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
+The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so a profile changed to
-private or a deleted user removes the previously stored public summary.
+private removes the previously stored public summary.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
 ordering is solved; owner-issued monotonic revisions remain the next ordering hardening task.
+It also does not treat `UserDeleted` as sufficient deletion evidence because that event does not
+prove that the Profiles owner has already removed or hidden its state.
 
 ## Search shape
 
@@ -68,6 +71,7 @@ document rows are replaced by the next Forum rebuild or relevant durable event.
 ## Remaining FORUM-23 scope
 
 - owner-issued monotonic projection revisions across Forum producers;
+- an owner-ordered profile or account deletion invalidation contract;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -55,7 +55,7 @@ prove that the Profiles owner has already removed or hidden its state.
 Topic and approved-reply documents now use:
 
 - `payload.author` for the bounded public summary or `null`;
-- `facets.author_id` only when the Profiles owner returned a public summary;
+- `facets.author_id` with a non-null value only when the Profiles owner returned a public summary;
 - `facets.has_public_author` as an explicit filterable boolean;
 - the Search `handle` column for the permitted public handle.
 

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -27,6 +27,7 @@ pub mod openapi;
 mod reply_create_transport;
 pub mod reply_read_transport;
 mod search_projection;
+mod search_projection_author;
 mod seo_audience_targets;
 #[path = "seo_targets.rs"]
 mod seo_targets_legacy;

--- a/crates/rustok-forum/src/search_projection.rs
+++ b/crates/rustok-forum/src/search_projection.rs
@@ -17,6 +17,10 @@ use uuid::Uuid;
 use crate::entities::{
     forum_category, forum_category_translation, forum_reply_body, forum_topic_translation,
 };
+use crate::search_projection_author::{
+    load_public_author_summary, public_author_handle, public_author_id, public_author_keywords,
+    public_author_payload,
+};
 use crate::state_machine::ReplyStatus;
 use crate::ForumPublicDiscoveryService;
 
@@ -269,6 +273,11 @@ impl ForumSearchProjectionSource {
         let Some(category) = category else {
             return Ok(None);
         };
+        let author = load_public_author_summary(&self.db, tenant_id, topic.author_id, locale).await?;
+        let author_id = public_author_id(author.as_ref());
+        let author_handle = public_author_handle(author.as_ref());
+        let author_keywords = public_author_keywords(author.as_ref());
+        let author_payload = public_author_payload(author.as_ref());
         let created_at = parse_timestamp(&topic.created_at, "created_at")?;
         let updated_at = parse_timestamp(&topic.updated_at, "updated_at")?;
         let tags = topic.tags.clone();
@@ -285,18 +294,21 @@ impl ForumSearchProjectionSource {
             title: topic.title.clone(),
             subtitle: Some(category.name.clone()),
             slug: Some(topic.slug.clone()),
-            handle: None,
+            handle: author_handle,
             body: topic.body.clone(),
             keywords_text: format!(
-                "{} {} {} {}",
+                "{} {} {} {} {}",
                 category.name,
                 topic.slug,
                 tags.join(" "),
-                channels.join(" ")
+                channels.join(" "),
+                author_keywords
             ),
             facets: json!({
                 "kind": "forum_topic",
                 "category_id": topic.category_id,
+                "author_id": author_id,
+                "has_public_author": author_id.is_some(),
                 "has_tags": !tags.is_empty(),
                 "has_channels": !channels.is_empty(),
                 "channel_slugs": channels
@@ -304,7 +316,7 @@ impl ForumSearchProjectionSource {
             payload: json!({
                 "topic_id": topic.id,
                 "category_id": topic.category_id,
-                "author_id": topic.author_id,
+                "author": author_payload,
                 "tags": tags,
                 "channel_slugs": topic.channel_slugs,
                 "reply_count": topic.reply_count,
@@ -370,6 +382,11 @@ impl ForumSearchProjectionSource {
         let Some(category) = category else {
             return Ok(None);
         };
+        let author = load_public_author_summary(&self.db, tenant_id, reply.author_id, locale).await?;
+        let author_id = public_author_id(author.as_ref());
+        let author_handle = public_author_handle(author.as_ref());
+        let author_keywords = public_author_keywords(author.as_ref());
+        let author_payload = public_author_payload(author.as_ref());
 
         let created_at = parse_timestamp(&reply.created_at, "reply.created_at")?;
         let updated_at = parse_timestamp(&reply.updated_at, "reply.updated_at")?;
@@ -387,13 +404,18 @@ impl ForumSearchProjectionSource {
             title: topic.title.clone(),
             subtitle: Some(category.name.clone()),
             slug: None,
-            handle: None,
+            handle: author_handle,
             body: reply.content,
-            keywords_text: format!("{} {} {}", category.name, topic.title, topic.slug),
+            keywords_text: format!(
+                "{} {} {} {}",
+                category.name, topic.title, topic.slug, author_keywords
+            ),
             facets: json!({
                 "kind": "forum_reply",
                 "category_id": topic.category_id,
                 "topic_id": topic.id,
+                "author_id": author_id,
+                "has_public_author": author_id.is_some(),
                 "has_parent": reply.parent_reply_id.is_some(),
                 "is_solution": is_solution
             }),
@@ -401,7 +423,7 @@ impl ForumSearchProjectionSource {
                 "reply_id": reply_id,
                 "topic_id": topic.id,
                 "category_id": topic.category_id,
-                "author_id": reply.author_id,
+                "author": author_payload,
                 "parent_reply_id": reply.parent_reply_id,
                 "is_solution": is_solution,
                 "route": route

--- a/crates/rustok-forum/src/search_projection_author.rs
+++ b/crates/rustok-forum/src/search_projection_author.rs
@@ -1,0 +1,89 @@
+use rustok_core::{Error, Result};
+use rustok_profiles::{ProfilePresentationService, ProfileSummary};
+use sea_orm::DatabaseConnection;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+pub(super) async fn load_public_author_summary(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    author_id: Option<Uuid>,
+    locale: &str,
+) -> Result<Option<ProfileSummary>> {
+    let Some(author_id) = author_id else {
+        return Ok(None);
+    };
+
+    ProfilePresentationService::new(db.clone())
+        .find_profile_summary(tenant_id, author_id, Some(locale), None)
+        .await
+        .map_err(|error| {
+            Error::External(format!(
+                "Forum Search public author summary failed: {error}"
+            ))
+        })
+}
+
+pub(super) fn public_author_id(summary: Option<&ProfileSummary>) -> Option<Uuid> {
+    summary.map(|summary| summary.user_id)
+}
+
+pub(super) fn public_author_handle(summary: Option<&ProfileSummary>) -> Option<String> {
+    summary.map(|summary| summary.handle.clone())
+}
+
+pub(super) fn public_author_keywords(summary: Option<&ProfileSummary>) -> String {
+    summary
+        .map(|summary| format!("{} {}", summary.handle, summary.display_name))
+        .unwrap_or_default()
+}
+
+pub(super) fn public_author_payload(summary: Option<&ProfileSummary>) -> Value {
+    summary.map_or(Value::Null, |summary| {
+        json!({
+            "user_id": summary.user_id,
+            "handle": summary.handle,
+            "display_name": summary.display_name,
+            "avatar_media_id": summary.avatar_media_id
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_profiles::ProfileVisibility;
+
+    #[test]
+    fn public_author_payload_exposes_only_the_safe_summary() {
+        let user_id = Uuid::new_v4();
+        let avatar_media_id = Uuid::new_v4();
+        let summary = ProfileSummary {
+            user_id,
+            handle: "public-handle".to_string(),
+            display_name: "Public Name".to_string(),
+            tags: vec!["private-owner-tag".to_string()],
+            avatar_media_id: Some(avatar_media_id),
+            preferred_locale: Some("de".to_string()),
+            visibility: ProfileVisibility::Public,
+        };
+
+        assert_eq!(
+            public_author_payload(Some(&summary)),
+            json!({
+                "user_id": user_id,
+                "handle": "public-handle",
+                "display_name": "Public Name",
+                "avatar_media_id": avatar_media_id
+            })
+        );
+    }
+
+    #[test]
+    fn absent_or_denied_author_is_not_serialized() {
+        assert_eq!(public_author_payload(None), Value::Null);
+        assert_eq!(public_author_id(None), None);
+        assert_eq!(public_author_handle(None), None);
+        assert_eq!(public_author_keywords(None), "");
+    }
+}

--- a/crates/rustok-search/src/forum_inbox.rs
+++ b/crates/rustok-search/src/forum_inbox.rs
@@ -38,8 +38,7 @@ impl ForumProjectionScope {
             | DomainEvent::LocaleDisabled { .. }
             | DomainEvent::TenantCreated { .. }
             | DomainEvent::TenantUpdated { .. } => Some(Self::Full),
-            DomainEvent::ProfileUpdated { user_id, .. }
-            | DomainEvent::UserDeleted { user_id } => Some(Self::Author(*user_id)),
+            DomainEvent::ProfileUpdated { user_id, .. } => Some(Self::Author(*user_id)),
             DomainEvent::TenantModuleToggled { module_slug, .. } if module_slug == "forum" => {
                 Some(Self::Full)
             }
@@ -556,10 +555,6 @@ mod tests {
                 handle: "safe-author".to_string(),
                 locale: Some("en".to_string()),
             }),
-            Some(ForumProjectionScope::Author(user_id))
-        );
-        assert_eq!(
-            ForumProjectionScope::for_event(&DomainEvent::UserDeleted { user_id }),
             Some(ForumProjectionScope::Author(user_id))
         );
         assert!(ForumProjectionScope::Author(user_id)

--- a/crates/rustok-search/src/forum_inbox.rs
+++ b/crates/rustok-search/src/forum_inbox.rs
@@ -12,6 +12,8 @@ use rustok_events::{DomainEvent, EventEnvelope};
 
 const FORUM_SOURCE_MODULE: &str = "forum";
 const FULL_SCOPE_KEY: &str = "forum";
+const CATEGORY_SCOPE_PREFIX: &str = "forum_category:";
+const AUTHOR_SCOPE_PREFIX: &str = "forum_author:";
 const MAX_ERROR_CHARS: usize = 2_000;
 const MAX_ATTEMPTS: u32 = 12;
 const RETRY_BASE_SECONDS: i64 = 5;
@@ -21,6 +23,7 @@ const RETRY_MAX_SECONDS: i64 = 300;
 pub(crate) enum ForumProjectionScope {
     Full,
     Category(Uuid),
+    Author(Uuid),
 }
 
 impl ForumProjectionScope {
@@ -35,6 +38,8 @@ impl ForumProjectionScope {
             | DomainEvent::LocaleDisabled { .. }
             | DomainEvent::TenantCreated { .. }
             | DomainEvent::TenantUpdated { .. } => Some(Self::Full),
+            DomainEvent::ProfileUpdated { user_id, .. }
+            | DomainEvent::UserDeleted { user_id } => Some(Self::Author(*user_id)),
             DomainEvent::TenantModuleToggled { module_slug, .. } if module_slug == "forum" => {
                 Some(Self::Full)
             }
@@ -53,7 +58,8 @@ impl ForumProjectionScope {
     fn key(&self) -> String {
         match self {
             Self::Full => FULL_SCOPE_KEY.to_string(),
-            Self::Category(category_id) => format!("forum_category:{category_id}"),
+            Self::Category(category_id) => format!("{CATEGORY_SCOPE_PREFIX}{category_id}"),
+            Self::Author(user_id) => format!("{AUTHOR_SCOPE_PREFIX}{user_id}"),
         }
     }
 }
@@ -372,12 +378,24 @@ async fn load_effective_watermark(
     tenant_id: Uuid,
     scope_key: &str,
 ) -> Result<Option<(DateTime<Utc>, Uuid)>> {
+    if scope_key.starts_with(AUTHOR_SCOPE_PREFIX) {
+        // Profile privacy changes are redaction barriers. They always rebuild from
+        // current owner state and must not be discarded because an unrelated Forum
+        // producer emitted a later wall-clock timestamp.
+        return Ok(None);
+    }
+
     let scope_watermark = load_watermark(transaction, tenant_id, scope_key).await?;
     if scope_key == FULL_SCOPE_KEY {
         return Ok(scope_watermark);
     }
-    let full_scope_watermark = load_watermark(transaction, tenant_id, FULL_SCOPE_KEY).await?;
-    Ok(max_watermark(scope_watermark, full_scope_watermark))
+    if scope_key.starts_with(CATEGORY_SCOPE_PREFIX) {
+        let full_scope_watermark = load_watermark(transaction, tenant_id, FULL_SCOPE_KEY).await?;
+        return Ok(max_watermark(scope_watermark, full_scope_watermark));
+    }
+    Err(Error::Validation(format!(
+        "Unsupported Forum projection watermark scope `{scope_key}`"
+    )))
 }
 
 async fn load_watermark(
@@ -527,6 +545,26 @@ mod tests {
             }),
             Some(ForumProjectionScope::Category(category_id))
         );
+    }
+
+    #[test]
+    fn profile_changes_have_redaction_barrier_scope() {
+        let user_id = Uuid::new_v4();
+        assert_eq!(
+            ForumProjectionScope::for_event(&DomainEvent::ProfileUpdated {
+                user_id,
+                handle: "safe-author".to_string(),
+                locale: Some("en".to_string()),
+            }),
+            Some(ForumProjectionScope::Author(user_id))
+        );
+        assert_eq!(
+            ForumProjectionScope::for_event(&DomainEvent::UserDeleted { user_id }),
+            Some(ForumProjectionScope::Author(user_id))
+        );
+        assert!(ForumProjectionScope::Author(user_id)
+            .key()
+            .starts_with(AUTHOR_SCOPE_PREFIX));
     }
 
     #[test]

--- a/crates/rustok-search/src/ingestion.rs
+++ b/crates/rustok-search/src/ingestion.rs
@@ -109,8 +109,7 @@ impl SearchIngestionHandler {
             | DomainEvent::ForumTopicStatusChanged { .. }
             | DomainEvent::ForumTopicPinned { .. }
             | DomainEvent::ForumReplyStatusChanged { .. }
-            | DomainEvent::ProfileUpdated { .. }
-            | DomainEvent::UserDeleted { .. } => {
+            | DomainEvent::ProfileUpdated { .. } => {
                 projector.rebuild_tenant(envelope.tenant_id).await
             }
             DomainEvent::TenantModuleToggled {
@@ -207,8 +206,7 @@ impl EventHandler for SearchIngestionHandler {
             | DomainEvent::ForumTopicStatusChanged { .. }
             | DomainEvent::ForumTopicPinned { .. }
             | DomainEvent::ForumReplyStatusChanged { .. }
-            | DomainEvent::ProfileUpdated { .. }
-            | DomainEvent::UserDeleted { .. } => self.forum_projector.is_some(),
+            | DomainEvent::ProfileUpdated { .. } => self.forum_projector.is_some(),
             DomainEvent::TagAttached { target_type, .. }
             | DomainEvent::TagDetached { target_type, .. } => target_type == "node",
             DomainEvent::TenantModuleToggled { module_slug, .. } => {
@@ -498,9 +496,7 @@ fn projector_operation_for_event(event: &DomainEvent) -> &'static str {
                 "delete_forum_scope"
             }
         }
-        DomainEvent::ProfileUpdated { .. } | DomainEvent::UserDeleted { .. } => {
-            "rebuild_forum_author_projection"
-        }
+        DomainEvent::ProfileUpdated { .. } => "rebuild_forum_author_projection",
         DomainEvent::ForumTopicCreated { .. }
         | DomainEvent::ForumTopicReplied { .. }
         | DomainEvent::ForumTopicStatusChanged { .. }

--- a/crates/rustok-search/src/ingestion.rs
+++ b/crates/rustok-search/src/ingestion.rs
@@ -108,7 +108,9 @@ impl SearchIngestionHandler {
             | DomainEvent::ForumTopicReplied { .. }
             | DomainEvent::ForumTopicStatusChanged { .. }
             | DomainEvent::ForumTopicPinned { .. }
-            | DomainEvent::ForumReplyStatusChanged { .. } => {
+            | DomainEvent::ForumReplyStatusChanged { .. }
+            | DomainEvent::ProfileUpdated { .. }
+            | DomainEvent::UserDeleted { .. } => {
                 projector.rebuild_tenant(envelope.tenant_id).await
             }
             DomainEvent::TenantModuleToggled {
@@ -204,7 +206,9 @@ impl EventHandler for SearchIngestionHandler {
             | DomainEvent::ForumTopicReplied { .. }
             | DomainEvent::ForumTopicStatusChanged { .. }
             | DomainEvent::ForumTopicPinned { .. }
-            | DomainEvent::ForumReplyStatusChanged { .. } => self.forum_projector.is_some(),
+            | DomainEvent::ForumReplyStatusChanged { .. }
+            | DomainEvent::ProfileUpdated { .. }
+            | DomainEvent::UserDeleted { .. } => self.forum_projector.is_some(),
             DomainEvent::TagAttached { target_type, .. }
             | DomainEvent::TagDetached { target_type, .. } => target_type == "node",
             DomainEvent::TenantModuleToggled { module_slug, .. } => {
@@ -439,6 +443,11 @@ mod tests {
             author_id: None,
             locale: "en".to_string(),
         }));
+        assert!(!handler.handles(&DomainEvent::ProfileUpdated {
+            user_id: Uuid::new_v4(),
+            handle: "public-author".to_string(),
+            locale: Some("en".to_string()),
+        }));
     }
 }
 
@@ -488,6 +497,9 @@ fn projector_operation_for_event(event: &DomainEvent) -> &'static str {
             } else {
                 "delete_forum_scope"
             }
+        }
+        DomainEvent::ProfileUpdated { .. } | DomainEvent::UserDeleted { .. } => {
+            "rebuild_forum_author_projection"
         }
         DomainEvent::ForumTopicCreated { .. }
         | DomainEvent::ForumTopicReplied { .. }

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const sourcePath = "crates/rustok-forum/src/search_projection.rs";
+const authorPath = "crates/rustok-forum/src/search_projection_author.rs";
+const forumLibPath = "crates/rustok-forum/src/lib.rs";
+const inboxPath = "crates/rustok-search/src/forum_inbox.rs";
+const ingestionPath = "crates/rustok-search/src/ingestion.rs";
+const profilesPath = "crates/rustok-profiles/src/presentation.rs";
+const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
+const notePath = "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md";
+
+const source = read(sourcePath);
+const author = read(authorPath);
+const forumLib = read(forumLibPath);
+const inbox = read(inboxPath);
+const ingestion = read(ingestionPath);
+const profiles = read(profilesPath);
+const note = read(notePath);
+let contract = null;
+try {
+  contract = JSON.parse(read(contractPath));
+} catch (error) {
+  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
+}
+
+for (const marker of [
+  "ProfilePresentationService::new(db.clone())",
+  ".find_profile_summary(tenant_id, author_id, Some(locale), None)",
+  "public_author_payload",
+  '"user_id": summary.user_id',
+  '"handle": summary.handle',
+  '"display_name": summary.display_name',
+  '"avatar_media_id": summary.avatar_media_id',
+  "public_author_payload_exposes_only_the_safe_summary",
+  "absent_or_denied_author_is_not_serialized",
+]) {
+  requireMarker(author, marker, authorPath);
+}
+for (const forbidden of [
+  '"tags": summary.tags',
+  '"preferred_locale": summary.preferred_locale',
+  '"visibility": summary.visibility',
+]) {
+  rejectMarker(author, forbidden, authorPath);
+}
+
+for (const marker of [
+  "load_public_author_summary",
+  "handle: author_handle",
+  "public_author_keywords",
+  '"author": author_payload',
+  '"author_id": author_id',
+  '"has_public_author": author_id.is_some()',
+]) {
+  requireMarker(source, marker, sourcePath);
+}
+for (const forbidden of [
+  '"author_id": topic.author_id',
+  '"author_id": reply.author_id',
+]) {
+  rejectMarker(source, forbidden, sourcePath);
+}
+requireMarker(forumLib, "mod search_projection_author;", forumLibPath);
+
+for (const marker of [
+  "ProfilePrivacyService::new(self.db.clone())",
+  "ProfileAccessAudience::Anonymous",
+  "ProfilePrivacyDecision::Allow",
+]) {
+  requireMarker(profiles, marker, profilesPath);
+}
+
+for (const marker of [
+  "Author(Uuid)",
+  "DomainEvent::ProfileUpdated { user_id, .. }",
+  "DomainEvent::UserDeleted { user_id }",
+  "AUTHOR_SCOPE_PREFIX",
+  "scope_key.starts_with(AUTHOR_SCOPE_PREFIX)",
+  "return Ok(None);",
+  "profile_changes_have_redaction_barrier_scope",
+]) {
+  requireMarker(inbox, marker, inboxPath);
+}
+for (const marker of [
+  "DomainEvent::ProfileUpdated { .. }",
+  "DomainEvent::UserDeleted { .. }",
+  '"rebuild_forum_author_projection"',
+  "projector.rebuild_tenant(envelope.tenant_id).await",
+]) {
+  requireMarker(ingestion, marker, ingestionPath);
+}
+
+for (const marker of [
+  "FORUM-23A",
+  "ProfilePresentationService",
+  "forum_author:<user_id>",
+  "raw `payload.author_id`",
+  "owner-issued monotonic",
+  "not run by the implementation agent",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${contractPath}: unexpected status`);
+  }
+  for (const key of [
+    "anonymous_profiles_presentation_is_authoritative",
+    "forum_does_not_copy_profile_privacy_policy",
+    "missing_or_denied_profile_projects_null_author",
+    "profile_owner_failure_is_retryable_not_empty",
+    "raw_topic_author_id_is_not_serialized",
+    "raw_reply_author_id_is_not_serialized",
+    "profile_tags_are_not_serialized",
+    "preferred_locale_is_not_serialized",
+    "profile_visibility_is_not_serialized",
+    "public_handle_populates_search_handle",
+    "author_filter_facet_is_present_only_for_public_author",
+  ]) {
+    if (contract.projection_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: projection boundary ${key} drift`);
+    }
+  }
+  for (const key of [
+    "profile_updated_is_durable",
+    "user_deleted_is_durable",
+    "author_scope_is_tenant_and_user_scoped",
+    "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
+    "author_change_rebuilds_current_forum_owner_state",
+    "projection_failure_remains_retryable",
+    "tenant_advisory_lock_is_preserved",
+  ]) {
+    if (contract.redaction_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: redaction boundary ${key} drift`);
+    }
+  }
+  if (contract.redaction_boundary?.schema_migration_added !== false) {
+    failures.push(`${contractPath}: schema migration must remain absent`);
+  }
+  for (const key of [
+    "forum_graphql_changed",
+    "forum_rest_changed",
+    "search_query_api_changed",
+    "search_document_schema_changed",
+    "forum_owner_storage_changed",
+    "profiles_owner_storage_changed",
+    "cargo_lock_changed",
+  ]) {
+    if (contract.compatibility?.[key] !== false) {
+      failures.push(`${contractPath}: compatibility ${key} must remain false`);
+    }
+  }
+  if (contract.downstream_task !== "FORUM-23B") {
+    failures.push(`${contractPath}: unexpected downstream task`);
+  }
+  if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+    failures.push(`${contractPath}: execution status drift`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Forum public author Search projection verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum public author Search projection verification passed.");

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -153,7 +153,7 @@ if (contract) {
     "preferred_locale_is_not_serialized",
     "profile_visibility_is_not_serialized",
     "public_handle_populates_search_handle",
-    "author_filter_facet_is_present_only_for_public_author",
+    "author_filter_value_is_populated_only_for_public_author",
   ]) {
     if (contract.projection_boundary?.[key] !== true) {
       failures.push(`${contractPath}: projection boundary ${key} drift`);

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -31,6 +31,7 @@ const forumLibPath = "crates/rustok-forum/src/lib.rs";
 const inboxPath = "crates/rustok-search/src/forum_inbox.rs";
 const ingestionPath = "crates/rustok-search/src/ingestion.rs";
 const profilesPath = "crates/rustok-profiles/src/presentation.rs";
+const profilesMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
 const notePath = "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md";
 
@@ -40,6 +41,7 @@ const forumLib = read(forumLibPath);
 const inbox = read(inboxPath);
 const ingestion = read(ingestionPath);
 const profiles = read(profilesPath);
+const profilesMutation = read(profilesMutationPath);
 const note = read(notePath);
 let contract = null;
 try {
@@ -94,11 +96,18 @@ for (const marker of [
 ]) {
   requireMarker(profiles, marker, profilesPath);
 }
+for (const marker of [
+  "service.update_profile_visibility",
+  "service.update_profile_media",
+  "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
+  "DomainEvent::ProfileUpdated",
+]) {
+  requireMarker(profilesMutation, marker, profilesMutationPath);
+}
 
 for (const marker of [
   "Author(Uuid)",
   "DomainEvent::ProfileUpdated { user_id, .. }",
-  "DomainEvent::UserDeleted { user_id }",
   "AUTHOR_SCOPE_PREFIX",
   "scope_key.starts_with(AUTHOR_SCOPE_PREFIX)",
   "return Ok(None);",
@@ -106,14 +115,15 @@ for (const marker of [
 ]) {
   requireMarker(inbox, marker, inboxPath);
 }
+rejectMarker(inbox, "DomainEvent::UserDeleted", inboxPath);
 for (const marker of [
   "DomainEvent::ProfileUpdated { .. }",
-  "DomainEvent::UserDeleted { .. }",
   '"rebuild_forum_author_projection"',
   "projector.rebuild_tenant(envelope.tenant_id).await",
 ]) {
   requireMarker(ingestion, marker, ingestionPath);
 }
+rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 
 for (const marker of [
   "FORUM-23A",
@@ -121,6 +131,7 @@ for (const marker of [
   "forum_author:<user_id>",
   "raw `payload.author_id`",
   "owner-issued monotonic",
+  "does not treat `UserDeleted`",
   "not run by the implementation agent",
 ]) {
   requireMarker(note, marker, notePath);
@@ -150,7 +161,7 @@ if (contract) {
   }
   for (const key of [
     "profile_updated_is_durable",
-    "user_deleted_is_durable",
+    "profile_updated_is_emitted_after_owner_write",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
     "author_change_rebuilds_current_forum_owner_state",
@@ -176,6 +187,9 @@ if (contract) {
     if (contract.compatibility?.[key] !== false) {
       failures.push(`${contractPath}: compatibility ${key} must remain false`);
     }
+  }
+  if (!contract.non_claims?.includes("account deletion redaction is complete")) {
+    failures.push(`${contractPath}: account deletion non-claim is missing`);
   }
   if (contract.downstream_task !== "FORUM-23B") {
     failures.push(`${contractPath}: unexpected downstream task`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A`, the first bounded slice of the visibility-aware Forum Search plan.

- resolve topic and approved-reply authors through the anonymous Profiles presentation owner;
- project only `user_id`, `handle`, `display_name`, and `avatar_media_id` when Profiles permits public presentation;
- remove raw Forum `author_id` values from Search payloads and populate the author filter value only for an approved public summary;
- durably consume post-owner-write `ProfileUpdated` events under a tenant/user author-redaction scope;
- prevent an unrelated Forum wall-clock watermark from suppressing privacy redaction;
- propagate Profiles failures into the existing durable retry path instead of silently serializing an empty author;
- document that account-deletion invalidation and owner-issued monotonic revisions remain open.

## Compatibility

No migration, public Forum API, Search query API, owner storage, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate forum
```

## Follow-up

- synchronize the large canonical Forum ledger through `FORUM-23A` with a repository-local edit;
- add owner-issued monotonic projection revisions;
- define owner-ordered profile/account-deletion invalidation;
- add the remaining filters and member projections.