### PR TITLE
docs(verification): advance Index handoff to Search

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -510,6 +510,23 @@ node scripts/verify/verify-index-many-link-filtering.mjs
   compiler-metadata-driven row adaptation. Server/consumer composition, plan/SQL
   snapshots, live PostgreSQL execution, and PostgreSQL/reference equivalence remain
   open.
+- 2026-07-30: bounded the non-authoritative Social Graph privacy shadow by the caller's
+  remaining deadline and repaired stale Index repository/evidence guards and retained
+  fixtures. No authoritative cutover, replay entrypoint, or live PostgreSQL evidence is
+  claimed by this change.
 - Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
   packet remain for the owner to execute and admit before production partition
   lifecycle work begins.
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `blocked`
+- Last verified at (UTC): `2026-07-30`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, and source/search/server boundaries`
+- Findings: `P0=0, P1=2, P2=0, P3=1`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards so current accepted M2/M4 contracts execute again`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; general CI/Hardening received no jobs; Rust-hosted smoke stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `execute the retained PostgreSQL packet, live query equivalence and per-tenant freshness/outage/recovery evidence; add a canonical bounded replay/rebuild owner path before reconsidering authoritative consumers or partition lifecycle`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-social-graph --all-targets --all-features && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-search/docs/implementation-plan.md
+++ b/crates/rustok-search/docs/implementation-plan.md
@@ -148,3 +148,16 @@ rebuild behavior through replayable event transport.
 - [Crate README](../README.md)
 - [Search documentation](./README.md)
 - [Search FBA registry](../contracts/search-fba-registry.json)
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `in_progress`
+- Last verified at (UTC): `2026-07-30`
+- Scope inspected: `owner README, module docs, current implementation plan, Index/Search boundary and carried event-delivery/rebuild concerns`
+- Findings: `P0=0, P1=0, P2=0, P3=0`
+- Fixed in this pass: `none; verification entrypoint only`
+- Remaining risks or blockers: `generic settings secret projection, tenant/locale/channel isolation, event replay/rebuild, deletion, duplicate and out-of-order delivery, connector boundaries, and operational recovery require source inspection`
+- Evidence: `current owner documentation and post-Index verification cursor read from main`
+- Next action: `trace settings serialization and every ingestion/rebuild publisher-consumer path; fix P0/P1 before running targeted static and Rust checks`
+- Resume command: `cargo xtask module validate search && npm run verify:search:fba && node scripts/verify/verify-search-blog-projection.mjs`

--- a/docs/verification/PLATFORM_VERIFICATION_PLAN.md
+++ b/docs/verification/PLATFORM_VERIFICATION_PLAN.md
@@ -38,13 +38,13 @@ This block is the first place an agent reads after `docs/index.md`.
 
 - Cycle: `cycle-001`
 - Cycle status: `active`
-- Current item: `core/index`
-- Next item: `core/index`
+- Current item: `core/search`
+- Next item: `core/search`
 - Started at (UTC): `2026-07-20`
 - Last handoff at (UTC): `2026-07-30`
-- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/search P1: the generic settings projection serializes search.api_key; core/outbox P1: sys_events dispatched state proves transport acceptance only, while terminal local handler failure or broadcast lag lacks a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale`
+- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/index P1: one retained admitted real PostgreSQL partition packet and live PostgreSQL/reference query equivalence are absent, and no retained per-tenant freshness, outage/restart, backlog catch-up or replay-repair evidence authorizes consumer or partition cutover; core/search P1: the generic settings projection serializes search.api_key; core/outbox P1: sys_events dispatched state proves transport acceptance only, while terminal local handler failure or broadcast lag lacks a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale`
 - Release readiness: `not_assessed`
-- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started, an earlier smoke stopped before compilation because Cargo.lock required an Athanor update, and dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
+- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email/index could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started; Index same-SHA Scale Run Contract and full Scale Evidence repository/fixture contracts passed on PR #2544, while general CI/Hardening received no jobs and Rust-hosted smoke stopped before compilation because Cargo.lock required an Athanor update under --locked; dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
 
 Allowed cycle statuses are `ready`, `active`, and `closing`. An item uses `pending`,
 `in_progress`, `completed`, or `blocked` in its local handoff block. Only one item may
@@ -181,8 +181,8 @@ These are Core modules because the current `modules.toml` declares them with
 - [x] `core/cache` — `crates/rustok-cache` — blocked
 - [x] `core/channel` — `crates/rustok-channel` — blocked
 - [x] `core/email` — `crates/rustok-email` — blocked
-- [ ] `core/index` — `crates/rustok-index`
-- [ ] `core/search` — `crates/rustok-search`
+- [x] `core/index` — `crates/rustok-index` — blocked
+- [ ] `core/search` — `crates/rustok-search` — in_progress
 - [x] `core/outbox` — `crates/rustok-outbox` — blocked
 - [ ] `core/tenant` — `crates/rustok-tenant`
 - [ ] `core/rbac` — `crates/rustok-rbac`
@@ -191,8 +191,8 @@ These are Core modules because the current `modules.toml` declares them with
   Core module lifecycle and migration ordering.
 
 `core/outbox` was visited ahead of the normal cursor to remove a confirmed P0 tenant
-isolation defect. The normal resume point remains `core/index`; Outbox must be revisited
-at the closing gate for its consumer-durability P1.
+isolation defect. Outbox and Index must be revisited at the closing gate for their
+consumer-durability, freshness, replay, and retained-evidence blockers.
 
 For each manifest module, run at minimum:
 


### PR DESCRIPTION
## Verification handoff

- records `core/index` as visited and blocked after the merged privacy-shadow deadline and stale evidence-gate fixes
- retains only factual open Index blockers: admitted PostgreSQL packet, live/reference equivalence, freshness, outage/restart and replay-repair evidence
- sets `core/search` to `in_progress` in its local implementation plan
- advances the master cursor to `core/search`
- preserves the early Outbox blocked visit and its consumer-durability blocker

No runtime code or workflow is changed.