### PR TITLE
fix(profiles): make visibility redaction event atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -8,6 +8,7 @@
   "forum_author_adapter": "crates/rustok-forum/src/search_projection_author.rs",
   "profiles_owner": "crates/rustok-profiles/src/presentation.rs",
   "profiles_event_owner": "crates/rustok-profiles/src/graphql/mutation.rs",
+  "profiles_visibility_event_owner": "crates/rustok-profiles/src/visibility_write.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -35,6 +36,9 @@
   "redaction_boundary": {
     "profile_updated_is_durable": true,
     "profile_updated_is_emitted_after_owner_write": true,
+    "profile_visibility_write_and_event_are_atomic": true,
+    "other_profile_update_write_and_event_pairs_are_atomic": false,
+    "visibility_event_failure_rolls_back_owner_write": true,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
     "author_change_rebuilds_current_forum_owner_state": true,
@@ -54,6 +58,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
+    "make non-visibility profile summary update events atomic with their owner writes",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -61,17 +66,20 @@
   "verification": {
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
+      "cargo test -p rustok-profiles error -- --nocapture",
       "cargo test -p rustok-forum search_projection_author -- --nocapture",
       "cargo test -p rustok-search forum_inbox -- --nocapture",
       "cargo test -p rustok-search ingestion -- --nocapture",
       "node scripts/verify/verify-forum-search-public-author-summary.mjs",
       "node scripts/verify/verify-forum-search-projection.mjs",
+      "cargo xtask module validate profiles",
       "cargo xtask module validate forum"
     ]
   },
   "non_claims": [
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
+    "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -39,6 +39,16 @@ Embedded summaries require invalidation when profile presentation changes. Profi
 and media changes. Search now treats that owner event as a Forum projection event whenever the
 Forum source is composed.
 
+The privacy-critical `update_my_profile_visibility` path writes the new visibility and the
+`ProfileUpdated` outbox envelope in the same Profiles-owned database transaction. If outbox
+publication fails, the visibility write is explicitly rolled back and the mutation returns a
+retryable owner error. A successful private visibility change therefore cannot commit without the
+durable invalidation consumed by Forum Search.
+
+Other profile summary mutations still publish their update event after the owner write and are
+not claimed to be transactionally coupled in this slice. Closing that non-ACL freshness gap
+remains follow-up work.
+
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so a profile changed to
@@ -72,6 +82,7 @@ document rows are replaced by the next Forum rebuild or relevant durable event.
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
+- transactionally couple non-visibility profile summary updates to their owner events;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;
@@ -84,10 +95,12 @@ Not run by the implementation agent, per maintainer instruction.
 Suggested commands:
 
 ```bash
+cargo test -p rustok-profiles error -- --nocapture
 cargo test -p rustok-forum search_projection_author -- --nocapture
 cargo test -p rustok-search forum_inbox -- --nocapture
 cargo test -p rustok-search ingestion -- --nocapture
 node scripts/verify/verify-forum-search-public-author-summary.mjs
 node scripts/verify/verify-forum-search-projection.mjs
+cargo xtask module validate profiles
 cargo xtask module validate forum
 ```

--- a/crates/rustok-profiles/src/error.rs
+++ b/crates/rustok-profiles/src/error.rs
@@ -34,6 +34,8 @@ pub enum ProfileError {
     Validation(String),
     #[error("profile presentation is temporarily unavailable")]
     PresentationUnavailable,
+    #[error("profile event publication is temporarily unavailable")]
+    EventPublishUnavailable,
     #[error(transparent)]
     Database(#[from] DbErr),
 }
@@ -55,12 +57,16 @@ impl ProfileError {
             Self::DuplicateHandle(_) => "profiles.handle_duplicate",
             Self::Validation(_) => "profiles.validation_failed",
             Self::PresentationUnavailable => "profiles.presentation_unavailable",
+            Self::EventPublishUnavailable => "profiles.event_publish_unavailable",
             Self::Database(_) => "profiles.storage_unavailable",
         }
     }
 
     pub const fn is_retryable(&self) -> bool {
-        matches!(self, Self::PresentationUnavailable | Self::Database(_))
+        matches!(
+            self,
+            Self::PresentationUnavailable | Self::EventPublishUnavailable | Self::Database(_)
+        )
     }
 }
 
@@ -99,6 +105,7 @@ mod tests {
     #[test]
     fn only_availability_failures_are_retryable() {
         assert!(ProfileError::PresentationUnavailable.is_retryable());
+        assert!(ProfileError::EventPublishUnavailable.is_retryable());
         assert!(!ProfileError::InvalidHandle.is_retryable());
     }
 }

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::{
     ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
     ProfileResult, ProfileService, validate_profile_media_asset,
+    visibility_write::update_profile_visibility_with_event,
 };
 
 use super::{MODULE_SLUG, types::*};
