### PR TITLE
docs(index): lock the current M4 implementation cursor

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (PostgreSQL query port source added; M3 retained packet owner gate remains open)`
+- Current milestone: `M4 - Query engine v1 (source-complete query/runtime and first parity shadow; retained live evidence remains open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -58,32 +58,19 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 many-link `EXISTS` filtering: `complete`
 - M4 nested many-link projection aggregation: `complete`
 - M4 PostgreSQL query port and strict row adapter: `source_complete`
-- Production persistence: mutation writes, schema/index coordination, fail-closed
-  partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
-  full-capture orchestration, exact-byte packet assembly, retained bundle review,
-  admitted archive manifest generation, saved-manifest verification, recursive
-  filesystem integrity checks, typed executable query planning, controlled projection,
-  root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
-  compilation, correlated many-link filtering, deterministic nested many-link
-  projection aggregation, one-row page lookahead, tagged row decoding, exact-count
-  decoding, scoped next-cursor construction, persisted-schema query preflight,
-  PostgreSQL page/count execution, and compiler-driven row adaptation are implemented;
-  one retained admitted packet, server/consumer query-port composition,
-  PostgreSQL/reference equivalence, and production partition lifecycle remain open
+- M4 retained plan/SQL snapshots: `source_complete`
+- M4 explicit many-link aggregate ordering: `source_complete`
+- M4 source-owned schema catalog and shared query runtime: `source_complete`
+- M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 
-The production crate contains the generic domain/application core, seven canonical
-M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
-lifecycle management, measured partition admission that emits shadow bootstrap
-plans only, an M4 typed structural query planner with deterministic relation aliases,
-a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
-exact count, keyset and bounded offset plus duplicate-free correlated many-link
-filtering and nested many-link projection aggregates, a strict compiled-row decoder
-with aligned nested identities/values, lookahead pagination, and scoped cursor
-construction, and `PostgresIndexQueryPort` for exact-schema-preflighted execution in
-one read-only repeatable-read page/count snapshot. Owner-operated evidence tools live
-under `ops/benches`; they do not become runtime storage code.
+Production persistence, typed planning/compilation/decoding, explicit many-link
+MIN/MAX aggregate ordering with the exact Decimal string wire, source-owned schema
+publication, shared query-runtime composition, and the default-off Social Graph
+privacy parity shadow are source complete. One retained admitted partition packet,
+live PostgreSQL/reference equivalence, authoritative consumer cutover, and production
+partition lifecycle remain open.
 
-## Ownership
+## Ownership and architecture
 
 Index owns schema/link registration, generic records and mutations, ingestion,
 inbox deduplication, PostgreSQL storage, query validation/planning/compilation,
@@ -93,8 +80,6 @@ reconciliation, drift repair, distributed coordination, and operator diagnostics
 Source modules own normalized domain data, schema declarations, conversion to
 generic Index records/mutations, rebuild scan/load adapters, and source ordering and
 version information.
-
-## Target architecture
 
 ```text
 source modules
@@ -107,44 +92,11 @@ source modules
     -> server, storefront, admin, and rustok-search
 ```
 
-```text
-crates/rustok-index/src/
-  domain/
-  application/
-    planner.rs
-    postgres_compiler.rs
-    postgres_query_sql.rs
-    postgres_query_result.rs
-    query_port.rs
-  migrations/
-  infrastructure/postgres/
-    mutation_store.rs
-    schema_lease.rs
-    secondary_index.rs
-    partition_admission.rs
-    query_port.rs
-  api/
-
-ops/benches/src/index_storage/
-  runner.rs
-  mutation_runner.rs
-  maintenance_runner.rs
-  partition_snapshot.rs
-  partition_query.rs
-  partition_mutation.rs
-  partition_maintenance.rs
-  partition_cutover.rs
-  partition_capture.rs
-```
-
-## Library decisions
-
 Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded
 async work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
 `tracing`/telemetry/prometheus for observability, `petgraph` for deterministic graph
 resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan,
-and retained-evidence identities. Add Testcontainers, retry, cancellation, or
-snapshot libraries only when their slices require them.
+and retained-evidence identities.
 
 Forbidden in Index core: source-domain dependencies, ranking/search libraries, a
 second database stack, unvalidated JSON-only public queries, unbounded rebuild ID
@@ -174,8 +126,7 @@ retained evidence and rollback proof.
 
 ### M2 - PostgreSQL storage benchmark
 
-- [x] Define the benchmark contract and keep candidate DDL outside production
-      migrations.
+- [x] Define the benchmark contract and keep candidate DDL outside production migrations.
 - [x] Add deterministic `smoke`, `100k`, and `1m` dataset presets.
 - [x] Prototype JSONB entity rows plus typed expression/GIN indexes.
 - [x] Compare JSONB, typed EAV, and specialized hot projection using equal result
@@ -191,10 +142,9 @@ retained evidence and rollback proof.
 - [x] Record the selected model and rejected alternatives in an ADR.
 - [x] Delete benchmark prototypes that are not selected.
 
-M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
-harness; it is not production persistence and does not reopen the accepted storage
-decision. Partitioning was not measured by M2, so canonical production tables remain
-unpartitioned until separate shadow evidence is retained and admitted.
+M2 is complete. The JSONB harness is selected-layout regression evidence, not
+production persistence. Canonical production tables remain unpartitioned until
+separate shadow evidence is retained and admitted.
 
 ### M3 - PostgreSQL storage engine
 
@@ -228,9 +178,6 @@ unpartitioned until separate shadow evidence is retained and admitted.
 
 #### Retained repository contract wording
 
-The following wording remains explicit because repository guards bind the completed
-slices and still-open owner evidence to these exact architectural boundaries:
-
 - [x] Add locking/leases for schema application.
 - [x] Add secondary-index planning and lifecycle management.
 - [x] Add tenant/schema/entity/locale keys and source-version guards.
@@ -248,63 +195,8 @@ slices and still-open owner evidence to these exact architectural boundaries:
 
 Partition admission remains fail-closed across tenant-predicate coverage,
 query/mutation latency and plan stability, WAL amplification, skew, and cutover lock
-evidence. Admitted plans emit shadow-only DDL. They never rename, drop, or alter production
-relations.
-
-#### Completed M3 slices
-
-1. Canonical migrations register the seven module-owned tables with complete tenant,
-   schema, entity, locale, and full-range non-negative source-version identity.
-2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
-   serializes the entity key, and applies entity/tombstone/link replacement atomically.
-3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
-   reclaim, heartbeat, terminal completion, and attempt fencing.
-4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
-   coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
-5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
-   fail-closed admission and deterministic shadow-only hash partition DDL.
-6. Immutable manifest preparation and packet validation bind commit, image, modulus,
-   repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
-7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
-   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
-8. The snapshot runner creates evidence-bound shadow parents/children, copies one
-   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
-   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
-9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
-   read-only, proves semantic parity and one-child pruning, retains full EXPLAIN JSON,
-   calculates p95 and normalized plan digests, and publishes `query.json` once.
-10. The mutation/WAL runner validates the same manifest and catalog, requires count
-    parity and matching generic anchors, executes rollback-only mutation samples,
-    proves one-child shadow pruning, retains EXPLAIN JSON and WAL evidence, and
-    publishes `mutation.json` without overwrite. Real database execution remains an
-    owner step.
-11. The maintenance runner revalidates the manifest and retained shadow catalog,
-    creates isolated ordinary and tenant-hash clone pairs, applies identical committed
-    churn only to those clones, times ordinary `VACUUM (ANALYZE)`, proves production
-    and retained snapshot-shadow relations unchanged, and publishes
-    `maintenance.json` without overwrite. Real database execution remains an owner
-    step.
-12. The cutover rehearsal runner validates production and retained shadow identities,
-    creates deterministic evidence-only ordinary clones, measures `ACCESS EXCLUSIVE`
-    lock acquisition, performs rename swaps only inside rollback-only transactions,
-    proves clone OIDs/names and production relations unchanged, and publishes
-    `cutover.json` without overwrite. Real database execution remains an owner step.
-13. The full-capture orchestrator requires one explicit owner opt-in, one immutable
-    manifest, one database URL, and a fresh empty output directory. It sequentially
-    runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
-    and run provenance, assembles exact retained bytes into `partition-packet.json`,
-    validates `admission.json`, and refuses partial-output reuse or resume.
-14. The retained bundle review inspects exactly nine authoritative files, recalculates
-    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
-    deterministic read-only owner report without editing the bundle.
-15. The archive tooling emits a deterministic admitted-only manifest outside the
-    immutable bundle and verifies a saved manifest into a read-only receipt with
-    `production_lifecycle_authorized: false`.
-16. Retained verification binds every authoritative file and required directory to
-    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
-    paths, and an exact recursive inventory. It rereads the saved manifest and fails
-    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
-    while keeping public manifest and receipt schemas unchanged.
+evidence. Admitted plans emit shadow-only DDL. They never rename, drop, or alter
+production relations.
 
 ### M4 - Query engine v1
 
@@ -319,58 +211,25 @@ relations.
 - [x] Add explicit many-link `EXISTS` filtering.
 - [x] Add nested many-link projection aggregation.
 - [x] Add PostgreSQL `IndexQueryPort` execution and strict SeaORM row adaptation.
-- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
+- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.
+- [x] Add explicit many-link MIN/MAX aggregate ordering for integer, string, timestamp,
+      and Decimal terminals under bounded offset pagination.
+- [x] Publish source-owned schemas, compose one shared query runtime, and stage the first
+      default-off owner-authoritative Social Graph privacy parity shadow.
+- [ ] Add PostgreSQL/reference-engine equivalence tests and retained live evidence.
 
-The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
-before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
-prefixes, and captures every referenced field with type, cardinality, nullability,
-path, alias, and propagated many-link traversal state. It groups selected many fields
-by terminal relation path while preserving first path appearance and field order. The
-typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
+Many-link ordering is admitted only through caller-explicit `min_asc`, `min_desc`,
+`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain
+typed PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate
+order value through the exact tagged string wire. UUID aggregate ordering, implicit
+first-row semantics, and aggregate cursor continuation remain fail closed. Aggregate
+ordering is bounded-offset-only and does not change root cardinality or exact count.
 
-The controlled compiler emits ordered typed binds, deterministic identity/projection/
-order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
-reference-compatible null ordering, validated lexicographic keyset predicates with an
-ascending root `entity_id` tie-breaker, bounded offset pagination, and an optional
-separate exact-count statement without pagination leakage. Opaque continuation tokens
-must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
-schema fingerprint, order arity, and order-value types before SQL emission.
-
-Each selected many path compiles as one correlated JSONB aggregate outside the outer
-rowset. Aggregate items preserve the complete linked entity identity chain and aligned
-tagged field values, are ordered by stored link ordinal plus target identity/locale at
-each hop, and produce an empty array when no reachable row exists. Many aggregates do
-not alter root pagination, lookahead, or exact-count cardinality.
-
-The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
-the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
-fingerprint, deterministic scalar and many-relation column contracts, page size, row
-count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
-identity/value arity, duplicate/nil nested identities, and optional count. It removes
-the lookahead row, reports `has_more`, preserves flat and nested selection order, and
-emits a query-scoped cursor from the last retained root identity plus hidden order
-values. Offset pages use the same lookahead rule but do not synthesize a cursor.
-
-Many-link filtering compiles every atomic predicate through an independent nested
-correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
-lookahead, result decoding, and exact count stay duplicate free. Positive operators use
-any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
-`Ne` requires at least one stored reachable value and rejects any null or equal value.
-This matches the test-only reference engine's flattened path-value semantics.
-
-`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
-query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
-PostgreSQL connection. It derives every root/source/target schema used by the plan,
-requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
-and schema JSON, executes the page and optional exact count in one read-only
-repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
-maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
-calling the strict decoder. Authentication and transport policy remain caller-owned.
-
-Many-link ordering remains rejected until an aggregate ordering policy exists.
-Server/storefront/admin/search composition, source schema/mutation publication,
-consumer cutover, plan/SQL snapshots, live PostgreSQL execution evidence, and
-PostgreSQL/reference-engine equivalence remain open.
+Source-owned schema publication, shared query-runtime composition, retained plan/SQL
+snapshots, and the first default-off Social Graph privacy parity shadow are source
+complete. The shadow is non-authoritative, records bounded parity observations, uses
+only the caller's remaining deadline budget, and always returns the owner result.
+Live metrics/evidence execution and authoritative consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
@@ -388,8 +247,7 @@ PostgreSQL/reference-engine equivalence remain open.
 - [ ] Add bounded streaming; never collect all IDs first.
 - [ ] Add cancellation, resume, dry-run, targeted/full/shadow rebuild.
 - [ ] Add reconciliation and drift repair.
-- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
-      equivalence.
+- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full equivalence.
 
 ### M7 - First vertical slice
 
@@ -397,8 +255,7 @@ Entities: Product, ProductVariant, SalesChannel.
 
 - [ ] Register owner-published schemas and links.
 - [ ] Implement mutations and rebuild sources.
-- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
-      pagination.
+- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor pagination.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
@@ -424,92 +281,41 @@ Entities: Product, ProductVariant, SalesChannel.
 
 ### M11 - Admin and cutover
 
-- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query
-      diagnostics.
+- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query diagnostics.
 - [ ] Add rebuild/cancel/retry commands.
 - [ ] Publish new FBA contracts and runtime evidence.
 - [ ] Migrate consumers and delete final compatibility code.
 - [ ] Promote FBA only after compiled/live evidence.
 
-## Verification
+## Verification handoff
+
+The owner runs formatting, Cargo checks/tests, PostgreSQL fixtures, evidence capture,
+admission, and CI. Targeted source guards include:
 
 ```bash
-cargo fmt --all -- --check
-cargo check --workspace --all-targets --all-features
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo nextest run --workspace --all-targets --all-features
-cargo test --workspace --doc --all-features
-cargo test -p rustok-index planner_tests -- --nocapture
-cargo test -p rustok-index postgres_compiler_tests -- --nocapture
-cargo test -p rustok-index postgres_query_result_tests -- --nocapture
+node scripts/verify/verify-index-fba.mjs
+node scripts/verify/verify-index-query-contract.mjs
+node scripts/verify/verify-index-query-snapshots.mjs
+node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+node scripts/verify/verify-index-decimal-aggregate-wire.mjs
+node scripts/verify/verify-index-source-schema-registry.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
 cargo xtask module validate index
-cargo xtask module test index
-npm run verify:index:fba
-npm run verify:index:runtime-fallback-smoke
-node scripts/verify/index-storage-tooling.mjs contract
-node scripts/verify/index-storage-tooling.mjs fixtures
-node --test scripts/verify/index-partition-evidence.test.mjs
-node --test scripts/verify/index-partition-evidence-assembly.test.mjs
-cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
-cargo test -p rustok-benchmarks partition_snapshot
-cargo check -p rustok-benchmarks --bin index-partition-query-evidence
-cargo test -p rustok-benchmarks partition_query
-cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
-cargo test -p rustok-benchmarks partition_mutation
-cargo check -p rustok-benchmarks --bin index-partition-maintenance-evidence
-cargo test -p rustok-benchmarks partition_maintenance
-cargo check -p rustok-benchmarks --bin index-partition-cutover-evidence
-cargo test -p rustok-benchmarks partition_cutover
-cargo check -p rustok-benchmarks --bin index-partition-capture-finalize
-```
-
-Targeted M3/M4 guards:
-
-```bash
-node scripts/verify/verify-index-mutation-storage.mjs
-node scripts/verify/verify-index-schema-leases.mjs
-node scripts/verify/verify-index-secondary-index-lifecycle.mjs
-node scripts/verify/verify-index-partition-admission.mjs
-node scripts/verify/verify-index-partition-evidence.mjs
-node scripts/verify/verify-index-partition-snapshot-capture.mjs
-node scripts/verify/verify-index-partition-query-evidence.mjs
-node scripts/verify/verify-index-partition-mutation-evidence.mjs
-node scripts/verify/verify-index-partition-maintenance-evidence.mjs
-node scripts/verify/verify-index-partition-cutover-evidence.mjs
-node scripts/verify/verify-index-partition-full-capture.mjs
-node scripts/verify/verify-index-partition-post-inspection-drift.mjs
-node scripts/verify/verify-index-query-planner.mjs
-node scripts/verify/verify-index-postgres-query-compiler.mjs
-node scripts/verify/verify-index-query-result-decoder.mjs
-node scripts/verify/verify-index-many-link-filtering.mjs
 ```
 
 ## Progress log
 
-- 2026-07-23: completed the destructive reset and generic M1 core.
-- 2026-07-24 through 2026-07-27: completed M2 comparison, archived replacement
-  evidence, accepted JSONB, and removed rejected prototypes.
-- 2026-07-27: completed canonical M3 schema, atomic mutation persistence, schema
-  leases, secondary-index lifecycle, partition admission/planning, immutable packet
-  tooling, exact-byte assembly, baseline/shadow snapshot capture, query evidence
-  capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
-  maintenance evidence capture.
-- 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
-  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
-  retained bundle review, admitted archive manifest generation, saved-manifest
-  verification receipts, and exact recursive filesystem snapshot enforcement.
-- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
-  M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
-  exact count, validated lexicographic keyset continuation, bounded offset
-  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
-  count decoding, relation identity reconstruction, scoped next-cursor creation,
-  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
-  deterministic nested many-link projection aggregation with aligned identity/value
-  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
-  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
-  compiler-metadata-driven row adaptation. Server/consumer composition, plan/SQL
-  snapshots, live PostgreSQL execution, and PostgreSQL/reference equivalence remain
-  open.
-- Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
-  packet remain for the owner to execute and admit before production partition
-  lifecycle work begins.
+- 2026-07-23 through 2026-07-28: completed the destructive reset, M1 domain core,
+  selected-layout M2 evidence, and source-complete M3 storage/evidence tooling.
+- 2026-07-29: completed typed M4 planning, controlled SQL, filters, projection,
+  pagination, strict decoding, PostgreSQL query-port source, retained v4 snapshots,
+  source-owned schema publication, shared query-runtime composition, and the first
+  default-off owner-authoritative Social Graph privacy parity shadow.
+- 2026-07-30: completed explicit many-link MIN/MAX aggregate ordering for integer,
+  string, timestamp, and Decimal terminals; locked Decimal aggregate order values to
+  the exact tagged string wire; retained metrics/two-snapshot shadow evidence tooling;
+  and bounded each non-authoritative comparison by the caller's remaining deadline.
+- Repository test/fixture suites, live shadow evidence, authoritative cutover,
+  PostgreSQL/reference equivalence, and one real full PostgreSQL partition packet
+  remain owner-executed gates.

--- a/scripts/verify/verify-index-implementation-plan-cursor.mjs
+++ b/scripts/verify/verify-index-implementation-plan-cursor.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const planPath = 'crates/rustok-index/docs/implementation-plan.md';
+const plan = readFileSync(new URL(planPath, root), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-implementation-plan-cursor] ${message}`);
+  process.exit(1);
+};
+
+for (const marker of [
+  '- Current milestone: `M4 - Query engine v1 (source-complete query/runtime and first parity shadow; retained live evidence remains open)`',
+  '- M4 retained plan/SQL snapshots: `source_complete`',
+  '- M4 explicit many-link aggregate ordering: `source_complete`',
+  '- M4 source-owned schema catalog and shared query runtime: `source_complete`',
+  '- M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [x] Add explicit many-link MIN/MAX aggregate ordering for integer, string, timestamp,',
+  '- [x] Publish source-owned schemas, compose one shared query runtime, and stage the first',
+  '- [ ] Add PostgreSQL/reference-engine equivalence tests and retained live evidence.',
+  'uses only the caller\'s remaining deadline budget, and always returns the owner result.',
+  'The owner runs formatting, Cargo checks/tests, PostgreSQL fixtures, evidence capture,',
+]) {
+  if (!plan.includes(marker)) fail(`${planPath} is missing ${marker}`);
+}
+
+for (const stale of [
+  'Many-link ordering remains rejected until an aggregate ordering policy exists.',
+  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  'server/consumer query-port composition, source schema/mutation publication,',
+]) {
+  if (plan.includes(stale)) fail(`${planPath} contains stale M4 wording: ${stale}`);
+}
+
+console.log('[verify-index-implementation-plan-cursor] OK');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const directory = path.dirname(fileURLToPath(import.meta.url));
 const scripts = [
+  'verify-index-implementation-plan-cursor.mjs',
   'verify-index-query-planner.mjs',
   'verify-index-postgres-query-compiler.mjs',
   'verify-index-query-result-decoder.mjs',

--- a/scripts/verify/verify-index-query-equivalence-admission.mjs
+++ b/scripts/verify/verify-index-query-equivalence-admission.mjs
@@ -88,7 +88,8 @@ requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', 
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Add PostgreSQL/reference-engine equivalence tests and retained live evidence.',
 ]);
 
 console.log('[verify-index-query-equivalence-admission] OK');

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -92,7 +92,8 @@ requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', 
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Add PostgreSQL/reference-engine equivalence tests and retained live evidence.',
 ]);
 
 console.log('[verify-index-query-equivalence-capture] OK');


### PR DESCRIPTION
## Superseded

This draft is superseded by #2554, which preserves the factual M4 cursor, repairs the stale snapshot/equivalence guards, and continues with the bounded M5/M6 source replay contract from the newer `main` handoff.

No tests or verifier commands were run by the implementation agent.