### PR TITLE
fix(forum): preserve Search runtime contract reference

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-projection.json
+++ b/crates/rustok-forum/contracts/forum-search-projection.json
@@ -9,6 +9,7 @@
   "forum_source_registration": "crates/rustok-forum/src/lib.rs",
   "search_projector": "crates/rustok-search/src/forum_projector.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
+  "search_runtime_composition": "crates/rustok-search/src/lib.rs",
   "search_storage": "search_documents",
   "source_module": "forum",
   "entity_types": [


### PR DESCRIPTION
## Summary

Restores the existing `search_runtime_composition` reference in the Forum Search projection contract after the FORUM-23A squash merge replaced the shared JSON file from a stale complete-file snapshot.

No runtime code, schema, dependency, or public API change.

## Verification

Not run, per maintainer instruction. The PR is intentionally limited to one contract line.