@@ -163,21 +164,22 @@ impl ProfilesMutation {
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
         let tenant = ctx.data::<TenantContext>()?;
-        let service = ProfileService::new(db.clone());
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateVisibility,
             tenant.id,
             auth.user_id,
-            service.update_profile_visibility(
+            update_profile_visibility_with_event(
+                db,
+                event_bus,
                 tenant.id,
+                auth.user_id,
                 auth.user_id,
                 visibility.into(),
                 Some(tenant.default_locale.as_str()),
             ),
         )
         .await?;
-        publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?;
 
         Ok(profile.into())
     }
@@ -368,6 +370,7 @@ fn map_profile_error(error: ProfileError) -> async_graphql::Error {
         }
         ProfileError::LocalizedCopyNotFound(_)
         | ProfileError::PresentationUnavailable
+        | ProfileError::EventPublishUnavailable
         | ProfileError::Database(_) => <FieldError as GraphQLError>::internal_error(&message),
     }
 }

--- a/crates/rustok-profiles/src/graphql/query.rs
+++ b/crates/rustok-profiles/src/graphql/query.rs
@@ -208,6 +208,7 @@ fn map_profile_error(error: ProfileError) -> async_graphql::Error {
         }
         ProfileError::LocalizedCopyNotFound(_)
         | ProfileError::PresentationUnavailable
+        | ProfileError::EventPublishUnavailable
         | ProfileError::Database(_) => <FieldError as GraphQLError>::internal_error(&message),
     }
 }

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -15,6 +15,7 @@ pub mod presentation;
 pub mod privacy;
 pub mod reader;
 pub mod services;
+mod visibility_write;
 
 pub use dto::{ProfileStatus, ProfileSummary, ProfileVisibility, UpsertProfileInput};
 pub use entities::ProfileRecord;

--- a/crates/rustok-profiles/src/visibility_write.rs
+++ b/crates/rustok-profiles/src/visibility_write.rs
@@ -1,0 +1,70 @@
+use chrono::Utc;
+use rustok_events::DomainEvent;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+use crate::{
+    ProfileError, ProfileOperation, ProfileOperationTimer, ProfileRecord, ProfileResult,
+    ProfileService, ProfileVisibility, entities,
+};
+
+pub(crate) async fn update_profile_visibility_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    user_id: Uuid,
+    visibility: ProfileVisibility,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileRecord> {
+    let txn = db.begin().await?;
+    let profile = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?
+        .ok_or(ProfileError::ProfileNotFound(user_id))?;
+
+    let mut active: entities::profile::ActiveModel = profile.into();
+    active.visibility = Set(visibility);
+    active.updated_at = Set(Utc::now().into());
+    let profile = active.update(&txn).await?;
+
+    let publish_timer = ProfileOperationTimer::start(
+        ProfileOperation::PublishUpdatedEvent,
+        tenant_id,
+        profile.user_id,
+    );
+    if let Err(error) = event_bus
+        .publish_in_tx(
+            &txn,
+            tenant_id,
+            Some(actor_id),
+            DomainEvent::ProfileUpdated {
+                user_id: profile.user_id,
+                handle: profile.handle.clone(),
+                locale: profile.preferred_locale.clone(),
+            },
+        )
+        .await
+    {
+        publish_timer.finish_failure(ProfileError::EventPublishUnavailable.code(), true);
+        tracing::error!(
+            tenant_id = %tenant_id,
+            user_id = %profile.user_id,
+            error = %error,
+            "Profile visibility event publication failed; rolling back owner write"
+        );
+        txn.rollback().await?;
+        return Err(ProfileError::EventPublishUnavailable);
+    }
+    publish_timer.finish_success();
+    txn.commit().await?;
+
+    ProfileService::new(db.clone())
+        .get_profile(tenant_id, user_id, None, tenant_default_locale)
+        .await
+}

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -25,6 +25,14 @@ function rejectMarker(source, marker, label) {
   if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
 }
 
+function requireOrder(source, first, second, label) {
+  const firstIndex = source.indexOf(first);
+  const secondIndex = source.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex) {
+    failures.push(`${label}: expected ${first} before ${second}`);
+  }
+}
+
 const sourcePath = "crates/rustok-forum/src/search_projection.rs";
 const authorPath = "crates/rustok-forum/src/search_projection_author.rs";
 const forumLibPath = "crates/rustok-forum/src/lib.rs";
@@ -32,6 +40,8 @@ const inboxPath = "crates/rustok-search/src/forum_inbox.rs";
 const ingestionPath = "crates/rustok-search/src/ingestion.rs";
 const profilesPath = "crates/rustok-profiles/src/presentation.rs";
 const profilesMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
+const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
+const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
 const notePath = "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md";
 
@@ -42,6 +52,8 @@ const inbox = read(inboxPath);
 const ingestion = read(ingestionPath);
 const profiles = read(profilesPath);
 const profilesMutation = read(profilesMutationPath);
+const profilesVisibilityWrite = read(profilesVisibilityWritePath);
+const profilesError = read(profilesErrorPath);
 const note = read(notePath);
 let contract = null;
 try {
@@ -97,12 +109,45 @@ for (const marker of [
   requireMarker(profiles, marker, profilesPath);
 }
 for (const marker of [
-  "service.update_profile_visibility",
+  "update_profile_visibility_with_event(",
   "service.update_profile_media",
   "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
   "DomainEvent::ProfileUpdated",
+  "ProfileError::EventPublishUnavailable",
 ]) {
   requireMarker(profilesMutation, marker, profilesMutationPath);
+}
+rejectMarker(profilesMutation, "service.update_profile_visibility(", profilesMutationPath);
+
+for (const marker of [
+  "db.begin().await?",
+  ".update(&txn).await?",
+  ".publish_in_tx(",
+  "txn.rollback().await?",
+  "txn.commit().await?",
+  "ProfileError::EventPublishUnavailable",
+  "Profile visibility event publication failed; rolling back owner write",
+]) {
+  requireMarker(profilesVisibilityWrite, marker, profilesVisibilityWritePath);
+}
+requireOrder(
+  profilesVisibilityWrite,
+  ".publish_in_tx(",
+  "txn.commit().await?",
+  profilesVisibilityWritePath,
+);
+requireOrder(
+  profilesVisibilityWrite,
+  ".update(&txn).await?",
+  ".publish_in_tx(",
+  profilesVisibilityWritePath,
+);
+for (const marker of [
+  "EventPublishUnavailable",
+  '"profiles.event_publish_unavailable"',
+  "Self::PresentationUnavailable | Self::EventPublishUnavailable | Self::Database(_)",
+]) {
+  requireMarker(profilesError, marker, profilesErrorPath);
 }
 
 for (const marker of [
@@ -131,6 +176,8 @@ for (const marker of [
   "forum_author:<user_id>",
   "raw `payload.author_id`",
   "owner-issued monotonic",
+  "same Profiles-owned database transaction",
+  "Other profile summary mutations",
   "does not treat `UserDeleted`",
   "not run by the implementation agent",
 ]) {
@@ -162,6 +209,8 @@ if (contract) {
   for (const key of [
     "profile_updated_is_durable",
     "profile_updated_is_emitted_after_owner_write",
+    "profile_visibility_write_and_event_are_atomic",
+    "visibility_event_failure_rolls_back_owner_write",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
     "author_change_rebuilds_current_forum_owner_state",
@@ -171,6 +220,9 @@ if (contract) {
     if (contract.redaction_boundary?.[key] !== true) {
       failures.push(`${contractPath}: redaction boundary ${key} drift`);
     }
+  }
+  if (contract.redaction_boundary?.other_profile_update_write_and_event_pairs_are_atomic !== false) {
+    failures.push(`${contractPath}: non-visibility profile mutations must remain a non-claim`);
   }
   if (contract.redaction_boundary?.schema_migration_added !== false) {
     failures.push(`${contractPath}: schema migration must remain absent`);
@@ -188,8 +240,13 @@ if (contract) {
       failures.push(`${contractPath}: compatibility ${key} must remain false`);
     }
   }
-  if (!contract.non_claims?.includes("account deletion redaction is complete")) {
-    failures.push(`${contractPath}: account deletion non-claim is missing`);
+  for (const nonClaim of [
+    "account deletion redaction is complete",
+    "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
+  ]) {
+    if (!contract.non_claims?.includes(nonClaim)) {
+      failures.push(`${contractPath}: missing non-claim ${nonClaim}`);
+    }
   }
   if (contract.downstream_task !== "FORUM-23B") {
     failures.push(`${contractPath}: unexpected downstream task`);


### PR DESCRIPTION
## Summary

Hardens the privacy-critical source event used by FORUM-23A.

- write profile visibility and the `ProfileUpdated` outbox envelope in the same Profiles-owned transaction;
- explicitly roll back the visibility write when outbox publication fails;
- classify event publication failure as a retryable Profiles availability error;
- keep handle/content/locale/media event publication behavior unchanged and document that those non-ACL paths are not yet atomic;
- extend the FORUM-23A contract, note, and static verifier with the atomic visibility boundary.

## Why

Forum Search removes an embedded public author summary after `ProfileUpdated`. A private visibility change must not commit unless its durable invalidation also commits.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```